### PR TITLE
Migrate FileHandle/StackFrame/ErlangModule/Erlang to compiled stdlib dispatch (BT-871)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_erlang_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_erlang_class.erl
@@ -1,0 +1,71 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%%% @doc Erlang class-side dispatch (BT-676, BT-871).
+%%%
+%%% **DDD Context:** Runtime — BEAM Interop
+%%%
+%%% Dispatches messages to the `Erlang` class object — a tagged map used as
+%%% the entry point for Erlang module interop. Unary selectors become
+%%% ErlangModule proxy lookups (`Erlang lists` → `ErlangModule` proxy for
+%%% `lists`).
+%%%
+%%% Implements the compiled stdlib dispatch interface (`dispatch/3`,
+%%% `has_method/1`) for `Erlang` tagged-map instances, enabling registration
+%%% in `module_for_value/1` without special-casing in `beamtalk_primitive`.
+%%%
+%%% @see beamtalk_erlang_proxy for ErlangModule instance dispatch
+
+-module(beamtalk_erlang_class).
+
+-export([dispatch/3, has_method/1]).
+
+-include("beamtalk.hrl").
+
+%% @doc Dispatch a message to the Erlang class object.
+%%
+%% Unary selectors (no colon, no args) resolve to ErlangModule proxies.
+%% Keyword selectors and multi-arg calls raise errors.
+%% Object protocol messages are handled via beamtalk_object_ops.
+-spec dispatch(atom(), list(), map()) -> term().
+dispatch('class', _Args, _Self) ->
+    'Erlang';
+dispatch('printString', _Args, _Self) ->
+    <<"Erlang">>;
+dispatch(Selector, Args, Self) ->
+    case beamtalk_object_ops:has_method(Selector) of
+        true ->
+            case beamtalk_object_ops:dispatch(Selector, Args, Self, Self) of
+                {reply, Result, _State} -> Result;
+                {error, Error, _State} -> beamtalk_error:raise(Error)
+            end;
+        false ->
+            case lists:member($:, atom_to_list(Selector)) of
+                true ->
+                    beamtalk_error:raise(
+                        beamtalk_error:new(
+                            does_not_understand,
+                            'Erlang',
+                            Selector,
+                            <<"Use unary message for module name: Erlang moduleName">>
+                        )
+                    );
+                false when Args =/= [] ->
+                    beamtalk_error:raise(
+                        beamtalk_error:new(
+                            arity_mismatch,
+                            'Erlang',
+                            Selector,
+                            <<"Module lookup takes no arguments: Erlang moduleName">>
+                        )
+                    );
+                false ->
+                    beamtalk_erlang_proxy:new(Selector)
+            end
+    end.
+
+%% @doc Check if Erlang class responds to the given selector.
+%%
+%% Always returns true — any unary selector is a valid module lookup.
+-spec has_method(atom()) -> boolean().
+has_method(_Selector) -> true.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_erlang_proxy.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_erlang_proxy.erl
@@ -36,7 +36,7 @@
 
 -module(beamtalk_erlang_proxy).
 
--export([dispatch/3, new/1]).
+-export([dispatch/3, has_method/1, new/1]).
 
 -include("beamtalk.hrl").
 
@@ -129,6 +129,13 @@ dispatch(Selector, Args, Self) ->
                     beamtalk_error:raise(Error3)
             end
     end.
+
+%% @doc Check if an ErlangModule responds to the given selector.
+%%
+%% Always returns true — any selector may map to an Erlang function call.
+%% Actual validation (arity, existence) happens at dispatch time.
+-spec has_method(atom()) -> boolean().
+has_method(_Selector) -> true.
 
 %%% ============================================================================
 %%% Internal helpers

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_file_handle.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_file_handle.erl
@@ -1,0 +1,49 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%%% @doc FileHandle instance-side dispatch (BT-513, BT-871).
+%%%
+%%% **DDD Context:** Runtime Context
+%%%
+%%% Implements the compiled stdlib dispatch interface (`dispatch/3`,
+%%% `has_method/1`) for `FileHandle` tagged-map instances, enabling
+%%% registration in `module_for_value/1` without special-casing in
+%%% `beamtalk_primitive`.
+%%%
+%%% @see beamtalk_file for File class-side methods (`exists:`, `readAll:`, etc.)
+
+-module(beamtalk_file_handle).
+
+-export([dispatch/3, has_method/1]).
+
+-include("beamtalk.hrl").
+
+%% @doc Dispatch a message to a FileHandle instance.
+%%
+%% Handles the `lines` selector directly, falls through to the base
+%% Object protocol for everything else, and raises DNU if unhandled.
+-spec dispatch(atom(), list(), map()) -> term().
+dispatch('lines', [], X) ->
+    beamtalk_file:handle_lines(X);
+dispatch(Selector, Args, X) ->
+    case beamtalk_object_ops:has_method(Selector) of
+        true ->
+            case beamtalk_object_ops:dispatch(Selector, Args, X, X) of
+                {reply, Result, _State} -> Result;
+                {error, Error, _State} -> beamtalk_error:raise(Error)
+            end;
+        false ->
+            beamtalk_error:raise(
+                beamtalk_error:new(
+                    does_not_understand,
+                    'FileHandle',
+                    Selector,
+                    <<"FileHandle does not understand this message">>
+                )
+            )
+    end.
+
+%% @doc Check if a FileHandle responds to the given selector.
+-spec has_method(atom()) -> boolean().
+has_method(Selector) ->
+    beamtalk_file:handle_has_method(Selector) orelse beamtalk_object_ops:has_method(Selector).


### PR DESCRIPTION
## Summary

- Migrate 4 tagged-map types from hardcoded `send_map`/`responds_to_map` cases to the standard `module_for_value` → `Mod:dispatch/3` pattern
- Create `beamtalk_file_handle.erl` and `beamtalk_erlang_class.erl` dispatch modules
- Add `has_method/1` to `beamtalk_erlang_proxy.erl`
- Net -96 lines deleted from `beamtalk_primitive.erl`, reducing fan-out for future tagged-map types from 3+ sites to 1

## Linear Issue

https://linear.app/beamtalk/issue/BT-871

## Test plan

- [x] All existing tests pass (2042 Rust, 237 stdlib, 484 BUnit, 2112 runtime)
- [x] Full CI passes (build, clippy, fmt, dialyzer, e2e)
- [x] No behavioral changes — pure routing refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal dispatch logic for Erlang runtime operations, consolidating multiple routing paths into unified handling for file operations, module lookups, and protocol dispatch.
  * Enhanced method resolution and error handling across runtime components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->