### PR TITLE
Integration test: multi-class file with non-last stdlib shadowing (BT-751)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_object_class_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_object_class_tests.erl
@@ -1367,7 +1367,7 @@ multi_class_stdlib_shadowing_short_circuits_test_() ->
 
               %% 2. MyHelper must NOT be registered (short-circuit skipped it)
               ?assertEqual(undefined,
-                  erlang:whereis(beamtalk_class_registry:registry_name('MultiShadowHelper'))),
+                  beamtalk_class_registry:whereis_class('MultiShadowHelper')),
 
               %% 3. The error must be in the pending load errors ETS table
               PendingErrors = beamtalk_class_registry:drain_pending_load_errors_by_names(


### PR DESCRIPTION
## Summary

Adds an Erlang-level integration test that validates BT-749's codegen fix at the runtime level. The test simulates the generated `register_class/0` for a two-class module where the first class shadows a stdlib class.

**Linear issue:** https://linear.app/beamtalk/issue/BT-751

## What's tested

The test mirrors the Core Erlang short-circuit chain that BT-749 generates:

1. Pre-registers a fake stdlib class (`bt@stdlib@integer` module)
2. Simulates on_load `register_class/0` for two classes:
   - Class 0: shadows the stdlib class → `stdlib_shadowing` error
   - Class 1: innocent bystander that should NOT be reached
3. Verifies all acceptance criteria:
   - ✅ `stdlib_shadowing` error propagates as the final result
   - ✅ Second class (MyHelper) is NOT registered (short-circuit skipped it)
   - ✅ Pending load error recorded only for the shadowing class
   - ✅ No stale ETS entries for the skipped class

## Key changes

- `runtime/apps/beamtalk_runtime/test/beamtalk_object_class_tests.erl`: Added `multi_class_stdlib_shadowing_short_circuits_test_/0` and cleanup entries in teardown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test coverage for multi-class stdlib shadowing scenarios, validating short-circuit behavior when class registration fails due to stdlib conflicts.
  * Enhanced test teardown to properly clean up additional test class registrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->