### PR TITLE
fix: devcontainer worktree and git auth improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,7 @@
     }
   },
   "postCreateCommand": "sudo chown -R vscode:vscode ${containerWorkspaceFolder} /usr/local/cargo/registry && cargo fetch",
-  "postStartCommand": "bash .devcontainer/fix-worktree-git.sh || true; mkdir -p ~/.copilot && cp .devcontainer/mcp-config.json ~/.copilot/mcp-config.json",
+  "postStartCommand": "bash .devcontainer/fix-worktree-git.sh || true; bash .devcontainer/setup-git-auth.sh || true; mkdir -p ~/.copilot && cp .devcontainer/mcp-config.json ~/.copilot/mcp-config.json",
   "postAttachCommand": "bash .devcontainer/fix-worktree-git.sh || true",
   "remoteUser": "vscode",
   // Caching:
@@ -57,10 +57,15 @@
   // ═══════════════════════════════════════════════════════════════════════════
   // To run multiple Copilot sessions in parallel containers from worktrees:
   //
-  // 1. Set env var on host pointing to main repo's .git directory:
-  //      Windows PowerShell: $env:BEAMTALK_MAIN_GIT_PATH = "C:/Users/you/source/beamtalk/.git"
-  //      Windows (permanent): setx BEAMTALK_MAIN_GIT_PATH "C:/Users/you/source/beamtalk/.git"
-  //      Linux/Mac: export BEAMTALK_MAIN_GIT_PATH="$HOME/source/beamtalk/.git"
+  // 1. Set env vars on host:
+  //      Windows (permanent):
+  //        setx BEAMTALK_MAIN_GIT_PATH "C:/Users/you/source/beamtalk/.git"
+  //        setx GIT_USER_NAME "Your Name"
+  //        setx GIT_USER_EMAIL "you@example.com"
+  //      Linux/Mac (add to ~/.bashrc):
+  //        export BEAMTALK_MAIN_GIT_PATH="$HOME/source/beamtalk/.git"
+  //        export GIT_USER_NAME="Your Name"
+  //        export GIT_USER_EMAIL="you@example.com"
   //
   // 2. Create worktrees and open each in its own container:
   //      git worktree add ../BT-99 -b BT-99-feature
@@ -74,6 +79,9 @@
   },
   "remoteEnv": {
     "LINEAR_API_KEY": "${localEnv:LINEAR_API_KEY}",
-    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "GITHUB_TOKEN": "${localEnv:GH_TOKEN}",
+    "GIT_USER_NAME": "${localEnv:GIT_USER_NAME}",
+    "GIT_USER_EMAIL": "${localEnv:GIT_USER_EMAIL}"
   }
 }

--- a/.devcontainer/setup-git-auth.sh
+++ b/.devcontainer/setup-git-auth.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+# Configure git authentication and user identity for devcontainer
+# Uses GH_TOKEN for GitHub auth and GIT_USER_NAME/GIT_USER_EMAIL for identity
+
+log() {
+    echo "[setup-git-auth] $*"
+}
+
+# Configure git user identity
+if [ -n "$GIT_USER_NAME" ]; then
+    git config --global user.name "$GIT_USER_NAME"
+    log "Set user.name to: $GIT_USER_NAME"
+fi
+
+if [ -n "$GIT_USER_EMAIL" ]; then
+    git config --global user.email "$GIT_USER_EMAIL"
+    log "Set user.email to: $GIT_USER_EMAIL"
+fi
+
+# Configure GitHub authentication via gh CLI
+# When GH_TOKEN is set, gh CLI uses it automatically - no login needed
+if [ -n "$GH_TOKEN" ]; then
+    # Clear any existing GitHub credential helpers to avoid duplicates
+    git config --global --unset-all credential.https://github.com.helper 2>/dev/null || true
+    
+    # Configure git to use gh as credential helper
+    gh auth setup-git 2>/dev/null
+    log "Configured git to use gh for GitHub authentication"
+else
+    log "WARNING: GH_TOKEN not set, GitHub push will require manual authentication"
+    log "Set GH_TOKEN environment variable on your host machine"
+fi
+
+# Trust the workspace directory
+git config --global safe.directory '*'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,23 @@
 
 This document provides guidance for AI coding agents working on the beamtalk compiler and ecosystem.
 
+## Repository Information
+
+**Always use these values for GitHub API calls:**
+
+| Property | Value |
+|----------|-------|
+| Owner | `jamesc` |
+| Repository | `beamtalk` |
+| Full name | `jamesc/beamtalk` |
+| URL | `https://github.com/jamesc/beamtalk` |
+
+Example `gh` CLI usage:
+```bash
+gh api repos/jamesc/beamtalk/pulls
+gh pr create --repo jamesc/beamtalk
+```
+
 ## Project Overview
 
 Beamtalk is a Smalltalk/Newspeak-inspired programming language that compiles to the BEAM virtual machine. The compiler is written in Rust and generates Core Erlang, which is then compiled to BEAM bytecode via erlc.

--- a/scripts/worktree-new.ps1
+++ b/scripts/worktree-new.ps1
@@ -146,7 +146,9 @@ else {
         }
         else {
             # Create new worktree
-            $worktreePath = Join-Path $WorktreeRoot $Branch
+            # Sanitize branch name for directory (replace / with -)
+            $dirName = $Branch -replace '/', '-'
+            $worktreePath = Join-Path $WorktreeRoot $dirName
             
             if (Test-BranchExists -BranchName $Branch) {
                 Write-Host "📌 Creating worktree for existing branch: $Branch" -ForegroundColor Yellow

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -113,7 +113,9 @@ else
         log_success "✅ Worktree already exists at: $EXISTING_WORKTREE"
         WORKTREE_PATH="$EXISTING_WORKTREE"
     else
-        WORKTREE_PATH="$WORKTREE_ROOT/$BRANCH"
+        # Sanitize branch name for directory (replace / with -)
+        DIR_NAME=$(echo "$BRANCH" | tr '/' '-')
+        WORKTREE_PATH="$WORKTREE_ROOT/$DIR_NAME"
         
         if branch_exists "$BRANCH"; then
             log_warn "📌 Creating worktree for existing branch: $BRANCH"


### PR DESCRIPTION
- Sanitize branch names with / in worktree scripts (feature/X -> feature-X)
- Add setup-git-auth.sh for GitHub authentication via gh CLI
- Add repository info section to AGENTS.md (jamesc/beamtalk)
- Configure git user.name/email from env vars in devcontainer

Required host env vars for devcontainer:
- GH_TOKEN (fine-grained PAT with Contents read/write)
- GIT_USER_NAME
- GIT_USER_EMAIL
- BEAMTALK_MAIN_GIT_PATH