### PR TITLE
TranscriptStream command methods return self instead of nil (BT-540)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -90,7 +90,7 @@ dialyzer:
 # ═══════════════════════════════════════════════════════════════════════════
 
 # Run fast tests (Rust unit/integration + stdlib + Erlang runtime, skip slow E2E)
-test: test-rust test-runtime test-stdlib
+test: test-rust test-stdlib test-runtime
 
 # Run Rust tests (unit + integration, skip slow E2E)
 test-rust:
@@ -207,7 +207,7 @@ _clean-daemon-state:
 
 # Run Erlang runtime unit tests
 # Note: Auto-discovers all *_tests modules. New test files are included automatically.
-test-runtime:
+test-runtime: build-stdlib
     #!/usr/bin/env bash
     set -euo pipefail
     cd runtime

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_transcript_stream.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_transcript_stream.erl
@@ -11,14 +11,14 @@
 %%%
 %%% ## Instance Methods
 %%%
-%%% | Selector      | Dispatch | Description                          |
-%%% |---------------|----------|--------------------------------------|
-%%% | `show:'       | cast     | Buffer text + push to subscribers    |
-%%% | `cr'          | cast     | Buffer newline + push to subscribers |
-%%% | `subscribe'   | cast     | Add caller to subscriber list        |
-%%% | `unsubscribe' | cast     | Remove caller from subscriber list   |
-%%% | `recent'      | call     | Return buffer contents as list       |
-%%% | `clear'       | call     | Empty the buffer                     |
+%%% | Selector      | Dispatch | Returns | Description                          |
+%%% |---------------|----------|---------|--------------------------------------|
+%%% | `show:'       | cast     | self    | Buffer text + push to subscribers    |
+%%% | `cr'          | cast     | self    | Buffer newline + push to subscribers |
+%%% | `subscribe'   | cast     | self    | Add caller to subscriber list        |
+%%% | `unsubscribe' | cast     | self    | Remove caller from subscriber list   |
+%%% | `recent'      | call     | list    | Return buffer contents as list       |
+%%% | `clear'       | call     | self    | Empty the buffer                     |
 %%%
 %%% ## Design
 %%%
@@ -51,7 +51,8 @@
     buffer_size  :: non_neg_integer(),
     max_buffer   :: max_buffer(),
     subscribers  :: #{pid() => reference()},
-    is_singleton :: boolean()
+    is_singleton :: boolean(),
+    self_ref     :: tuple() | undefined
 }).
 
 -type state() :: #state{}.
@@ -125,24 +126,25 @@ class_info() ->
 %% @private
 -spec init([max_buffer()] | [{singleton, max_buffer()}]) -> {ok, state()} | {stop, term()}.
 init([{singleton, MaxBuffer}]) when is_integer(MaxBuffer), MaxBuffer > 0 ->
-    %% Singleton path: register persistent_term binding for codegen lookup (~13ns)
-    %% Store a full beamtalk_object tuple so intrinsics (class, respondsTo:) work naturally.
-    persistent_term:put({beamtalk_binding, 'Transcript'},
-                        {beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, self()}),
+    SelfRef = {beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, self()},
+    persistent_term:put({beamtalk_binding, 'Transcript'}, SelfRef),
     {ok, #state{
         buffer       = queue:new(),
         buffer_size  = 0,
         max_buffer   = MaxBuffer,
         subscribers  = #{},
-        is_singleton = true
+        is_singleton = true,
+        self_ref     = SelfRef
     }};
 init([MaxBuffer]) when is_integer(MaxBuffer), MaxBuffer > 0 ->
+    SelfRef = {beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, self()},
     {ok, #state{
         buffer       = queue:new(),
         buffer_size  = 0,
         max_buffer   = MaxBuffer,
         subscribers  = #{},
-        is_singleton = false
+        is_singleton = false,
+        self_ref     = SelfRef
     }};
 init([MaxBuffer]) ->
     {stop, {invalid_max_buffer, MaxBuffer}}.
@@ -152,8 +154,8 @@ init([MaxBuffer]) ->
     {reply, term(), state()}.
 handle_call(recent, _From, #state{buffer = Buffer} = State) ->
     {reply, queue:to_list(Buffer), State};
-handle_call(clear, _From, State) ->
-    {reply, ok, State#state{buffer = queue:new(), buffer_size = 0}};
+handle_call(clear, _From, #state{self_ref = SelfRef} = State) ->
+    {reply, SelfRef, State#state{buffer = queue:new(), buffer_size = 0}};
 handle_call({recent, []}, From, State) ->
     handle_call(recent, From, State);
 handle_call({clear, []}, From, State) ->
@@ -166,31 +168,31 @@ handle_call(Request, _From, State) ->
 %% @private
 -spec handle_cast(term(), state()) -> {noreply, state()}.
 %% Actor protocol: {Selector, Args, FuturePid} from beamtalk_actor:async_send/4
-handle_cast({'show:', [Value], FuturePid}, State) when is_pid(FuturePid) ->
+handle_cast({'show:', [Value], FuturePid}, #state{self_ref = SelfRef} = State) when is_pid(FuturePid) ->
     Text = to_string(Value),
     State1 = buffer_text(Text, State),
     push_to_subscribers(Text, State1),
-    beamtalk_future:resolve(FuturePid, nil),
+    beamtalk_future:resolve(FuturePid, SelfRef),
     {noreply, State1};
-handle_cast({cr, [], FuturePid}, State) when is_pid(FuturePid) ->
+handle_cast({cr, [], FuturePid}, #state{self_ref = SelfRef} = State) when is_pid(FuturePid) ->
     Text = <<"\n">>,
     State1 = buffer_text(Text, State),
     push_to_subscribers(Text, State1),
-    beamtalk_future:resolve(FuturePid, nil),
+    beamtalk_future:resolve(FuturePid, SelfRef),
     {noreply, State1};
 handle_cast({recent, [], FuturePid}, State) when is_pid(FuturePid) ->
     beamtalk_future:resolve(FuturePid, queue:to_list(State#state.buffer)),
     {noreply, State};
-handle_cast({clear, [], FuturePid}, State) when is_pid(FuturePid) ->
-    beamtalk_future:resolve(FuturePid, nil),
+handle_cast({clear, [], FuturePid}, #state{self_ref = SelfRef} = State) when is_pid(FuturePid) ->
+    beamtalk_future:resolve(FuturePid, SelfRef),
     {noreply, State#state{buffer = queue:new(), buffer_size = 0}};
-handle_cast({subscribe, [], FuturePid}, State) when is_pid(FuturePid) ->
+handle_cast({subscribe, [], FuturePid}, #state{self_ref = SelfRef} = State) when is_pid(FuturePid) ->
     CallerPid = caller_from_future(FuturePid),
-    beamtalk_future:resolve(FuturePid, nil),
+    beamtalk_future:resolve(FuturePid, SelfRef),
     {noreply, add_subscriber(CallerPid, State)};
-handle_cast({unsubscribe, [], FuturePid}, State) when is_pid(FuturePid) ->
+handle_cast({unsubscribe, [], FuturePid}, #state{self_ref = SelfRef} = State) when is_pid(FuturePid) ->
     CallerPid = caller_from_future(FuturePid),
-    beamtalk_future:resolve(FuturePid, nil),
+    beamtalk_future:resolve(FuturePid, SelfRef),
     {noreply, remove_subscriber(CallerPid, State)};
 %% Legacy format (direct gen_server:cast without Future)
 handle_cast({'show:', Value}, State) ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_transcript_stream_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_transcript_stream_tests.erl
@@ -159,7 +159,8 @@ recent_empty_buffer_test() ->
 clear_empties_buffer_test() ->
     {ok, Pid} = beamtalk_transcript_stream:start_link(),
     gen_server:cast(Pid, {'show:', <<"data">>}),
-    ok = gen_server:call(Pid, clear),
+    SelfRef = gen_server:call(Pid, clear),
+    ?assertMatch({beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, Pid}, SelfRef),
     Result = gen_server:call(Pid, recent),
     ?assertEqual([], Result),
     gen_server:stop(Pid).
@@ -259,7 +260,8 @@ tuple_format_recent_test() ->
 tuple_format_clear_test() ->
     {ok, Pid} = beamtalk_transcript_stream:start_link(),
     gen_server:cast(Pid, {'show:', <<"data">>}),
-    ok = gen_server:call(Pid, {clear, []}),
+    SelfRef = gen_server:call(Pid, {clear, []}),
+    ?assertMatch({beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, Pid}, SelfRef),
     Result = gen_server:call(Pid, recent),
     ?assertEqual([], Result),
     gen_server:stop(Pid).

--- a/tests/e2e/cases/hanoi.bt
+++ b/tests/e2e/cases/hanoi.bt
@@ -4,7 +4,7 @@
 // E2E tests for Towers of Hanoi example
 // Tests the classic recursive algorithm that moves n disks between three pegs.
 // Hanoi is an Object subclass (not Actor), so use `new` not `spawn`.
-// BT-374: Transcript show:/cr are async sends, REPL auto-awaits to nil.
+// BT-374: Transcript show:/cr are async sends, return self (BT-540).
 
 // @load examples/hanoi.bt
 

--- a/tests/e2e/cases/transcript.bt
+++ b/tests/e2e/cases/transcript.bt
@@ -4,20 +4,20 @@
 // E2E tests for Transcript class
 // Transcript is a workspace-bound actor for writing to stdout.
 // show: prints a value, cr prints a newline.
-// BT-374: Workspace bindings dispatch via persistent_term + async send,
-// so all sends return a Future (not nil).
+// BT-374: Workspace bindings dispatch via persistent_term + async send.
+// BT-540: Command methods return self (not nil) per Command-Query Separation.
 
 // ===========================================================================
 // BASIC OUTPUT
 // ===========================================================================
 
-// show: prints a string (async send, REPL auto-awaits to nil)
+// show: prints a string (async send, returns self per Command-Query Separation)
 Transcript show: 'Hello'
-// => nil
+// => #Actor<TranscriptStream,_>
 
-// cr prints a newline (async send, REPL auto-awaits to nil)
+// cr prints a newline (async send, returns self)
 Transcript cr
-// => nil
+// => #Actor<TranscriptStream,_>
 
 // ===========================================================================
 // SHOW: WITH DIFFERENT TYPES
@@ -25,15 +25,15 @@ Transcript cr
 
 // show: with an integer
 Transcript show: 42
-// => nil
+// => #Actor<TranscriptStream,_>
 
 // show: with a boolean
 Transcript show: true
-// => nil
+// => #Actor<TranscriptStream,_>
 
 // show: with nil
 Transcript show: nil
-// => nil
+// => #Actor<TranscriptStream,_>
 
 // ===========================================================================
 // CASCADE (SEMICOLON CHAINING)
@@ -43,6 +43,24 @@ Transcript show: nil
 // requires metaclass dispatch which is not yet implemented.
 // Use separate statements instead:
 Transcript show: 'Hello'
-// => nil
+// => #Actor<TranscriptStream,_>
 Transcript cr
-// => nil
+// => #Actor<TranscriptStream,_>
+
+// ===========================================================================
+// RETURN VALUE IS SELF (BT-540)
+// ===========================================================================
+
+// Command methods return self (the Transcript actor), not nil
+// This follows Smalltalk convention and Command-Query Separation
+t := (Transcript show: 'test') await
+// => #Actor<TranscriptStream,_>
+
+t class
+// => TranscriptStream
+
+t2 := (Transcript cr) await
+// => #Actor<TranscriptStream,_>
+
+t2 class
+// => TranscriptStream

--- a/tests/e2e/cases/workspace_bindings.bt
+++ b/tests/e2e/cases/workspace_bindings.bt
@@ -12,13 +12,13 @@
 // TRANSCRIPT BINDING — BASIC DISPATCH
 // ===========================================================================
 
-// Transcript show: dispatches through workspace binding (async send, REPL auto-awaits to nil)
+// Transcript show: dispatches through workspace binding (async send, returns self)
 Transcript show: 'Hello'
-// => nil
+// => #Actor<TranscriptStream,_>
 
-// Transcript cr dispatches through workspace binding (async send, REPL auto-awaits to nil)
+// Transcript cr dispatches through workspace binding (async send, returns self)
 Transcript cr
-// => nil
+// => #Actor<TranscriptStream,_>
 
 // ===========================================================================
 // TRANSCRIPT BINDING — CLASS INTROSPECTION
@@ -75,7 +75,7 @@ version isEmpty
 
 // Cascade on workspace binding: all messages dispatched to same actor
 Transcript show: 'Hello'; cr; show: 'World'
-// => nil
+// => #Actor<TranscriptStream,_>
 
 // ===========================================================================
 // BEAMTALK BINDING — GLOBALS
@@ -99,11 +99,11 @@ intClass := (Beamtalk classNamed: #Integer) await
 
 // Clear transcript buffer first
 (Transcript clear) await
-// => nil
+// => #Actor<TranscriptStream,_>
 
 // Write something to transcript
 (Transcript show: 'TestOutput') await
-// => nil
+// => #Actor<TranscriptStream,_>
 
 // Recent returns buffer contents (list of recent output)
 recent := (Transcript recent) await
@@ -115,7 +115,7 @@ recent isEmpty
 
 // Clear empties the buffer
 (Transcript clear) await
-// => nil
+// => #Actor<TranscriptStream,_>
 
 // Buffer should be empty after clear
 recentAfterClear := (Transcript recent) await
@@ -130,8 +130,8 @@ recentAfterClear isEmpty
 
 // Transcript subscribe dispatches as unary method (BT-530)
 (Transcript subscribe) await
-// => nil
+// => #Actor<TranscriptStream,_>
 
 // Transcript unsubscribe dispatches as unary method (BT-530)
 (Transcript unsubscribe) await
-// => nil
+// => #Actor<TranscriptStream,_>


### PR DESCRIPTION
## Summary

TranscriptStream command methods (`show:`, `cr`, `clear`, `subscribe`, `unsubscribe`) now return self (the Transcript actor reference) instead of `nil`, following Smalltalk convention and Command-Query Separation.

**Linear issue:** https://linear.app/beamtalk/issue/BT-540

## Changes

### Runtime (`beamtalk_transcript_stream.erl`)
- Added `self_ref` field to `#state{}` record — stores `{beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, self()}`
- All command methods (`show:`, `cr`, `clear`, `subscribe`, `unsubscribe`) resolve futures with `self_ref` instead of `nil`
- Query method (`recent`) unchanged — still returns buffer list
- Updated module doc table with return value column

### Build fix (`Justfile`)
- `test-runtime` now depends on `build-stdlib` — fixes 123 pre-existing test failures where stdlib `.beam` files weren't available
- Reordered `test` recipe: `test-rust test-stdlib test-runtime` (was `test-rust test-runtime test-stdlib`)

### Tests
- Updated unit tests for `clear` return value (`ok` → self-ref tuple)
- Updated all E2E transcript/workspace_bindings assertions (`nil` → `#Actor<TranscriptStream,_>`)
- Added new E2E tests verifying `(Transcript show: 'test') await class` returns `TranscriptStream`

## Verification
- All CI checks pass: clippy, fmt, dialyzer, 1332 Rust tests, 1305 stdlib tests, 1220 runtime tests, 9 integration tests, 11 MCP tests, 328 E2E tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transcript commands (`show:`, `cr`, `clear`, `subscribe`, `unsubscribe`) now return the actor reference, enabling method chaining and consistent return semantics.

* **Tests**
  * Updated end-to-end tests to reflect new command return values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->