### PR TITLE
beamtalk workspace stop should default to current directory's workspace (BT-788)

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -644,7 +644,7 @@ pub fn run(
     // Ephemeral mode: stop workspace node on REPL exit (only in workspace mode)
     if should_stop_workspace(ephemeral, beam_guard_opt.is_some()) {
         if let Some(workspace_id) = workspace_id_opt {
-            if let Err(e) = crate::commands::workspace::stop_workspace(&workspace_id, false) {
+            if let Err(e) = crate::commands::workspace::stop_workspace(Some(&workspace_id), false) {
                 eprintln!("Warning: failed to stop workspace {workspace_id}: {e}");
             }
         }

--- a/crates/beamtalk-cli/src/commands/workspace/cli.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/cli.rs
@@ -27,8 +27,8 @@ pub enum WorkspaceCommand {
 
     /// Stop a running workspace
     Stop {
-        /// Workspace name or ID to stop
-        name: String,
+        /// Workspace name or ID to stop (default: current project's workspace)
+        name: Option<String>,
 
         /// Force stop without graceful shutdown
         #[arg(long)]
@@ -84,7 +84,7 @@ pub enum WorkspaceCommand {
 pub fn run(command: WorkspaceCommand) -> Result<()> {
     match command {
         WorkspaceCommand::List { json } => run_list(json),
-        WorkspaceCommand::Stop { name, force } => stop_workspace(&name, force),
+        WorkspaceCommand::Stop { name, force } => stop_workspace(name.as_deref(), force),
         WorkspaceCommand::Status { name } => run_status(name.as_deref()),
         WorkspaceCommand::Create {
             name,

--- a/crates/beamtalk-cli/src/commands/workspace/mod.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/mod.rs
@@ -669,7 +669,7 @@ mod tests {
 
     #[test]
     fn test_stop_workspace_fails_for_nonexistent() {
-        let result = stop_workspace("nonexistent_stop_test_ws", false);
+        let result = stop_workspace(Some("nonexistent_stop_test_ws"), false);
         assert!(result.is_err());
     }
 
@@ -683,7 +683,7 @@ mod tests {
         };
         save_workspace_metadata(&metadata).unwrap();
 
-        let result = stop_workspace(&ws.id, false);
+        let result = stop_workspace(Some(&ws.id), false);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("is not running"), "Error: {err}");
@@ -1140,7 +1140,7 @@ mod tests {
         assert_eq!(info2.pid, info1.pid, "should return same PID");
 
         // Step 3: Stop the node gracefully via TCP shutdown
-        stop_workspace(&tw.id, false).expect("graceful stop should succeed");
+        stop_workspace(Some(&tw.id), false).expect("graceful stop should succeed");
         assert_node_stopped(&info1, "node should not be running after stop");
 
         // Wait for epmd to deregister the old node name before restarting.
@@ -1330,7 +1330,7 @@ mod tests {
 
         // Graceful stop (force=false) uses TCP shutdown + init:stop(),
         // which should succeed for detached BEAM nodes
-        let result = stop_workspace(&tw.id, false);
+        let result = stop_workspace(Some(&tw.id), false);
         assert!(
             result.is_ok(),
             "Graceful TCP shutdown should succeed, got: {:?}",
@@ -1377,7 +1377,7 @@ mod tests {
         );
 
         // Force stop (SIGKILL) should succeed
-        let result = stop_workspace(&tw.id, true);
+        let result = stop_workspace(Some(&tw.id), true);
         assert!(
             result.is_ok(),
             "Force stop should succeed, got: {:?}",
@@ -1397,7 +1397,7 @@ mod tests {
         let _ = create_workspace(&project_path, Some(&tw.id)).unwrap();
 
         // Workspace exists but no node is running
-        let result = stop_workspace(&tw.id, false);
+        let result = stop_workspace(Some(&tw.id), false);
         assert!(
             result.is_err(),
             "Stopping non-running workspace should fail"


### PR DESCRIPTION
## Summary

- Make the `name` argument optional for `beamtalk workspace stop`, defaulting to the current directory's workspace
- Uses existing `discover_project_root` + `find_workspace_by_project_path` pattern (same as `workspace status`)
- Shows helpful error when no workspace found for current directory

Closes [BT-788](https://linear.app/beamtalk/issue/BT-788)

## Key Changes

- `cli.rs`: Changed `Stop.name` from `String` to `Option<String>`
- `lifecycle.rs`: Updated `stop_workspace` to accept `Option<&str>` with auto-detect fallback
- Updated all call sites in repl and tests

## Test plan

- [x] `just test` passes (1961 Rust + 392 stdlib + 322 BUnit + 2146 runtime tests)
- [x] `just clippy` passes
- [x] `just fmt-check` passes
- [x] Explicit name still works: `beamtalk workspace stop <name>`
- [x] `beamtalk workspace status` (already optional) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `workspace stop` command now auto-detects the workspace associated with your current directory, allowing you to stop it without specifying a name.
  * Enhanced error messages provide clearer guidance when a workspace is not found in the current directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->