### PR TITLE
feat: self-host List indexOf: and eachWithIndex: in pure Beamtalk (BT-816)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
@@ -239,22 +239,6 @@ fn generate_list_misc_bif(selector: &str, params: &[String]) -> Option<Document<
                 ")",
             ])
         }
-        "indexOf:" => {
-            let p0 = params.first().map_or("_Item", String::as_str);
-            Some(docvec![
-                "call 'beamtalk_list_ops':'index_of'(Self, ",
-                p0.to_string(),
-                ")"
-            ])
-        }
-        "eachWithIndex:" => {
-            let p0 = params.first().map_or("_Block", String::as_str);
-            Some(docvec![
-                "call 'beamtalk_list_ops':'each_with_index'(Self, ",
-                p0.to_string(),
-                ")",
-            ])
-        }
         "printString" => Some(Document::Str(
             "call 'beamtalk_primitive':'print_string'(Self)",
         )),

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs
@@ -392,32 +392,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_list_index_of() {
-        let result = doc_to_string(generate_primitive_bif(
-            "List",
-            "indexOf:",
-            &["Item".to_string()],
-        ));
-        assert_eq!(
-            result,
-            Some("call 'beamtalk_list_ops':'index_of'(Self, Item)".to_string())
-        );
-    }
-
-    #[test]
-    fn test_list_each_with_index() {
-        let result = doc_to_string(generate_primitive_bif(
-            "List",
-            "eachWithIndex:",
-            &["Block".to_string()],
-        ));
-        assert_eq!(
-            result,
-            Some("call 'beamtalk_list_ops':'each_with_index'(Self, Block)".to_string())
-        );
-    }
-
     // Character primitive tests (BT-339)
 
     #[test]

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_list_ops.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_list_ops.erl
@@ -24,9 +24,7 @@
     take/2,
     drop/2,
     sort_with/2,
-    from_to/3,
-    index_of/2,
-    each_with_index/2
+    from_to/3
 ]).
 
 -include("beamtalk.hrl").
@@ -274,25 +272,6 @@ from_to(List, Start, _End) when is_list(List), is_integer(Start), Start < 1 ->
     Error2 = beamtalk_error:with_hint(Error1, Hint),
     beamtalk_error:raise(Error2).
 
-%% @doc Find 1-based index of element, nil if not found.
--spec index_of(list(), term()) -> integer() | nil.
-index_of(List, Item) when is_list(List) ->
-    index_of_helper(List, Item, 1).
-
-%% @doc Iterate with 1-based index, calling block with element and index.
--spec each_with_index(list(), function()) -> nil.
-each_with_index(List, Block) when is_list(List), is_function(Block, 2) ->
-    each_with_index_helper(List, Block, 1),
-    nil;
-each_with_index(List, Block) when is_list(List) ->
-    Error0 = beamtalk_error:new(type_error, 'List'),
-    Error1 = beamtalk_error:with_selector(Error0, 'eachWithIndex:'),
-    Hint = iolist_to_binary(
-        io_lib:format("Block must be a 2-argument function (element, index), got: ~p", [Block])
-    ),
-    Error2 = beamtalk_error:with_hint(Error1, Hint),
-    beamtalk_error:raise(Error2).
-
 %% Internal helpers
 
 detect_helper(_Block, []) ->
@@ -310,13 +289,3 @@ safe_nthtail(N, [_ | T]) -> safe_nthtail(N - 1, T).
 zip_to_maps([], _) -> [];
 zip_to_maps(_, []) -> [];
 zip_to_maps([H1 | T1], [H2 | T2]) -> [#{<<"key">> => H1, <<"value">> => H2} | zip_to_maps(T1, T2)].
-
-index_of_helper([], _Item, _Index) -> nil;
-index_of_helper([Item | _T], Item, Index) -> Index;
-index_of_helper([_ | T], Item, Index) -> index_of_helper(T, Item, Index + 1).
-
-each_with_index_helper([], _Block, _Index) ->
-    ok;
-each_with_index_helper([H | T], Block, Index) ->
-    Block(H, Index),
-    each_with_index_helper(T, Block, Index + 1).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_list_ops_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_list_ops_tests.erl
@@ -6,7 +6,10 @@
 %%%
 %%% Tests list operations: at, detect, detect_if_none, do, reject,
 %%% zip, group_by, partition, intersperse, take, drop, sort_with,
-%%% from_to, index_of, each_with_index — including error cases.
+%%% from_to — including error cases.
+%%%
+%%% Note: index_of/2 and each_with_index/2 were removed in BT-816
+%%% (self-hosted in pure Beamtalk in List.bt).
 
 -module(beamtalk_list_ops_tests).
 -include_lib("eunit/include/eunit.hrl").
@@ -584,76 +587,4 @@ from_to_negative_start_test() ->
             }
         },
         beamtalk_list_ops:from_to([1, 2, 3], -1, 2)
-    ).
-
-%%% ============================================================================
-%%% index_of/2 tests
-%%% ============================================================================
-
-index_of_found_test() ->
-    ?assertEqual(2, beamtalk_list_ops:index_of([a, b, c], b)).
-
-index_of_first_test() ->
-    ?assertEqual(1, beamtalk_list_ops:index_of([a, b, c], a)).
-
-index_of_last_test() ->
-    ?assertEqual(3, beamtalk_list_ops:index_of([a, b, c], c)).
-
-index_of_not_found_test() ->
-    ?assertEqual(nil, beamtalk_list_ops:index_of([a, b, c], d)).
-
-index_of_empty_test() ->
-    ?assertEqual(nil, beamtalk_list_ops:index_of([], a)).
-
-%%% ============================================================================
-%%% each_with_index/2 tests
-%%% ============================================================================
-
-each_with_index_test() ->
-    Ref = make_ref(),
-    Self = self(),
-    beamtalk_list_ops:each_with_index(
-        [a, b, c],
-        fun(Elem, Idx) -> Self ! {Ref, Elem, Idx} end
-    ),
-    ?assertEqual(
-        {Ref, a, 1},
-        receive
-            {Ref, E1, I1} -> {Ref, E1, I1}
-        after 100 -> timeout
-        end
-    ),
-    ?assertEqual(
-        {Ref, b, 2},
-        receive
-            {Ref, E2, I2} -> {Ref, E2, I2}
-        after 100 -> timeout
-        end
-    ),
-    ?assertEqual(
-        {Ref, c, 3},
-        receive
-            {Ref, E3, I3} -> {Ref, E3, I3}
-        after 100 -> timeout
-        end
-    ).
-
-each_with_index_returns_nil_test() ->
-    ?assertEqual(nil, beamtalk_list_ops:each_with_index([1], fun(_, _) -> ok end)).
-
-each_with_index_empty_test() ->
-    ?assertEqual(nil, beamtalk_list_ops:each_with_index([], fun(_, _) -> ok end)).
-
-each_with_index_invalid_block_test() ->
-    ?assertException(
-        error,
-        #{
-            '$beamtalk_class' := 'TypeError',
-            error := #beamtalk_error{
-                kind = type_error,
-                class = 'List',
-                selector = 'eachWithIndex:'
-            }
-        },
-        beamtalk_list_ops:each_with_index([1, 2], not_a_function)
     ).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_list_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_list_tests.erl
@@ -361,15 +361,6 @@ partition_non_function_test() ->
         beamtalk_list_ops:partition([1, 2, 3], not_a_function)
     ).
 
-each_with_index_non_function_test() ->
-    ?assertError(
-        #{
-            '$beamtalk_class' := _,
-            error := #beamtalk_error{kind = type_error, class = 'List', selector = 'eachWithIndex:'}
-        },
-        beamtalk_list_ops:each_with_index([1, 2, 3], not_a_function)
-    ).
-
 %%% ============================================================================
 %%% from_to/3 Error Path Tests (BT-622)
 %%% ============================================================================
@@ -408,55 +399,6 @@ from_to_negative_start_test() ->
         },
         beamtalk_list_ops:from_to([1, 2, 3], 0, 2)
     ).
-
-%%% ============================================================================
-%%% index_of/2 Tests (BT-622)
-%%% ============================================================================
-
-index_of_found_test() ->
-    ?assertEqual(2, beamtalk_list_ops:index_of([a, b, c], b)),
-    ?assertEqual(1, beamtalk_list_ops:index_of([a, b, c], a)),
-    ?assertEqual(3, beamtalk_list_ops:index_of([a, b, c], c)).
-
-index_of_not_found_test() ->
-    ?assertEqual(nil, beamtalk_list_ops:index_of([a, b, c], d)),
-    ?assertEqual(nil, beamtalk_list_ops:index_of([], a)).
-
-%%% ============================================================================
-%%% each_with_index/2 Tests (BT-622)
-%%% ============================================================================
-
-each_with_index_test() ->
-    Self = self(),
-    Ref = make_ref(),
-    beamtalk_list_ops:each_with_index([a, b, c], fun(Elem, Idx) -> Self ! {Ref, Elem, Idx} end),
-    ?assertEqual(
-        {a, 1},
-        receive
-            {Ref, Elem1, Idx1} -> {Elem1, Idx1}
-        after 100 -> timeout
-        end
-    ),
-    ?assertEqual(
-        {b, 2},
-        receive
-            {Ref, Elem2, Idx2} -> {Elem2, Idx2}
-        after 100 -> timeout
-        end
-    ),
-    ?assertEqual(
-        {c, 3},
-        receive
-            {Ref, Elem3, Idx3} -> {Elem3, Idx3}
-        after 100 -> timeout
-        end
-    ).
-
-each_with_index_returns_nil_test() ->
-    ?assertEqual(nil, beamtalk_list_ops:each_with_index([1, 2], fun(_, _) -> ok end)).
-
-each_with_index_empty_test() ->
-    ?assertEqual(nil, beamtalk_list_ops:each_with_index([], fun(_, _) -> ok end)).
 
 %%% ============================================================================
 %%% sort_with/2 non-list receiver test (BT-622)

--- a/stdlib/src/List.bt
+++ b/stdlib/src/List.bt
@@ -252,7 +252,13 @@ sealed Collection subclass: List
   /// #(10, 20, 30) indexOf: 20        // => 2
   /// #(10, 20, 30) indexOf: 99        // => nil
   /// ```
-  indexOf: item -> Integer | Nil => @primitive "indexOf:"
+  indexOf: item -> Integer | Nil =>
+    self inject: 0 into: [:each :i |
+      newI := i + 1.
+      each =:= item ifTrue: [^newI].
+      newI
+    ].
+    nil
 
   /// Iterate with both element and 1-based index.
   ///
@@ -260,7 +266,13 @@ sealed Collection subclass: List
   /// ```beamtalk
   /// #("a", "b") eachWithIndex: [:item :i | Transcript show: i]
   /// ```
-  eachWithIndex: block: Block -> Nil => @primitive "eachWithIndex:"
+  eachWithIndex: block: Block -> Nil =>
+    self inject: 0 into: [:each :i |
+      newI := i + 1.
+      block value: each value: newI.
+      newI
+    ].
+    nil
 
   /// Combine two lists element-wise into a list of pairs.
   ///

--- a/test-package-compiler/cases/stdlib_class_list/main.bt
+++ b/test-package-compiler/cases/stdlib_class_list/main.bt
@@ -45,10 +45,22 @@ sealed Object subclass: List
 
   // Subsequence / Search
   from: start to: end => @primitive "from:to:"
-  indexOf: item => @primitive "indexOf:"
+  indexOf: item =>
+    self inject: 0 into: [:each :i |
+      newI := i + 1.
+      each =:= item ifTrue: [^newI].
+      newI
+    ].
+    nil
 
   // Iteration with index
-  eachWithIndex: block => @primitive "eachWithIndex:"
+  eachWithIndex: block =>
+    self inject: 0 into: [:each :i |
+      newI := i + 1.
+      block value: each value: newI.
+      newI
+    ].
+    nil
 
   // Advanced
   zip: other => @primitive "zip:"

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_codegen.snap
@@ -99,31 +99,41 @@ call 'erlang':'++'(Self, _other19)
 call 'beamtalk_list_ops':'from_to'(Self, _start20, _end21)
 
 'indexOf:'/2 = fun (Self, _item22) ->
-call 'beamtalk_list_ops':'index_of'(Self, _item22)
+    let _NlrToken23 = call 'erlang':'make_ref'() in
+    try
+    let _seq24 = let _temp25 = Self in let _temp26 = 0 in let _temp27 = fun (_each28, _i29) -> let NewI = call 'erlang':'+'(_i29, 1) in let _Unit = call 'beamtalk_message_dispatch':'send'(call 'erlang':'=:='(_each28, _item22), 'ifTrue:', [fun () -> call 'erlang':'throw'({'$bt_nlr', _NlrToken23, NewI})]) in NewI in case call 'erlang':'is_list'(_temp25) of <'true'> when 'true' -> call 'lists':'foldl'(_temp27, _temp26, _temp25) <'false'> when 'true' -> call 'beamtalk_primitive':'send'(_temp25, 'inject:into:', [_temp26, _temp27]) end in
+    'nil'
+    of _NlrResult30 -> _NlrResult30
+    catch <_NlrCls31, _NlrErr32, _NlrStk33> ->
+      case {_NlrCls31, _NlrErr32} of
+        <{'throw', {'$bt_nlr', _CatchTok34, _NlrVal35}}> when call 'erlang':'=:='(_CatchTok34, _NlrToken23) -> _NlrVal35
+        <_OtherPair36> when 'true' -> primop 'raw_raise'(_NlrCls31, _NlrErr32, _NlrStk33)
+      end
 
-'eachWithIndex:'/2 = fun (Self, _block23) ->
-call 'beamtalk_list_ops':'each_with_index'(Self, _block23)
+'eachWithIndex:'/2 = fun (Self, _block37) ->
+    let _seq38 = let _temp39 = Self in let _temp40 = 0 in let _temp41 = fun (_each42, _i43) -> let NewI = call 'erlang':'+'(_i43, 1) in let _Unit = let _Fun44 = _block37 in apply _Fun44 (_each42, NewI) in NewI in case call 'erlang':'is_list'(_temp39) of <'true'> when 'true' -> call 'lists':'foldl'(_temp41, _temp40, _temp39) <'false'> when 'true' -> call 'beamtalk_primitive':'send'(_temp39, 'inject:into:', [_temp40, _temp41]) end in
+    'nil'
 
-'zip:'/2 = fun (Self, _other24) ->
-call 'beamtalk_list_ops':'zip'(Self, _other24)
+'zip:'/2 = fun (Self, _other45) ->
+call 'beamtalk_list_ops':'zip'(Self, _other45)
 
-'groupBy:'/2 = fun (Self, _block25) ->
-call 'beamtalk_list_ops':'group_by'(Self, _block25)
+'groupBy:'/2 = fun (Self, _block46) ->
+call 'beamtalk_list_ops':'group_by'(Self, _block46)
 
-'partition:'/2 = fun (Self, _block26) ->
-call 'beamtalk_list_ops':'partition'(Self, _block26)
+'partition:'/2 = fun (Self, _block47) ->
+call 'beamtalk_list_ops':'partition'(Self, _block47)
 
-'takeWhile:'/2 = fun (Self, _block27) ->
-call 'lists':'takewhile'(_block27, Self)
+'takeWhile:'/2 = fun (Self, _block48) ->
+call 'lists':'takewhile'(_block48, Self)
 
-'dropWhile:'/2 = fun (Self, _block28) ->
-call 'lists':'dropwhile'(_block28, Self)
+'dropWhile:'/2 = fun (Self, _block49) ->
+call 'lists':'dropwhile'(_block49, Self)
 
-'intersperse:'/2 = fun (Self, _separator29) ->
-call 'beamtalk_list_ops':'intersperse'(Self, _separator29)
+'intersperse:'/2 = fun (Self, _separator50) ->
+call 'beamtalk_list_ops':'intersperse'(Self, _separator50)
 
-'add:'/2 = fun (Self, _item30) ->
-call 'erlang':'++'(Self, [_item30|[]])
+'add:'/2 = fun (Self, _item51) ->
+call 'erlang':'++'(Self, [_item51|[]])
 
 'dispatch'/3 = fun (Selector, Args, Self) ->
     case Selector of

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_lexer.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_lexer.snap
@@ -140,47 +140,98 @@ Token { kind: AtPrimitive, span: Span { start: 1398, end: 1408 }, leading_trivia
 Token { kind: String("from:to:"), span: Span { start: 1409, end: 1419 }, leading_trivia: [], trailing_trivia: [] }
 Token { kind: Keyword("indexOf:"), span: Span { start: 1422, end: 1430 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
 Token { kind: Identifier("item"), span: Span { start: 1431, end: 1435 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 1436, end: 1438 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: AtPrimitive, span: Span { start: 1439, end: 1449 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: String("indexOf:"), span: Span { start: 1450, end: 1460 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Keyword("eachWithIndex:"), span: Span { start: 1490, end: 1504 }, leading_trivia: [Whitespace("\n\n  "), LineComment("// Iteration with index"), Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("block"), span: Span { start: 1505, end: 1510 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 1511, end: 1513 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: AtPrimitive, span: Span { start: 1514, end: 1524 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: String("eachWithIndex:"), span: Span { start: 1525, end: 1541 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Keyword("zip:"), span: Span { start: 1559, end: 1563 }, leading_trivia: [Whitespace("\n\n  "), LineComment("// Advanced"), Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("other"), span: Span { start: 1564, end: 1569 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 1570, end: 1572 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: AtPrimitive, span: Span { start: 1573, end: 1583 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: String("zip:"), span: Span { start: 1584, end: 1590 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Keyword("groupBy:"), span: Span { start: 1593, end: 1601 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("block"), span: Span { start: 1602, end: 1607 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 1608, end: 1610 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: AtPrimitive, span: Span { start: 1611, end: 1621 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: String("groupBy:"), span: Span { start: 1622, end: 1632 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Keyword("partition:"), span: Span { start: 1635, end: 1645 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("block"), span: Span { start: 1646, end: 1651 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 1652, end: 1654 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: AtPrimitive, span: Span { start: 1655, end: 1665 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: String("partition:"), span: Span { start: 1666, end: 1678 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Keyword("takeWhile:"), span: Span { start: 1681, end: 1691 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("block"), span: Span { start: 1692, end: 1697 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 1698, end: 1700 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: AtPrimitive, span: Span { start: 1701, end: 1711 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: String("takeWhile:"), span: Span { start: 1712, end: 1724 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Keyword("dropWhile:"), span: Span { start: 1727, end: 1737 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("block"), span: Span { start: 1738, end: 1743 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 1744, end: 1746 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: AtPrimitive, span: Span { start: 1747, end: 1757 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: String("dropWhile:"), span: Span { start: 1758, end: 1770 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Keyword("intersperse:"), span: Span { start: 1773, end: 1785 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("separator"), span: Span { start: 1786, end: 1795 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 1796, end: 1798 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: AtPrimitive, span: Span { start: 1799, end: 1809 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: String("intersperse:"), span: Span { start: 1810, end: 1824 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Keyword("add:"), span: Span { start: 1827, end: 1831 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("item"), span: Span { start: 1832, end: 1836 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 1837, end: 1839 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: AtPrimitive, span: Span { start: 1840, end: 1850 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: String("add:"), span: Span { start: 1851, end: 1857 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Eof, span: Span { start: 1859, end: 1859 }, leading_trivia: [Whitespace("\n\n")], trailing_trivia: [] }
+Token { kind: FatArrow, span: Span { start: 1436, end: 1438 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("self"), span: Span { start: 1443, end: 1447 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("inject:"), span: Span { start: 1448, end: 1455 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("0"), span: Span { start: 1456, end: 1457 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("into:"), span: Span { start: 1458, end: 1463 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftBracket, span: Span { start: 1464, end: 1465 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Colon, span: Span { start: 1465, end: 1466 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("each"), span: Span { start: 1466, end: 1470 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Colon, span: Span { start: 1471, end: 1472 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("i"), span: Span { start: 1472, end: 1473 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Pipe, span: Span { start: 1474, end: 1475 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("newI"), span: Span { start: 1482, end: 1486 }, leading_trivia: [Whitespace("\n      ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 1487, end: 1489 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("i"), span: Span { start: 1490, end: 1491 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("+"), span: Span { start: 1492, end: 1493 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("1"), span: Span { start: 1494, end: 1495 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1495, end: 1496 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("each"), span: Span { start: 1503, end: 1507 }, leading_trivia: [Whitespace("\n      ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("=:="), span: Span { start: 1508, end: 1511 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("item"), span: Span { start: 1512, end: 1516 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("ifTrue:"), span: Span { start: 1517, end: 1524 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftBracket, span: Span { start: 1525, end: 1526 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Caret, span: Span { start: 1526, end: 1527 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("newI"), span: Span { start: 1527, end: 1531 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: RightBracket, span: Span { start: 1531, end: 1532 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1532, end: 1533 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("newI"), span: Span { start: 1540, end: 1544 }, leading_trivia: [Whitespace("\n      ")], trailing_trivia: [] }
+Token { kind: RightBracket, span: Span { start: 1549, end: 1550 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1550, end: 1551 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("nil"), span: Span { start: 1556, end: 1559 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Keyword("eachWithIndex:"), span: Span { start: 1589, end: 1603 }, leading_trivia: [Whitespace("\n\n  "), LineComment("// Iteration with index"), Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("block"), span: Span { start: 1604, end: 1609 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 1610, end: 1612 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("self"), span: Span { start: 1617, end: 1621 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("inject:"), span: Span { start: 1622, end: 1629 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("0"), span: Span { start: 1630, end: 1631 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("into:"), span: Span { start: 1632, end: 1637 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftBracket, span: Span { start: 1638, end: 1639 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Colon, span: Span { start: 1639, end: 1640 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("each"), span: Span { start: 1640, end: 1644 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Colon, span: Span { start: 1645, end: 1646 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("i"), span: Span { start: 1646, end: 1647 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Pipe, span: Span { start: 1648, end: 1649 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("newI"), span: Span { start: 1656, end: 1660 }, leading_trivia: [Whitespace("\n      ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 1661, end: 1663 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("i"), span: Span { start: 1664, end: 1665 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("+"), span: Span { start: 1666, end: 1667 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("1"), span: Span { start: 1668, end: 1669 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1669, end: 1670 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("block"), span: Span { start: 1677, end: 1682 }, leading_trivia: [Whitespace("\n      ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("value:"), span: Span { start: 1683, end: 1689 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("each"), span: Span { start: 1690, end: 1694 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("value:"), span: Span { start: 1695, end: 1701 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("newI"), span: Span { start: 1702, end: 1706 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1706, end: 1707 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("newI"), span: Span { start: 1714, end: 1718 }, leading_trivia: [Whitespace("\n      ")], trailing_trivia: [] }
+Token { kind: RightBracket, span: Span { start: 1723, end: 1724 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1724, end: 1725 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("nil"), span: Span { start: 1730, end: 1733 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Keyword("zip:"), span: Span { start: 1751, end: 1755 }, leading_trivia: [Whitespace("\n\n  "), LineComment("// Advanced"), Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("other"), span: Span { start: 1756, end: 1761 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 1762, end: 1764 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: AtPrimitive, span: Span { start: 1765, end: 1775 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: String("zip:"), span: Span { start: 1776, end: 1782 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("groupBy:"), span: Span { start: 1785, end: 1793 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("block"), span: Span { start: 1794, end: 1799 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 1800, end: 1802 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: AtPrimitive, span: Span { start: 1803, end: 1813 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: String("groupBy:"), span: Span { start: 1814, end: 1824 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("partition:"), span: Span { start: 1827, end: 1837 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("block"), span: Span { start: 1838, end: 1843 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 1844, end: 1846 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: AtPrimitive, span: Span { start: 1847, end: 1857 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: String("partition:"), span: Span { start: 1858, end: 1870 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("takeWhile:"), span: Span { start: 1873, end: 1883 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("block"), span: Span { start: 1884, end: 1889 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 1890, end: 1892 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: AtPrimitive, span: Span { start: 1893, end: 1903 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: String("takeWhile:"), span: Span { start: 1904, end: 1916 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("dropWhile:"), span: Span { start: 1919, end: 1929 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("block"), span: Span { start: 1930, end: 1935 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 1936, end: 1938 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: AtPrimitive, span: Span { start: 1939, end: 1949 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: String("dropWhile:"), span: Span { start: 1950, end: 1962 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("intersperse:"), span: Span { start: 1965, end: 1977 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("separator"), span: Span { start: 1978, end: 1987 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 1988, end: 1990 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: AtPrimitive, span: Span { start: 1991, end: 2001 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: String("intersperse:"), span: Span { start: 2002, end: 2016 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("add:"), span: Span { start: 2019, end: 2023 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("item"), span: Span { start: 2024, end: 2028 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 2029, end: 2031 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: AtPrimitive, span: Span { start: 2032, end: 2042 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: String("add:"), span: Span { start: 2043, end: 2049 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Eof, span: Span { start: 2051, end: 2051 }, leading_trivia: [Whitespace("\n\n")], trailing_trivia: [] }

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_parser.snap
@@ -1085,14 +1085,212 @@ Module {
                         },
                     ],
                     body: [
-                        Primitive {
-                            name: "indexOf:",
-                            is_quoted: true,
+                        MessageSend {
+                            receiver: Identifier(
+                                Identifier {
+                                    name: "self",
+                                    span: Span {
+                                        start: 1443,
+                                        end: 1447,
+                                    },
+                                },
+                            ),
+                            selector: Keyword(
+                                [
+                                    KeywordPart {
+                                        keyword: "inject:",
+                                        span: Span {
+                                            start: 1448,
+                                            end: 1455,
+                                        },
+                                    },
+                                    KeywordPart {
+                                        keyword: "into:",
+                                        span: Span {
+                                            start: 1458,
+                                            end: 1463,
+                                        },
+                                    },
+                                ],
+                            ),
+                            arguments: [
+                                Literal(
+                                    Integer(
+                                        0,
+                                    ),
+                                    Span {
+                                        start: 1456,
+                                        end: 1457,
+                                    },
+                                ),
+                                Block(
+                                    Block {
+                                        parameters: [
+                                            BlockParameter {
+                                                name: "each",
+                                                span: Span {
+                                                    start: 1466,
+                                                    end: 1470,
+                                                },
+                                            },
+                                            BlockParameter {
+                                                name: "i",
+                                                span: Span {
+                                                    start: 1472,
+                                                    end: 1473,
+                                                },
+                                            },
+                                        ],
+                                        body: [
+                                            Assignment {
+                                                target: Identifier(
+                                                    Identifier {
+                                                        name: "newI",
+                                                        span: Span {
+                                                            start: 1482,
+                                                            end: 1486,
+                                                        },
+                                                    },
+                                                ),
+                                                value: MessageSend {
+                                                    receiver: Identifier(
+                                                        Identifier {
+                                                            name: "i",
+                                                            span: Span {
+                                                                start: 1490,
+                                                                end: 1491,
+                                                            },
+                                                        },
+                                                    ),
+                                                    selector: Binary(
+                                                        "+",
+                                                    ),
+                                                    arguments: [
+                                                        Literal(
+                                                            Integer(
+                                                                1,
+                                                            ),
+                                                            Span {
+                                                                start: 1494,
+                                                                end: 1495,
+                                                            },
+                                                        ),
+                                                    ],
+                                                    span: Span {
+                                                        start: 1490,
+                                                        end: 1495,
+                                                    },
+                                                },
+                                                span: Span {
+                                                    start: 1482,
+                                                    end: 1495,
+                                                },
+                                            },
+                                            MessageSend {
+                                                receiver: MessageSend {
+                                                    receiver: Identifier(
+                                                        Identifier {
+                                                            name: "each",
+                                                            span: Span {
+                                                                start: 1503,
+                                                                end: 1507,
+                                                            },
+                                                        },
+                                                    ),
+                                                    selector: Binary(
+                                                        "=:=",
+                                                    ),
+                                                    arguments: [
+                                                        Identifier(
+                                                            Identifier {
+                                                                name: "item",
+                                                                span: Span {
+                                                                    start: 1512,
+                                                                    end: 1516,
+                                                                },
+                                                            },
+                                                        ),
+                                                    ],
+                                                    span: Span {
+                                                        start: 1503,
+                                                        end: 1516,
+                                                    },
+                                                },
+                                                selector: Keyword(
+                                                    [
+                                                        KeywordPart {
+                                                            keyword: "ifTrue:",
+                                                            span: Span {
+                                                                start: 1517,
+                                                                end: 1524,
+                                                            },
+                                                        },
+                                                    ],
+                                                ),
+                                                arguments: [
+                                                    Block(
+                                                        Block {
+                                                            parameters: [],
+                                                            body: [
+                                                                Return {
+                                                                    value: Identifier(
+                                                                        Identifier {
+                                                                            name: "newI",
+                                                                            span: Span {
+                                                                                start: 1527,
+                                                                                end: 1531,
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    span: Span {
+                                                                        start: 1526,
+                                                                        end: 1531,
+                                                                    },
+                                                                },
+                                                            ],
+                                                            span: Span {
+                                                                start: 1525,
+                                                                end: 1532,
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                                span: Span {
+                                                    start: 1503,
+                                                    end: 1532,
+                                                },
+                                            },
+                                            Identifier(
+                                                Identifier {
+                                                    name: "newI",
+                                                    span: Span {
+                                                        start: 1540,
+                                                        end: 1544,
+                                                    },
+                                                },
+                                            ),
+                                        ],
+                                        span: Span {
+                                            start: 1464,
+                                            end: 1550,
+                                        },
+                                    },
+                                ),
+                            ],
                             span: Span {
-                                start: 1439,
-                                end: 1460,
+                                start: 1443,
+                                end: 1550,
                             },
                         },
+                        Identifier(
+                            Identifier {
+                                name: "nil",
+                                span: Span {
+                                    start: 1556,
+                                    end: 1559,
+                                },
+                            },
+                        ),
                     ],
                     return_type: None,
                     is_sealed: false,
@@ -1100,7 +1298,7 @@ Module {
                     doc_comment: None,
                     span: Span {
                         start: 1422,
-                        end: 1460,
+                        end: 1559,
                     },
                 },
                 MethodDefinition {
@@ -1109,8 +1307,8 @@ Module {
                             KeywordPart {
                                 keyword: "eachWithIndex:",
                                 span: Span {
-                                    start: 1490,
-                                    end: 1504,
+                                    start: 1589,
+                                    end: 1603,
                                 },
                             },
                         ],
@@ -1120,30 +1318,207 @@ Module {
                             name: Identifier {
                                 name: "block",
                                 span: Span {
-                                    start: 1505,
-                                    end: 1510,
+                                    start: 1604,
+                                    end: 1609,
                                 },
                             },
                             type_annotation: None,
                         },
                     ],
                     body: [
-                        Primitive {
-                            name: "eachWithIndex:",
-                            is_quoted: true,
+                        MessageSend {
+                            receiver: Identifier(
+                                Identifier {
+                                    name: "self",
+                                    span: Span {
+                                        start: 1617,
+                                        end: 1621,
+                                    },
+                                },
+                            ),
+                            selector: Keyword(
+                                [
+                                    KeywordPart {
+                                        keyword: "inject:",
+                                        span: Span {
+                                            start: 1622,
+                                            end: 1629,
+                                        },
+                                    },
+                                    KeywordPart {
+                                        keyword: "into:",
+                                        span: Span {
+                                            start: 1632,
+                                            end: 1637,
+                                        },
+                                    },
+                                ],
+                            ),
+                            arguments: [
+                                Literal(
+                                    Integer(
+                                        0,
+                                    ),
+                                    Span {
+                                        start: 1630,
+                                        end: 1631,
+                                    },
+                                ),
+                                Block(
+                                    Block {
+                                        parameters: [
+                                            BlockParameter {
+                                                name: "each",
+                                                span: Span {
+                                                    start: 1640,
+                                                    end: 1644,
+                                                },
+                                            },
+                                            BlockParameter {
+                                                name: "i",
+                                                span: Span {
+                                                    start: 1646,
+                                                    end: 1647,
+                                                },
+                                            },
+                                        ],
+                                        body: [
+                                            Assignment {
+                                                target: Identifier(
+                                                    Identifier {
+                                                        name: "newI",
+                                                        span: Span {
+                                                            start: 1656,
+                                                            end: 1660,
+                                                        },
+                                                    },
+                                                ),
+                                                value: MessageSend {
+                                                    receiver: Identifier(
+                                                        Identifier {
+                                                            name: "i",
+                                                            span: Span {
+                                                                start: 1664,
+                                                                end: 1665,
+                                                            },
+                                                        },
+                                                    ),
+                                                    selector: Binary(
+                                                        "+",
+                                                    ),
+                                                    arguments: [
+                                                        Literal(
+                                                            Integer(
+                                                                1,
+                                                            ),
+                                                            Span {
+                                                                start: 1668,
+                                                                end: 1669,
+                                                            },
+                                                        ),
+                                                    ],
+                                                    span: Span {
+                                                        start: 1664,
+                                                        end: 1669,
+                                                    },
+                                                },
+                                                span: Span {
+                                                    start: 1656,
+                                                    end: 1669,
+                                                },
+                                            },
+                                            MessageSend {
+                                                receiver: Identifier(
+                                                    Identifier {
+                                                        name: "block",
+                                                        span: Span {
+                                                            start: 1677,
+                                                            end: 1682,
+                                                        },
+                                                    },
+                                                ),
+                                                selector: Keyword(
+                                                    [
+                                                        KeywordPart {
+                                                            keyword: "value:",
+                                                            span: Span {
+                                                                start: 1683,
+                                                                end: 1689,
+                                                            },
+                                                        },
+                                                        KeywordPart {
+                                                            keyword: "value:",
+                                                            span: Span {
+                                                                start: 1695,
+                                                                end: 1701,
+                                                            },
+                                                        },
+                                                    ],
+                                                ),
+                                                arguments: [
+                                                    Identifier(
+                                                        Identifier {
+                                                            name: "each",
+                                                            span: Span {
+                                                                start: 1690,
+                                                                end: 1694,
+                                                            },
+                                                        },
+                                                    ),
+                                                    Identifier(
+                                                        Identifier {
+                                                            name: "newI",
+                                                            span: Span {
+                                                                start: 1702,
+                                                                end: 1706,
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                                span: Span {
+                                                    start: 1677,
+                                                    end: 1706,
+                                                },
+                                            },
+                                            Identifier(
+                                                Identifier {
+                                                    name: "newI",
+                                                    span: Span {
+                                                        start: 1714,
+                                                        end: 1718,
+                                                    },
+                                                },
+                                            ),
+                                        ],
+                                        span: Span {
+                                            start: 1638,
+                                            end: 1724,
+                                        },
+                                    },
+                                ),
+                            ],
                             span: Span {
-                                start: 1514,
-                                end: 1541,
+                                start: 1617,
+                                end: 1724,
                             },
                         },
+                        Identifier(
+                            Identifier {
+                                name: "nil",
+                                span: Span {
+                                    start: 1730,
+                                    end: 1733,
+                                },
+                            },
+                        ),
                     ],
                     return_type: None,
                     is_sealed: false,
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 1490,
-                        end: 1541,
+                        start: 1589,
+                        end: 1733,
                     },
                 },
                 MethodDefinition {
@@ -1152,8 +1527,8 @@ Module {
                             KeywordPart {
                                 keyword: "zip:",
                                 span: Span {
-                                    start: 1559,
-                                    end: 1563,
+                                    start: 1751,
+                                    end: 1755,
                                 },
                             },
                         ],
@@ -1163,8 +1538,8 @@ Module {
                             name: Identifier {
                                 name: "other",
                                 span: Span {
-                                    start: 1564,
-                                    end: 1569,
+                                    start: 1756,
+                                    end: 1761,
                                 },
                             },
                             type_annotation: None,
@@ -1175,8 +1550,8 @@ Module {
                             name: "zip:",
                             is_quoted: true,
                             span: Span {
-                                start: 1573,
-                                end: 1590,
+                                start: 1765,
+                                end: 1782,
                             },
                         },
                     ],
@@ -1185,8 +1560,8 @@ Module {
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 1559,
-                        end: 1590,
+                        start: 1751,
+                        end: 1782,
                     },
                 },
                 MethodDefinition {
@@ -1195,8 +1570,8 @@ Module {
                             KeywordPart {
                                 keyword: "groupBy:",
                                 span: Span {
-                                    start: 1593,
-                                    end: 1601,
+                                    start: 1785,
+                                    end: 1793,
                                 },
                             },
                         ],
@@ -1206,8 +1581,8 @@ Module {
                             name: Identifier {
                                 name: "block",
                                 span: Span {
-                                    start: 1602,
-                                    end: 1607,
+                                    start: 1794,
+                                    end: 1799,
                                 },
                             },
                             type_annotation: None,
@@ -1218,8 +1593,8 @@ Module {
                             name: "groupBy:",
                             is_quoted: true,
                             span: Span {
-                                start: 1611,
-                                end: 1632,
+                                start: 1803,
+                                end: 1824,
                             },
                         },
                     ],
@@ -1228,8 +1603,8 @@ Module {
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 1593,
-                        end: 1632,
+                        start: 1785,
+                        end: 1824,
                     },
                 },
                 MethodDefinition {
@@ -1238,8 +1613,8 @@ Module {
                             KeywordPart {
                                 keyword: "partition:",
                                 span: Span {
-                                    start: 1635,
-                                    end: 1645,
+                                    start: 1827,
+                                    end: 1837,
                                 },
                             },
                         ],
@@ -1249,8 +1624,8 @@ Module {
                             name: Identifier {
                                 name: "block",
                                 span: Span {
-                                    start: 1646,
-                                    end: 1651,
+                                    start: 1838,
+                                    end: 1843,
                                 },
                             },
                             type_annotation: None,
@@ -1261,8 +1636,8 @@ Module {
                             name: "partition:",
                             is_quoted: true,
                             span: Span {
-                                start: 1655,
-                                end: 1678,
+                                start: 1847,
+                                end: 1870,
                             },
                         },
                     ],
@@ -1271,8 +1646,8 @@ Module {
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 1635,
-                        end: 1678,
+                        start: 1827,
+                        end: 1870,
                     },
                 },
                 MethodDefinition {
@@ -1281,8 +1656,8 @@ Module {
                             KeywordPart {
                                 keyword: "takeWhile:",
                                 span: Span {
-                                    start: 1681,
-                                    end: 1691,
+                                    start: 1873,
+                                    end: 1883,
                                 },
                             },
                         ],
@@ -1292,8 +1667,8 @@ Module {
                             name: Identifier {
                                 name: "block",
                                 span: Span {
-                                    start: 1692,
-                                    end: 1697,
+                                    start: 1884,
+                                    end: 1889,
                                 },
                             },
                             type_annotation: None,
@@ -1304,8 +1679,8 @@ Module {
                             name: "takeWhile:",
                             is_quoted: true,
                             span: Span {
-                                start: 1701,
-                                end: 1724,
+                                start: 1893,
+                                end: 1916,
                             },
                         },
                     ],
@@ -1314,8 +1689,8 @@ Module {
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 1681,
-                        end: 1724,
+                        start: 1873,
+                        end: 1916,
                     },
                 },
                 MethodDefinition {
@@ -1324,8 +1699,8 @@ Module {
                             KeywordPart {
                                 keyword: "dropWhile:",
                                 span: Span {
-                                    start: 1727,
-                                    end: 1737,
+                                    start: 1919,
+                                    end: 1929,
                                 },
                             },
                         ],
@@ -1335,8 +1710,8 @@ Module {
                             name: Identifier {
                                 name: "block",
                                 span: Span {
-                                    start: 1738,
-                                    end: 1743,
+                                    start: 1930,
+                                    end: 1935,
                                 },
                             },
                             type_annotation: None,
@@ -1347,8 +1722,8 @@ Module {
                             name: "dropWhile:",
                             is_quoted: true,
                             span: Span {
-                                start: 1747,
-                                end: 1770,
+                                start: 1939,
+                                end: 1962,
                             },
                         },
                     ],
@@ -1357,8 +1732,8 @@ Module {
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 1727,
-                        end: 1770,
+                        start: 1919,
+                        end: 1962,
                     },
                 },
                 MethodDefinition {
@@ -1367,8 +1742,8 @@ Module {
                             KeywordPart {
                                 keyword: "intersperse:",
                                 span: Span {
-                                    start: 1773,
-                                    end: 1785,
+                                    start: 1965,
+                                    end: 1977,
                                 },
                             },
                         ],
@@ -1378,8 +1753,8 @@ Module {
                             name: Identifier {
                                 name: "separator",
                                 span: Span {
-                                    start: 1786,
-                                    end: 1795,
+                                    start: 1978,
+                                    end: 1987,
                                 },
                             },
                             type_annotation: None,
@@ -1390,8 +1765,8 @@ Module {
                             name: "intersperse:",
                             is_quoted: true,
                             span: Span {
-                                start: 1799,
-                                end: 1824,
+                                start: 1991,
+                                end: 2016,
                             },
                         },
                     ],
@@ -1400,8 +1775,8 @@ Module {
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 1773,
-                        end: 1824,
+                        start: 1965,
+                        end: 2016,
                     },
                 },
                 MethodDefinition {
@@ -1410,8 +1785,8 @@ Module {
                             KeywordPart {
                                 keyword: "add:",
                                 span: Span {
-                                    start: 1827,
-                                    end: 1831,
+                                    start: 2019,
+                                    end: 2023,
                                 },
                             },
                         ],
@@ -1421,8 +1796,8 @@ Module {
                             name: Identifier {
                                 name: "item",
                                 span: Span {
-                                    start: 1832,
-                                    end: 1836,
+                                    start: 2024,
+                                    end: 2028,
                                 },
                             },
                             type_annotation: None,
@@ -1433,8 +1808,8 @@ Module {
                             name: "add:",
                             is_quoted: true,
                             span: Span {
-                                start: 1840,
-                                end: 1857,
+                                start: 2032,
+                                end: 2049,
                             },
                         },
                     ],
@@ -1443,8 +1818,8 @@ Module {
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 1827,
-                        end: 1857,
+                        start: 2019,
+                        end: 2049,
                     },
                 },
             ],
@@ -1453,7 +1828,7 @@ Module {
             doc_comment: None,
             span: Span {
                 start: 208,
-                end: 1857,
+                end: 2049,
             },
         },
     ],
@@ -1461,7 +1836,7 @@ Module {
     expressions: [],
     span: Span {
         start: 208,
-        end: 1857,
+        end: 2049,
     },
     leading_comments: [
         Comment {


### PR DESCRIPTION
## Summary

- Replaced `@primitive "indexOf:"` and `@primitive "eachWithIndex:"` in `stdlib/src/List.bt` with pure Beamtalk implementations using `inject:into:` and non-local returns (NLR)
- Removed `index_of/2` and `each_with_index/2` functions and their exports from `runtime/apps/beamtalk_runtime/src/beamtalk_list_ops.erl`
- Removed corresponding test functions from `runtime/apps/beamtalk_runtime/test/beamtalk_list_ops_tests.erl`
- Removed `"indexOf:"` and `"eachWithIndex:"` primitive codegen entries from `crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs`
- Removed test cases for those primitives from `crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs`
- Updated `test-package-compiler/cases/stdlib_class_list/main.bt` and associated snapshots to reflect the pure BT implementations

## Test plan

- [ ] `just test` passes
- [ ] `just test-stdlib` passes (List tests cover indexOf: and eachWithIndex: behavior)
- [ ] `just build` succeeds with removed Erlang primitives
- [ ] Snapshot tests match updated codegen output

Closes BT-816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * List methods indexOf: and eachWithIndex: moved from primitive/runtime-backed implementations to inline/computed implementations; their externally observable behavior (1-based index for indexOf:, iteration with index for eachWithIndex:) is preserved.
* **Tests**
  * Removed tests covering the old primitive/runtime-backed variants; remaining list operation tests retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->