### PR TITLE
docs: add implementation tracking to ADR 0031 BT-736

### DIFF
--- a/docs/ADR/0031-flat-namespace-for-v01.md
+++ b/docs/ADR/0031-flat-namespace-for-v01.md
@@ -261,6 +261,14 @@ For v0.2 (import system), the leading candidate is Option B (package-scoped impo
 - Whether collision policy should be configurable (error vs. warn vs. replace)
 - How class identity surfaces in tooling, error messages, and serialization
 
+## Implementation Tracking
+
+**Epic:** [BT-736](https://linear.app/beamtalk/issue/BT-736) — Epic: Flat Namespace for v0.1 (ADR 0031)
+**Issues:**
+- [BT-737](https://linear.app/beamtalk/issue/BT-737) — Add class redefinition collision warning and document flat namespace
+- [BT-738](https://linear.app/beamtalk/issue/BT-738) — Prevent stdlib class shadowing with structured error (blocked by BT-737)
+**Status:** Planned
+
 ## Migration Path
 
 No migration needed — this ADR formalizes the current behavior. When a module/import system is added in a future version, a migration path will be specified in that ADR.


### PR DESCRIPTION
Add Epic BT-736 and child issues BT-737 (collision warning) and BT-738 (stdlib shadowing protection) to the implementation tracking section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architecture documentation with implementation tracking information.

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->