### PR TITLE
remove beamtalk MCP for now

### DIFF
--- a/.devcontainer/mcp-config.json
+++ b/.devcontainer/mcp-config.json
@@ -13,13 +13,6 @@
       "env": {
         "LINEAR_API_TOKEN": "${LINEAR_API_TOKEN}"
       }
-    },
-    "beamtalk": {
-      "type": "stdio",
-      "command": "./target/debug/beamtalk-mcp",
-      "tools": [
-        "*"
-      ]
-    }
+    }   
   }
 }


### PR DESCRIPTION
It's broken and we don't need it here yet until it's stable