### PR TITLE
Metaclass bootstrap stub, runtime wiring, and primitives (BT-802)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -33,7 +33,7 @@
 %%% | classInstVarNames/1         | Instance variable names from class gen_server state       |
 %%% | classAllInstVarNames/1      | Combined instance variable names via superclass chain     |
 %%% | className/1                 | Class name from class gen_server state                    |
-%%% | classClass/1                | Virtual metaclass sentinel                                |
+%%% | classClass/1                | Real metaclass object (ADR 0036)                          |
 %%% | classDoc/1                  | Class doc string from class gen_server state (ADR 0033)   |
 %%% | classSetDoc/2               | Set class doc string (ADR 0033)                           |
 %%% | classSetMethodDoc/3         | Set method doc string for a selector (ADR 0033)           |
@@ -61,6 +61,12 @@
     classAllInstVarNames/1,
     className/1,
     classClass/1,
+    %% ADR 0036: Metaclass primitives
+    metaclassThisClass/1,
+    metaclassSuperclass/1,
+    metaclassClassMethods/1,
+    metaclassLocalClassMethods/1,
+    metaclassIncludesSelector/2,
     %% ADR 0033: Runtime-embedded documentation
     classDoc/1,
     classSetDoc/2,
@@ -300,13 +306,20 @@ className(Self) ->
     ClassPid = erlang:element(4, Self),
     gen_server:call(ClassPid, class_name).
 
-%% @doc Return the virtual metaclass sentinel.
+%% @doc Return the metaclass object for the receiver.
 %%
-%% ADR 0013: Virtual metaclasses — full metaclass tower is future work.
-%% Returns 'Metaclass' as the sentinel atom for now.
--spec classClass(#beamtalk_object{}) -> atom().
-classClass(_Self) ->
-    'Metaclass'.
+%% ADR 0036: Replaces the sentinel atom with a real `#beamtalk_object{}`.
+%% Wraps the same class pid but dispatches through the 'Metaclass' chain.
+%% No new gen_server process — virtual tag approach from ADR 0013 continues.
+%%
+%% Idempotent: when called on a `class='Metaclass'`-tagged object (i.e.,
+%% `Metaclass class class`), extracts pid and returns a new structurally
+%% identical record. This enables `Metaclass class class == Metaclass class`
+%% (Erlang structural `==` compares all three fields: class, class_mod, pid).
+-spec classClass(#beamtalk_object{}) -> #beamtalk_object{}.
+classClass(Self) ->
+    Pid = erlang:element(4, Self),
+    #beamtalk_object{class = 'Metaclass', class_mod = beamtalk_metaclass_bt, pid = Pid}.
 
 %% @doc Return the class documentation string, or nil if none set.
 %%
@@ -404,6 +417,78 @@ classRemoveFromSystem(Self) ->
                     beamtalk_error:raise(Error2)
             end
     end.
+
+%%% ============================================================================
+%%% Metaclass Primitives (ADR 0036 Phase 1)
+%%% ============================================================================
+
+%% @doc Return the class this metaclass describes.
+%%
+%% ADR 0036: Backs `@primitive "metaclassThisClass"` in Metaclass.bt.
+%% A metaclass object carries the class pid; we retrieve its name and return
+%% the class object. Example: `Counter class class thisClass == Counter`.
+-spec metaclassThisClass(#beamtalk_object{}) -> #beamtalk_object{} | nil.
+metaclassThisClass(Self) ->
+    Pid = erlang:element(4, Self),
+    ClassName = gen_server:call(Pid, class_name),
+    atom_to_class_object(ClassName).
+
+%% @doc Return the superclass of the metaclass parallel hierarchy.
+%%
+%% ADR 0036: Backs `@primitive "metaclassSuperclass"` in Metaclass.bt.
+%% The superclass of Counter's metaclass is the metaclass of Counter's superclass.
+%% Example: `Counter class superclass == Actor class`.
+-spec metaclassSuperclass(#beamtalk_object{}) -> #beamtalk_object{} | nil.
+metaclassSuperclass(Self) ->
+    Pid = erlang:element(4, Self),
+    case gen_server:call(Pid, superclass) of
+        none ->
+            nil;
+        SuperName ->
+            case atom_to_class_object(SuperName) of
+                nil -> nil;
+                SuperClassObj -> classClass(SuperClassObj)
+            end
+    end.
+
+%% @doc Return all class-side method selectors (full inheritance chain).
+%%
+%% ADR 0036: Backs `@primitive "metaclassClassMethods"` in Metaclass.bt.
+%% Walks the superclass chain collecting all class-side selectors.
+-spec metaclassClassMethods(#beamtalk_object{}) -> [atom()].
+metaclassClassMethods(Self) ->
+    Pid = erlang:element(4, Self),
+    ClassName = gen_server:call(Pid, class_name),
+    Acc = walk_hierarchy(
+        ClassName,
+        fun(_CN, CPid, A) ->
+            ClassMethods = gen_server:call(CPid, get_local_class_methods),
+            Selectors = maps:keys(ClassMethods),
+            {cont, ordsets:union(A, ordsets:from_list(Selectors))}
+        end,
+        ordsets:new()
+    ),
+    ordsets:to_list(Acc).
+
+%% @doc Return local class-side method selectors (non-inherited).
+%%
+%% ADR 0036: Backs `@primitive "metaclassLocalClassMethods"` in Metaclass.bt.
+%% Returns only class methods defined directly on this class.
+-spec metaclassLocalClassMethods(#beamtalk_object{}) -> [atom()].
+metaclassLocalClassMethods(Self) ->
+    Pid = erlang:element(4, Self),
+    ClassMethods = gen_server:call(Pid, get_local_class_methods),
+    maps:keys(ClassMethods).
+
+%% @doc Test whether the selector is defined as a class-side method.
+%%
+%% ADR 0036: Backs `@primitive "metaclassIncludesSelector"` in Metaclass.bt.
+%% Does NOT check superclasses — local containment only.
+-spec metaclassIncludesSelector(#beamtalk_object{}, atom()) -> boolean().
+metaclassIncludesSelector(Self, Selector) ->
+    Pid = erlang:element(4, Self),
+    ClassMethods = gen_server:call(Pid, get_local_class_methods),
+    maps:is_key(Selector, ClassMethods).
 
 %%% ============================================================================
 %%% Internal Helpers

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -21,6 +21,7 @@
 
 -export([
     class_send/3,
+    metaclass_send/4,
     unwrap_class_call/1,
     class_method_fun_name/1,
     is_test_execution_selector/1,
@@ -106,6 +107,46 @@ class_send(ClassPid, Selector, Args) ->
             end;
         Other ->
             unwrap_class_call(Other)
+    end.
+
+%% @doc Send a message to a metaclass object (ADR 0036 Phase 1, BT-802).
+%%
+%% Routes messages on metaclass objects (tagged `class='Metaclass'`) through:
+%%   1. `{metaclass_method_call, Selector, Args}` to the class gen_server — returns
+%%      `{error, not_found}` for the Phase 1 stub (user-defined metaclass methods
+%%      are not yet supported).
+%%   2. Fallthrough to `beamtalk_dispatch:lookup/5` starting at 'Metaclass', which
+%%      walks the Metaclass → Class → Behaviour → Object → ProtoObject chain.
+%%
+%% The class pid is the same as the described class (virtual tag approach, ADR 0013).
+%% Self carries `class='Metaclass'` so method dispatch receives the correct receiver.
+-spec metaclass_send(pid(), atom(), list(), #beamtalk_object{}) -> term().
+metaclass_send(Pid, Selector, Args, Self) ->
+    case gen_server:call(Pid, {metaclass_method_call, Selector, Args}) of
+        {ok, Result} ->
+            Result;
+        {error, not_found} ->
+            case beamtalk_dispatch:lookup(Selector, Args, Self, #{}, 'Metaclass') of
+                {reply, Result, _NewState} ->
+                    Result;
+                {error, #beamtalk_error{kind = does_not_understand}} ->
+                    ClassName = gen_server:call(Pid, class_name),
+                    Error = beamtalk_error:new(
+                        does_not_understand,
+                        ClassName,
+                        Selector,
+                        <<"Metaclass does not understand this message">>
+                    ),
+                    beamtalk_error:raise(Error);
+                {error, #beamtalk_error{kind = class_not_found}} ->
+                    %% 'Metaclass' process not registered — graceful fallback.
+                    Error = beamtalk_error:new(does_not_understand, 'Metaclass', Selector),
+                    beamtalk_error:raise(Error);
+                {error, Error} ->
+                    %% A real error from a method in the chain. Wrap idempotently.
+                    Wrapped = beamtalk_exception_handler:ensure_wrapped(Error),
+                    error(Wrapped)
+            end
     end.
 
 %% @doc Unwrap a class gen_server call result for use in class_send.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_message_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_message_dispatch.erl
@@ -43,15 +43,23 @@
 send(Receiver, Selector, Args) ->
     case is_actor(Receiver) of
         true ->
-            case beamtalk_class_registry:is_class_object(Receiver) of
-                true ->
-                    ClassPid = element(4, Receiver),
-                    beamtalk_object_class:class_send(ClassPid, Selector, Args);
-                false ->
-                    Pid = element(4, Receiver),
-                    Future = beamtalk_future:new(),
-                    beamtalk_actor:async_send(Pid, Selector, Args, Future),
-                    Future
+            case element(2, Receiver) of
+                'Metaclass' ->
+                    %% ADR 0036 (BT-802): Metaclass objects dispatch synchronously via
+                    %% the Metaclass → Class → Behaviour chain. They must NOT be treated
+                    %% as regular actor instances (which would return a Future PID).
+                    beamtalk_primitive:send(Receiver, Selector, Args);
+                _ ->
+                    case beamtalk_class_registry:is_class_object(Receiver) of
+                        true ->
+                            ClassPid = element(4, Receiver),
+                            beamtalk_object_class:class_send(ClassPid, Selector, Args);
+                        false ->
+                            Pid = element(4, Receiver),
+                            Future = beamtalk_future:new(),
+                            beamtalk_actor:async_send(Pid, Selector, Args, Future),
+                            Future
+                    end
             end;
         false ->
             beamtalk_primitive:send(Receiver, Selector, Args)

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_metaclass_bt.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_metaclass_bt.erl
@@ -1,0 +1,127 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%%% @doc Minimal Metaclass bootstrap stub for ADR 0036 (Full Metaclass Tower Phase 1).
+%%%
+%% **DDD Context:** Object System
+%%%
+%%% This module acts as the implementation module for the 'Metaclass' class,
+%%% enabling ADR 0036 Phase 1: replacing the `#Metaclass` sentinel atom with a
+%%% real `#beamtalk_object{}` and wiring up metaclass dispatch through the runtime.
+%%%
+%%% ## Phase 1 (BT-802): Bootstrap Stub and Runtime Wiring
+%%%
+%%% Implements the 3 identity predicates that differ from the 'Class' chain:
+%%%   - `isMeta`      → true  (overrides Behaviour's false)
+%%%   - `isClass`     → false (overrides Class's true)
+%%%   - `isMetaclass` → true  (not defined in superclasses)
+%%%
+%%% All other selectors return `does_not_understand` and fall through to the
+%%% Class → Behaviour → Object → ProtoObject chain via beamtalk_dispatch.
+%%%
+%%% ## Future (ADR 0036 Phase 3)
+%%%
+%%% This stub will be replaced by a compiled Metaclass.bt stdlib module once
+%%% the full Metaclass protocol (thisClass, name, superclass, printString) is
+%%% implemented (BT-803 or equivalent Phase 2/3 issue).
+%%%
+%%% ## Metaclass Chain
+%%%
+%%% Metaclass objects (e.g., Counter class class) dispatch through:
+%%%   Metaclass instance methods → Class instance methods → Behaviour → Object → ProtoObject
+%%%
+%%% This module provides the 'Metaclass' instance methods entry point.
+
+-module(beamtalk_metaclass_bt).
+
+-include("beamtalk.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+%% API
+-export([dispatch/4, has_method/1, register_class/0]).
+
+%%% ============================================================================
+%%% Instance Method Dispatch (called by beamtalk_dispatch:lookup when Self is a metaclass object)
+%%% ============================================================================
+
+%% @doc Dispatch instance messages on Metaclass objects.
+%%
+%% Metaclass objects (e.g., Counter class class) respond to identity predicates
+%% via this module. All other selectors fall through to the Class/Behaviour chain.
+%%
+%% ADR 0036 Phase 1 (BT-802): Implements the 3 identity predicates that are
+%% overridden from the Class chain:
+%%   - isMeta      → true  (Behaviour defines isMeta → false; Metaclass overrides)
+%%   - isClass     → false (Class defines isClass → true; Metaclass overrides)
+%%   - isMetaclass → true  (new predicate, not in superclasses)
+%%
+%% Future (ADR 0036 Phase 3): This stub will be replaced by compiled Metaclass.bt.
+-spec dispatch(atom(), list(), term(), map()) ->
+    {reply, term(), map()} | {error, #beamtalk_error{}, map()}.
+dispatch('isMeta', [], _Self, State) ->
+    {reply, true, State};
+dispatch('isClass', [], _Self, State) ->
+    {reply, false, State};
+dispatch('isMetaclass', [], _Self, State) ->
+    {reply, true, State};
+dispatch(Selector, _Args, _Self, State) ->
+    Error0 = beamtalk_error:new(does_not_understand, 'Metaclass'),
+    Error = beamtalk_error:with_selector(Error0, Selector),
+    {error, Error, State}.
+
+%% @doc Check if Metaclass has an instance method.
+%%
+%% Returns true for the 3 identity predicates implemented directly in this stub.
+%% All other selectors are inherited from Class/Behaviour via chain walk.
+%%
+%% ADR 0036 Phase 3: Will be replaced by compiled Metaclass.bt exports.
+-spec has_method(atom()) -> boolean().
+has_method('isMeta') -> true;
+has_method('isClass') -> true;
+has_method('isMetaclass') -> true;
+has_method(_) -> false.
+
+%%% ============================================================================
+%%% Class Registration (called during bootstrap)
+%%% ============================================================================
+
+%% @doc Register the 'Metaclass' class in the class registry.
+%%
+%% Called during bootstrap (beamtalk_bootstrap) after 'Class' is registered.
+%% Bootstrap order: ProtoObject → Object → Behaviour → Class → Metaclass → Actor → user modules.
+%%
+%% The 'Metaclass' class:
+%%   - superclass: 'Class' (inherits class protocol)
+%%   - module: beamtalk_metaclass_bt (this module)
+%%   - instance_methods: 3 identity predicates (isMeta, isClass, isMetaclass)
+%%
+%% ADR 0036 Phase 1: Bootstrap stub. Full protocol in Phase 3 (Metaclass.bt).
+-spec register_class() -> ok.
+register_class() ->
+    ClassInfo = #{
+        name => 'Metaclass',
+        superclass => 'Class',
+        module => beamtalk_metaclass_bt,
+        instance_variables => [],
+        class_methods => #{},
+        instance_methods => #{
+            'isMeta' => #{arity => 0},
+            'isClass' => #{arity => 0},
+            'isMetaclass' => #{arity => 0},
+            'thisClass' => #{arity => 0},
+            'name' => #{arity => 0}
+        }
+    },
+    case beamtalk_object_class:start('Metaclass', ClassInfo) of
+        {ok, _Pid} ->
+            ?LOG_INFO("Registered Metaclass (ADR 0036 Phase 1 stub)", #{module => ?MODULE}),
+            ok;
+        {error, {already_started, _}} ->
+            %% Metaclass was already registered (e.g., bootstrap ran twice or a prior
+            %% test registered it). Refresh the metadata to keep it consistent.
+            beamtalk_object_class:update_class('Metaclass', ClassInfo),
+            ok;
+        {error, Reason} ->
+            ?LOG_WARNING("Failed to register Metaclass", #{reason => Reason}),
+            ok
+    end.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -462,6 +462,11 @@ handle_call({set_doc, DocBinary}, _From, State) ->
 handle_call({set_method_doc, Selector, DocBinary}, _From, State) ->
     NewMethodDocs = maps:put(Selector, DocBinary, State#class_state.method_docs),
     {reply, ok, State#class_state{method_docs = NewMethodDocs}};
+%% ADR 0036: Metaclass method dispatch stub.
+%% Returns {error, not_found} — the fallthrough to the 'Metaclass' chain is
+%% handled by beamtalk_class_dispatch:metaclass_send/4 in the caller.
+handle_call({metaclass_method_call, _Selector, _Args}, _From, State) ->
+    {reply, {error, not_found}, State};
 %% BT-411/BT-412/BT-440: Class method dispatch.
 %% Delegates to beamtalk_class_dispatch (BT-704).
 %% ADR 0032 Phase 1: Passes local class_methods (no flattened table).

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl
@@ -57,14 +57,24 @@ class_of(_) ->
     'Object'.
 
 %% @doc Return the class of any value as a first-class class object (BT-412).
--spec class_of_object(term()) -> tuple() | atom().
-class_of_object('Metaclass') ->
-    'Metaclass';
-class_of_object(#beamtalk_object{class = ClassName}) ->
-    %% BT-412: class of a class object → 'Metaclass' sentinel (terminal)
+%%
+%% ADR 0036: For class objects (tagged with " class" suffix) returns a real
+%% metaclass object instead of the sentinel atom 'Metaclass'. For metaclass
+%% objects (tagged with 'Metaclass'), returns the same struct (idempotent) to
+%% enable the self-grounding invariant: `Metaclass class class == Metaclass class`.
+-spec class_of_object(term()) -> #beamtalk_object{} | atom().
+class_of_object(#beamtalk_object{class = 'Metaclass', class_mod = ClassMod, pid = Pid}) ->
+    %% ADR 0036 self-grounding: class of a metaclass object is itself (idempotent).
+    %% This ensures `Metaclass class class == Metaclass class` holds via structural
+    %% equality: both produce #beamtalk_object{class='Metaclass', pid=MetaclassPid}.
+    #beamtalk_object{class = 'Metaclass', class_mod = ClassMod, pid = Pid};
+class_of_object(#beamtalk_object{class = ClassName, pid = Pid}) ->
+    %% ADR 0036: class of a class object → real metaclass object (wraps same pid).
     case beamtalk_class_registry:is_class_name(ClassName) of
-        true -> 'Metaclass';
-        false -> class_of_object_inner(ClassName)
+        true ->
+            #beamtalk_object{class = 'Metaclass', class_mod = beamtalk_metaclass_bt, pid = Pid};
+        false ->
+            class_of_object_inner(ClassName)
     end;
 class_of_object(X) ->
     ClassName = class_of(X),
@@ -97,12 +107,14 @@ print_string(false) ->
     <<"false">>;
 print_string(nil) ->
     <<"nil">>;
-print_string('Metaclass') ->
-    <<"Metaclass">>;
 print_string(X) when is_atom(X) ->
     iolist_to_binary([<<"#">>, erlang:atom_to_binary(X, utf8)]);
 print_string(X) when is_list(X) ->
     iolist_to_binary([<<"#(">>, lists:join(<<", ">>, [print_string(E) || E <- X]), <<")">>]);
+print_string(#beamtalk_object{class = 'Metaclass', pid = Pid}) ->
+    %% ADR 0036: Metaclass objects display as "ClassName class" (e.g. "Integer class").
+    ClassName = beamtalk_object_class:class_name(Pid),
+    iolist_to_binary([atom_to_binary(ClassName, utf8), <<" class">>]);
 print_string(#beamtalk_object{class = ClassName}) ->
     case beamtalk_class_registry:is_class_name(ClassName) of
         true -> beamtalk_class_registry:class_display_name(ClassName);
@@ -148,6 +160,10 @@ print_string_map(X) ->
 
 %% @doc Send a message to any value (actor or primitive).
 -spec send(term(), atom(), list()) -> term().
+send(#beamtalk_object{class = 'Metaclass', pid = Pid} = Self, Selector, Args) ->
+    %% ADR 0036: Route metaclass objects through the Metaclass dispatch chain.
+    %% Must be matched before the generic #beamtalk_object{} clause below.
+    beamtalk_class_dispatch:metaclass_send(Pid, Selector, Args, Self);
 send(#beamtalk_object{pid = Pid}, Selector, Args) ->
     gen_server:call(Pid, {Selector, Args});
 send(X, Selector, Args) when is_tuple(X) ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_runtime_app.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_runtime_app.erl
@@ -7,6 +7,9 @@
 -module(beamtalk_runtime_app).
 -behaviour(application).
 
+-include("beamtalk.hrl").
+-include_lib("kernel/include/logger.hrl").
+
 -export([start/2, stop/1]).
 
 %% @private
@@ -25,7 +28,57 @@ start(_StartType, _StartArgs) ->
 
     %% Start the runtime supervisor tree (which starts beamtalk_bootstrap, beamtalk_stdlib,
     %% and beamtalk_object_instances; pg is conditionally started inside beamtalk_bootstrap:init/1)
-    beamtalk_runtime_sup:start_link().
+    case beamtalk_runtime_sup:start_link() of
+        {ok, _} = Ok ->
+            %% ADR 0036 Phase 1 (BT-802): Post-bootstrap self-grounding assertion.
+            %% Validates that Metaclass class class == Metaclass class holds
+            %% after bootstrap. This is a soft assertion (logs on failure, does not crash).
+            verify_metaclass_self_grounding(),
+            Ok;
+        Error ->
+            Error
+    end.
+
+%% @private
+%% @doc Verify the ADR 0036 metaclass self-grounding invariant after bootstrap.
+%%
+%% The invariant: `Metaclass class class == Metaclass class`
+%% In Erlang terms: class_of_object(class_of_object(MetaclassRef)) =:= class_of_object(MetaclassRef)
+%% This holds because class_of_object/1 is idempotent for 'Metaclass'-tagged objects.
+-spec verify_metaclass_self_grounding() -> ok.
+verify_metaclass_self_grounding() ->
+    case beamtalk_class_registry:whereis_class('Metaclass') of
+        undefined ->
+            %% Metaclass not registered — bootstrap may not have run yet.
+            ok;
+        MetaclassPid ->
+            Module = beamtalk_object_class:module_name(MetaclassPid),
+            Tag = beamtalk_class_registry:class_object_tag('Metaclass'),
+            %% MetaclassRef is the Metaclass class reference (tag='Metaclass class')
+            MetaclassRef = #beamtalk_object{class = Tag, class_mod = Module, pid = MetaclassPid},
+            %% MetaclassClass is "Metaclass class" (tag='Metaclass')
+            MetaclassClass = beamtalk_primitive:class_of_object(MetaclassRef),
+            %% MetaclassClassClass is "Metaclass class class" (must equal MetaclassClass)
+            MetaclassClassClass = beamtalk_primitive:class_of_object(MetaclassClass),
+            case MetaclassClass =:= MetaclassClassClass of
+                true ->
+                    ?LOG_INFO(
+                        "ADR 0036: Metaclass self-grounding OK (Metaclass class class == Metaclass class)",
+                        #{module => ?MODULE}
+                    ),
+                    ok;
+                false ->
+                    ?LOG_ERROR(
+                        "ADR 0036: Metaclass self-grounding FAILED: Metaclass class class =/= Metaclass class",
+                        #{
+                            module => ?MODULE,
+                            metaclass_class => MetaclassClass,
+                            metaclass_class_class => MetaclassClassClass
+                        }
+                    ),
+                    ok
+            end
+    end.
 
 %% @private
 %% @doc Stop the Beamtalk runtime application.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_json.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_json.erl
@@ -288,6 +288,10 @@ term_to_json(#beamtalk_error{} = Error) ->
     iolist_to_binary(beamtalk_error:format(Error));
 term_to_json(Value) when is_tuple(Value) ->
     case Value of
+        {beamtalk_object, 'Metaclass', _Module, Pid} ->
+            %% ADR 0036: Metaclass objects display as "ClassName class" (e.g. "Integer class").
+            ClassName = beamtalk_object_class:class_name(Pid),
+            iolist_to_binary([atom_to_binary(ClassName, utf8), <<" class">>]);
         {beamtalk_object, Class, _Module, Pid} ->
             case beamtalk_class_registry:is_class_name(Class) of
                 true ->

--- a/stdlib/bootstrap-test/class_hierarchy.bt
+++ b/stdlib/bootstrap-test/class_hierarchy.bt
@@ -113,6 +113,6 @@ nil class
 3.14 class
 // => Float
 
-// class on a class object returns the metaclass terminal
+// BT-802 (ADR 0036): class on a class object returns a real metaclass object
 Integer class
-// => Metaclass
+// => Integer class

--- a/stdlib/test/erlang_interop_test.bt
+++ b/stdlib/test/erlang_interop_test.bt
@@ -32,8 +32,9 @@ TestCase subclass: ErlangInteropTest
     self assert: (proxy reverse: #(#a, #b, #c)) equals: #(#c, #b, #a)
 
   testClassProtocolOnErlang =>
+    // BT-802 (ADR 0036): class of a class returns a real metaclass object
     // Class-protocol selectors should NOT generate proxy maps
-    self assert: (Erlang class) equals: #Metaclass
+    self assert: (Erlang class) isMeta equals: true
 
   testProxyObjectProtocol =>
     proxy := Erlang lists.

--- a/stdlib/test/json_test.bt
+++ b/stdlib/test/json_test.bt
@@ -81,5 +81,5 @@ TestCase subclass: JsonTest
     self should: [JSON parse: 42] raise: #type_error
 
   testClassIdentity =>
-    // JSON is a class — class on class returns Metaclass
-    self assert: (JSON class) equals: #Metaclass
+    // BT-802 (ADR 0036): class on class returns a real metaclass object
+    self assert: (JSON class) isMeta equals: true

--- a/stdlib/test/metaclass_test.bt
+++ b/stdlib/test/metaclass_test.bt
@@ -13,9 +13,11 @@ TestCase subclass: MetaclassTest
     self assert: (false class) equals: False.
     self assert: (nil class) equals: UndefinedObject.
     self assert: (#symbol class) equals: Symbol.
-    // Metaclass terminal: class of a class returns "Metaclass" sentinel
-    self assert: (42 class class) equals: #Metaclass.
-    self assert: ("hello" class class) equals: #Metaclass.
-    self assert: (true class class) equals: #Metaclass.
-    // Metaclass tower terminates
-    self assert: (42 class class class) equals: #Metaclass
+    // BT-802 (ADR 0036 Phase 1): Metaclass objects replace the #Metaclass sentinel
+    self assert: (42 class class) isMeta equals: true.
+    self assert: ("hello" class class) isMeta equals: true.
+    self assert: (true class class) isMeta equals: true.
+    // Metaclass objects are not plain classes
+    self assert: (42 class class) isClass equals: false.
+    // Metaclass tower terminates: self-grounding invariant (class class class == class class)
+    self assert: (42 class class class) equals: (42 class class)

--- a/stdlib/test/random_test.bt
+++ b/stdlib/test/random_test.bt
@@ -100,5 +100,5 @@ TestCase subclass: RandomTest
     self should: [rng6 nextInteger: -1] raise: #type_error
 
   testClassIdentity =>
-    // Random is a class — class on class returns Metaclass
-    self assert: (Random class) equals: #Metaclass
+    // BT-802 (ADR 0036): class on class returns a real metaclass object
+    self assert: (Random class) isMeta equals: true

--- a/stdlib/test/regex_test.bt
+++ b/stdlib/test/regex_test.bt
@@ -85,5 +85,5 @@ TestCase subclass: RegexTest
     self should: ["hello" matchesRegex: "[invalid"] raise: #regex_error
 
   testClassIdentity =>
-    // Regex class identity
-    self assert: (Regex class) equals: #Metaclass
+    // BT-802 (ADR 0036): class on class returns a real metaclass object
+    self assert: (Regex class) isMeta equals: true


### PR DESCRIPTION
## Summary

Implements ADR 0036 Phase 1 — replaces the `'Metaclass'` sentinel atom with a real `#beamtalk_object{class='Metaclass'}` throughout the runtime.

- Add `beamtalk_metaclass_bt.erl` bootstrap stub (isMeta/isClass/isMetaclass primitives)
- Wire metaclass into bootstrap sequence via `beamtalk_bootstrap` and class registry
- `class_of_object/1` now returns a real metaclass object (self-grounding invariant)
- `beamtalk_message_dispatch:send/3` routes metaclass objects synchronously (not as async actors)
- `metaclass_send/4` dispatches through the Metaclass → Behaviour chain
- Metaclass display in `beamtalk_stdlib_test` and `beamtalk_repl_json` (e.g. `"Integer class"`)
- Tests updated to use `isMeta equals: true` instead of `equals: #Metaclass` sentinel

Linear: https://linear.app/beamtalk/issue/BT-802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Metaclass is now a real object with dedicated messaging and display, including JSON/REPL output as “<ClassName> class”.
  - Added metaclass introspection: querying its class, superclass, method lists, and selector presence.
  - Specialized dispatch for metaclass messages for consistent behavior across actors and classes.

- Documentation
  - Updated comments and examples to reflect metaclass as a first-class object (ADR 0036).

- Tests
  - Updated expectations to use isMeta and metaclass object structure across stdlib and runtime tests.
  - Added runtime startup verification for metaclass self-grounding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->