### PR TITLE
Add Document API and clippy discipline rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1772,9 +1772,13 @@ write!(result, "let {var} = ").unwrap();
 
 // ✅ RIGHT - Document API (structural, composable)
 docvec![
-    Document::String(format!("call '{module}':'{function}'(")),
+    Document::String("call '".into()),
+    Document::String(module.clone()),
+    Document::String("':'".into()),
+    Document::String(function.clone()),
+    Document::String("'(".into()),
     args_doc,
-    Document::String(")".to_string()),
+    Document::String(")".into()),
 ]
 ```
 


### PR DESCRIPTION
## Summary

Adds two new development guidelines to AGENTS.md based on a full-repo code quality audit:

### Code Generation — Document API Only
- Includes examples of correct vs incorrect patterns

### Clippy Discipline
- Requires justification comments for all `#[allow(...)]` suppressions
- Target: reduce from 88 suppressions to <30
- Per-lint guidance: `too_many_lines` → split, `unnecessary_wraps` → fix type, `dead_code` → remove

## Context

Supports [BT-574: Codegen and Runtime Refactoring](https://linear.app/beamtalk/issue/BT-574) epic with 6 child issues tracking the cleanup work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Code Generation discipline section detailing the preferred API-based approach with comparative examples of incorrect vs. correct generation patterns.
  * Added a Clippy discipline section outlining suppression rules and examples for justified lint allowances.
  * Expanded the Logging Strategy section with clearer guidance and examples for choosing log macros and instrumentation practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->