### PR TITLE
Non-local return (^) inside blocks for Actor subclass methods (BT-761)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/dispatch.rs
@@ -250,9 +250,56 @@ impl CoreErlangGenerator {
                         .map(|p| self.fresh_var(&p.name))
                         .collect();
 
+                    // BT-761: Detect whether any block in this method body contains ^.
+                    let needs_nlr = block
+                        .body
+                        .iter()
+                        .any(|expr| Self::expr_has_block_nlr(expr, false));
+
+                    let nlr_token_var = if needs_nlr {
+                        let token_var = self.fresh_temp_var("NlrToken");
+                        self.current_nlr_token = Some(token_var.clone());
+                        Some(token_var)
+                    } else {
+                        None
+                    };
+
                     // Generate body as Document, render to string for embedding
                     let body_doc = self.generate_method_body_with_reply(block)?;
                     let body_str = body_doc.to_pretty_string();
+
+                    self.current_nlr_token = None;
+
+                    // BT-761: Wrap body in letrec function with try/catch.
+                    let body_str = if let Some(ref token_var) = nlr_token_var {
+                        let result_var = self.fresh_temp_var("NlrResult");
+                        let cls_var = self.fresh_temp_var("NlrCls");
+                        let err_var = self.fresh_temp_var("NlrErr");
+                        let stk_var = self.fresh_temp_var("NlrStk");
+                        let ctk_var = self.fresh_temp_var("CatchTok");
+                        let val_var = self.fresh_temp_var("NlrVal");
+                        let state_var = self.fresh_temp_var("NlrState");
+                        let ot_pair_var = self.fresh_temp_var("OtherPair");
+
+                        format!(
+                            "letrec '__nlr_body'/0 = fun () ->\n\
+                             let {token_var} = call 'erlang':'make_ref'() in\n\
+                             try\n\
+                             {body_str}\n\
+                             of {result_var} -> {result_var}\n\
+                             catch <{cls_var}, {err_var}, {stk_var}> ->\n\
+                               case {{{cls_var}, {err_var}}} of\n\
+                                 <{{'throw', {{'$bt_nlr', {ctk_var}, {val_var}, {state_var}}}}}> \
+                             when call 'erlang':'=:='({ctk_var}, {token_var}) -> \
+                             {{'reply', {val_var}, {state_var}}}\n\
+                                 <{ot_pair_var}> when 'true' -> \
+                             primop 'raw_raise'({cls_var}, {err_var}, {stk_var})\n\
+                               end\n\
+                             in apply '__nlr_body'/0 ()"
+                        )
+                    } else {
+                        body_str
+                    };
 
                     // Build method clause as Document tree
                     let clause_doc = if param_vars.is_empty() {

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -57,9 +57,61 @@ impl CoreErlangGenerator {
             })
             .collect();
 
+        // BT-761: Detect whether any block argument in this method body contains ^.
+        // If so, set up a non-local return token so ^ inside blocks can throw to escape
+        // the closure and return from the enclosing actor method.
+        let needs_nlr = method
+            .body
+            .iter()
+            .any(|expr| Self::expr_has_block_nlr(expr, false));
+
+        let nlr_token_var = if needs_nlr {
+            let token_var = self.fresh_temp_var("NlrToken");
+            self.current_nlr_token = Some(token_var.clone());
+            Some(token_var)
+        } else {
+            None
+        };
+
         // Generate body as Document, render to string for embedding
         let method_body_doc = self.generate_method_definition_body_with_reply(method)?;
         let body_str = method_body_doc.to_pretty_string();
+
+        self.current_nlr_token = None;
+
+        // BT-761: If NLR was detected, wrap body in a letrec function with
+        // try/catch and immediately apply it. letrec creates a genuine separate
+        // function frame, avoiding BEAM validator ambiguous_catch_try_state
+        // errors that arise when try/catch is nested inside case arms.
+        let body_str = if let Some(ref token_var) = nlr_token_var {
+            let result_var = self.fresh_temp_var("NlrResult");
+            let cls_var = self.fresh_temp_var("NlrCls");
+            let err_var = self.fresh_temp_var("NlrErr");
+            let stk_var = self.fresh_temp_var("NlrStk");
+            let ctk_var = self.fresh_temp_var("CatchTok");
+            let val_var = self.fresh_temp_var("NlrVal");
+            let state_var = self.fresh_temp_var("NlrState");
+            let ot_pair_var = self.fresh_temp_var("OtherPair");
+
+            format!(
+                "letrec '__nlr_body'/0 = fun () ->\n\
+                 let {token_var} = call 'erlang':'make_ref'() in\n\
+                 try\n\
+                 {body_str}\n\
+                 of {result_var} -> {result_var}\n\
+                 catch <{cls_var}, {err_var}, {stk_var}> ->\n\
+                   case {{{cls_var}, {err_var}}} of\n\
+                     <{{'throw', {{'$bt_nlr', {ctk_var}, {val_var}, {state_var}}}}}> \
+                 when call 'erlang':'=:='({ctk_var}, {token_var}) -> \
+                 {{'reply', {val_var}, {state_var}}}\n\
+                     <{ot_pair_var}> when 'true' -> \
+                 primop 'raw_raise'({cls_var}, {err_var}, {stk_var})\n\
+                   end\n\
+                 in apply '__nlr_body'/0 ()"
+            )
+        } else {
+            body_str
+        };
 
         // Build method clause as Document tree
         let has_params = !param_vars.is_empty();

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -542,7 +542,10 @@ impl CoreErlangGenerator {
     ///
     /// Each `Expression` variant is matched explicitly (no wildcard) so the Rust
     /// compiler enforces exhaustiveness: adding a new AST node forces an update here.
-    fn expr_has_block_nlr(expr: &Expression, inside_block: bool) -> bool {
+    pub(in crate::codegen::core_erlang) fn expr_has_block_nlr(
+        expr: &Expression,
+        inside_block: bool,
+    ) -> bool {
         match expr {
             Expression::Return { value, .. } => {
                 // ^ at method-body level is NOT an NLR — it is handled by the

--- a/tests/e2e/fixtures/actor_nlr_basic.bt
+++ b/tests/e2e/fixtures/actor_nlr_basic.bt
@@ -1,0 +1,19 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-761: ActorNlrBasic — ifTrue: non-local return in Actor method.
+
+Actor subclass: ActorNlrBasic
+  state: x = 0
+
+  test: items =>
+    items isEmpty ifTrue: [^"empty"]
+    "not empty"
+
+  classify: n =>
+    n > 0 ifTrue: [^"positive"] ifFalse: [^"non-positive"]
+    "unreachable"
+
+  checkFalse: items =>
+    items isEmpty ifFalse: [^"not empty"]
+    "empty"

--- a/tests/e2e/fixtures/actor_nlr_computed.bt
+++ b/tests/e2e/fixtures/actor_nlr_computed.bt
@@ -1,0 +1,11 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-761: ActorNlrComputed — NLR with computed return values in Actor methods.
+
+Actor subclass: ActorNlrComputed
+  state: x = 0
+
+  doubleIfPositive: n =>
+    n > 0 ifTrue: [^n * 2]
+    0

--- a/tests/e2e/fixtures/actor_nlr_local_var.bt
+++ b/tests/e2e/fixtures/actor_nlr_local_var.bt
@@ -1,0 +1,15 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-761: ActorNlrLocalVar — NLR with local variable bindings in Actor methods.
+
+Actor subclass: ActorNlrLocalVar
+  state: data = #{}
+
+  store: key val: v =>
+    self.data := self.data at: key put: v
+
+  fetch: key =>
+    val := self.data at: key ifAbsent: [nil]
+    val notNil ifTrue: [^val]
+    "not found"

--- a/tests/e2e/fixtures/actor_nlr_mutate.bt
+++ b/tests/e2e/fixtures/actor_nlr_mutate.bt
@@ -1,0 +1,12 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-761: ActorNlrMutate — NLR after field mutation preserves updated state.
+
+Actor subclass: ActorNlrMutate
+  state: count = 0
+
+  incAndCheck: n =>
+    self.count := self.count + 1
+    self.count >= n ifTrue: [^self.count]
+    "not yet"

--- a/tests/e2e/fixtures/actor_nlr_on_do.bt
+++ b/tests/e2e/fixtures/actor_nlr_on_do.bt
@@ -1,0 +1,11 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-761: ActorNlrOnDo — NLR throw propagates through on:do: in Actor methods.
+
+Actor subclass: ActorNlrOnDo
+  state: x = 0
+
+  test: items =>
+    [items isEmpty ifTrue: [^"early"]] on: Error do: [:e | "caught"]
+    "not early"

--- a/tests/e2e/fixtures/actor_nlr_recursive.bt
+++ b/tests/e2e/fixtures/actor_nlr_recursive.bt
@@ -1,0 +1,11 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-761: ActorNlrRecursive — NLR in recursive Actor methods.
+
+Actor subclass: ActorNlrRecursive
+  state: count = 0
+
+  countDown: n =>
+    n <= 0 ifTrue: [^"done"]
+    self countDown: n - 1

--- a/tests/stdlib/actor_non_local_return.bt
+++ b/tests/stdlib/actor_non_local_return.bt
@@ -1,0 +1,109 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-761: Non-local return (^) inside block arguments in Actor subclass methods.
+//
+// @load tests/e2e/fixtures/actor_nlr_basic.bt
+// @load tests/e2e/fixtures/actor_nlr_local_var.bt
+// @load tests/e2e/fixtures/actor_nlr_computed.bt
+// @load tests/e2e/fixtures/actor_nlr_on_do.bt
+// @load tests/e2e/fixtures/actor_nlr_recursive.bt
+// @load tests/e2e/fixtures/actor_nlr_mutate.bt
+
+// === ifTrue: with non-local return ===
+
+a := ActorNlrBasic spawn
+// => #Actor<ActorNlrBasic,_>
+
+(a test: #()) await
+// => empty
+
+(a test: #(1)) await
+// => not empty
+
+// === ifTrue:ifFalse: with non-local returns in both branches ===
+
+(a classify: 5) await
+// => positive
+
+(a classify: -1) await
+// => non-positive
+
+(a classify: 0) await
+// => non-positive
+
+// === ifFalse: with non-local return ===
+
+(a checkFalse: #()) await
+// => empty
+
+(a checkFalse: #(1)) await
+// => not empty
+
+// === Local variable + NLR ===
+
+b := ActorNlrLocalVar spawn
+// => #Actor<ActorNlrLocalVar,_>
+
+(b store: "x" val: 42) await
+// => _
+
+(b fetch: "x") await
+// => 42
+
+(b fetch: "y") await
+// => not found
+
+// === NLR with computed return value ===
+
+c := ActorNlrComputed spawn
+// => #Actor<ActorNlrComputed,_>
+
+(c doubleIfPositive: 5) await
+// => 10
+
+(c doubleIfPositive: -1) await
+// => 0
+
+// === NLR in recursive Actor method ===
+
+d := ActorNlrRecursive spawn
+// => #Actor<ActorNlrRecursive,_>
+
+(d countDown: 3) await
+// => done
+
+(d countDown: 0) await
+// => done
+
+// === NLR propagates through on:do: (not swallowed) ===
+
+e := ActorNlrOnDo spawn
+// => #Actor<ActorNlrOnDo,_>
+
+(e test: #()) await
+// => early
+
+(e test: #(1)) await
+// => not early
+
+// === NLR after field mutation preserves updated state ===
+
+f := ActorNlrMutate spawn
+// => #Actor<ActorNlrMutate,_>
+
+// count starts at 0; incAndCheck: 1 sets count=1, 1>=1 triggers NLR
+(f incAndCheck: 1) await
+// => 1
+
+// count is now 1 (mutation was preserved); incAndCheck: 5 sets count=2, 2<5 falls through
+(f incAndCheck: 5) await
+// => not yet
+
+// count is now 2; incAndCheck: 3 sets count=3, 3>=3 triggers NLR
+(f incAndCheck: 3) await
+// => 3
+
+// count is now 3 (verified mutation persisted across NLR and non-NLR paths)
+(f incAndCheck: 10) await
+// => not yet


### PR DESCRIPTION
## Summary

Implements non-local return (`^`) support inside block arguments in Actor subclass methods. This is the Actor-side equivalent of BT-754, which fixed NLR for Object subclass methods.

**Linear issue:** https://linear.app/beamtalk/issue/BT-761

## Key Changes

- **Actor NLR throws** include state in a 4-tuple `{'$bt_nlr', Token, Value, State}` (vs 3-tuple for value types), so the catch handler can build the `{reply, Value, State}` gen_server response
- **NLR detection + try/catch wrapping** added to three Actor method codegen paths: `methods.rs` (keyword methods), `dispatch.rs` (block-syntax methods), `actor_codegen.rs` (sealed methods)
- **`letrec` wrapper** used in dispatch case arms to avoid BEAM validator `ambiguous_catch_try_state` errors; sealed methods use direct try/catch since they're standalone functions
- **`on:do:` exception handlers** updated to match both 3-tuple (value type) and 4-tuple (actor) NLR throw formats, ensuring NLR propagates through exception handling without being swallowed
- **`expr_has_block_nlr`** visibility widened to `pub(in crate::codegen::core_erlang)` for cross-module access

## Test Plan

- [x] 7 test fixtures with 26 assertions covering:
  - `ifTrue:`, `ifTrue:ifFalse:`, `ifFalse:` with NLR
  - Local variable bindings + NLR
  - Computed return values in NLR (`^n * 2`)
  - NLR propagation through `on:do:` (not swallowed)
  - Recursive Actor method with NLR
  - Field mutation + NLR preserving updated state
- [x] All CI passes (1907 stdlib, 2140 runtime, 9 integration, 20 MCP, 1 E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced actor method control flow with non-local return support, enabling early returns from conditional blocks while preserving state changes.

* **Tests**
  * Added test fixtures for non-local return scenarios in actors, covering state mutations, recursive methods, computed returns, and exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->