### PR TITLE
Remove deprecated @load directives from stdlib test files (BT-779)

### DIFF
--- a/stdlib/test/class_object_dispatch_test.bt
+++ b/stdlib/test/class_object_dispatch_test.bt
@@ -4,8 +4,6 @@
 // BT-753: Class objects correctly dispatch Object base class methods
 // and pure Beamtalk Behaviour methods.
 
-// @load stdlib/test/fixtures/counter.bt
-
 TestCase subclass: ClassObjectDispatchTest
 
   // --- Object base class methods on class objects (BT-753 core fix) ---

--- a/stdlib/test/class_self_dispatch_test.bt
+++ b/stdlib/test/class_self_dispatch_test.bt
@@ -4,8 +4,6 @@
 // BT-773: self and explicit class name in class methods should both use
 // direct dispatch (not actor message send) to avoid deadlock.
 
-// @load stdlib/test/fixtures/class_self_dispatch.bt
-
 TestCase subclass: ClassSelfDispatchTest
 
   testSelfNewInClassMethod =>

--- a/stdlib/test/codegen_doc_test.bt
+++ b/stdlib/test/codegen_doc_test.bt
@@ -3,8 +3,6 @@
 
 // BUnit tests for doc comment codegen emission (ADR 0033, BT-771)
 
-// @load stdlib/test/fixtures/doc_counter.bt
-
 TestCase subclass: CodegenDocTest
 
   // --- Class doc from /// comment ---

--- a/stdlib/test/method_resolver_hierarchy_test.bt
+++ b/stdlib/test/method_resolver_hierarchy_test.bt
@@ -6,9 +6,6 @@
 // Verifies that >> walks the superclass chain to find inherited methods,
 // matching Pharo's semantics.
 
-// @load stdlib/test/fixtures/hierarchy_test_classes.bt
-// @load stdlib/test/fixtures/hierarchy_test_child.bt
-
 TestCase subclass: MethodResolverHierarchyTest
 
   // --- Inherited method resolution ---


### PR DESCRIPTION
## Summary

Removes 5 deprecated `// @load` directives from 4 stdlib test files. Since BT-766, fixtures in `stdlib/test/fixtures/` are automatically compiled into the shared test code path, making these directives redundant.

**Linear:** https://linear.app/beamtalk/issue/BT-779

## Changes

- Removed `// @load stdlib/test/fixtures/counter.bt` from `class_object_dispatch_test.bt`
- Removed `// @load stdlib/test/fixtures/class_self_dispatch.bt` from `class_self_dispatch_test.bt`
- Removed `// @load stdlib/test/fixtures/doc_counter.bt` from `codegen_doc_test.bt`
- Removed `// @load stdlib/test/fixtures/hierarchy_test_classes.bt` and `hierarchy_test_child.bt` from `method_resolver_hierarchy_test.bt`

## Test plan

- [x] No remaining `// @load` directives in `stdlib/test/`
- [x] `just test-stdlib` passes (392 tests)
- [x] `just ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test fixture loading directives from multiple test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->