### PR TITLE
fix: class method delegating to another class method via self generates incomplete Core Erlang (BT-891)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -1511,6 +1511,17 @@ impl CoreErlangGenerator {
                             docs.push(doc);
                         }
                     }
+                } else if self.is_class_method_self_send(expr) {
+                    // BT-891: Class method self-send as last expression with no class vars.
+                    // The generated code leaves an open scope ending with `in ` — we must
+                    // close it with the unwrapped result variable.
+                    self.last_open_scope_result = None;
+                    let expr_str = self.expression_doc(expr)?;
+                    if let Some(result_var) = &self.last_open_scope_result.clone() {
+                        docs.push(docvec![expr_str, Document::String(result_var.clone()),]);
+                    } else {
+                        docs.push(docvec![expr_str]);
+                    }
                 } else {
                     let expr_str = self.expression_doc(expr)?;
                     docs.push(docvec![expr_str]);

--- a/tests/e2e/cases/class_methods.bt
+++ b/tests/e2e/cases/class_methods.bt
@@ -12,6 +12,7 @@
 // Class methods run on the class process, not instances.
 
 // @load tests/e2e/fixtures/class_methods_fixture.bt
+// @load tests/e2e/fixtures/class_methods_delegator_fixture.bt
 
 // ===========================================================================
 // BASIC CLASS METHOD DISPATCH
@@ -25,3 +26,19 @@ cls defaultValue
 
 cls add: 10 to: 20
 // => 30
+
+// ===========================================================================
+// CLASS METHOD TO CLASS METHOD DELEGATION (BT-891)
+// ===========================================================================
+
+del := (Beamtalk classNamed: #Delegator) await
+// => Delegator
+
+del helper: 5
+// => 10
+
+del delegateHelper: 5
+// => 10
+
+del chained: 5
+// => 10

--- a/tests/e2e/fixtures/class_methods_delegator_fixture.bt
+++ b/tests/e2e/fixtures/class_methods_delegator_fixture.bt
@@ -1,0 +1,11 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-891: Class method delegating to another class method via self
+Actor subclass: Delegator
+
+  class helper: x => x * 2
+
+  class delegateHelper: x => self helper: x
+
+  class chained: x => self delegateHelper: x


### PR DESCRIPTION
## Summary

Fixes [BT-891](https://linear.app/beamtalk/issue/BT-891): When a class method's last expression is a `self` send targeting another class method and the class has no class variables, the compiler generated truncated Core Erlang — the `let ... in` scope from `generate_class_method_self_send` was never closed with the result variable.

### Key changes

- Add handling in `generate_class_method_body` for class method self-sends as last expression when `has_class_vars` is false
- Close the open scope with the unwrapped result variable
- Add E2E tests covering direct call, single-hop delegation, and chained delegation

## Test plan

- [x] `just test` passes (unit + stdlib + BUnit + runtime)
- [x] `just test-e2e cases/class_methods` passes with new delegation tests
- [x] `just ci` passes (pre-existing e2e failures unrelated)
- [x] Generated Core Erlang verified syntactically complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of class method self-send expressions as final expressions when no class variables are present, ensuring proper scope closure and result emission.

* **Tests**
  * Added end-to-end tests for class method delegation, including chained delegation patterns where class methods delegate to other class methods via self-reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->