### PR TITLE
docs: ADR 0034 — Stdlib Self-Hosting in Beamtalk

### DIFF
--- a/docs/ADR/0034-stdlib-self-hosting-in-beamtalk.md
+++ b/docs/ADR/0034-stdlib-self-hosting-in-beamtalk.md
@@ -1,7 +1,7 @@
 # ADR 0034: Stdlib Self-Hosting — Moving Logic from Erlang to Beamtalk
 
 ## Status
-Proposed (2026-02-22)
+Accepted (2026-02-22)
 
 ## Context
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -60,7 +60,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0031](0031-flat-namespace-for-v01.md) | Flat Namespace for v0.1 | Accepted | 2026-02-18 |
 | [0032](0032-early-class-protocol.md) | Early Class Protocol — Behaviour and Class in Beamtalk Stdlib | Accepted | 2026-02-20 |
 | [0033](0033-runtime-embedded-documentation.md) | Runtime-Embedded Documentation on Class and CompiledMethod | Accepted | 2026-02-21 |
-| [0034](0034-stdlib-self-hosting-in-beamtalk.md) | Stdlib Self-Hosting — Moving Logic from Erlang to Beamtalk | Proposed | 2026-02-22 |
+| [0034](0034-stdlib-self-hosting-in-beamtalk.md) | Stdlib Self-Hosting — Moving Logic from Erlang to Beamtalk | Accepted | 2026-02-22 |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## Summary

- Adds ADR 0034: phased strategy to move pure-algorithmic stdlib logic from Erlang to Beamtalk
- Introduces `addFirst:` (O(1) list cons) to enable the classic prepend-then-reverse accumulator pattern
- Four phases: missing `.bt` files (Future, FileHandle), collection protocol self-hosting, algorithmic operations, test assertions
- Updates ADR index

## Key Design Decisions

- `do:` and `size` are the primitive boundary per concrete collection — everything else can be pure Beamtalk
- `addFirst:` + `reversed` replaces Pharo's mutable `OrderedCollection` accumulation (matches Gleam's pattern)
- Concrete classes (List, Set, Dictionary) keep BIF fast-paths; pure-BT defaults serve user-defined collections
- Non-local return operations (`detect:`, `anySatisfy:`) gated on benchmarks due to throw/catch cost on BEAM

## Related

- BT-507: Future class ADR (separate, covers combinators/auto-await)
- BT-792: Full Metaclass Tower ADR (created during this research)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR 0034 describing a phased plan for standard library self-hosting and updated ADR index.
  * Clarifies migration, testing, and governance; confirms no breaking API changes.

* **New Features**
  * Exposes Future and FileHandle concepts to tooling and docs.
  * Provides new default, self-hosted behaviors for core collection operations and test assertions, improving visibility and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->