### PR TITLE
Add addFirst: O(1) list cons primitive to List.bt (BT-814)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
@@ -212,6 +212,10 @@ fn generate_list_misc_bif(selector: &str, params: &[String]) -> Option<Document<
                 ")",
             ])
         }
+        "addFirst:" => {
+            let p0 = params.first().map_or("_Item", String::as_str);
+            Some(docvec!["[", p0.to_string(), "|Self]"])
+        }
         "add:" => {
             let p0 = params.first().map_or("_Item", String::as_str);
             Some(docvec![

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
@@ -802,6 +802,7 @@ pub(super) fn generated_builtin_classes() -> HashMap<EcoString, ClassInfo> {
                 MethodInfo { selector: "takeWhile:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "List".into(), is_sealed: false, return_type: Some("List".into()), param_types: vec![Some("Block".into())] },
                 MethodInfo { selector: "dropWhile:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "List".into(), is_sealed: false, return_type: Some("List".into()), param_types: vec![Some("Block".into())] },
                 MethodInfo { selector: "intersperse:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "List".into(), is_sealed: false, return_type: Some("List".into()), param_types: vec![None] },
+                MethodInfo { selector: "addFirst:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "List".into(), is_sealed: false, return_type: Some("List".into()), param_types: vec![None] },
                 MethodInfo { selector: "add:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "List".into(), is_sealed: false, return_type: Some("List".into()), param_types: vec![None] },
                 MethodInfo { selector: "stream".into(), arity: 0, kind: MethodKind::Primary, defined_in: "List".into(), is_sealed: false, return_type: Some("Stream".into()), param_types: vec![] },
                 MethodInfo { selector: "atRandom".into(), arity: 0, kind: MethodKind::Primary, defined_in: "List".into(), is_sealed: false, return_type: None, param_types: vec![] },

--- a/stdlib/src/List.bt
+++ b/stdlib/src/List.bt
@@ -310,6 +310,15 @@ sealed Collection subclass: List
   /// ```
   intersperse: separator -> List => @primitive "intersperse:"
 
+  /// Prepend an item to the front of the list in O(1) time (returns a new list).
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// #(2, 3) addFirst: 1              // => #(1, 2, 3)
+  /// #() addFirst: "x"               // => #("x")
+  /// ```
+  addFirst: item -> List => @primitive "addFirst:"
+
   /// Append an item to the end of the list (returns a new list).
   ///
   /// ## Examples

--- a/stdlib/test/collections_test.bt
+++ b/stdlib/test/collections_test.bt
@@ -55,6 +55,11 @@ TestCase subclass: CollectionsTest
     self assert: (#(1, 2, 3) allSatisfy: [:x | x > 0]).
     self deny: (#(1, 2, 3) allSatisfy: [:x | x > 1])
 
+  testAddFirst =>
+    // --- addFirst: (O(1) cons prepend) ---
+    self assert: (#(2, 3) addFirst: 1) equals: #(1, 2, 3).
+    self assert: (#() addFirst: "x") equals: #("x")
+
   testTier3AdvancedMethods =>
     // --- unique ---
     self assert: (#(3, 1, 2, 1, 3) unique) equals: #(1, 2, 3).


### PR DESCRIPTION
## Summary

Adds `addFirst:` as an O(1) list prepend primitive to `List.bt`, enabling efficient accumulator-based collection building for Phase 2 of ADR 0034 (Stdlib Self-Hosting).

- **`stdlib/src/List.bt`** — Added `addFirst: item -> List` with `@primitive "addFirst:"` annotation and doc comment
- **`list.rs` codegen** — Added case emitting `[Item|Self]` Core Erlang cons syntax (single cons cell allocation)
- **`collections_test.bt`** — Added `testAddFirst` with tests for non-empty and empty list prepend

## Linear Issue

https://linear.app/beamtalk/issue/BT-814

## Test Plan

- [x] `#(2, 3) addFirst: 1` evaluates to `#(1, 2, 3)`
- [x] `#() addFirst: "x"` evaluates to `#("x")`
- [x] `just test` passes
- [x] `just build && just clippy && just fmt-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `addFirst:` method to the List class for constant-time prepending. This method adds an element to the front of a list and returns a new List.

* **Tests**
  * Added test coverage for `addFirst:` operation, validating prepending to both empty and non-empty lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->