### PR TITLE
Add Towers of Hanoi E2E test (BT-326)

### DIFF
--- a/tests/e2e/cases/hanoi.bt
+++ b/tests/e2e/cases/hanoi.bt
@@ -14,7 +14,7 @@
 
 // Create a Hanoi instance
 h := Hanoi new
-// => _
+// => {"$beamtalk_class":"Hanoi"}
 
 // ===========================================================================
 // BASE CASE (n=1)


### PR DESCRIPTION
## Summary

Adds an E2E test for the Towers of Hanoi example to prevent regressions.

**Linear issue:** https://linear.app/beamtalk/issue/BT-326

## Changes

- New test file: `tests/e2e/cases/hanoi.bt`
- Loads `examples/hanoi.bt` directly via `@load` (no separate fixture needed)
- Tests instantiation (`Hanoi new`)
- Tests base case (`solve: 1 from: 'A' to: 'C' via: 'B'`)
- Tests recursive case (`solve: 3 from: 'A' to: 'C' via: 'B'`)
- All `Transcript show:`/`cr` assertions return `nil` (async send per BT-374)
- Every expression has a `// =>` assertion (no skipped lines)

## Testing

All CI checks pass: clippy, fmt, dialyzer, Rust tests (1242), runtime tests (1179), stdlib tests (1149), E2E tests.