### PR TITLE
docs: Add documentation index and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 **A live, interactive Smalltalk for the BEAM VM**
 
-Beamtalk brings Smalltalk's legendary live programming experience to Erlang's battle-tested runtime. Write code in a running system, hot-reload behavior without restarts, and scale to millions of concurrent actors.
+Beamtalk brings Smalltalk's legendary live programming experience to Erlang's battle-tested runtime. Write code in a running system, hot-reload modules without restarts, and scale to millions of concurrent actors.
 
 ```beamtalk
-// Spawn an actor
+// Spawn an actor with state
 counter := Counter spawn
 
 // Send messages (async by default)
@@ -15,11 +15,11 @@ counter increment
 counter increment
 value := counter getValue await  // => 2
 
-// Hot-patch while running
-patch Counter >> #increment {
-  Telemetry log: 'incrementing'
-  self.value += 1
-}
+// Cascades - multiple messages to same receiver
+Transcript show: 'Hello'; cr; show: 'World'
+
+// Map literals
+config := #{#host => 'localhost', #port => 8080}
 ```
 
 ---
@@ -29,7 +29,7 @@ patch Counter >> #increment {
 | Feature | Benefit |
 |---------|---------|
 | **Interactive-first** | REPL and live workspace, not batch compilation |
-| **Hot code reload** | Edit behavior in running systems, sub-200ms feedback |
+| **Hot code reload** | Edit and reload modules in running systems |
 | **Actors everywhere** | Every object is a BEAM process with fault isolation |
 | **Async by default** | Message sends return futures; no blocking |
 | **Full reflection** | Inspect any actor's state, mailbox, and methods at runtime |
@@ -50,7 +50,7 @@ Actor subclass: Counter
 
   increment => self.value += 1
   decrement => self.value -= 1
-  getValue => self.value
+  getValue => ^self.value
 ```
 
 ### Async Message Passing
@@ -138,34 +138,155 @@ See [Beamtalk for Agents](docs/beamtalk-for-agents.md) for detailed use cases.
 
 ---
 
+## Getting Started
+
+### Prerequisites
+
+- **Rust** (latest stable)
+- **Erlang/OTP 26+** with `erlc` on PATH
+
+### Build & Run
+
+```bash
+# Clone and build
+git clone https://github.com/jamesc/beamtalk.git
+cd beamtalk
+cargo build
+
+# Start the REPL
+cargo run -- repl
+```
+
+### REPL Usage
+
+```
+Beamtalk v0.1.0
+Type :help for available commands, :exit to quit.
+
+> message := 'Hello, Beamtalk!'
+"Hello, Beamtalk!"
+
+> 2 + 3 * 4
+14
+
+> :load examples/hello.bt
+Loaded
+
+> :bindings
+message = "Hello, Beamtalk!"
+```
+
+### Load Files
+
+```
+> :load examples/counter.bt
+Loaded
+
+> :reload
+Reloaded
+```
+
+---
+
 ## Project Status
 
-**Early development** — compiler and tooling are being built.
+**Active development** — the compiler core is working with an interactive REPL.
 
-The language design is documented:
+### What Works Now
+
+- ✅ **REPL** — Interactive evaluation with variable persistence
+- ✅ **Lexer & Parser** — Full expression parsing with error recovery
+- ✅ **Core Erlang codegen** — Compiles to BEAM bytecode via `erlc`
+- ✅ **Actors** — Spawn actors with state, send async messages
+- ✅ **Cascades** — Multiple messages to same receiver
+- ✅ **Map literals** — `#{key => value}` syntax with Dictionary codegen
+- ✅ **Class definitions** — AST support for class and method definitions
+- ✅ **Standard library** — Boolean, Block, Integer, String, Collections
+
+### In Progress
+
+- 🔄 **Field assignments** — Actor state mutations
+- 🔄 **Method dispatch** — Full message routing
+- 🔄 **Supervision trees** — Declarative fault tolerance
+
+### Planned
+
+- 📋 **LSP** — Language server for IDE integration
+- 📋 **Live browser** — Smalltalk-style class browser (Phoenix `LiveView`)
+- 📋 **Hot patching** — Edit running actors in place
+
+---
+
+## Documentation
+
+📚 **[Documentation Index](docs/README.md)** — Start here for a guided tour
+
+### Core Documents
+
 - [Design Principles](docs/beamtalk-principles.md) — 13 core principles guiding all decisions
-- [Language Features](docs/beamtalk-language-features.md) — Planned syntax, semantics, and tooling
+- [Language Features](docs/beamtalk-language-features.md) — Syntax, semantics, and examples
 - [Syntax Rationale](docs/beamtalk-syntax-rationale.md) — Why we keep/change Smalltalk conventions
-- [Architecture](docs/beamtalk-architecture.md) — Compiler, runtime, and live development flow
-- [IDE and Live Development](docs/beamtalk-ide.md) — Smalltalk-style integrated environment
-- [BEAM Interop](docs/beamtalk-interop.md) — Erlang/Elixir integration specification
-- [Feasibility Assessment](docs/beamtalk-feasibility.md) — Technical and market analysis
-- [Agent Systems](docs/beamtalk-for-agents.md) — Multi-agent AI use cases
+- [Object Model](docs/beamtalk-object-model.md) — How Smalltalk objects map to BEAM
 
-### Planned Architecture
+### Architecture
+
+- [Architecture](docs/beamtalk-architecture.md) — Compiler pipeline, runtime, hot reload
+- [BEAM Interop](docs/beamtalk-interop.md) — Erlang/Elixir integration specification
+- [Testing Strategy](docs/beamtalk-testing-strategy.md) — How we verify compiler correctness
+
+### Tooling & Vision
+
+- [IDE and Live Development](docs/beamtalk-ide.md) — Smalltalk-style integrated environment
+- [Agent Systems](docs/beamtalk-for-agents.md) — Multi-agent AI use cases
+- [Feasibility Assessment](docs/beamtalk-feasibility.md) — Technical and market analysis
+
+---
+
+## Examples & Standard Library
+
+### Examples ([examples/](examples/))
+
+Simple programs demonstrating language features:
+
+```bash
+cargo run -- repl
+> :load examples/hello.bt
+```
+
+### Standard Library ([lib/](lib/))
+
+Foundational classes implementing "everything is a message":
+
+| Class | Description |
+|-------|-------------|
+| `Actor` | Base class for all actors |
+| `Block` | First-class closures |
+| `True` / `False` | Boolean control flow |
+| `Integer` | Arbitrary precision arithmetic |
+| `String` | UTF-8 text operations |
+| `Array` / `List` | Ordered collections |
+| `Set` / `Dictionary` | Unordered collections |
+| `Nil` | Null object pattern |
+
+See [lib/README.md](lib/README.md) for full documentation.
+
+---
+
+## Repository Structure
 
 ```text
 beamtalk/
 ├── crates/
-│   ├── beamtalk-core/     # Lexer, parser, AST, type checking, codegen
-│   ├── beamtalk-cli/      # Command-line interface
-│   └── beamtalk-lsp/      # Language server
-├── lib/                    # Standard library (.bt files)
-├── docs/                   # Documentation
-└── examples/               # Example programs
+│   ├── beamtalk-core/       # Lexer, parser, AST, codegen
+│   └── beamtalk-cli/        # Command-line interface & REPL
+├── lib/                      # Standard library (.bt files)
+├── runtime/                  # Erlang runtime (actors, REPL backend)
+├── docs/                     # Design documents
+├── examples/                 # Example programs
+└── test-package-compiler/    # Snapshot tests for compiler
 ```
 
-The compiler is written in Rust and generates Core Erlang, which compiles to BEAM bytecode via `erlc`.
+The compiler is written in **Rust** and generates **Core Erlang**, which compiles to BEAM bytecode via `erlc`.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,142 @@
+# Beamtalk Documentation
+
+Welcome to the Beamtalk documentation! This guide will help you navigate the design documents and understand how Beamtalk brings Smalltalk's live programming philosophy to the BEAM virtual machine.
+
+---
+
+## Quick Start
+
+**New to Beamtalk?** Start here:
+
+1. **[Design Principles](beamtalk-principles.md)** — The core philosophy guiding all decisions
+2. **[Language Features](beamtalk-language-features.md)** — Syntax reference and planned features
+3. **[Examples](../examples/)** — Simple programs to see the language in action
+
+---
+
+## Documentation Overview
+
+### Core Language Design
+
+| Document | Description |
+|----------|-------------|
+| [Design Principles](beamtalk-principles.md) | Interactive-first, actors, hot reload, async-first — the foundational ideas |
+| [Language Features](beamtalk-language-features.md) | Complete syntax reference: messages, blocks, classes, strings |
+| [Syntax Rationale](beamtalk-syntax-rationale.md) | Why we keep certain Smalltalk conventions and diverge from others |
+| [Object Model](beamtalk-object-model.md) | How "everything is an object" maps to the BEAM |
+
+### Architecture & Implementation
+
+| Document | Description |
+|----------|-------------|
+| [Architecture](beamtalk-architecture.md) | Compiler pipeline, runtime, and hot code loading |
+| [BEAM Interop](beamtalk-interop.md) | Calling Erlang/Elixir from Beamtalk and vice versa |
+| [Testing Strategy](beamtalk-testing-strategy.md) | How we test the compiler and runtime |
+
+### Tooling & Environment
+
+| Document | Description |
+|----------|-------------|
+| [IDE & Live Development](beamtalk-ide.md) | Smalltalk-style browser, inspector, and debugger |
+
+### Vision & Planning
+
+| Document | Description |
+|----------|-------------|
+| [For AI Agents](beamtalk-for-agents.md) | Multi-agent AI systems with live actors |
+| [Feasibility Assessment](beamtalk-feasibility.md) | Technical and market analysis |
+
+---
+
+## Reading Paths
+
+### "I want to understand the language"
+
+1. [Design Principles](beamtalk-principles.md) — Philosophy and core ideas
+2. [Syntax Rationale](beamtalk-syntax-rationale.md) — Why Beamtalk looks the way it does
+3. [Language Features](beamtalk-language-features.md) — Full syntax reference
+4. [Examples](../examples/) — See it in practice
+
+### "I want to understand how it works"
+
+1. [Architecture](beamtalk-architecture.md) — Compiler and runtime overview
+2. [Object Model](beamtalk-object-model.md) — Smalltalk objects on BEAM
+3. [BEAM Interop](beamtalk-interop.md) — Integration with Erlang/Elixir
+4. [Testing Strategy](beamtalk-testing-strategy.md) — How we verify correctness
+
+### "I want to build AI agents"
+
+1. [For AI Agents](beamtalk-for-agents.md) — Multi-agent AI systems
+2. [Design Principles](beamtalk-principles.md) — Live programming for exploration
+3. [IDE & Live Development](beamtalk-ide.md) — Interactive debugging and inspection
+
+---
+
+## Code Examples
+
+### Examples Directory ([examples/](../examples/))
+
+Simple programs demonstrating language features:
+
+- [hello.bt](../examples/hello.bt) — Basic expressions and string literals
+- [counter.bt](../examples/counter.bt) — Assignment and arithmetic
+
+Use the REPL to load examples:
+
+```
+$ beamtalk repl
+> :load examples/hello.bt
+Loaded
+```
+
+### Standard Library ([lib/](../lib/))
+
+The foundational classes implementing Smalltalk's "everything is a message" philosophy:
+
+| Class | Description |
+|-------|-------------|
+| [Actor](../lib/Actor.bt) | Base class for all actors (BEAM processes) |
+| [Block](../lib/Block.bt) | First-class closures |
+| [True](../lib/True.bt) / [False](../lib/False.bt) | Boolean control flow via messages |
+| [Nil](../lib/Nil.bt) | Null object pattern |
+| [Integer](../lib/Integer.bt) | Arbitrary precision arithmetic |
+| [String](../lib/String.bt) | UTF-8 text with grapheme operations |
+| [Array](../lib/Array.bt) | Fixed-size indexed collection (tuple) |
+| [List](../lib/List.bt) | Linked list with fast prepend |
+| [Set](../lib/Set.bt) | Unordered unique elements |
+| [Dictionary](../lib/Dictionary.bt) | Key-value map |
+| [Collection](../lib/Collection.bt) | Abstract collection protocol |
+
+See [lib/README.md](../lib/README.md) for detailed documentation.
+
+### Test Cases ([test-package-compiler/cases/](../test-package-compiler/cases/))
+
+Comprehensive test cases for language features, each containing:
+- `.bt` source files
+- Expected Core Erlang output (snapshots)
+
+Browse these for real-world usage patterns.
+
+---
+
+## Contributing
+
+See [AGENTS.md](../AGENTS.md) in the repository root for:
+- Development guidelines
+- Code conventions
+- How to add new features
+- Testing requirements
+
+---
+
+## About Beamtalk
+
+Beamtalk is a Smalltalk/Newspeak-inspired language targeting the BEAM (Erlang VM). It combines:
+
+- **Smalltalk's simplicity** — Everything is a message send
+- **BEAM's reliability** — Lightweight processes, fault tolerance, hot code reload
+- **Live development** — No compile-deploy-restart cycle
+
+The compiler is written in Rust and generates Core Erlang, which is then compiled to BEAM bytecode.
+
+**Repository:** [github.com/jamesc/beamtalk](https://github.com/jamesc/beamtalk)


### PR DESCRIPTION
## Summary

Adds a documentation navigation index and updates the main README with current project status.

### Changes

**docs/README.md** (new)
- Quick start guide for newcomers
- Documentation overview with categorized tables
- Reading paths for different audiences (language learners, implementers, AI builders)
- Links to examples/, lib/, and test-package-compiler/cases/
- Standard library class table with links

**README.md** (updated)
- Getting Started section with prerequisites, build instructions, REPL examples
- Project Status with ✅ What Works Now / 🔄 In Progress / 📋 Planned sections
- Documentation section linking to new docs/README.md index
- Examples & Standard Library section
- Updated repository structure including runtime/
- Updated hero code example with cascades and map literals