### PR TITLE
fix: eliminate intermittent race in stop_workspace graceful shutdown

### DIFF
--- a/crates/beamtalk-cli/src/commands/workspace/lifecycle.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/lifecycle.rs
@@ -266,8 +266,8 @@ pub fn stop_workspace(name_or_id: &str, force: bool) -> Result<()> {
                     Ok(()) => {
                         // Wait for the workspace to actually exit.
                         // OTP init:stop() does orderly application teardown which
-                        // can take 10+ seconds under load.
-                        if wait_for_workspace_exit(host, info.port, 15).is_err() {
+                        // can take 10+ seconds under CI load.
+                        if wait_for_workspace_exit(host, info.port, 30).is_err() {
                             // Graceful shutdown acknowledged but process didn't exit
                             // Fall back to force-kill (if PID available)
                             if info.pid == 0 {

--- a/crates/beamtalk-cli/src/commands/workspace/process.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/process.rs
@@ -715,7 +715,10 @@ pub(super) fn force_kill_process(pid: u32) -> Result<()> {
             Err(miette!("Failed to kill process {pid}"))
         }
     } else {
-        Err(miette!("Process {pid} not found"))
+        // Process already exited — the goal of ensuring it is not running is achieved.
+        // This is the expected outcome when graceful shutdown succeeds just after a
+        // wait_for_workspace_exit timeout (race: BEAM exits naturally before we SIGKILL).
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes an intermittent failure in `test_stop_workspace_graceful_integration` caused by a race condition in the graceful shutdown path.

## Root Cause

Two related races existed in `stop_workspace` (graceful path):

**Race 1 (primary):** `wait_for_workspace_exit` polls for up to 15s waiting for the BEAM port to close. Under CI load, OTP `init:stop()` teardown can take just over 15s. At the deadline the function returns `Err`, and the code falls back to `force_kill_process`. But between those two lines, the BEAM process finishes shutting down naturally. `sysinfo` can't find the PID → the old code returned `Err("Process {pid} not found")` → propagated as a test failure.

**Race 2 (less common):** `tcp_send_shutdown` read times out because the BEAM node closed the connection immediately after processing `init:stop()`, before writing the ACK. Falls to the force-kill path with the same PID-not-found race.

## Changes

- **`force_kill_process` (`process.rs`)**: `None` arm now returns `Ok(())` instead of `Err`. The function's contract is "ensure the process is not running" — process not found means that goal is already achieved. Comment explains the specific race for future readers.

- **Graceful shutdown timeout (`lifecycle.rs`)**: Bumped from 15s → 30s. Gives OTP more room for orderly teardown before the force-kill fallback triggers, reducing how often the race window opens.

Both call sites after `force_kill_process` already call `wait_for_workspace_exit`, so port-release verification is still performed even when the process exits naturally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended graceful shutdown timeout from 15 to 30 seconds to allow more time for clean process termination
  * Improved process termination robustness when handling shutdown edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->