### PR TITLE
Fix Transcript subscribe/unsubscribe dispatch (BT-530)

### DIFF
--- a/tests/e2e/cases/workspace_bindings.bt
+++ b/tests/e2e/cases/workspace_bindings.bt
@@ -123,3 +123,15 @@ recentAfterClear := (Transcript recent) await
 
 recentAfterClear isEmpty
 // => true
+
+// ===========================================================================
+// TRANSCRIPT BINDING — SUBSCRIBE / UNSUBSCRIBE
+// ===========================================================================
+
+// Transcript subscribe dispatches as unary method (BT-530)
+(Transcript subscribe) await
+// => nil
+
+// Transcript unsubscribe dispatches as unary method (BT-530)
+(Transcript unsubscribe) await
+// => nil


### PR DESCRIPTION
## Summary

Fixes `Transcript subscribe` and `Transcript unsubscribe` failing with `does_not_understand` despite being defined in stdlib and having runtime handlers.

**Linear issue:** https://linear.app/beamtalk/issue/BT-530

## Root Cause

Two dispatch mismatches in `beamtalk_transcript_stream.erl`:

1. **`subscribe`** — handler expected `{subscribe, [Pid], FuturePid}` but unary dispatch sends `{subscribe, [], FuturePid}`
2. **`unsubscribe`** — handler used keyword selector `'unsubscribe:'` but stdlib defines it as unary `unsubscribe` (no colon)

## Changes

- **`beamtalk_transcript_stream.erl`**: Fix both handler patterns to match unary dispatch. Extract `caller_from_future/1` helper to derive subscriber PID from the future's group_leader. Fix hint string.
- **`workspace_bindings.bt`**: Add E2E tests for subscribe/unsubscribe.

## Testing

All CI passes: 1252 Rust tests, 1183 Erlang runtime tests, 1149 stdlib tests, E2E tests ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal subscription handling mechanism for transcript operations.

* **Tests**
  * Added test coverage for transcript binding subscription and unsubscription operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->