### PR TITLE
Add regression tests for REPL loop mutation accumulation (BT-800)

### DIFF
--- a/tests/e2e/cases/multi_statement.bt
+++ b/tests/e2e/cases/multi_statement.bt
@@ -89,6 +89,13 @@ x := 1. 5 timesRepeat: [x := x + 1]. x
 :clear
 // => ok
 
+// BT-800: starting from zero, mutations must accumulate (not repeat initial read)
+x := 0. 5 timesRepeat: [x := x + 1]. x
+// => 5
+
+:clear
+// => ok
+
 // whileTrue: in intermediate position threads state to final read
 x := 0. [x < 5] whileTrue: [x := x + 1]. x
 // => 5

--- a/tests/e2e/cases/variable_persistence.bt
+++ b/tests/e2e/cases/variable_persistence.bt
@@ -33,3 +33,19 @@ x := 100
 // Use updated value
 x + y
 // => 110
+
+// ===========================================================================
+// BT-800: LOOP MUTATIONS PERSIST ACROSS SEPARATE REPL INPUTS
+// ===========================================================================
+
+// Assign counter variable
+count := 0
+// => 0
+
+// Run loop as a standalone REPL input - mutations must accumulate and persist
+5 timesRepeat: [count := count + 1]
+// => _
+
+// Counter must reflect accumulated loop mutations
+count
+// => 5


### PR DESCRIPTION
## Summary

- Adds unit tests verifying REPL loop codegen uses plain keys (not `__local__` prefix) and reads from `StateAcc` for accumulation
- Adds E2E test for `x := 0. 5 timesRepeat: [x := x + 1]. x // => 5` (multi-statement starting from zero)
- Adds E2E test for standalone loop mutation persisting across separate REPL inputs

## Context

BT-800 was discovered during code review of BT-790. The key read/write mismatch was already fixed by BT-790's write path change. These tests verify the fix is complete and prevent regression.

[Linear: BT-800](https://linear.app/beamtalk/issue/BT-800)

## Test plan

- [x] Unit tests pass
- [x] E2E tests pass
- [x] Full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)