### PR TITLE
fix: BUnit test runner discards setUp return value; state lost (BT-900)

### DIFF
--- a/stdlib/test/setup_state_test.bt
+++ b/stdlib/test/setup_state_test.bt
@@ -1,0 +1,19 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-900: Tests that setUp state flows into test methods.
+// Value objects are immutable maps — setUp returns a new Self with fields set.
+// The BUnit runner must use that return value as the receiver for test methods.
+
+TestCase subclass: SetupStateTest
+  state: value = 0
+
+  setUp =>
+    self.value := 42
+
+  testFieldFromSetUp =>
+    self assert: self.value equals: 42
+
+  testFieldFromSetUpAgain =>
+    // Each test gets a fresh setUp instance — verify isolation
+    self assert: self.value equals: 42

--- a/tests/e2e/fixtures/lifecycle_test.bt
+++ b/tests/e2e/fixtures/lifecycle_test.bt
@@ -1,21 +1,22 @@
 // Copyright 2026 James Casey
 // SPDX-License-Identifier: Apache-2.0
 
-// LifecycleTest — TestCase subclass with setUp/tearDown (BT-440)
-// Verifies that setUp and tearDown are called without error.
-// setUp and tearDown are no-ops here; their presence exercises
-// the lifecycle dispatch code path in run_test_method.
+// LifecycleTest — TestCase subclass with setUp/tearDown (BT-440, BT-900)
+// Verifies that setUp state flows into test methods.
+// setUp assigns a field; tests verify the field is accessible.
+// Value objects are immutable maps, so the runner must use setUp's return value.
 
 TestCase subclass: LifecycleTest
+  state: log = "init"
 
   setUp =>
-    nil
+    self.log := "S"
 
   tearDown =>
     nil
 
   testFirst =>
-    self assert: true
+    self assert: self.log equals: "S"
 
   testSecond =>
-    self assert: 1 equals: 1
+    self assert: self.log equals: "S"


### PR DESCRIPTION
## Summary

- Fix BUnit test runner to capture setUp's return value and use it as the receiver for test methods and tearDown
- Value objects are immutable maps — setUp returns a new instance with fields set, but the runner was discarding it
- Fix applied to three layers: Erlang runtime (`run_test_method`), CLI EUnit wrapper generation, and value type method codegen

## Changes

- **`runtime/.../beamtalk_test_case.erl`**: `run_test_method/4` captures setUp return into `SetUpInstance` and threads it to test method and tearDown
- **`crates/beamtalk-cli/src/commands/test.rs`**: EUnit wrapper captures setUp return into `Instance1` variable
- **`crates/beamtalk-core/.../value_type_codegen.rs`**: Value type methods whose last expression is a field assignment now return the updated Self (not the assigned value), while preserving expression-level semantics (`(self.x := 5) + 1` still returns 6)
- **`stdlib/test/setup_state_test.bt`**: New BUnit test verifying setUp state flows into test methods
- **`tests/e2e/fixtures/lifecycle_test.bt`**: Updated to exercise stateful setUp

## Linear issue

https://linear.app/beamtalk/issue/BT-900/bunit-test-runner-discards-setup-return-value-state-lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test setUp methods now properly propagate state changes to test methods and teardown execution, ensuring state modifications are preserved throughout the test lifecycle.
  * Methods ending with field assignments now return the updated instance instead of just the assigned value.

* **Tests**
  * Added comprehensive test validation for setUp state propagation and test isolation across multiple test invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->