### PR TITLE
Expand DDD model: REPL Session, Workspace, and Beamtalk Global contexts (BT-874)

### DIFF
--- a/docs/beamtalk-ddd-model.md
+++ b/docs/beamtalk-ddd-model.md
@@ -175,10 +175,10 @@ A bounded context is an explicit boundary within which a domain model is defined
 │  │  - Binding Management: Per-session variable state             │  │
 │  │  - Protocol: WebSocket JSON (nREPL-inspired)                  │  │
 │  └───────────────────────────────────────────────────────────────┘  │
-│                              ▲                                        │
-│                              │ exposes via                            │
-│  ┌───────────────────────────┴───────────────────────────────────┐  │
+│                                                                       │
+│  ┌───────────────────────────────────────────────────────────────┐  │
 │  │              BEAMTALK GLOBAL CONTEXT (Erlang)                  │  │
+│  │  - Façade over Workspace + Object System for user code        │  │
 │  │  - Runtime introspection: actors, modules, sessions           │  │
 │  │  - Project metadata: version, nodeName, projectPath           │  │
 │  └───────────────────────────────────────────────────────────────┘  │
@@ -211,6 +211,7 @@ The context map shows how bounded contexts relate and communicate:
 - **Published Language:** Well-defined intermediate format (Core Erlang)
 - **Conformist:** Downstream accepts upstream's model wholesale
 - **Anti-Corruption Layer:** Downstream protects itself with translation layer
+- **Façade:** Upstream provides a simplified, unified interface over multiple downstream contexts
 
 ---
 


### PR DESCRIPTION
## Summary

Expands `docs/beamtalk-ddd-model.md` with three new bounded context sections that document the already-implemented `beamtalk_workspace` OTP application:

- **Workspace Context** — WorkspaceMeta aggregate, IdleMonitor, ActorSupervisor, SessionSupervisor domain services, key patterns (node-per-workspace, self-terminating idle monitor, process monitors for actor tracking, debounced metadata persistence)
- **REPL Session Context** — Session aggregate, Evaluator, BindingManager, ProtocolHandler, IoCapture domain services, all operation handlers (eval, session, load, actors, dev, docs)
- **Beamtalk Global Context** — Singleton façade over Workspace + Object System for user code introspection (`Beamtalk allClasses`, `Beamtalk actors`, etc.)

Also updates:
- Bounded context diagram with 3 new boxes
- Context Map with 3 new relationships + "Façade" relationship type
- Ubiquitous language table with 13 new domain terms
- Domain events table with 7 new events

**Linear:** https://linear.app/beamtalk/issue/BT-874

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Cross-reference module names against `runtime/apps/beamtalk_workspace/src/`
- [ ] Verify ubiquitous language entries match code terminology

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated domain-driven design model documentation with comprehensive architecture definitions, including new Workspace Context, REPL Session Context, and Beamtalk Global Context components.
  * Expanded runtime context documentation with lifecycle details, session protocols, and updated domain events.
  * Enhanced context interaction mapping to show relationships across system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->