### PR TITLE
REPL name resolution walks Workspace globals instead of hardcoded singleton injection (BT-883)

### DIFF
--- a/docs/ADR/0040-workspace-native-repl-commands.md
+++ b/docs/ADR/0040-workspace-native-repl-commands.md
@@ -151,7 +151,7 @@ Session locals (implicit)  →  Workspace user bindings  →  Workspace globals 
                                                            project singletons     Object = <class>
 ```
 
-This is a **conceptual model for users**, not an implementation change. The compiler continues to resolve names through its existing mechanisms (session binding maps, `beamtalk_class_registry`, workspace binding injection). The model describes the *effective* resolution order that users experience:
+Since BT-883, this is partially implemented: session startup walks Workspace globals (via `beamtalk_workspace_interface:get_session_bindings/0`) to inject singletons and `bind:as:` registered names into session bindings. Class names continue to resolve via `beamtalk_class_registry` (not injected into bindings). The model describes the *effective* resolution order that users experience:
 
 1. **Session locals** — per-connection variable bindings (`x := 42`), implicit scope
 2. **Workspace user bindings** — workspace-level bindings registered via `bind:as:`

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_config.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_config.erl
@@ -10,8 +10,7 @@
 %%% Used by:
 %%% - beamtalk_workspace_sup — to build supervisor child specs
 %%% - beamtalk_workspace_bootstrap — to wire class variables
-%%% - beamtalk_repl_shell — to inject REPL convenience bindings
-%%% - beamtalk_repl_server — to filter workspace binding names
+%%% - beamtalk_repl_ops_eval / beamtalk_repl_ops_dev — to filter workspace binding names
 %%%
 %%% **DDD Context:** Workspace
 


### PR DESCRIPTION
## Summary

- Adds `get_session_bindings/0` API to `WorkspaceInterface` that returns non-class workspace globals (singletons + `bind:as:` entries) for REPL session binding injection
- Replaces hardcoded `beamtalk_workspace_config:singletons()` iteration in `beamtalk_repl_shell` with the new dynamic API
- Refactors `handle_globals/2` to delegate to `handle_session_bindings/2`, eliminating duplicated singleton resolution logic
- Updates ADR 0040 to reflect partial implementation of the dictionary chain model

## Key Design Decisions

Per James's guidance: **Option A only** — inject singletons and `bind:as:` registered names into session bindings, but NOT class objects. Class name resolution continues via `beamtalk_class_registry` codegen fallback.

## Test plan

- [x] `just test` — all 4,898 tests pass
- [x] `just test-e2e` — workspace bindings and bind:as: e2e tests pass
- [x] `just ci` — full CI green (build, clippy, fmt, dialyzer, all test suites)

Closes BT-883
https://linear.app/beamtalk/issue/BT-883

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural documentation to clarify how workspace names resolve in sessions, reflecting current implementation of session binding injection and class registry interactions.

* **Refactor**
  * Revised workspace binding injection mechanism to use session-based approach. Updated workspace interface API with new session binding retrieval method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->