### PR TITLE
doc: update for GH_TOKEN scopes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@
 LINEAR_API_KEY=lin_api_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # GitHub API token for gh CLI
-# Create a token at: https://github.com/settings/tokens
-# Required scopes: repo, read:org
+# Create a fine-grained token at: https://github.com/settings/tokens
+# Required permissions:
+#   - Contents: Read and write
+#   - Issues: Read and write
+#   - Pull requests: Read and write
+#   - Metadata: Read-only (automatically included)
 GH_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
This pull request updates the `.env.example` file to clarify the requirements for the `GH_TOKEN` environment variable. The instructions now specify that a fine-grained GitHub token is needed, along with a detailed list of required permissions.

Environment configuration update:

* Updated the instructions for generating a `GH_TOKEN` to require a fine-grained GitHub token, and provided a clear list of necessary permissions: Contents (Read and write), Issues (Read and write), Pull requests (Read and write), and Metadata (Read-only).