### PR TITLE
docs: ADR 0023 — String interpolation syntax (double quotes only, universal {expr}) BT-39

### DIFF
--- a/docs/ADR/0023-string-interpolation-and-binaries.md
+++ b/docs/ADR/0023-string-interpolation-and-binaries.md
@@ -18,7 +18,7 @@ Beamtalk needs string interpolation — the ability to embed expressions inside 
 - The **lexer** currently uses single quotes (`'...'`) for strings and double quotes (`"..."`) for "interpolated strings" — but this was a preliminary choice inherited from Smalltalk convention, not a deliberate design decision
 - The **parser, AST, and codegen** have no interpolation support
 - `test-package-compiler/cases/future_string_interpolation/main.bt` documents expected behavior
-- ~90 `.bt` files use single-quoted strings throughout
+- ~150 `.bt` files use single-quoted strings throughout
 
 ### Constraints
 
@@ -124,8 +124,7 @@ If `printString` is not understood by the receiver, the standard `doesNotUnderst
 
 ### REPL Session
 
-```
-> name := "Alice"
+```text
 Alice
 > "Hello, {name}!"
 Hello, Alice!
@@ -141,7 +140,7 @@ No braces here
 
 ### Error Examples
 
-```
+```text
 > "Hello, {undefined}"
 ERROR: UndefinedObject does not understand 'printString'
   Hint: Variable 'undefined' is not defined in this scope
@@ -336,7 +335,7 @@ literal := "Hello, {name}!"          // no prefix = no interpolation
 - No ambiguity with existing syntax — `{` inside `"..."` is lexed in string mode (separate from expression-level `{` for tuples/arrays)
 
 ### Negative
-- **Breaking change**: ~90 `.bt` files must be updated from `'...'` to `"..."` (mechanical find-replace, but large diff)
+- **Breaking change**: ~150 `.bt` files must be updated from `'...'` to `"..."` (mechanical find-replace, but large diff)
 - Departs from Smalltalk's single-quote convention — Smalltalk developers must adjust
 - Documentation overhaul: `beamtalk-syntax-rationale.md`, `beamtalk-language-features.md`, examples, tests, and `lib/*.bt` all reference single-quoted strings
 - `\{` escaping required for literal braces in strings — minor but new escape to learn
@@ -356,7 +355,7 @@ Since the language is pre-release with no external users, the quote change and i
 ### Phase 1: Quote Convention + Lexer/Parser
 - Update lexer: `"..."` becomes the sole string syntax, remove `'...'` string support
 - `#'quoted symbols'` remain valid (single quotes in symbol context only)
-- Mechanical `sed` to update all ~90 `.bt` files from `'...'` to `"..."`
+- Mechanical `sed` to update all ~150 `.bt` files from `'...'` to `"..."`
 - Enhance `"..."` lexing to detect `{expr}` segments via lexer mode-switching (track brace depth for nested expressions)
 - Reject empty `{}` as syntax error
 - Parse `{expr}` segments as embedded expressions
@@ -367,7 +366,7 @@ Since the language is pre-release with no external users, the quote change and i
 - Generate binary construction: `<<literal_bytes, (printString_result)/binary, ...>>`
 - Insert `printString` dispatch for non-literal segments via object system
 - Plain strings (no `{expr}`) compile to simple binary literals as today — zero overhead
-- Ensure `printString` is implemented on all stdlib classes (already done for 36+ classes)
+- Ensure `printString` is implemented on all stdlib classes (currently implemented on 18 core classes)
 - Update `tests/stdlib/string_interpolation.bt` and `test-package-compiler/cases/future_string_interpolation/main.bt`
 - **Affected**: `codegen/core_erlang/expressions.rs`, `lib/*.bt`, `tests/stdlib/`, `test-package-compiler/cases/`
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -49,7 +49,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0020](0020-connection-security.md) | Connection Security — mTLS, Proxies, and Network Overlays | Proposed | 2026-02-12 |
 | [0021](0021-streams-and-io-design.md) | Stream — Universal Data Interface | Accepted | 2026-02-12 |
 | [0022](0022-embedded-compiler-via-otp-port.md) | Embedded Compiler via OTP Port (with NIF option) | Accepted | 2026-02-14 |
-| [0023](0023-string-interpolation-and-binaries.md) | String Interpolation Syntax and Compilation | Proposed | 2026-02-14 |
+| [0023](0023-string-interpolation-and-binaries.md) | String Interpolation Syntax and Compilation | Accepted | 2026-02-15 |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## Summary

ADR 0023 proposes the string interpolation design for beamtalk:

1. **Double quotes only** — drop single-quoted strings entirely
2. **Universal interpolation** — every `"..."` string supports `{expr}`
3. **Binary compilation** — interpolation compiles to Erlang binary construction
4. **`printString` auto-conversion** — non-string values converted via object protocol

### Key Design Rationale

- **Modern convention**: Rust, Go, Swift, Kotlin all use double quotes — this is what developers expect
- **Eliminates Elixir's #1 gotcha**: The charlist/binary quote confusion. Elixir's own community [proposed deprecating single-quote charlists](https://groups.google.com/g/elixir-lang-core/c/_pAjPEayLLI)
- **No charlists in beamtalk**: There's no technical reason for two string types
- **Zero overhead**: Strings without `{expr}` compile identically to plain binary literals

### ADR Review (3-pass)

- **Pass 1 (Structural)**: Fixed file count (~180 → ~90), corrected Core Erlang dispatch example, added empty `{}` error case
- **Pass 2 (Reasoning)**: Added edge cases section, future syntax considerations (heredocs, raw strings), streamlined implementation from 5→3 phases
- **Pass 3 (Adversarial, claude-opus-4.5)**: Addressed tuple/array brace conflict (lexer mode-switching), bundling rationale, pre-release simplification

### Files Changed

- `docs/ADR/0023-string-interpolation-and-binaries.md` — new ADR
- `docs/ADR/README.md` — index entry

### Related

- Closes BT-39 (Define string interpolation syntax)
- References: ADR 0003, ADR 0021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR 0023 detailing new string interpolation rules: double-quoted strings with {expr} interpolation, binary-based compilation behavior, auto-conversion of non-string values, escape rules, error conditions, examples, and phased implementation plan.
  * Updated ADR index to include the new entry and migration guidance for adopting the convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->