### PR TITLE
fix: symbol parsing for keyword/operator symbols and E2E test fixes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -100,7 +100,7 @@ test-rust:
     @echo "✅ Rust tests complete"
 
 # Run E2E tests (slow - full pipeline, ~50s)
-test-e2e: _clean-daemon-state
+test-e2e: build-stdlib _clean-daemon-state
     @echo "🧪 Running E2E tests (slow - ~50s)..."
     cargo test --test e2e -- --ignored
 

--- a/tests/e2e/cases/self_reference.bt
+++ b/tests/e2e/cases/self_reference.bt
@@ -52,7 +52,7 @@ a perform: #getValue
 // => 99
 
 // perform:withArgs: dispatches methods with arguments on actors
-a perform: #setValue: withArgs: [42]
+a perform: #setValue: withArgs: #(42)
 // => _
 
 a getValue
@@ -60,8 +60,8 @@ a getValue
 
 // perform: also works on primitives (synchronous dispatch)
 42 perform: #asString
-// => "42"
+// => 42
 
 // perform:withArgs: works on primitives
-10 perform: #+ withArgs: [32]
+10 perform: #+ withArgs: #(32)
 // => 42


### PR DESCRIPTION
## Summary

Fix 4 pre-existing E2E test failures in `self_reference.bt` (lines 55-66) related to symbol parsing and `perform:withArgs:` tests. Also fix ~80 stdlib-related E2E failures caused by missing `build-stdlib` dependency.

## Changes

### Lexer: Keyword and binary operator symbol support
- Extend `lex_symbol_or_hash()` to handle **keyword symbols** (`#setValue:`, `#at:put:`) by consuming trailing colons (with `:=` guard)
- Add **binary operator symbols** (`#+`, `#>=`, `#~=`) using a new shared `is_binary_selector_char()` helper
- The helper is shared between `lex_binary_selector()` and symbol lexing to prevent operator charset drift

### E2E test fixes
- Fix `self_reference.bt`: use `#(42)` list literals instead of `[42]` blocks for `perform:withArgs:` arguments
- Fix expected value for `42 perform: #asString` — E2E harness strips JSON string quotes

### Build: Justfile dependency
- Add `build-stdlib` as dependency of `test-e2e` recipe to prevent ~80 `undef` errors when stdlib isn't pre-built

## Tests
- 4 new lexer tests: keyword symbols, binary operator symbols, keyword-before-assignment edge case
- All 431 E2E tests pass (was 83 failures)
- All 773 Rust tests pass
- All 521 Erlang runtime tests pass
- Clippy, fmt, Dialyzer clean

## Code Review Summary

### Pass 1: Diff Review
- ✅ Lexer logic correct with proper edge case handling (`:=` guard, `#-3` separation)
- ✅ Added edge case test for `#foo:=` → `Symbol("foo") + Assign`
- ✅ DDD compliance: lexer in correct bounded context (Source Analysis)

### Pass 2: System Review
- ✅ All Symbol token consumers (parser, codegen, LSP) treat content as opaque strings — safe
- ✅ No contract violations in Parser → AST → Codegen → Core Erlang atom pipeline
- ✅ Justfile dependency chain correct (no duplicate work in `ci` recipe)

### Pass 3: Adversarial Review (GPT-5.2-Codex)
- ✅ Fixed: Extracted `is_binary_selector_char()` to prevent operator charset drift
- Noted: `#at:put` (missing trailing colon) produces valid symbol — harmless, matches Smalltalk semantics