### PR TITLE
docs: add comprehensive UTF-8 string support documentation BT-24

### DIFF
--- a/docs/beamtalk-interop.md
+++ b/docs/beamtalk-interop.md
@@ -212,18 +212,51 @@ The `beamtalk_` prefix avoids collisions with existing modules.
 
 ### Strings and Binaries
 
-```
-// Single-quoted strings are binaries (recommended)
-name := 'Alice'           // => <<"Alice">> in Erlang
+Beamtalk strings are **UTF-8 binaries** by default, matching Elixir's approach:
 
-// Double-quoted strings support interpolation
+```
+// Single-quoted strings are UTF-8 binaries (recommended)
+name := 'Alice'           // => <<"Alice">> in Erlang
+multilang := '你好世界'    // => UTF-8 encoded binary
+emoji := '🎉'             // => <<240,159,142,137>>
+
+// Double-quoted strings support interpolation (also UTF-8)
 greeting := "Hello, {name}!"  // => <<"Hello, Alice!">>
+localized := "欢迎 {name}"     // => UTF-8 binary
+
+// Character literals are Unicode codepoints
+$a                        // => 97
+$世                       // => 19990
 
 // Erlang charlists (legacy, rarely needed)
-charlist := Erlang.string: "hello"  // => [104,101,108,108,111]
+charlist := 'hello' toCharlist  // => [104,101,108,108,111]
 ```
 
-**Default:** Beamtalk strings compile to Erlang binaries, not charlists. This matches modern BEAM convention.
+**Default:** Beamtalk strings compile to Erlang UTF-8 binaries, **not charlists**. This matches modern BEAM convention.
+
+#### String Encoding Details
+
+| Beamtalk | Erlang/Elixir | Bytes (example) |
+|----------|---------------|----------------|
+| `'hello'` | `<<"hello">>` | `[104,101,108,108,111]` (ASCII) |
+| `'世界'` | `<<228,184,150,231,149,140>>` | UTF-8 encoded |
+| `"Hi, {x}"` | `<<"Hi, ", X/binary>>` | Interpolated UTF-8 |
+| Charlist | `[104,101,108,108,111]` | List of integers |
+
+#### When to Use Charlists
+
+Most Erlang modules accept binaries now. Use charlists only when:
+- Required by old Erlang APIs (`:io.format/2`, some `:file` functions)
+- Explicitly documented as charlist-only
+
+```
+// Modern Erlang - accepts binaries
+Erlang.file read_file: 'data.txt'  // Binary path works
+
+// Legacy Erlang - needs charlist
+path := 'data.txt' toCharlist
+Erlang.io format: '~s~n' toCharlist arguments: [name toCharlist]
+```
 
 ### Collections
 


### PR DESCRIPTION
## Summary

Establishes UTF-8 as the official string encoding for Beamtalk, following modern BEAM conventions and matching Elixir's approach.

## Changes

### beamtalk-language-features.md
- **New Section**: "String Encoding and UTF-8" covering:
  - UTF-8 by default design decision and rationale
  - String types (single/double-quoted, interpolation)
  - Character encoding mapping to BEAM
  - Grapheme-aware string operations (length, slicing, case conversion)
  - Binary pattern matching for byte-level access
  - Legacy charlist support for Erlang interop
  - Implementation status checklist

### beamtalk-interop.md
- **Enhanced**: "Strings and Binaries" section with:
  - UTF-8 encoding details and examples
  - Multi-language support (Chinese, emoji)
  - Byte representation table
  - Clear guidance on when to use charlists vs binaries
  - Interop examples with legacy Erlang APIs

## Rationale

**Why UTF-8 by default?**
1. Modern web/API standard (JSON, HTTP, REST)
2. Compact for ASCII (1 byte per character)
3. Seamless Elixir compatibility
4. BEAM's :string module is Unicode-aware
5. LLM/AI agent-friendly (models output UTF-8)

## Related

- Linear Issue: [BT-24 - Implement UTF-8 string support and validation](https://linear.app/beamtalk/issue/BT-24)
- Tracks implementation work: lexer validation, codegen verification, standard library design

## Documentation Quality

- ✅ Clear examples with multi-language strings
- ✅ BEAM mapping reference tables
- ✅ Interop guidance for Erlang/Elixir
- ✅ Implementation status tracking
- ✅ Performance considerations noted

## Impact

- **No breaking changes** - documentation only
- Establishes design direction for string implementation
- Guides future compiler and standard library work