### PR TITLE
Fix: Add Copilot Chat extension to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
         "usernamehw.errorlens",
         "erlang-ls.erlang-ls",
         "github.copilot",
+        "github.copilot-chat",
         "github.vscode-github-actions",
         "github.vscode-pull-request-github",
         "linear.linear",


### PR DESCRIPTION
## Summary

Adds `github.copilot-chat` extension to the devcontainer configuration.

## Problem

Without the Copilot Chat extension installed, Claude and other model options don't appear in the VS Code model picker when working inside a dev container. Only the base `github.copilot` extension was included.

## Solution

Added `github.copilot-chat` to the extensions list in `.devcontainer/devcontainer.json`.

## Testing

After rebuilding the container, the model picker now shows all available models including Claude.