### PR TITLE
REPL: suggest colon-prefixed commands when user omits the colon (BT-526)

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -629,6 +629,29 @@ pub fn run(
                     _ => {}
                 }
 
+                // Detect common commands typed without ':' prefix.
+                // Only match full command names to avoid false positives with
+                // single-letter variable names (e.g. `r`, `l`, `b`).
+                let first_word = line.split_whitespace().next().unwrap_or("");
+                if let Some(suggestion) = match first_word {
+                    "load" => Some(":load"),
+                    "reload" => Some(":reload"),
+                    "help" => Some(":help"),
+                    "exit" | "quit" => Some(":exit"),
+                    "clear" => Some(":clear"),
+                    "bindings" => Some(":bindings"),
+                    "actors" => Some(":actors"),
+                    "modules" => Some(":modules"),
+                    "unload" => Some(":unload"),
+                    "kill" => Some(":kill"),
+                    "inspect" => Some(":inspect"),
+                    "sessions" => Some(":sessions"),
+                    _ => None,
+                } {
+                    eprintln!("Hint: did you mean `{suggestion}`? REPL commands start with `:`");
+                    continue;
+                }
+
                 // Evaluate expression
                 match client.eval(line) {
                     Ok(response) => {


### PR DESCRIPTION
## Summary

When a user types `load examples/counter.bt` instead of `:load examples/counter.bt`, the REPL previously fell through to the compiler, producing two confusing "Undefined variable" errors. Now it detects the common mistake and shows a helpful hint.

**Before:**
```
> load examples/counter.bt
Error: beamtalk::compile
  × Undefined variable: load
  × Undefined variable: counter
```

**After:**
```
> load examples/counter.bt
Hint: did you mean `:load`? REPL commands start with `:`
```

## Changes

- Added command name detection between the command dispatch match and eval fallthrough in `crates/beamtalk-cli/src/commands/repl/mod.rs`
- Matches all full REPL command names: `load`, `reload`, `help`, `exit`, `quit`, `clear`, `bindings`, `actors`, `modules`, `unload`, `inspect`, `sessions`
- Deliberately excludes single-letter aliases (`r`, `l`, `h`, etc.) to avoid false positives with variable names

## Linear Issue

https://linear.app/beamtalk/issue/BT-526