### PR TITLE
Self-host TestCase assertions (assert:, deny:, assert:equals:) (BT-819)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/misc.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/misc.rs
@@ -355,33 +355,6 @@ pub(crate) fn generate_test_case_bif(
     params: &[String],
 ) -> Option<Document<'static>> {
     match selector {
-        "assert:" => {
-            let p0 = params.first().map_or("_Condition", String::as_str);
-            Some(docvec![
-                "call 'beamtalk_test_case':'assert'(",
-                p0.to_string(),
-                ")"
-            ])
-        }
-        "assert:equals:" => {
-            let p0 = params.first().map_or("_Actual", String::as_str);
-            let p1 = params.get(1).map_or("_Expected", String::as_str);
-            Some(docvec![
-                "call 'beamtalk_test_case':'assert_equals'(",
-                p1.to_string(),
-                ", ",
-                p0.to_string(),
-                ")",
-            ])
-        }
-        "deny:" => {
-            let p0 = params.first().map_or("_Condition", String::as_str);
-            Some(docvec![
-                "call 'beamtalk_test_case':'deny'(",
-                p0.to_string(),
-                ")"
-            ])
-        }
         "should:raise:" => {
             let p0 = params.first().map_or("_Block", String::as_str);
             let p1 = params.get(1).map_or("_ErrorKind", String::as_str);

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
@@ -1231,9 +1231,9 @@ pub(super) fn generated_builtin_classes() -> HashMap<EcoString, ClassInfo> {
             methods: vec![
                 MethodInfo { selector: "setUp".into(), arity: 0, kind: MethodKind::Primary, defined_in: "TestCase".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![] },
                 MethodInfo { selector: "tearDown".into(), arity: 0, kind: MethodKind::Primary, defined_in: "TestCase".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![] },
-                MethodInfo { selector: "assert:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "TestCase".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![Some("Object".into())] },
+                MethodInfo { selector: "assert:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "TestCase".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![Some("Boolean".into())] },
+                MethodInfo { selector: "deny:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "TestCase".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![Some("Boolean".into())] },
                 MethodInfo { selector: "assert:equals:".into(), arity: 2, kind: MethodKind::Primary, defined_in: "TestCase".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![None, None] },
-                MethodInfo { selector: "deny:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "TestCase".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![Some("Object".into())] },
                 MethodInfo { selector: "should:raise:".into(), arity: 2, kind: MethodKind::Primary, defined_in: "TestCase".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![Some("Block".into()), Some("Object".into())] },
                 MethodInfo { selector: "fail:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "TestCase".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![Some("String".into())] },
             ],

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_test_case_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_test_case_tests.erl
@@ -11,58 +11,8 @@
 -include("beamtalk.hrl").
 
 %%% ============================================================================
-%%% Assertion Tests (direct EUnit coverage of primitives)
+%%% fail: Tests (direct EUnit coverage — fail: remains @primitive)
 %%% ============================================================================
-
-assert_true_test() ->
-    ?assertEqual(nil, beamtalk_test_case:assert(true)).
-
-assert_false_raises_test() ->
-    ?assertError(
-        #{
-            '$beamtalk_class' := _,
-            error := #beamtalk_error{kind = assertion_failed, class = 'TestCase'}
-        },
-        beamtalk_test_case:assert(false)
-    ).
-
-assert_non_boolean_raises_type_error_test() ->
-    ?assertError(
-        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = type_error, class = 'TestCase'}},
-        beamtalk_test_case:assert(42)
-    ).
-
-deny_false_test() ->
-    ?assertEqual(nil, beamtalk_test_case:deny(false)).
-
-deny_true_raises_test() ->
-    ?assertError(
-        #{
-            '$beamtalk_class' := _,
-            error := #beamtalk_error{kind = assertion_failed, class = 'TestCase'}
-        },
-        beamtalk_test_case:deny(true)
-    ).
-
-deny_non_boolean_raises_type_error_test() ->
-    ?assertError(
-        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = type_error, class = 'TestCase'}},
-        beamtalk_test_case:deny(<<"not a bool">>)
-    ).
-
-assert_equals_matching_test() ->
-    ?assertEqual(nil, beamtalk_test_case:assert_equals(42, 42)),
-    ?assertEqual(nil, beamtalk_test_case:assert_equals(<<"hello">>, <<"hello">>)),
-    ?assertEqual(nil, beamtalk_test_case:assert_equals(true, true)).
-
-assert_equals_mismatch_raises_test() ->
-    ?assertError(
-        #{
-            '$beamtalk_class' := _,
-            error := #beamtalk_error{kind = assertion_failed, class = 'TestCase'}
-        },
-        beamtalk_test_case:assert_equals(1, 2)
-    ).
 
 fail_with_binary_test() ->
     ?assertError(

--- a/stdlib/src/TestCase.bt
+++ b/stdlib/src/TestCase.bt
@@ -18,10 +18,16 @@ Object subclass: TestCase
   setUp -> Nil => nil
   tearDown -> Nil => nil
 
-  // Core assertions — @primitive methods implemented in beamtalk_test_case.erl
-  assert: condition: Object -> Nil => @primitive "assert:"
-  assert: actual equals: expected -> Nil => @primitive "assert:equals:"
-  deny: condition: Object -> Nil => @primitive "deny:"
+  // Core assertions — pure Beamtalk implementations (ADR 0034 Phase 4)
+  assert: condition: Boolean -> Nil =>
+    condition ifFalse: [self fail: "Assertion failed: expected true, got {condition}"].
+    nil
+  deny: condition: Boolean -> Nil =>
+    condition ifTrue: [self fail: "Denial failed: expected false, got {condition}"].
+    nil
+  assert: actual equals: expected -> Nil =>
+    (actual =:= expected) ifFalse: [self fail: "Expected {expected}, got {actual}"].
+    nil
   should: block: Block raise: errorKind: Object -> Nil => @primitive "should:raise:"
   fail: message: String -> Nil => @primitive "fail:"
 


### PR DESCRIPTION
## Summary

Replaces `@primitive` backed `assert:`, `deny:`, and `assert:equals:` in `TestCase.bt` with pure Beamtalk implementations using `ifFalse:`/`ifTrue:` and string interpolation. Part of ADR 0034: Stdlib Self-Hosting, Phase 4.

**Linear issue:** https://linear.app/beamtalk/issue/BT-819

## Key Changes

- `TestCase.bt`: Replace 3 `@primitive` assertion methods with pure BT using `ifFalse:`/`ifTrue:` + `self fail:` (fail: remains @primitive)
- `beamtalk_test_case.erl`: Remove `assert/1`, `deny/1`, `assert_equals/2` and dead helper functions (`format_comparison_error`, `format_value`)
- `beamtalk_test_case_tests.erl`: Remove EUnit tests for deleted Erlang primitives
- `generated_builtins.rs`: Auto-updated param types from `Object` to `Boolean` for `assert:` and `deny:`

## Test Plan

- [x] All 325 BUnit tests pass (exercise the new pure-BT assertion path)
- [x] All 2147 Erlang runtime tests pass
- [x] All 2028 Rust tests pass
- [x] `just ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TestCase assertions (`assert:` and `deny:`) now require Boolean parameters, fixing incorrect type handling for test conditions.

* **Refactor**
  * Core assertion primitives replaced with inline implementations to unify behavior and simplify execution.

* **Tests**
  * Test suite reduced to focus on failure cases; several direct primitive assertion tests were removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->