### PR TITLE
Implement beamtalk_classes registry for class metadata (BT-76)

### DIFF
--- a/runtime/src/beamtalk_classes.erl
+++ b/runtime/src/beamtalk_classes.erl
@@ -1,0 +1,174 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%% @doc Global class registry for Beamtalk.
+%%
+%% Like Smalltalk's global `Smalltalk` dictionary, this module maintains
+%% a central registry of class metadata. The Erlang code server only knows
+%% about modules, not class hierarchies, instance variables, or method
+%% dictionaries needed for metaprogramming.
+%%
+%% ClassInfo structure:
+%% ```
+%% #{
+%%   module => atom(),              % compiled BEAM module name
+%%   superclass => atom() | none,   % parent class name
+%%   methods => #{selector() => method_info()},
+%%   instance_variables => [atom()],
+%%   class_variables => map(),
+%%   source_file => string() | undefined
+%% }
+%% ```
+-module(beamtalk_classes).
+-behaviour(gen_server).
+
+%% API
+-export([
+    start_link/0,
+    register_class/2,      % register_class(Name, ClassInfo)
+    lookup/1,              % lookup(Name) -> ClassInfo | undefined
+    all_classes/0,         % all_classes() -> [Name]
+    subclasses_of/1,       % subclasses_of(Name) -> [Name]
+    add_method/3,          % add_method(Class, Selector, Block) - for live dev
+    remove_method/2        % remove_method(Class, Selector)
+]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2
+]).
+
+-type class_name() :: atom().
+-type selector() :: atom().
+-type method_info() :: map().
+-type class_info() :: #{
+    module := atom(),
+    superclass := class_name() | none,
+    methods := #{selector() => method_info()},
+    instance_variables := [atom()],
+    class_variables := map(),
+    source_file => string()
+}.
+
+-record(state, {
+    classes = #{} :: #{class_name() => class_info()}
+}).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+%% @doc Start the class registry server.
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% @doc Register a class with the given metadata.
+-spec register_class(class_name(), class_info()) -> ok.
+register_class(Name, ClassInfo) ->
+    gen_server:call(?MODULE, {register_class, Name, ClassInfo}).
+
+%% @doc Look up a class by name.
+-spec lookup(class_name()) -> {ok, class_info()} | undefined.
+lookup(Name) ->
+    gen_server:call(?MODULE, {lookup, Name}).
+
+%% @doc Get all registered class names.
+-spec all_classes() -> [class_name()].
+all_classes() ->
+    gen_server:call(?MODULE, all_classes).
+
+%% @doc Get all direct subclasses of a class.
+-spec subclasses_of(class_name()) -> [class_name()].
+subclasses_of(Name) ->
+    gen_server:call(?MODULE, {subclasses_of, Name}).
+
+%% @doc Add or update a method on a class (for live development).
+-spec add_method(class_name(), selector(), fun()) -> ok | {error, class_not_found}.
+add_method(Class, Selector, Block) ->
+    gen_server:call(?MODULE, {add_method, Class, Selector, Block}).
+
+%% @doc Remove a method from a class (for live development).
+-spec remove_method(class_name(), selector()) -> ok | {error, class_not_found}.
+remove_method(Class, Selector) ->
+    gen_server:call(?MODULE, {remove_method, Class, Selector}).
+
+%%====================================================================
+%% gen_server callbacks
+%%====================================================================
+
+%% @private
+init([]) ->
+    {ok, #state{}}.
+
+%% @private
+handle_call({register_class, Name, ClassInfo}, _From, State) ->
+    NewClasses = maps:put(Name, ClassInfo, State#state.classes),
+    {reply, ok, State#state{classes = NewClasses}};
+
+handle_call({lookup, Name}, _From, State) ->
+    Result = case maps:find(Name, State#state.classes) of
+        {ok, ClassInfo} -> {ok, ClassInfo};
+        error -> undefined
+    end,
+    {reply, Result, State};
+
+handle_call(all_classes, _From, State) ->
+    ClassNames = maps:keys(State#state.classes),
+    {reply, ClassNames, State};
+
+handle_call({subclasses_of, ParentName}, _From, State) ->
+    Subclasses = maps:fold(
+        fun(Name, #{superclass := Super}, Acc) when Super =:= ParentName ->
+                [Name | Acc];
+            (_Name, _ClassInfo, Acc) ->
+                Acc
+        end,
+        [],
+        State#state.classes
+    ),
+    {reply, Subclasses, State};
+
+handle_call({add_method, Class, Selector, Block}, _From, State) ->
+    case maps:find(Class, State#state.classes) of
+        {ok, ClassInfo} ->
+            Methods = maps:get(methods, ClassInfo),
+            MethodInfo = #{block => Block},
+            NewMethods = maps:put(Selector, MethodInfo, Methods),
+            NewClassInfo = maps:put(methods, NewMethods, ClassInfo),
+            NewClasses = maps:put(Class, NewClassInfo, State#state.classes),
+            {reply, ok, State#state{classes = NewClasses}};
+        error ->
+            {reply, {error, class_not_found}, State}
+    end;
+
+handle_call({remove_method, Class, Selector}, _From, State) ->
+    case maps:find(Class, State#state.classes) of
+        {ok, ClassInfo} ->
+            Methods = maps:get(methods, ClassInfo),
+            NewMethods = maps:remove(Selector, Methods),
+            NewClassInfo = maps:put(methods, NewMethods, ClassInfo),
+            NewClasses = maps:put(Class, NewClassInfo, State#state.classes),
+            {reply, ok, State#state{classes = NewClasses}};
+        error ->
+            {reply, {error, class_not_found}, State}
+    end;
+
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+%% @private
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% @private
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @private
+terminate(_Reason, _State) ->
+    ok.

--- a/runtime/src/beamtalk_runtime.app.src
+++ b/runtime/src/beamtalk_runtime.app.src
@@ -2,6 +2,7 @@
     {description, "Beamtalk Runtime - Actor and Future implementations"},
     {vsn, "0.1.0"},
     {modules, []},
-    {registered, []},
-    {applications, [kernel, stdlib]}
+    {registered, [beamtalk_classes]},
+    {applications, [kernel, stdlib]},
+    {mod, {beamtalk_runtime_app, []}}
 ]}.

--- a/runtime/src/beamtalk_runtime_app.erl
+++ b/runtime/src/beamtalk_runtime_app.erl
@@ -1,0 +1,16 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%% @doc Application callback module for the Beamtalk runtime.
+-module(beamtalk_runtime_app).
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+%% @private
+start(_StartType, _StartArgs) ->
+    beamtalk_runtime_sup:start_link().
+
+%% @private
+stop(_State) ->
+    ok.

--- a/runtime/src/beamtalk_runtime_sup.erl
+++ b/runtime/src/beamtalk_runtime_sup.erl
@@ -1,0 +1,35 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%% @doc Top-level supervisor for the Beamtalk runtime.
+-module(beamtalk_runtime_sup).
+-behaviour(supervisor).
+
+-export([start_link/0]).
+-export([init/1]).
+
+%% @doc Start the runtime supervisor.
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @private
+init([]) ->
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 10,
+        period => 10
+    },
+    
+    ChildSpecs = [
+        #{
+            id => beamtalk_classes,
+            start => {beamtalk_classes, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [beamtalk_classes]
+        }
+    ],
+    
+    {ok, {SupFlags, ChildSpecs}}.

--- a/runtime/test/beamtalk_classes_tests.erl
+++ b/runtime/test/beamtalk_classes_tests.erl
@@ -1,0 +1,250 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_classes_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Setup/Teardown
+%%====================================================================
+
+setup() ->
+    {ok, Pid} = beamtalk_classes:start_link(),
+    Pid.
+
+cleanup(Pid) ->
+    gen_server:stop(Pid).
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+register_and_lookup_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     fun(_Pid) ->
+         [?_test(begin
+             ClassInfo = #{
+                 module => counter,
+                 superclass => object,
+                 methods => #{
+                     increment => #{arity => 0},
+                     value => #{arity => 0}
+                 },
+                 instance_variables => [count],
+                 class_variables => #{},
+                 source_file => "Counter.bt"
+             },
+             
+             % Register class
+             ok = beamtalk_classes:register_class('Counter', ClassInfo),
+             
+             % Lookup should return the class info
+             {ok, Retrieved} = beamtalk_classes:lookup('Counter'),
+             ?assertEqual(ClassInfo, Retrieved),
+             
+             % Lookup non-existent class
+             ?assertEqual(undefined, beamtalk_classes:lookup('NonExistent'))
+         end)]
+     end}.
+
+all_classes_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     fun(_Pid) ->
+         [?_test(begin
+             % Initially empty
+             ?assertEqual([], beamtalk_classes:all_classes()),
+             
+             % Register multiple classes
+             ok = beamtalk_classes:register_class('Counter', #{
+                 module => counter,
+                 superclass => object,
+                 methods => #{},
+                 instance_variables => [],
+                 class_variables => #{}
+             }),
+             ok = beamtalk_classes:register_class('Point', #{
+                 module => point,
+                 superclass => object,
+                 methods => #{},
+                 instance_variables => [],
+                 class_variables => #{}
+             }),
+             
+             % all_classes should return both
+             Classes = beamtalk_classes:all_classes(),
+             ?assertEqual(2, length(Classes)),
+             ?assert(lists:member('Counter', Classes)),
+             ?assert(lists:member('Point', Classes))
+         end)]
+     end}.
+
+subclasses_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     fun(_Pid) ->
+         [?_test(begin
+             % Build a simple hierarchy: Object <- Actor <- Counter
+             ok = beamtalk_classes:register_class('Object', #{
+                 module => object,
+                 superclass => none,
+                 methods => #{},
+                 instance_variables => [],
+                 class_variables => #{}
+             }),
+             ok = beamtalk_classes:register_class('Actor', #{
+                 module => actor,
+                 superclass => 'Object',
+                 methods => #{},
+                 instance_variables => [],
+                 class_variables => #{}
+             }),
+             ok = beamtalk_classes:register_class('Counter', #{
+                 module => counter,
+                 superclass => 'Actor',
+                 methods => #{},
+                 instance_variables => [],
+                 class_variables => #{}
+             }),
+             ok = beamtalk_classes:register_class('Point', #{
+                 module => point,
+                 superclass => 'Object',
+                 methods => #{},
+                 instance_variables => [],
+                 class_variables => #{}
+             }),
+             
+             % Object has two direct subclasses
+             ObjectSubs = beamtalk_classes:subclasses_of('Object'),
+             ?assertEqual(2, length(ObjectSubs)),
+             ?assert(lists:member('Actor', ObjectSubs)),
+             ?assert(lists:member('Point', ObjectSubs)),
+             
+             % Actor has one direct subclass
+             ActorSubs = beamtalk_classes:subclasses_of('Actor'),
+             ?assertEqual(['Counter'], ActorSubs),
+             
+             % Counter has no subclasses
+             ?assertEqual([], beamtalk_classes:subclasses_of('Counter'))
+         end)]
+     end}.
+
+add_method_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     fun(_Pid) ->
+         [?_test(begin
+             % Register a class with one method
+             ClassInfo = #{
+                 module => counter,
+                 superclass => object,
+                 methods => #{
+                     value => #{arity => 0}
+                 },
+                 instance_variables => [count],
+                 class_variables => #{}
+             },
+             ok = beamtalk_classes:register_class('Counter', ClassInfo),
+             
+             % Add a new method
+             IncrementBlock = fun() -> ok end,
+             ok = beamtalk_classes:add_method('Counter', increment, IncrementBlock),
+             
+             % Verify the method was added
+             {ok, Updated} = beamtalk_classes:lookup('Counter'),
+             Methods = maps:get(methods, Updated),
+             ?assert(maps:is_key(increment, Methods)),
+             #{block := Block} = maps:get(increment, Methods),
+             ?assertEqual(IncrementBlock, Block)
+         end)]
+     end}.
+
+add_method_to_nonexistent_class_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     fun(_Pid) ->
+         [?_test(begin
+             Block = fun() -> ok end,
+             ?assertEqual({error, class_not_found}, 
+                          beamtalk_classes:add_method('NonExistent', foo, Block))
+         end)]
+     end}.
+
+remove_method_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     fun(_Pid) ->
+         [?_test(begin
+             % Register a class with two methods
+             ClassInfo = #{
+                 module => counter,
+                 superclass => object,
+                 methods => #{
+                     value => #{arity => 0},
+                     increment => #{arity => 0}
+                 },
+                 instance_variables => [count],
+                 class_variables => #{}
+             },
+             ok = beamtalk_classes:register_class('Counter', ClassInfo),
+             
+             % Remove a method
+             ok = beamtalk_classes:remove_method('Counter', increment),
+             
+             % Verify the method was removed
+             {ok, Updated} = beamtalk_classes:lookup('Counter'),
+             Methods = maps:get(methods, Updated),
+             ?assertNot(maps:is_key(increment, Methods)),
+             ?assert(maps:is_key(value, Methods))
+         end)]
+     end}.
+
+remove_method_from_nonexistent_class_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     fun(_Pid) ->
+         [?_test(begin
+             ?assertEqual({error, class_not_found}, 
+                          beamtalk_classes:remove_method('NonExistent', foo))
+         end)]
+     end}.
+
+overwrite_class_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     fun(_Pid) ->
+         [?_test(begin
+             % Register a class
+             ClassInfo1 = #{
+                 module => counter,
+                 superclass => object,
+                 methods => #{value => #{}},
+                 instance_variables => [count],
+                 class_variables => #{}
+             },
+             ok = beamtalk_classes:register_class('Counter', ClassInfo1),
+             
+             % Re-register with different info (simulating hot reload)
+             ClassInfo2 = #{
+                 module => counter,
+                 superclass => actor,
+                 methods => #{value => {}, increment => #{}},
+                 instance_variables => [count, step],
+                 class_variables => #{}
+             },
+             ok = beamtalk_classes:register_class('Counter', ClassInfo2),
+             
+             % Lookup should return the new info
+             {ok, Retrieved} = beamtalk_classes:lookup('Counter'),
+             ?assertEqual(ClassInfo2, Retrieved)
+         end)]
+     end}.


### PR DESCRIPTION
## Context

Implements a central class registry for Beamtalk, similar to Smalltalk's global `Smalltalk` dictionary. The Erlang code server only knows about modules, not class hierarchies, instance variables, or method dictionaries needed for metaprogramming.

## Implementation

- **beamtalk_classes.erl**: gen_server managing global class registry
- **Class metadata**: stores module, superclass, methods, instance/class variables, source file
- **OTP supervision**: created app and supervisor modules for proper startup
- **API functions**:
  - `register_class/2` - register class metadata
  - `lookup/1` - retrieve class info
  - `all_classes/0` - list all registered classes
  - `subclasses_of/1` - query class hierarchy
  - `add_method/3`, `remove_method/2` - stubs for future live development

## Testing

- 8 unit tests covering all registry operations
- Tests for hierarchy queries, method mutation, class overwriting
- All 101 tests pass (Erlang + Rust)

## Related

Linear issue: https://linear.app/beamtalk/issue/BT-76/implement-beamtalk-classes-registry-for-class-metadata

Blocks future issues:
- REPL `:load` command (needs this to register loaded classes)
- Metaprogramming features (`Class` object, method queries)