### PR TITLE
fix: list join causes infinite dispatch loop (BT-895)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
@@ -244,6 +244,15 @@ fn generate_list_misc_bif(selector: &str, params: &[String]) -> Option<Document<
         )),
         "stream" => Some(Document::Str("call 'beamtalk_stream':'on'(Self)")),
         "atRandom" => Some(Document::Str("call 'beamtalk_random':'atRandom'(Self)")),
+        "join" => Some(Document::Str("call 'erlang':'iolist_to_binary'(Self)")),
+        "join:" => {
+            let p0 = params.first().map_or("_Sep", String::as_str);
+            Some(docvec![
+                "call 'erlang':'iolist_to_binary'(call 'lists':'join'(",
+                p0.to_string(),
+                ", Self))"
+            ])
+        }
         // Class-side factory: List class withAll: list is identity (list is already a List)
         "withAll:" => {
             let p0 = params.first().map_or("_List", String::as_str);

--- a/stdlib/test/collections_test.bt
+++ b/stdlib/test/collections_test.bt
@@ -125,3 +125,15 @@ TestCase subclass: CollectionsTest
     self assert: a equals: #(1, 2, 3).
     // Direct index assertion not possible in E2E since blocks can't accumulate results.
     self assert: (a ++ #(4, 5)) equals: #(1, 2, 3, 4, 5)
+
+  testJoin =>
+    // BT-895: join and join: caused infinite dispatch loop
+    // --- join (no separator) ---
+    self assert: (#("hello", "world") join) equals: "helloworld".
+    self assert: (#("a", "b", "c") join) equals: "abc".
+    self assert: (#() join) equals: "".
+    // --- join: (with separator) ---
+    self assert: (#("a", "b", "c") join: ", ") equals: "a, b, c".
+    self assert: (#("hello", "world") join: " ") equals: "hello world".
+    self assert: (#("x") join: ", ") equals: "x".
+    self assert: (#() join: ", ") equals: ""


### PR DESCRIPTION
## Summary

Fixes [BT-895](https://linear.app/beamtalk/issue/BT-895/list-join-causes-infinite-dispatch-loop): `#('hello' 'world') join` caused an infinite dispatch loop, hanging the process.

**Root cause:** The `"join"` and `"join:"` primitives declared in `List.bt` had no BIF mapping in the codegen. The fallback generated `call 'bt@stdlib@list':'dispatch'('join', [], Self)` as the method body, but `dispatch/3` routed back to this same function — creating an infinite loop.

**Fix:** Add BIF mappings in `primitives/list.rs`:
- `join` → `erlang:iolist_to_binary(Self)` (concatenate list of strings)
- `join:` → `erlang:iolist_to_binary(lists:join(Sep, Self))` (intersperse separator, then concatenate)

## Changes

- `crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs` — Add `"join"` and `"join:"` match arms
- `stdlib/test/collections_test.bt` — Add `testJoin` with regression tests for both methods

## Test plan

- [x] `#("hello", "world") join` returns `"helloworld"`
- [x] `#("a", "b", "c") join: ", "` returns `"a, b, c"`
- [x] Empty list cases: `#() join` returns `""`, `#() join: ", "` returns `""`
- [x] Single element: `#("x") join: ", "` returns `"x"`
- [x] All 490 BUnit tests pass
- [x] All 237 stdlib tests pass
- [x] All 2077 Erlang runtime tests pass
- [x] Clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added join methods for lists to combine elements with optional separators and convert to binary format.

* **Tests**
  * Added test coverage for the new list join functionality, including various separator and input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->