### PR TITLE
Add missing @expect directives to BUnit tests

### DIFF
--- a/stdlib/test/array_test.bt
+++ b/stdlib/test/array_test.bt
@@ -88,5 +88,7 @@ TestCase subclass: ArrayTest
 
   testLiteralEquality =>
     self assert: (#[1, 2, 3]) equals: #[1, 2, 3].
+    @expect dnu
     self deny: (#[1, 2, 3] =:= #[1, 2, 4]).
+    @expect dnu
     self deny: (#[1, 2] =:= #[1, 2, 3])

--- a/stdlib/test/compiled_method_test.bt
+++ b/stdlib/test/compiled_method_test.bt
@@ -36,6 +36,7 @@ TestCase subclass: CompiledMethodTest
 
   testLookupOnNonClass =>
     // >> on non-class value produces type_error
+    @expect dnu
     self should: [42 >> #foo] raise: #type_error
 
   testAsString =>

--- a/stdlib/test/custom_exceptions_test.bt
+++ b/stdlib/test/custom_exceptions_test.bt
@@ -52,6 +52,7 @@ TestCase subclass: CustomExceptionsTest
 
   testBuiltInDoesNotUnderstandStillWorks =>
     // Built-in does_not_understand still maps to RuntimeError
+    @expect dnu
     result := [42 noSuchMethod] on: RuntimeError do: [:e | e class].
     self assert: result equals: RuntimeError
 

--- a/stdlib/test/error_method_test.bt
+++ b/stdlib/test/error_method_test.bt
@@ -30,7 +30,10 @@ TestCase subclass: ErrorMethodTest
 
   testErrorWithNonStringArgument =>
     // Integer error message is coerced — raises user_error not type_error
+    @expect type
     self should: [42 error: 99] raise: #user_error.
     // Verify kind and errorClass via on:do:
+    @expect type
     self assert: ([42 error: 99] on: Exception do: [:e | e kind]) equals: #user_error.
+    @expect type
     self assert: ([42 error: 99] on: Exception do: [:e | e errorClass]) equals: #Integer

--- a/stdlib/test/file_stream_test.bt
+++ b/stdlib/test/file_stream_test.bt
@@ -90,13 +90,16 @@ TestCase subclass: FileStreamTest
     // File not found
     self should: [File lines: "test/fixtures/nonexistent.txt"] raise: #file_not_found.
     // Type error: non-string path
+    @expect type
     self should: [File lines: 42] raise: #type_error.
     // File not found with open:do:
     self should: [File open: "test/fixtures/nonexistent.txt" do: [:h | h lines asList]] raise: #file_not_found
 
   testErrorPathsTypeErrors =>
     // Type errors that produce compile-time warnings but still run correctly
+    @expect type
     self should: [File open: 42 do: [:h | h lines asList]] raise: #type_error.
+    @expect type
     self should: [File open: "test/fixtures/stream_test.txt" do: "not a block"] raise: #type_error.
     // lines: with absolute path (security)
     self should: [File lines: "/etc/passwd"] raise: #invalid_path.

--- a/stdlib/test/json_test.bt
+++ b/stdlib/test/json_test.bt
@@ -78,6 +78,7 @@ TestCase subclass: JsonTest
     // Parse invalid JSON produces a parse_error
     self should: [JSON parse: "not json"] raise: #parse_error.
     // Parse with non-string argument produces type_error
+    @expect type
     self should: [JSON parse: 42] raise: #type_error
 
   testClassIdentity =>

--- a/stdlib/test/language_features_doc_test.bt
+++ b/stdlib/test/language_features_doc_test.bt
@@ -36,6 +36,7 @@ TestCase subclass: LanguageFeaturesDocTest
     self assert: (5 =:= 5).
     self assert: (5 == 5.0).
     self assert: (5 /= 6).
+    @expect dnu
     self assert: (5 =/= 6)
 
   testGradualTyping =>

--- a/stdlib/test/reflection_basic_test.bt
+++ b/stdlib/test/reflection_basic_test.bt
@@ -37,5 +37,7 @@ TestCase subclass: ReflectionBasicTest
     // BT-359: fieldAt: on value types raises immutable_value error
     self should: [42 fieldAt: #x] raise: #immutable_value.
     // BT-765: fieldAt:put: on immutable literals raises immutable_value error
+    @expect type
     self should: [42 fieldAt: #x put: 99] raise: #immutable_value.
+    @expect type
     self should: ["hello" fieldAt: #x put: "world"] raise: #immutable_value

--- a/stdlib/test/stack_frame_test.bt
+++ b/stdlib/test/stack_frame_test.bt
@@ -17,6 +17,7 @@ TestCase subclass: StackFrameTest
 
   testStackTraceFromDoesNotUnderstand =>
     // stackTrace from does_not_understand has entries
+    @expect dnu
     result := [42 noSuchMethod] on: Exception do: [:e | e stackTrace size > 0].
     self assert: result
 
@@ -27,6 +28,7 @@ TestCase subclass: StackFrameTest
 
   testRuntimeErrorStackTrace =>
     // RuntimeError also has stackTrace
+    @expect dnu
     result := [42 noSuchMethod] on: RuntimeError do: [:e | e stackTrace class].
     self assert: result equals: List
 

--- a/stdlib/test/stream_test.bt
+++ b/stdlib/test/stream_test.bt
@@ -88,7 +88,10 @@ TestCase subclass: StreamTest
 
   testInstanceMethodTypeErrors =>
     // Instance method type errors (constructor errors cannot be tested due to gen_server limitation)
+    @expect type
     self should: [(Stream from: 1) select: "not a block"] raise: #type_error.
+    @expect type
     self should: [(Stream from: 1) collect: 42] raise: #type_error.
     // BT-765: take: with non-integer argument raises type_error
+    @expect all
     self should: [(Stream from: 1) take: "five"] raise: #type_error

--- a/stdlib/test/system_test.bt
+++ b/stdlib/test/system_test.bt
@@ -39,8 +39,11 @@ TestCase subclass: SystemTest
     // --- pid ---
     self assert: (System pid > 0).
     // getEnv: requires String argument
+    @expect type
     self should: [System getEnv: 42] raise: #type_error.
     // getEnv:default: validates both arguments
+    @expect type
     self should: [System getEnv: 42 default: "fallback"] raise: #type_error.
     // --- error cases ---
+    @expect type
     self should: [System getEnv: "PATH" default: 42] raise: #type_error

--- a/stdlib/test/test_case_assertion_test.bt
+++ b/stdlib/test/test_case_assertion_test.bt
@@ -53,6 +53,7 @@ TestCase subclass: TestCaseAssertionTest
     // Test should:raise: with matching error kind
     self assert: (TestCase new should: [1 / 0] raise: #badarith) equals: nil.
     // Test should:raise: with does_not_understand error
+    @expect dnu
     self assert: (TestCase new should: [42 nonExistentMethod] raise: #does_not_understand) equals: nil.
     // Test should:raise: block completes normally (no error raised)
     self should: [TestCase new should: [42] raise: #does_not_understand] raise: #assertion_failed.


### PR DESCRIPTION
## Summary
- Add `@expect dnu` / `@expect type` / `@expect all` directives to 12 BUnit test files that intentionally trigger compiler diagnostics (DNU hints, type warnings)
- Reduces BUnit compilation diagnostics from 14 files to 1 (the `empty_method_actor.bt` fixture's empty body warning, which is being considered for removal from the language)
- No behavior changes — purely suppresses expected compile-time diagnostics

## Test plan
- [x] `just test` passes (237 stdlib + 476 BUnit tests, 0 failures)
- [x] Verified with `RUST_LOG=debug` that only 1 diagnostic remains (empty_method_actor.bt)
- [x] Pre-push hooks pass (clippy, fmt, dialyzer, erlfmt, biome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test expectations with explicit annotation directives across multiple standard library test files, adding validation markers for error handling, type assertions, and method resolution cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->