### PR TITLE
Fix: -spec return type nil should be 'nil' across runtime modules (BT-821)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_array_ops.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_array_ops.erl
@@ -112,7 +112,7 @@ at_put(#{'$beamtalk_class' := 'Array'}, _Index, _Value) ->
 %%% ============================================================================
 
 %% @doc Apply a block to each element of the Array. Returns nil.
--spec do(map(), fun((term()) -> term())) -> nil.
+-spec do(map(), fun((term()) -> term())) -> 'nil'.
 do(#{'$beamtalk_class' := 'Array', 'data' := Arr}, Block) when is_function(Block, 1) ->
     array:foldl(fun(_I, Elem, _Acc) -> Block(Elem) end, nil, Arr),
     nil;

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -85,7 +85,7 @@
 %% ADR 0032: Returns a proper #beamtalk_object{} instead of a bare atom,
 %% fixing the inconsistency where `Counter class` returned an object but
 %% `Counter superclass` returned an atom.
--spec classSuperclass(#beamtalk_object{}) -> #beamtalk_object{} | nil.
+-spec classSuperclass(#beamtalk_object{}) -> #beamtalk_object{} | 'nil'.
 classSuperclass(Self) ->
     ClassPid = erlang:element(4, Self),
     case gen_server:call(ClassPid, superclass) of
@@ -252,7 +252,7 @@ classIncludesBehaviour(Self, TargetClassObj) ->
     end.
 
 %% @doc Walk the hierarchy and return the class object that defines the selector, or nil.
--spec classWhichIncludesSelector(#beamtalk_object{}, atom()) -> #beamtalk_object{} | nil.
+-spec classWhichIncludesSelector(#beamtalk_object{}, atom()) -> #beamtalk_object{} | 'nil'.
 classWhichIncludesSelector(Self, Selector) ->
     ClassPid = erlang:element(4, Self),
     ClassName = gen_server:call(ClassPid, class_name),
@@ -326,7 +326,7 @@ classClass(Self) ->
 %%
 %% ADR 0033: Runtime-embedded documentation.
 %% The class gen_server stores `none` internally; we return `nil` for Beamtalk.
--spec classDoc(#beamtalk_object{}) -> binary() | nil.
+-spec classDoc(#beamtalk_object{}) -> binary() | 'nil'.
 classDoc(Self) ->
     ClassPid = erlang:element(4, Self),
     case gen_server:call(ClassPid, get_doc) of
@@ -364,7 +364,7 @@ classSetMethodDoc(Self, Selector, DocBinary) ->
 %%   1. Stop all live actors of this class (via beamtalk_actor_registry)
 %%   2. Stop the class gen_server (terminate/2 removes ETS entry and pg group)
 %%   3. Purge the BEAM module (code:soft_purge + code:delete)
--spec classRemoveFromSystem(#beamtalk_object{}) -> nil.
+-spec classRemoveFromSystem(#beamtalk_object{}) -> 'nil'.
 classRemoveFromSystem(Self) ->
     ClassPid = erlang:element(4, Self),
     ClassName = gen_server:call(ClassPid, class_name),
@@ -428,7 +428,7 @@ classRemoveFromSystem(Self) ->
 %% ADR 0036: Backs `@primitive "metaclassThisClass"` in Metaclass.bt.
 %% A metaclass object carries the class pid; we retrieve its name and return
 %% the class object. Example: `Counter class class thisClass == Counter`.
--spec metaclassThisClass(#beamtalk_object{}) -> #beamtalk_object{} | nil.
+-spec metaclassThisClass(#beamtalk_object{}) -> #beamtalk_object{} | 'nil'.
 metaclassThisClass(Self) ->
     Pid = erlang:element(4, Self),
     ClassName = gen_server:call(Pid, class_name),
@@ -439,7 +439,7 @@ metaclassThisClass(Self) ->
 %% ADR 0036: Backs `@primitive "metaclassSuperclass"` in Metaclass.bt.
 %% The superclass of Counter's metaclass is the metaclass of Counter's superclass.
 %% Example: `Counter class superclass == Actor class`.
--spec metaclassSuperclass(#beamtalk_object{}) -> #beamtalk_object{} | nil.
+-spec metaclassSuperclass(#beamtalk_object{}) -> #beamtalk_object{} | 'nil'.
 metaclassSuperclass(Self) ->
     Pid = erlang:element(4, Self),
     case gen_server:call(Pid, superclass) of
@@ -555,7 +555,7 @@ walk_hierarchy(ClassName, Fun, Acc, Depth) ->
 %% Looks up the class process, gets its module name, and constructs
 %% the class object tuple. Returns nil if the class is not registered
 %% (safe during bootstrap window).
--spec atom_to_class_object(atom()) -> #beamtalk_object{} | nil.
+-spec atom_to_class_object(atom()) -> #beamtalk_object{} | 'nil'.
 atom_to_class_object(ClassName) ->
     case beamtalk_class_registry:whereis_class(ClassName) of
         undefined ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_list_ops.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_list_ops.erl
@@ -108,7 +108,7 @@ detect_if_none(List, Block, _Default) when is_list(List) ->
     beamtalk_error:raise(Error2).
 
 %% @doc Iterate over elements with side effects.
--spec do(list(), function()) -> nil.
+-spec do(list(), function()) -> 'nil'.
 do(List, Block) when is_list(List), is_function(Block, 1) ->
     lists:foreach(Block, List),
     nil;

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_map_ops.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_map_ops.erl
@@ -23,7 +23,7 @@ at_if_absent(Map, Key, Block) when is_function(Block, 0) ->
     end.
 
 %% @doc Iterate over all values in the dictionary.
--spec do(map(), fun((term()) -> term())) -> nil.
+-spec do(map(), fun((term()) -> term())) -> 'nil'.
 do(Map, Block) when is_function(Block, 1) ->
     maps:foreach(fun(_K, V) -> Block(V) end, Map),
     nil.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl
@@ -33,7 +33,7 @@
 %%
 %% Returns a CompiledMethod map or nil if the method is not found.
 %% Raises beamtalk_error for invalid class references.
--spec resolve(ClassRef, selector()) -> compiled_method() | nil when
+-spec resolve(ClassRef, selector()) -> compiled_method() | 'nil' when
     ClassRef :: pid() | atom() | tuple().
 resolve(ClassPid, Selector) when is_pid(ClassPid) ->
     resolve_with_hierarchy(ClassPid, Selector);
@@ -78,7 +78,7 @@ resolve(Other, _Selector) ->
 
 %% @private
 %% @doc Resolve a method, walking the superclass chain if not found locally.
--spec resolve_with_hierarchy(pid(), selector()) -> compiled_method() | nil.
+-spec resolve_with_hierarchy(pid(), selector()) -> compiled_method() | 'nil'.
 resolve_with_hierarchy(ClassPid, Selector) ->
     case gen_server:call(ClassPid, {method, Selector}) of
         nil ->
@@ -94,7 +94,7 @@ resolve_with_hierarchy(ClassPid, Selector) ->
 %% and checks for the method. Recurses until the method is found or
 %% the chain is exhausted (superclass = none). Guarded by
 %% MAX_HIERARCHY_DEPTH to prevent infinite recursion on corrupted hierarchies.
--spec walk_superclass_chain(pid(), selector(), non_neg_integer()) -> compiled_method() | nil.
+-spec walk_superclass_chain(pid(), selector(), non_neg_integer()) -> compiled_method() | 'nil'.
 walk_superclass_chain(_ClassPid, _Selector, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
     ?LOG_WARNING(">> hierarchy walk exceeded ~p levels", [?MAX_HIERARCHY_DEPTH]),
     nil;

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -172,7 +172,7 @@ class_send(ClassPid, Selector, Args) ->
 
 %% @doc Get a compiled method object.
 %% Delegates to beamtalk_method_resolver.
--spec method(pid() | class_name() | tuple(), selector()) -> compiled_method() | nil.
+-spec method(pid() | class_name() | tuple(), selector()) -> compiled_method() | 'nil'.
 method(ClassRef, Selector) ->
     beamtalk_method_resolver:resolve(ClassRef, Selector).
 

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_regex.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_regex.erl
@@ -149,7 +149,7 @@ matches_regex_options(_, _, _) ->
     beamtalk_error:raise(Error2).
 
 %% @doc Find first match in string, return String or nil.
--spec first_match(binary(), binary() | map()) -> binary() | nil.
+-spec first_match(binary(), binary() | map()) -> binary() | 'nil'.
 first_match(Str, #{'$beamtalk_class' := 'Regex', compiled := MP}) when is_binary(Str) ->
     case re:run(Str, MP, [{capture, first, binary}]) of
         {match, [Match]} -> Match;

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_set_ops.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_set_ops.erl
@@ -154,7 +154,7 @@ as_list(#{'$beamtalk_class' := 'Set', elements := Elements}) ->
 %%% ============================================================================
 
 %% @doc Apply a block to each element of the Set.
--spec do(map(), fun((term()) -> term())) -> nil.
+-spec do(map(), fun((term()) -> term())) -> 'nil'.
 do(#{'$beamtalk_class' := 'Set', elements := Elements}, Block) when is_function(Block, 1) ->
     lists:foreach(Block, Elements),
     nil;

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_stack_frame.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_stack_frame.erl
@@ -86,7 +86,7 @@ wrap_frame(_Other) ->
 %%   - 'bt@integer' → 'Integer' (stdlib alt format)
 %%   - 'beamtalk_integer' → 'Integer' (runtime primitives)
 %%   - Other modules → nil (not a Beamtalk class)
--spec module_to_class(atom()) -> atom() | nil.
+-spec module_to_class(atom()) -> atom() | 'nil'.
 module_to_class(Module) when is_atom(Module) ->
     ModStr = atom_to_list(Module),
     case ModStr of
@@ -118,7 +118,7 @@ module_to_class(_) ->
 %% @doc Convert snake_case module name to CamelCase class name atom.
 %%
 %% Uses list_to_existing_atom to avoid atom table growth from arbitrary module names.
--spec snake_to_class(string()) -> atom() | nil.
+-spec snake_to_class(string()) -> atom() | 'nil'.
 snake_to_class(Snake) ->
     Words = string:split(Snake, "_", all),
     Capitalized = [capitalize(W) || W <- Words],

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_stream.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_stream.erl
@@ -195,7 +195,7 @@ take(_, _) ->
     raise_type_error('take:', <<"Expected a non-negative Integer">>).
 
 %% @doc Iterate with side effects, return nil.
--spec do(map(), fun((term()) -> term())) -> nil.
+-spec do(map(), fun((term()) -> term())) -> 'nil'.
 do(#{'$beamtalk_class' := 'Stream', generator := Gen} = Stream, Block) when is_function(Block, 1) ->
     try
         do_loop(Gen, Block)

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_string_ops.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_string_ops.erl
@@ -112,7 +112,7 @@ ends_with(Str, Suffix) when is_binary(Str), is_binary(Suffix) ->
     end.
 
 %% @doc Find first occurrence of substring, return 1-based grapheme index or nil.
--spec index_of(binary(), binary()) -> integer() | nil.
+-spec index_of(binary(), binary()) -> integer() | 'nil'.
 index_of(_Str, <<>>) ->
     nil;
 index_of(Str, Sub) when is_binary(Str), is_binary(Sub) ->
@@ -145,7 +145,7 @@ join(List) when is_list(List) ->
     iolist_to_binary(List).
 
 %% @doc Iterate over graphemes, applying block to each. Returns nil.
--spec each(binary(), function()) -> nil.
+-spec each(binary(), function()) -> 'nil'.
 each(Str, Block) when is_binary(Str), is_function(Block, 1) ->
     lists:foreach(Block, as_list(Str)),
     nil.
@@ -232,7 +232,7 @@ is_alpha(Str) when is_binary(Str) ->
 %% @private
 %% @doc Grapheme-aware substring search.
 -spec index_of_graphemes([string:grapheme_cluster()], [string:grapheme_cluster()], integer()) ->
-    integer() | nil.
+    integer() | 'nil'.
 index_of_graphemes([], _SubGs, _Idx) ->
     nil;
 index_of_graphemes(StrGs, SubGs, Idx) ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_system.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_system.erl
@@ -36,7 +36,7 @@
 %%% ============================================================================
 
 %% @doc Read an environment variable. Returns nil if not set.
--spec 'getEnv:'(binary()) -> binary() | nil.
+-spec 'getEnv:'(binary()) -> binary() | 'nil'.
 'getEnv:'(Name) when is_binary(Name) ->
     case os:getenv(binary_to_list(Name)) of
         false -> nil;

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_system_dictionary.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_system_dictionary.erl
@@ -283,7 +283,7 @@ handle_all_classes() ->
 %% Returns the class as a beamtalk_object record (for dispatch), or nil if not found.
 %% BT-246: Wraps result in {beamtalk_object, ClassTag, ModuleName, Pid} tuple
 %% where ClassTag is 'ClassName class' (e.g., 'Point class') for is_class_object detection.
--spec handle_class_named(binary() | atom()) -> tuple() | nil | {error, #beamtalk_error{}}.
+-spec handle_class_named(binary() | atom()) -> tuple() | 'nil' | {error, #beamtalk_error{}}.
 handle_class_named(ClassName) when is_binary(ClassName) ->
     %% Use binary_to_existing_atom to avoid creating atoms at runtime
     try

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_test_case.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_test_case.erl
@@ -42,7 +42,7 @@
 %%   should_raise(Block, my_error)  % => passes
 %%
 %% Note: Block is a zero-argument Erlang fun in Core Erlang codegen.
--spec should_raise(fun(() -> term()), atom()) -> nil.
+-spec should_raise(fun(() -> term()), atom()) -> 'nil'.
 should_raise(Block, ExpectedKind) when is_function(Block, 0), is_atom(ExpectedKind) ->
     try Block() of
         _ ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_tuple_ops.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_tuple_ops.erl
@@ -60,7 +60,7 @@ as_string(X) ->
     iolist_to_binary([<<"{">>, Joined, <<"}">>]).
 
 %% @doc Iterate over each element of the tuple.
--spec do(tuple(), fun((term()) -> term())) -> nil.
+-spec do(tuple(), fun((term()) -> term())) -> 'nil'.
 do(Tuple, Block) when is_function(Block, 1) ->
     lists:foreach(Block, tuple_to_list(Tuple)),
     nil.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_environment.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_environment.erl
@@ -218,7 +218,7 @@ handle_actors() ->
 
 %% @doc Look up a specific actor by pid string.
 %% Returns beamtalk_object or nil if not found.
--spec handle_actor_at(binary() | list()) -> tuple() | nil.
+-spec handle_actor_at(binary() | list()) -> tuple() | 'nil'.
 handle_actor_at(PidStr) when is_binary(PidStr) ->
     handle_actor_at(binary_to_list(PidStr));
 handle_actor_at(PidStr) when is_list(PidStr) ->


### PR DESCRIPTION
## Summary

Fixes `-spec` return type declarations across 16 Erlang runtime modules where bare `nil` (which Erlang interprets as the empty list type `[]`) was used instead of quoted `'nil'` (the atom literal).

- Fixed 9 standalone `-> nil.` return types
- Fixed 18 `| nil` union type occurrences
- All affected functions return the atom `nil`, so specs must use `'nil'`

## Linear Issue

https://linear.app/beamtalk/issue/BT-821

## Test Plan

- [x] `just build` passes
- [x] `just test` passes (2,042 Rust + 418 stdlib + 385 BUnit + 2,138 Erlang tests)
- [x] `just clippy` clean
- [x] `just fmt-check` clean
- [x] Dialyzer clean (verified via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type specifications across runtime modules to use quoted atom notation for improved type clarity and consistency.
  * Enhanced class resolution functionality to accept binary input alongside atom input in system dictionary operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->