### PR TITLE
Test coverage: primitive ops modules (BT-622)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_character_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_character_tests.erl
@@ -160,6 +160,24 @@ print_string_basic_test() ->
     ?assertEqual(<<"$0">>, beamtalk_character:print_string($0)).
 
 %%% ============================================================================
+%%% as_string/1 and print_string/1 Edge Cases
+%%% ============================================================================
+
+%% Negative and out-of-range codepoints raise function_clause
+%% (guards reject them — no matching clause exists)
+as_string_negative_test() ->
+    ?assertError(function_clause, beamtalk_character:as_string(-1)).
+
+as_string_out_of_range_test() ->
+    ?assertError(function_clause, beamtalk_character:as_string(16#110000)).
+
+print_string_negative_test() ->
+    ?assertError(function_clause, beamtalk_character:print_string(-1)).
+
+print_string_out_of_range_test() ->
+    ?assertError(function_clause, beamtalk_character:print_string(16#110000)).
+
+%%% ============================================================================
 %%% value/1 Tests
 %%% ============================================================================
 

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_list_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_list_tests.erl
@@ -301,10 +301,11 @@ index_of_not_found_test() ->
 
 each_with_index_test() ->
     Self = self(),
-    beamtalk_list_ops:each_with_index([a, b, c], fun(Elem, Idx) -> Self ! {Elem, Idx} end),
-    ?assertEqual({a, 1}, receive M1 -> M1 after 100 -> timeout end),
-    ?assertEqual({b, 2}, receive M2 -> M2 after 100 -> timeout end),
-    ?assertEqual({c, 3}, receive M3 -> M3 after 100 -> timeout end).
+    Ref = make_ref(),
+    beamtalk_list_ops:each_with_index([a, b, c], fun(Elem, Idx) -> Self ! {Ref, Elem, Idx} end),
+    ?assertEqual({a, 1}, receive {Ref, Elem1, Idx1} -> {Elem1, Idx1} after 100 -> timeout end),
+    ?assertEqual({b, 2}, receive {Ref, Elem2, Idx2} -> {Elem2, Idx2} after 100 -> timeout end),
+    ?assertEqual({c, 3}, receive {Ref, Elem3, Idx3} -> {Elem3, Idx3} after 100 -> timeout end).
 
 each_with_index_returns_nil_test() ->
     ?assertEqual(nil, beamtalk_list_ops:each_with_index([1, 2], fun(_, _) -> ok end)).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_tuple_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_tuple_tests.erl
@@ -184,10 +184,11 @@ primitive_send_as_string_test() ->
 
 do_iterates_elements_test() ->
     Self = self(),
-    beamtalk_tuple_ops:do({a, b, c}, fun(X) -> Self ! X end),
-    ?assertEqual(a, receive Msg1 -> Msg1 after 100 -> timeout end),
-    ?assertEqual(b, receive Msg2 -> Msg2 after 100 -> timeout end),
-    ?assertEqual(c, receive Msg3 -> Msg3 after 100 -> timeout end).
+    Ref = make_ref(),
+    beamtalk_tuple_ops:do({a, b, c}, fun(X) -> Self ! {Ref, X} end),
+    ?assertEqual(a, receive {Ref, Msg1} -> Msg1 after 100 -> timeout end),
+    ?assertEqual(b, receive {Ref, Msg2} -> Msg2 after 100 -> timeout end),
+    ?assertEqual(c, receive {Ref, Msg3} -> Msg3 after 100 -> timeout end).
 
 do_returns_nil_test() ->
     ?assertEqual(nil, beamtalk_tuple_ops:do({1, 2, 3}, fun(_) -> ok end)).


### PR DESCRIPTION
## Summary

Adds EUnit tests to improve combined coverage for the four lowest-coverage primitive ops modules, as part of Epic BT-621 (Erlang runtime test coverage >80%).

## Changes

### New: `beamtalk_character_tests.erl` (28 tests)
- All 10 character functions: is_letter, is_digit, is_uppercase, is_lowercase, is_whitespace, to_uppercase, to_lowercase, as_string, print_string, value
- Edge cases: negative codepoints, surrogate range (0xD800-0xDFFF), out-of-range (>0x10FFFF)
- Error path: value/1 with invalid codepoints raises structured `type_error`

### Extended: `beamtalk_tuple_tests.erl` (+3 tests)
- `do/2` iteration: element ordering, nil return, empty tuple

### Extended: `beamtalk_list_tests.erl` (+20 tests)  
- Error paths: detect, detect_if_none, do, reject, zip, group_by, partition, each_with_index, sort_with with non-function/non-list arguments
- Happy paths: from_to, index_of, each_with_index iteration with ordering verification
- Edge cases: zip with uneven/empty lists, from_to with End < Start

**Total: 31 new EUnit tests (1332 → 1363), all passing**

## Linear Issue
https://linear.app/beamtalk/issue/BT-622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for character operations including type validation, case conversion, and error handling
  * Added comprehensive test suite for list operations covering error paths and edge cases
  * Enhanced tuple operation testing for iteration and side-effect validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->