### PR TITLE
Fix CI erlang change detection and worktree-up docker output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -71,7 +73,14 @@ jobs:
       - name: Check for Erlang changes
         id: erlang-changes
         run: |
-          if git diff --name-only origin/main...HEAD | grep -qE '^runtime/'; then
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # On push to main, compare with previous commit
+            BASE="${{ github.event.before }}"
+          else
+            # On PR, compare with the merge base against main
+            BASE="origin/main"
+          fi
+          if git diff --name-only "$BASE"...HEAD | grep -qE '^runtime/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes two infra issues:

### CI: Erlang change detection fails with `fatal: ambiguous argument 'origin/main...HEAD'`

- **Root cause:** `actions/checkout` does a shallow clone by default, so `origin/main` ref doesn't exist for the `git diff` comparison
- **Fix:** Added `fetch-depth: 0` to checkout step, and made the diff base context-aware (`github.event.before` on push, `origin/main` on PR) as a defensive measure

### worktree-up.ps1: Docker build output leaking through filters

- **Root cause:** `devcontainer up` prefixes stderr lines with `[timestamp]`, so regexes like `^\s*#\d+\s` never match
- **Fix:** Strip timestamp prefix into `$stripped` variable before filtering, preserving original `$line` for downstream JSON parsing

## Changes
- `.github/workflows/ci.yml` — fetch-depth: 0 + context-aware base ref
- `scripts/worktree-up.ps1` — timestamp stripping for docker output filter