### PR TITLE
Add stdlib tests for field mutations in do: blocks (BT-251)

### DIFF
--- a/tests/e2e/fixtures/field_mutation_accumulator.bt
+++ b/tests/e2e/fixtures/field_mutation_accumulator.bt
@@ -23,8 +23,10 @@ Actor subclass: FieldMutationAccumulator
     ^#{#sum => self.sum, #product => self.product, #count => self.count}
 
   // NOTE: accumulateWithInject: and processWithLocal: commented out —
-  // they use local variables in blocks and inject:into: block params,
-  // which are not yet supported by the compiler. See BT-98 follow-up.
+  // accumulateWithInject: combines field mutation inside inject:into: blocks
+  // with local variable references after the block, which the compiler
+  // cannot resolve. processWithLocal: has similar issues with local
+  // variable mutations in blocks. See BT-98 follow-up.
 
   // accumulateWithInject: items =>
   //   | result |

--- a/tests/stdlib/field_mutations_do.bt
+++ b/tests/stdlib/field_mutations_do.bt
@@ -41,6 +41,9 @@ counter getValue await
 (counter sumArray: #(10, 20, 30)) await
 // => 60
 
+counter getValue await
+// => 60
+
 // === sumWithInject: — functional alternative (no field mutation) ===
 
 (counter sumWithInject: #(1, 2, 3)) await


### PR DESCRIPTION
## Summary

Add stdlib tests for field mutations inside `do:` blocks, exercising the BT-98 feature with collection iteration using `#()` list literal syntax.

**Linear issue:** https://linear.app/beamtalk/issue/BT-251

## Changes

### `tests/stdlib/field_mutations_do.bt`
- **`sumArray:` tests** — `do:` with field mutation accumulating sum (`#(1, 2, 3)` → 6, `#(10, 20, 30)` → 60)
- **`sumWithInject:` tests** — functional alternative using `inject:into:` for comparison
- **`FieldMutationAccumulator.processArray:`** — multiple field mutations (`sum`, `product`, `count`) in a single `do:` block, verified via individual getters

### `tests/e2e/fixtures/field_mutation_accumulator.bt`
- Fixed map literal keys to use symbol syntax (`#sum` not `sum`)
- Commented out `accumulateWithInject:` and `processWithLocal:` (use patterns not yet supported by compiler)

## Test Results

- `field_mutations_do`: 6 → 18 tests, all passing
- Total stdlib: 899 tests, 0 failures
- Full CI passes

## Follow-up Issues

- **BT-478**: Codegen bug in nested `to:do:` with field mutations (blocked by BT-245 IR refactor)