### PR TITLE
REPL futures timeout in E2E tests despite BT-175 actor persistence (BT-187)

### DIFF
--- a/tests/e2e/cases/protoobject_actors.bt
+++ b/tests/e2e/cases/protoobject_actors.bt
@@ -2,19 +2,40 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // E2E tests for ProtoObject with actor loading
+//
+// These tests verify that actor futures are automatically awaited in the REPL
+// via `maybe_await_future/1` (see runtime/src/beamtalk_repl_eval.erl).
+// No explicit `await` keyword is needed for synchronous REPL interaction.
 
 // @load tests/e2e/fixtures/counter.bt
 
-// Test actor spawn and async method calls
+// Test actor spawn
 counter := Counter spawn
 // => _
 
-// Test async method call with auto-await
+// Test initial state (auto-await)
 counter getValue
 // => 0
 
+// Test increment (auto-await, returns new value)
 counter increment
 // => 1
 
+// Verify state persisted
 counter getValue
 // => 1
+
+// Test multiple consecutive increments
+counter increment
+// => 2
+
+counter increment
+// => 3
+
+// Test decrement
+counter decrement
+// => 2
+
+// Final state verification
+counter getValue
+// => 2


### PR DESCRIPTION
## Issue

https://linear.app/beamtalk/issue/BT-187/repl-futures-timeout-in-e2e-tests-despite-bt-175-actor-persistence

## Summary

Investigated BT-187 future timeout issue. **The problem was already fixed in BT-195** (commit fd16109) which corrected the actor-future message protocol mismatch.

### Root Cause (Already Fixed)

**Before (broken):**
- Actor code sent: `{resolved, Result}` and `{rejected, Error}`
- beamtalk_future expected: `{resolve, Value}` and `{reject, Reason}`
- Result: Futures timed out waiting for messages that never matched

**After (fixed in BT-195):**
- Actor code now sends: `{resolve, Result}` and `{reject, Reason}`
- Result: Futures resolve correctly, auto-await works in REPL

## Deliverables

### Manual Verification
Verified that actor futures work correctly in manual REPL:
- `counter getValue` returns `0` ✅
- `counter increment` returns `1` ✅
- State persists correctly across calls ✅

### Comprehensive E2E Tests Added
Added full behavioral tests to `tests/e2e/cases/protoobject_actors.bt`:
- Actor spawn with Counter class
- Initial state verification (`getValue` → `0`)
- State mutation (`increment` → `1`, `2`, `3`)
- Decrement operation (`decrement` → `2`)
- Final state verification (`getValue` → `2`)

### Documentation
- Added comments explaining REPL auto-await behavior (`maybe_await_future/1`)
- Clarified that no explicit `await` keyword is needed in REPL
- Reference to runtime implementation

### Follow-up Issue Created
**BT-222:** Inconsistent await usage in E2E tests
- Found inconsistency: `inheritance_super.bt` uses explicit `await` while this test relies on auto-await
- Tracked for systematic cleanup across all E2E tests

## Key Changes

- `tests/e2e/cases/protoobject_actors.bt` - Added comprehensive actor behavior tests

## Test Results

- ✅ All 693 tests pass (124 runtime + 5 E2E + 387 core + 176 compiler + 1 integration)
- ✅ E2E test count: 316/316 (was 312/312 before enhancements)
- ✅ Clippy: 0 warnings (with `-D warnings`)
- ✅ Formatting: compliant
- ✅ Build: successful

## Acceptance Criteria

- ✅ Investigated why futures timeout in E2E tests
- ✅ Identified root cause: Already fixed in BT-195 (actor-future protocol mismatch)
- ✅ Documented findings in Linear issue comment
- ✅ Updated `protoobject_actors.bt` with full behavioral tests
- ✅ All E2E tests pass with actor behavior verification (316/316)

## References

- BT-195 fix: commit fd16109
- File changed: `crates/beamtalk-core/src/codegen/core_erlang/gen_server.rs`
- Auto-await implementation: `runtime/src/beamtalk_repl_eval.erl:maybe_await_future/1`