### PR TITLE
fix: verify reloaded file still contains target class (BT-868)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -480,7 +480,7 @@ classReload(Self) ->
                     Self;
                 {error, {class_not_found, _, Path, Defined}} ->
                     Error0 = beamtalk_error:new(reload_failed, ClassName),
-                    DefinedStr = lists:join(<<", ">>, [atom_to_binary(D, utf8) || D <- Defined]),
+                    DefinedStr = lists:join(<<", ">>, [list_to_binary(D) || D <- Defined]),
                     Msg = iolist_to_binary([
                         atom_to_binary(ClassName, utf8),
                         <<" is no longer defined in ">>,

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
@@ -1074,8 +1074,9 @@ reload_class_file_impl(Path, ExpectedClassName) ->
 verify_class_present(undefined, _ClassNames, _Path) ->
     ok;
 verify_class_present(ExpectedClassName, ClassNames, Path) ->
-    DefinedNames = [list_to_atom(N) || #{name := N} <- ClassNames],
-    case lists:member(ExpectedClassName, DefinedNames) of
+    ExpectedName = atom_to_list(ExpectedClassName),
+    DefinedNames = [N || #{name := N} <- ClassNames],
+    case lists:member(ExpectedName, DefinedNames) of
         true -> ok;
         false -> {error, {class_not_found, ExpectedClassName, Path, DefinedNames}}
     end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
@@ -1221,7 +1221,7 @@ verify_class_present_not_found_test() ->
         'Counter', ClassNames, "/some/path.bt"
     ),
     ?assertEqual(
-        {error, {class_not_found, 'Counter', "/some/path.bt", ['OtherClass']}},
+        {error, {class_not_found, 'Counter', "/some/path.bt", ["OtherClass"]}},
         Result
     ).
 


### PR DESCRIPTION
## Summary

- `reload_class_file` now verifies the compiled file still defines the expected class before loading
- Returns a descriptive `class_not_found` error with human-readable message if the class was removed/renamed
- `handle_load` path (no expected class) is unchanged via `reload_class_file/1`

Closes https://linear.app/beamtalk/issue/BT-868

## Changes

- **`beamtalk_repl_eval.erl`**: Add `reload_class_file/2` with class name verification, extract `verify_class_present/3` helper
- **`beamtalk_behaviour_intrinsics.erl`**: Pass `ClassName` to `reload_class_file/2`, add specific error message for `class_not_found`
- **`beamtalk_repl_eval_tests.erl`**: Update existing tests to use `/2`, add 4 unit tests for `verify_class_present/3`

## Test plan

- [x] `verify_class_present` returns `ok` when `undefined` (handle_load path)
- [x] `verify_class_present` returns `ok` when class is found
- [x] `verify_class_present` returns `class_not_found` error when class is missing
- [x] `verify_class_present` returns `class_not_found` error for empty class list
- [x] Existing `reload_class_file` tests updated and passing
- [x] Full CI passes (2083 Erlang, 2052 Rust, 506 BUnit, 237 stdlib tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reload operation can now accept an expected class name to verify compiled output before loading.
* **Bug Fixes**
  * Improved error reporting when reloads fail — messages include class name, file path, and available symbols.
* **Tests**
  * Added/updated tests covering the new verification behavior and enhanced error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->