### PR TITLE
docs: mark ADR 0017 and 0025 phases as implemented

### DIFF
--- a/docs/ADR/0025-gradual-typing-and-protocols.md
+++ b/docs/ADR/0025-gradual-typing-and-protocols.md
@@ -1,7 +1,7 @@
 # ADR 0025: Gradual Typing and Protocols
 
 ## Status
-Accepted (2026-02-15)
+Accepted (2026-02-15) — Phases 1 and 2 complete; Phase 3 (Protocols) planned
 
 ## Context
 
@@ -566,8 +566,8 @@ Union types, generic types, singleton types, type narrowing. Deferred to future 
 
 | Phase | Issue | Description | Size | Status |
 |-------|-------|-------------|------|--------|
-| 1 | BT-587, BT-671, BT-672 | Type inference from class definitions; argument/return/state checks | M-L | In Progress |
-| 2 | BT-673 | Optional type annotations syntax + user-facing coverage (stdlib/docs/examples); Dialyzer spec generation pending | M | In Progress |
+| 1 | BT-587, BT-671, BT-672 | Type inference from class definitions; argument/return/state checks | M-L | Done |
+| 2 | BT-673 | Optional type annotations syntax + user-facing coverage (stdlib/docs/examples); Dialyzer spec generation pending | M | Done |
 | 3 | TBD | Protocol definitions and structural conformance | L | Planned |
 | 4 | TBD | Advanced types (union, generic, singleton, narrowing) | XL | Future |
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -43,7 +43,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0014](0014-beamtalk-test-framework.md) | Beamtalk Test Framework — Native Unit Tests and CLI Integration Tests | Implemented | 2026-02-15 |
 | [0015](0015-repl-error-objects-and-exception-hierarchy.md) | Signal-Time Exception Objects and Error Class Hierarchy | Implemented | 2026-02-15 |
 | [0016](0016-unified-stdlib-module-naming.md) | Unified Stdlib Packaging and Module Naming | Implemented | 2026-02-10 |
-| [0017](0017-browser-connectivity-to-running-workspaces.md) | Browser Connectivity to Running Workspaces | Accepted | 2026-02-17 |
+| [0017](0017-browser-connectivity-to-running-workspaces.md) | Browser Connectivity to Running Workspaces | Implemented (Phases 0–2) | 2026-02-17 |
 | [0018](0018-document-tree-codegen.md) | Document Tree Code Generation (Wadler-Lindig Pretty Printer) | Implemented | 2026-02-15 |
 | [0019](0019-singleton-class-variables.md) | Singleton Access via Class Variables | Implemented | 2026-02-15 |
 | [0020](0020-connection-security.md) | Connection Security — mTLS, Proxies, and Network Overlays | Implemented | 2026-02-17 |
@@ -51,7 +51,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0022](0022-embedded-compiler-via-otp-port.md) | Embedded Compiler via OTP Port (with NIF option) | Implemented | 2026-02-15 |
 | [0023](0023-string-interpolation-and-binaries.md) | String Interpolation Syntax and Compilation | Implemented | 2026-02-17 |
 | [0024](0024-static-first-live-augmented-ide-tooling.md) | Static-First, Live-Augmented IDE Tooling | Implemented (Phase 1) | 2026-02-17 |
-| [0025](0025-gradual-typing-and-protocols.md) | Gradual Typing and Protocols | Accepted | 2026-02-15 |
+| [0025](0025-gradual-typing-and-protocols.md) | Gradual Typing and Protocols | Implemented (Phases 1–2) | 2026-02-15 |
 | [0026](0026-package-definition-and-project-manifest.md) | Package Definition and Project Manifest | Implemented | 2026-02-17 |
 | [0027](0027-cross-platform-support.md) | Cross-Platform Support | Implemented | 2026-02-17 |
 | [0028](0028-beam-interop-strategy.md) | BEAM Interop Strategy | Implemented | 2026-02-17 |


### PR DESCRIPTION
## Summary
- ADR 0017 (Browser Connectivity): `Accepted` → `Implemented (Phases 0–2)` in README and status line
- ADR 0025 (Gradual Typing): `Accepted` → `Implemented (Phases 1–2)` in README; tracking table phases 1 and 2 marked `Done`

These were committed after PR #868 was merged, so they need a new PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Architecture Decision Records documentation to reflect completed project phases.
  * Status updates for architectural decisions now show phases 1–2 completion with phase 3 planned and phase 4 as future work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->