### PR TITLE
Add proptest compiler-port round-trip error properties (BT-364)

### DIFF
--- a/crates/beamtalk-compiler-port/Cargo.toml
+++ b/crates/beamtalk-compiler-port/Cargo.toml
@@ -23,5 +23,9 @@ beamtalk-core = { workspace = true }
 # why: encode/decode Erlang External Term Format for compiler port protocol
 eetf = "0.11"
 
+[dev-dependencies]
+# why: property-based testing for compiler port robustness (ADR 0011 Phase 4)
+proptest = { workspace = true }
+
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Adds property-based tests for the `beamtalk-compiler-port` crate, ensuring `handle_compile()` and `handle_compile_expression()` never panic on arbitrary input and always return well-formed ETF responses.

**Linear issue:** https://linear.app/beamtalk/issue/BT-364

## Changes

- **`crates/beamtalk-compiler-port/Cargo.toml`** — Added `proptest` as dev-dependency (workspace reference)
- **`crates/beamtalk-compiler-port/src/main.rs`** — Added `#[cfg(test)] mod property_tests` with 6 properties:

### Properties

| Property | Description |
|----------|-------------|
| 1a: `compile_never_panics` | Arbitrary string → `handle_compile()` returns valid status |
| 1b: `compile_expression_never_panics` | Arbitrary string → `handle_compile_expression()` returns valid status |
| 1c: `compile_never_panics_near_valid` | Near-valid structured input → never panics |
| 1d: `compile_expression_never_panics_near_valid` | Near-valid structured input → never panics |
| 2: `error_responses_have_diagnostics` | Error responses always have non-empty diagnostics list |
| 3: `diagnostics_are_nonempty_strings` | All diagnostic entries are non-empty valid UTF-8 |

All 6 properties pass in ~1s (512 cases each). Part of `just test-rust`.

ADR 0011 Phase 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive property-based test suite to validate compiler stability and error handling under varied inputs.

* **Chores**
  * Updated development dependencies to support property-based testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->