### PR TITLE
LSP go-to-definition: resolve selector target with receiver class context (BT-634)

### DIFF
--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -905,6 +905,37 @@ mod tests {
     }
 
     #[test]
+    fn goto_definition_method_with_self_receiver_resolves_in_class() {
+        let mut service = SimpleLanguageService::new();
+        let file_foo = Utf8PathBuf::from("foo.bt");
+
+        service.update_file(
+            file_foo.clone(),
+            "Object subclass: Foo\n  ping => self other\n  other => 1".to_string(),
+        );
+
+        let def = service.goto_definition(&file_foo, Position::new(1, 15));
+        assert!(def.is_some());
+        assert_eq!(def.unwrap().file, file_foo);
+    }
+
+    #[test]
+    fn goto_definition_method_with_super_receiver_resolves_in_superclass() {
+        let mut service = SimpleLanguageService::new();
+        let file_hierarchy = Utf8PathBuf::from("hierarchy.bt");
+
+        service.update_file(
+            file_hierarchy.clone(),
+            "Object subclass: Foo\n  other => 1\nFoo subclass: Bar\n  ping => super other"
+                .to_string(),
+        );
+
+        let def = service.goto_definition(&file_hierarchy, Position::new(3, 16));
+        assert!(def.is_some());
+        assert_eq!(def.unwrap().file, file_hierarchy);
+    }
+
+    #[test]
     fn find_references_selector_cross_file_unary() {
         let mut service = SimpleLanguageService::new();
         let file_a = Utf8PathBuf::from("a.bt");

--- a/crates/beamtalk-core/src/queries/definition_provider.rs
+++ b/crates/beamtalk-core/src/queries/definition_provider.rs
@@ -339,6 +339,14 @@ pub fn find_selector_in_expr(expr: &Expression, offset: u32) -> Option<(EcoStrin
 }
 
 /// Find selector lookup details at a given byte offset in an expression.
+///
+/// Returns a [`SelectorLookup`] containing:
+/// - full selector name,
+/// - selector span under the cursor, and
+/// - receiver hint used for context-aware method resolution.
+///
+/// Unlike [`find_selector_in_expr`], this API keeps receiver metadata so
+/// callers can resolve class-side/instance-side selector targets.
 pub fn find_selector_lookup_in_expr(expr: &Expression, offset: u32) -> Option<SelectorLookup> {
     let span = expr.span();
     if offset < span.start() || offset >= span.end() {


### PR DESCRIPTION
## Summary
- Use receiver class context for selector go-to-definition when available
- Resolve class-side vs instance-side selector targets based on receiver context
- Make ambiguous selector fallback deterministic and add conflict coverage tests

## Links
- Linear: https://linear.app/beamtalk/issue/BT-634/lsp-go-to-definition-resolve-selector-target-with-receiver-class

## Key Changes
- Added selector lookup metadata with receiver hints in definition provider
- Added receiver-context-aware cross-file method definition resolution
- Added deterministic lexical fallback behavior for ambiguous selectors
- Added language service tests for inferred receiver, class-side receiver, and deterministic fallback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced go-to-definition with context-aware receiver resolution for improved navigation accuracy
  * Improved cross-file method definition lookup with support for class-side and instance method disambiguation
  * Better handling of self and super receiver references
  * More deterministic behavior for ambiguous receiver contexts

* **Tests**
  * Added comprehensive test coverage for complex cross-file definition and reference resolution scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->