### PR TITLE
Refactor: Erlang runtime — remove dead code, DRY error builders and type dispatch (BT-636)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -272,10 +272,12 @@ async_send(ActorPid, stop, [], FuturePid) ->
             beamtalk_future:resolve(FuturePid, ok);
         exit:Reason ->
             %% Other stop failures (e.g., timeout) - reject Future deterministically
-            Error0 = beamtalk_error:new(actor_dead, unknown),
-            Error1 = beamtalk_error:with_selector(Error0, stop),
-            Error2 = beamtalk_error:with_hint(Error1, iolist_to_binary(io_lib:format("Actor stop failed: ~p", [Reason]))),
-            beamtalk_future:reject(FuturePid, Error2)
+            Error = beamtalk_error:new(
+                actor_dead,
+                unknown,
+                stop,
+                iolist_to_binary(io_lib:format("Actor stop failed: ~p", [Reason]))),
+            beamtalk_future:reject(FuturePid, Error)
     end,
     ok;
 async_send(ActorPid, monitor, [], FuturePid) ->
@@ -360,10 +362,12 @@ sync_send(ActorPid, Selector, Args) ->
 %% @doc Construct a structured actor_dead error for the given selector.
 -spec actor_dead_error(atom()) -> {error, #beamtalk_error{}}.
 actor_dead_error(Selector) ->
-    Error0 = beamtalk_error:new(actor_dead, unknown),
-    Error1 = beamtalk_error:with_selector(Error0, Selector),
-    Error2 = beamtalk_error:with_hint(Error1, <<"Use 'isAlive' to check, or use monitors for lifecycle events">>),
-    {error, Error2}.
+    Error = beamtalk_error:new(
+        actor_dead,
+        unknown,
+        Selector,
+        <<"Use 'isAlive' to check, or use monitors for lifecycle events">>),
+    {error, Error}.
 
 %%% gen_server callbacks
 
@@ -530,8 +534,7 @@ dispatch(Selector, Args, Self, State) ->
                     dispatch(TargetSelector, [], Self, State);
                 false ->
                     ClassName = beamtalk_tagged_map:class_of(State, unknown),
-                    Error0 = beamtalk_error:new(type_error, ClassName),
-                    Error = beamtalk_error:with_selector(Error0, 'perform:'),
+                    Error = beamtalk_error:new(type_error, ClassName, 'perform:'),
                     {error, Error, State}
             end;
         'perform:withArguments:' when length(Args) =:= 2 ->
@@ -542,8 +545,7 @@ dispatch(Selector, Args, Self, State) ->
                     dispatch(TargetSelector, ArgList, Self, State);
                 false ->
                     ClassName = beamtalk_tagged_map:class_of(State, unknown),
-                    Error0 = beamtalk_error:new(type_error, ClassName),
-                    Error = beamtalk_error:with_selector(Error0, 'perform:withArguments:'),
+                    Error = beamtalk_error:new(type_error, ClassName, 'perform:withArguments:'),
                     {error, Error, State}
             end;
         _ ->
@@ -567,20 +569,7 @@ dispatch_user_method(Selector, Args, Self, State) ->
                     %% Preserve structured beamtalk errors from method implementations
                     {error, BtError, State};
                 Class:Reason:_Stacktrace ->
-                    %% Non-beamtalk exception - wrap with context
-                    ?LOG_ERROR("Error in method", #{
-                        selector => Selector,
-                        class => Class,
-                        reason => Reason
-                    }),
-                    ClassName = beamtalk_tagged_map:class_of(State, unknown),
-                    Error0 = beamtalk_error:new(type_error, ClassName),
-                    Error1 = beamtalk_error:with_selector(Error0, Selector),
-                    Error = beamtalk_error:with_details(Error1, #{
-                        original_class => Class,
-                        original_reason => Reason
-                    }),
-                    {error, Error, State}
+                    wrap_method_error(Selector, State, Class, Reason)
             end;
         {ok, Fun} when is_function(Fun, 2) ->
             %% Old-style method: Fun(Args, State) - for backward compatibility
@@ -591,26 +580,12 @@ dispatch_user_method(Selector, Args, Self, State) ->
                     %% Preserve structured beamtalk errors from method implementations
                     {error, BtError, State};
                 Class:Reason:_Stacktrace ->
-                    %% Non-beamtalk exception - wrap with context
-                    ?LOG_ERROR("Error in method", #{
-                        selector => Selector,
-                        class => Class,
-                        reason => Reason
-                    }),
-                    ClassName = beamtalk_tagged_map:class_of(State, unknown),
-                    Error0 = beamtalk_error:new(type_error, ClassName),
-                    Error1 = beamtalk_error:with_selector(Error0, Selector),
-                    Error = beamtalk_error:with_details(Error1, #{
-                        original_class => Class,
-                        original_reason => Reason
-                    }),
-                    {error, Error, State}
+                    wrap_method_error(Selector, State, Class, Reason)
             end;
         {ok, _NotAFunction} ->
             %% Method value is not a function
             ClassName = beamtalk_tagged_map:class_of(State, unknown),
-            Error0 = beamtalk_error:new(type_error, ClassName),
-            Error = beamtalk_error:with_selector(Error0, Selector),
+            Error = beamtalk_error:new(type_error, ClassName, Selector),
             {error, Error, State};
         error ->
             %% Method not found - try doesNotUnderstand
@@ -633,16 +608,7 @@ handle_dnu(Selector, Args, Self, State) ->
                 DnuFun([Selector, Args], Self, State)
             catch
                 Class:Reason:_Stacktrace ->
-                    %% DNU handler threw an exception - log without stack trace to avoid leaking sensitive data
-                    ?LOG_ERROR("Error in doesNotUnderstand handler", #{
-                        selector => Selector,
-                        class => Class,
-                        reason => Reason
-                    }),
-                    ClassName = beamtalk_tagged_map:class_of(State, unknown),
-                    Error0 = beamtalk_error:new(type_error, ClassName),
-                    Error = beamtalk_error:with_selector(Error0, 'doesNotUnderstand:args:'),
-                    {error, Error, State}
+                    wrap_dnu_handler_error(Selector, State, Class, Reason)
             end;
         {ok, DnuFun} when is_function(DnuFun, 2) ->
             %% Old-style DNU handler (backward compatibility)
@@ -650,16 +616,7 @@ handle_dnu(Selector, Args, Self, State) ->
                 DnuFun([Selector, Args], State)
             catch
                 Class:Reason:_Stacktrace ->
-                    %% DNU handler threw an exception - log without stack trace to avoid leaking sensitive data
-                    ?LOG_ERROR("Error in doesNotUnderstand handler", #{
-                        selector => Selector,
-                        class => Class,
-                        reason => Reason
-                    }),
-                    ClassName = beamtalk_tagged_map:class_of(State, unknown),
-                    Error0 = beamtalk_error:new(type_error, ClassName),
-                    Error = beamtalk_error:with_selector(Error0, 'doesNotUnderstand:args:'),
-                    {error, Error, State}
+                    wrap_dnu_handler_error(Selector, State, Class, Reason)
             end;
         _ ->
             %% No DNU handler — delegate to class hierarchy walk (BT-427)
@@ -707,9 +664,45 @@ handle_dnu(Selector, Args, Self, State) ->
 %% @doc Create a does_not_understand error result.
 -spec make_dnu_error(atom(), atom(), map()) -> {error, term(), map()}.
 make_dnu_error(Selector, ClassName, State) ->
-    Error0 = beamtalk_error:new(does_not_understand, ClassName),
-    Error1 = beamtalk_error:with_selector(Error0, Selector),
-    Error = beamtalk_error:with_hint(Error1, <<"Check spelling or use 'respondsTo:' to verify method exists">>),
+    Error = beamtalk_error:new(
+        does_not_understand,
+        ClassName,
+        Selector,
+        <<"Check spelling or use 'respondsTo:' to verify method exists">>),
+    {error, Error, State}.
+
+%% @private
+%% @doc Wrap method dispatch exceptions as type_error with source exception details.
+-spec wrap_method_error(atom(), map(), term(), term()) -> {error, term(), map()}.
+wrap_method_error(Selector, State, Class, Reason) ->
+    ?LOG_ERROR("Error in method", #{
+        selector => Selector,
+        class => Class,
+        reason => Reason
+    }),
+    ClassName = beamtalk_tagged_map:class_of(State, unknown),
+    Error0 = beamtalk_error:new(type_error, ClassName, Selector),
+    Error = beamtalk_error:with_details(Error0, #{
+        original_class => Class,
+        original_reason => Reason
+    }),
+    {error, Error, State}.
+
+%% @private
+%% @doc Wrap doesNotUnderstand handler exceptions consistently for both arities.
+-spec wrap_dnu_handler_error(atom(), map(), term(), term()) -> {error, term(), map()}.
+wrap_dnu_handler_error(Selector, State, Class, Reason) ->
+    ?LOG_ERROR("Error in doesNotUnderstand handler", #{
+        selector => Selector,
+        class => Class,
+        reason => Reason
+    }),
+    ClassName = beamtalk_tagged_map:class_of(State, unknown),
+    Error0 = beamtalk_error:new(type_error, ClassName, 'doesNotUnderstand:args:'),
+    Error = beamtalk_error:with_details(Error0, #{
+        original_class => Class,
+        original_reason => Reason
+    }),
     {error, Error, State}.
 
 %% @private
@@ -724,4 +717,3 @@ object_fallback(Selector, Args, Self, State, ClassName) ->
         Result ->
             Result
     end.
-

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_error.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_error.erl
@@ -14,6 +14,8 @@
 
 -export([
     new/2,
+    new/3,
+    new/4,
     with_message/2,
     with_selector/2,
     with_hint/2,
@@ -44,6 +46,16 @@ new(Kind, Class) ->
         hint = undefined,
         details = #{}
     }.
+
+%% @doc Create a new error with kind, class, and selector.
+-spec new(atom(), atom(), atom()) -> #beamtalk_error{}.
+new(Kind, Class, Selector) ->
+    with_selector(new(Kind, Class), Selector).
+
+%% @doc Create a new error with kind, class, selector, and hint.
+-spec new(atom(), atom(), atom(), binary()) -> #beamtalk_error{}.
+new(Kind, Class, Selector, Hint) ->
+    with_hint(new(Kind, Class, Selector), Hint).
 
 %% @doc Set the message on an existing error.
 %%

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl
@@ -231,20 +231,19 @@ send(#beamtalk_object{pid = Pid}, Selector, Args) ->
     %% Actor: use gen_server
     gen_server:call(Pid, {Selector, Args});
 send(X, Selector, Args) when is_integer(X) ->
-    %% Primitive: static dispatch to class module (ADR 0016)
-    'bt@stdlib@integer':dispatch(Selector, Args, X);
+    dispatch_via_module(X, Selector, Args);
 send(X, Selector, Args) when is_binary(X) ->
-    'bt@stdlib@string':dispatch(Selector, Args, X);
+    dispatch_via_module(X, Selector, Args);
 send(X, Selector, Args) when X =:= true ->
-    'bt@stdlib@true':dispatch(Selector, Args, X);
+    dispatch_via_module(X, Selector, Args);
 send(X, Selector, Args) when X =:= false ->
-    'bt@stdlib@false':dispatch(Selector, Args, X);
+    dispatch_via_module(X, Selector, Args);
 send(nil, Selector, Args) ->
-    'bt@stdlib@undefined_object':dispatch(Selector, Args, nil);
+    dispatch_via_module(nil, Selector, Args);
 send(X, Selector, Args) when is_atom(X) ->
-    'bt@stdlib@symbol':dispatch(Selector, Args, X);
+    dispatch_via_module(X, Selector, Args);
 send(X, Selector, Args) when is_function(X) ->
-    'bt@stdlib@block':dispatch(Selector, Args, X);
+    dispatch_via_module(X, Selector, Args);
 send(X, Selector, Args) when is_tuple(X) ->
     %% Check if it's a beamtalk_object (should not happen - covered by clause above)
     %% but handle tuples that might not match the record pattern
@@ -256,24 +255,24 @@ send(X, Selector, Args) when is_tuple(X) ->
             gen_server:call(Pid, {Selector, Args});
         false ->
             %% Regular tuple - dispatch to tuple class
-            'bt@stdlib@tuple':dispatch(Selector, Args, X)
+            dispatch_via_module(X, Selector, Args)
     end;
 send(X, Selector, Args) when is_float(X) ->
-    'bt@stdlib@float':dispatch(Selector, Args, X);
+    dispatch_via_module(X, Selector, Args);
 send(X, Selector, Args) when is_map(X) ->
     %% Check for tagged maps (CompiledMethod, value type instances, plain maps)
     case beamtalk_tagged_map:class_of(X) of
         'CompiledMethod' ->
-            'bt@stdlib@compiled_method':dispatch(Selector, Args, X);
+            dispatch_via_module(X, Selector, Args);
         'Association' ->
             %% BT-335: Association value type - direct dispatch (ADR 0016)
-            'bt@stdlib@association':dispatch(Selector, Args, X);
+            dispatch_via_module(X, Selector, Args);
         'Set' ->
             %% BT-73: Set value type - dispatch to compiled stdlib
-            'bt@stdlib@set':dispatch(Selector, Args, X);
+            dispatch_via_module(X, Selector, Args);
         'Stream' ->
             %% BT-511: Stream value type - dispatch to compiled stdlib
-            'bt@stdlib@stream':dispatch(Selector, Args, X);
+            dispatch_via_module(X, Selector, Args);
         'FileHandle' ->
             %% BT-513: FileHandle - dispatch to beamtalk_file runtime
             case Selector of
@@ -295,13 +294,13 @@ send(X, Selector, Args) when is_map(X) ->
             end;
         'TestCase' ->
             %% BT-438: TestCase value type - dispatch to compiled stdlib
-            'bt@stdlib@test_case':dispatch(Selector, Args, X);
+            dispatch_via_module(X, Selector, Args);
         'StackFrame' ->
             %% BT-107: StackFrame value type - dispatch to runtime
             beamtalk_stack_frame:dispatch(Selector, Args, X);
         undefined ->
             %% Plain map (Dictionary) — BT-418: compiled stdlib dispatch
-            'bt@stdlib@dictionary':dispatch(Selector, Args, X);
+            dispatch_via_module(X, Selector, Args);
         Class ->
             case beamtalk_exception_handler:is_exception_class(Class) of
                 true ->
@@ -314,7 +313,7 @@ send(X, Selector, Args) when is_map(X) ->
     end;
 send(X, Selector, Args) when is_list(X) ->
     %% List/Array dispatch
-    'bt@stdlib@list':dispatch(Selector, Args, X);
+    dispatch_via_module(X, Selector, Args);
 send(X, Selector, _Args) ->
     %% Other primitives: dispatch to generic handler
     Class = class_of(X),
@@ -342,19 +341,19 @@ responds_to(#beamtalk_object{class_mod = Mod}, Selector) ->
     %% Actor: check if module exports has_method/1
     erlang:function_exported(Mod, has_method, 1) andalso Mod:has_method(Selector);
 responds_to(X, Selector) when is_integer(X) ->
-    'bt@stdlib@integer':has_method(Selector);
+    responds_via_module(X, Selector);
 responds_to(X, Selector) when is_binary(X) ->
-    'bt@stdlib@string':has_method(Selector);
+    responds_via_module(X, Selector);
 responds_to(X, Selector) when X =:= true ->
-    'bt@stdlib@true':has_method(Selector);
+    responds_via_module(X, Selector);
 responds_to(X, Selector) when X =:= false ->
-    'bt@stdlib@false':has_method(Selector);
+    responds_via_module(X, Selector);
 responds_to(nil, Selector) ->
-    'bt@stdlib@undefined_object':has_method(Selector);
+    responds_via_module(nil, Selector);
 responds_to(X, Selector) when is_atom(X) ->
-    'bt@stdlib@symbol':has_method(Selector);
+    responds_via_module(X, Selector);
 responds_to(X, Selector) when is_function(X) ->
-    'bt@stdlib@block':has_method(Selector);
+    responds_via_module(X, Selector);
 responds_to(X, Selector) when is_tuple(X) ->
     %% Check if it's a beamtalk_object (should not happen - covered by clause above)
     case tuple_size(X) >= 2 andalso element(1, X) =:= beamtalk_object of
@@ -364,23 +363,23 @@ responds_to(X, Selector) when is_tuple(X) ->
             erlang:function_exported(Mod, has_method, 1) andalso Mod:has_method(Selector);
         false ->
             %% Regular tuple
-            'bt@stdlib@tuple':has_method(Selector)
+            responds_via_module(X, Selector)
     end;
 responds_to(X, Selector) when is_float(X) ->
-    'bt@stdlib@float':has_method(Selector);
+    responds_via_module(X, Selector);
 responds_to(X, Selector) when is_map(X) ->
     case beamtalk_tagged_map:class_of(X) of
         'CompiledMethod' ->
-            'bt@stdlib@compiled_method':has_method(Selector);
+            responds_via_module(X, Selector);
         'Association' ->
             %% BT-335: Association value type (ADR 0016)
-            'bt@stdlib@association':has_method(Selector);
+            responds_via_module(X, Selector);
         'Set' ->
             %% BT-73: Set value type
-            'bt@stdlib@set':has_method(Selector);
+            responds_via_module(X, Selector);
         'Stream' ->
             %% BT-511: Stream value type
-            'bt@stdlib@stream':has_method(Selector);
+            responds_via_module(X, Selector);
         'StackFrame' ->
             %% BT-107: StackFrame value type
             beamtalk_stack_frame:has_method(Selector);
@@ -389,7 +388,7 @@ responds_to(X, Selector) when is_map(X) ->
             beamtalk_file:handle_has_method(Selector) orelse
                 beamtalk_object_ops:has_method(Selector);
         undefined ->
-            'bt@stdlib@dictionary':has_method(Selector);
+            responds_via_module(X, Selector);
         Class ->
             case beamtalk_exception_handler:is_exception_class(Class) of
                 true ->
@@ -401,10 +400,62 @@ responds_to(X, Selector) when is_map(X) ->
             end
     end;
 responds_to(X, Selector) when is_list(X) ->
-    'bt@stdlib@list':has_method(Selector);
+    responds_via_module(X, Selector);
 responds_to(_, _) ->
     %% Other primitives: no methods yet
     false.
+
+%% @private
+%% @doc Dispatch a value using its mapped stdlib module.
+-spec dispatch_via_module(term(), atom(), list()) -> term().
+dispatch_via_module(X, Selector, Args) ->
+    case module_for_value(X) of
+        undefined ->
+            Class = class_of(X),
+            Error = beamtalk_error:new(
+                does_not_understand,
+                Class,
+                Selector,
+                <<"Primitive type does not support this message">>),
+            beamtalk_error:raise(Error);
+        Mod ->
+            Mod:dispatch(Selector, Args, X)
+    end.
+
+%% @private
+%% @doc Check method support using the mapped stdlib module.
+-spec responds_via_module(term(), atom()) -> boolean().
+responds_via_module(X, Selector) ->
+    case module_for_value(X) of
+        undefined -> false;
+        Mod -> Mod:has_method(Selector)
+    end.
+
+%% @private
+%% @doc Map a runtime value to its stdlib dispatch module.
+-spec module_for_value(term()) -> atom() | undefined.
+module_for_value(X) when is_integer(X) -> 'bt@stdlib@integer';
+module_for_value(X) when is_binary(X) -> 'bt@stdlib@string';
+module_for_value(true) -> 'bt@stdlib@true';
+module_for_value(false) -> 'bt@stdlib@false';
+module_for_value(nil) -> 'bt@stdlib@undefined_object';
+module_for_value(X) when is_atom(X) -> 'bt@stdlib@symbol';
+module_for_value(X) when is_function(X) -> 'bt@stdlib@block';
+module_for_value(X) when is_tuple(X) -> 'bt@stdlib@tuple';
+module_for_value(X) when is_float(X) -> 'bt@stdlib@float';
+module_for_value(X) when is_list(X) -> 'bt@stdlib@list';
+module_for_value(X) when is_map(X) ->
+    case beamtalk_tagged_map:class_of(X) of
+        'CompiledMethod' -> 'bt@stdlib@compiled_method';
+        'Association' -> 'bt@stdlib@association';
+        'Set' -> 'bt@stdlib@set';
+        'Stream' -> 'bt@stdlib@stream';
+        'TestCase' -> 'bt@stdlib@test_case';
+        undefined -> 'bt@stdlib@dictionary';
+        _ -> undefined
+    end;
+module_for_value(_) ->
+    undefined.
 
 %%% ============================================================================
 %%% Internal: Value Type Dispatch (BT-354)

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_dispatch_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_dispatch_tests.erl
@@ -63,11 +63,10 @@ dispatch_test_() ->
           {"dispatch errors are always 2-tuples", fun test_error_tuple_shape/0},
           {"super finds inherited reflection method", fun test_super_finds_inherited/0},
           {"responds_to existing method", fun test_responds_to_existing_method/0},
-          {"responds_to missing method", fun test_responds_to_missing_method/0},
-          {"responds_to nonexistent class", fun test_responds_to_nonexistent_class/0},
-          {"responds_to inherited method", fun test_responds_to_inherited_method/0},
-          {"invoke_with_combinations delegates", fun test_invoke_with_combinations_delegates/0},
-          {"extension error propagation", fun test_extension_error_propagation/0},
+           {"responds_to missing method", fun test_responds_to_missing_method/0},
+           {"responds_to nonexistent class", fun test_responds_to_nonexistent_class/0},
+           {"responds_to inherited method", fun test_responds_to_inherited_method/0},
+           {"extension error propagation", fun test_extension_error_propagation/0},
           {"responds_to extension method", fun test_responds_to_extension_method/0},
           {"BT-283: flattened table performance", fun test_flattened_table_performance/0},
           {"BT-283: flattened table memory overhead", fun test_flattened_table_memory_overhead/0},
@@ -323,20 +322,6 @@ test_responds_to_inherited_method() ->
     ok = ensure_counter_loaded(),
     %% 'class' is defined in Object (inherited through Actor -> Counter)
     ?assert(beamtalk_dispatch:responds_to(class, 'Counter')).
-
-%% Test invoke_with_combinations delegates to lookup (placeholder implementation)
-test_invoke_with_combinations_delegates() ->
-    ok = ensure_counter_loaded(),
-
-    State = #{
-        '$beamtalk_class' => 'Counter',
-        'value' => 0
-    },
-    Self = make_ref(),
-
-    %% invoke_with_combinations should behave same as lookup (TODO: combinations not implemented)
-    Result = beamtalk_dispatch:invoke_with_combinations(increment, [], Self, State, 'Counter'),
-    ?assertMatch({reply, _Result, _NewState}, Result).
 
 %% Test extension method error propagation
 test_extension_error_propagation() ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_error_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_error_tests.erl
@@ -14,6 +14,25 @@ new_creates_error_with_kind_and_class_test() ->
     ?assertEqual(undefined, Error#beamtalk_error.hint),
     ?assertEqual(#{}, Error#beamtalk_error.details).
 
+%%% Test: Create error with new/3
+new3_creates_error_with_selector_test() ->
+    Error = beamtalk_error:new(does_not_understand, 'Integer', 'foo'),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind),
+    ?assertEqual('Integer', Error#beamtalk_error.class),
+    ?assertEqual('foo', Error#beamtalk_error.selector),
+    ?assertEqual(undefined, Error#beamtalk_error.hint),
+    ?assertEqual(<<"Integer does not understand 'foo'">>, Error#beamtalk_error.message).
+
+%%% Test: Create error with new/4
+new4_creates_error_with_selector_and_hint_test() ->
+    Hint = <<"Check spelling">>,
+    Error = beamtalk_error:new(does_not_understand, 'Integer', 'foo', Hint),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind),
+    ?assertEqual('Integer', Error#beamtalk_error.class),
+    ?assertEqual('foo', Error#beamtalk_error.selector),
+    ?assertEqual(Hint, Error#beamtalk_error.hint),
+    ?assertEqual(<<"Integer does not understand 'foo'">>, Error#beamtalk_error.message).
+
 %%% Test: with_selector/2 adds selector and updates message
 with_selector_adds_selector_test() ->
     Error0 = beamtalk_error:new(does_not_understand, 'Integer'),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_object_class_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_object_class_tests.erl
@@ -527,55 +527,6 @@ whereis_nonexistent_class_test() ->
     ?assertEqual(undefined, Result).
 
 %%====================================================================
-%% BT-344: Super dispatch tests
-%%====================================================================
-
-super_dispatch_missing_class_field_test_() ->
-    {setup,
-     fun setup/0,
-     fun teardown/1,
-     fun(_) ->
-         [?_test(begin
-              %% State without $beamtalk_class field
-              State = #{value => 0},
-              Result = beamtalk_object_class:super_dispatch(State, increment, []),
-              ?assertMatch({error, #beamtalk_error{kind = internal_error}}, Result)
-          end)]
-     end}.
-
-super_dispatch_class_not_found_test_() ->
-    {setup,
-     fun setup/0,
-     fun teardown/1,
-     fun(_) ->
-         [?_test(begin
-              %% State with class that doesn't exist
-              State = #{'$beamtalk_class' => 'NonexistentClass999'},
-              Result = beamtalk_object_class:super_dispatch(State, increment, []),
-              ?assertMatch({error, #beamtalk_error{kind = class_not_found, class = 'NonexistentClass999'}}, Result)
-          end)]
-     end}.
-
-super_dispatch_no_superclass_test_() ->
-    {setup,
-     fun setup/0,
-     fun teardown/1,
-     fun(_) ->
-         [?_test(begin
-              %% Create a root class (no superclass)
-              ClassInfo = #{
-                  name => 'RootTestClass',
-                  module => test_class,
-                  superclass => none
-              },
-              {ok, _Pid} = beamtalk_object_class:start_link('RootTestClass', ClassInfo),
-              State = #{'$beamtalk_class' => 'RootTestClass'},
-              Result = beamtalk_object_class:super_dispatch(State, someMethod, []),
-              ?assertMatch({error, #beamtalk_error{kind = no_superclass, class = 'RootTestClass', selector = someMethod}}, Result)
-          end)]
-     end}.
-
-%%====================================================================
 %% BT-344: create_subclass tests
 %%====================================================================
 


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-636

## Summary
Refactor Erlang runtime internals for dead-code removal and reduced duplication while preserving behavior.

## Key changes
- Added beamtalk_error convenience constructors new/3 and new/4 with tests.
- Removed dead/deprecated runtime APIs in beamtalk_dispatch and beamtalk_object_class.
- DRYed primitive module dispatch and actor method/DNU error wrapping helpers.
- Updated runtime tests to remove dead-path coverage and verify new constructors.

## Validation
- just ci
- just coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages with richer context information for better debugging.
  * Enhanced error propagation consistency across method dispatch and error handling paths.

* **Removed Features**
  * Removed method combinations feature from dispatch.
  * Removed deprecated public APIs for class introspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->