### PR TITLE
ADR 0042: Immutable Value Objects and Actor-Only Mutable State

### DIFF
--- a/docs/ADR/0042-immutable-value-objects-actor-mutable-state.md
+++ b/docs/ADR/0042-immutable-value-objects-actor-mutable-state.md
@@ -1,7 +1,7 @@
 # ADR 0042: Immutable Value Objects and Actor-Only Mutable State
 
 ## Status
-Proposed (2026-02-25)
+Accepted (2026-02-26)
 
 ## Context
 

--- a/docs/ADR/0043-sync-by-default-actor-messaging.md
+++ b/docs/ADR/0043-sync-by-default-actor-messaging.md
@@ -1,7 +1,7 @@
 # ADR 0043: Sync-by-Default Actor Messaging
 
 ## Status
-Proposed (2026-02-26)
+Accepted (2026-02-26)
 
 ## Context
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -68,8 +68,8 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0039](0039-syntax-pragmatism-vs-smalltalk.md) | Syntax Pragmatism vs Smalltalk | Implemented | 2026-02-24 |
 | [0040](0040-workspace-native-repl-commands.md) | Workspace-Native REPL Commands, Facade/Dictionary Split, and Class-Based Reload | Accepted | 2026-02-24 |
 | [0041](0041-universal-state-threading-block-protocol.md) | Universal State-Threading Block Protocol | Accepted | 2026-02-24 |
-| [0042](0042-immutable-value-objects-actor-mutable-state.md) | Immutable Value Objects and Actor-Only Mutable State | Proposed | 2026-02-25 |
-| [0043](0043-sync-by-default-actor-messaging.md) | Sync-by-Default Actor Messaging | Proposed | 2026-02-26 |
+| [0042](0042-immutable-value-objects-actor-mutable-state.md) | Immutable Value Objects and Actor-Only Mutable State | Accepted | 2026-02-26 |
+| [0043](0043-sync-by-default-actor-messaging.md) | Sync-by-Default Actor Messaging | Accepted | 2026-02-26 |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## Summary

- Introduces ADR 0042: the fundamental object model decision for BeamTalk
- Value objects (`Value subclass:`) are immutable; actors (`Actor subclass:`) own mutable state via gen_server
- Retains `state:`/`classState:` as universal declaration keywords — the `Value`/`Actor` superclass determines mutability, not the declaration keyword
- Introduces ADR 0043: sync-by-default actor messaging (`.` = call, `!` = cast)
- Cascade semantics deferred to future ADR 0044

## Key Decisions

- **Two kinds of entities:** Value (immutable maps) and Actor (gen_server processes)
- **`with*:` functional setters** auto-generated for all declared slots
- **`state:`/`classState:`** universal declaration keywords (retained from current codebase)
- **Local variable rebinding** preserved via ADR 0041 state threading
- **`fieldAt:`/`fieldNames`** reflection API unchanged (per ADR 0035)

## Test plan

- [x] ADR review completed (3-pass: structural, reasoning, adversarial)
- [x] All code examples verified against codebase
- [x] Cross-referenced with existing ADRs
- [x] No implementation code changes — ADR only

🤖 Generated with [Claude Code](https://claude.com/claude-code)