### PR TITLE
Add stream method to List, String, Set, Dictionary (BT-514)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitive_implementations.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitive_implementations.rs
@@ -222,6 +222,8 @@ fn generate_string_bif(selector: &str, params: &[String]) -> Option<String> {
         "each:" => Some(format!("call 'beamtalk_string_ops':'each'(Self, {p0})")),
         "collect:" => Some(format!("call 'beamtalk_string_ops':'collect'(Self, {p0})")),
         "select:" => Some(format!("call 'beamtalk_string_ops':'select'(Self, {p0})")),
+        // Streaming (BT-514)
+        "stream" => Some("call 'beamtalk_stream':'on'(Self)".to_string()),
         _ => None,
     }
 }
@@ -595,6 +597,8 @@ fn generate_list_bif(selector: &str, params: &[String]) -> Option<String> {
         }
         // Display
         "printString" => Some("call 'beamtalk_primitive':'print_string'(Self)".to_string()),
+        // Streaming (BT-514)
+        "stream" => Some("call 'beamtalk_stream':'on'(Self)".to_string()),
         _ => None,
     }
 }
@@ -650,6 +654,8 @@ fn generate_dictionary_bif(selector: &str, params: &[String]) -> Option<String> 
             Some(format!("call 'beamtalk_map_ops':'includes'(Self, {p0})"))
         }
         "printString" => Some("call 'beamtalk_map_ops':'print_string'(Self)".to_string()),
+        // Streaming (BT-514)
+        "stream" => Some("call 'beamtalk_stream':'on'(Self)".to_string()),
         _ => None,
     }
 }
@@ -736,6 +742,8 @@ fn generate_set_bif(selector: &str, params: &[String]) -> Option<String> {
             // formats Sets as "Set(element1, element2, ...)"
             Some("call 'beamtalk_primitive':'print_string'(Self)".to_string())
         }
+        // Streaming (BT-514)
+        "stream" => Some("call 'beamtalk_stream':'on'(Self)".to_string()),
         _ => None,
     }
 }

--- a/lib/Dictionary.bt
+++ b/lib/Dictionary.bt
@@ -123,6 +123,14 @@ sealed Collection subclass: Dictionary
   /// ```
   printString => @primitive 'printString'
 
+  /// Return a lazy Stream over the dictionary entries as Associations.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// (#{#a => 1} stream) asList
+  /// ```
+  stream => @primitive 'stream'
+
   /// Human-readable description of the receiver.
   ///
   /// ## Examples

--- a/lib/List.bt
+++ b/lib/List.bt
@@ -318,6 +318,14 @@ sealed Collection subclass: List
   /// ```
   add: item => @primitive 'add:'
 
+  /// Return a lazy Stream over the list elements.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// (#(1, 2, 3) stream) asList       // => #(1, 2, 3)
+  /// ```
+  stream => @primitive 'stream'
+
   /// Human-readable description of the receiver.
   ///
   /// ## Examples

--- a/lib/Set.bt
+++ b/lib/Set.bt
@@ -121,6 +121,14 @@ sealed Collection subclass: Set
   /// ```
   printString => @primitive 'printString'
 
+  /// Return a lazy Stream over the set elements.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// ((Set new add: 1) stream) asList   // => #(1)
+  /// ```
+  stream => @primitive 'stream'
+
   /// Human-readable description of the receiver.
   ///
   /// ## Examples

--- a/lib/String.bt
+++ b/lib/String.bt
@@ -410,6 +410,14 @@ sealed Object subclass: String
   /// ```
   describe => self
 
+  /// Return a lazy Stream over the characters (grapheme clusters).
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// ('hello' stream) take: 3         // => #('h', 'e', 'l')
+  /// ```
+  stream => @primitive 'stream'
+
   /// Return the string itself.
   ///
   /// ## Examples

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_stream.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_stream.erl
@@ -74,13 +74,37 @@ from_by(Start, StepFun) when is_function(StepFun, 1) ->
 from_by(_, _) ->
     raise_type_error('from:by:', <<"Expected a Block as step function">>).
 
-%% @doc Create a Stream from a collection (list).
+%% @doc Create a Stream from a collection (list, set, dictionary, or string).
 %% `Stream on: #(1, 2, 3)` => 1, 2, 3
--spec on(list()) -> map().
+%% BT-514: Extended to support Set, Dictionary, and String.
+-spec on(term()) -> map().
 on(List) when is_list(List) ->
     make_stream(make_list_gen(List), <<"Stream(on: [...])">>);
+on(Str) when is_binary(Str) ->
+    Graphemes = beamtalk_string_ops:as_list(Str),
+    make_stream(make_list_gen(Graphemes), <<"Stream(on: '...')">>);
+on(Map) when is_map(Map) ->
+    case beamtalk_tagged_map:class_of(Map) of
+        'Set' ->
+            Elements = beamtalk_set_ops:as_list(Map),
+            make_stream(make_list_gen(Elements), <<"Stream(on: Set(...))">>);
+        undefined ->
+            %% Dictionary (plain map without $beamtalk_class tag)
+            Assocs = maps:fold(
+                fun(K, V, Acc) ->
+                    [#{'$beamtalk_class' => 'Association', key => K, value => V} | Acc]
+                end,
+                [],
+                Map
+            ),
+            make_stream(make_list_gen(lists:reverse(Assocs)), <<"Stream(on: #{...})">>);
+        Other ->
+            raise_type_error('on:', iolist_to_binary([
+                <<"Expected a collection, got ">>,
+                atom_to_binary(Other, utf8)]))
+    end;
 on(_) ->
-    raise_type_error('on:', <<"Expected a List argument">>).
+    raise_type_error('on:', <<"Expected a collection (List, String, Set, or Dictionary)">>).
 
 %%% ============================================================================
 %%% Lazy Operations (return new Stream)

--- a/tests/stdlib/stream_collections.bt
+++ b/tests/stdlib/stream_collections.bt
@@ -1,0 +1,267 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Stream — collection stream methods
+// BT-514: Phase 3 of ADR 0021
+
+// === List stream ===
+
+// Basic list stream
+(#(1, 2, 3) stream) asList
+// => [1,2,3]
+
+// Empty list stream
+(#() stream) asList
+// => []
+
+// Single element
+(#(42) stream) asList
+// => [42]
+
+// Lazy pipeline on list stream
+((#(1, 2, 3, 4, 5) stream) select: [:n | n > 2]) asList
+// => [3,4,5]
+
+// Collect on list stream
+((#(1, 2, 3) stream) collect: [:n | n * 10]) asList
+// => [10,20,30]
+
+// Stream returns Stream, not List
+(#(1, 2, 3) stream) class
+// => Stream
+
+// Chained lazy pipeline
+(((#(1, 2, 3, 4, 5, 6) stream) select: [:n | n > 2]) collect: [:n | n * 10]) asList
+// => [30,40,50,60]
+
+// Take on list stream
+(#(1, 2, 3, 4, 5) stream) take: 3
+// => [1,2,3]
+
+// Inject into on list stream
+(#(1, 2, 3) stream) inject: 0 into: [:sum :n | sum + n]
+// => 6
+
+// Detect on list stream
+(#(1, 2, 3, 4) stream) detect: [:n | n > 2]
+// => 3
+
+// anySatisfy on list stream
+(#(1, 2, 3) stream) anySatisfy: [:n | n > 2]
+// => true
+
+// allSatisfy on list stream
+(#(1, 2, 3) stream) allSatisfy: [:n | n > 0]
+// => true
+
+// respondsTo: #stream
+#(1, 2, 3) respondsTo: #stream
+// => true
+
+'hello' respondsTo: #stream
+// => true
+
+(Set new) respondsTo: #stream
+// => true
+
+#{#a => 1} respondsTo: #stream
+// => true
+
+// === String stream ===
+
+// Basic string stream — characters as graphemes
+('hello' stream) take: 3
+// => ["h","e","l"]
+
+// Full string stream
+('abc' stream) asList
+// => ["a","b","c"]
+
+// Empty string stream
+('' stream) asList
+// => []
+
+// Single character
+('x' stream) asList
+// => ["x"]
+
+// Select on string stream
+(('hello' stream) select: [:ch | ch ~= 'l']) asList
+// => ["h","e","o"]
+
+// Collect on string stream
+(('abc' stream) collect: [:ch | ch uppercase]) asList
+// => ["A","B","C"]
+
+// String stream returns Stream
+('hello' stream) class
+// => Stream
+
+// reject on string stream
+(('hello' stream) reject: [:ch | ch = 'l']) asList
+// => ["h","e","o"]
+
+// drop on string stream
+(('hello' stream) drop: 3) asList
+// => ["l","o"]
+
+// do: on string stream (side effect, returns nil)
+('abc' stream) do: [:ch | ch]
+// => nil
+
+// inject:into: on string stream
+('abc' stream) inject: '' into: [:acc :ch | acc ++ ch]
+// => abc
+
+// anySatisfy on string stream
+('hello' stream) anySatisfy: [:ch | ch = 'e']
+// => true
+
+// allSatisfy on string stream
+('hello' stream) allSatisfy: [:ch | ch ~= 'z']
+// => true
+
+// === Set stream ===
+
+// Basic set stream
+s := ((Set new add: 3) add: 1) add: 2
+// => _
+
+(s stream) asList
+// => [1,2,3]
+
+// Empty set stream
+(Set new stream) asList
+// => []
+
+// Single element set stream
+((Set new add: 42) stream) asList
+// => [42]
+
+// Select on set stream
+(((((Set new add: 1) add: 2) add: 3) stream) select: [:n | n > 1]) asList
+// => [2,3]
+
+// Collect on set stream
+(((((Set new add: 1) add: 2) add: 3) stream) collect: [:n | n * 10]) asList
+// => [10,20,30]
+
+// Set stream returns Stream
+((Set new add: 1) stream) class
+// => Stream
+
+// reject on set stream
+(((((Set new add: 1) add: 2) add: 3) stream) reject: [:n | n = 2]) asList
+// => [1,3]
+
+// drop on set stream
+(((((Set new add: 1) add: 2) add: 3) stream) drop: 1) asList
+// => [2,3]
+
+// take on set stream
+(((((Set new add: 1) add: 2) add: 3) stream) take: 2)
+// => [1,2]
+
+// do: on set stream (returns nil)
+((Set new add: 1) stream) do: [:n | n]
+// => nil
+
+// inject:into: on set stream
+(((((Set new add: 1) add: 2) add: 3) stream) inject: 0 into: [:sum :n | sum + n])
+// => 6
+
+// detect on set stream
+(((((Set new add: 1) add: 2) add: 3) stream) detect: [:n | n > 1])
+// => 2
+
+// anySatisfy on set stream
+(((Set new add: 1) add: 2) stream) anySatisfy: [:n | n > 1]
+// => true
+
+// allSatisfy on set stream
+(((Set new add: 1) add: 2) stream) allSatisfy: [:n | n > 0]
+// => true
+
+// === Dictionary stream ===
+
+// Dictionary stream produces Associations
+d := #{#a => 1}
+// => _
+
+(d stream) asList
+// => _
+
+// Single-entry dictionary stream — verify Association
+a := ((#{#x => 42} stream) asList) first
+// => _
+
+a class
+// => Association
+
+a key
+// => x
+
+a value
+// => 42
+
+// Empty dictionary stream
+(#{} stream) asList
+// => []
+
+// Dictionary stream returns Stream
+(#{#a => 1} stream) class
+// => Stream
+
+// Select on dictionary stream
+((#{#a => 1, #b => 2, #c => 3} stream) select: [:assoc | assoc value > 1]) asList
+// => _
+
+// Collect on dictionary stream — transform associations
+((#{#a => 1, #b => 2} stream) collect: [:assoc | assoc value]) asList
+// => _
+
+// Detect on dictionary stream
+((#{#a => 1, #b => 2, #c => 3} stream) detect: [:assoc | assoc value > 2]) value
+// => 3
+
+// reject on dictionary stream
+((#{#a => 1, #b => 2, #c => 3} stream) reject: [:assoc | assoc value = 2]) asList
+// => _
+
+// drop on dictionary stream
+((#{#a => 1, #b => 2} stream) drop: 1) asList
+// => _
+
+// take on dictionary stream
+((#{#a => 1, #b => 2, #c => 3} stream) take: 1)
+// => _
+
+// do: on dictionary stream (returns nil)
+(#{#a => 1} stream) do: [:assoc | assoc]
+// => nil
+
+// inject:into: on dictionary stream — sum values
+(#{#a => 1, #b => 2, #c => 3} stream) inject: 0 into: [:sum :assoc | sum + (assoc value)]
+// => 6
+
+// anySatisfy on dictionary stream
+(#{#a => 1, #b => 2} stream) anySatisfy: [:assoc | assoc value > 1]
+// => true
+
+// allSatisfy on dictionary stream
+(#{#a => 1, #b => 2} stream) allSatisfy: [:assoc | assoc value > 0]
+// => true
+
+// === Stream on: constructor extended ===
+
+// Stream on: with string
+(Stream on: 'abc') asList
+// => ["a","b","c"]
+
+// Stream on: with set
+(Stream on: ((Set new add: 1) add: 2)) asList
+// => [1,2]
+
+// Stream on: with dictionary
+((Stream on: #{#x => 99}) asList) first value
+// => 99


### PR DESCRIPTION
## Summary

Part of ADR 0021: Stream — Universal Data Interface (Phase 3 of 4).

Collections gain a `stream` method that returns a lazy Stream over their elements. Collections keep their eager methods (`select:`, `collect:`, etc.) — `stream` is the explicit opt-in to laziness.

## Changes

- **`beamtalk_stream:on/1`** — Extended to handle Set, Dictionary, and String types (not just lists)
- **`lib/List.bt`** — Added `stream` method returning `Stream on: self`
- **`lib/String.bt`** — Added `stream` method (yields grapheme clusters)
- **`lib/Set.bt`** — Added `stream` method (yields sorted elements)
- **`lib/Dictionary.bt`** — Added `stream` method (yields Association key-value pairs)
- **`primitive_implementations.rs`** — Added BIF dispatch for each collection's `stream` method
- **`tests/stdlib/stream_collections.bt`** — 44 assertions covering all collection types

## Key Design Decisions

- Dictionary stream yields **Association** objects (not raw values), matching ADR 0021 spec
- String stream yields grapheme clusters as individual strings via `beamtalk_string_ops:as_list`
- Set uses `beamtalk_set_ops:as_list/1` for proper encapsulation
- `beamtalk_stream:on/1` validates map types — only Set and plain Dictionary are accepted; other tagged maps get a type error

## Testing

- 44 new stdlib tests covering List, String, Set, Dictionary
- Tests verify: lazy behavior, pipeline ops, terminal ops, class checks, `respondsTo:`, empty collections, Association structure
- All 1276 stdlib tests pass
- Full CI passes (clippy, fmt, dialyzer, all test suites)

Linear: https://linear.app/beamtalk/issue/BT-514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming support added to String, List, Set, and Dictionary collections. Users can now create lazy streams and chain operations like filtering, mapping, and detection.
  * Stream operations enable efficient processing of large collections without materializing intermediate results.
  * All supported collection types now provide consistent streaming semantics for streamlined data processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->