### PR TITLE
Self-host abstract Collection protocol in pure Beamtalk (BT-815)

### DIFF
--- a/stdlib/src/Collection.bt
+++ b/stdlib/src/Collection.bt
@@ -8,7 +8,7 @@
 ///
 /// Subclasses must implement `size` and `do:` at minimum.
 /// All other iteration methods have default implementations built
-/// on those two primitives via `beamtalk_collection_ops`.
+/// in pure Beamtalk on those two primitives.
 ///
 /// ## Protocol
 /// ```beamtalk
@@ -51,20 +51,29 @@ abstract Object subclass: Collection
 
   /// Test if the collection contains the given element.
   ///
-  /// Default implementation iterates with `do:`. Subclasses
-  /// may override with more efficient lookup.
+  /// Default implementation iterates with `do:` and returns early on match.
+  /// Subclasses may override with more efficient lookup.
   ///
   /// ## Examples
   /// ```beamtalk
   /// #(1, 2, 3) includes: 2      // => true
   /// #(1, 2, 3) includes: 9      // => false
   /// ```
-  includes: element -> Boolean => @primitive "includes:"
+  includes: element -> Boolean =>
+    self do: [:each | each =:= element ifTrue: [^true]].
+    false
 
   /// Reduce the collection with an accumulator.
   ///
-  /// Evaluates `block` with the accumulator and each element.
+  /// Evaluates `block` with `(accumulator, element)` for each element.
   /// Returns the final accumulator value.
+  ///
+  /// Kept as `@primitive` because the pure-BT implementation using `do:` with
+  /// local-variable mutation does not work for abstract-class methods: the
+  /// compiler generates `lists:foreach` (no state threading) instead of
+  /// `lists:foldl`.  The Erlang helper calls the block as `Block(Acc, Elem)`
+  /// (accumulator first) to match the Beamtalk `block value: acc value: each`
+  /// convention expected by `collect:`, `select:`, and `reject:`.
   ///
   /// ## Examples
   /// ```beamtalk
@@ -74,19 +83,27 @@ abstract Object subclass: Collection
 
   /// Collect results of evaluating `block` on each element.
   ///
+  /// Builds the result in reverse using `addFirst:` then reverses once.
+  ///
   /// ## Examples
   /// ```beamtalk
   /// #(1, 2, 3) collect: [:x | x * 2]  // => #(2, 4, 6)
   /// ```
-  collect: block: Block => @primitive "collect:"
+  collect: block: Block =>
+    (self inject: #() into: [:acc :each | acc addFirst: (block value: each)]) reversed
 
   /// Select elements for which `block` returns true.
+  ///
+  /// Builds the result in reverse using `addFirst:` then reverses once.
   ///
   /// ## Examples
   /// ```beamtalk
   /// #(1, 2, 3, 4) select: [:x | x > 2]  // => #(3, 4)
   /// ```
-  select: block: Block => @primitive "select:"
+  select: block: Block =>
+    (self inject: #() into: [:acc :each |
+      (block value: each) ifTrue: [acc addFirst: each] ifFalse: [acc]
+    ]) reversed
 
   /// Reject elements for which `block` returns true.
   ///
@@ -94,41 +111,57 @@ abstract Object subclass: Collection
   /// ```beamtalk
   /// #(1, 2, 3, 4) reject: [:x | x > 2]  // => #(1, 2)
   /// ```
-  reject: block: Block => @primitive "reject:"
+  reject: block: Block =>
+    self select: [:each | (block value: each) not]
 
   /// Find the first element for which `block` returns true.
   ///
-  /// Returns nil if no element matches.
+  /// Returns nil if no element matches. Uses `^` (non-local return) for
+  /// early exit — this compiles to throw/catch on BEAM.
   ///
   /// ## Examples
   /// ```beamtalk
   /// #(1, 2, 3) detect: [:x | x > 1]     // => 2
   /// ```
-  detect: block: Block => @primitive "detect:"
+  detect: block: Block =>
+    self do: [:each | (block value: each) ifTrue: [^each]].
+    nil
 
   /// Find the first element matching `block`, or evaluate `noneBlock` if none.
+  ///
+  /// Uses `^` (non-local return) for early exit — compiles to throw/catch on BEAM.
   ///
   /// ## Examples
   /// ```beamtalk
   /// #(1, 2) detect: [:x | x > 5] ifNone: [0]  // => 0
   /// ```
-  detect: block: Block ifNone: noneBlock: Block => @primitive "detect:ifNone:"
+  detect: block: Block ifNone: noneBlock: Block =>
+    self do: [:each | (block value: each) ifTrue: [^each]].
+    noneBlock value
 
   /// Test if any element satisfies `block`.
+  ///
+  /// Uses `^` (non-local return) for early exit — compiles to throw/catch on BEAM.
   ///
   /// ## Examples
   /// ```beamtalk
   /// #(1, 2, 3) anySatisfy: [:x | x > 2]  // => true
   /// ```
-  anySatisfy: block: Block -> Boolean => @primitive "anySatisfy:"
+  anySatisfy: block: Block -> Boolean =>
+    self do: [:each | (block value: each) ifTrue: [^true]].
+    false
 
   /// Test if all elements satisfy `block`.
+  ///
+  /// Uses `^` (non-local return) for early exit — compiles to throw/catch on BEAM.
   ///
   /// ## Examples
   /// ```beamtalk
   /// #(2, 4, 6) allSatisfy: [:x | x isEven]  // => true
   /// ```
-  allSatisfy: block: Block -> Boolean => @primitive "allSatisfy:"
+  allSatisfy: block: Block -> Boolean =>
+    self do: [:each | (block value: each) ifFalse: [^false]].
+    true
 
   /// Return a string representation.
   asString -> String => self printString

--- a/stdlib/test/custom_collection_test.bt
+++ b/stdlib/test/custom_collection_test.bt
@@ -1,0 +1,68 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-815: Tests that a user-defined Collection subclass (implementing only
+// do: and size) correctly inherits the abstract Collection protocol.
+
+TestCase subclass: CustomCollectionTest
+
+  testInheritedInjectInto =>
+    col := NumberList new: #{#items => #(1, 2, 3)}.
+    self assert: (col inject: 0 into: [:sum :x | sum + x]) equals: 6.
+    // Non-commutative: verifies block arg order is (accumulator, element).
+    self assert: (col inject: #() into: [:acc :x | acc addFirst: x]) equals: #(3, 2, 1)
+
+  testInheritedCollect =>
+    col := NumberList new: #{#items => #(1, 2, 3)}.
+    self assert: (col collect: [:x | x * 2]) equals: #(2, 4, 6)
+
+  testInheritedSelect =>
+    col := NumberList new: #{#items => #(1, 2, 3, 4)}.
+    self assert: (col select: [:x | x > 2]) equals: #(3, 4)
+
+  testInheritedReject =>
+    col := NumberList new: #{#items => #(1, 2, 3, 4)}.
+    self assert: (col reject: [:x | x > 2]) equals: #(1, 2)
+
+  testInheritedIncludes =>
+    col := NumberList new: #{#items => #(1, 2, 3)}.
+    self assert: (col includes: 2).
+    self deny: (col includes: 9)
+
+  testInheritedIsEmpty =>
+    empty := NumberList new: #{#items => #()}.
+    self assert: empty isEmpty.
+    self deny: empty isNotEmpty.
+    col := NumberList new: #{#items => #(1)}.
+    self deny: col isEmpty.
+    self assert: col isNotEmpty
+
+  testInheritedDetect =>
+    col := NumberList new: #{#items => #(1, 2, 3)}.
+    self assert: (col detect: [:x | x > 1]) equals: 2
+
+  testInheritedDetectIfNone =>
+    col := NumberList new: #{#items => #(1, 2, 3)}.
+    self assert: (col detect: [:x | x > 10] ifNone: [0]) equals: 0
+
+  testInheritedAnySatisfy =>
+    col := NumberList new: #{#items => #(1, 2, 3)}.
+    self assert: (col anySatisfy: [:x | x > 2]).
+    self deny: (col anySatisfy: [:x | x > 5])
+
+  testInheritedAllSatisfy =>
+    col := NumberList new: #{#items => #(1, 2, 3)}.
+    self assert: (col allSatisfy: [:x | x > 0]).
+    self deny: (col allSatisfy: [:x | x > 1])
+
+  testEmptyCollectionEdgeCases =>
+    empty := NumberList new: #{#items => #()}.
+    self assert: (empty inject: 0 into: [:acc :x | acc + x]) equals: 0.
+    self assert: (empty collect: [:x | x * 2]) equals: #().
+    self assert: (empty select: [:x | x > 0]) equals: #().
+    self assert: (empty reject: [:x | x > 0]) equals: #().
+    self deny: (empty includes: 1).
+    self assert: (empty detect: [:x | x > 0]) equals: nil.
+    self assert: (empty detect: [:x | x > 0] ifNone: [42]) equals: 42.
+    self deny: (empty anySatisfy: [:x | x > 0]).
+    self assert: (empty allSatisfy: [:x | x > 0])

--- a/stdlib/test/fixtures/number_list.bt
+++ b/stdlib/test/fixtures/number_list.bt
@@ -1,0 +1,18 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// NumberList — a user-defined Collection subclass for testing BT-815.
+// Implements only do:, size, and printString; all higher-order collection
+// methods (collect:, select:, inject:into:, etc.) are inherited from Collection.
+
+Collection subclass: NumberList
+  state: items = #()
+
+  // Return number of elements.
+  size -> Integer => self.items size
+
+  // Iterate over each element, evaluating block with each one.
+  do: block: Block -> Nil => self.items do: block
+
+  // Return a developer-readable string representation.
+  printString -> String => "NumberList"


### PR DESCRIPTION
## Summary

Implements Phase 2b of ADR 0034 (Stdlib Self-Hosting): replaces `@primitive` bodies on Collection's abstract protocol methods with pure Beamtalk implementations.

- **8 methods self-hosted**: `includes:`, `detect:`, `detect:ifNone:`, `anySatisfy:`, `allSatisfy:`, `collect:`, `select:`, `reject:` — all implemented in pure BT using `do:` with non-local return (`^`) or delegation to `inject:into:`
- **1 method kept as primitive**: `inject:into:` remains `@primitive` because the compiler's mutation threading doesn't work through abstract-class `do:` calls (generates `lists:foreach` instead of `lists:foldl`)
- **Argument order fix**: `beamtalk_collection_ops:inject_into/3` now wraps the block to call `Block(Acc, Elem)`, matching the Beamtalk `block value: acc value: each` convention
- **7 Erlang functions removed** from `beamtalk_collection_ops.erl` (only `inject_into/3` and `to_list/1` remain)
- **New test fixture**: `NumberList` — user-defined Collection subclass implementing only `do:`, `size`, `printString`
- **11 new tests** in `custom_collection_test.bt` including non-commutative inject and empty collection edge cases

### Follow-up
- BT-820: List `inject:into:` has pre-existing argument order inconsistency with Collection convention

Closes https://linear.app/beamtalk/issue/BT-815

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for custom collection implementations, including filtering, transformation, and iteration methods.
  * Introduced test fixture for user-defined collection subclasses.

* **Refactor**
  * Streamlined collection operations implementation for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->