### PR TITLE
Design: Self-as-Object and Reflection API (BT-151)

### DIFF
--- a/docs/internal/design-metaprogramming.md
+++ b/docs/internal/design-metaprogramming.md
@@ -1,0 +1,394 @@
+# Design: Metaprogramming and Class-as-Process
+
+**Issue:** Future (TBD)  
+**Status:** Draft — captures deferred work from BT-151  
+**Depends on:** BT-151 (Self-as-Object and Reflection API)  
+**Date:** 2026-02-01
+
+## Executive Summary
+
+This document captures metaprogramming features deferred from BT-151. These features require "class-as-process" — treating classes as first-class actor objects rather than just modules.
+
+**Key features:**
+- Classes as actor objects (full metaclass protocol)
+- Runtime method dictionaries (dynamic dispatch)
+- Dynamic `super` dispatch
+- Class method inheritance
+- Passing classes as values
+- Method objects (CompiledMethod introspection)
+- `thisContext` emulation
+- `become:` emulation
+
+---
+
+## Part 1: Class-as-Process Architecture
+
+### Current State (after BT-151)
+
+- Classes compile to Erlang modules
+- Class "methods" are module functions (`Counter.spawn` → `counter:spawn()`)
+- No `self` in class methods
+- No class method inheritance
+- Classes can't be passed as values
+
+### Target State
+
+Each class is represented by two things:
+1. **Module** — compiled methods (for performance)
+2. **Class process** — holds method dictionary, superclass ref, metadata (for dynamism)
+
+```erlang
+%% Class process state
+#{
+    '__class__' => 'Counter class',      % Metaclass
+    '__superclass__' => 'Actor',          % Superclass reference
+    '__instance_methods__' => #{          % Method dictionary
+        increment => fun counter:handle_increment/4,
+        getValue => fun counter:handle_getValue/4
+    },
+    '__class_methods__' => #{
+        spawn => fun counter:class_spawn/3,
+        defaultValue => fun counter:class_defaultValue/3
+    },
+    '__instance_variables__' => [value],
+    '__name__' => 'Counter'
+}
+```
+
+### Class Process Registration
+
+```erlang
+%% Each class registers its process
+%% Name: beamtalk_class_<classname>
+register(beamtalk_class_counter, ClassPid).
+
+%% Lookup
+beamtalk:class('Counter') -> #beamtalk_object{class='Counter class', ...}
+```
+
+---
+
+## Part 2: Dynamic Method Dispatch
+
+### Current (BT-151): Static Dispatch
+
+```erlang
+%% Method call compiles to direct dispatch
+call 'counter':'dispatch'('increment', Args, Self, State)
+```
+
+### Target: Dynamic Dispatch
+
+```erlang
+%% Method call looks up in method dictionary
+dispatch(Selector, Args, Self, State) ->
+    Class = Self#beamtalk_object.class,
+    ClassPid = beamtalk:class_process(Class),
+    case beamtalk_class:lookup_method(ClassPid, Selector) of
+        {ok, Fun} -> Fun(Args, Self, State);
+        not_found -> handle_dnu(Selector, Args, Self, State)
+    end.
+```
+
+### Method Lookup Chain
+
+```
+SpecialCounter (method dict) 
+    ↓ not found
+Counter (method dict)
+    ↓ not found  
+Actor (method dict)
+    ↓ not found
+Object (method dict)
+    ↓ not found
+doesNotUnderstand:
+```
+
+### Performance Optimization
+
+- **Inline caching:** Remember last lookup result, revalidate on class change
+- **Method combination:** Pre-compute before/after chains at class load time
+- **Fallback to static:** For sealed classes, use compile-time dispatch
+
+---
+
+## Part 3: Dynamic `super` Dispatch
+
+### Current (BT-151): Static Super
+
+```erlang
+%% super increment → direct call to superclass module
+call 'counter':'dispatch'('increment', Args, Self, State)
+```
+
+### Target: Dynamic Super
+
+```erlang
+%% super increment → lookup starting from superclass
+super_dispatch(Selector, Args, Self, State, DefiningClass) ->
+    Superclass = beamtalk:superclass_of(DefiningClass),
+    lookup_method_from(Superclass, Selector, Args, Self, State).
+```
+
+**Key:** `super` starts lookup from the superclass of the class *where the method is defined*, not the receiver's class. This requires passing the defining class context.
+
+---
+
+## Part 4: Class Methods with Self
+
+### Current (BT-151): No Self in Class Methods
+
+```
+Counter class method
+  defaultValue => 42   // Works
+  
+  withLogging =>
+    self log: "creating"  // ERROR: no self
+    self spawn
+```
+
+### Target: Class Methods Have Self = Class Object
+
+```
+Counter class method
+  withLogging =>
+    self log: "creating"   // self = Counter class object
+    self spawn             // Calls class method spawn
+```
+
+**Implementation:**
+```erlang
+%% Class method dispatch
+class_dispatch(Selector, Args, ClassSelf, ClassState) ->
+    %% ClassSelf = #beamtalk_object{class='Counter class', pid=ClassProcessPid}
+    Methods = maps:get('__class_methods__', ClassState),
+    case maps:find(Selector, Methods) of
+        {ok, Fun} -> Fun(Args, ClassSelf, ClassState);
+        error -> class_handle_dnu(Selector, Args, ClassSelf, ClassState)
+    end.
+```
+
+---
+
+## Part 5: Passing Classes as Values
+
+### Current (BT-151): Can't Pass Classes
+
+```
+factory := Counter        // What is Counter? Just an atom reference
+factory spawn             // Can't dispatch to an atom
+```
+
+### Target: Classes Are Objects
+
+```
+factory := Counter        // Counter is a #beamtalk_object{} (class object)
+factory spawn             // Sends 'spawn' message to class object
+factory class             // => 'Counter class' (the metaclass)
+
+// Factory pattern
+createWith: factory =>
+    factory spawn
+    
+createWith: Counter       // Works!
+createWith: SpecialCounter // Also works!
+```
+
+**Implementation:**
+- `Counter` (bare class name) compiles to lookup of class object
+- Class objects are `#beamtalk_object{}` with `class = 'Counter class'`
+- Message sends to class objects go through class dispatch
+
+---
+
+## Part 6: Method Objects (CompiledMethod)
+
+### Target API
+
+```
+method := Counter >> #increment   // Get method object
+
+method selector          // => #increment
+method argumentCount     // => 0
+method source            // => "increment => self.value += 1"
+method pragmas           // => []
+method valueWithReceiver: obj args: []  // Execute method
+```
+
+### Implementation
+
+```erlang
+-record(beamtalk_method, {
+    selector :: atom(),
+    class :: atom(),
+    arity :: non_neg_integer(),
+    source :: binary() | undefined,
+    pragmas :: list(),
+    fun_ref :: function()
+}).
+```
+
+### Method Replacement (Hot Patching)
+
+```
+Counter >> #increment put: [:self |
+    Telemetry log: "incrementing"
+    self.value := self.value + 1
+]
+```
+
+Updates the method dictionary in the class process. Existing instances see the new method on next call (dynamic dispatch).
+
+---
+
+## Part 7: thisContext Emulation
+
+### What Smalltalk Provides
+
+```smalltalk
+thisContext          "Current stack frame"
+thisContext sender   "Caller's frame"  
+thisContext method   "Current method"
+```
+
+### BEAM Limitation
+
+BEAM doesn't expose stack frames as first-class objects. We can only get stack traces after exceptions.
+
+### Partial Emulation
+
+```
+// Available (via process dictionary or parameter passing)
+thisMethod           // Current method being executed (compile-time known)
+
+// Available (after exception)
+Exception stack      // Stack trace with method names
+
+// NOT available
+thisContext sender   // Can't access caller's frame
+thisContext restart  // Can't restart execution
+```
+
+### Implementation
+
+```erlang
+%% Compile-time: inject method info
+handle_increment(Args, Self, State) ->
+    put('$beamtalk_current_method', {counter, increment, 0}),
+    %% ... method body ...
+    erase('$beamtalk_current_method').
+```
+
+---
+
+## Part 8: `become:` Emulation
+
+### What Smalltalk Provides
+
+```smalltalk
+obj1 become: obj2   "Swap identities - all refs to obj1 now point to obj2"
+```
+
+### BEAM Limitation
+
+Can't mutate references held by other processes. Each process has its own copy of terms.
+
+### Proxy Pattern Workaround
+
+```
+// Instead of become:, use a proxy that can change its target
+Proxy subclass: MutableRef
+  state: target = nil
+  
+  become: newTarget =>
+    self.target := newTarget
+    
+  doesNotUnderstand: selector args: args =>
+    self.target perform: selector withArgs: args
+```
+
+**Limitation:** Only works if all references go through the proxy. Direct pid references won't redirect.
+
+### Registry Pattern
+
+```erlang
+%% Global registry maps stable IDs to current pids
+beamtalk_registry:register(myObject, Pid1),
+beamtalk_registry:become(myObject, Pid2),  %% Updates mapping
+beamtalk_registry:lookup(myObject) -> Pid2
+```
+
+---
+
+## Part 9: Full Reflection API
+
+### Instance Reflection (BT-151)
+
+```
+obj class
+obj respondsTo: #selector
+obj instVarNames
+obj instVarAt: #name
+obj instVarAt: #name put: value
+obj perform: #selector
+obj perform: #selector withArgs: args
+```
+
+### Class Reflection (This Doc)
+
+```
+Counter superclass           // => Actor
+Counter allSuperclasses      // => [Actor, Object]
+Counter subclasses           // => [SpecialCounter, ...]
+Counter allInstances         // => [...all instances...]
+Counter instanceVariables    // => [value]
+Counter methods              // => [increment, getValue, ...]
+Counter methodDictionary     // => #{increment => Method, ...}
+Counter >> #increment        // => CompiledMethod
+```
+
+### System Reflection
+
+```
+Beamtalk allClasses          // => [Counter, Actor, Object, ...]
+Beamtalk classNamed: #Counter // => Counter class object
+Beamtalk globals             // => #{...}
+```
+
+---
+
+## Part 10: Implementation Roadmap
+
+### Phase 1: Class Process Infrastructure
+- [ ] Create class process for each compiled class
+- [ ] Register class processes with well-known names
+- [ ] Implement `beamtalk:class/1` lookup
+
+### Phase 2: Dynamic Dispatch
+- [ ] Add method dictionary to class process state
+- [ ] Implement `lookup_method/2` with inheritance chain
+- [ ] Update codegen to use dynamic dispatch (opt-in or default)
+
+### Phase 3: Class Methods with Self
+- [ ] Implement class method dispatch
+- [ ] Allow `self` in class methods (refers to class object)
+- [ ] Implement class method inheritance
+
+### Phase 4: Method Objects
+- [ ] Define `#beamtalk_method{}` record
+- [ ] Implement `Class >> #selector` syntax
+- [ ] Implement method replacement API
+
+### Phase 5: Full Metaclass Protocol
+- [ ] Each class has a metaclass
+- [ ] Metaclasses are classes too
+- [ ] `Counter class class` works
+
+---
+
+## References
+
+- [BT-151: Self-as-Object Design](design-self-as-object.md)
+- [Smalltalk-80 Blue Book](http://stephane.ducasse.free.fr/FreeBooks/BlueBook/Bluebook.pdf) — Chapter 5
+- [Pharo Metaclasses](https://books.pharo.org/booklet-ReflectiveCore/)
+- [Newspeak Modules](https://newspeaklanguage.org/documents.html)

--- a/docs/internal/design-self-as-object.md
+++ b/docs/internal/design-self-as-object.md
@@ -1,0 +1,1354 @@
+# Design: Self-as-Object and Reflection API
+
+**Issue:** BT-151  
+**Status:** Draft  
+**Author:** Design Review  
+**Date:** 2026-02-01
+
+## Executive Summary
+
+This document specifies how Beamtalk methods receive a proper "self" reference (completing the object model started in BT-100) and defines the reflection API for runtime introspection.
+
+**Key Decisions:**
+1. Methods receive `Self` as a separate `#beamtalk_object{}` record parameter
+2. State is kept separate from Self (no infinite recursion risk)
+3. Primitives use virtual dispatch via `beamtalk_primitive` module (not actors)
+4. Phased rollout with backward compatibility layer
+
+---
+
+## Part 1: Current State Analysis
+
+### What BT-100 Implemented
+
+BT-100 introduced the `#beamtalk_object{}` record for **external** object references:
+
+```erlang
+%% From runtime/include/beamtalk.hrl
+-record(beamtalk_object, {
+    class :: atom(),      % 'Counter'
+    class_mod :: atom(),  % 'counter'
+    pid :: pid()
+}).
+```
+
+**What works now:**
+- `spawn/0` and `spawn/1` return `#beamtalk_object{}` records
+- Message sends extract pid via `element(4, Obj)`
+- External code can pass object references around
+
+**What's missing:**
+- Methods receive only `(Args, State)` — no proper `self` reference
+- No reflection API (`obj class`, `obj respondsTo:`, etc.)
+- Primitives (integers, strings) have no class identity
+
+### Current Method Signature
+
+Generated code in `dispatch/3`:
+
+```erlang
+'dispatch'/3 = fun (Selector, Args, State) ->
+    case Selector of
+        <'increment'> when 'true' ->
+            %% Method body has access to State (a map) but not Self
+            NewValue = maps:get('value', State) + 1,
+            {'reply', NewValue, maps:put('value', NewValue, State)}
+        ...
+```
+
+The method has:
+- ✅ Access to `State` (the field values map)
+- ✅ Access to `Args` (method arguments)
+- ❌ No access to `Self` (the `#beamtalk_object{}` reference)
+- ❌ No way to get own class, pid, or call reflection methods on self
+
+---
+
+## Part 2: Design Decisions
+
+### Question 1: Method Signatures
+
+**Decision: Pass Self as separate parameter, keep State separate**
+
+```erlang
+%% NEW signature
+'dispatch'/4 = fun (Selector, Args, Self, State) ->
+    %% Self = #beamtalk_object{class='Counter', class_mod='counter', pid=<0.123.0>}
+    %% State = #{value => 0, '__class__' => 'Counter', '__methods__' => #{...}}
+```
+
+**Rationale:**
+
+1. **Follows LFE Flavors pattern**: Flavors passes `self` (the instance record) as second argument to `combined-method`:
+   ```erlang
+   Fm:'combined-method'(Meth, Inst, Args)
+   %% Inst is #'flavor-instance'{flavor_mod=Fm, instance=Pid}
+   ```
+
+2. **Avoids circular reference**: If we merged Self into State, we'd have:
+   ```erlang
+   State = #{
+       '__self__' => #beamtalk_object{..., state = State}  % INFINITE!
+   }
+   ```
+   
+3. **Clear separation of concerns**:
+   - `Self`: Identity and metadata (immutable during method execution)
+   - `State`: Mutable field values
+
+4. **Efficient**: Self is constructed once at dispatch, reused for all method calls within a single message handling.
+
+**Code Generation Changes:**
+
+```erlang
+%% BEFORE (current)
+'dispatch'/3 = fun (Selector, Args, State) ->
+
+%% AFTER
+'dispatch'/4 = fun (Selector, Args, Self, State) ->
+```
+
+**Performance Impact:** One additional parameter pass per method call. Negligible — Erlang is optimized for passing terms.
+
+---
+
+### Question 2: Primitive Types
+
+**Decision: Virtual dispatch via `beamtalk_primitive` module, not actors**
+
+Primitives (integers, floats, strings, atoms, lists, maps, booleans, nil) should NOT be actors:
+- Creating a process for `42` would be absurdly expensive
+- Would break BEAM interop (Erlang expects bare integers)
+- Would prevent pattern matching
+
+**Implementation:**
+
+```erlang
+%% beamtalk_primitive.erl - handles reflection on primitive types
+-module(beamtalk_primitive).
+-export([class_of/1, responds_to/2, send/3]).
+
+%% Get the class of any Beamtalk value
+class_of(X) when is_integer(X) -> 'Integer';
+class_of(X) when is_float(X) -> 'Float';
+class_of(X) when is_binary(X) -> 'String';
+class_of(X) when is_atom(X), X =:= true; X =:= false -> 'Boolean';
+class_of(nil) -> 'UndefinedObject';
+class_of(X) when is_atom(X) -> 'Symbol';
+class_of(X) when is_list(X) -> 'Array';
+class_of(X) when is_map(X) -> 'Dictionary';
+class_of(#beamtalk_object{class = C}) -> C;
+class_of(_) -> 'Object'.  % Fallback
+
+%% Check if a value responds to a selector
+responds_to(X, Selector) when is_integer(X) ->
+    beamtalk_integer:has_method(Selector);
+responds_to(#beamtalk_object{class_mod = Mod}, Selector) ->
+    Mod:has_method(Selector);
+%% ... etc for other types
+
+%% Universal message send (for primitives)
+send(X, Selector, Args) when is_integer(X) ->
+    beamtalk_integer:dispatch(Selector, Args, X);
+%% ... etc
+```
+
+**Beamtalk Usage:**
+
+```
+42 class                    // => Integer
+42 + 8                      // => 50 (handled by Integer class)
+42 respondsTo: #factorial   // => true (if defined)
+
+"hello" class               // => String
+"hello" size                // => 5
+```
+
+**Class Hierarchy for Primitives:**
+
+```
+Object
+├── Integer (wraps Erlang integer)
+├── Float (wraps Erlang float)
+├── String (wraps Erlang binary)
+├── Symbol (wraps Erlang atom)
+├── Boolean (wraps true/false atoms)
+├── UndefinedObject (wraps nil atom)
+├── Array (wraps Erlang list)
+├── Dictionary (wraps Erlang map)
+├── Block (wraps Erlang fun)
+└── Actor (base for all actor classes)
+    ├── Counter
+    └── ...
+```
+
+**Key Insight:** Primitives are *value types* with *class identity*. They're not actors, but they respond to messages through static dispatch to their class module.
+
+**Dispatch Strategy Decision:** Start with uniform dispatch (all primitive operations go through `beamtalk_primitive:send/3`). This enables tracing, debugging, and a consistent object model. Optimize to direct Erlang calls for operators (Option C) later when performance data justifies it — this is purely a codegen optimization with no semantic change.
+
+**`doesNotUnderstand:` on Primitives:** Primitives support DNU handlers, enabling runtime extension of primitive types without modifying core modules. When a method isn't found in `beamtalk_string:dispatch`, it falls through to a DNU handler that checks an extension registry. This allows libraries to add methods like `"hello" json` without recompiling `beamtalk_string.erl`.
+
+**Extension Registry Design (Pharo-style):**
+
+Extensions use a global namespace with conflict tracking (following Pharo's proven approach):
+
+```erlang
+%% Registration tracks owner for provenance
+beamtalk_extensions:register('String', 'json', Fun, mylib)
+
+%% Conflict handling: warn and overwrite (last-writer-wins)
+beamtalk_extensions:register('String', 'json', OtherFun, otherlib)
+%% => Warning: 'json' on 'String' (from 'mylib') overwritten by 'otherlib'
+
+%% Tooling: list all extensions on a class
+beamtalk_extensions:list('String')
+%% => [{json, otherlib}, {trim, stdlib}, ...]
+
+%% Tooling: show all conflicts (methods registered by multiple owners)
+beamtalk_extensions:conflicts()
+%% => [{'String', json, [mylib, otherlib]}]
+
+%% Lookup (returns current registration)
+beamtalk_extensions:lookup('String', 'json')
+%% => {ok, Fun, otherlib} | not_found
+```
+
+This approach is simple (no import declarations needed), but conflicts are visible and manageable through tooling.
+
+---
+
+### Question 3: Reflection API
+
+**Decision: Implement core Smalltalk-80 reflection methods in phases**
+
+#### Phase 1: Basic Identity (BT-152)
+
+```
+obj class                   // => Counter (class object/symbol)
+obj respondsTo: #selector   // => true/false
+```
+
+**Implementation:**
+- `class` is a special selector handled in `beamtalk_actor:handle_call/3`
+- Returns `Self#beamtalk_object.class` for actors
+- Returns result from `beamtalk_primitive:class_of/1` for primitives
+
+```erlang
+%% In beamtalk_actor.erl
+handle_call({class}, _From, State) ->
+    Class = maps:get('__class__', State),
+    {reply, Class, State};
+
+handle_call({respondsTo, Selector}, _From, State) ->
+    Methods = maps:get('__methods__', State),
+    {reply, maps:is_key(Selector, Methods), State};
+```
+
+#### Phase 2: Instance Variable Access (BT-153)
+
+```
+obj instVarNames            // => [value, name, ...]
+obj instVarAt: #value       // => current value
+obj instVarAt: #value put: 42  // => sets value, returns self
+```
+
+**Implementation:**
+```erlang
+handle_call({instVarNames}, _From, State) ->
+    %% Filter out internal keys
+    Names = [K || K <- maps:keys(State), 
+             not lists:member(K, ['__class__', '__methods__'])],
+    {reply, Names, State};
+
+handle_call({instVarAt, Name}, _From, State) ->
+    {reply, maps:get(Name, State, nil), State};
+
+handle_call({instVarAt, Name, put, Value}, _From, State) ->
+    Self = build_self_from_state(State),  % Reconstruct #beamtalk_object{}
+    {reply, Self, maps:put(Name, Value, State)};
+```
+
+#### Phase 3: Dynamic Message Send (BT-154)
+
+```
+obj perform: #increment                    // => sends increment message
+obj perform: #at:put: withArgs: [1, 'x']   // => sends at:put: with args
+```
+
+**Implementation:**
+```erlang
+handle_call({perform, Selector}, From, State) ->
+    %% Recursive dispatch
+    handle_call({Selector, []}, From, State);
+
+handle_call({perform, Selector, withArgs, Args}, From, State) ->
+    handle_call({Selector, Args}, From, State);
+```
+
+#### Phase 4: Method Introspection (BT-155)
+
+```
+Counter methods              // => [increment, getValue, spawn, ...]
+Counter >> #increment        // => CompiledMethod object
+method selector              // => #increment
+method argumentCount         // => 0
+```
+
+**Implementation Strategy:** Start with module function calls (`counter:method_table()`), evolve to class-as-process later.
+
+- **Phase 4a (this design):** `Counter methods` compiles to `counter:method_table()` — simple, no extra processes
+- **Phase 4b (future BT-xxx):** Full class-as-process for metaclass protocol (`Counter superclass`, runtime class modification, `Counter new` as message send)
+
+This mirrors the primitive dispatch decision — start simple, optimize/expand when needed.
+
+#### Reflection Method Summary
+
+| Method | Returns | Phase |
+|--------|---------|-------|
+| `class` | Class symbol | 1 |
+| `respondsTo:` | Boolean | 1 |
+| `instVarNames` | Array of symbols | 2 |
+| `instVarAt:` | Field value | 2 |
+| `instVarAt:put:` | Self | 2 |
+| `perform:` | Result | 3 |
+| `perform:withArgs:` | Result | 3 |
+| `methods` | Array of selectors | 4 |
+| `>>` (method lookup) | CompiledMethod | 4 |
+
+---
+
+### Question 4: Self-Reference Semantics
+
+#### Can `self` be reassigned?
+
+**Decision: No. `self` is immutable within a method.**
+
+Smalltalk-80 technically allows `self := other`, but:
+1. It's widely considered bad practice
+2. BEAM has no mechanism to change "which process am I"
+3. It would break the actor model
+
+```
+// DISALLOWED
+increment =>
+    self := Counter spawn   // Compile error: cannot assign to self
+```
+
+#### How does `super` work?
+
+**Decision: Static dispatch to superclass module (compile-time resolved)**
+
+```
+Counter subclass: SpecialCounter
+  increment =>
+    self log: "incrementing"
+    super increment    // Call Counter's increment
+```
+
+**Compiles to:**
+```erlang
+%% super increment → direct call to superclass module
+call 'counter':'dispatch'('increment', [], Self, State)
+```
+
+**Rules:**
+- `super message` → call superclass module's dispatch directly
+- `super.field` → compile error (super is not an object reference)
+- `super` alone → compile error (must be followed by message)
+- Superclass is resolved at compile time from class definition
+
+**Codegen changes:**
+```rust
+// In generate_message_send, check if receiver is "super"
+if receiver_is_super {
+    let superclass_mod = self.current_class_superclass_module();
+    write!(self.output, 
+        "call '{superclass_mod}':'dispatch'('{selector}', Args, Self, State)")?;
+}
+```
+
+**Future (with class-as-process):** When we implement runtime method dictionaries, `super` will use dynamic lookup starting from the superclass. The static approach is forward-compatible — we're just optimizing what would be a runtime lookup.
+
+#### Class methods vs instance methods
+
+**Decision: Class methods are module functions (no actor involved)**
+
+```
+// Class "methods" - compiled to module functions
+Counter spawn           // → counter:spawn()
+Counter defaultValue    // → counter:default_value()
+
+// Instance methods - dispatched through actor
+counter increment       // → gen_server:cast(pid, {increment, ...})
+```
+
+**Limitations (to be addressed with class-as-process):**
+
+| Limitation | Current Behavior | Future Fix |
+|------------|------------------|------------|
+| `self` in class method | **Compile error** | Class-as-process provides self = class object |
+| Class method inheritance | No automatic inheritance | Class-as-process with method dictionaries |
+| Passing class as value | Use atom + lookup | Class-as-process makes classes first-class |
+| `Counter respondsTo: #spawn` | Returns false (instance methods only) | Class-as-process reflection |
+
+**Codegen for class methods:**
+```rust
+// If method is marked as class method:
+// - Error if `self` is used in body
+// - Generate as module function, not in dispatch/4
+```
+
+**Workaround for passing classes:**
+```
+// Can't do: factory := Counter
+// Instead:
+factory := #Counter
+instance := (Beamtalk classNamed: factory) spawn
+```
+
+#### Initialization and Self
+
+**Question:** How does the `initialize` method receive `Self`?
+
+**Problem:** `Self` needs `pid`, but pid isn't known until the process starts.
+
+**Solution:** Call `initialize` after process starts, when pid is available:
+
+```erlang
+%% Generated init/1 in counter.core
+init(Args) ->
+    %% 1. Create initial state with defaults
+    State0 = #{
+        '__class__' => 'Counter',
+        '__class_mod__' => 'counter',
+        '__methods__' => method_table(),
+        value => 0
+    },
+    
+    %% 2. Now pid is known - construct Self
+    Self = #beamtalk_object{
+        class = 'Counter',
+        class_mod = 'counter', 
+        pid = self()
+    },
+    
+    %% 3. Call initialize if defined, passing spawn args
+    State1 = case maps:find('initialize', maps:get('__methods__', State0)) of
+        {ok, InitFun} -> 
+            {reply, _, NewState} = InitFun(Args, Self, State0),
+            NewState;
+        error -> 
+            State0
+    end,
+    
+    {ok, State1}.
+```
+
+**Beamtalk usage:**
+```
+Counter subclass: ConfigurableCounter
+  state: value = 0, name = ""
+  
+  initialize: config =>
+    self.value := config at: #initial ifAbsent: [0]
+    self.name := config at: #name ifAbsent: ["unnamed"]
+    
+// Spawn with config
+counter := ConfigurableCounter spawn: #{initial => 10, name => "myCounter"}
+```
+
+**Key points:**
+- `initialize` is called *inside* `init/1`, after process starts
+- `Self` is fully constructed (pid = self())
+- `initialize` receives spawn arguments
+- `initialize` can set up state using `self.field :=`
+- If no `initialize` defined, defaults are used
+
+#### How does `self` interact with closures/blocks?
+
+**Decision: Blocks capture `self` by value at block creation time.**
+
+```
+Counter subclass: Example
+  state: value = 0
+  
+  makeIncrementer =>
+    // Block captures self at creation time
+    [self increment]
+    
+  useLater =>
+    callback := self makeIncrementer await
+    // Later, even if called from another context:
+    callback value  // Still calls increment on original self
+```
+
+**Implementation:** When generating a block, if `self` is referenced, capture `Self` variable:
+
+```erlang
+%% Block captures Self in its closure environment
+fun() ->
+    %% Self is bound from outer scope
+    gen_server:cast(Self#beamtalk_object.pid, {increment, [], FuturePid})
+end
+```
+
+#### What's the pid in `Self#beamtalk_object.pid`?
+
+**Decision: Always `self()` — the current process.**
+
+```erlang
+%% In dispatch, construct Self:
+Self = #beamtalk_object{
+    class = maps:get('__class__', State),
+    class_mod = ?MODULE,
+    pid = self()  % Always the current process
+}
+```
+
+#### Thread-safety: can `Self` be passed to other actors?
+
+**Decision: Yes, `Self` is just data. Passing it is safe.**
+
+```
+// Actor A sends its reference to Actor B
+actorB tell: self
+
+// Actor B can then send messages to Actor A
+// (This is standard actor model behavior)
+```
+
+The `#beamtalk_object{}` record is immutable data. Passing it between processes is safe and efficient (BEAM optimizes this).
+
+#### Cascades and Self
+
+**Question:** Does `self foo; bar; baz` work correctly with dispatch/4?
+
+**Answer: Yes.** Cascades reuse the receiver (Self), and state threads through.
+
+```
+self increment; increment; getValue
+// Sends increment, then increment, then getValue to self
+// Returns result of getValue (which is 2)
+```
+
+**Generated code:**
+```erlang
+%% self increment; increment; getValue
+%% Self stays constant, State threads through
+let <_Cascade0, State1> = dispatch('increment', [], Self, State0) in
+let <_Cascade1, State2> = dispatch('increment', [], Self, State1) in
+let <Result, State3> = dispatch('getValue', [], Self, State2) in
+{'reply', Result, State3}
+```
+
+**Key points:**
+- `Self` is the same for all messages (object identity)
+- `State` threads through (each message sees previous state changes)
+- Final result is the return value of the last message
+
+#### Actor Crash Semantics
+
+**Question:** What happens when sending to a dead actor?
+
+```
+counter := Counter spawn
+other saveRef: counter    // other holds reference
+counter crash             // counter process dies
+
+// Later...
+other useSavedRef         // Tries to send message to dead actor — what happens?
+```
+
+**The problem:**
+- `#beamtalk_object{}` record still exists (immutable data)
+- `pid` inside points to dead process
+- Sync call → `noproc` error
+- Async call → message lost, future never resolves
+
+**Solution: Detect and report gracefully**
+
+1. **`isAlive` method:** Check if actor is still running
+   ```
+   counter isAlive   // => true or false
+   ```
+
+2. **Async sends to dead actors:** Future rejects with `actor_dead` error
+   ```
+   counter increment        // => Future
+   counter increment await  // => raises BeamtalkError(actor_dead)
+   ```
+
+3. **Error structure:**
+   ```erlang
+   #beamtalk_error{
+       kind = actor_dead,
+       class = 'Counter',
+       selector = 'increment',
+       message = <<"Actor process has terminated">>,
+       hint = <<"Use 'isAlive' to check, or use monitors for lifecycle events">>
+   }
+   ```
+
+**Implementation:**
+```erlang
+%% In message send codegen or runtime
+send_async(#beamtalk_object{pid = Pid, class = Class}, Selector, Args, FuturePid) ->
+    case erlang:is_process_alive(Pid) of
+        true -> 
+            gen_server:cast(Pid, {Selector, Args, FuturePid});
+        false ->
+            beamtalk_future:reject(FuturePid, #beamtalk_error{
+                kind = actor_dead,
+                class = Class,
+                selector = Selector,
+                message = <<"Actor process has terminated">>,
+                hint = <<"Use 'isAlive' to check before sending">>
+            })
+    end.
+```
+
+**Monitoring (alternative):** For proactive notification, use BEAM monitors:
+```
+monitor := counter monitor    // Returns monitor reference
+
+// When counter dies, receive notification:
+receive: {#DOWN, monitor, #process, pid, reason} =>
+    self handleDeath: reason
+```
+
+**⚠️ `isAlive` race condition:** The check-then-act pattern is inherently racy:
+```
+// DANGEROUS: actor could die between check and send
+counter isAlive ifTrue: [counter increment]
+```
+`isAlive` is a hint, not a guarantee. The robust pattern is to **handle the error**:
+```
+// SAFE: handle the error
+counter increment await 
+    onError: [:e | e kind = #actor_dead ifTrue: [self handleDead]]
+```
+
+#### Future Await Timeout
+
+**Question:** What if an actor is alive but hung?
+
+```
+counter verySlowMethod await  // Blocks forever?
+```
+
+**Decision: Configurable timeout with sensible default**
+
+```
+// Default timeout (e.g., 30 seconds)
+result := counter slowMethod await
+
+// Explicit timeout
+result := counter slowMethod await: 5 seconds
+
+// No timeout (explicit infinite wait)
+result := counter slowMethod awaitForever
+```
+
+**Implementation:**
+```erlang
+%% await with timeout
+await(Future) -> await(Future, 30000).  %% 30 second default
+
+await(Future, Timeout) ->
+    receive
+        {resolved, Future, Value} -> Value;
+        {rejected, Future, Error} -> error(Error)
+    after Timeout ->
+        error(#beamtalk_error{
+            kind = timeout,
+            message = <<"Await timed out">>,
+            hint = <<"Use 'await: duration' for longer timeout, or 'awaitForever' for no timeout">>
+        })
+    end.
+```
+
+**Note:** Default timeout value (30s) should be configurable at system level.
+
+---
+
+### Question 5: Implementation Strategy
+
+**Decision: Phased rollout with compatibility shim**
+
+#### Phase 1: Runtime Changes (Non-Breaking)
+
+1. Add `dispatch/4` alongside existing `dispatch/3`
+2. `handle_call` and `handle_cast` construct `Self` and call `dispatch/4`
+3. Old generated code using `dispatch/3` continues to work (shim layer)
+
+```erlang
+%% Backward compatibility: dispatch/3 wraps dispatch/4
+dispatch(Selector, Args, State) ->
+    %% Construct Self from State for legacy code
+    Self = #beamtalk_object{
+        class = maps:get('__class__', State),
+        class_mod = maps:get('__class_mod__', State, undefined),
+        pid = self()
+    },
+    dispatch(Selector, Args, Self, State).
+```
+
+#### Phase 2: Code Generation Changes
+
+1. Update `generate_dispatch` in `mod.rs` to emit `dispatch/4`
+2. Generate methods that use `Self` parameter
+3. Add `__class_mod__` to state map for Self reconstruction
+
+#### Phase 3: Add Reflection Methods
+
+1. Add special-case handling in `dispatch/4` for `class`, `respondsTo:`, etc.
+2. Generate `has_method/1` function in each class module
+
+#### Phase 4: Remove Compatibility Layer
+
+After all generated code uses new format, remove `dispatch/3`.
+
+---
+
+### Question 6: Actor State Structure
+
+**Decision: State does NOT include Self reference directly**
+
+**Current state structure:**
+```erlang
+#{
+    '__class__' => 'Counter',
+    '__methods__' => #{increment => fun/2, ...},
+    value => 0
+}
+```
+
+**New state structure (add `__class_mod__`):**
+```erlang
+#{
+    '__class__' => 'Counter',
+    '__class_mod__' => 'counter',  % NEW: needed to reconstruct Self
+    '__methods__' => #{increment => fun/3, ...},  % Arity changes!
+    value => 0
+}
+```
+
+**Why store both?** Avoids locking in a naming convention. `HTTPClient` → `httpclient` vs `http_client` is ambiguous. Explicit is safer and consistent with `#beamtalk_object{}` from BT-100.
+
+**Why not store Self in State?**
+
+```erlang
+%% DON'T DO THIS - infinite recursion risk
+#{
+    '__self__' => #beamtalk_object{
+        class = 'Counter',
+        class_mod = 'counter',
+        pid = <0.123.0>
+    },
+    ...
+}
+%% What if someone does: maps:get('__self__', State)?
+%% And then passes it around? The pid is fine, but it's redundant.
+```
+
+**Reconstructing Self at dispatch time:**
+
+```erlang
+%% In handle_call/handle_cast:
+Self = #beamtalk_object{
+    class = maps:get('__class__', State),
+    class_mod = maps:get('__class_mod__', State),
+    pid = self()
+}
+```
+
+This is:
+- **Safe:** No circular reference
+- **Efficient:** Record construction is cheap
+- **Correct:** `pid = self()` is always accurate
+
+---
+
+## Part 3: Detailed Specifications
+
+### 3.1 Method Signature Format
+
+**Generated method dispatch (after changes):**
+
+```erlang
+'dispatch'/4 = fun (Selector, Args, Self, State) ->
+    %% Self = #beamtalk_object{class, class_mod, pid}
+    %% State = #{...fields..., '__class__', '__class_mod__', '__methods__'}
+    case Selector of
+        <'increment'> when 'true' ->
+            %% Method body can use Self for reflection, self-sends, etc.
+            NewValue = call 'erlang':'+'(
+                call 'maps':'get'('value', State),
+                1
+            ),
+            NewState = call 'maps':'put'('value', NewValue, State),
+            {'reply', NewValue, NewState};
+        
+        <'getSelf'> when 'true' ->
+            %% Method can return Self
+            {'reply', Self, State};
+        
+        %% ... more methods ...
+        
+        %% Reflection methods (built-in)
+        <'class'> when 'true' ->
+            {'reply', call 'erlang':'element'(2, Self), State};
+        
+        <'respondsTo:'> when 'true' ->
+            case Args of
+                <[Selector]> when 'true' ->
+                    Methods = call 'maps':'get'('__methods__', State),
+                    {'reply', call 'maps':'is_key'(Selector, Methods), State}
+            end;
+        
+        %% Default: doesNotUnderstand
+        <_> when 'true' ->
+            %% ... DNU handling ...
+    end
+```
+
+### 3.2 Dispatch Implementation
+
+**Changes to `beamtalk_actor.erl`:**
+
+```erlang
+%% handle_cast constructs Self before dispatch
+handle_cast({Selector, Args, FuturePid}, State) ->
+    Self = make_self(State),
+    case dispatch(Selector, Args, Self, State) of
+        {reply, Result, NewState} ->
+            beamtalk_future:resolve(FuturePid, Result),
+            {noreply, NewState};
+        %% ...
+    end.
+
+%% handle_call constructs Self before dispatch
+handle_call({Selector, Args}, _From, State) ->
+    Self = make_self(State),
+    dispatch(Selector, Args, Self, State).
+
+%% Helper to construct Self from State
+make_self(State) ->
+    #beamtalk_object{
+        class = maps:get('__class__', State),
+        class_mod = maps:get('__class_mod__', State),
+        pid = self()
+    }.
+```
+
+### 3.3 Primitive Type Handling
+
+**New module: `beamtalk_primitive.erl`**
+
+```erlang
+-module(beamtalk_primitive).
+-export([class_of/1, send/3, responds_to/2]).
+
+-include("beamtalk.hrl").
+
+%% Determine class of any Beamtalk value
+-spec class_of(term()) -> atom().
+class_of(X) when is_integer(X) -> 'Integer';
+class_of(X) when is_float(X) -> 'Float';
+class_of(X) when is_binary(X) -> 'String';
+class_of(true) -> 'Boolean';
+class_of(false) -> 'Boolean';
+class_of(nil) -> 'UndefinedObject';
+class_of(X) when is_function(X) -> 'Block';
+class_of(X) when is_atom(X) -> 'Symbol';
+class_of(X) when is_list(X) -> 'Array';
+class_of(X) when is_map(X) -> 'Dictionary';
+class_of(X) when is_tuple(X), element(1, X) =:= beamtalk_object ->
+    element(2, X);  % class field
+class_of(_) -> 'Object'.
+
+%% Send message to any value (actors or primitives)
+-spec send(term(), atom(), list()) -> term().
+send(#beamtalk_object{pid = Pid}, Selector, Args) ->
+    %% Actor: use gen_server
+    gen_server:call(Pid, {Selector, Args});
+send(X, Selector, Args) when is_integer(X) ->
+    %% Primitive: static dispatch to class module
+    beamtalk_integer:dispatch(Selector, Args, X);
+send(X, Selector, Args) when is_binary(X) ->
+    beamtalk_string:dispatch(Selector, Args, X);
+%% ... etc for other primitives
+
+%% Check if value responds to selector
+-spec responds_to(term(), atom()) -> boolean().
+responds_to(#beamtalk_object{class_mod = Mod}, Selector) ->
+    Mod:has_method(Selector);
+responds_to(X, Selector) when is_integer(X) ->
+    beamtalk_integer:has_method(Selector);
+%% ... etc
+```
+
+**Example primitive class module: `beamtalk_integer.erl`**
+
+```erlang
+-module(beamtalk_integer).
+-export([dispatch/3, has_method/1]).
+
+dispatch(Selector, Args, Value) ->
+    case builtin_dispatch(Selector, Args, Value) of
+        {ok, Result} -> Result;
+        not_found -> does_not_understand(Selector, Args, Value)
+    end.
+
+builtin_dispatch('+', [Y], X) -> {ok, X + Y};
+builtin_dispatch('-', [Y], X) -> {ok, X - Y};
+builtin_dispatch('*', [Y], X) -> {ok, X * Y};
+builtin_dispatch('/', [Y], X) -> {ok, X / Y};
+builtin_dispatch('class', [], _X) -> {ok, 'Integer'};
+builtin_dispatch('asString', [], X) -> {ok, integer_to_binary(X)};
+builtin_dispatch('abs', [], X) -> {ok, abs(X)};
+builtin_dispatch('negated', [], X) -> {ok, -X};
+builtin_dispatch(_, _, _) -> not_found.
+
+does_not_understand(Selector, Args, Value) ->
+    %% Check extension registry for user-added methods
+    case beamtalk_extensions:lookup('Integer', Selector) of
+        {ok, Fun} -> Fun(Args, Value);
+        not_found -> error({does_not_understand, 'Integer', Selector, length(Args)})
+    end.
+
+has_method(Selector) ->
+    %% Check both builtins and extensions
+    builtin_dispatch(Selector, [], 0) =/= not_found
+        orelse beamtalk_extensions:has('Integer', Selector).
+```
+
+### 3.4 Reflection API Specification
+
+| Method | Signature | Return Type | Works On |
+|--------|-----------|-------------|----------|
+| `class` | `obj class` | Symbol | All values |
+| `respondsTo:` | `obj respondsTo: #sel` | Boolean | All values |
+| `instVarNames` | `obj instVarNames` | Array | All values (empty for primitives) |
+| `instVarAt:` | `obj instVarAt: #name` | Any | All values (nil for primitives) |
+| `instVarAt:put:` | `obj instVarAt: #name put: val` | Self | Actors only (error on primitives) |
+| `perform:` | `obj perform: #sel` | Any | All values |
+| `perform:withArgs:` | `obj perform: #sel withArgs: args` | Any | All values |
+
+**Primitive reflection behavior:** Primitives return sensible defaults for read-only reflection (`instVarNames` → `[]`, `instVarAt:` → `nil`). Mutating reflection (`instVarAt:put:`) errors on primitives since they're immutable values.
+
+**Error messages for primitives:** When mutation is attempted on a primitive, provide helpful guidance:
+```erlang
+%% Instead of cryptic error:
+{does_not_understand, 'Integer', 'instVarAt:put:', 2}
+
+%% Provide actionable message:
+{error, {immutable_primitive, 'Integer', 
+         <<"Integers are immutable values. Use assignment (x := newValue) instead of mutation.">>}}
+```
+
+**Reflection is synchronous:** All reflection methods (`class`, `respondsTo:`, `instVarNames`, `instVarAt:`, `instVarAt:put:`, `perform:`) are **synchronous** even on actors. This ensures consistent behavior for introspection and debugging. The async-first model applies to user-defined methods, not reflection.
+
+**Sync vs Async Mental Model:**
+
+| Operation | Location | Sync/Async | Why |
+|-----------|----------|------------|-----|
+| `class` | Local (in `#beamtalk_object{}`) | Sync | Metadata in reference |
+| `respondsTo:` | Local (check method table) | Sync | Can query module |
+| `instVarNames` | Actor process | **Async (Future)** | Needs actor state |
+| `instVarAt:` | Actor process | **Async (Future)** | Needs actor state |
+| `instVarAt:put:` | Actor process | **Async (Future)** | Modifies actor state |
+| `perform:` | Actor process | **Async (Future)** | Delegates to actor |
+| User methods | Actor process | **Async (Future)** | Actor model |
+
+**Rule:** If it needs to ask the actor, it returns a Future. Metadata in the object reference is sync.
+
+**Error messages for Future confusion:** When a developer sends a message to a Future instead of awaiting:
+```
+Error: Sent 'size' to a Future.
+  Did you mean: (counter instVarNames await) size
+  
+  instVarNames returns a Future because it queries actor state.
+  Use 'await' to get the value.
+```
+
+### 3.5 Code Generation Changes
+
+**File:** `crates/beamtalk-core/src/codegen/core_erlang/mod.rs`
+
+1. **`generate_dispatch`**: Change from `/3` to `/4`, add `Self` parameter
+
+2. **`generate_init`**: Add `'__class_mod__'` to initial state map
+
+3. **Add built-in reflection selectors**: Handle `class`, `respondsTo:`, `instVarNames`, etc. in dispatch before user-defined methods
+
+4. **Update method arity**: Methods now receive `(Args, Self, State)` internally
+
+5. **Fix `self` identifier generation** (CRITICAL):
+
+**Current behavior (WRONG):**
+```rust
+// In generate_identifier()
+// `self` falls through and generates: maps:get('self', State)
+```
+
+**Required fix:**
+```rust
+fn generate_identifier(&mut self, id: &Identifier) -> Result<()> {
+    match id.name.as_str() {
+        "true" => write!(self.output, "'true'")?,
+        "false" => write!(self.output, "'false'")?,
+        "nil" => write!(self.output, "'nil'")?,
+        "self" => write!(self.output, "Self")?,  // NEW: self → Self parameter
+        _ => {
+            // Check if it's a bound variable in current or outer scopes
+            if let Some(var_name) = self.lookup_var(id.name.as_str()).cloned() {
+                write!(self.output, "{var_name}")?;
+            } else {
+                // Field access from state
+                let state_var = self.current_state_var();
+                write!(self.output, "call 'maps':'get'('{}', {state_var})", id.name)?;
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+**Developer writes → Compiler generates:**
+
+| Beamtalk Source | Meaning | Generated Core Erlang |
+|-----------------|---------|----------------------|
+| `self` | Object reference | `Self` |
+| `self.value` | Field read | `call 'maps':'get'('value', State)` |
+| `self.value := x` | Field write | State threading |
+| `self increment` | Message to self | `gen_server:cast(element(4, Self), ...)` |
+| `^self` | Return self | `Self` |
+| `other tell: self` | Pass self | `Self` |
+
+**Key insight:** The developer never sees `Self` vs `State` — they just write `self`. The compiler distinguishes:
+- `self.field` → State (field access, handled by `generate_field_access`)
+- `self` alone → Self (object reference, handled by `generate_identifier`)
+
+### 3.6 Runtime Changes
+
+**File:** `runtime/src/beamtalk_actor.erl`
+
+1. Add `make_self/1` helper function
+2. Modify `handle_call/3` to construct Self and call dispatch/4
+3. Modify `handle_cast/2` to construct Self and call dispatch/4
+4. Keep `dispatch/3` for backward compatibility (calls dispatch/4)
+5. Add new `dispatch/4` export
+
+**New files:**
+- `runtime/src/beamtalk_primitive.erl` — Universal dispatch for primitives
+- `runtime/src/beamtalk_extensions.erl` — Extension registry for adding methods to primitives
+- `runtime/src/beamtalk_integer.erl` — Integer class methods
+- `runtime/src/beamtalk_string.erl` — String class methods
+- `runtime/src/beamtalk_boolean.erl` — Boolean class methods
+- `runtime/src/beamtalk_nil.erl` — UndefinedObject (nil) class methods
+- `runtime/src/beamtalk_block.erl` — Block/closure class methods
+- (etc. for other primitive classes)
+
+### 3.7 Migration Strategy
+
+1. **Update runtime first** (backward compatible)
+   - Add `dispatch/4`
+   - Add `make_self/1`
+   - Keep `dispatch/3` as wrapper
+
+2. **Update codegen** (generates new format)
+   - All new compilations use `dispatch/4`
+   - Add `__class_mod__` to state
+
+3. **Existing compiled code**
+   - Continues to work via `dispatch/3` → `dispatch/4` wrapper
+   - `__class_mod__` defaults to deriving from `__class__`
+
+4. **Future cleanup** (after transition period)
+   - Remove `dispatch/3` wrapper
+   - Require `__class_mod__` in state
+
+### 3.8 Error Handling Taxonomy
+
+All Beamtalk errors use a consistent structure for tooling and developer experience:
+
+```erlang
+%% runtime/include/beamtalk.hrl
+
+-record(beamtalk_error, {
+    kind    :: atom(),              % does_not_understand | immutable_value | type_error | arity_mismatch | ...
+    class   :: atom(),              % 'Integer', 'Counter', 'String'
+    selector:: atom() | undefined,  % method that failed
+    message :: binary(),            % human-readable explanation
+    hint    :: binary() | undefined,% actionable suggestion
+    details :: map()                % additional context (arity, expected types, etc.)
+}).
+
+%% Separate wrapper for source locations (compile-time errors)
+-record(located_error, {
+    error :: #beamtalk_error{},
+    span  :: span() | undefined     % {file, start_line, start_col, end_line, end_col}
+}).
+```
+
+**Error kinds:**
+
+| Kind | When | Example |
+|------|------|---------|
+| `does_not_understand` | Unknown method | `42 foo` |
+| `immutable_value` | Mutation on primitive | `42 instVarAt:put:` |
+| `arity_mismatch` | Wrong argument count | `counter at:` (missing arg) |
+| `type_error` | Wrong argument type | `"hello" + 42` |
+| `future_not_awaited` | Message sent to Future | `(counter getValue) size` |
+
+**Example errors:**
+
+```erlang
+#beamtalk_error{
+    kind = does_not_understand,
+    class = 'Integer',
+    selector = 'foo',
+    message = <<"Integer does not understand 'foo'">>,
+    hint = <<"Check spelling or use 'respondsTo:' to verify method exists">>,
+    details = #{arity => 0}
+}
+
+#beamtalk_error{
+    kind = future_not_awaited,
+    class = 'Future',
+    selector = 'size',
+    message = <<"Sent 'size' to a Future">>,
+    hint = <<"Use 'await' to get the value: (expr await) size">>,
+    details = #{original_selector => 'instVarNames'}
+}
+```
+
+**Design rationale:** Spans are separate because compile-time errors have source locations, runtime errors have stack traces instead.
+
+**User-facing error messages:** Error messages must use developer-facing names, not internal compiler names:
+
+| Internal | User-facing |
+|----------|-------------|
+| `Self` | `self` |
+| `State` | (not shown — refer to fields by name) |
+| `#beamtalk_object{}` | "object" or class name |
+| `dispatch/4` | (not shown — refer to method name) |
+
+Example:
+```
+// WRONG (exposes internals)
+Error: Self#beamtalk_object.pid is undefined
+
+// RIGHT (user-facing)
+Error: 'self' has no associated process (object not spawned?)
+```
+
+| Operation | Overhead | Notes |
+|-----------|----------|-------|
+| Self construction | ~100ns | One record creation per message |
+| Extra parameter pass | ~10ns | Erlang is optimized for this |
+| Reflection calls | ~1μs | Map lookup + function call |
+| Primitive dispatch | ~100ns | Pattern match on type |
+
+**Conclusion:** Overhead is negligible compared to gen_server message passing (~10-100μs).
+
+### 3.9 Test Strategy
+
+#### Unit Tests (runtime/test/)
+
+1. **Self parameter tests**
+   - Method receives correct Self
+   - Self.pid equals self()
+   - Self.class matches state.__class__
+
+2. **Reflection tests**
+   - `class` returns correct class
+   - `respondsTo:` returns true/false correctly
+   - `instVarNames` lists fields
+   - `instVarAt:` reads fields
+   - `instVarAt:put:` writes fields
+
+3. **Primitive tests**
+   - `42 class` returns `'Integer'`
+   - `"hello" class` returns `'String'`
+   - Primitive methods dispatch correctly
+
+4. **Backward compatibility tests**
+   - Old-style `dispatch/3` calls still work
+   - Missing `__class_mod__` handled gracefully
+
+#### Snapshot Tests (test-package-compiler/)
+
+1. Generated code uses `dispatch/4`
+2. State includes `__class_mod__`
+3. Reflection methods are built-in
+
+#### E2E Tests (tests/e2e/cases/)
+
+1. `self-reference.bt` — Self works correctly in methods
+2. `reflection.bt` — Reflection API works
+3. `primitives.bt` — Primitive class identity
+
+### 3.10 Erlang/Beamtalk Interop
+
+**Beamtalk → Erlang:**
+
+Erlang calls return an `ErlangResult` wrapper (not raw tuples) for type safety:
+
+```erlang
+%% runtime/include/beamtalk.hrl
+-record(erlang_result, {
+    value :: {ok, term()} | {error, term()} | term()
+}).
+```
+
+```
+// Erlang call returns ErlangResult
+result := Erlang.gen_tcp connect: {127, 0, 0, 1} port: 8080
+
+// Unwrap methods (only on ErlangResult, not all tuples)
+socket := result unwrap                          // => value or raises
+socket := result unwrapOr: defaultSocket         // => value or default
+socket := result unwrapOrElse: [self makeSocket] // => value or evaluate block
+
+// Query methods
+result isOk      // => true if {ok, _}
+result isError   // => true if {error, _}
+result ok        // => value if ok, nil if error
+result error     // => reason if error, nil if ok
+
+// Functional combinators
+result mapOk: [:socket | socket configure]    // Transform value if ok
+result mapError: [:e | self logError: e]      // Transform error if error
+result andThen: [:socket | socket read]       // Chain operations
+```
+
+**Note:** Raw Erlang interop (when you need the actual tuple) is available via `Erlang.raw`:
+```
+tuple := Erlang.raw gen_tcp connect: host port: 8080  // => {ok, Socket} or {error, Reason}
+```
+
+**Erlang → Beamtalk:**
+
+Beamtalk objects are `#beamtalk_object{}` records. Use the helper module:
+
+```erlang
+%% Preferred: beamtalk helper module
+Obj = counter:spawn(),
+beamtalk:send(Obj, increment, []),              %% Sync call
+Future = beamtalk:send_async(Obj, increment, []), %% Async, returns future
+Result = beamtalk:await(Future),                %% Wait for future
+
+%% Low-level: extract pid and use gen_server directly
+Pid = Obj#beamtalk_object.pid,
+gen_server:call(Pid, {increment, []})
+```
+
+**Primitive mapping:**
+
+| Erlang | Beamtalk Class |
+|--------|----------------|
+| integer | `Integer` |
+| float | `Float` |
+| binary | `String` |
+| atom | `Symbol` (or `Boolean` for true/false) |
+| list | `Array` |
+| map | `Dictionary` |
+| tuple | `Tuple` |
+| fun | `Block` |
+| pid | `Pid` |
+| port | `Port` |
+| reference | `Reference` |
+| `#beamtalk_object{}` | User class (`Counter`, etc.) |
+
+---
+
+## Part 4: Implementation Breakdown
+
+### Proposed PR Sequence
+
+| PR | Description | Blocks | Estimate |
+|----|-------------|--------|----------|
+| **BT-152** | Runtime: Add dispatch/4 and make_self | — | S |
+| **BT-156** | Runtime: Add beamtalk_primitive module | — | M |
+| **BT-157** | Codegen: Generate dispatch/4 | BT-152 | M |
+| **BT-158** | Codegen: Add __class_mod__ to state | BT-157 | S |
+| **BT-159** | Runtime: Reflection methods (class, respondsTo:) | BT-152 | S |
+| **BT-160** | Runtime: instVar reflection methods | BT-159 | S |
+| **BT-161** | Runtime: perform: dynamic send | BT-159 | S |
+| **BT-162** | Stdlib: Integer class methods | BT-156 | M |
+| **BT-163** | Stdlib: String class methods | BT-156 | M |
+| **BT-164** | E2E tests for reflection | BT-159 | S |
+| **BT-165** | Remove dispatch/3 compatibility | BT-164 | S |
+
+### Dependency Graph
+
+```
+BT-152 (dispatch/4) ──┬──> BT-157 (codegen dispatch/4) ──> BT-158 (__class_mod__)
+                      │
+                      └──> BT-159 (class, respondsTo:) ──┬──> BT-160 (instVar)
+                                                         │
+                                                         └──> BT-161 (perform:)
+                                                         │
+                                                         └──> BT-164 (E2E tests) ──> BT-165 (cleanup)
+
+BT-156 (primitive) ──┬──> BT-162 (Integer)
+                     │
+                     └──> BT-163 (String)
+```
+
+---
+
+## Part 5: Open Questions
+
+### Resolved During Design Review
+
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| Primitive dispatch strategy | Uniform dispatch via `beamtalk_primitive:send/3` | Enables tracing, consistent model. Optimize to direct Erlang later. |
+| Reflection on primitives | Return sensible defaults (`instVarNames` → `[]`) | "Everything is an object" — uniform protocol |
+| `__class_mod__` storage | Explicit — store both class and module | Avoids naming convention lock-in |
+| Method introspection | Module call now, class-as-process later | Unblocks reflection without registry complexity |
+| DNU on primitives | Yes — route to extension registry | Enables runtime extension of String, Integer, etc. |
+| Nil handling | Explicit `beamtalk_nil.erl` module | Consistent with other primitives |
+| Async mental model | Local metadata sync, actor state async | Clear rule: "if it asks the actor, it's a Future" |
+| Extension conflicts | Pharo-style: global + tracking + tooling | Simple, conflicts visible, no import declarations |
+| Error taxonomy | Structured `#beamtalk_error{}` record | Consistent for tooling, spans separate |
+| Interop | `ErlangResult` wrapper + `beamtalk:send/3` | Type-safe unwrapping, clean Erlang→Beamtalk API |
+
+### Deferred for Future Design
+
+See **[design-metaprogramming.md](design-metaprogramming.md)** for comprehensive coverage of:
+
+- Class objects as processes (full metaclass protocol)
+- Runtime method dictionaries and dynamic dispatch
+- Dynamic `super` dispatch
+- Class method inheritance and `self` in class methods
+- Passing classes as first-class values
+- Method objects (CompiledMethod introspection)
+- `thisContext` emulation
+- `become:` emulation
+- Full class/system reflection API
+
+**Also deferred (not metaprogramming):**
+
+- **`isActor` method** — Distinguish actors from primitives at runtime
+- **Tooling/IDE story** — Autocomplete, type inference, language server
+
+### Decisions Needed from Human
+
+None identified. This design follows established patterns from:
+- LFE Flavors (self-reference pattern)
+- Smalltalk-80 (reflection API)
+- BT-100 (object record structure)
+
+---
+
+## References
+
+- [BT-100 PR](https://github.com/jamesc/beamtalk/pull/103) — Object record implementation
+- [LFE Flavors](https://github.com/rvirding/flavors) — Robert Virding's OOP on BEAM
+- [Smalltalk-80 Blue Book](http://stephane.ducasse.free.fr/FreeBooks/BlueBook/Bluebook.pdf) — Chapter 5: Object Memory
+- [docs/beamtalk-object-model.md](../beamtalk-object-model.md) — Part 5: Code Sketches
+- [Pharo Reflection](https://books.pharo.org/booklet-ReflectiveCore/) — Modern Smalltalk reflection

--- a/docs/internal/design-tooling-ide.md
+++ b/docs/internal/design-tooling-ide.md
@@ -1,0 +1,469 @@
+# Design: Tooling and IDE Experience
+
+**Issue:** Future (TBD)  
+**Status:** Early Thoughts — captures concerns from design review  
+**Depends on:** BT-151 (Self-as-Object), metaprogramming design  
+**Date:** 2026-02-01
+
+## Executive Summary
+
+This document captures tooling and IDE concerns raised during the BT-151 design review (channeling Anders Hejlsberg's perspective). Beamtalk's dynamic nature creates challenges for static tooling that TypeScript solved for JavaScript.
+
+**Key question:** How do we make a dynamic, Smalltalk-inspired language *toolable*?
+
+---
+
+## Part 1: The Challenge
+
+### Anders' Critique
+
+> "You've designed a runtime, not a language experience. When I type `counter.` in my editor, what happens?"
+
+**The problems:**
+
+1. **Autocomplete:** What methods are available on `counter`?
+2. **Dynamic methods:** Extensions and DNU can add methods at runtime
+3. **Type inference:** What is `counter`? What can I send to it?
+4. **Error detection:** Can we catch `counter foo` (unknown method) before runtime?
+
+### Why TypeScript Won
+
+TypeScript succeeded by making JavaScript *toolable*:
+- Type annotations (optional but helpful)
+- `.d.ts` declaration files for untyped libraries
+- Language server with rich IDE integration
+- Errors at compile time, not runtime
+
+### Beamtalk's Dynamic Features
+
+| Feature | Tooling Challenge |
+|---------|-------------------|
+| Duck typing | Can't know methods without type info |
+| `doesNotUnderstand:` | Any message might be handled |
+| Extension registry | Methods added at runtime |
+| Hot code reload | Methods can change while running |
+| Primitives | `42 foo` — does Integer have `foo`? |
+
+---
+
+## Part 2: Potential Approaches
+
+### Approach 1: Gradual Typing (TypeScript-style)
+
+Add optional type annotations:
+
+```
+// Untyped (works today)
+increment =>
+    self.value := self.value + 1
+
+// Typed (optional)
+increment -> Integer =>
+    self.value := self.value + 1
+    
+// Parameter types
+add: (x: Integer) -> Integer =>
+    self.value + x
+    
+// Variable types
+counter: Counter := Counter spawn
+```
+
+**Benefits:**
+- IDE knows types when annotations present
+- Can infer types from annotations
+- Errors caught at compile time
+- Gradual adoption (like TypeScript's `any`)
+
+**Challenges:**
+- Design type system that works with Smalltalk semantics
+- Handle dynamic features (`doesNotUnderstand:`, extensions)
+- Erlang interop typing
+
+### Approach 2: Type Inference (Hindley-Milner style)
+
+Infer types without annotations:
+
+```
+// No annotations needed
+increment =>
+    self.value := self.value + 1  // Infer: value is numeric
+    
+add: x =>
+    self.value + x                 // Infer: x must support +
+```
+
+**Benefits:**
+- No annotation burden
+- Works with existing code
+
+**Challenges:**
+- Smalltalk's dynamic dispatch is hard to infer
+- Message sends to unknown receivers
+- Inference may be imprecise
+
+### Approach 3: Flow Analysis (like Flow for JS)
+
+Track types through control flow:
+
+```
+maybeCounter := something getValue
+
+maybeCounter ifNotNil: [:c |
+    // Inside block: c is known non-nil
+    c increment   // IDE knows c has Counter methods
+]
+```
+
+**Benefits:**
+- Works with dynamic patterns
+- No annotations for common cases
+
+**Challenges:**
+- Complex implementation
+- May not scale to all dynamic patterns
+
+### Approach 4: Declaration Files (like .d.ts)
+
+Describe types separately from implementation:
+
+```
+// counter.bt.d (declaration file)
+class Counter
+    state: value: Integer
+    
+    spawn -> Counter
+    increment -> Integer
+    getValue -> Integer
+```
+
+**Benefits:**
+- Don't modify existing code
+- Can describe Erlang libraries
+- IDE reads declarations for completion
+
+**Challenges:**
+- Declarations can drift from implementation
+- Extra maintenance burden
+
+### Approach 5: Smalltalk-style (Image-based)
+
+The IDE *is* the environment — it knows everything because it runs everything:
+
+```
+// In Smalltalk:
+// - IDE has live objects
+// - Can query any object for its methods
+// - Completion comes from runtime introspection
+```
+
+**Benefits:**
+- Perfect accuracy (asking the actual objects)
+- Works with all dynamic features
+- True to Smalltalk philosophy
+
+**Challenges:**
+- Requires live environment
+- Can't analyze files in isolation
+- Different development model
+
+---
+
+## Part 3: Hybrid Proposal
+
+### Core Idea: Static + Dynamic
+
+1. **Static layer:** Infer/declare what we can at compile time
+2. **Dynamic layer:** Query live environment for runtime additions
+3. **Graceful degradation:** When static analysis fails, fall back to "any"
+
+### Type Annotations (Optional)
+
+```
+// Level 0: No types (fully dynamic)
+add: x => self.value + x
+
+// Level 1: Return type only
+add: x -> Integer => self.value + x
+
+// Level 2: Full signature
+add: (x: Integer) -> Integer => self.value + x
+
+// Level 3: Generic
+map: (block: Block[T, U]) -> Array[U] => ...
+```
+
+### IDE Features by Type Level
+
+| Feature | No Types | Return Type | Full Types |
+|---------|----------|-------------|------------|
+| Syntax highlighting | ✅ | ✅ | ✅ |
+| Basic autocomplete | ⚠️ (methods from class) | ✅ | ✅ |
+| Parameter hints | ❌ | ⚠️ | ✅ |
+| Type errors | ❌ | ⚠️ | ✅ |
+| Refactoring | ⚠️ | ✅ | ✅ |
+
+### Extension Registry Integration
+
+```
+// Extensions are registered with type info
+beamtalk_extensions:register('String', 'json', Fun, #{
+    owner => mylib,
+    signature => "-> String",  // For tooling
+    doc => "Convert to JSON string"
+})
+```
+
+IDE queries extension registry for additional methods.
+
+### Live Environment Connection
+
+```
+// Language server can connect to running BEAM
+// For completion on unknown types, query live system:
+
+LSP -> BEAM: "What methods does this pid respond to?"
+BEAM -> LSP: [increment, getValue, ...]
+```
+
+---
+
+## Part 4: Language Server Architecture
+
+### Components
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    IDE / Editor                      │
+└─────────────────┬───────────────────────────────────┘
+                  │ LSP Protocol
+┌─────────────────▼───────────────────────────────────┐
+│              Beamtalk Language Server                │
+│  ┌─────────────┐ ┌─────────────┐ ┌───────────────┐  │
+│  │   Parser    │ │Type Checker │ │ Live Connector│  │
+│  └─────────────┘ └─────────────┘ └───────────────┘  │
+│  ┌─────────────┐ ┌─────────────┐ ┌───────────────┐  │
+│  │Symbol Index │ │ Extension   │ │  Diagnostics  │  │
+│  │             │ │  Registry   │ │               │  │
+│  └─────────────┘ └─────────────┘ └───────────────┘  │
+└─────────────────┬───────────────────────────────────┘
+                  │ (optional)
+┌─────────────────▼───────────────────────────────────┐
+│              Running BEAM Node                       │
+│         (for live introspection)                     │
+└─────────────────────────────────────────────────────┘
+```
+
+### LSP Features
+
+| Feature | Priority | Static/Dynamic |
+|---------|----------|----------------|
+| Syntax errors | P0 | Static |
+| Go to definition | P0 | Static |
+| Find references | P0 | Static |
+| Autocomplete (known types) | P0 | Static |
+| Autocomplete (unknown types) | P1 | Dynamic |
+| Hover (type info) | P1 | Static |
+| Hover (runtime value) | P2 | Dynamic |
+| Rename symbol | P1 | Static |
+| Type errors | P1 | Static |
+| Inline hints | P2 | Static |
+
+### Incremental Parsing
+
+For responsive IDE, need incremental parsing:
+- Re-parse only changed region
+- Update symbol index incrementally
+- Cache type inference results
+
+---
+
+## Part 5: Error Experience
+
+### Compile-Time Errors (Static)
+
+```
+// Error: Unknown method
+counter foo
+       ^^^ Counter does not respond to 'foo'
+           Did you mean: 'getValue'?
+           
+// Error: Type mismatch (if typed)
+counter add: "hello"
+             ^^^^^^^ Expected Integer, got String
+             
+// Warning: Unused variable
+x := 42
+^   'x' is never used
+```
+
+### Runtime Errors (Enhanced)
+
+```
+// Current: cryptic
+{does_not_understand, 'Counter', foo, 0}
+
+// Goal: helpful
+BeamtalkError: Counter does not understand 'foo'
+  
+  counter foo
+          ^^^ 
+          
+  Similar methods on Counter:
+    - getValue
+    - setValue:
+    
+  At: examples/test.bt:15:10
+  Stack:
+    - Counter.someMethod (counter.bt:42)
+    - Main.run (main.bt:10)
+```
+
+### IDE Integration
+
+- Errors appear inline as you type
+- Quick fixes: "Did you mean...?" → one-click fix
+- Type errors have explanations linking to docs
+
+---
+
+## Part 6: Autocomplete Deep Dive
+
+### Scenario 1: Known Type
+
+```
+counter: Counter := Counter spawn
+counter |  // Cursor here
+```
+
+**What we know:**
+- `counter` has type `Counter`
+- `Counter` class has methods: `increment`, `getValue`, `setValue:`
+
+**Completion list:**
+```
+increment       -> Integer    Increment the counter
+getValue        -> Integer    Get current value
+setValue:       (Integer)     Set the value
+class           -> Symbol     [inherited from Object]
+respondsTo:     (Symbol) -> Boolean
+...
+```
+
+### Scenario 2: Unknown Type
+
+```
+result := someService fetch: url
+result |  // Cursor here — what is result?
+```
+
+**Options:**
+1. Show nothing (unhelpful)
+2. Show common methods (class, respondsTo:)
+3. Query live environment if connected
+4. Infer from usage elsewhere in file
+
+### Scenario 3: Extensions
+
+```
+"hello" |  // Cursor here
+```
+
+**What we know:**
+- `"hello"` is a String
+- String has built-in methods
+- Extension registry may have more methods
+
+**Completion list:**
+```
+// Built-in
+size            -> Integer
+uppercase       -> String
+...
+
+// Extensions (from mylib)
+json            -> String     [mylib] Convert to JSON
+trim            -> String     [stdlib] Remove whitespace
+```
+
+### Scenario 4: Inside Block
+
+```
+collection do: [:each |
+    each |  // Cursor here — what is each?
+]
+```
+
+**Type inference:**
+- `collection` is `Array[Counter]` (if known)
+- Therefore `each` is `Counter`
+- Show Counter methods
+
+---
+
+## Part 7: Implementation Roadmap
+
+### Phase 1: Basic LSP (Syntax-level)
+- [ ] Syntax highlighting
+- [ ] Parse errors
+- [ ] Go to definition (same file)
+- [ ] Basic autocomplete (class methods)
+
+### Phase 2: Cross-file Analysis
+- [ ] Symbol index across project
+- [ ] Go to definition (cross-file)
+- [ ] Find all references
+- [ ] Rename symbol
+
+### Phase 3: Type Inference
+- [ ] Infer types from assignments
+- [ ] Infer types from method signatures
+- [ ] Type error detection (where inferable)
+- [ ] Richer autocomplete
+
+### Phase 4: Optional Type Annotations
+- [ ] Syntax for type annotations
+- [ ] Type checker
+- [ ] Full type errors
+- [ ] Generic types
+
+### Phase 5: Live Environment
+- [ ] Connect to running BEAM
+- [ ] Query objects for methods
+- [ ] Show runtime values on hover
+- [ ] Hot reload from IDE
+
+---
+
+## Part 8: Open Questions
+
+1. **Type syntax:** What does Beamtalk type annotation syntax look like?
+   - `x: Integer` (colon)
+   - `x :: Integer` (double colon, Haskell-style)
+   - `Integer x` (prefix, C-style)
+
+2. **Generics:** Do we need generics? How complex?
+   - `Array[T]`, `Block[T, U]`, `Future[T]`?
+
+3. **Union types:** For Erlang interop
+   - `{ok, Value} | {error, Reason}` → `ErlangResult[T, E]`?
+
+4. **Structural vs nominal:** 
+   - Structural: "anything with `increment` method"
+   - Nominal: "must be Counter or subclass"
+
+5. **Strictness levels:**
+   - Strict mode (all types required)?
+   - Loose mode (types optional)?
+   - Per-file pragma?
+
+---
+
+## References
+
+- [TypeScript Design Goals](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Design-Goals)
+- [Language Server Protocol](https://microsoft.github.io/language-server-protocol/)
+- [Sorbet (Ruby type checker)](https://sorbet.org/)
+- [Dialyzer (Erlang)](https://www.erlang.org/doc/man/dialyzer.html)
+- [Pharo IDE Architecture](https://books.pharo.org/)
+- [Gleam Type System](https://gleam.run/book/tour/type-annotations.html)


### PR DESCRIPTION
Closes https://linear.app/beamtalk/issue/BT-151

## Summary

Comprehensive design documents for completing the Beamtalk object model.

### Documents Created

1. **design-self-as-object.md** - Core design (ready to implement)
2. **design-metaprogramming.md** - Class-as-process (future work)  
3. **design-tooling-ide.md** - Tooling vision (future work)

### Key Decisions

- dispatch/4 with separate Self and State parameters
- Uniform primitive dispatch via beamtalk_primitive module
- Structured #beamtalk_error{} record
- ErlangResult wrapper for interop
- Pharo-style extension conflict tracking
- Local metadata sync, actor state returns Future