### PR TITLE
Fix file_stream_test.bt fixture paths

### DIFF
--- a/stdlib/test/file_stream_test.bt
+++ b/stdlib/test/file_stream_test.bt
@@ -6,98 +6,98 @@
 TestCase subclass: FileStreamTest
 
   testFileLinesBasicReading =>
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") asList) equals: #("line one", "line two", "line three").
+    self assert: ((File lines: "test/fixtures/stream_test.txt") asList) equals: #("line one", "line two", "line three").
     // Take first N lines
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") take: 2) equals: #("line one", "line two").
+    self assert: ((File lines: "test/fixtures/stream_test.txt") take: 2) equals: #("line one", "line two").
     // Take more lines than exist
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") take: 100) equals: #("line one", "line two", "line three").
+    self assert: ((File lines: "test/fixtures/stream_test.txt") take: 100) equals: #("line one", "line two", "line three").
     // Single line file (no trailing newline)
-    self assert: ((File lines: "stdlib/test/fixtures/stream_single.txt") asList) equals: #("only line").
+    self assert: ((File lines: "test/fixtures/stream_single.txt") asList) equals: #("only line").
     // File without trailing newline
-    self assert: ((File lines: "stdlib/test/fixtures/stream_no_trailing.txt") asList) equals: #("first", "second")
+    self assert: ((File lines: "test/fixtures/stream_no_trailing.txt") asList) equals: #("first", "second")
 
   testEmptyFile =>
     // Empty file returns empty stream
-    self assert: ((File lines: "stdlib/test/fixtures/stream_empty.txt") asList) equals: #().
-    self assert: ((File lines: "stdlib/test/fixtures/stream_empty.txt") take: 5) equals: #()
+    self assert: ((File lines: "test/fixtures/stream_empty.txt") asList) equals: #().
+    self assert: ((File lines: "test/fixtures/stream_empty.txt") take: 5) equals: #()
 
   testStreamPipelineComposition =>
     // Select lines matching a pattern
-    self assert: (((File lines: "stdlib/test/fixtures/stream_test.txt") select: [:l | l includes: "two"]) asList) equals: #("line two").
+    self assert: (((File lines: "test/fixtures/stream_test.txt") select: [:l | l includes: "two"]) asList) equals: #("line two").
     // Collect (transform) lines
-    self assert: (((File lines: "stdlib/test/fixtures/stream_test.txt") collect: [:l | l size]) asList) equals: #(8, 8, 10).
+    self assert: (((File lines: "test/fixtures/stream_test.txt") collect: [:l | l size]) asList) equals: #(8, 8, 10).
     // Drop first line
-    self assert: (((File lines: "stdlib/test/fixtures/stream_test.txt") drop: 1) asList) equals: #("line two", "line three").
+    self assert: (((File lines: "test/fixtures/stream_test.txt") drop: 1) asList) equals: #("line two", "line three").
     // Inject (fold) - count lines
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") inject: 0 into: [:count :line | count + 1]) equals: 3.
+    self assert: ((File lines: "test/fixtures/stream_test.txt") inject: 0 into: [:count :line | count + 1]) equals: 3.
     // Detect first matching line
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") detect: [:l | l includes: "three"]) equals: "line three".
+    self assert: ((File lines: "test/fixtures/stream_test.txt") detect: [:l | l includes: "three"]) equals: "line three".
     // Detect returns nil when no match
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") detect: [:l | l includes: "four"]) equals: nil.
+    self assert: ((File lines: "test/fixtures/stream_test.txt") detect: [:l | l includes: "four"]) equals: nil.
     // anySatisfy
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") anySatisfy: [:l | l includes: "one"]).
-    self deny: ((File lines: "stdlib/test/fixtures/stream_test.txt") anySatisfy: [:l | l includes: "four"]).
+    self assert: ((File lines: "test/fixtures/stream_test.txt") anySatisfy: [:l | l includes: "one"]).
+    self deny: ((File lines: "test/fixtures/stream_test.txt") anySatisfy: [:l | l includes: "four"]).
     // allSatisfy
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") allSatisfy: [:l | l includes: "line"]).
-    self deny: ((File lines: "stdlib/test/fixtures/stream_test.txt") allSatisfy: [:l | l includes: "one"])
+    self assert: ((File lines: "test/fixtures/stream_test.txt") allSatisfy: [:l | l includes: "line"]).
+    self deny: ((File lines: "test/fixtures/stream_test.txt") allSatisfy: [:l | l includes: "one"])
 
   testFileOpenDoBlockScopedHandle =>
     // Read lines through handle
-    self assert: (File open: "stdlib/test/fixtures/stream_test.txt" do: [:handle | handle lines asList]) equals: #("line one", "line two", "line three").
+    self assert: (File open: "test/fixtures/stream_test.txt" do: [:handle | handle lines asList]) equals: #("line one", "line two", "line three").
     // Take lines through handle
-    self assert: (File open: "stdlib/test/fixtures/stream_test.txt" do: [:handle | handle lines take: 1]) equals: #("line one").
+    self assert: (File open: "test/fixtures/stream_test.txt" do: [:handle | handle lines take: 1]) equals: #("line one").
     // Pipeline through handle
-    self assert: (File open: "stdlib/test/fixtures/stream_test.txt" do: [:handle | (handle lines select: [:l | l includes: "two"]) asList]) equals: #("line two").
+    self assert: (File open: "test/fixtures/stream_test.txt" do: [:handle | (handle lines select: [:l | l includes: "two"]) asList]) equals: #("line two").
     // Block returns result
-    self assert: (File open: "stdlib/test/fixtures/stream_test.txt" do: [:handle | handle lines inject: 0 into: [:count :line | count + 1]]) equals: 3.
+    self assert: (File open: "test/fixtures/stream_test.txt" do: [:handle | handle lines inject: 0 into: [:count :line | count + 1]]) equals: 3.
     // Empty file through handle
-    self assert: (File open: "stdlib/test/fixtures/stream_empty.txt" do: [:handle | handle lines asList]) equals: #()
+    self assert: (File open: "test/fixtures/stream_empty.txt" do: [:handle | handle lines asList]) equals: #()
 
   testLazyEvaluationConstantMemory =>
     // take: only reads needed lines (lazy)
-    self assert: ((File lines: "stdlib/test/fixtures/stream_large.txt") take: 3) equals: #("a", "b", "c").
+    self assert: ((File lines: "test/fixtures/stream_large.txt") take: 3) equals: #("a", "b", "c").
     // Chained lazy operations
-    self assert: (((File lines: "stdlib/test/fixtures/stream_large.txt") drop: 5) take: 3) equals: #("f", "g", "h").
+    self assert: (((File lines: "test/fixtures/stream_large.txt") drop: 5) take: 3) equals: #("f", "g", "h").
     // reject: with lazy evaluation
-    self assert: (((File lines: "stdlib/test/fixtures/stream_large.txt") reject: [:l | l =:= "e"]) take: 5) equals: #("a", "b", "c", "d", "f")
+    self assert: (((File lines: "test/fixtures/stream_large.txt") reject: [:l | l =:= "e"]) take: 5) equals: #("a", "b", "c", "d", "f")
 
   testDoSideEffects =>
     // do: iterates for side effects, returns nil
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") do: [:l | l size]) equals: nil
+    self assert: ((File lines: "test/fixtures/stream_test.txt") do: [:l | l size]) equals: nil
 
   testPrintstringStreamDescription =>
-    (File lines: "stdlib/test/fixtures/stream_test.txt") printString
+    (File lines: "test/fixtures/stream_test.txt") printString
 
   testStreamFinalizerPartialConsumption =>
     // take: on file stream closes handle via finalizer
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") take: 1) equals: #("line one").
+    self assert: ((File lines: "test/fixtures/stream_test.txt") take: 1) equals: #("line one").
     // detect: on file stream closes handle via finalizer
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") detect: [:l | l includes: "two"]) equals: "line two".
+    self assert: ((File lines: "test/fixtures/stream_test.txt") detect: [:l | l includes: "two"]) equals: "line two".
     // anySatisfy: on file stream closes handle via finalizer
-    self assert: ((File lines: "stdlib/test/fixtures/stream_test.txt") anySatisfy: [:l | l includes: "one"]).
+    self assert: ((File lines: "test/fixtures/stream_test.txt") anySatisfy: [:l | l includes: "one"]).
     // allSatisfy: on file stream with early exit closes handle via finalizer
-    self deny: ((File lines: "stdlib/test/fixtures/stream_large.txt") allSatisfy: [:l | l =:= "a"]).
+    self deny: ((File lines: "test/fixtures/stream_large.txt") allSatisfy: [:l | l =:= "a"]).
     // Pipeline with finalizer propagation: select + take
-    self assert: (((File lines: "stdlib/test/fixtures/stream_test.txt") select: [:l | l includes: "line"]) take: 2) equals: #("line one", "line two").
+    self assert: (((File lines: "test/fixtures/stream_test.txt") select: [:l | l includes: "line"]) take: 2) equals: #("line one", "line two").
     // Pipeline with finalizer propagation: collect + take
-    self assert: (((File lines: "stdlib/test/fixtures/stream_large.txt") collect: [:l | l size]) take: 3) equals: #(1, 1, 1).
+    self assert: (((File lines: "test/fixtures/stream_large.txt") collect: [:l | l size]) take: 3) equals: #(1, 1, 1).
     // Pipeline with finalizer propagation: drop + take
-    self assert: (((File lines: "stdlib/test/fixtures/stream_large.txt") drop: 2) take: 2) equals: #("c", "d").
+    self assert: (((File lines: "test/fixtures/stream_large.txt") drop: 2) take: 2) equals: #("c", "d").
     // Pipeline with finalizer propagation: reject + detect
-    self assert: (((File lines: "stdlib/test/fixtures/stream_test.txt") reject: [:l | l includes: "one"]) detect: [:l | l includes: "two"]) equals: "line two"
+    self assert: (((File lines: "test/fixtures/stream_test.txt") reject: [:l | l includes: "one"]) detect: [:l | l includes: "two"]) equals: "line two"
 
   testErrorPaths =>
     // File not found
-    self should: [File lines: "stdlib/test/fixtures/nonexistent.txt"] raise: #file_not_found.
+    self should: [File lines: "test/fixtures/nonexistent.txt"] raise: #file_not_found.
     // Type error: non-string path
     self should: [File lines: 42] raise: #type_error.
     // File not found with open:do:
-    self should: [File open: "stdlib/test/fixtures/nonexistent.txt" do: [:h | h lines asList]] raise: #file_not_found
+    self should: [File open: "test/fixtures/nonexistent.txt" do: [:h | h lines asList]] raise: #file_not_found
 
   testErrorPathsTypeErrors =>
     // Type errors that produce compile-time warnings but still run correctly
     self should: [File open: 42 do: [:h | h lines asList]] raise: #type_error.
-    self should: [File open: "stdlib/test/fixtures/stream_test.txt" do: "not a block"] raise: #type_error.
+    self should: [File open: "test/fixtures/stream_test.txt" do: "not a block"] raise: #type_error.
     // lines: with absolute path (security)
     self should: [File lines: "/etc/passwd"] raise: #invalid_path.
     // lines: with directory traversal
@@ -109,8 +109,8 @@ TestCase subclass: FileStreamTest
 
   testWindowsStyleLineEndingsRN =>
     // Windows CRLF line endings are stripped correctly
-    self assert: ((File lines: "stdlib/test/fixtures/stream_crlf.txt") asList) equals: #("alpha", "beta", "gamma")
+    self assert: ((File lines: "test/fixtures/stream_crlf.txt") asList) equals: #("alpha", "beta", "gamma")
 
   testUnicodeFileContent =>
     // Unicode content (multi-byte UTF-8) reads correctly through streams
-    self assert: ((File lines: "stdlib/test/fixtures/stream_unicode.txt") asList) equals: #("Hello 世界", "café", "über")
+    self assert: ((File lines: "test/fixtures/stream_unicode.txt") asList) equals: #("Hello 世界", "café", "über")


### PR DESCRIPTION
## Summary

Fix all 12 failing tests in `FileStreamTest` caused by incorrect relative file paths.

## Problem

The `test-bunit` recipe runs with `[working-directory: 'stdlib']`, so the CWD is `stdlib/`. The test was using paths like `"stdlib/test/fixtures/stream_test.txt"` which resolved to the non-existent `stdlib/stdlib/test/fixtures/stream_test.txt`.

## Fix

Changed all fixture paths from `"stdlib/test/fixtures/..."` to `"test/fixtures/..."` to be relative to the actual CWD, consistent with `file_io_test.bt` which uses `"target/bt-test-tmp/..."`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture paths in the test suite.

**Note:** No user-facing features or API changes included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->