### PR TITLE
Document network protocols (CLI ↔ REPL ↔ Daemon) (BT-65)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Welcome to the Beamtalk documentation! This guide will help you navigate the des
 | Document | Description |
 |----------|-------------|
 | [Architecture](beamtalk-architecture.md) | Compiler pipeline, runtime, and hot code loading |
+| [Network Protocols](beamtalk-protocols.md) | CLI ↔ REPL, compiler daemon JSON-RPC, actor messages |
 | [BEAM Interop](beamtalk-interop.md) | Calling Erlang/Elixir from Beamtalk and vice versa |
 | [Testing Strategy](beamtalk-testing-strategy.md) | How we test the compiler and runtime |
 
@@ -60,9 +61,10 @@ Welcome to the Beamtalk documentation! This guide will help you navigate the des
 ### "I want to understand how it works"
 
 1. [Architecture](beamtalk-architecture.md) — Compiler and runtime overview
-2. [Object Model](beamtalk-object-model.md) — Smalltalk objects on BEAM
-3. [BEAM Interop](beamtalk-interop.md) — Integration with Erlang/Elixir
-4. [Testing Strategy](beamtalk-testing-strategy.md) — How we verify correctness
+2. [Network Protocols](beamtalk-protocols.md) — IPC between components
+3. [Object Model](beamtalk-object-model.md) — Smalltalk objects on BEAM
+4. [BEAM Interop](beamtalk-interop.md) — Integration with Erlang/Elixir
+5. [Testing Strategy](beamtalk-testing-strategy.md) — How we verify correctness
 
 ### "I want to build AI agents"
 

--- a/docs/beamtalk-protocols.md
+++ b/docs/beamtalk-protocols.md
@@ -1,6 +1,8 @@
 # Beamtalk Network Protocols
 
-This document describes the network protocols used for communication between Beamtalk components. It is intended for contributors, debugging, and potential client implementations in other languages.
+This document describes the network protocols used for communication between Beamtalk components. It covers the CLI ↔ REPL backend protocol, the compiler daemon JSON-RPC API, and the actor message protocol.
+
+For architecture context, see [beamtalk-architecture.md](beamtalk-architecture.md). For the actor runtime model, see [beamtalk-object-model.md](beamtalk-object-model.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for all Beamtalk network protocols in `docs/beamtalk-protocols.md`.

**Linear Issue:** https://linear.app/beamtalk/issue/BT-65

## What's Documented

### 1. CLI ↔ REPL Backend Protocol (JSON over TCP)
- All request/response message types (eval, clear, bindings, load)
- Session state management and variable bindings
- Error handling and response codes
- Value serialization rules (PIDs, blocks, tuples, etc.)
- Connection lifecycle with sequence diagram

### 2. Compiler Daemon Protocol (JSON-RPC 2.0 over Unix socket)
- JSON-RPC 2.0 framing (newline-delimited)
- All RPC methods: ping, compile, compile_expression, diagnostics, shutdown
- Error codes and their meanings
- Parameter/return type documentation for each method
- Connection example in Erlang

### 3. Actor Message Protocol (Erlang terms)
- Async message format: `{Selector, Args, FuturePid}`
- Sync message format: `{Selector, Args}`
- Message dispatch and doesNotUnderstand fallback behavior
- Future resolution protocol with state diagram
- Sequence diagrams for message dispatch and await

## Changes
- Create `docs/beamtalk-protocols.md` with full protocol documentation
- Update `docs/README.md` to include new doc in index and reading paths
