### PR TITLE
ADR 0025: Gradual Typing and Protocols

### DIFF
--- a/docs/ADR/0025-gradual-typing-and-protocols.md
+++ b/docs/ADR/0025-gradual-typing-and-protocols.md
@@ -1,7 +1,7 @@
 # ADR 0025: Gradual Typing and Protocols
 
 ## Status
-Proposed (2026-02-15)
+Accepted (2026-02-15)
 
 ## Context
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -51,7 +51,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0022](0022-embedded-compiler-via-otp-port.md) | Embedded Compiler via OTP Port (with NIF option) | Implemented | 2026-02-15 |
 | [0023](0023-string-interpolation-and-binaries.md) | String Interpolation Syntax and Compilation | Accepted | 2026-02-15 |
 | [0024](0024-static-first-live-augmented-ide-tooling.md) | Static-First, Live-Augmented IDE Tooling | Accepted | 2026-02-15 |
-| [0025](0025-gradual-typing-and-protocols.md) | Gradual Typing and Protocols | Proposed | 2026-02-15 |
+| [0025](0025-gradual-typing-and-protocols.md) | Gradual Typing and Protocols | Accepted | 2026-02-15 |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## Summary

Proposes gradual typing and structural protocols for Beamtalk, implemented in four phases:

### Phase 1: Type Inference (Zero New Syntax)
Use existing class definitions to check message sends at compile time. `c decrement` → warning if Counter has no `decrement` method. No annotations needed.

### Phase 2: Optional Type Annotations
`state: balance: Integer = 0`, `getBalance -> Integer => ...`, parameter types on keyword messages. Generates Dialyzer `-spec` attributes in Core Erlang.

### Phase 3: Protocols (Structural Typing)
`Protocol define: Printable requiring: [asString]` — named message sets. Conformance is automatic and structural (like TypeScript interfaces).

### Phase 4: Advanced Types (Future)
Union types, generics, singleton types, type narrowing.

### Key Design Principles
- Types are **always optional** — nothing breaks
- **Warnings, not errors** — code always compiles
- **Compile-time only** — zero runtime cost
- **Structural** — compatibility by shape, not by name

### Prior Art
Strongtalk (protocol typing for Smalltalk), TypeScript (structural inference), Dylan (gradual + optimization), Gleam (full static on BEAM — rejected as too restrictive).

### References
- Supports ADR 0024 (IDE tooling depends on type information)
- Builds on existing infrastructure: TypeChecker stub, ClassHierarchy, TypeAnnotation AST

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR 0025: Gradual Typing and Protocols — outlines design principles, phased implementation (inference, optional annotations, typed classes, protocols, advanced features), per-class typing contracts, BEAM/Dialyzer integration, tooling, migration path, risk/mitigation, and references.
  * Updated ADR index to include [0025] Gradual Typing and Protocols (status: Proposed, date: 2026-02-15).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->