### PR TITLE
Deploy stdlib API docs to GitHub Pages via CI (BT-617)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,93 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+name: Deploy API Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'lib/**'
+      - 'crates/beamtalk-cli/src/commands/doc.rs'
+      - 'crates/beamtalk-core/src/codegen/core_erlang/doc_chunks.rs'
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Erlang/OTP
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '27.0'
+          rebar3-version: '3.23'
+
+      - name: Install Just
+        uses: extractions/setup-just@v3
+
+      - name: Cache Erlang/rebar3 artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/rebar3
+            runtime/_build
+            ~/.rebar3
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.23
+          restore-keys: |
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.23
+            ${{ runner.os }}-erlang-otp-27.0-
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build compiler
+        run: just build-rust
+
+      - name: Build Erlang runtime
+        run: just build-erlang
+
+      - name: Build standard library
+        run: just build-stdlib
+
+      - name: Generate API documentation
+        run: cargo run --bin beamtalk -- doc lib/ --output _site/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ _rel/
 # Build outputs
 /build/
 /lib/build/
+/docs/api/
 *.backup
 *.crashdump
 _bt_stdlib_*.txt

--- a/Justfile
+++ b/Justfile
@@ -688,6 +688,11 @@ docs:
     @echo "📚 Generating Rust documentation..."
     cargo doc --workspace --no-deps --open
 
+# Generate stdlib API documentation (HTML)
+docs-api:
+    @echo "📚 Generating stdlib API documentation..."
+    cargo run --bin beamtalk -- doc lib/ --output docs/api/
+
 # Check documentation for broken links
 docs-check:
     @echo "🔍 Checking documentation..."

--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ BEAMTALK_NODE_NAME=beamtalk_custom@localhost
 ## Documentation
 
 📚 **[Documentation Index](docs/README.md)** — Start here for a guided tour
+🌐 **[API Reference](https://jamesc.github.io/beamtalk/)** — Standard library API docs (auto-generated)
 
 ### Core Documents
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to automatically build and deploy stdlib API documentation to GitHub Pages on every push to main.

**Linear issue:** https://linear.app/beamtalk/issue/BT-617

## Changes

- **`.github/workflows/docs.yml`** — New workflow with build + deploy jobs
  - Triggers on push to `main` when `lib/**`, `doc.rs`, or `doc_chunks.rs` change
  - Supports manual trigger via `workflow_dispatch`
  - Uses same Rust/Erlang/Just setup as CI
  - Deploys to GitHub Pages via `actions/deploy-pages@v4`
- **`Justfile`** — Added `docs-api` recipe for local doc generation
- **`README.md`** — Added link to hosted API docs at `https://jamesc.github.io/beamtalk/`
- **`.gitignore`** — Added `/docs/api/` to prevent local doc output from being committed

## Notes

- Requires GitHub Pages to be enabled in repo settings (Source: GitHub Actions)
- Docs will be available at `https://jamesc.github.io/beamtalk/`
- Dependency BT-616 (improve doc HTML output) is already Done ✅