### PR TITLE
Simplify worktree env setup and fix path handling

### DIFF
--- a/.devcontainer/fix-worktree-git.sh
+++ b/.devcontainer/fix-worktree-git.sh
@@ -105,9 +105,8 @@ if [ -f "$GIT_FILE" ]; then
         fi
     else
         log "ERROR: Main .git not mounted at /workspaces/.beamtalk-git"
-        log "Make sure BEAMTALK_MAIN_GIT_PATH is set on the host to your main repo's .git directory"
-        log "  Windows: setx BEAMTALK_MAIN_GIT_PATH \"C:\\Users\\you\\source\\beamtalk\\.git\""
-        log "  Linux/Mac: export BEAMTALK_MAIN_GIT_PATH=\"\$HOME/source/beamtalk/.git\""
+        log "The worktree script should have mounted this automatically."
+        log "Check that the devcontainer was started via worktree-new.ps1"
         exit 1
     fi
 elif [ -d "$GIT_FILE" ]; then

--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,3 @@
 # Linear API token for MCP server
 # Get your token from: https://linear.app/settings/api
 LINEAR_API_TOKEN=lin_api_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# GitHub API token for gh CLI
-# Create a fine-grained token at: https://github.com/settings/tokens
-# Required permissions:
-#   - Contents: Read and write
-#   - Issues: Read and write
-#   - Pull requests: Read and write
-#   - Metadata: Read-only (automatically included)
-GH_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-# (Optional) For git worktrees with parallel devcontainers
-# Point to the main beamtalk repo's .git directory
-# See devcontainer.json comments for setup instructions
-# BEAMTALK_MAIN_GIT_PATH=C:/Users/you/source/beamtalk/.git

--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ Reloaded
 - **Rust** (latest stable) — For building the compiler  
 - **Erlang/OTP 26+** — With `erlc` on PATH
 
+#### Required Environment Variables
+
+| Variable | Purpose | How to Set |
+|----------|---------|------------|
+| `GH_TOKEN` | GitHub authentication for devcontainers | `gh auth login`, then `$env:GH_TOKEN = (gh auth token)` |
+| `LINEAR_API_TOKEN` | Linear issue tracking | Get from [Linear API settings](https://linear.app/settings/api) |
+
 #### Optional: Devcontainer CLI
 
 For worktree-based parallel development, install the devcontainer CLI:
@@ -270,33 +277,25 @@ Git worktrees enable **multiple Copilot agents working in parallel** on differen
 
 **Required for worktree devcontainers:**
 
-| Variable | Purpose | Example |
-|----------|---------|---------|
-| `BEAMTALK_MAIN_GIT_PATH` | Path to main `.git` directory (mounted in containers) | `C:\Users\you\source\beamtalk\.git` (Windows)<br>`/home/you/source/beamtalk/.git` (Linux) |
+| Variable | Purpose | How to Set |
+|----------|---------|------------|
+| `GH_TOKEN` | GitHub authentication | `gh auth login`, then `$env:GH_TOKEN = (gh auth token)` |
 
-**Optional for GitHub/Linear integration:**
+**Optional for Linear integration:**
 
 | Variable | Purpose | Where to Set |
 |----------|---------|--------------|
-| `GH_TOKEN` | GitHub authentication (for `gh` CLI and API) | Host environment |
-| `GITHUB_TOKEN` | Alias for `GH_TOKEN` | Auto-set if `GH_TOKEN` exists |
 | `LINEAR_API_TOKEN` | Linear issue tracking | Host environment |
-| `GIT_USER_NAME` | Git commit author name | Host environment or `.env` |
-| `GIT_USER_EMAIL` | Git commit author email | Host environment or `.env` |
 
 **Setting environment variables permanently (Windows):**
 
 ```powershell
-# Required for worktrees
-setx BEAMTALK_MAIN_GIT_PATH "C:\Users\you\source\beamtalk\.git"
+# GitHub: authenticate first, then set GH_TOKEN
+gh auth login
+$env:GH_TOKEN = (gh auth token)  # Set for current session
+# Or add to your PowerShell profile for persistence
 
-# Optional: GitHub/Linear integration
-setx GIT_USER_NAME "Your Name"
-setx GIT_USER_EMAIL "you@example.com"
-
-# For tokens, use secure methods instead of setx:
-# - GitHub: Use `gh auth login` (recommended)
-# - Linear: Store in password manager, retrieve at runtime
+# Linear: store securely, retrieve at runtime
 ```
 
 > **Note:** Linux/Mac instructions will be added once the scripts are tested.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,9 +35,8 @@ Start a Copilot devcontainer session for a git worktree branch. This enables run
 
 1. **Checks if worktree exists** for the branch
 2. **Creates worktree** if needed (new branch from base, or existing branch)
-3. **Sets up environment** (`BEAMTALK_MAIN_GIT_PATH` for git access)
-4. **Starts the devcontainer** using `devcontainer up`
-5. **Connects via bash** using `devcontainer exec`
+3. **Starts the devcontainer** using `devcontainer up`
+4. **Connects via bash** using `devcontainer exec`
 
 You'll get a shell inside the container where you can run Copilot CLI or other tools.
 
@@ -46,22 +45,6 @@ You'll get a shell inside the container where you can run Copilot CLI or other t
 - Git with worktree support
 - VS Code with Dev Containers extension
 - `devcontainer` CLI (auto-installed if missing): `npm install -g @devcontainers/cli`
-
-### First-time setup
-
-Set the `BEAMTALK_MAIN_GIT_PATH` environment variable permanently:
-
-**Windows:**
-```powershell
-setx BEAMTALK_MAIN_GIT_PATH "C:\Users\you\source\beamtalk\.git"
-```
-
-**Linux/Mac:**
-```bash
-echo 'export BEAMTALK_MAIN_GIT_PATH="$HOME/source/beamtalk/.git"' >> ~/.bashrc
-```
-
-Then add the worktree mount to `.devcontainer/devcontainer.json` (see comments in that file).
 
 ---
 


### PR DESCRIPTION
## Summary

Simplifies worktree setup by auto-deriving paths and requiring GH_TOKEN for authentication.

## Changes

- **Remove BEAMTALK_MAIN_GIT_PATH requirement** - Now auto-derived from the main repo location
- **Require GH_TOKEN** - Script exits with clear instructions if not set (prevents credential prompts in container)
- **Remove git hooks installation** - The \install-git-hooks.sh\ script never existed
- **Fix worktree-rm path handling** - Converts container paths (\/workspaces/foo\) back to host paths before deletion
- **Add try/finally cleanup** - Resets git paths to Windows format when copilot exits
- **Update documentation** - Simplified setup instructions in README and scripts/README

## Files Changed

- \.devcontainer/fix-worktree-git.sh\ - Updated error message
- \.env.example\ - Removed GH_TOKEN scaffolding (use \gh auth\ instead)
- \README.md\ - Simplified env var docs, added GH_TOKEN/LINEAR_API_TOKEN requirements
- \scripts/README.md\ - Removed first-time setup section
- \scripts/worktree-new.ps1\ - Main changes (GH_TOKEN check, auto-derive paths, cleanup on exit)
- \scripts/worktree-rm.ps1\ - Fix container path conversion