### PR TITLE
chore: pretty-print Core Erlang in compiler port & CLI

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/display.rs
+++ b/crates/beamtalk-cli/src/commands/repl/display.rs
@@ -231,12 +231,16 @@ pub(crate) fn display_codegen(core_erlang: &str) {
             }
 
             // Try to receive any captured output (small timeout).
-            let output_bytes = rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap_or_default();
-
+            // Only use formatted output when receive succeeds and bytes are non-empty,
+            // to avoid printing a blank line on timeout.
             if exited {
-                if let Ok(formatted) = String::from_utf8(output_bytes) {
-                    println!("{}", color::paint(color::CYAN, &formatted));
-                    return;
+                if let Ok(output_bytes) = rx.recv_timeout(std::time::Duration::from_secs(1)) {
+                    if !output_bytes.is_empty() {
+                        if let Ok(formatted) = String::from_utf8(output_bytes) {
+                            println!("{}", color::paint(color::CYAN, &formatted));
+                            return;
+                        }
+                    }
                 }
             }
         }

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_port.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_port.erl
@@ -137,7 +137,7 @@ handle_response(#{status := error, diagnostics := Diagnostics}) ->
     {error, Diagnostics};
 handle_response(Other) ->
     ?LOG_ERROR("Unexpected compiler response", #{response => Other}),
-    {error, [<<"Unexpected compiler response">>]}. 
+    {error, [<<"Unexpected compiler response">>]}.
 
 %% Try to pretty-print textual Core Erlang using Erlang's core parser/pretty-printer.
 %% Falls back to the original Core Erlang text on any failure.
@@ -149,7 +149,8 @@ maybe_pretty_core(CoreErlang) when is_binary(CoreErlang) ->
             case catch core_parse:parse(Tokens) of
                 {ok, CoreModule} ->
                     case catch core_pp:format(CoreModule) of
-                        {'EXIT', _} -> CoreErlang;
+                        {'EXIT', _} ->
+                            CoreErlang;
                         Formatted ->
                             %% Ensure we return a binary
                             try iolist_to_binary(Formatted) of
@@ -158,9 +159,11 @@ maybe_pretty_core(CoreErlang) when is_binary(CoreErlang) ->
                                 _:_ -> CoreErlang
                             end
                     end;
-                _ -> CoreErlang
+                _ ->
+                    CoreErlang
             end;
-        _ -> CoreErlang
+        _ ->
+            CoreErlang
     end;
 maybe_pretty_core(Other) when not is_binary(Other) -> erlang:error(badarg).
 


### PR DESCRIPTION
Server-side formatting via Erlang core_pp; CLI fallback uses external core_pp.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Core Erlang output now attempts to be prettified using an external formatter (with a timeout); when successful the formatted output is shown (in cyan).
  * If formatting fails or times out, the display gracefully falls back to the original raw output.

* **Documentation**
  * Compiler binary lookup docs note a fallback to PATH when development/release locations aren't found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->