### PR TITLE
List inject:into: block argument order inconsistent with Collection convention (BT-820)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
@@ -128,11 +128,11 @@ fn generate_list_iteration_bif(selector: &str, params: &[String]) -> Option<Docu
         "inject:into:" => {
             let p1 = params.get(1).map_or("_Block", String::as_str);
             Some(docvec![
-                "call 'lists':'foldl'(",
-                p1.to_string(),
-                ", ",
+                "call 'beamtalk_collection_ops':'inject_into'(Self, ",
                 p0.to_string(),
-                ", Self)"
+                ", ",
+                p1.to_string(),
+                ")"
             ])
         }
         "take:" => Some(docvec![

--- a/docs/stdlib-implementation-status.md
+++ b/docs/stdlib-implementation-status.md
@@ -225,7 +225,7 @@ _Note:_ `sealed` is a method **modifier** in Beamtalk (for example, `sealed getV
 | `collect:` | @primitive BIF (`lists:map`) | ✅ | 🧪 | `Collection>>collect:` |
 | `select:` | @primitive BIF (`lists:filter`) | ✅ | 🧪 | `Collection>>select:` |
 | `reject:` | @primitive → `beamtalk_list_ops:reject/2` | ✅ | 🧪 | `Collection>>reject:` |
-| `inject:into:` | @primitive BIF (`lists:foldl`) | ✅ | 🧪 | `Collection>>inject:into:` |
+| `inject:into:` | @primitive → `beamtalk_collection_ops:inject_into/3` | ✅ | 🧪 | `Collection>>inject:into:` |
 | `detect:` | @primitive → `beamtalk_list_ops:detect/2` | ✅ | 🧪 | `Collection>>detect:` |
 | `detect:ifNone:` | @primitive → `beamtalk_list_ops:detect_if_none/3` | ✅ | | `Collection>>detect:ifNone:` |
 | `flatMap:` | @primitive BIF (`lists:flatmap`) | ✅ | 🧪 | `Collection>>flatCollect:` |

--- a/stdlib/src/Dictionary.bt
+++ b/stdlib/src/Dictionary.bt
@@ -119,7 +119,7 @@ sealed Collection subclass: Dictionary
   /// ```
   collect: block: Block -> Dictionary =>
     dict := self.
-    self keys inject: #{} into: [:k :acc |
+    self keys inject: #{} into: [:acc :k |
       acc at: k put: (block value: (dict at: k))
     ]
 

--- a/stdlib/src/List.bt
+++ b/stdlib/src/List.bt
@@ -253,7 +253,7 @@ sealed Collection subclass: List
   /// #(10, 20, 30) indexOf: 99        // => nil
   /// ```
   indexOf: item -> Integer | Nil =>
-    self inject: 0 into: [:each :i |
+    self inject: 0 into: [:i :each |
       newI := i + 1.
       each =:= item ifTrue: [^newI].
       newI
@@ -267,7 +267,7 @@ sealed Collection subclass: List
   /// #("a", "b") eachWithIndex: [:item :i | Transcript show: i]
   /// ```
   eachWithIndex: block: Block -> Nil =>
-    self inject: 0 into: [:each :i |
+    self inject: 0 into: [:i :each |
       newI := i + 1.
       block value: each value: newI.
       newI

--- a/stdlib/test/collection_methods_test.bt
+++ b/stdlib/test/collection_methods_test.bt
@@ -30,7 +30,11 @@ TestCase subclass: CollectionMethodsTest
     // inject:into: product
     self assert: (#(1, 2, 3, 4) inject: 1 into: [:product :x | product * x]) equals: 24.
     // inject:into: on single element
-    self assert: (#(42) inject: 0 into: [:acc :x | acc + x]) equals: 42
+    self assert: (#(42) inject: 0 into: [:acc :x | acc + x]) equals: 42.
+    // inject:into: non-commutative — verifies (acc, elem) argument order
+    self assert: (#("b", "c") inject: "a" into: [:acc :x | acc ++ x]) equals: "abc".
+    // inject:into: non-commutative — list prepend reverses
+    self assert: (#(1, 2, 3) inject: #() into: [:acc :x | acc addFirst: x]) equals: #(3, 2, 1)
 
   testDoIteration =>
     // do: returns ok (side-effect only)

--- a/stdlib/test/fixtures/collection_mutation_counter.bt
+++ b/stdlib/test/fixtures/collection_mutation_counter.bt
@@ -19,7 +19,7 @@ Actor subclass: CollectionMutationCounter
   // inject:into: with field mutation on a Dictionary receiver
   // The block mutates self.total as a side effect while accumulating
   sumDictValues: aDict =>
-    aDict inject: 0 into: [:val :acc |
+    aDict inject: 0 into: [:acc :val |
       self.total := self.total + val
       acc + val
     ]

--- a/stdlib/test/fixtures/mutation_return_values.bt
+++ b/stdlib/test/fixtures/mutation_return_values.bt
@@ -12,10 +12,9 @@ Actor subclass: MutationReturnValues
   setValue: v => self.value := v
 
   // inject:into: should return the accumulator result
-  // Note: foldl calls fun(Elem, Acc), so first block param is list element,
-  // second is accumulator
+  // Block receives (accumulator, element) matching Beamtalk convention (BT-820)
   sumViaInject: items =>
-    items inject: 0 into: [:elem :acc |
+    items inject: 0 into: [:acc :elem |
       self.value := self.value + elem.
       acc + elem
     ]

--- a/stdlib/test/mutation_return_values_test.bt
+++ b/stdlib/test/mutation_return_values_test.bt
@@ -9,9 +9,9 @@ TestCase subclass: MutationReturnValuesTest
   testSection1 =>
     actor := MutationReturnValues spawn.
     self assert: ((actor setValue: 0) await) equals: 0.
-    // foldl calls fun(Elem, Acc): first param is list element, second is accumulator
+    // Block receives (acc, elem) — accumulator first, element second (BT-820)
     self assert: ((actor sumViaInject: #(1, 2, 3)) await) equals: 6.
-    // self.value += elem (list element): 0 + 1 + 2 + 3 = 6
+    // self.value += elem: 0 + 1 + 2 + 3 = 6
     self assert: (actor getValue await) equals: 6.
     // State should also be updated (side effect of mutations)
     self assert: ((actor setValue: 0) await) equals: 0.

--- a/test-package-compiler/cases/stdlib_class_list/main.bt
+++ b/test-package-compiler/cases/stdlib_class_list/main.bt
@@ -46,7 +46,7 @@ sealed Object subclass: List
   // Subsequence / Search
   from: start to: end => @primitive "from:to:"
   indexOf: item =>
-    self inject: 0 into: [:each :i |
+    self inject: 0 into: [:i :each |
       newI := i + 1.
       each =:= item ifTrue: [^newI].
       newI
@@ -55,7 +55,7 @@ sealed Object subclass: List
 
   // Iteration with index
   eachWithIndex: block =>
-    self inject: 0 into: [:each :i |
+    self inject: 0 into: [:i :each |
       newI := i + 1.
       block value: each value: newI.
       newI

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_codegen.snap
@@ -69,7 +69,7 @@ call 'lists':'filter'(_block9, Self)
 call 'beamtalk_list_ops':'reject'(Self, _block10)
 
 'inject:into:'/3 = fun (Self, _initial11, _block12) ->
-call 'lists':'foldl'(_block12, _initial11, Self)
+call 'beamtalk_collection_ops':'inject_into'(Self, _initial11, _block12)
 
 'take:'/2 = fun (Self, _n13) ->
 call 'beamtalk_list_ops':'take'(Self, _n13)
@@ -101,39 +101,39 @@ call 'beamtalk_list_ops':'from_to'(Self, _start20, _end21)
 'indexOf:'/2 = fun (Self, _item22) ->
     let _NlrToken23 = call 'erlang':'make_ref'() in
     try
-    let _seq24 = let _temp25 = Self in let _temp26 = 0 in let _temp27 = fun (_each28, _i29) -> let NewI = call 'erlang':'+'(_i29, 1) in let _Unit = call 'beamtalk_message_dispatch':'send'(call 'erlang':'=:='(_each28, _item22), 'ifTrue:', [fun () -> call 'erlang':'throw'({'$bt_nlr', _NlrToken23, NewI})]) in NewI in case call 'erlang':'is_list'(_temp25) of <'true'> when 'true' -> call 'lists':'foldl'(_temp27, _temp26, _temp25) <'false'> when 'true' -> call 'beamtalk_primitive':'send'(_temp25, 'inject:into:', [_temp26, _temp27]) end in
+    let _seq24 = call 'beamtalk_collection_ops':'inject_into'(Self, 0, fun (_i25, _each26) -> let NewI = call 'erlang':'+'(_i25, 1) in let _Unit = call 'beamtalk_message_dispatch':'send'(call 'erlang':'=:='(_each26, _item22), 'ifTrue:', [fun () -> call 'erlang':'throw'({'$bt_nlr', _NlrToken23, NewI})]) in NewI) in
     'nil'
-    of _NlrResult30 -> _NlrResult30
-    catch <_NlrCls31, _NlrErr32, _NlrStk33> ->
-      case {_NlrCls31, _NlrErr32} of
-        <{'throw', {'$bt_nlr', _CatchTok34, _NlrVal35}}> when call 'erlang':'=:='(_CatchTok34, _NlrToken23) -> _NlrVal35
-        <_OtherPair36> when 'true' -> primop 'raw_raise'(_NlrCls31, _NlrErr32, _NlrStk33)
+    of _NlrResult27 -> _NlrResult27
+    catch <_NlrCls28, _NlrErr29, _NlrStk30> ->
+      case {_NlrCls28, _NlrErr29} of
+        <{'throw', {'$bt_nlr', _CatchTok31, _NlrVal32}}> when call 'erlang':'=:='(_CatchTok31, _NlrToken23) -> _NlrVal32
+        <_OtherPair33> when 'true' -> primop 'raw_raise'(_NlrCls28, _NlrErr29, _NlrStk30)
       end
 
-'eachWithIndex:'/2 = fun (Self, _block37) ->
-    let _seq38 = let _temp39 = Self in let _temp40 = 0 in let _temp41 = fun (_each42, _i43) -> let NewI = call 'erlang':'+'(_i43, 1) in let _Unit = let _Fun44 = _block37 in apply _Fun44 (_each42, NewI) in NewI in case call 'erlang':'is_list'(_temp39) of <'true'> when 'true' -> call 'lists':'foldl'(_temp41, _temp40, _temp39) <'false'> when 'true' -> call 'beamtalk_primitive':'send'(_temp39, 'inject:into:', [_temp40, _temp41]) end in
+'eachWithIndex:'/2 = fun (Self, _block34) ->
+    let _seq35 = call 'beamtalk_collection_ops':'inject_into'(Self, 0, fun (_i36, _each37) -> let NewI = call 'erlang':'+'(_i36, 1) in let _Unit = let _Fun38 = _block34 in apply _Fun38 (_each37, NewI) in NewI) in
     'nil'
 
-'zip:'/2 = fun (Self, _other45) ->
-call 'beamtalk_list_ops':'zip'(Self, _other45)
+'zip:'/2 = fun (Self, _other39) ->
+call 'beamtalk_list_ops':'zip'(Self, _other39)
 
-'groupBy:'/2 = fun (Self, _block46) ->
-call 'beamtalk_list_ops':'group_by'(Self, _block46)
+'groupBy:'/2 = fun (Self, _block40) ->
+call 'beamtalk_list_ops':'group_by'(Self, _block40)
 
-'partition:'/2 = fun (Self, _block47) ->
-call 'beamtalk_list_ops':'partition'(Self, _block47)
+'partition:'/2 = fun (Self, _block41) ->
+call 'beamtalk_list_ops':'partition'(Self, _block41)
 
-'takeWhile:'/2 = fun (Self, _block48) ->
-call 'lists':'takewhile'(_block48, Self)
+'takeWhile:'/2 = fun (Self, _block42) ->
+call 'lists':'takewhile'(_block42, Self)
 
-'dropWhile:'/2 = fun (Self, _block49) ->
-call 'lists':'dropwhile'(_block49, Self)
+'dropWhile:'/2 = fun (Self, _block43) ->
+call 'lists':'dropwhile'(_block43, Self)
 
-'intersperse:'/2 = fun (Self, _separator50) ->
-call 'beamtalk_list_ops':'intersperse'(Self, _separator50)
+'intersperse:'/2 = fun (Self, _separator44) ->
+call 'beamtalk_list_ops':'intersperse'(Self, _separator44)
 
-'add:'/2 = fun (Self, _item51) ->
-call 'erlang':'++'(Self, [_item51|[]])
+'add:'/2 = fun (Self, _item45) ->
+call 'erlang':'++'(Self, [_item45|[]])
 
 'dispatch'/3 = fun (Selector, Args, Self) ->
     case Selector of

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_lexer.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_lexer.snap
@@ -147,9 +147,9 @@ Token { kind: Integer("0"), span: Span { start: 1456, end: 1457 }, leading_trivi
 Token { kind: Keyword("into:"), span: Span { start: 1458, end: 1463 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
 Token { kind: LeftBracket, span: Span { start: 1464, end: 1465 }, leading_trivia: [], trailing_trivia: [] }
 Token { kind: Colon, span: Span { start: 1465, end: 1466 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Identifier("each"), span: Span { start: 1466, end: 1470 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Colon, span: Span { start: 1471, end: 1472 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Identifier("i"), span: Span { start: 1472, end: 1473 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("i"), span: Span { start: 1466, end: 1467 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Colon, span: Span { start: 1468, end: 1469 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("each"), span: Span { start: 1469, end: 1473 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
 Token { kind: Pipe, span: Span { start: 1474, end: 1475 }, leading_trivia: [], trailing_trivia: [] }
 Token { kind: Identifier("newI"), span: Span { start: 1482, end: 1486 }, leading_trivia: [Whitespace("\n      ")], trailing_trivia: [Whitespace(" ")] }
 Token { kind: Assign, span: Span { start: 1487, end: 1489 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
@@ -179,9 +179,9 @@ Token { kind: Integer("0"), span: Span { start: 1630, end: 1631 }, leading_trivi
 Token { kind: Keyword("into:"), span: Span { start: 1632, end: 1637 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
 Token { kind: LeftBracket, span: Span { start: 1638, end: 1639 }, leading_trivia: [], trailing_trivia: [] }
 Token { kind: Colon, span: Span { start: 1639, end: 1640 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Identifier("each"), span: Span { start: 1640, end: 1644 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Colon, span: Span { start: 1645, end: 1646 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Identifier("i"), span: Span { start: 1646, end: 1647 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("i"), span: Span { start: 1640, end: 1641 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Colon, span: Span { start: 1642, end: 1643 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("each"), span: Span { start: 1643, end: 1647 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
 Token { kind: Pipe, span: Span { start: 1648, end: 1649 }, leading_trivia: [], trailing_trivia: [] }
 Token { kind: Identifier("newI"), span: Span { start: 1656, end: 1660 }, leading_trivia: [Whitespace("\n      ")], trailing_trivia: [Whitespace(" ")] }
 Token { kind: Assign, span: Span { start: 1661, end: 1663 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_parser.snap
@@ -1127,16 +1127,16 @@ Module {
                                     Block {
                                         parameters: [
                                             BlockParameter {
-                                                name: "each",
+                                                name: "i",
                                                 span: Span {
                                                     start: 1466,
-                                                    end: 1470,
+                                                    end: 1467,
                                                 },
                                             },
                                             BlockParameter {
-                                                name: "i",
+                                                name: "each",
                                                 span: Span {
-                                                    start: 1472,
+                                                    start: 1469,
                                                     end: 1473,
                                                 },
                                             },
@@ -1368,16 +1368,16 @@ Module {
                                     Block {
                                         parameters: [
                                             BlockParameter {
-                                                name: "each",
+                                                name: "i",
                                                 span: Span {
                                                     start: 1640,
-                                                    end: 1644,
+                                                    end: 1641,
                                                 },
                                             },
                                             BlockParameter {
-                                                name: "i",
+                                                name: "each",
                                                 span: Span {
-                                                    start: 1646,
+                                                    start: 1643,
                                                     end: 1647,
                                                 },
                                             },


### PR DESCRIPTION
## Summary

Fixes [BT-820](https://linear.app/beamtalk/issue/BT-820): List's `inject:into:` passed the block directly to Erlang's `lists:foldl`, which calls `Fun(Elem, Acc)`. But Beamtalk convention is `Block(Acc, Elem)` — accumulator first, element second. This caused silent wrong results for non-commutative operations.

### Key Changes

- **Primitive path** (`list.rs`): Delegate to `beamtalk_collection_ops:inject_into/3` which wraps the block
- **Intrinsic simple path** (`list_ops.rs`): Same delegation to `beamtalk_collection_ops:inject_into/3`
- **Intrinsic mutation-threading path** (`list_ops.rs`): Swap parameter bindings so `params[0]` = Acc, `params[1]` = Item
- **List.bt**: Fix `indexOf:` and `eachWithIndex:` to use `[:i :each |]` convention
- **Dictionary.bt**: Fix `collect:` to use `[:acc :k |]` convention
- **Tests**: Add non-commutative tests (string concat, list prepend) and fix fixtures using old argument order

## Test plan

- [x] Non-commutative `inject:into:` tests verify `(acc, elem)` order
- [x] All 385 BUnit tests pass
- [x] All 418 stdlib tests pass
- [x] All 2138 runtime tests pass
- [x] Full CI passes (build, clippy, fmt, tests, e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive tests for `inject:into:` operations with non-commutative arguments.

* **Bug Fixes**
  * Standardized accumulator-first parameter order in `inject:into:` blocks across the standard library for consistent behavior.

* **Documentation**
  * Updated implementation references to reflect optimized collection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->