### PR TITLE
Remove dead Flavors before/after method infrastructure (BT-796)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/erlang_types.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/erlang_types.rs
@@ -237,8 +237,8 @@ impl fmt::Display for ErlangVar {
 /// # DDD: Value Object
 ///
 /// `ModuleName` is a value object in the Code Generation bounded context.
-/// It encapsulates the Two-Module Pattern from the Flavors architecture
-/// where each Beamtalk class generates two Erlang modules.
+/// It encapsulates the two-module actor pattern where each Beamtalk class
+/// generates two Erlang modules.
 ///
 /// # Invariants
 ///

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -407,7 +407,7 @@ impl CoreErlangGenerator {
                 INDENT,
                 docvec![
                     line(),
-                    "%% Call terminate method if defined (Flavors pattern)",
+                    "%% Call terminate method if defined",
                     line(),
                     "let Self = call 'beamtalk_actor':'make_self'(State) in",
                     line(),

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/dispatch.rs
@@ -159,9 +159,8 @@ impl CoreErlangGenerator {
 
     /// Generates the `safe_dispatch/3` function with error isolation.
     ///
-    /// Per BT-29 design doc (following LFE Flavors pattern), errors in method
-    /// dispatch are caught and returned to the caller rather than crashing
-    /// the actor instance.
+    /// Per BT-29 design doc, errors in method dispatch are caught and returned
+    /// to the caller rather than crashing the actor instance.
     ///
     /// Note: Core Erlang try expression uses simple variable patterns (not case-style).
     /// Stacktrace is captured but not returned to caller to prevent information leakage.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_object_class_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_object_class_tests.erl
@@ -451,50 +451,6 @@ replace_method_test_() ->
     end}.
 
 %%====================================================================
-%% Method Combinations (Flavors Pattern)
-%%====================================================================
-
-add_before_method_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(_) ->
-        [
-            ?_test(begin
-                ClassInfo = #{
-                    name => 'Counter',
-                    module => counter,
-                    instance_methods => #{}
-                },
-                {ok, Pid} = beamtalk_object_class:start_link('Counter', ClassInfo),
-
-                BeforeFun = fun() -> ok end,
-                ok = beamtalk_object_class:add_before(Pid, increment, BeforeFun),
-
-                %% Can't easily verify without accessing internal state,
-                %% but at least verify the call succeeds
-                ?assert(true)
-            end)
-        ]
-    end}.
-
-add_after_method_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(_) ->
-        [
-            ?_test(begin
-                ClassInfo = #{
-                    name => 'Counter',
-                    module => counter,
-                    instance_methods => #{}
-                },
-                {ok, Pid} = beamtalk_object_class:start_link('Counter', ClassInfo),
-
-                AfterFun = fun() -> ok end,
-                ok = beamtalk_object_class:add_after(Pid, increment, AfterFun),
-
-                ?assert(true)
-            end)
-        ]
-    end}.
-
-%%====================================================================
 %% All Classes Enumeration
 %%====================================================================
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_codegen.snap
@@ -104,7 +104,7 @@ module 'actor_spawn' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'/3
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'actor_spawn':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_codegen.snap
@@ -104,7 +104,7 @@ module 'actor_spawn_with_args' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'hand
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'actor_spawn_with_args':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_codegen.snap
@@ -104,7 +104,7 @@ module 'actor_state_mutation' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handl
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'actor_state_mutation':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_codegen.snap
@@ -103,7 +103,7 @@ module 'async_keyword_message' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'hand
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'async_keyword_message':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_codegen.snap
@@ -103,7 +103,7 @@ module 'async_unary_message' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'async_unary_message':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_codegen.snap
@@ -103,7 +103,7 @@ module 'async_with_await' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_ca
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'async_with_await':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_codegen.snap
@@ -105,7 +105,7 @@ module 'binary_operators' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_ca
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'binary_operators':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_codegen.snap
@@ -104,7 +104,7 @@ module 'blocks_no_args' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'blocks_no_args':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_codegen.snap
@@ -103,7 +103,7 @@ module 'boundary_deeply_nested' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'han
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'boundary_deeply_nested':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_codegen.snap
@@ -105,7 +105,7 @@ module 'boundary_long_identifiers' ['start_link'/1, 'init'/1, 'handle_cast'/2, '
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'boundary_long_identifiers':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_codegen.snap
@@ -103,7 +103,7 @@ module 'boundary_mixed_errors' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'hand
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'boundary_mixed_errors':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_codegen.snap
@@ -103,7 +103,7 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'init'/1, 'handle_cast'/2
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'boundary_unicode_identifiers':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_codegen.snap
@@ -103,7 +103,7 @@ module 'cascade_complex' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_cal
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'cascade_complex':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascades_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascades_codegen.snap
@@ -103,7 +103,7 @@ module 'cascades' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'/3, '
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'cascades':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__character_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__character_literals_codegen.snap
@@ -107,7 +107,7 @@ module 'character_literals' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'character_literals':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_definition_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_definition_codegen.snap
@@ -105,7 +105,7 @@ module 'class_definition' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_ca
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'class_definition':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
@@ -105,7 +105,7 @@ module 'class_methods' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'class_methods':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_codegen.snap
@@ -107,7 +107,7 @@ module 'comment_handling' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_ca
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'comment_handling':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_codegen.snap
@@ -110,7 +110,7 @@ module 'control_flow_mutations' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'han
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'control_flow_mutations':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_codegen.snap
@@ -103,7 +103,7 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'init'/1, 'handle_cast'/
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'control_flow_mutations_errors':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_codegen.snap
@@ -103,7 +103,7 @@ module 'empty_blocks' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'/
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'empty_blocks':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_codegen.snap
@@ -105,7 +105,7 @@ module 'empty_method_body' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_c
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'empty_method_body':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_message_codegen.snap
@@ -104,7 +104,7 @@ module 'error_message' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'error_message':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_codegen.snap
@@ -103,7 +103,7 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'init'/1, 'handle_cast'/
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'error_recovery_invalid_syntax':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_codegen.snap
@@ -103,7 +103,7 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'init'/1, 'handle_cas
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'error_recovery_malformed_message':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_codegen.snap
@@ -103,7 +103,7 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'init'/1, 'handle_c
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'error_recovery_unterminated_string':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_codegen.snap
@@ -103,7 +103,7 @@ module 'future_pattern_matching' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'ha
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'future_pattern_matching':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_codegen.snap
@@ -110,7 +110,7 @@ module 'future_string_interpolation' ['start_link'/1, 'init'/1, 'handle_cast'/2,
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'future_string_interpolation':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__hello_world_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__hello_world_codegen.snap
@@ -103,7 +103,7 @@ module 'hello_world' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'/3
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'hello_world':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__map_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__map_literals_codegen.snap
@@ -103,7 +103,7 @@ module 'map_literals' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'/
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'map_literals':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_codegen.snap
@@ -103,7 +103,7 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'init'/1, 'handle_cast'/2, 
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'multi_keyword_complex_args':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_codegen.snap
@@ -103,7 +103,7 @@ module 'nested_blocks' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'nested_blocks':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_codegen.snap
@@ -103,7 +103,7 @@ module 'nested_keyword_messages' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'ha
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'nested_keyword_messages':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__string_operations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__string_operations_codegen.snap
@@ -108,7 +108,7 @@ module 'string_operations' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_c
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'string_operations':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_codegen.snap
@@ -111,7 +111,7 @@ module 'typed_methods' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'typed_methods':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_codegen.snap
@@ -104,7 +104,7 @@ module 'unary_operators' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_cal
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'unary_operators':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_codegen.snap
@@ -107,7 +107,7 @@ module 'unicode_string_literals' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'ha
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'unicode_string_literals':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_codegen.snap
@@ -103,7 +103,7 @@ module 'while_true_simple' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_c
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'while_true_simple':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_codegen.snap
@@ -105,7 +105,7 @@ module 'whitespace_handling' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'whitespace_handling':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_codegen.snap
@@ -104,7 +104,7 @@ module 'workspace_binding_cascade' ['start_link'/1, 'init'/1, 'handle_cast'/2, '
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'workspace_binding_cascade':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_codegen.snap
@@ -104,7 +104,7 @@ module 'workspace_binding_send' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'han
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'workspace_binding_send':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_codegen.snap
@@ -103,7 +103,7 @@ module 'ws_stdlib_array' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_cal
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'ws_stdlib_array':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_codegen.snap
@@ -105,7 +105,7 @@ module 'ws_stdlib_block' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_cal
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'ws_stdlib_block':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_codegen.snap
@@ -103,7 +103,7 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_c
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'ws_stdlib_boolean':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_codegen.snap
@@ -103,7 +103,7 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handl
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'ws_stdlib_dictionary':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_codegen.snap
@@ -105,7 +105,7 @@ module 'ws_stdlib_integer' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_c
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'ws_stdlib_integer':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_codegen.snap
@@ -103,7 +103,7 @@ module 'ws_stdlib_list' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'ws_stdlib_list':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_codegen.snap
@@ -103,7 +103,7 @@ module 'ws_stdlib_nil' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'ws_stdlib_nil':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_codegen.snap
@@ -108,7 +108,7 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handl
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'ws_stdlib_nil_object':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_codegen.snap
@@ -103,7 +103,7 @@ module 'ws_stdlib_set' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'ws_stdlib_set':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_codegen.snap
@@ -105,7 +105,7 @@ module 'ws_stdlib_string' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_ca
 
 
 'terminate'/2 = fun (Reason, State) ->
-    %% Call terminate method if defined (Flavors pattern)
+    %% Call terminate method if defined
     let Self = call 'beamtalk_actor':'make_self'(State) in
     case call 'ws_stdlib_string':'dispatch'('terminate', [Reason], Self, State) of
         <{'reply', _TermResult, _TermState}> when 'true' -> 'ok'


### PR DESCRIPTION
## Summary

Removes the completely unused before/after method infrastructure from the Flavors-inspired design in `beamtalk_object_class.erl`, and updates stale Flavors comments in Rust codegen files.

**Linear issue:** https://linear.app/beamtalk/issue/BT-796

## Changes

- Remove `before_methods` and `after_methods` fields from `#class_state{}` record
- Remove `add_before/3` and `add_after/3` exported API functions and handle_call clauses
- Remove before/after population during class registration in `init/1`
- Remove `add_before_method_test_/0` and `add_after_method_test_/0` tests
- Update `callbacks.rs`: remove "(Flavors pattern)" from terminate comment
- Update `dispatch.rs`: remove "(following LFE Flavors pattern)" from doc comment
- Update `erlang_types.rs`: replace "from the Flavors architecture" with "two-module actor pattern"
- Regenerate 51 codegen snapshot files to reflect updated comment

## Test plan

- [x] `just test` passes (316 codegen + 2156 runtime tests)
- [x] `just test-stdlib` passes (392 tests)
- [x] `just build && just clippy && just fmt-check` passes
- [x] No remaining references to `before_methods`/`after_methods`/`add_before`/`add_after` in runtime or codegen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology and documentation strings in core code generation modules.

* **Refactor**
  * Removed public method addition APIs from the runtime object class.
  * Removed associated state fields from class definitions.

* **Tests**
  * Removed related test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->