### PR TITLE
Replace io:format with OTP logger macro in idle monitor (BT-580)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_idle_monitor.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_idle_monitor.erl
@@ -30,6 +30,7 @@
 
 -module(beamtalk_idle_monitor).
 -behaviour(gen_server).
+-include_lib("kernel/include/logger.hrl").
 
 %% Public API
 -export([start_link/1, mark_activity/0]).
@@ -101,7 +102,7 @@ handle_info(check_idle, State = #state{enabled = true, max_idle_seconds = MaxIdl
     %% Check if we should terminate
     case should_terminate(MaxIdle) of
         true ->
-            io:format(standard_error, "Workspace idle for >~p seconds, shutting down~n", [MaxIdle]),
+            ?LOG_WARNING("Workspace idle, shutting down", #{max_idle_seconds => MaxIdle}),
             %% Graceful shutdown - let supervisor tree clean up
             init:stop();
         false ->


### PR DESCRIPTION
## Summary


## Changes

- Added `-include_lib("kernel/include/logger.hrl")` to `beamtalk_idle_monitor.erl`
- Replaced `io:format(standard_error, "Workspace idle for >~p seconds, shutting down~n", [MaxIdle])` with `?LOG_WARNING("Workspace idle, shutting down", #{max_idle_seconds => MaxIdle})`

## Benefits

- Consistent with all other runtime modules using OTP logger
- Structured metadata map enables filtering/parsing
- Automatic MFA (module/function/arity) metadata in log output
- Log output captured by workspace file logging (BT-541)

## Testing

- All 1329 runtime tests pass
- All 1338 stdlib tests pass
- Dialyzer passes cleanly
- Full CI passes (clippy, fmt, tests, E2E)

## Linear Issue

https://linear.app/beamtalk/issue/BT-580

Part of refactoring epic BT-574.