### PR TITLE
Validate compilation latency improvement after Port migration (BT-548)

### DIFF
--- a/docs/development/perf-after-port.md
+++ b/docs/development/perf-after-port.md
@@ -58,7 +58,7 @@ Round-trip latency for evaluating expressions in a running REPL workspace.
 
 ### Port Backend (default)
 
-```
+```text
 TCP connect → JSON request → REPL server → Port protocol (ETF) →
 Rust compile → Core Erlang → Port response → BEAM compile:forms →
 execute → format result → JSON response → TCP response
@@ -72,7 +72,7 @@ execute → format result → JSON response → TCP response
 
 ### Daemon Backend (legacy)
 
-```
+```text
 TCP connect → JSON request → REPL server → Unix socket (JSON-RPC) →
 Rust compile → Core Erlang → daemon response → BEAM compile:forms →
 execute → format result → JSON response → TCP response
@@ -113,6 +113,9 @@ execute → format result → JSON response → TCP response
    Under load, it may reach ~2-5ms — still well within the <5ms target.
 
 ## Latency Breakdown (Estimated — Port Backend)
+
+These estimates are derived by subtracting measured phases from the total
+round-trip time, not from direct per-phase instrumentation.
 
 | Phase                          | Estimated (ms) | Notes |
 |--------------------------------|----------------|-------|


### PR DESCRIPTION
## Summary

Validates the compilation latency improvement after completing the OTP Port migration (ADR 0022, BT-543).

**Linear issue:** https://linear.app/beamtalk/issue/BT-548

## Key Results

| Metric | Before (BT-544) | Port (default) | Daemon (legacy) |
|--------|-----------------|----------------|-----------------|
| REPL p50 latency | ~50ms | ~29ms | ~28ms |
| File compilation p50 | ~260ms | ~253ms | ~252ms |
| Port overhead | N/A | <1ms (idle) | N/A |

### ADR 0022 Claims Verified
- ✅ Port overhead < 5ms per compilation (<1ms measured on idle machine)
- ✅ In-memory `compile:forms` ~20x faster than `erlc` subprocess
- ✅ Port provides fault isolation (compiler crash ≠ node crash)

### Key Finding
Both Port and daemon backends perform **identically** (~29ms p50) on an idle machine. The ~42% improvement vs baseline comes from the unified `beamtalk_compiler` module (BT-547), not the backend choice.

## Changes
- Added `docs/development/perf-after-port.md` with full benchmark comparison
- 50-iteration benchmarks for both Port and daemon backends (idle machine)
- REPL expression evaluation and file compilation measurements
- Comparison tables against BT-544 baseline