### PR TITLE
Fix on:do: wrapping of Erlang exit/throw as ExitError/ThrowError (BT-728)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/exception_handling.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/exception_handling.rs
@@ -24,8 +24,8 @@
 //! of _Result -> _Result
 //! catch <_Type, _Error, _RawStack> ->
 //!     let _BuiltStack = primop 'build_stacktrace'(_RawStack) in
-//!     let _ExObj = call 'beamtalk_exception_handler':'ensure_wrapped'(_Error, _BuiltStack) in
-//!     case matches_class(ExClass, Error) of
+//!     let _ExObj = call 'beamtalk_exception_handler':'ensure_wrapped'(_Type, _Error, _BuiltStack) in
+//!     case matches_class(ExClass, ExObj) of
 //!         true  -> apply _HandlerFun (_ExObj)
 //!         false -> primop 'raw_raise'(_Type, _Error, _RawStack)
 //! ```
@@ -136,11 +136,11 @@ impl CoreErlangGenerator {
             )),
             Document::String(format!(
                 "let {ex_obj_var} = call 'beamtalk_exception_handler':'ensure_wrapped'\
-                 ({error_var}, {built_stack_var}) in "
+                 ({type_var}, {error_var}, {built_stack_var}) in "
             )),
             Document::String(format!(
                 "let {match_var} = call 'beamtalk_exception_handler':'matches_class'\
-                 ({ex_class_var}, {error_var}) in "
+                 ({ex_class_var}, {ex_obj_var}) in "
             )),
             Document::String(format!("case {match_var} of ")),
             Document::Str("<'true'> when 'true' -> "),
@@ -168,8 +168,8 @@ impl CoreErlangGenerator {
     /// of StateAfterTry -> StateAfterTry
     /// catch <Type, Error, RawStack> ->
     ///     let BuiltStack = primop 'build_stacktrace'(RawStack) in
-    ///     let ExObj = call 'beamtalk_exception_handler':'ensure_wrapped'(Error, BuiltStack) in
-    ///     let Match = call 'beamtalk_exception_handler':'matches_class'(ExClass, Error) in
+    ///     let ExObj = call 'beamtalk_exception_handler':'ensure_wrapped'(Type, Error, BuiltStack) in
+    ///     let Match = call 'beamtalk_exception_handler':'matches_class'(ExClass, ExObj) in
     ///     case Match of
     ///         true  -> let _e = ExObj in <handler body with threading> StateAccM
     ///         false -> primop 'raw_raise'(Type, Error, RawStack)
@@ -226,11 +226,11 @@ impl CoreErlangGenerator {
             )),
             Document::String(format!(
                 "let {ex_obj_var} = call 'beamtalk_exception_handler':'ensure_wrapped'\
-                 ({error_var}, {built_stack_var}) in "
+                 ({type_var}, {error_var}, {built_stack_var}) in "
             )),
             Document::String(format!(
                 "let {match_var} = call 'beamtalk_exception_handler':'matches_class'\
-                 ({ex_class_var}, {error_var}) in "
+                 ({ex_class_var}, {ex_obj_var}) in "
             )),
             Document::String(format!("case {match_var} of ")),
             Document::Str("<'true'> when 'true' -> "),

--- a/tests/stdlib/erlang_exceptions.bt
+++ b/tests/stdlib/erlang_exceptions.bt
@@ -60,3 +60,35 @@
 // ThrowError signal preserves kind as signal
 [ThrowError new signal: "test"] on: Exception do: [:e | e kind]
 // => signal
+
+// ===========================================================================
+// ERLANG FFI EXIT/THROW — ACTUAL BEAM EXCEPTIONS (BT-728)
+// ===========================================================================
+
+// Erlang exit caught by ExitError handler
+[Erlang erlang exit: 1] on: ExitError do: [:e | e message]
+// => 1
+
+// Erlang exit caught by BEAMError handler (superclass)
+[Erlang erlang exit: 1] on: BEAMError do: [:e | e message]
+// => 1
+
+// Erlang exit caught by Error handler (ancestor)
+[Erlang erlang exit: 1] on: Error do: [:e | e message]
+// => 1
+
+// Erlang throw caught by ThrowError handler
+[Erlang erlang throw: 1] on: ThrowError do: [:e | e message]
+// => 1
+
+// Erlang throw caught by BEAMError handler (superclass)
+[Erlang erlang throw: 1] on: BEAMError do: [:e | e message]
+// => 1
+
+// Erlang throw caught by Error handler (ancestor)
+[Erlang erlang throw: 1] on: Error do: [:e | e message]
+// => 1
+
+// Erlang error still caught by Error handler (no regression)
+[Erlang erlang error: 1] on: Error do: [:e | e message]
+// => 1


### PR DESCRIPTION
## Summary

Fixes [BT-728](https://linear.app/beamtalk/issue/BT-728/bug-ondo-wraps-erlang-exitthrow-as-runtimeerror-instead-of): `on:do:` now correctly wraps Erlang `exit`/`throw` exceptions as `ExitError`/`ThrowError` instead of `RuntimeError`.

## Problem

When catching Erlang `exit` or `throw` via `on:do:`, the Erlang exception type (`exit`/`throw`) was discarded by codegen. `ensure_wrapped/2` only received the raw error reason, so `wrap_raw` wrapped it as `RuntimeError`. The `kind_to_class` mapping for `erlang_exit → ExitError` and `erlang_throw → ThrowError` existed but was unreachable.

Additionally, `matches_class` was called on the raw error value rather than the wrapped exception object, so class hierarchy matching failed for raw Erlang exceptions.

## Changes

### Runtime (`beamtalk_exception_handler.erl`)
- Add `ensure_wrapped/3` accepting the Erlang exception type atom (`error`/`exit`/`throw`)
- Maps `exit → erlang_exit` kind and `throw → erlang_throw` kind before wrapping
- Already-wrapped exceptions and `#beamtalk_error{}` records pass through unchanged

### Codegen (`exception_handling.rs`)
- Pass the caught `Type` variable to `ensure_wrapped/3` (was `ensure_wrapped/2`)
- Pass the wrapped `ExObj` to `matches_class` (was raw `Error`)
- Updated in both simple (closure-based) and mutation-threaded `on:do:` paths
- Updated doc comments to match

### Tests
- 7 new stdlib tests for Erlang FFI exit/throw/error catching via `on:do:`
- 6 new runtime unit tests for `ensure_wrapped/3` (exit, throw, error, idempotent, beamtalk_error, message preservation)

## Test Results
- 1700 stdlib tests ✅
- 2113 runtime unit tests ✅
- Full CI (`just ci`) passes ✅