### PR TITLE
Improve REPL error formatting to use beamtalk_error (BT-237)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
@@ -877,6 +877,9 @@ format_error_message({eval_error, _Class, #{'$beamtalk_class' := ExClass, error 
     %% ADR 0015/BT-452: Evaluation error with wrapped Exception — use actual class name
     ClassName = atom_to_binary(ExClass, utf8),
     iolist_to_binary([ClassName, <<": ">>, beamtalk_error:format(Error)]);
+format_error_message({eval_error, _Class, #beamtalk_error{} = Error}) ->
+    %% BT-237: Format structured beamtalk_error from eval context
+    iolist_to_binary(beamtalk_error:format(Error));
 format_error_message({eval_error, Class, Reason}) ->
     iolist_to_binary([<<"Evaluation error: ">>, atom_to_binary(Class, utf8), <<":">>, format_name(Reason)]);
 format_error_message({load_error, Reason}) ->

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_server_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_server_tests.erl
@@ -620,6 +620,22 @@ format_error_message_fallback_test() ->
     ?assert(is_binary(Msg)),
     ?assert(byte_size(Msg) > 0).
 
+%%% BT-237: eval_error with #beamtalk_error{} formatting
+
+format_error_message_eval_error_beamtalk_error_test() ->
+    Error = beamtalk_error:with_selector(
+        beamtalk_error:new(does_not_understand, 'Integer'), nonExistentMethod),
+    Msg = beamtalk_repl_server:format_error_message({eval_error, error, Error}),
+    ?assertEqual(<<"Integer does not understand 'nonExistentMethod'">>, Msg).
+
+format_error_message_eval_error_beamtalk_error_with_hint_test() ->
+    Error0 = beamtalk_error:new(instantiation_error, 'Actor'),
+    Error1 = beamtalk_error:with_selector(Error0, new),
+    Error = beamtalk_error:with_hint(Error1, <<"Use spawn instead">>),
+    Msg = beamtalk_repl_server:format_error_message({eval_error, error, Error}),
+    ?assert(binary:match(Msg, <<"Actor">>) =/= nomatch),
+    ?assert(binary:match(Msg, <<"Hint: Use spawn instead">>) =/= nomatch).
+
 %%% BT-342: format_actors tests
 
 format_actors_empty_test() ->


### PR DESCRIPTION
## Summary

Fixes [BT-237](https://linear.app/beamtalk/issue/BT-237/improve-repl-error-formatting-to-use-beamtalk-error): REPL now displays structured error messages instead of raw tuples when evaluation errors contain `#beamtalk_error{}` records.

**Before:**
```
Evaluation error: error:{beamtalk_error,does_not_understand,'Integer',nonExistentMethod,...}
```

**After:**
```
Integer does not understand 'nonExistentMethod'
```

## Changes

- Added `format_error_message({eval_error, _Class, #beamtalk_error{}})` clause in `beamtalk_repl_server.erl` that delegates to `beamtalk_error:format/1`
- Placed between the wrapped Exception clause and the catch-all to maintain correct pattern matching order
- Added 2 unit tests: basic error formatting and error-with-hint formatting

## Testing

- All 110 repl_server_tests pass
- Full CI passes (clippy, fmt, dialyzer, 1221 Rust tests, 1089 runtime tests, 1091 stdlib tests, E2E tests)