### PR TITLE
ADR 0027: Windows Platform Support

### DIFF
--- a/docs/ADR/0027-cross-platform-support.md
+++ b/docs/ADR/0027-cross-platform-support.md
@@ -1,7 +1,7 @@
 # ADR 0027: Cross-Platform Support
 
 ## Status
-Proposed (2026-02-16)
+Accepted (2026-02-16)
 
 ## Context
 
@@ -286,6 +286,26 @@ Originally proposed abstracting all process operations behind a `ProcessManager`
 ## Migration Path
 
 Not applicable. This is an infrastructure enhancement — no existing user code, APIs, or language semantics change. All modifications are internal to the toolchain (CI configuration, build scripts, `#[cfg]` guards in workspace management).
+
+## Implementation Tracking
+
+**Epic:** [BT-609](https://linear.app/beamtalk/issue/BT-609)
+**Status:** Planned
+
+| Phase | Issue | Title | Size |
+|-------|-------|-------|------|
+| 1 | BT-610 | Fix cross-platform code issues (Rust + Erlang) | M |
+| 2 | BT-611 | Add TCP health and shutdown endpoints to workspace | L |
+| 2 | BT-612 | Replace process management with TCP probes and force-kill | L |
+| 3 | BT-613 | Add cross-platform CI and release workflow | M |
+
+**Dependency graph:**
+```
+BT-610 (code fixes)
+  ├── BT-611 (TCP endpoints) ──► BT-612 (TCP process mgmt)
+  │                                      │
+  └──────────────────────────────────────►├── BT-613 (CI + release)
+```
 
 ## References
 - Prior art: [Gleam Windows support](https://gleam.run), [Erlang Windows install](https://www.erlang.org/downloads)

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -53,7 +53,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0024](0024-static-first-live-augmented-ide-tooling.md) | Static-First, Live-Augmented IDE Tooling | Accepted | 2026-02-15 |
 | [0025](0025-gradual-typing-and-protocols.md) | Gradual Typing and Protocols | Accepted | 2026-02-15 |
 | [0026](0026-package-definition-and-project-manifest.md) | Package Definition and Project Manifest | Accepted | 2026-02-16 |
-| [0027](0027-cross-platform-support.md) | Cross-Platform Support | Proposed | 2026-02-16 |
+| [0027](0027-cross-platform-support.md) | Cross-Platform Support | Accepted | 2026-02-16 |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## Summary

Proposes a tiered approach to Windows platform support for Beamtalk.

### Three Tiers

| Tier | Scope | Status |
|------|-------|--------|
| **Tier 1** | Compiler + build command | Already mostly portable (pure Rust) |
| **Tier 2** | Workspace + REPL | Needs `ProcessManager` trait abstraction |
| **Tier 3** | Build scripts + dev tooling | Justfile, rebar3 hooks, CI scripts |

### Key Decisions

- **No WSL requirement** — native Windows support via `#[cfg]` attributes
- **ProcessManager trait** — abstracts platform-specific process operations
- **Tiered rollout** — ship portable parts immediately, iterate on the rest
- **Same crate structure** — no separate Windows build

### Prior Art

Follows the Gleam model: Rust compiler is inherently portable, platform differences only in process management. Compares against Gleam, Elixir, Cargo, and Erlang/OTP approaches.

### Inventory

Includes detailed audit of all Unix-specific code across the codebase with file locations and current fallback status.

---

*Docs-only change — ADR 0027 and README index update.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Marked the package-definition/project-manifest ADR as Accepted.
  * Added a new ADR proposing a cross-platform support roadmap for Linux, Windows, and macOS with tiered readiness levels, phased rollout, process-management and observability guidance, migration stance (no user-facing API changes), and success criteria including CI and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->