### PR TITLE
Compiler optimization: direct BEAM calls for Erlang interop (BT-682)

### DIFF
--- a/tests/stdlib/erlang_interop.bt
+++ b/tests/stdlib/erlang_interop.bt
@@ -1,8 +1,10 @@
 // Copyright 2026 James Casey
 // SPDX-License-Identifier: Apache-2.0
 
-// Stdlib tests for Erlang interop (ADR 0028, BT-677)
-// Tests inline proxy construction and erlang:apply dispatch.
+// Stdlib tests for Erlang interop (ADR 0028, BT-677, BT-682)
+// Tests direct call optimization (BT-682) and cached proxy dispatch.
+// Direct calls: `Erlang lists reverse: xs` → `call 'lists':'reverse'(Xs)`
+// Cached proxy: `proxy := Erlang lists; proxy reverse: xs` → runtime dispatch
 
 // ===========================================================================
 // MODULE PROXY CONSTRUCTION
@@ -86,4 +88,28 @@ proxy isNil
 // => false
 
 proxy notNil
+// => true
+
+// ===========================================================================
+// BT-682: DIRECT CALL vs PROXY EQUIVALENCE
+// ===========================================================================
+// Verify optimized (direct call) and unoptimized (cached proxy) paths
+// produce identical results.
+
+// Single-arg keyword: direct vs proxy
+directResult := Erlang lists reverse: #(1, 2, 3)
+// => _
+proxyLists := Erlang lists
+// => _
+proxyResult := proxyLists reverse: #(1, 2, 3)
+// => _
+directResult =:= proxyResult
+// => true
+
+// Multi-arg keyword: direct vs proxy
+directSeq := Erlang lists seq: 1 with: 5
+// => _
+proxySeq := proxyLists seq: 1 with: 5
+// => _
+directSeq =:= proxySeq
 // => true


### PR DESCRIPTION
## Summary

Implements ADR 0028 Phase 4: compiler optimization that detects `Erlang <module> <function>` patterns at compile time and emits direct `call 'module':'function'(args)` Core Erlang — eliminating proxy map allocation entirely.

**Linear issue:** https://linear.app/beamtalk/issue/BT-682

## Key Changes

- **Pattern detection** in `try_handle_erlang_interop`: detects chained `MessageSend(ClassReference("Erlang"), Unary(module))` as receiver and emits direct calls
- **Direct call generation** via new `generate_direct_erlang_call` helper:
  - Zero-arg: `Erlang erlang node` → `call 'erlang':'node'()`
  - Single keyword: `Erlang lists reverse: xs` → `call 'lists':'reverse'(Xs)`
  - Multi keyword: `Erlang lists seq: 1 with: 10` → `call 'lists':'seq'(1, 10)`
- **Protocol selector exclusion**: `printString`, `asString`, `inspect` fall through to runtime dispatch (not optimized as Erlang calls)
- **Backward compatibility**: Standalone proxy (`Erlang lists`) and cached proxy (`proxy := Erlang lists; proxy reverse: xs`) unchanged

## Tests

- 6 codegen unit tests (keyword single/multi-arg, zero-arg, standalone proxy, cached proxy, protocol selector exclusion)
- 6 stdlib equivalence tests verifying direct call and proxy dispatch produce identical results
- Full CI passes: 1128 Rust, 1556 stdlib, 1879 runtime, integration, MCP, E2E

## Files Changed

- `crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs` — Pattern detection + direct call generation
- `crates/beamtalk-core/src/codegen/core_erlang/tests.rs` — 6 new codegen tests
- `tests/stdlib/erlang_interop.bt` — 6 new equivalence tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized Erlang function calls with direct BEAM invocation when possible, reducing overhead while maintaining proxy-based fallback for complex scenarios.

* **Tests**
  * Added comprehensive test coverage validating direct call optimization paths, cached proxy dispatch, and protocol selector behavior in Erlang interop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->