### PR TITLE
Add REPL docs for Metaclass and class objects (BT-618)

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_docs_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_docs_tests.erl
@@ -166,24 +166,31 @@ format_class_docs_metaclass_test() ->
     ?assert(binary:match(Result, <<"== Metaclass ==">>)  =/= nomatch).
 
 format_metaclass_method_doc_known_test() ->
-    Result = beamtalk_repl_docs:format_metaclass_method_doc(<<"spawn">>),
+    {ok, Result} = beamtalk_repl_docs:format_metaclass_method_doc(<<"spawn">>),
     ?assert(binary:match(Result, <<"Metaclass >> spawn">>)  =/= nomatch),
     ?assert(binary:match(Result, <<"actor">>)               =/= nomatch).
 
 format_metaclass_method_doc_new_test() ->
-    Result = beamtalk_repl_docs:format_metaclass_method_doc(<<"new">>),
+    {ok, Result} = beamtalk_repl_docs:format_metaclass_method_doc(<<"new">>),
     ?assert(binary:match(Result, <<"Metaclass >> new">>)       =/= nomatch),
     ?assert(binary:match(Result, <<"new instance">>)           =/= nomatch).
 
 format_metaclass_method_doc_unknown_test() ->
-    Result = beamtalk_repl_docs:format_metaclass_method_doc(<<"unknownMethod">>),
-    ?assert(binary:match(Result, <<"Metaclass >> unknownMethod">>)  =/= nomatch),
-    ?assert(binary:match(Result, <<"terminal sentinel">>)           =/= nomatch).
+    ?assertMatch(
+        {error, {method_not_found, 'Metaclass', <<"unknownMethod">>}},
+        beamtalk_repl_docs:format_metaclass_method_doc(<<"unknownMethod">>)
+    ).
 
 format_method_doc_metaclass_test() ->
     ?assertMatch({ok, _}, beamtalk_repl_docs:format_method_doc('Metaclass', <<"spawn">>)),
     {ok, Result} = beamtalk_repl_docs:format_method_doc('Metaclass', <<"spawn">>),
     ?assert(binary:match(Result, <<"Metaclass >> spawn">>)  =/= nomatch).
+
+format_method_doc_metaclass_unknown_test() ->
+    ?assertMatch(
+        {error, {method_not_found, 'Metaclass', <<"unknownMethod">>}},
+        beamtalk_repl_docs:format_method_doc('Metaclass', <<"unknownMethod">>)
+    ).
 
 %%====================================================================
 %% EEP-48 doc chunk tests (require stdlib .beam files)

--- a/tests/e2e/cases/help_docs.bt
+++ b/tests/e2e/cases/help_docs.bt
@@ -28,3 +28,7 @@
 // :help Metaclass with a known class-side method (BT-618)
 :help Metaclass spawn
 // => Metaclass >> spawn_
+
+// :help Metaclass with unknown method — should show error (BT-618)
+:help Metaclass nonExistentMethod
+// => ERROR: Metaclass does not understand nonExistentMethod


### PR DESCRIPTION
## Summary

Adds REPL documentation for the Metaclass terminal sentinel, fixing `:help Metaclass` which previously returned `class_not_found`.

**Linear issue:** https://linear.app/beamtalk/issue/BT-618

## Changes

- **`beamtalk_repl_docs.erl`**: Add special case in `format_class_docs/1` and `format_method_doc/2` for `'Metaclass'` atom before registry lookup
- **`format_metaclass_docs/0`**: Returns documentation explaining the metaclass concept, terminal sentinel, and common class-side methods (new, spawn, spawnWith:, describe)
- **`format_metaclass_method_doc/1`**: Returns method-specific docs for known class-side selectors
- **Unit tests**: 7 new tests covering class docs, method docs (known/unknown), and public API entry points
- **E2E tests**: 2 new assertions verifying `:help Metaclass` and `:help Metaclass spawn` in the REPL