### PR TITLE
docs: Clarify primitive vs actor class hierarchy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,7 +99,7 @@ The foundational classes implementing Smalltalk's "everything is a message" phil
 
 | Class | Description |
 |-------|-------------|
-| [Actor](../lib/Actor.bt) | Base class for all actors (BEAM processes) |
+| [Object](../lib/Object.bt) | Base class for all user-defined classes (actors/BEAM processes) |
 | [Block](../lib/Block.bt) | First-class closures |
 | [True](../lib/True.bt) / [False](../lib/False.bt) | Boolean control flow via messages |
 | [Nil](../lib/Nil.bt) | Null object pattern |

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -38,7 +38,7 @@ which differs from the planned `=>` method syntax documented in design docs.
 
 Demonstrates super keyword for superclass method dispatch in inheritance hierarchy.
 
-Inheritance: `Actor -> Counter -> LoggingCounter`
+Inheritance: `Object -> Counter -> LoggingCounter`
 
 Methods:
 - `increment` - increments logCount, calls `super increment`, returns value


### PR DESCRIPTION
## Summary

Clarifies the Beamtalk class hierarchy based on design discussion:

**Key insight:** All values are objects, but not all objects are actors.

\\\
ProtoObject (true root)
  ├─ Integer, Float, String, Boolean, etc.  (primitives - sealed)
  └─ Object (actor root - has process/pid)
        └─ Counter, MyService, etc. (user classes)
\\\

## Changes

- **Uniform Message-Sending Illusion** - Documents how \42 + 3\ and \counter increment\ use the same syntax but different machinery
- **BEAM Value Categories** - Explains immediate vs boxed vs actor
- **Primitives Are Sealed But Extensible** - Can't subclass Integer, but CAN add methods via extension registry
- Updated class hierarchy diagrams throughout

## Why This Design?

1. **Matches BEAM reality** - BEAM already distinguishes terms from processes
2. **Zero overhead for primitives** - \42 + 3\ compiles to \rlang:'+'(42, 3)\
3. **Full actor power for user classes** - Each Object instance is a process
4. **Smalltalk flexibility** - Extension methods let you add to primitives

---

Pairs well with BT-180 (Object.bt implementation).