### PR TITLE
Fix allClasses: register SystemDictionary/TranscriptStream classes, not Beamtalk instance (BT-420)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_system_dictionary.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_system_dictionary.erl
@@ -55,7 +55,8 @@
     start_link/1,
     start_link_singleton/0,
     start_link_singleton/1,
-    has_method/1
+    has_method/1,
+    class_info/0
 ]).
 
 %% gen_server callbacks
@@ -115,6 +116,26 @@ has_method('classNamed:') -> true;
 has_method(globals) -> true;
 has_method(version) -> true;
 has_method(_) -> false.
+
+%% @doc Return class registration metadata for SystemDictionary.
+%%
+%% Used by beamtalk_stdlib to register this singleton's class.
+%% Single source of truth for class name, superclass, and method table.
+-spec class_info() -> map().
+class_info() ->
+    #{
+        name => 'SystemDictionary',
+        module => ?MODULE,
+        superclass => 'Actor',
+        instance_methods => #{
+            allClasses => #{arity => 0},
+            'classNamed:' => #{arity => 1},
+            globals => #{arity => 0},
+            version => #{arity => 0}
+        },
+        class_methods => #{},
+        instance_variables => []
+    }.
 
 %%====================================================================
 %% gen_server callbacks

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_transcript_stream.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_transcript_stream.erl
@@ -34,7 +34,7 @@
 
 %% API
 -export([start_link/0, start_link/1, start_link_singleton/1, spawn/0, spawn/1]).
--export([has_method/1]).
+-export([has_method/1, class_info/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
@@ -94,6 +94,28 @@ has_method(unsubscribe)  -> true;
 has_method(recent)       -> true;
 has_method(clear)        -> true;
 has_method(_)            -> false.
+
+%% @doc Return class registration metadata for TranscriptStream.
+%%
+%% Used by beamtalk_stdlib to register this singleton's class.
+%% Single source of truth for class name, superclass, and method table.
+-spec class_info() -> map().
+class_info() ->
+    #{
+        name => 'TranscriptStream',
+        module => ?MODULE,
+        superclass => 'Actor',
+        instance_methods => #{
+            'show:' => #{arity => 1},
+            cr => #{arity => 0},
+            subscribe => #{arity => 0},
+            unsubscribe => #{arity => 0},
+            recent => #{arity => 0},
+            clear => #{arity => 0}
+        },
+        class_methods => #{},
+        instance_variables => []
+    }.
 
 %%% ============================================================================
 %%% gen_server callbacks

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_stdlib_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_stdlib_tests.erl
@@ -41,7 +41,8 @@ stdlib_test_() ->
         {"UndefinedObject class is registered", fun nil_class_registered_test/0},
         {"Block class is registered", fun block_class_registered_test/0},
         {"Tuple class is registered", fun tuple_class_registered_test/0},
-        {"Beamtalk class is registered", fun beamtalk_class_registered_test/0},
+        {"SystemDictionary class is registered", fun system_dictionary_class_registered_test/0},
+        {"TranscriptStream class is registered", fun transcript_stream_class_registered_test/0},
         {"Integer class has correct superclass", fun integer_superclass_test/0},
         {"Integer class has expected methods", fun integer_methods_test/0},
         %% Beamtalk class method tests
@@ -63,7 +64,7 @@ init_registers_all_classes_test() ->
     
     %% After init, should have bootstrap + stdlib classes
     ClassesAfter = [beamtalk_object_class:class_name(Pid) || Pid <- beamtalk_object_class:all_classes()],
-    ?assertEqual(14, length(ClassesAfter)),  % 4 bootstrap + 10 stdlib (Transcript removed - BT-376, Number added from main)
+    ?assertEqual(15, length(ClassesAfter)),  % 3 bootstrap + 10 primitives + 2 workspace globals
     
     %% Verify expected classes are present
     ?assert(lists:member('ProtoObject', ClassesAfter)),
@@ -77,7 +78,8 @@ init_registers_all_classes_test() ->
     ?assert(lists:member('Block', ClassesAfter)),
     ?assert(lists:member('Tuple', ClassesAfter)),
     ?assert(lists:member('Float', ClassesAfter)),
-    ?assert(lists:member('Beamtalk', ClassesAfter)).
+    ?assert(lists:member('SystemDictionary', ClassesAfter)),
+    ?assert(lists:member('TranscriptStream', ClassesAfter)).
 
 init_idempotent_test() ->
     %% Call init multiple times
@@ -86,7 +88,7 @@ init_idempotent_test() ->
     
     %% Should still have same number of classes (no duplicates)
     Classes = [beamtalk_object_class:class_name(Pid) || Pid <- beamtalk_object_class:all_classes()],
-    ?assertEqual(14, length(Classes)).
+    ?assertEqual(15, length(Classes)).
 
 integer_class_registered_test() ->
     ok = beamtalk_stdlib:init(),
@@ -130,11 +132,17 @@ tuple_class_registered_test() ->
     ?assertNotEqual(undefined, Pid),
     ?assertEqual('Tuple', beamtalk_object_class:class_name(Pid)).
 
-beamtalk_class_registered_test() ->
+system_dictionary_class_registered_test() ->
     ok = beamtalk_stdlib:init(),
-    Pid = beamtalk_object_class:whereis_class('Beamtalk'),
+    Pid = beamtalk_object_class:whereis_class('SystemDictionary'),
     ?assertNotEqual(undefined, Pid),
-    ?assertEqual('Beamtalk', beamtalk_object_class:class_name(Pid)).
+    ?assertEqual('SystemDictionary', beamtalk_object_class:class_name(Pid)).
+
+transcript_stream_class_registered_test() ->
+    ok = beamtalk_stdlib:init(),
+    Pid = beamtalk_object_class:whereis_class('TranscriptStream'),
+    ?assertNotEqual(undefined, Pid),
+    ?assertEqual('TranscriptStream', beamtalk_object_class:class_name(Pid)).
 
 integer_superclass_test() ->
     ok = beamtalk_stdlib:init(),
@@ -174,7 +182,8 @@ beamtalk_all_classes_test() ->
     ?assert(lists:member('True', Classes)),
     ?assert(lists:member('False', Classes)),
     ?assert(lists:member('Block', Classes)),
-    ?assert(lists:member('Beamtalk', Classes)),
+    ?assert(lists:member('SystemDictionary', Classes)),
+    ?assert(lists:member('TranscriptStream', Classes)),
     ?assert(lists:member('ProtoObject', Classes)),
     ?assert(lists:member('Object', Classes)),
     ?assert(lists:member('Actor', Classes)).


### PR DESCRIPTION
## Summary

`Beamtalk allClasses` incorrectly included `Beamtalk` (a singleton *instance* of SystemDictionary) instead of the actual classes `SystemDictionary` and `TranscriptStream`.

## Changes

- **Each singleton module now exports `class_info/0`** — single source of truth for class registration metadata (DDD: each module owns its own metadata)
- **`beamtalk_stdlib.erl` uses `WORKSPACE_GLOBALS` macro** — iterates singleton modules and calls `class_info/0` to register their classes. Adding a new workspace global = implement `class_info/0` + append to list.
- **`SystemDictionary` and `TranscriptStream`** now appear in `allClasses`; `Beamtalk` (the instance) does not

## Files Changed

| File | Change |
|------|--------|
| `beamtalk_system_dictionary.erl` | Added `class_info/0` export |
| `beamtalk_transcript_stream.erl` | Added `class_info/0` export |
| `beamtalk_stdlib.erl` | Replaced hand-coded registration with `WORKSPACE_GLOBALS` + `register_workspace_globals/0` |
| `beamtalk_stdlib_tests.erl` | Updated class count and assertions |

## Linear Issue

https://linear.app/beamtalk/issue/BT-420