### PR TITLE
Fix flaky stdlib tests: add EUnit timeout wrapper (BT-729)

### DIFF
--- a/crates/beamtalk-cli/src/commands/test.rs
+++ b/crates/beamtalk-cli/src/commands/test.rs
@@ -612,8 +612,9 @@ fn generate_doc_test_eunit_wrapper(
         let bindings_out = format!("Bindings{}", i + 1);
 
         // Build assertion comment showing Beamtalk source location (BT-729)
+        let escaped_file = source_file.replace('\\', "\\\\").replace('"', "\\\"");
         let escaped_expr = case.expression.replace('\\', "\\\\").replace('"', "\\\"");
-        let comment = format!("{source_file}:{} `{escaped_expr}`", case.source_line);
+        let comment = format!("{escaped_file}:{} `{escaped_expr}`", case.source_line);
         let comment_bin = format!("<<\"{comment}\">>");
 
         match &case.expected {

--- a/crates/beamtalk-cli/src/commands/test_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/test_stdlib.rs
@@ -426,9 +426,10 @@ fn generate_eunit_wrapper(
         let bindings_out = format!("Bindings{}", i + 1);
 
         // Build assertion comment showing Beamtalk source location (BT-729)
+        let escaped_file = test_file_path.replace('\\', "\\\\").replace('"', "\\\"");
         let escaped_expr = case.expression.replace('\\', "\\\\").replace('"', "\\\"");
-        let comment = format!("{test_file_path}:{} `{escaped_expr}`", case.line);
-        let comment_bin = format!("<<\"{comment}\">>",);
+        let comment = format!("{escaped_file}:{} `{escaped_expr}`", case.line);
+        let comment_bin = format!("<<\"{comment}\">>");
 
         match &case.expected {
             Expected::Error { kind } => {


### PR DESCRIPTION
## Summary

Fixes intermittent stdlib test failures caused by EUnit's default 5-second timeout.

**Root cause:** Each `.bt` test file generates a single EUnit `_test()` function containing all assertions chained sequentially. Under CI resource pressure (slow filesystem I/O, cold caches), tests with many assertions or I/O-heavy operations (File, JSON) exceed EUnit's default 5-second timeout, causing `*timed out*` failures.

**Fix:** Changed the generated EUnit wrapper from a bare `_test()` function to a `_test_()` generator with `{timeout, 60, fun() -> ... end}`, giving each test file 60 seconds instead of 5.

## Changes

- `crates/beamtalk-cli/src/commands/test_stdlib.rs`: Modified `generate_eunit_wrapper()` to emit EUnit test generators with timeout wrappers

## Verification

- All 1733 stdlib tests pass
- All 20 unit tests for test_stdlib pass  
- Full CI suite green (build, clippy, fmt, test, test-stdlib, runtime tests, integration, MCP, E2E)

## Linear Issue

https://linear.app/beamtalk/issue/BT-729/flaky-stdlib-tests-file-and-json-operations-intermittently-fail-with

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now run inside a 60‑second timeout-wrapped generator to prevent hangs and improve reliability.
  * Generated test output exposes the timeout-wrapped generator name.
  * Assertions now include per-case source-location comments for both success and error cases, improving diagnostics and traceability.
  * Error and value assertions are updated to surface these comments in test output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->