### PR TITLE
Self-host Dictionary keysAndValuesDo: and Association formatting (BT-818)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_map_ops.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_map_ops.erl
@@ -12,7 +12,7 @@
 %% Replaces the former beamtalk_map.erl hand-written dispatch module.
 -module(beamtalk_map_ops).
 
--export([at_if_absent/3, keys_and_values_do/2, do/2, includes/2, print_string/1]).
+-export([at_if_absent/3, do/2, includes/2, print_string/1]).
 
 %% @doc Get value at key, or evaluate block if absent.
 -spec at_if_absent(map(), term(), fun(() -> term())) -> term().
@@ -21,12 +21,6 @@ at_if_absent(Map, Key, Block) when is_function(Block, 0) ->
         {ok, Value} -> Value;
         error -> Block()
     end.
-
-%% @doc Iterate over all key-value pairs.
--spec keys_and_values_do(map(), fun((term(), term()) -> term())) -> nil.
-keys_and_values_do(Map, Block) when is_function(Block, 2) ->
-    maps:foreach(Block, Map),
-    nil.
 
 %% @doc Iterate over all values in the dictionary.
 -spec do(map(), fun((term()) -> term())) -> nil.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_map_ops_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_map_ops_tests.erl
@@ -21,16 +21,6 @@ at_if_absent_empty_map_test() ->
     ?assertEqual(42, beamtalk_map_ops:at_if_absent(#{}, x, fun() -> 42 end)).
 
 %%% ============================================================================
-%%% keys_and_values_do/2
-%%% ============================================================================
-
-keys_and_values_do_test() ->
-    ?assertEqual(nil, beamtalk_map_ops:keys_and_values_do(#{a => 1}, fun(_, _) -> ok end)).
-
-keys_and_values_do_empty_test() ->
-    ?assertEqual(nil, beamtalk_map_ops:keys_and_values_do(#{}, fun(_, _) -> ok end)).
-
-%%% ============================================================================
 %%% Compiled bt@stdlib@dictionary dispatch/3
 %%% ============================================================================
 

--- a/stdlib/src/Association.bt
+++ b/stdlib/src/Association.bt
@@ -34,7 +34,7 @@ sealed Object subclass: Association
   /// ```beamtalk
   /// (#name -> "James") asString // => "#name -> James"
   /// ```
-  asString -> String => @primitive "asString"
+  asString -> String => "{self key} -> {self value}"
 
   /// Return a developer-readable string representation.
   ///

--- a/stdlib/src/Dictionary.bt
+++ b/stdlib/src/Dictionary.bt
@@ -113,7 +113,8 @@ sealed Collection subclass: Dictionary
   /// ```beamtalk
   /// #{#a => 1} keysAndValuesDo: [:k :v | Transcript show: k]
   /// ```
-  keysAndValuesDo: block: Block -> Nil => @primitive "keysAndValuesDo:"
+  keysAndValuesDo: block: Block -> Nil =>
+    self stream do: [:assoc | block value: assoc key value: assoc value]
 
   /// Return a string representation using Beamtalk syntax.
   ///

--- a/stdlib/test/association_test.bt
+++ b/stdlib/test/association_test.bt
@@ -23,8 +23,8 @@ TestCase subclass: AssociationTest
 
   testDisplayAsstringPrintstring =>
     self assert: ((#name -> "James") asString) equals: "#name -> James".
-    (42 -> "answer") asString.
-    ("count" -> 5) asString.
+    self assert: ((42 -> "answer") asString) equals: "42 -> answer".
+    self assert: (("count" -> 5) asString) equals: "count -> 5".
     // printString delegates to asString (Association.bt)
     self assert: ((#name -> "James") printString) equals: "#name -> James"
 

--- a/stdlib/test/dictionary_test.bt
+++ b/stdlib/test/dictionary_test.bt
@@ -60,7 +60,14 @@ TestCase subclass: DictionaryTest
     self assert: ((#{#a => 1} merge: #{#a => 99}) at: #a) equals: 99
 
   testKeysandvaluesdo =>
-    self assert: (#{#a => 1} keysAndValuesDo: [:k :v | nil]) equals: nil
+    // Returns nil
+    self assert: (#{#a => 1} keysAndValuesDo: [:k :v | nil]) equals: nil.
+    // Works for empty dictionary
+    self assert: (#{} keysAndValuesDo: [:k :v | nil]) equals: nil.
+    // Works for multi-entry dictionary
+    self assert: (#{#a => 1, #b => 2} keysAndValuesDo: [:k :v | nil]) equals: nil.
+    // Block is called with correct key and value types (no errors)
+    self assert: (#{#x => 10} keysAndValuesDo: [:k :v | k class]) equals: nil
 
   testNestedDictionaries =>
     // Nested dictionaries display correctly


### PR DESCRIPTION
## Summary

- Self-hosts `Dictionary>>keysAndValuesDo:` in pure Beamtalk using `self stream do: [:assoc | block value: assoc key value: assoc value]`
- Self-hosts `Association>>asString` in pure Beamtalk using string interpolation: `"{self key} -> {self value}"`
- Removes `keys_and_values_do/2` from `beamtalk_map_ops.erl` (no longer needed)
- Removes corresponding Erlang unit tests for the deleted function
- Expands test coverage for both methods

Closes https://linear.app/beamtalk/issue/BT-818

## Test plan

- [x] `DictionaryTest` — 13 tests, all pass
- [x] `AssociationTest` — 5 tests, all pass
- [x] `just ci` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated string representation of associations to display formatted "key -> value" output.
  * Modified Dictionary iteration method to use keyword arguments for block parameters.

* **Tests**
  * Added comprehensive test coverage for Dictionary iteration across various scenarios.
  * Updated Association string representation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->