### PR TITLE
Use proper JSON parsing library in REPL backend (BT-55)

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl.rs
+++ b/crates/beamtalk-cli/src/commands/repl.rs
@@ -279,7 +279,9 @@ fn start_beam_node(port: u16) -> Result<Child> {
     eprintln!("Using runtime at: {}", runtime_dir.display());
 
     // Build runtime first
-    let runtime_beam_dir = runtime_dir.join("_build/default/lib/beamtalk_runtime/ebin");
+    let build_lib_dir = runtime_dir.join("_build/default/lib");
+    let runtime_beam_dir = build_lib_dir.join("beamtalk_runtime/ebin");
+    let jsx_beam_dir = build_lib_dir.join("jsx/ebin");
 
     // Check if runtime is built
     if !runtime_beam_dir.exists() {
@@ -304,6 +306,8 @@ fn start_beam_node(port: u16) -> Result<Child> {
             "-noshell",
             "-pa",
             runtime_beam_dir.to_str().unwrap_or(""),
+            "-pa",
+            jsx_beam_dir.to_str().unwrap_or(""),
             "-eval",
             &format!(
                 "{{ok, _}} = beamtalk_repl:start_link({port}), io:format(\"REPL backend started on port {port}~n\"), receive stop -> ok end."

--- a/runtime/rebar.config
+++ b/runtime/rebar.config
@@ -1,6 +1,8 @@
 {erl_opts, [debug_info]}.
 
-{deps, []}.
+{deps, [
+    {jsx, "~> 3.0"}
+]}.
 
 {profiles, [
     {test, [

--- a/runtime/test/beamtalk_repl_tests.erl
+++ b/runtime/test/beamtalk_repl_tests.erl
@@ -48,50 +48,64 @@ parse_whitespace_only_test() ->
 
 format_integer_response_test() ->
     Response = beamtalk_repl:format_response(42),
-    ?assertEqual(<<"{\"type\":\"result\",\"value\":42}">>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(#{<<"type">> => <<"result">>, <<"value">> => 42}, Decoded).
 
 format_float_response_test() ->
     Response = beamtalk_repl:format_response(3.14),
-    %% Float formatting may vary slightly
-    ?assertMatch(<<"{\"type\":\"result\",\"value\":", _/binary>>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(<<"result">>, maps:get(<<"type">>, Decoded)),
+    Value = maps:get(<<"value">>, Decoded),
+    ?assert(is_float(Value) andalso Value > 3.1 andalso Value < 3.2).
 
 format_atom_response_test() ->
     Response = beamtalk_repl:format_response(ok),
-    ?assertEqual(<<"{\"type\":\"result\",\"value\":\"ok\"}">>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(#{<<"type">> => <<"result">>, <<"value">> => <<"ok">>}, Decoded).
 
 format_string_response_test() ->
     Response = beamtalk_repl:format_response(<<"hello">>),
-    ?assertEqual(<<"{\"type\":\"result\",\"value\":\"hello\"}">>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(#{<<"type">> => <<"result">>, <<"value">> => <<"hello">>}, Decoded).
 
 format_string_with_quotes_test() ->
     Response = beamtalk_repl:format_response(<<"say \"hi\"">>),
-    ?assertEqual(<<"{\"type\":\"result\",\"value\":\"say \\\"hi\\\"\"}">>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(#{<<"type">> => <<"result">>, <<"value">> => <<"say \"hi\"">>}, Decoded).
 
 format_nil_response_test() ->
     Response = beamtalk_repl:format_response(nil),
-    ?assertEqual(<<"{\"type\":\"result\",\"value\":\"nil\"}">>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(#{<<"type">> => <<"result">>, <<"value">> => <<"nil">>}, Decoded).
 
 format_list_response_test() ->
     Response = beamtalk_repl:format_response([1, 2, 3]),
-    ?assertEqual(<<"{\"type\":\"result\",\"value\":[1,2,3]}">>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(#{<<"type">> => <<"result">>, <<"value">> => [1, 2, 3]}, Decoded).
 
 format_pid_response_test() ->
     Response = beamtalk_repl:format_response(self()),
-    ?assertMatch(<<"{\"type\":\"result\",\"value\":\"#<pid ", _/binary>>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(<<"result">>, maps:get(<<"type">>, Decoded)),
+    Value = maps:get(<<"value">>, Decoded),
+    ?assertMatch(<<"#<pid ", _/binary>>, Value).
 
 %%% Error Formatting Tests
 
 format_undefined_variable_error_test() ->
     Response = beamtalk_repl:format_error({undefined_variable, "foo"}),
-    ?assertEqual(<<"{\"type\":\"error\",\"message\":\"Undefined variable: foo\"}">>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(#{<<"type">> => <<"error">>, <<"message">> => <<"Undefined variable: foo">>}, Decoded).
 
 format_empty_expression_error_test() ->
     Response = beamtalk_repl:format_error(empty_expression),
-    ?assertEqual(<<"{\"type\":\"error\",\"message\":\"Empty expression\"}">>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(#{<<"type">> => <<"error">>, <<"message">> => <<"Empty expression">>}, Decoded).
 
 format_timeout_error_test() ->
     Response = beamtalk_repl:format_error(timeout),
-    ?assertEqual(<<"{\"type\":\"error\",\"message\":\"Request timed out\"}">>, Response).
+    Decoded = jsx:decode(Response, [return_maps]),
+    ?assertEqual(#{<<"type">> => <<"error">>, <<"message">> => <<"Request timed out">>}, Decoded).
 
 %%% Server Lifecycle Tests
 


### PR DESCRIPTION
This pull request modernizes and simplifies the way JSON is handled in the REPL backend by replacing all ad-hoc string manipulation with the standard `jsx` library for JSON encoding and decoding. It updates the runtime dependencies, refactors core serialization/deserialization logic, and improves test robustness by decoding and inspecting structured JSON rather than comparing raw strings.

The most important changes are:

**Adoption of `jsx` for JSON Handling:**
* Added `jsx` as a dependency in `runtime/rebar.config` and updated the CLI to include the `jsx` BEAM files in the runtime path, ensuring the library is available at runtime. [[1]](diffhunk://#diff-6833dee75eb78c788d4ed26274587f2d7a324381e6d5ea779f8682f867bc8332L3-R5) [[2]](diffhunk://#diff-5bfa15fc48f0e8ff810a94dc5ac0007d1d1e4dca75eb813231080a84889deeeaL282-R284) [[3]](diffhunk://#diff-5bfa15fc48f0e8ff810a94dc5ac0007d1d1e4dca75eb813231080a84889deeeaR309-R310)

**Refactoring JSON Serialization and Deserialization:**
* Rewrote all JSON response formatting in `beamtalk_repl.erl` to use `jsx:encode/1` and introduced a new `term_to_json/1` function for robust Erlang-to-JSON conversion, replacing manual string concatenation and escaping.
* Refactored the REPL's communication with the daemon to use `jsx` for both encoding JSON-RPC requests and decoding responses, eliminating fragile manual parsing and extraction functions. [[1]](diffhunk://#diff-244f35e0d35c64d39ef61f85a109c0e5f5ae1443e7617cb649b781d947c95eaaL649-R631) [[2]](diffhunk://#diff-244f35e0d35c64d39ef61f85a109c0e5f5ae1443e7617cb649b781d947c95eaaL676-R682)
* Removed all custom JSON parsing and escaping utilities, relying entirely on `jsx` for correctness and maintainability.

**Test Improvements:**
* Updated tests in `beamtalk_repl_tests.erl` to decode responses with `jsx` and assert on the resulting maps, making tests less brittle and easier to maintain.