### PR TITLE
Launch copilot --yolo in worktree-new scripts

### DIFF
--- a/scripts/worktree-new.ps1
+++ b/scripts/worktree-new.ps1
@@ -216,7 +216,7 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-Write-Host "`n✨ Container ready! Connecting..." -ForegroundColor Green
+Write-Host "`n✨ Container ready! Starting Copilot..." -ForegroundColor Green
 
-# Connect to the container
-devcontainer exec --workspace-folder $worktreePath bash
+# Connect to the container and start Copilot in yolo mode
+devcontainer exec --workspace-folder $worktreePath copilot --yolo

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -173,7 +173,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo ""
-log_success "✨ Container ready! Connecting..."
+log_success "✨ Container ready! Starting Copilot..."
 
-# Connect to the container
-devcontainer exec --workspace-folder "$WORKTREE_PATH" bash
+# Connect to the container and start Copilot in yolo mode
+devcontainer exec --workspace-folder "$WORKTREE_PATH" copilot --yolo


### PR DESCRIPTION
Changes worktree-new scripts to launch `copilot --yolo` instead of `bash` when connecting to the devcontainer.

## Summary
- Updated `scripts/worktree-new.ps1` to run `copilot --yolo`
- Updated `scripts/worktree-new.sh` to run `copilot --yolo`

The `--yolo` flag enables all permissions (tools, paths, URLs) with no confirmation prompts, enabling fully autonomous agent operation in worktree sessions.