### PR TITLE
Handle non-UTF8 paths explicitly instead of to_string_lossy() (BT-312)

### DIFF
--- a/crates/beamtalk-cli/src/commands/workspace/mod.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/mod.rs
@@ -86,12 +86,9 @@ pub struct NodeInfo {
 /// Uses SHA256 hash of the absolute path.
 pub fn generate_workspace_id(project_path: &Path) -> Result<String> {
     let absolute = project_path.canonicalize().into_diagnostic()?;
-    let path_str = absolute.to_str().ok_or_else(|| {
-        miette!(
-            "Project path contains invalid UTF-8: {}",
-            absolute.display()
-        )
-    })?;
+    let path_str = absolute
+        .to_str()
+        .ok_or_else(|| miette!("Project path contains invalid UTF-8: {:?}", absolute))?;
 
     let mut hasher = Sha256::new();
     hasher.update(path_str.as_bytes());
@@ -440,12 +437,9 @@ pub fn start_detached_node(
 
     // Build the eval command to start workspace supervisor and keep running
     let project_path = get_workspace_metadata(workspace_id)?.project_path;
-    let project_path_str = project_path.to_str().ok_or_else(|| {
-        miette!(
-            "Project path contains invalid UTF-8: {}",
-            project_path.display()
-        )
-    })?;
+    let project_path_str = project_path
+        .to_str()
+        .ok_or_else(|| miette!("Project path contains invalid UTF-8: {:?}", project_path))?;
     let eval_cmd = format!(
         "application:set_env(beamtalk_runtime, workspace_id, <<\"{workspace_id}\">>), \
          application:set_env(beamtalk_runtime, project_path, <<\"{project_path_str}\">>), \
@@ -2109,20 +2103,27 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_generate_workspace_id_rejects_non_utf8_path() {
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
 
-        // Create a temp dir with a valid name, then append a non-UTF8 child
+        // Include PID in name to avoid collisions in parallel test runs
         let tmp = std::env::temp_dir();
-        let invalid_bytes: &[u8] = b"beamtalk-test-\xff\xfe";
-        let invalid_name = OsStr::from_bytes(invalid_bytes);
+        let mut invalid_bytes = b"beamtalk-test-\xff\xfe-".to_vec();
+        invalid_bytes.extend_from_slice(std::process::id().to_string().as_bytes());
+        let invalid_name = OsStr::from_bytes(&invalid_bytes);
         let non_utf8_path = tmp.join(invalid_name);
 
-        // Create the directory so canonicalize() can succeed
-        let _ = fs::create_dir(&non_utf8_path);
+        // Create the directory so canonicalize() can succeed.
+        // Skip test if the filesystem rejects non-UTF8 names.
+        if let Err(e) = fs::create_dir(&non_utf8_path) {
+            if e.kind() != std::io::ErrorKind::AlreadyExists {
+                eprintln!("skipping test: failed to create non-UTF8 dir {non_utf8_path:?}: {e}");
+                return;
+            }
+        }
 
         let result = generate_workspace_id(&non_utf8_path);
         // Clean up before asserting


### PR DESCRIPTION
## Summary

Replaces `to_string_lossy()` with explicit `to_str().ok_or_else()` at two dangerous sites in workspace code, preventing silent data corruption from non-UTF8 paths.

## Changes

- **`generate_workspace_id()`**: Fail explicitly on non-UTF8 paths instead of silently replacing invalid bytes (which could cause hash collisions)
- **`start_detached_node()`**: Fail explicitly instead of passing corrupted path strings to Erlang `-eval` commands
- **Test**: Unix-only test verifying explicit error on non-UTF8 paths

The remaining 10 `to_string_lossy()` sites in the codebase are display-only and acceptable.

## Linear Issue

https://linear.app/beamtalk/issue/BT-312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path validation to properly reject paths with invalid UTF-8 characters instead of using lossy conversion.

* **Tests**
  * Added test coverage for non-UTF-8 path rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->