### PR TITLE
Downgrade DNU type checker warnings from warning to hint/info severity (BT-781)

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -743,9 +743,13 @@ pub fn compile_source_with_bindings(
             "Found diagnostics during compilation"
         );
         for diagnostic in &diagnostics {
-            // Skip warnings when suppress_warnings is enabled
+            // Skip warnings and hints when suppress_warnings is enabled
             if options.suppress_warnings
-                && diagnostic.severity == beamtalk_core::source_analysis::Severity::Warning
+                && matches!(
+                    diagnostic.severity,
+                    beamtalk_core::source_analysis::Severity::Warning
+                        | beamtalk_core::source_analysis::Severity::Hint
+                )
             {
                 continue;
             }

--- a/crates/beamtalk-cli/src/diagnostic.rs
+++ b/crates/beamtalk-cli/src/diagnostic.rs
@@ -47,6 +47,7 @@ impl CompileDiagnostic {
         let label = match diagnostic.severity {
             Severity::Error => "error here",
             Severity::Warning => "warning here",
+            Severity::Hint => "hint here",
         };
 
         Self {

--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -276,11 +276,15 @@ fn partition_diagnostics(
             matches!(
                 d.severity,
                 beamtalk_core::source_analysis::Severity::Warning
+                    | beamtalk_core::source_analysis::Severity::Hint
             )
         })
         .map(|d| DiagInfo {
             message: d.message.to_string(),
-            severity: "warning".to_string(),
+            severity: match d.severity {
+                beamtalk_core::source_analysis::Severity::Hint => "hint".to_string(),
+                _ => "warning".to_string(),
+            },
             start: d.span.start(),
             end: d.span.end(),
         })
@@ -337,6 +341,7 @@ fn handle_compile_expression(request: &Map) -> Term {
             matches!(
                 d.severity,
                 beamtalk_core::source_analysis::Severity::Warning
+                    | beamtalk_core::source_analysis::Severity::Hint
             )
         })
         .map(|d| d.message.to_string())
@@ -592,6 +597,7 @@ fn handle_diagnostics(request: &Map) -> Term {
             severity: match d.severity {
                 beamtalk_core::source_analysis::Severity::Error => "error".to_string(),
                 beamtalk_core::source_analysis::Severity::Warning => "warning".to_string(),
+                beamtalk_core::source_analysis::Severity::Hint => "hint".to_string(),
             },
             start: d.span.start(),
             end: d.span.end(),

--- a/crates/beamtalk-core/src/queries/diagnostic_provider.rs
+++ b/crates/beamtalk-core/src/queries/diagnostic_provider.rs
@@ -463,7 +463,7 @@ mod tests {
     }
 
     #[test]
-    fn type_checker_warning_severity_is_warning() {
+    fn type_checker_dnu_severity_is_hint() {
         use crate::source_analysis::Severity;
 
         let source = "42 foo";
@@ -471,17 +471,17 @@ mod tests {
         let (module, parse_diags) = parse(tokens);
         let diagnostics = compute_diagnostics(&module, parse_diags);
 
-        let type_warning = diagnostics
+        let dnu_diag = diagnostics
             .iter()
             .find(|d| d.message.contains("does not understand"));
         assert!(
-            type_warning.is_some(),
-            "Should have type warning. Got: {diagnostics:?}"
+            dnu_diag.is_some(),
+            "Should have DNU diagnostic. Got: {diagnostics:?}"
         );
         assert_eq!(
-            type_warning.unwrap().severity,
-            Severity::Warning,
-            "Type checker warnings should be Warning severity"
+            dnu_diag.unwrap().severity,
+            Severity::Hint,
+            "DNU diagnostics should be Hint severity, not Warning"
         );
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker.rs
@@ -964,7 +964,7 @@ impl TypeChecker {
         let message: EcoString =
             format!("{class_name}{side} does not understand '{selector}'").into();
 
-        let mut diag = Diagnostic::warning(message, span);
+        let mut diag = Diagnostic::hint(message, span);
 
         // Try to suggest similar selectors
         if let Some(suggestion) =
@@ -1550,7 +1550,7 @@ mod tests {
 
     #[test]
     fn test_warnings_only_never_errors() {
-        // All diagnostics should be warnings, never errors
+        // All diagnostics should be warnings or hints, never errors
         let module = make_module(vec![msg_send(
             int_lit(42),
             MessageSelector::Unary("bogus".into()),
@@ -1560,10 +1560,11 @@ mod tests {
         let mut checker = TypeChecker::new();
         checker.check_module(&module, &hierarchy);
         for diag in checker.diagnostics() {
-            assert_eq!(
+            assert_ne!(
                 diag.severity,
-                crate::source_analysis::Severity::Warning,
-                "type checker should only emit warnings"
+                crate::source_analysis::Severity::Error,
+                "type checker should only emit warnings or hints, not errors: {}",
+                diag.message
             );
         }
     }

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -325,7 +325,7 @@ fn is_diagnostic_error(msg: &str) -> bool {
     msg.starts_with(|c: char| c.is_ascii_lowercase())
 }
 
-/// A diagnostic message (error or warning).
+/// A diagnostic message (error, warning, or hint).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
     /// The severity of the diagnostic.
@@ -360,6 +360,17 @@ impl Diagnostic {
             hint: None,
         }
     }
+
+    /// Creates a new hint diagnostic (informational, lower severity than warning).
+    #[must_use]
+    pub fn hint(message: impl Into<EcoString>, span: Span) -> Self {
+        Self {
+            severity: Severity::Hint,
+            message: message.into(),
+            span,
+            hint: None,
+        }
+    }
 }
 
 /// Diagnostic severity level.
@@ -369,6 +380,8 @@ pub enum Severity {
     Error,
     /// A warning that should be addressed.
     Warning,
+    /// A hint or informational note (e.g. DNU that may be intentional).
+    Hint,
 }
 
 /// Maximum nesting depth for expressions before the parser bails out.

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -879,6 +879,7 @@ fn to_lsp_diagnostic(
         severity: Some(match diag.severity {
             Severity::Error => DiagnosticSeverity::ERROR,
             Severity::Warning => DiagnosticSeverity::WARNING,
+            Severity::Hint => DiagnosticSeverity::HINT,
         }),
         source: Some("beamtalk".into()),
         message: if let Some(ref hint) = diag.hint {


### PR DESCRIPTION
## Summary

Downgrades "does not understand" (DNU) diagnostics from `Severity::Warning` to `Severity::Hint`. In Smalltalk tradition, sending any message to any object is valid — `doesNotUnderstand:` is a normal part of the language (proxies, method_missing patterns, debugger entry). Warning severity caused false alarms in legitimate code patterns.

**Linear issue:** https://linear.app/beamtalk/issue/BT-781

## Key Changes

- Add `Severity::Hint` variant and `Diagnostic::hint()` constructor to `beamtalk-core`
- Change `emit_unknown_selector_warning` to use `Diagnostic::hint()` instead of `Diagnostic::warning()`
- Update LSP server: `Severity::Hint` → `DiagnosticSeverity::HINT`
- Update CLI diagnostic display: "hint here" label for hints
- Update compiler-port: Hint serialized as "hint" severity string, included in non-error partition
- Update `suppress_warnings` to also suppress hints
- Update tests to validate new severity levels

## Test Plan

- [x] `just ci` passes — all 1953 Rust + 392 stdlib + 322 BUnit tests pass
- [x] DNU diagnostics display as "hint here" in BUnit output
- [x] Type mismatch warnings remain as "warning here"
- [x] All match arms on `Severity` are exhaustive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Hint diagnostic severity level to provide informational compiler feedback alongside errors and warnings.

* **Improvements**
  * Unknown selector diagnostics now emit as hints instead of warnings, improving diagnostic clarity and categorization.
  * Enhanced diagnostic suppression to filter out hint-level diagnostics when suppression is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->