### PR TITLE
Fix standalone method definition after :load (BT-588)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
@@ -171,10 +171,13 @@ handle_load(Path, State) ->
                                     beamtalk_workspace_meta:update_activity(),
                                     
                                     %% BT-571: Store class source for method patching
+                                    %% ClassNames have string keys from compile_file,
+                                    %% but class_sources map uses binary keys
                                     NewState3 = lists:foldl(
                                         fun(#{name := Name}, AccState) ->
+                                            NameBin = list_to_binary(Name),
                                             beamtalk_repl_state:set_class_source(
-                                                Name, Source, AccState)
+                                                NameBin, Source, AccState)
                                         end,
                                         NewState2, ClassNames),
                                     

--- a/tests/e2e/cases/load_method_patch.bt
+++ b/tests/e2e/cases/load_method_patch.bt
@@ -1,0 +1,64 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E test for method patching on file-loaded classes (BT-588)
+//
+// Tests that standalone method definitions (>>) work on classes
+// loaded from files via :load, not just inline-defined classes.
+// This was broken because handle_load stored class sources with
+// string keys but handle_method_definition looked them up with
+// binary keys.
+
+// @load tests/e2e/fixtures/counter.bt
+
+// ===========================================================================
+// LOAD + USE CLASS
+// ===========================================================================
+
+// Spawn and use the file-loaded Counter
+c := Counter spawn
+// => #Actor<Counter,_>
+
+c increment
+// => 1
+
+c increment
+// => 2
+
+c getValue
+// => 2
+
+// ===========================================================================
+// PATCH METHOD ON FILE-LOADED CLASS
+// ===========================================================================
+
+// Replace increment to add 10 instead of 1
+Counter >> increment => self.value := self.value + 10
+// => _
+
+// New instances should use patched method
+c2 := Counter spawn
+// => #Actor<Counter,_>
+
+c2 increment
+// => 10
+
+c2 getValue
+// => 10
+
+// ===========================================================================
+// ADD NEW METHOD TO FILE-LOADED CLASS
+// ===========================================================================
+
+// Add a new method that didn't exist in the original file
+Counter >> doubleValue => ^self.value * 2
+// => _
+
+c3 := Counter spawn
+// => #Actor<Counter,_>
+
+c3 increment
+// => 10
+
+c3 doubleValue
+// => 20


### PR DESCRIPTION
## Summary

Fixes a bug where `Counter >> increment => ...` failed with "Class not found" after loading Counter from a file via `:load`.

**Linear issue:** https://linear.app/beamtalk/issue/BT-588

## Root Cause

`handle_load` stored class sources with **string** keys (Erlang lists) because `compile_file_via_port` converts names via `binary_to_list`. But `handle_method_definition` looked them up with **binary** keys from the compiler port. In Erlang, `"Counter" ≠ <<"Counter">>` in map lookups, so the class was never found.

The inline class path (`handle_class_definition`) worked because `compile_expression_via_port` passes class names as binaries directly from the compiler port.

## Changes

- **`beamtalk_repl_eval.erl`**: Convert `Name` to binary via `list_to_binary/1` before calling `set_class_source` in `handle_load`
- **`load_method_patch.bt`**: New E2E test covering load→patch method, load→add new method workflows

## Testing

- All CI checks pass (clippy, fmt, dialyzer, 1378 Rust tests, 1338 stdlib tests, 1329 runtime tests, 29 E2E tests)
- New E2E test verifies: load Counter from file, replace `increment` via `>>`, add new `doubleValue` method via `>>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed class source storage consistency for method patching operations.

* **Tests**
  * Added comprehensive end-to-end test coverage for loading classes from files, patching existing methods, and adding new methods to file-loaded classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->