### PR TITLE
Avoid temp var collisions in value-type method sequencing (BT-369)

### DIFF
--- a/test-package-compiler/cases/value_type_param_collision/main.bt
+++ b/test-package-compiler/cases/value_type_param_collision/main.bt
@@ -1,0 +1,19 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Compiler snapshot test for BT-369: value-type temp var collision avoidance
+//
+// Verifies that method parameters with underscore-prefixed names (e.g., _seq0)
+// don't collide with codegen-internal temp vars used for expression sequencing.
+// Both parameter binding and sequencing temp vars go through the fresh_var
+// counter, ensuring unique Core Erlang variable names.
+
+Object subclass: ParamCollisionTest
+
+  // Multi-expression method with a parameter named _seq0.
+  // Before BT-369, to_core_var kept "_seq0" verbatim while fresh_temp_var("seq")
+  // could produce "_seq1", "_seq2" — a near-miss that could collide if naming
+  // conventions changed. Now both use the counter.
+  compute: _seq0 =>
+    _seq0 + 1
+    _seq0 * 2

--- a/test-package-compiler/tests/snapshots/compiler_tests__method_lookup_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__method_lookup_codegen.snap
@@ -17,8 +17,8 @@ module 'method_lookup' ['new'/0, 'new'/1, 'lookupLiteral'/1, 'lookupVariable:'/2
 'lookupLiteral'/1= fun (Self) ->
 call 'beamtalk_method_resolver':'resolve'('Counter', 'increment')
 
-'lookupVariable:'/2= fun (Self, Cls) ->
-call 'beamtalk_method_resolver':'resolve'(Cls, 'getValue')
+'lookupVariable:'/2= fun (Self, _cls1) ->
+call 'beamtalk_method_resolver':'resolve'(_cls1, 'getValue')
 
 'dispatch'/3 = fun (Selector, Args, Self) ->
     case Selector of

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_dictionary_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_dictionary_codegen.snap
@@ -22,26 +22,26 @@ call 'maps':'keys'(Self)
 'values'/1= fun (Self) ->
 call 'maps':'values'(Self)
 
-'at:'/2= fun (Self, Key) ->
-call 'maps':'get'(Key, Self)
+'at:'/2= fun (Self, _key1) ->
+call 'maps':'get'(_key1, Self)
 
-'at:ifAbsent:'/3= fun (Self, Key, Block) ->
-call 'beamtalk_map_ops':'at_if_absent'(Self, Key, Block)
+'at:ifAbsent:'/3= fun (Self, _key2, _block3) ->
+call 'beamtalk_map_ops':'at_if_absent'(Self, _key2, _block3)
 
-'at:put:'/3= fun (Self, Key, Value) ->
-call 'maps':'put'(Key, Value, Self)
+'at:put:'/3= fun (Self, _key4, _value5) ->
+call 'maps':'put'(_key4, _value5, Self)
 
-'includesKey:'/2= fun (Self, Key) ->
-call 'maps':'is_key'(Key, Self)
+'includesKey:'/2= fun (Self, _key6) ->
+call 'maps':'is_key'(_key6, Self)
 
-'removeKey:'/2= fun (Self, Key) ->
-call 'maps':'remove'(Key, Self)
+'removeKey:'/2= fun (Self, _key7) ->
+call 'maps':'remove'(_key7, Self)
 
-'merge:'/2= fun (Self, Other) ->
-call 'maps':'merge'(Self, Other)
+'merge:'/2= fun (Self, _other8) ->
+call 'maps':'merge'(Self, _other8)
 
-'keysAndValuesDo:'/2= fun (Self, Block) ->
-call 'beamtalk_map_ops':'keys_and_values_do'(Self, Block)
+'keysAndValuesDo:'/2= fun (Self, _block9) ->
+call 'beamtalk_map_ops':'keys_and_values_do'(Self, _block9)
 
 'describe'/1= fun (Self) ->
 #{#<97>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<68>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']])}#

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_codegen.snap
@@ -31,17 +31,17 @@ case Self of <[_H|T]> when 'true' -> T <[]> when 'true' -> [] end
 'last'/1= fun (Self) ->
 case Self of <[]> when 'true' -> let Error0 = call 'beamtalk_error':'new'('does_not_understand', 'List') in let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'last') in let Error2 = call 'beamtalk_error':'with_hint'(Error1, #{#<67>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']])}#) in call 'beamtalk_error':'raise'(Error2) <_> when 'true' -> call 'lists':'last'(Self) end
 
-'at:'/2= fun (Self, Index) ->
-call 'beamtalk_list_ops':'at'(Self, Index)
+'at:'/2= fun (Self, _index1) ->
+call 'beamtalk_list_ops':'at'(Self, _index1)
 
-'includes:'/2= fun (Self, Item) ->
-call 'lists':'member'(Item, Self)
+'includes:'/2= fun (Self, _item2) ->
+call 'lists':'member'(_item2, Self)
 
 'sort'/1= fun (Self) ->
 call 'lists':'sort'(Self)
 
-'sort:'/2= fun (Self, Comparator) ->
-call 'beamtalk_list_ops':'sort_with'(Self, Comparator)
+'sort:'/2= fun (Self, _comparator3) ->
+call 'beamtalk_list_ops':'sort_with'(Self, _comparator3)
 
 'reversed'/1= fun (Self) ->
 call 'lists':'reverse'(Self)
@@ -49,80 +49,80 @@ call 'lists':'reverse'(Self)
 'unique'/1= fun (Self) ->
 call 'lists':'usort'(Self)
 
-'detect:'/2= fun (Self, Block) ->
-call 'beamtalk_list_ops':'detect'(Self, Block)
+'detect:'/2= fun (Self, _block4) ->
+call 'beamtalk_list_ops':'detect'(Self, _block4)
 
-'detect:ifNone:'/3= fun (Self, Block, Default) ->
-call 'beamtalk_list_ops':'detect_if_none'(Self, Block, Default)
+'detect:ifNone:'/3= fun (Self, _block5, _default6) ->
+call 'beamtalk_list_ops':'detect_if_none'(Self, _block5, _default6)
 
-'do:'/2= fun (Self, Block) ->
-call 'beamtalk_list_ops':'do'(Self, Block)
+'do:'/2= fun (Self, _block7) ->
+call 'beamtalk_list_ops':'do'(Self, _block7)
 
-'collect:'/2= fun (Self, Block) ->
-call 'lists':'map'(Block, Self)
+'collect:'/2= fun (Self, _block8) ->
+call 'lists':'map'(_block8, Self)
 
-'select:'/2= fun (Self, Block) ->
-call 'lists':'filter'(Block, Self)
+'select:'/2= fun (Self, _block9) ->
+call 'lists':'filter'(_block9, Self)
 
-'reject:'/2= fun (Self, Block) ->
-call 'beamtalk_list_ops':'reject'(Self, Block)
+'reject:'/2= fun (Self, _block10) ->
+call 'beamtalk_list_ops':'reject'(Self, _block10)
 
-'inject:into:'/3= fun (Self, Initial, Block) ->
-call 'lists':'foldl'(Block, Initial, Self)
+'inject:into:'/3= fun (Self, _initial11, _block12) ->
+call 'lists':'foldl'(_block12, _initial11, Self)
 
-'take:'/2= fun (Self, N) ->
-call 'beamtalk_list_ops':'take'(Self, N)
+'take:'/2= fun (Self, _n13) ->
+call 'beamtalk_list_ops':'take'(Self, _n13)
 
-'drop:'/2= fun (Self, N) ->
-call 'beamtalk_list_ops':'drop'(Self, N)
+'drop:'/2= fun (Self, _n14) ->
+call 'beamtalk_list_ops':'drop'(Self, _n14)
 
 'flatten'/1= fun (Self) ->
 call 'lists':'flatten'(Self)
 
-'flatMap:'/2= fun (Self, Block) ->
-call 'lists':'flatmap'(Block, Self)
+'flatMap:'/2= fun (Self, _block15) ->
+call 'lists':'flatmap'(_block15, Self)
 
-'count:'/2= fun (Self, Block) ->
-call 'erlang':'length'(call 'lists':'filter'(Block, Self))
+'count:'/2= fun (Self, _block16) ->
+call 'erlang':'length'(call 'lists':'filter'(_block16, Self))
 
-'anySatisfy:'/2= fun (Self, Block) ->
-call 'lists':'any'(Block, Self)
+'anySatisfy:'/2= fun (Self, _block17) ->
+call 'lists':'any'(_block17, Self)
 
-'allSatisfy:'/2= fun (Self, Block) ->
-call 'lists':'all'(Block, Self)
+'allSatisfy:'/2= fun (Self, _block18) ->
+call 'lists':'all'(_block18, Self)
 
-'++'/2= fun (Self, Other) ->
-call 'erlang':'++'(Self, Other)
+'++'/2= fun (Self, _other19) ->
+call 'erlang':'++'(Self, _other19)
 
-'from:to:'/3= fun (Self, Start, End) ->
-call 'beamtalk_list_ops':'from_to'(Self, Start, End)
+'from:to:'/3= fun (Self, _start20, _end21) ->
+call 'beamtalk_list_ops':'from_to'(Self, _start20, _end21)
 
-'indexOf:'/2= fun (Self, Item) ->
-call 'beamtalk_list_ops':'index_of'(Self, Item)
+'indexOf:'/2= fun (Self, _item22) ->
+call 'beamtalk_list_ops':'index_of'(Self, _item22)
 
-'eachWithIndex:'/2= fun (Self, Block) ->
-call 'beamtalk_list_ops':'each_with_index'(Self, Block)
+'eachWithIndex:'/2= fun (Self, _block23) ->
+call 'beamtalk_list_ops':'each_with_index'(Self, _block23)
 
-'zip:'/2= fun (Self, Other) ->
-call 'beamtalk_list_ops':'zip'(Self, Other)
+'zip:'/2= fun (Self, _other24) ->
+call 'beamtalk_list_ops':'zip'(Self, _other24)
 
-'groupBy:'/2= fun (Self, Block) ->
-call 'beamtalk_list_ops':'group_by'(Self, Block)
+'groupBy:'/2= fun (Self, _block25) ->
+call 'beamtalk_list_ops':'group_by'(Self, _block25)
 
-'partition:'/2= fun (Self, Block) ->
-call 'beamtalk_list_ops':'partition'(Self, Block)
+'partition:'/2= fun (Self, _block26) ->
+call 'beamtalk_list_ops':'partition'(Self, _block26)
 
-'takeWhile:'/2= fun (Self, Block) ->
-call 'lists':'takewhile'(Block, Self)
+'takeWhile:'/2= fun (Self, _block27) ->
+call 'lists':'takewhile'(_block27, Self)
 
-'dropWhile:'/2= fun (Self, Block) ->
-call 'lists':'dropwhile'(Block, Self)
+'dropWhile:'/2= fun (Self, _block28) ->
+call 'lists':'dropwhile'(_block28, Self)
 
-'intersperse:'/2= fun (Self, Separator) ->
-call 'beamtalk_list_ops':'intersperse'(Self, Separator)
+'intersperse:'/2= fun (Self, _separator29) ->
+call 'beamtalk_list_ops':'intersperse'(Self, _separator29)
 
-'add:'/2= fun (Self, Item) ->
-call 'erlang':'++'(Self, [Item|[]])
+'add:'/2= fun (Self, _item30) ->
+call 'erlang':'++'(Self, [_item30|[]])
 
 'describe'/1= fun (Self) ->
 #{#<97>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<76>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']])}#

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_set_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_set_codegen.snap
@@ -20,35 +20,35 @@ call 'beamtalk_set_ops':'size'(Self)
 'isEmpty'/1= fun (Self) ->
 call 'beamtalk_set_ops':'is_empty'(Self)
 
-'includes:'/2= fun (Self, Element) ->
-call 'beamtalk_set_ops':'includes'(Self, Element)
+'includes:'/2= fun (Self, _element1) ->
+call 'beamtalk_set_ops':'includes'(Self, _element1)
 
-'add:'/2= fun (Self, Element) ->
-call 'beamtalk_set_ops':'add'(Self, Element)
+'add:'/2= fun (Self, _element2) ->
+call 'beamtalk_set_ops':'add'(Self, _element2)
 
-'remove:'/2= fun (Self, Element) ->
-call 'beamtalk_set_ops':'remove'(Self, Element)
+'remove:'/2= fun (Self, _element3) ->
+call 'beamtalk_set_ops':'remove'(Self, _element3)
 
-'union:'/2= fun (Self, Other) ->
-call 'beamtalk_set_ops':'union'(Self, Other)
+'union:'/2= fun (Self, _other4) ->
+call 'beamtalk_set_ops':'union'(Self, _other4)
 
-'intersection:'/2= fun (Self, Other) ->
-call 'beamtalk_set_ops':'intersection'(Self, Other)
+'intersection:'/2= fun (Self, _other5) ->
+call 'beamtalk_set_ops':'intersection'(Self, _other5)
 
-'difference:'/2= fun (Self, Other) ->
-call 'beamtalk_set_ops':'difference'(Self, Other)
+'difference:'/2= fun (Self, _other6) ->
+call 'beamtalk_set_ops':'difference'(Self, _other6)
 
-'isSubsetOf:'/2= fun (Self, Other) ->
-call 'beamtalk_set_ops':'is_subset_of'(Self, Other)
+'isSubsetOf:'/2= fun (Self, _other7) ->
+call 'beamtalk_set_ops':'is_subset_of'(Self, _other7)
 
 'asList'/1= fun (Self) ->
 call 'beamtalk_set_ops':'as_list'(Self)
 
-'fromList:'/2= fun (Self, List) ->
-call 'beamtalk_set_ops':'from_list'(List)
+'fromList:'/2= fun (Self, _list8) ->
+call 'beamtalk_set_ops':'from_list'(_list8)
 
-'do:'/2= fun (Self, Block) ->
-call 'beamtalk_set_ops':'do'(Self, Block)
+'do:'/2= fun (Self, _block9) ->
+call 'beamtalk_set_ops':'do'(Self, _block9)
 
 'describe'/1= fun (Self) ->
 #{#<97>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<83>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']])}#

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_tuple_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_tuple_codegen.snap
@@ -19,8 +19,8 @@ module 'stdlib_class_tuple' ['new'/0, 'new'/1, 'size'/1, 'at:'/2, 'isOk'/1, 'isE
 'size'/1= fun (Self) ->
 call 'erlang':'tuple_size'(Self)
 
-'at:'/2= fun (Self, Index) ->
-call 'beamtalk_tuple_ops':'at'(Self, Index)
+'at:'/2= fun (Self, _index1) ->
+call 'beamtalk_tuple_ops':'at'(Self, _index1)
 
 'isOk'/1= fun (Self) ->
 case Self of <{'ok', _Value}> when 'true' -> 'true' <_> when 'true' -> 'false' end
@@ -31,11 +31,11 @@ case Self of <{'error', _Reason}> when 'true' -> 'true' <_> when 'true' -> 'fals
 'unwrap'/1= fun (Self) ->
 call 'beamtalk_tuple_ops':'unwrap'(Self)
 
-'unwrapOr:'/2= fun (Self, Default) ->
-call 'beamtalk_tuple_ops':'unwrap_or'(Self, Default)
+'unwrapOr:'/2= fun (Self, _default2) ->
+call 'beamtalk_tuple_ops':'unwrap_or'(Self, _default2)
 
-'unwrapOrElse:'/2= fun (Self, Block) ->
-call 'beamtalk_tuple_ops':'unwrap_or_else'(Self, Block)
+'unwrapOrElse:'/2= fun (Self, _block3) ->
+call 'beamtalk_tuple_ops':'unwrap_or_else'(Self, _block3)
 
 'asString'/1= fun (Self) ->
 call 'beamtalk_tuple_ops':'as_string'(Self)

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_codegen.snap
@@ -1,0 +1,109 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: core_erlang
+---
+module 'value_type_param_collision' ['new'/0, 'new'/1, 'compute:'/2, 'dispatch'/3, 'dispatch'/4, 'has_method'/1, 'superclass'/0, 'register_class'/0]
+  attributes ['on_load' = [{'register_class', 0}]]
+
+'new'/0 = fun () ->
+    ~{'$beamtalk_class' => 'ParamCollisionTest'}~
+
+
+'new'/1 = fun (InitArgs) ->
+    let DefaultState = call 'value_type_param_collision':'new'() in
+    call 'maps':'merge'(DefaultState, InitArgs)
+
+
+'compute:'/2= fun (Self, _seq01) ->
+    let _seq2 = call 'erlang':'+'(_seq01, 1) in
+    call 'erlang':'*'(_seq01, 2)
+
+'dispatch'/3 = fun (Selector, Args, Self) ->
+    case Selector of
+        <'class'> when 'true' ->
+            'ParamCollisionTest'
+        <'respondsTo:'> when 'true' ->
+            case Args of
+                <[RtSelector | _]> when 'true' -> call 'value_type_param_collision':'has_method'(RtSelector)
+                <_> when 'true' -> 'false'
+            end
+        <'instVarNames'> when 'true' ->
+            []
+        <'instVarAt:'> when 'true' ->
+            let <IvaErr0> = call 'beamtalk_error':'new'('immutable_value', 'ParamCollisionTest') in
+            let <IvaErr1> = call 'beamtalk_error':'with_selector'(IvaErr0, 'instVarAt:') in
+            let <IvaErr2> = call 'beamtalk_error':'with_hint'(IvaErr1, #{#<80>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<67>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<84>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<98>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<118>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<118>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<98>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']])}#) in
+            call 'beamtalk_error':'raise'(IvaErr2)
+        <'instVarAt:put:'> when 'true' ->
+            let <ImmErr0> = call 'beamtalk_error':'new'('immutable_value', 'ParamCollisionTest') in
+            let <ImmErr1> = call 'beamtalk_error':'with_selector'(ImmErr0, 'instVarAt:put:') in
+            let <ImmErr2> = call 'beamtalk_error':'with_hint'(ImmErr1, #{#<80>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<67>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<84>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<98>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<85>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<40>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<86>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<41>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']])}#) in
+            call 'beamtalk_error':'raise'(ImmErr2)
+        <'perform:'> when 'true' ->
+            let <PerfSel> = call 'erlang':'hd'(Args) in
+            call 'value_type_param_collision':'dispatch'(PerfSel, [], Self)
+        <'perform:withArguments:'> when 'true' ->
+            let <PwaSel> = call 'erlang':'hd'(Args) in
+            let <PwaArgs> = call 'erlang':'hd'(call 'erlang':'tl'(Args)) in
+            call 'value_type_param_collision':'dispatch'(PwaSel, PwaArgs, Self)
+        <'compute:'> when 'true' ->
+            let <DispArg0> = call 'erlang':'hd'(Args) in
+            call 'value_type_param_collision':'compute:'(Self, DispArg0)
+        <_Other> when 'true' ->
+            case call 'beamtalk_extensions':'lookup'('ParamCollisionTest', Selector) of
+                <{'ok', ExtFun, _ExtOwner}> when 'true' ->
+                    apply ExtFun(Args, Self)
+                <'not_found'> when 'true' ->
+                    call 'bt@stdlib@object':'dispatch'(Selector, Args, Self)
+            end
+    end
+
+
+'dispatch'/4 = fun (Selector, Args, Self, State) ->
+    try call 'value_type_param_collision':'dispatch'(Selector, Args, Self)
+    of <D4Result> -> {'reply', D4Result, State}
+    catch <_D4Type, D4Error, _D4Stack> -> {'error', D4Error, State}
+
+
+'has_method'/1 = fun (Selector) ->
+    case call 'lists':'member'(Selector, ['class', 'respondsTo:', 'instVarNames', 'instVarAt:', 'instVarAt:put:', 'perform:', 'perform:withArguments:', 'compute:']) of
+        <'true'> when 'true' -> 'true'
+        <'false'> when 'true' ->
+            case call 'beamtalk_extensions':'has'('ParamCollisionTest', Selector) of
+                <'true'> when 'true' -> 'true'
+                <'false'> when 'true' -> call 'bt@stdlib@object':'has_method'(Selector)
+            end
+    end
+
+
+'superclass'/0 = fun () -> 'Object'
+
+'register_class'/0 = fun () ->
+    try
+        let _Reg0 = case call 'beamtalk_object_class':'start'('ParamCollisionTest', ~{
+            'name' => 'ParamCollisionTest',
+            'module' => 'value_type_param_collision',
+            'superclass' => 'Object',
+            'is_sealed' => 'false',
+            'is_abstract' => 'false',
+            'instance_methods' => ~{'compute:' => ~{'arity' => 1, 'is_sealed' => 'false'}~}~,
+            'instance_variables' => [],
+            'class_methods' => ~{
+                'new' => ~{'arity' => 0}~,
+                'new:' => ~{'arity' => 1}~,
+                'superclass' => ~{'arity' => 0}~
+            }~,
+            'method_source' => ~{'compute:' => #{#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']])}#}~,
+            'class_variables' => ~{}~
+        }~) of
+            <{'ok', _Pid0}> when 'true' -> 'ok'
+            <{'error', {'already_started', _Existing0}}> when 'true' -> 'ok'
+            <{'error', _Reason0}> when 'true' -> 'ok'
+        end
+
+        in 'ok'
+    of RegResult -> RegResult
+    catch <CatchType, CatchError, CatchStack> -> 'ok'
+
+
+end

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_lexer.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_lexer.snap
@@ -1,0 +1,17 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+Token { kind: Identifier("Object"), span: Span { start: 445, end: 451 }, leading_trivia: [LineComment("// Copyright 2026 James Casey"), Whitespace("\n"), LineComment("// SPDX-License-Identifier: Apache-2.0"), Whitespace("\n\n"), LineComment("// Compiler snapshot test for BT-369: value-type temp var collision avoidance"), Whitespace("\n"), LineComment("//"), Whitespace("\n"), LineComment("// Verifies that method parameters with underscore-prefixed names (e.g., _seq0)"), Whitespace("\n"), LineComment("// don't collide with codegen-internal temp vars used for expression sequencing."), Whitespace("\n"), LineComment("// Both parameter binding and sequencing temp vars go through the fresh_var"), Whitespace("\n"), LineComment("// counter, ensuring unique Core Erlang variable names."), Whitespace("\n\n")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("subclass:"), span: Span { start: 452, end: 461 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("ParamCollisionTest"), span: Span { start: 462, end: 480 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("compute:"), span: Span { start: 758, end: 766 }, leading_trivia: [Whitespace("\n\n  "), LineComment("// Multi-expression method with a parameter named _seq0."), Whitespace("\n  "), LineComment("// Before BT-369, to_core_var kept \"_seq0\" verbatim while fresh_temp_var(\"seq\")"), Whitespace("\n  "), LineComment("// could produce \"_seq1\", \"_seq2\" — a near-miss that could collide if naming"), Whitespace("\n  "), LineComment("// conventions changed. Now both use the counter."), Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("_seq0"), span: Span { start: 767, end: 772 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 773, end: 775 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("_seq0"), span: Span { start: 780, end: 785 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("+"), span: Span { start: 786, end: 787 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("1"), span: Span { start: 788, end: 789 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("_seq0"), span: Span { start: 794, end: 799 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("*"), span: Span { start: 800, end: 801 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("2"), span: Span { start: 802, end: 803 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Eof, span: Span { start: 804, end: 804 }, leading_trivia: [Whitespace("\n")], trailing_trivia: [] }

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_parser.snap
@@ -1,0 +1,200 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+AST:
+Module {
+    classes: [
+        ClassDefinition {
+            name: Identifier {
+                name: "ParamCollisionTest",
+                span: Span {
+                    start: 462,
+                    end: 480,
+                },
+            },
+            superclass: Some(
+                Identifier {
+                    name: "Object",
+                    span: Span {
+                        start: 445,
+                        end: 451,
+                    },
+                },
+            ),
+            is_abstract: false,
+            is_sealed: false,
+            state: [],
+            methods: [
+                MethodDefinition {
+                    selector: Keyword(
+                        [
+                            KeywordPart {
+                                keyword: "compute:",
+                                span: Span {
+                                    start: 758,
+                                    end: 766,
+                                },
+                            },
+                        ],
+                    ),
+                    parameters: [
+                        Identifier {
+                            name: "_seq0",
+                            span: Span {
+                                start: 767,
+                                end: 772,
+                            },
+                        },
+                    ],
+                    body: [
+                        MessageSend {
+                            receiver: Identifier(
+                                Identifier {
+                                    name: "_seq0",
+                                    span: Span {
+                                        start: 780,
+                                        end: 785,
+                                    },
+                                },
+                            ),
+                            selector: Binary(
+                                "+",
+                            ),
+                            arguments: [
+                                Literal(
+                                    Integer(
+                                        1,
+                                    ),
+                                    Span {
+                                        start: 788,
+                                        end: 789,
+                                    },
+                                ),
+                            ],
+                            span: Span {
+                                start: 780,
+                                end: 789,
+                            },
+                        },
+                        MessageSend {
+                            receiver: Identifier(
+                                Identifier {
+                                    name: "_seq0",
+                                    span: Span {
+                                        start: 794,
+                                        end: 799,
+                                    },
+                                },
+                            ),
+                            selector: Binary(
+                                "*",
+                            ),
+                            arguments: [
+                                Literal(
+                                    Integer(
+                                        2,
+                                    ),
+                                    Span {
+                                        start: 802,
+                                        end: 803,
+                                    },
+                                ),
+                            ],
+                            span: Span {
+                                start: 794,
+                                end: 803,
+                            },
+                        },
+                    ],
+                    return_type: None,
+                    is_sealed: false,
+                    kind: Primary,
+                    doc_comment: None,
+                    span: Span {
+                        start: 758,
+                        end: 803,
+                    },
+                },
+            ],
+            class_methods: [],
+            class_variables: [],
+            doc_comment: None,
+            span: Span {
+                start: 445,
+                end: 803,
+            },
+        },
+    ],
+    expressions: [],
+    span: Span {
+        start: 445,
+        end: 803,
+    },
+    leading_comments: [
+        Comment {
+            content: "// Copyright 2026 James Casey",
+            span: Span {
+                start: 445,
+                end: 451,
+            },
+            kind: Line,
+        },
+        Comment {
+            content: "// SPDX-License-Identifier: Apache-2.0",
+            span: Span {
+                start: 445,
+                end: 451,
+            },
+            kind: Line,
+        },
+        Comment {
+            content: "// Compiler snapshot test for BT-369: value-type temp var collision avoidance",
+            span: Span {
+                start: 445,
+                end: 451,
+            },
+            kind: Line,
+        },
+        Comment {
+            content: "//",
+            span: Span {
+                start: 445,
+                end: 451,
+            },
+            kind: Line,
+        },
+        Comment {
+            content: "// Verifies that method parameters with underscore-prefixed names (e.g., _seq0)",
+            span: Span {
+                start: 445,
+                end: 451,
+            },
+            kind: Line,
+        },
+        Comment {
+            content: "// don't collide with codegen-internal temp vars used for expression sequencing.",
+            span: Span {
+                start: 445,
+                end: 451,
+            },
+            kind: Line,
+        },
+        Comment {
+            content: "// Both parameter binding and sequencing temp vars go through the fresh_var",
+            span: Span {
+                start: 445,
+                end: 451,
+            },
+            kind: Line,
+        },
+        Comment {
+            content: "// counter, ensuring unique Core Erlang variable names.",
+            span: Span {
+                start: 445,
+                end: 451,
+            },
+            kind: Line,
+        },
+    ],
+}

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_semantic.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_semantic.snap
@@ -1,0 +1,5 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+No semantic errors


### PR DESCRIPTION
## Summary

Fixes a potential variable name collision in value-type codegen where method parameters with underscore-prefixed names (e.g., `_seq0`) could collide with codegen-internal temp vars used for expression sequencing.

**Linear issue:** https://linear.app/beamtalk/issue/BT-369

## Changes

- **`value_type_codegen.rs`**: Replace `VariableContext::to_core_var()` with `self.fresh_var()` for parameter binding in `generate_value_type_method`, matching the pattern already used in actor codegen (`gen_server/methods.rs`). This routes all variable names through the counter, guaranteeing uniqueness.
- **New test case**: `value_type_param_collision` — a value-type class with a `_seq0` parameter and multi-expression method body, verifying the generated Core Erlang has unique variable names.
- **Updated snapshots**: 5 existing snapshots updated for the new parameter naming format (`to_core_var` style → `fresh_var` style).

## Root Cause

`generate_value_type_method` used `VariableContext::to_core_var()` (a static method with no counter) for parameter names, while `fresh_temp_var("seq")` used the counter for sequencing temp vars. A parameter like `_seq0` would keep its name verbatim, risking collision with counter-generated names like `_seq1`, `_seq2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential variable name collisions in code generation for value-type methods, ensuring generated code correctly handles method parameters alongside internal temporary variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->