### PR TITLE
Add networking and debugging tools to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,10 +4,12 @@
 FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
 #FROM mcr.microsoft.com/devcontainers/rust:latest
 
-# Install Erlang/OTP and git from Debian packages
+# Install Erlang/OTP, git, and networking/debugging tools
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
         erlang rebar3 git \
+        socat netcat-openbsd lsof \
+        curl wget jq htop strace \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Adds useful networking and debugging tools to the devcontainer for easier development and troubleshooting.

## Changes

- **socat** - multipurpose relay for bidirectional data transfer
- **netcat-openbsd** - `nc` command for TCP/UDP connections  
- **lsof** - list open files and sockets
- **jq** - JSON parsing
- **htop** - interactive process viewer
- **strace** - system call tracing
- **curl/wget** - explicitly included for completeness