### PR TITLE
fix: coverage-stdlib path broken after stdlib dir reorganization

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -439,15 +439,15 @@ coverage-e2e: build-stdlib
 
 # Unix-only: uses bash constructs (wc, file size checks)
 # Collect stdlib test coverage (runs stdlib tests with Erlang cover instrumentation)
+# [working-directory: 'stdlib'] ensures @load fixture paths (e.g. test/fixtures/counter.bt)
+# resolve correctly, matching the test-stdlib recipe.
 [unix]
+[working-directory: 'stdlib']
 coverage-stdlib: build-stdlib
     #!/usr/bin/env bash
     set -euo pipefail
     echo "📊 Running stdlib tests with Erlang cover instrumentation..."
     echo "   (This is slower than normal stdlib tests due to cover overhead)"
-    # Run from stdlib/ so @load fixture paths (e.g. test/fixtures/counter.bt) resolve correctly,
-    # matching the [working-directory: 'stdlib'] behaviour of the test-stdlib recipe.
-    cd stdlib
     STDLIB_COVER=1 cargo run --bin beamtalk --quiet -- test-stdlib --no-warnings bootstrap-test || true
     if [ -f ../runtime/_build/test/cover/stdlib.coverdata ]; then
         SIZE=$(wc -c < ../runtime/_build/test/cover/stdlib.coverdata)


### PR DESCRIPTION
## Summary

- After `ae4c253` reorganized stdlib into `stdlib/` subdirectories, `@load test/fixtures/counter.bt` directives in `stdlib/bootstrap-test/*.bt` files stopped resolving when running `coverage-stdlib` from the repo root
- `coverage-stdlib` recipe now `cd`s into `stdlib/` before invoking the CLI, matching the `[working-directory: 'stdlib']` behaviour of `test-stdlib`

## Root Cause

`coverage-stdlib` ran `cargo run -- test-stdlib --no-warnings stdlib/bootstrap-test` from the repo root. The `@load` paths in bootstrap-test files (e.g. `test/fixtures/counter.bt`) resolve relative to cwd. After the reorganization, `test/fixtures/` only exists under `stdlib/`, so the paths were broken.

## Test plan

- [x] `just coverage-stdlib` runs 16 files, 391 tests, 0 failures and produces `stdlib.coverdata`
- [x] `just coverage-all` completes with combined HTML + XML reports generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted the coverage workflow for the standard library: changed working-directory context and updated path handling for generated coverage data.  
  * Preserved existing test behavior and user-facing output while improving fixture resolution and where coverage files are referenced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->