### PR TITLE
Codegen: Integrate actor registry with Counter spawn (BT-175)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/message_dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/message_dispatch.rs
@@ -358,12 +358,12 @@ impl CoreErlangGenerator {
     ///   <'undefined'> when 'true' ->
     ///     call 'counter':'spawn'()
     ///   <RegistryPid> when 'true' ->
-    ///     call 'beamtalk_actor':'spawn_with_registry'(
-    ///       RegistryPid,
-    ///       'counter',
-    ///       [],
-    ///       'Counter'
-    ///     )
+    ///     case call 'beamtalk_actor':'spawn_with_registry'(RegistryPid, 'counter', ~{}~, 'Counter') of
+    ///       <{'ok', Pid}> when 'true' ->
+    ///         {'beamtalk_object', 'Counter', 'counter', Pid}
+    ///       <{'error', Reason}> when 'true' ->
+    ///         call 'erlang':'error'({'spawn_failed', Reason})
+    ///     end
     /// end
     /// ```
     ///


### PR DESCRIPTION
Integrates the actor registry (from BT-157) with the spawn codegen so that actors spawned in the REPL persist across eval cycles.

## Changes

- Modified `generate_message_send` to call new `generate_actor_spawn` method for spawn/spawnWith: patterns
- Added `generate_actor_spawn` method that:
  - Detects REPL context by checking for `__bindings__` in scope
  - Generates conditional Core Erlang checking for `__repl_actor_registry__` in bindings
  - Calls `beamtalk_actor:spawn_with_registry` when registry present
  - Falls back to normal `module:spawn()` in non-REPL contexts
  - Wraps result in `#beamtalk_object{}` record for type consistency
- Handles both `spawn` (no args) and `spawnWith:` (with args) patterns
- Passes class name as 4th argument for `:actors` display

## Generated Code (REPL)

```erlang
case call 'maps':'get'('__repl_actor_registry__', Bindings, 'undefined') of
  <'undefined'> when 'true' -> call 'counter':'spawn'()
  <RegistryPid> when 'true' ->
    case call 'beamtalk_actor':'spawn_with_registry'(RegistryPid, 'counter', ~{}~, 'Counter') of
      <{'ok', Pid}> when 'true' -> {'beamtalk_object', 'Counter', 'counter', Pid}
      <{'error', Reason}> when 'true' -> call 'erlang':'error'({'spawn_failed', Reason})
    end
end
```

## Generated Code (non-REPL)

```erlang
call 'counter':'spawn'()
```

## Testing

**Manual REPL Test:**
```
> Counter spawn
#Actor<Counter,0.84.0>
> :actors
Running actors:
  <0.84.0> - Counter (counter)
> 1 + 1
2
> :actors
Running actors:
  <0.84.0> - Counter (counter)  ← persists!
```

 All actors spawned correctly  
 All actors appear in `:actors` output  
 Actors persist across eval cycles

**Automated Tests:**
- ✅ All 567 tests passing
- ✅ Clippy clean
- ✅ Snapshot tests unchanged (non-REPL code generates same output)

## Linear Issue

https://linear.app/beamtalk/issue/BT-175/codegen-integrate-actor-registry-with-counter-spawn
