### PR TITLE
Improve workspace module test coverage (BT-534)

### DIFF
--- a/crates/beamtalk-cli/src/commands/workspace/mod.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/mod.rs
@@ -2048,6 +2048,9 @@ mod tests {
             Some(60),
         )
         .expect("start_detached_node should succeed");
+        // Safety net: NodeGuard ensures cleanup if test fails before stop_workspace runs.
+        // NodeGuard is a no-op for already-dead PIDs, so it won't conflict with stop_workspace.
+        let _guard = NodeGuard { pid: node_info.pid };
 
         // Verify node is running before we stop it
         assert!(


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for the workspace module functions identified as coverage gaps in BT-280.

**Linear issue:** https://linear.app/beamtalk/issue/BT-534

## Changes

### Unit tests (no BEAM needed)
- `validate_workspace_name` valid cases: simple, hyphens, underscores, mixed, single char, numeric-only
- `validate_workspace_name` invalid cases: empty, unicode, spaces, dots, slashes, special chars
- `validate_workspace_name` boundary: 256+ character name

### Integration tests (require Erlang/OTP runtime)
- `list_workspaces` with running node: verifies Running status, correct port and PID
- `list_workspaces` stale cleanup: kills node without cleanup, verifies Stopped detection
- `workspace_status` with running node: verifies node_name, port, pid, and Running status
- `stop_workspace` force (SIGKILL): verifies force=true succeeds and node is stopped
- `stop_workspace` graceful timeout: verifies force=false returns timeout error suggesting --force
- `stop_workspace` non-running: verifies appropriate error for non-running workspace

All tests use existing `NodeGuard` and `TestWorkspace` helpers for proper cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for workspace management functionality, including workspace validation, lifecycle operations, node management, and status reporting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->