### PR TITLE
Add recursion depth guard to class hierarchy chain walks (BT-746)

### DIFF
--- a/runtime/apps/beamtalk_runtime/include/beamtalk.hrl
+++ b/runtime/apps/beamtalk_runtime/include/beamtalk.hrl
@@ -79,6 +79,10 @@
     span :: {binary(), integer(), integer(), integer(), integer()} | undefined
 }).
 
+%% Maximum class hierarchy depth before aborting chain walks.
+%% Prevents infinite loops if the ETS hierarchy table ever contains a cycle.
+-define(MAX_HIERARCHY_DEPTH, 20).
+
 %% @doc CompiledMethod value object type.
 %%
 %% DDD Context: Object System

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -19,10 +19,6 @@
 -include("beamtalk.hrl").
 -include_lib("kernel/include/logger.hrl").
 
-%% Maximum class hierarchy depth before aborting chain walks.
-%% Prevents infinite loops if the ETS hierarchy table ever contains a cycle.
--define(MAX_HIERARCHY_DEPTH, 20).
-
 -export([
     class_send/3,
     unwrap_class_call/1,

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
@@ -67,10 +67,6 @@
 
 -include_lib("kernel/include/logger.hrl").
 
-%% Maximum class hierarchy depth before aborting chain walks.
-%% Prevents infinite loops if the ETS hierarchy table ever contains a cycle.
--define(MAX_HIERARCHY_DEPTH, 20).
-
 %%% ============================================================================
 %%% Types
 %%% ============================================================================


### PR DESCRIPTION
## Summary

Adds a `MAX_HIERARCHY_DEPTH=20` guard to all unbounded chain-walk functions introduced by ADR 0032 Phase 1 ([BT-733](https://linear.app/beamtalk/issue/BT-733)). Previously, if the ETS hierarchy table ever contained a cycle (A → B → A), these functions would infinite-loop until the stack blew or gen_server timeouts cascaded.

Fixes: [BT-746 — Add recursion depth guard to class hierarchy chain walks](https://linear.app/beamtalk/issue/BT-746/add-recursion-depth-guard-to-class-hierarchy-chain-walks)

## Changes

- **`beamtalk_dispatch`**: Added depth counter to `responds_to_chain/2`, `lookup_in_class_chain_slow/6`, `invoke_method/6`, and `continue_to_superclass/5` — each class-level hop increments the counter; returns `false` / structured `#beamtalk_error{}` at limit
- **`beamtalk_class_dispatch`**: Added depth counter to `find_class_method_in_ancestors/2`
- **`beamtalk_repl_docs`**: Added depth counter to `collect_flattened_methods/2` and `find_method_in_chain/2`; added `include_lib("kernel/include/logger.hrl")` for consistent warning logging on limit exceeded
- All public 2-arity entry points are unchanged; depth is hidden in private 3-arity variants

## Test plan

- [x] `just test` — all 1907 stdlib + 2145 Erlang runtime tests pass
- [x] `just ci` — full CI (build, clippy, fmt-check, dialyzer, test, test-e2e) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a maximum class-hierarchy depth guard to prevent infinite traversal during method lookups, improving runtime stability.
  * Enhanced detection and handling of potential cycles with clearer failure responses.
  * Added warnings/logging when depth limits are exceeded to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->