### PR TITLE
ADR 0040: Workspace-Native REPL Commands, Facade/Dictionary Split, Class-Based Reload (BT-841)

### DIFF
--- a/docs/ADR/0040-workspace-native-repl-commands.md
+++ b/docs/ADR/0040-workspace-native-repl-commands.md
@@ -1,7 +1,7 @@
 # ADR 0040: Workspace-Native REPL Commands, Facade/Dictionary Split, and Class-Based Reload
 
 ## Status
-Proposed (2026-02-24)
+Accepted (2026-02-24)
 
 ## Context
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -65,7 +65,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0036](0036-full-metaclass-tower.md) | Full Metaclass Tower | Implemented | 2026-02-24 |
 | [0037](0037-collection-class-hierarchy.md) | Collection Class Hierarchy — Shallow Abstract Layer with Minimal Primitive Surface | Implemented | 2026-02-24 |
 | [0038](0038-subclass-classbuilder-protocol.md) | `subclass:` Grammar Desugaring to ClassBuilder Protocol | Accepted | 2026-02-24 |
-| [0040](0040-workspace-native-repl-commands.md) | Workspace-Native REPL Commands, Facade/Dictionary Split, and Class-Based Reload | Proposed | 2026-02-24 |
+| [0040](0040-workspace-native-repl-commands.md) | Workspace-Native REPL Commands, Facade/Dictionary Split, and Class-Based Reload | Accepted | 2026-02-24 |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## Summary

- Add ADR 0040 documenting three related design decisions for workspace-native APIs
- **Facade/Dictionary Split**: Rename `SystemDictionary` → `BeamtalkInterface` (typed facade); `globals` returns plain immutable `Dictionary`
- **Class-Based Reload**: Add `sourceFile` and `reload` to `Behaviour` — classes track their source and reload themselves
- **REPL Migration**: Convert `:load`, `:help`, `:test` etc. to eval of message sends (`Workspace load:`, `Beamtalk help:`, `Counter reload`)
- Drops `sessions`, `modules`, `reload` from Workspace; adds `classes`, `load:`, `test`, `clear`, `globals`

Linear: https://linear.app/beamtalk/issue/BT-841

## Test plan

- [ ] Review ADR for completeness and correctness
- [ ] Verify design aligns with Pharo facade/dictionary split precedent
- [ ] Confirm class-based reload semantics match BEAM hot code swap behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-level REPL commands and project primitives (load, clear, test, classes, globals) plus class-based hot-reload semantics.

* **Documentation**
  * Added ADR 0040 describing the facade/dictionary model, help APIs, migration phases, testing plans, and REPL→API mappings.

* **Deprecated**
  * Deprecates legacy session/protocol operations with migration guidance and compatibility notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->