### PR TITLE
chore: add .app.src to .gitattributes for consistent LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 *.erl text eol=lf
 *.hrl text eol=lf
 *.core text eol=lf
+*.app.src text eol=lf
 
 # Shell scripts
 *.sh text eol=lf


### PR DESCRIPTION
Erlang OTP application source files (.app.src) should use LF line endings
consistently with other Erlang source files (.erl, .hrl, .core).

This fixes an issue where runtime/apps/beamtalk_stdlib/src/beamtalk_stdlib.app.src
was being flagged as modified due to line ending conversion on Windows with
core.autocrlf=true.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to standardize line ending handling for specific file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->