### PR TITLE
fix: make worktree-init hook fail gracefully on diverged branches

### DIFF
--- a/.claude/hooks/worktree-init.sh
+++ b/.claude/hooks/worktree-init.sh
@@ -25,10 +25,16 @@ fi
 
 # Check whether the branch exists on origin (anchor match to avoid substring hits)
 if git ls-remote --heads origin "${BRANCH}" 2>/dev/null | grep -qF "refs/heads/${BRANCH}"; then
-  git fetch origin "${BRANCH}" 2>&1
+  if ! git fetch origin "${BRANCH}" 2>&1; then
+    echo "Warning: failed to fetch '${BRANCH}' from origin — continuing without pull."
+    exit 0
+  fi
   BEHIND=$(git rev-list HEAD..origin/"${BRANCH}" --count 2>/dev/null || echo 0)
-  git pull --ff-only origin "${BRANCH}" 2>&1
-  echo "Worktree branch '${BRANCH}' pulled from origin (was ${BEHIND} commit(s) behind)."
+  if git pull --ff-only origin "${BRANCH}" 2>&1; then
+    echo "Worktree branch '${BRANCH}' pulled from origin (was ${BEHIND} commit(s) behind)."
+  else
+    echo "Warning: branch '${BRANCH}' has diverged from origin (${BEHIND} commit(s) behind) — run 'git pull --rebase' to sync."
+  fi
 else
   echo "Worktree branch '${BRANCH}' has no remote counterpart on origin — nothing to pull."
 fi


### PR DESCRIPTION
## Summary

Instead of crashing with a fatal error when `git pull --ff-only` fails (e.g., diverged branches), the worktree-init hook now emits a warning with instructions and exits cleanly. Also handles fetch failures gracefully.

## Test plan

- [x] Manual verification: worktree-init hook exits cleanly when branch has diverged
- [x] Normal case still works: fast-forward pull succeeds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Git fetch operations now fail gracefully with warning messages instead of proceeding silently.
  * Pull operations now handle diverged branches gracefully, providing rebase suggestions to resolve conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->