### PR TITLE
fix: use unique project path in find_workspace_by_project_path test to prevent flaky collision

### DIFF
--- a/crates/beamtalk-cli/src/commands/workspace/mod.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/mod.rs
@@ -1248,7 +1248,9 @@ mod tests {
     #[test]
     fn test_find_workspace_by_project_path() {
         let ws = TestWorkspace::new("find_by_path");
-        let project_path = std::env::current_dir().unwrap();
+        // Use a unique project path so this test doesn't collide with other
+        // tests that also save metadata pointing at current_dir().
+        let project_path = std::env::current_dir().unwrap().join("find_by_path_unique");
         let metadata = WorkspaceMetadata {
             workspace_id: ws.id.clone(),
             project_path: project_path.clone(),


### PR DESCRIPTION
## Summary

Fix flaky test `test_find_workspace_by_project_path` that intermittently failed because it used `current_dir()` as `project_path` — the same path used by other workspace tests that run concurrently.

## Root Cause

`find_workspace_by_project_path()` iterates all workspace directories and returns the **first** match. When multiple concurrent tests (e.g., `test_create_workspace_creates_files`) save metadata with the same `current_dir()` as `project_path`, the wrong workspace could be found first depending on filesystem iteration order.

## Fix

Use a unique project path (`current_dir().join("find_by_path_unique")`) so this test's metadata cannot collide with other concurrent tests.

## Verification

- Ran the test 5 times consecutively — 5/5 passes
- Scanned all workspace tests for similar race conditions — no other issues found
- `just ci` passes