### PR TITLE
Disallow empty method bodies; add Object>>notImplemented (BT-859)

### DIFF
--- a/crates/beamtalk-core/src/ast.rs
+++ b/crates/beamtalk-core/src/ast.rs
@@ -656,8 +656,6 @@ pub enum ExpectCategory {
     Type,
     /// Suppress unused-variable warnings.
     Unused,
-    /// Suppress empty-method-body warnings (`empty-method`; `emptyBody` accepted as alias).
-    EmptyBody,
     /// Suppress any diagnostic on the following expression.
     All,
 }
@@ -670,7 +668,6 @@ impl ExpectCategory {
             "dnu" => Some(Self::Dnu),
             "type" => Some(Self::Type),
             "unused" => Some(Self::Unused),
-            "empty-method" | "emptyBody" => Some(Self::EmptyBody),
             "all" => Some(Self::All),
             _ => None,
         }
@@ -683,7 +680,6 @@ impl ExpectCategory {
             Self::Dnu => "dnu",
             Self::Type => "type",
             Self::Unused => "unused",
-            Self::EmptyBody => "empty-method",
             Self::All => "all",
         }
     }

--- a/crates/beamtalk-core/src/queries/diagnostic_provider.rs
+++ b/crates/beamtalk-core/src/queries/diagnostic_provider.rs
@@ -152,10 +152,6 @@ fn category_matches(expect_cat: ExpectCategory, diag_cat: Option<DiagnosticCateg
             (ExpectCategory::Dnu, Some(DiagnosticCategory::Dnu))
                 | (ExpectCategory::Type, Some(DiagnosticCategory::Type))
                 | (ExpectCategory::Unused, Some(DiagnosticCategory::Unused))
-                | (
-                    ExpectCategory::EmptyBody,
-                    Some(DiagnosticCategory::EmptyBody)
-                )
         )
 }
 
@@ -588,38 +584,35 @@ mod tests {
     // ── BT-631: Empty method body warnings ──
 
     #[test]
-    fn warn_empty_instance_method_body() {
+    fn error_empty_instance_method_body() {
         let source = "Object subclass: Foo\n  doNothing =>";
         let tokens = lex_with_eof(source);
         let (module, parse_diags) = parse(tokens);
         let diagnostics = compute_diagnostics(&module, parse_diags);
 
-        let has_warning = diagnostics.iter().any(|d| {
+        let has_error = diagnostics.iter().any(|d| {
             d.message.contains("doNothing")
                 && d.message.contains("empty body")
-                && d.severity == crate::source_analysis::Severity::Warning
+                && d.severity == crate::source_analysis::Severity::Error
         });
-        assert!(
-            has_warning,
-            "Expected empty body warning, got: {diagnostics:?}"
-        );
+        assert!(has_error, "Expected empty body error, got: {diagnostics:?}");
     }
 
     #[test]
-    fn warn_empty_class_method_body() {
+    fn error_empty_class_method_body() {
         let source = "Object subclass: Foo\n  class reset =>";
         let tokens = lex_with_eof(source);
         let (module, parse_diags) = parse(tokens);
         let diagnostics = compute_diagnostics(&module, parse_diags);
 
-        let has_warning = diagnostics.iter().any(|d| {
+        let has_error = diagnostics.iter().any(|d| {
             d.message.contains("reset")
                 && d.message.contains("empty body")
-                && d.severity == crate::source_analysis::Severity::Warning
+                && d.severity == crate::source_analysis::Severity::Error
         });
         assert!(
-            has_warning,
-            "Expected empty body warning for class method, got: {diagnostics:?}"
+            has_error,
+            "Expected empty body error for class method, got: {diagnostics:?}"
         );
     }
 
@@ -638,20 +631,17 @@ mod tests {
     }
 
     #[test]
-    fn empty_body_warning_has_hint() {
+    fn empty_body_error_has_hint() {
         let source = "Object subclass: Foo\n  doNothing =>";
         let tokens = lex_with_eof(source);
         let (module, parse_diags) = parse(tokens);
         let diagnostics = compute_diagnostics(&module, parse_diags);
 
-        let warning = diagnostics
+        let error = diagnostics
             .iter()
             .find(|d| d.message.contains("empty body"));
-        assert!(warning.is_some(), "Expected warning, got: {diagnostics:?}");
-        assert!(
-            warning.unwrap().hint.is_some(),
-            "Warning should have a hint"
-        );
+        assert!(error.is_some(), "Expected error, got: {diagnostics:?}");
+        assert!(error.unwrap().hint.is_some(), "Error should have a hint");
     }
 
     // ── BT-782: @expect directive ──

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
@@ -967,6 +967,7 @@ pub(super) fn generated_builtin_classes() -> HashMap<EcoString, ClassInfo> {
                 MethodInfo { selector: "perform:withArguments:".into(), arity: 2, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: true, return_type: None, param_types: vec![Some("Symbol".into()), Some("List".into())] },
                 MethodInfo { selector: "->".into(), arity: 1, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: false, return_type: None, param_types: vec![None] },
                 MethodInfo { selector: "subclassResponsibility".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: false, return_type: None, param_types: vec![] },
+                MethodInfo { selector: "notImplemented".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: false, return_type: None, param_types: vec![] },
                 MethodInfo { selector: "error:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: false, return_type: None, param_types: vec![Some("String".into())] },
             ],
             class_methods: vec![],

--- a/crates/beamtalk-core/src/semantic_analysis/validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators.rs
@@ -484,22 +484,24 @@ pub fn check_stdlib_name_shadowing(module: &Module, diagnostics: &mut Vec<Diagno
     }
 }
 
-/// BT-631: Warn about empty method bodies.
+/// BT-859: Error on empty method bodies.
 ///
-/// Methods declared with `=>` but no body expressions are likely incomplete.
-/// The codegen returns `self` for these, but users should be aware.
+/// Methods declared with `=>` but no body expressions are a compile error.
+/// Use `self notImplemented` for work-in-progress stubs, or
+/// `self subclassResponsibility` for abstract interface contracts.
 pub(crate) fn check_empty_method_bodies(module: &Module, diagnostics: &mut Vec<Diagnostic>) {
     for class in &module.classes {
         for method in class.methods.iter().chain(class.class_methods.iter()) {
             if method.body.is_empty() {
                 let selector = method.selector.name();
-                let mut diag = Diagnostic::warning(
-                    format!("Method `{selector}` has an empty body and will return `self`"),
+                let mut diag = Diagnostic::error(
+                    format!("Method `{selector}` has an empty body"),
                     method.span,
                 )
                 .with_category(DiagnosticCategory::EmptyBody);
-                diag.hint =
-                    Some("Add an expression after `=>`, or remove the method if unneeded".into());
+                diag.hint = Some(
+                    "Use `self notImplemented` for stubs, or `self subclassResponsibility` for abstract methods".into(),
+                );
                 diagnostics.push(diag);
             }
         }
@@ -507,13 +509,14 @@ pub(crate) fn check_empty_method_bodies(module: &Module, diagnostics: &mut Vec<D
     for standalone in &module.method_definitions {
         if standalone.method.body.is_empty() {
             let selector = standalone.method.selector.name();
-            let mut diag = Diagnostic::warning(
-                format!("Method `{selector}` has an empty body and will return `self`"),
+            let mut diag = Diagnostic::error(
+                format!("Method `{selector}` has an empty body"),
                 standalone.method.span,
             )
             .with_category(DiagnosticCategory::EmptyBody);
-            diag.hint =
-                Some("Add an expression after `=>`, or remove the method if unneeded".into());
+            diag.hint = Some(
+                "Use `self notImplemented` for stubs, or `self subclassResponsibility` for abstract methods".into(),
+            );
             diagnostics.push(diag);
         }
     }

--- a/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
@@ -951,7 +951,7 @@ impl Parser {
             if let Some(category) = ExpectCategory::from_name(&name) {
                 Expression::ExpectDirective { category, span }
             } else {
-                let valid = "dnu, type, unused, empty-method, all";
+                let valid = "dnu, type, unused, all";
                 let message: EcoString =
                     format!("unknown @expect category '{name}', valid categories are: {valid}")
                         .into();
@@ -962,8 +962,7 @@ impl Parser {
         } else {
             let span = start;
             let message: EcoString =
-                "@expect must be followed by a category name (dnu, type, unused, empty-method, all)"
-                    .into();
+                "@expect must be followed by a category name (dnu, type, unused, all)".into();
             self.diagnostics
                 .push(Diagnostic::error(message.clone(), span));
             Expression::Error { message, span }

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -334,7 +334,7 @@ pub enum DiagnosticCategory {
     Type,
     /// Unused-variable warning.
     Unused,
-    /// Empty-method-body warning.
+    /// Empty-method-body error (BT-859).
     EmptyBody,
 }
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -300,6 +300,25 @@ Object subclass: Validator
 
 `^` at the top level of a method body is an early return (the method exits immediately). `^` inside a block argument causes the *method* to exit with that value.
 
+### Abstract and Stub Methods
+
+Empty method bodies are a **compile-time error**. Use one of these two explicit forms instead:
+
+```beamtalk
+// Abstract interface contract — must be overridden by subclasses
+area => self subclassResponsibility
+
+// Work-in-progress stub — not yet implemented
+processPayment => self notImplemented
+```
+
+| Method | Purpose | Error message |
+|--------|---------|---------------|
+| `subclassResponsibility` | Abstract method; subclass must override | `"This method is abstract and must be overridden by a subclass"` |
+| `notImplemented` | Work-in-progress stub | `"Method not yet implemented"` |
+
+Both methods raise a runtime error with a clear message. The distinction is intent: `subclassResponsibility` signals an interface contract, while `notImplemented` marks incomplete work.
+
 ---
 
 ## Gradual Typing (ADR 0025)
@@ -963,7 +982,6 @@ anything                    // any diagnostic suppressed
 | `dnu` | Does-not-understand hints |
 | `type` | Type mismatch warnings |
 | `unused` | Unused variable warnings |
-| `empty-method` | Empty method body warnings |
 | `all` | Any diagnostic on the following expression |
 
 **Stale directives:** If `@expect` does not suppress any diagnostic (because no matching diagnostic exists on the following expression), the compiler emits an error to prevent directives from silently becoming out of date.

--- a/stdlib/src/Object.bt
+++ b/stdlib/src/Object.bt
@@ -189,6 +189,17 @@ ProtoObject subclass: Object
   /// ```
   subclassResponsibility => self error: "This method is abstract and must be overridden by a subclass"
 
+  /// Raise an error indicating this method has not yet been implemented.
+  ///
+  /// Use this for work-in-progress stubs. Distinct from `subclassResponsibility`,
+  /// which signals an interface contract violation.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// self notImplemented
+  /// ```
+  notImplemented => self error: "Method not yet implemented"
+
   /// Raise an error with the given message.
   ///
   /// ## Examples

--- a/stdlib/test/empty_method_self_test.bt
+++ b/stdlib/test/empty_method_self_test.bt
@@ -1,15 +1,15 @@
 // Copyright 2026 James Casey
 // SPDX-License-Identifier: Apache-2.0
 
-// BT-631: Tests that an empty actor method body returns self (the actor reference)
-// rather than nil, and that the returned reference is usable for further messages.
+// BT-631/BT-859: Tests that an actor method explicitly returning self
+// returns the actor reference and that reference is usable for further messages.
 
 
 TestCase subclass: EmptyMethodSelfTest
 
-  testEmptyMethodReturnsSelf =>
+  testDoNothingReturnsSelf =>
     a := EmptyMethodActor spawn.
-    // Call empty method — should return self (the actor), not nil
+    // Call method that explicitly returns self
     ref := a doNothing await.
     // Returned reference should be the same actor
     self assert: (ref =:= a).

--- a/stdlib/test/fixtures/empty_method_actor.bt
+++ b/stdlib/test/fixtures/empty_method_actor.bt
@@ -1,14 +1,13 @@
 // Copyright 2026 James Casey
 // SPDX-License-Identifier: Apache-2.0
 
-// EmptyMethodActor - Actor fixture for testing empty method body behavior (BT-631)
-// Empty methods should return self instead of nil.
+// EmptyMethodActor - Actor fixture used by empty_method_self_test.bt
 
 Actor subclass: EmptyMethodActor
   state: value = 42
 
-  // Empty method body — should return self
-  doNothing =>
+  // Returns self explicitly (BT-859: empty bodies are now errors)
+  doNothing => self
 
   // Non-empty method for comparison
   getValue => self.value

--- a/test-package-compiler/cases/empty_method_body/main.bt
+++ b/test-package-compiler/cases/empty_method_body/main.bt
@@ -1,8 +1,9 @@
 // Copyright 2026 James Casey
 // SPDX-License-Identifier: Apache-2.0
 
-// Test empty method body codegen (BT-631)
-// Empty methods should return self instead of nil.
+// Test empty method bodies (BT-859)
+// Empty method bodies are a compile-time error.
+// Developers must use `self notImplemented` or `self subclassResponsibility` instead.
 
 Actor subclass: EmptyActor
   state: value = 0

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_lexer.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_lexer.snap
@@ -2,21 +2,21 @@
 source: test-package-compiler/tests/compiler_tests.rs
 expression: output
 ---
-Token { kind: Identifier("Actor"), span: Span { start: 166, end: 171 }, leading_trivia: [LineComment("// Copyright 2026 James Casey"), Whitespace("\n"), LineComment("// SPDX-License-Identifier: Apache-2.0"), Whitespace("\n\n"), LineComment("// Test empty method body codegen (BT-631)"), Whitespace("\n"), LineComment("// Empty methods should return self instead of nil."), Whitespace("\n\n")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Keyword("subclass:"), span: Span { start: 172, end: 181 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("EmptyActor"), span: Span { start: 182, end: 192 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Keyword("state:"), span: Span { start: 195, end: 201 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("value"), span: Span { start: 202, end: 207 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: BinarySelector("="), span: Span { start: 208, end: 209 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Integer("0"), span: Span { start: 210, end: 211 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Identifier("doNothing"), span: Span { start: 215, end: 224 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 225, end: 227 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Identifier("getValue"), span: Span { start: 231, end: 239 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 240, end: 242 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("self"), span: Span { start: 243, end: 247 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Period, span: Span { start: 247, end: 248 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Identifier("value"), span: Span { start: 248, end: 253 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Identifier("class"), span: Span { start: 257, end: 262 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
-Token { kind: Identifier("classEmpty"), span: Span { start: 263, end: 273 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
-Token { kind: FatArrow, span: Span { start: 274, end: 276 }, leading_trivia: [], trailing_trivia: [] }
-Token { kind: Eof, span: Span { start: 277, end: 277 }, leading_trivia: [Whitespace("\n")], trailing_trivia: [] }
+Token { kind: Identifier("Actor"), span: Span { start: 244, end: 249 }, leading_trivia: [LineComment("// Copyright 2026 James Casey"), Whitespace("\n"), LineComment("// SPDX-License-Identifier: Apache-2.0"), Whitespace("\n\n"), LineComment("// Test empty method bodies (BT-859)"), Whitespace("\n"), LineComment("// Empty method bodies are a compile-time error."), Whitespace("\n"), LineComment("// Developers must use `self notImplemented` or `self subclassResponsibility` instead."), Whitespace("\n\n")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("subclass:"), span: Span { start: 250, end: 259 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("EmptyActor"), span: Span { start: 260, end: 270 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("state:"), span: Span { start: 273, end: 279 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("value"), span: Span { start: 280, end: 285 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("="), span: Span { start: 286, end: 287 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("0"), span: Span { start: 288, end: 289 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("doNothing"), span: Span { start: 293, end: 302 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 303, end: 305 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("getValue"), span: Span { start: 309, end: 317 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 318, end: 320 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("self"), span: Span { start: 321, end: 325 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 325, end: 326 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("value"), span: Span { start: 326, end: 331 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("class"), span: Span { start: 335, end: 340 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("classEmpty"), span: Span { start: 341, end: 351 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 352, end: 354 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Eof, span: Span { start: 355, end: 355 }, leading_trivia: [Whitespace("\n")], trailing_trivia: [] }

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_parser.snap
@@ -9,16 +9,16 @@ Module {
             name: Identifier {
                 name: "EmptyActor",
                 span: Span {
-                    start: 182,
-                    end: 192,
+                    start: 260,
+                    end: 270,
                 },
             },
             superclass: Some(
                 Identifier {
                     name: "Actor",
                     span: Span {
-                        start: 166,
-                        end: 171,
+                        start: 244,
+                        end: 249,
                     },
                 },
             ),
@@ -30,8 +30,8 @@ Module {
                     name: Identifier {
                         name: "value",
                         span: Span {
-                            start: 202,
-                            end: 207,
+                            start: 280,
+                            end: 285,
                         },
                     },
                     type_annotation: None,
@@ -41,14 +41,14 @@ Module {
                                 0,
                             ),
                             Span {
-                                start: 210,
-                                end: 211,
+                                start: 288,
+                                end: 289,
                             },
                         ),
                     ),
                     span: Span {
-                        start: 195,
-                        end: 211,
+                        start: 273,
+                        end: 289,
                     },
                 },
             ],
@@ -64,8 +64,8 @@ Module {
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 215,
-                        end: 224,
+                        start: 293,
+                        end: 302,
                     },
                 },
                 MethodDefinition {
@@ -79,21 +79,21 @@ Module {
                                 Identifier {
                                     name: "self",
                                     span: Span {
-                                        start: 243,
-                                        end: 247,
+                                        start: 321,
+                                        end: 325,
                                     },
                                 },
                             ),
                             field: Identifier {
                                 name: "value",
                                 span: Span {
-                                    start: 248,
-                                    end: 253,
+                                    start: 326,
+                                    end: 331,
                                 },
                             },
                             span: Span {
-                                start: 243,
-                                end: 253,
+                                start: 321,
+                                end: 331,
                             },
                         },
                     ],
@@ -102,8 +102,8 @@ Module {
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 231,
-                        end: 253,
+                        start: 309,
+                        end: 331,
                     },
                 },
             ],
@@ -119,55 +119,63 @@ Module {
                     kind: Primary,
                     doc_comment: None,
                     span: Span {
-                        start: 257,
-                        end: 262,
+                        start: 335,
+                        end: 340,
                     },
                 },
             ],
             class_variables: [],
             doc_comment: None,
             span: Span {
-                start: 166,
-                end: 262,
+                start: 244,
+                end: 340,
             },
         },
     ],
     method_definitions: [],
     expressions: [],
     span: Span {
-        start: 166,
-        end: 276,
+        start: 244,
+        end: 354,
     },
     leading_comments: [
         Comment {
             content: "// Copyright 2026 James Casey",
             span: Span {
-                start: 166,
-                end: 171,
+                start: 244,
+                end: 249,
             },
             kind: Line,
         },
         Comment {
             content: "// SPDX-License-Identifier: Apache-2.0",
             span: Span {
-                start: 166,
-                end: 171,
+                start: 244,
+                end: 249,
             },
             kind: Line,
         },
         Comment {
-            content: "// Test empty method body codegen (BT-631)",
+            content: "// Test empty method bodies (BT-859)",
             span: Span {
-                start: 166,
-                end: 171,
+                start: 244,
+                end: 249,
             },
             kind: Line,
         },
         Comment {
-            content: "// Empty methods should return self instead of nil.",
+            content: "// Empty method bodies are a compile-time error.",
             span: Span {
-                start: 166,
-                end: 171,
+                start: 244,
+                end: 249,
+            },
+            kind: Line,
+        },
+        Comment {
+            content: "// Developers must use `self notImplemented` or `self subclassResponsibility` instead.",
+            span: Span {
+                start: 244,
+                end: 249,
             },
             kind: Line,
         },

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_semantic.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_semantic.snap
@@ -2,4 +2,6 @@
 source: test-package-compiler/tests/compiler_tests.rs
 expression: output
 ---
-No semantic errors
+Semantic errors (2):
+  - Method `doNothing` has an empty body
+  - Method `classEmpty` has an empty body


### PR DESCRIPTION
## Summary

- Empty method bodies are now a **compile-time error** instead of a warning
- Added `Object>>notImplemented` method for work-in-progress stubs
- Removed `empty-method` from `@expect` suppression categories (errors are not suppressible)
- Updated docs with new "Abstract and Stub Methods" section

## Linear Issue

https://linear.app/beamtalk/issue/BT-859

## Key Changes

- **`validators.rs`**: `check_empty_method_bodies` now emits `Diagnostic::error` with hint suggesting `self notImplemented` or `self subclassResponsibility`
- **`Object.bt`**: New `notImplemented` method that raises `"Method not yet implemented"`
- **`ast.rs`**: Removed `ExpectCategory::EmptyBody` variant (errors not suppressible via `@expect`)
- **`diagnostic_provider.rs`**: Removed EmptyBody from category matching, updated tests
- **`beamtalk-language-features.md`**: New section documenting abstract and stub methods, removed `empty-method` from suppression table
- **Test updates**: Updated fixture to use explicit `self` return, updated snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty method bodies now generate compile-time errors instead of warnings, requiring explicit use of stubs or abstract method declarations.
  * Removed "empty-method" from valid @expect directive suppression categories.

* **New Features**
  * Added `notImplemented` method to the standard library for marking work-in-progress stubs.
  * Added comprehensive documentation on abstract and stub method patterns with examples and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->