### PR TITLE
:help shows truncated docs and too many inherited methods (BT-528)

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/client.rs
+++ b/crates/beamtalk-cli/src/commands/repl/client.rs
@@ -141,7 +141,12 @@ impl ReplClient {
     }
 
     /// Get documentation for a class or method.
-    pub(super) fn get_docs(&mut self, class: &str, selector: Option<&str>) -> Result<ReplResponse> {
+    pub(super) fn get_docs(
+        &mut self,
+        class: &str,
+        selector: Option<&str>,
+        show_inherited: bool,
+    ) -> Result<ReplResponse> {
         let mut req = serde_json::json!({
             "op": "docs",
             "id": protocol::next_msg_id(),
@@ -149,6 +154,9 @@ impl ReplClient {
         });
         if let Some(sel) = selector {
             req["selector"] = serde_json::Value::String(sel.to_string());
+        }
+        if show_inherited {
+            req["show_inherited"] = serde_json::Value::Bool(true);
         }
         self.send_request(&req)
     }

--- a/crates/beamtalk-cli/src/commands/repl/display.rs
+++ b/crates/beamtalk-cli/src/commands/repl/display.rs
@@ -56,7 +56,8 @@ pub(super) fn print_help() {
     println!("Beamtalk REPL Commands:");
     println!();
     println!("  :help, :h       Show this help message");
-    println!("  :help <Class>   Show class documentation and methods");
+    println!("  :help <Class>   Show class documentation and own methods");
+    println!("  :help <C> all   Include inherited methods");
     println!("  :help <C> <sel> Show method documentation");
     println!("  :exit, :q       Exit the REPL");
     println!("  :clear          Clear all variable bindings");

--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -389,13 +389,14 @@ pub fn run(
                             continue;
                         }
 
-                        // Parse "ClassName" or "ClassName selector"
-                        let (class_name, selector) = match args.split_once(' ') {
-                            Some((cls, sel)) => (cls.trim(), Some(sel.trim())),
-                            None => (args, None),
+                        // Parse "ClassName", "ClassName all", or "ClassName selector"
+                        let (class_name, selector, show_inherited) = match args.split_once(' ') {
+                            Some((cls, "all")) => (cls.trim(), None, true),
+                            Some((cls, sel)) => (cls.trim(), Some(sel.trim()), false),
+                            None => (args, None, false),
                         };
 
-                        match client.get_docs(class_name, selector) {
+                        match client.get_docs(class_name, selector, show_inherited) {
                             Ok(response) => {
                                 if response.is_error() {
                                     if let Some(msg) = response.error_message() {

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
@@ -515,9 +515,10 @@ handle_op(<<"docs">>, Params, Msg, _SessionPid) ->
                 {class_not_found, ClassBin}, Msg, fun format_error_message/1);
         {ok, ClassName} ->
             Selector = maps:get(<<"selector">>, Params, undefined),
+            ShowInherited = maps:get(<<"show_inherited">>, Params, false),
             case Selector of
                 undefined ->
-                    case beamtalk_repl_docs:format_class_docs(ClassName) of
+                    case beamtalk_repl_docs:format_class_docs(ClassName, ShowInherited) of
                         {ok, DocText} ->
                             beamtalk_repl_protocol:encode_docs(DocText, Msg);
                         {error, {class_not_found, _}} ->


### PR DESCRIPTION
## Summary

Fixes [BT-528](https://linear.app/beamtalk/issue/BT-528): `:help Class` was truncating class docs to first paragraph and showing all inherited methods, overwhelming REPL output.

## Changes

- **Show full class docs** — Removed `first_paragraph()` truncation
- **Hide inherited methods by default** — Added `show_inherited` flag through CLI → server → docs pipeline  
- **New syntax: `:help Class all`** — Shows inherited methods when explicitly requested
- **Hint text** — Adds note about `:help ClassName all` option

Supersedes #460 (rebased on latest main).