### PR TITLE
fix: optimize explicit class name dispatch in class methods to use direct call (BT-773)

### DIFF
--- a/stdlib/test/class_self_dispatch_test.bt
+++ b/stdlib/test/class_self_dispatch_test.bt
@@ -1,0 +1,18 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-773: self and explicit class name in class methods should both use
+// direct dispatch (not actor message send) to avoid deadlock.
+
+// @load stdlib/test/fixtures/class_self_dispatch.bt
+
+TestCase subclass: ClassSelfDispatchTest
+
+  testSelfNewInClassMethod =>
+    // self new: in a class method uses direct dispatch
+    self assert: (ClassSelfDispatch makeSelf: 42) x equals: 42
+
+  testExplicitClassNameNewInClassMethod =>
+    // ClassName new: in a class method should also use direct dispatch
+    // Before BT-773, this would deadlock because it routed through class_send
+    self assert: (ClassSelfDispatch makeExplicit: 99) x equals: 99

--- a/stdlib/test/fixtures/class_self_dispatch.bt
+++ b/stdlib/test/fixtures/class_self_dispatch.bt
@@ -1,0 +1,12 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-773: Test fixture for class method self vs explicit class name dispatch
+Object subclass: ClassSelfDispatch
+  state: x = 0
+
+  class makeSelf: v => self new: #{#x => v}
+
+  class makeExplicit: v => ClassSelfDispatch new: #{#x => v}
+
+  x => self.x


### PR DESCRIPTION
Fixes deadlock where `ClassName new:` inside a class method would route through `class_send` (a `gen_server:call`), deadlocking since the class actor is already processing the outer call.

## Changes

- **`dispatch_codegen.rs`**: Extract `generate_class_method_self_send` helper and add a 4-line guard in `try_handle_class_reference` — when inside a class method and the explicit class name matches the current class, use direct dispatch (same as `self` sends).
- **`stdlib/test/class_self_dispatch_test.bt`**: New BUnit tests for both `self new:` and `ClassName new:` in class methods.
- **`stdlib/test/fixtures/class_self_dispatch.bt`**: Test fixture with `makeSelf:` and `makeExplicit:` class methods.

## Verification

```
392 stdlib tests, 392 passed, 0 failed
```

Linear: https://linear.app/beamtalk/issue/BT-773

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential deadlock when class methods call themselves by implementing a direct dispatch pathway that avoids intermediate message routing (BT-773). Both self-references and explicit class-name references in class methods are now handled consistently and efficiently without deadlock.

* **Tests**
  * Added comprehensive test suite to validate the class method self-dispatch fix functions correctly in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->