### PR TITLE
test: fix race condition in read_port_file_nonce tests

### DIFF
--- a/crates/beamtalk-cli/src/commands/workspace/process.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/process.rs
@@ -871,7 +871,10 @@ mod tests {
         std::fs::create_dir_all(&ws_dir).unwrap();
 
         let port_file = ws_dir.join("port");
-        std::fs::write(&port_file, "12345\nnonce_value\n").unwrap();
+        // Use a distinct port (23456) to avoid racing with read_port_file_nonce_from_plain_text
+        // which also writes port 12345. Both tests scan all workspace dirs, so sharing a port
+        // number causes non-deterministic results depending on directory enumeration order.
+        std::fs::write(&port_file, "23456\nnonce_value\n").unwrap();
 
         // Looking for a different port should return None
         let nonce = read_port_file_nonce(54321);


### PR DESCRIPTION
## Summary

- Two tests (`read_port_file_nonce_from_plain_text` and `read_port_file_nonce_wrong_port`) both wrote port files containing port `12345` in separate workspace directories
- `read_port_file_nonce` scans **all** workspace directories, so when tests ran concurrently the wrong nonce could be found first → non-deterministic failures
- Fix: give `read_port_file_nonce_wrong_port` a distinct port number (`23456`) so the two tests no longer share a port and cannot interfere

## Test plan

- [x] `cargo test -p beamtalk-cli --bin beamtalk read_port_file_nonce` — all 3 nonce tests pass
- [x] `just test` — 367 Rust tests pass, 0 failures
- [x] `just build && just clippy && just fmt-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability in workspace process testing to reduce nondeterministic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->