### PR TITLE
LSP: stdlib hover profile notes and VS Code server-path fallback (BT-633)

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -74,7 +74,7 @@ function resolveServerPath(context: vscode.ExtensionContext): ResolvedServerPath
 
     warning =
       `Configured beamtalk.server.path does not exist: ${override}. ` +
-      "Falling back to bundled beamtalk-lsp.";
+      "Falling back to bundled beamtalk-lsp (or PATH if bundled binary is missing).";
     // Path-like override was invalid: warn and fall through to bundled/PATH.
   }
 


### PR DESCRIPTION
## Linear Issue
https://linear.app/beamtalk/issue/BT-633

## Summary
Complete BT-633 by preserving fallback behavior for invalid path-like `beamtalk.server.path` while still surfacing a warning in VS Code output logs.

## Key Changes
- Keep invalid path-like override warning, but continue resolving bundled/PATH fallback in `resolveServerPath`.
- Thread `warning` through bundled and PATH return branches so startup logs include the warning.
- Remove dead legacy override branch logic that returned early with empty server path.

## Validation
- `cargo test -p beamtalk-lsp`
- `just build-vscode`
- `just ci`
- `just coverage` (Rust line coverage 75.17%, Erlang total coverage 62%)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warning messages are now surfaced in the output channel when configured server path overrides are invalid or missing, clarifying why the extension falls back to bundled or PATH servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->