### PR TITLE
Refactor: Fix REPL user input panics & tighten internal API visibility (BT-641)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/block_context.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_context.rs
@@ -21,17 +21,12 @@ use crate::source_analysis::Span;
 ///
 /// # Examples
 ///
+/// ```text
+/// is_control_flow_selector("whileTrue:", 0)  // true
+/// is_control_flow_selector("to:do:", 1)      // true
+/// is_control_flow_selector("at:put:", 0)     // false
 /// ```
-/// # use beamtalk_core::semantic_analysis::block_context::is_control_flow_selector;
-/// assert!(is_control_flow_selector("whileTrue:", 0));
-/// assert!(is_control_flow_selector("to:do:", 1));
-/// assert!(is_control_flow_selector("ifTrue:ifFalse:", 0));
-/// assert!(is_control_flow_selector("ifTrue:ifFalse:", 1));
-/// assert!(is_control_flow_selector("on:do:", 1));
-/// assert!(is_control_flow_selector("ensure:", 0));
-/// assert!(!is_control_flow_selector("at:put:", 0));
-/// ```
-pub fn is_control_flow_selector(selector: &str, arg_index: usize) -> bool {
+pub(crate) fn is_control_flow_selector(selector: &str, arg_index: usize) -> bool {
     match selector {
         // Loop constructs - block at index 0
         "whileTrue:" | "whileFalse:" | "timesRepeat:" | "do:" | "collect:" | "select:"
@@ -54,19 +49,21 @@ pub fn is_control_flow_selector(selector: &str, arg_index: usize) -> bool {
 /// Determines if an expression is a block variable (identifier).
 ///
 /// Returns true if the expression is an identifier that could be a block variable.
-pub fn is_block_variable(expr: &Expression) -> bool {
+#[allow(dead_code)] // Used by classify_block, which is tested but not yet called from production code
+pub(crate) fn is_block_variable(expr: &Expression) -> bool {
     matches!(expr, Expression::Identifier(_))
 }
 
 /// Determines if an expression is a literal block.
 ///
 /// Returns true if the expression is a block literal (not a block variable).
-pub fn is_literal_block(expr: &Expression) -> bool {
+#[allow(dead_code)] // Used by classify_block, which is tested but not yet called from production code
+pub(crate) fn is_literal_block(expr: &Expression) -> bool {
     matches!(expr, Expression::Block(_))
 }
 
 /// Extracts the selector string from a message selector.
-pub fn selector_to_string(selector: &MessageSelector) -> String {
+pub(crate) fn selector_to_string(selector: &MessageSelector) -> String {
     match selector {
         MessageSelector::Unary(name) => name.to_string(),
         MessageSelector::Binary(op) => op.to_string(),
@@ -106,22 +103,16 @@ pub fn selector_to_string(selector: &MessageSelector) -> String {
 ///
 /// # Examples
 ///
-/// ```
-/// # use beamtalk_core::semantic_analysis::block_context::classify_block;
-/// # use beamtalk_core::semantic_analysis::BlockContext;
-/// # use beamtalk_core::ast::{Expression, Block, MessageSelector, Identifier};
-/// # use beamtalk_core::source_analysis::Span;
+/// ```text
 /// // Control flow: literal block in whileTrue:
 /// // [x < 10] whileTrue: [x := x + 1]
 /// // The argument block [x := x + 1] is ControlFlow
 ///
 /// // Stored: block on RHS of assignment
 /// // myBlock := [x + 1]
-/// // let block_expr = Expression::Block(...);
-/// // let context = classify_block(block_expr.span(), &parent, true);
-/// // assert_eq!(context, BlockContext::Stored);
 /// ```
-pub fn classify_block(
+#[allow(dead_code)] // Tested but not yet called from production code
+pub(crate) fn classify_block(
     block_span: Span,
     parent_expr: &Expression,
     in_assignment: bool,

--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -17,14 +17,14 @@ use crate::source_analysis::{Diagnostic, Span};
 use ecow::EcoString;
 use std::collections::HashMap;
 
-pub mod block_context;
+pub(crate) mod block_context;
 pub mod class_hierarchy;
 pub mod error;
 pub(crate) mod method_validators;
 pub mod module_validator;
 pub mod name_resolver;
 pub mod primitive_validator;
-pub mod scope;
+pub(crate) mod scope;
 pub mod type_checker;
 
 pub use class_hierarchy::ClassHierarchy;

--- a/crates/beamtalk-core/src/semantic_analysis/name_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/name_resolver.rs
@@ -55,7 +55,8 @@ impl NameResolver {
 
     /// Returns a reference to the current scope.
     #[must_use]
-    pub fn scope(&self) -> &Scope {
+    #[allow(dead_code)] // Accessor for future analysis phases
+    pub(crate) fn scope(&self) -> &Scope {
         &self.scope
     }
 
@@ -64,7 +65,7 @@ impl NameResolver {
     /// This allows the scope to be passed to other analysis phases (e.g., Analyser)
     /// without duplicating scope construction.
     #[must_use]
-    pub fn into_scope(self) -> Scope {
+    pub(crate) fn into_scope(self) -> Scope {
         self.scope
     }
 


### PR DESCRIPTION
## Summary

Fixes REPL command parser safety and tightens internal API surface.

**Linear:** https://linear.app/beamtalk/issue/BT-641

## Changes

### REPL Error Handling
- Extracted `extract_command_arg()` helper function that safely parses REPL command arguments using `strip_prefix().or_else().unwrap_or("")` instead of `unwrap()`
- Replaced all 9 `strip_prefix().unwrap()` calls with the safe helper
- Zero production `unwrap()` calls remain in REPL code
- Added 7 unit tests for edge cases (empty args, whitespace, no match, short/long prefix)

### API Surface Tightening
- Changed 5 public functions in `block_context.rs` to `pub(crate)`
- Changed `Scope`, `Binding` structs and all 10 methods in `scope.rs` to `pub(crate)`
- Tightened `block_context` and `scope` module visibility to `pub(crate)`
- `BindingKind` enum remains `pub` (re-exported from `mod.rs`)
- Verified no external crate consumers are affected

### Files Modified
- `crates/beamtalk-cli/src/commands/repl/mod.rs`
- `crates/beamtalk-core/src/semantic_analysis/block_context.rs`
- `crates/beamtalk-core/src/semantic_analysis/mod.rs`
- `crates/beamtalk-core/src/semantic_analysis/name_resolver.rs`
- `crates/beamtalk-core/src/semantic_analysis/scope.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated command argument parsing logic in the CLI to reduce code duplication.
  * Restricted internal API visibility to reduce the public surface area and tighten internal dependencies.

* **Chores**
  * Added dead code annotations on internal components used only in testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->