### PR TITLE
E2E tests read ~/.erlang.cookie instead of workspace cookie (BT-758)

### DIFF
--- a/crates/beamtalk-cli/tests/e2e.rs
+++ b/crates/beamtalk-cli/tests/e2e.rs
@@ -51,7 +51,12 @@ const REPL_PORT: u16 = 9000;
 /// Explicit cookie for E2E test BEAM nodes.
 /// Both the `erl` process and the WebSocket client use this value so that
 /// authentication succeeds regardless of whether `~/.erlang.cookie` exists.
-const E2E_COOKIE: &str = "beamtalk_e2e_test_cookie";
+/// The value can be overridden at compile time via the `E2E_COOKIE` environment
+/// variable to avoid a single, predictable repo-wide cookie.
+const E2E_COOKIE: &str = match option_env!("E2E_COOKIE") {
+    Some(v) => v,
+    None => "beamtalk_e2e_test_cookie",
+};
 
 /// Timeout for REPL operations.
 /// Cover-instrumented BEAM is slower; `E2E_COVER` bumps this to 120s.


### PR DESCRIPTION
## Summary

Fixes the E2E test cookie authentication to use an explicit cookie instead of reading `~/.erlang.cookie`.

**Problem:** The E2E test BEAM node was started without `-setcookie`, so `erlang:get_cookie()` returned `nocookie`. Meanwhile, `read_erlang_cookie()` read `~/.erlang.cookie` which could contain a different value, causing cookie auth mismatch.

**Fix:**
- Added `E2E_COOKIE` constant used by both the BEAM node (`-setcookie`) and the WebSocket client
- Added `-sname beamtalk_e2e_test` so `erlang:get_cookie()` returns the explicit cookie (requires a named node)
- Removed `read_erlang_cookie()` fallback to `~/.erlang.cookie`

**Files changed:** `crates/beamtalk-cli/tests/e2e.rs`

Linear: https://linear.app/beamtalk/issue/BT-758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test infrastructure by standardizing cookie handling for backend communication. Tests now use a configurable, deterministic cookie value (with an override option) and fixed backend startup settings to make authentication and E2E runs more reliable and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->