### PR TITLE
Consolidate hierarchy walks into walk_hierarchy/3 fold (BT-752)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -175,16 +175,21 @@ classInheritsFrom(Self, TargetClassObj) ->
     TargetName = gen_server:call(TargetPid, class_name),
     ClassPid = erlang:element(4, Self),
     SuperName = gen_server:call(ClassPid, superclass),
-    walk_hierarchy(
-        SuperName,
-        fun(CN, _CPid, _Acc) ->
-            case CN of
-                TargetName -> {halt, true};
-                _ -> {cont, false}
-            end
-        end,
-        false
-    ).
+    case SuperName of
+        TargetName ->
+            true;
+        _ ->
+            walk_hierarchy(
+                SuperName,
+                fun(CN, _CPid, _Acc) ->
+                    case CN of
+                        TargetName -> {halt, true};
+                        _ -> {cont, false}
+                    end
+                end,
+                false
+            )
+    end.
 
 %% @doc Test whether aBehaviour is the receiver or one of its ancestors.
 -spec classIncludesBehaviour(#beamtalk_object{}, #beamtalk_object{}) -> boolean().
@@ -193,16 +198,21 @@ classIncludesBehaviour(Self, TargetClassObj) ->
     SelfName = gen_server:call(SelfPid, class_name),
     TargetPid = erlang:element(4, TargetClassObj),
     TargetName = gen_server:call(TargetPid, class_name),
-    walk_hierarchy(
-        SelfName,
-        fun(CN, _CPid, _Acc) ->
-            case CN of
-                TargetName -> {halt, true};
-                _ -> {cont, false}
-            end
-        end,
-        false
-    ).
+    case SelfName of
+        TargetName ->
+            true;
+        _ ->
+            walk_hierarchy(
+                SelfName,
+                fun(CN, _CPid, _Acc) ->
+                    case CN of
+                        TargetName -> {halt, true};
+                        _ -> {cont, false}
+                    end
+                end,
+                false
+            )
+    end.
 
 %% @doc Walk the hierarchy and return the class object that defines the selector, or nil.
 -spec classWhichIncludesSelector(#beamtalk_object{}, atom()) -> #beamtalk_object{} | nil.
@@ -280,8 +290,8 @@ classClass(_Self) ->
 %%   {halt, Result}   — stop and return Result immediately
 %%
 %% Returns Acc when the chain is exhausted (none or unregistered class).
--spec walk_hierarchy(atom() | none, fun((atom(), pid(), Acc) -> {cont, Acc} | {halt, Acc}), Acc) ->
-    Acc.
+-spec walk_hierarchy(atom() | none, fun((atom(), pid(), Acc) -> {cont, Acc} | {halt, Result}), Acc) ->
+    Acc | Result.
 walk_hierarchy(none, _Fun, Acc) ->
     Acc;
 walk_hierarchy(ClassName, Fun, Acc) ->


### PR DESCRIPTION
## Summary

Refactors `beamtalk_behaviour_intrinsics.erl` to replace 7 separate tail-recursive hierarchy walk helpers with a single generic `walk_hierarchy/3` fold function.

**Linear issue:** https://linear.app/beamtalk/issue/BT-752

## Changes

- Added `walk_hierarchy/3` — a generic fold over the superclass chain with `{cont, NewAcc} | {halt, Result}` protocol
- Replaced `collect_superclasses/2`, `collect_all_methods/2`, `can_understand_check/2`, `inherits_from_check/2`, `includes_behaviour_check/2`, `which_includes_check/2`, and `collect_all_inst_vars/2` with inline `walk_hierarchy` calls
- Eliminated ~90 lines of duplicated walk logic
- Avoided redundant `whereis_class` lookup in `classWhichIncludesSelector` by constructing the class object directly from the already-resolved pid

## Test plan

- [x] All 1881 stdlib tests pass
- [x] All 2137 runtime unit tests pass
- [x] All Rust tests pass
- [x] Build, clippy, fmt-check all pass
- [x] No behaviour change — pure refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of class/hierarchy handling to unify traversal and reduce legacy helper code.
  * Improved internal consistency and maintainability while preserving all public behaviors and APIs—no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->