### PR TITLE
Derive exception hierarchy from class system (BT-475)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -85,7 +85,8 @@
     is_class_name/1,
     class_display_name/1,
     class_send/3,
-    class_object_tag/1
+    class_object_tag/1,
+    inherits_from/2
 ]).
 
 %% gen_server callbacks
@@ -991,8 +992,11 @@ invalidate_subclass_flattened_tables(ChangedClass) ->
     end, AllClasses),
     ok.
 
-%% @private
 %% @doc Check if a class inherits from a given ancestor (walks superclass chain).
+%%
+%% Returns true if ClassName is equal to or a subclass of Ancestor.
+%% Returns false if the class is not registered (safe during bootstrap).
+%% Used by beamtalk_exception_handler for hierarchy-aware matching (BT-475).
 -spec inherits_from(class_name() | none, class_name()) -> boolean().
 inherits_from(none, _Ancestor) ->
     false;


### PR DESCRIPTION
## Summary

Replaces hardcoded exception hierarchy whitelist in `beamtalk_exception_handler.erl` with dynamic class system queries via `beamtalk_object_class:inherits_from/2`.

**Linear issue:** https://linear.app/beamtalk/issue/BT-475

## Key Changes

- **`is_exception_class/1`** — Now delegates to `beamtalk_object_class:inherits_from(ClassName, 'Exception')` instead of a 5-clause hardcoded whitelist
- **`matches_class_name/2`** — Uses `kind_to_class/1` + `inherits_from/2` to walk the class hierarchy dynamically, with `strip_class_suffix/1` for metaclass name handling
- **`inherits_from/2`** — Exported from `beamtalk_object_class` as public API (was private)
- **`kind_to_class/1`** — Unchanged (codegen-level mapping, single source of kind→class)
- **Tests** — Hierarchy tests now use `{setup, ...}` fixture to initialize class system; pure tests (wrap, ensure_wrapped, kind_to_class) unchanged

## Impact

Adding a new error subclass (e.g., IOError in ADR 0015 Phase 6) now only requires:
1. New `.bt` file (e.g., `lib/IOError.bt`)
2. New `kind_to_class/1` clause
3. `.app.src` entry

Previously required updating 5 co-maintenance points. No bootstrap fallback needed — exception handler is only called from user code paths (after class system is initialized).

## Follow-up

- **BT-480** — User-defined error subclasses (created as follow-up, blocked by this PR)

## Test Results

- ✅ Rust: 1086 tests pass
- ✅ Runtime: 1121 tests, 0 failures  
- ✅ E2E: all pass (including error hierarchy tests)
- ✅ Stdlib: 885/914 pass (29 failures = pre-existing `exceptions.bt`, not caused by this PR)
- ✅ Dialyzer, clippy, fmt: clean