### PR TITLE
fix: inherited class factory methods create wrong instance type (BT-908)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -548,15 +548,22 @@ impl CoreErlangGenerator {
         }
         // BT-893: Instantiation selectors (new, new:, spawn, spawnWith:) must bypass
         // gen_server to avoid deadlock — route through class_self_new/class_self_spawn.
-        let class_name = self.class_name();
+        //
+        // BT-908: Use the process dictionary instead of hardcoded class name/module so that
+        // inherited class factory methods (e.g. `wrap:` from a parent) create an instance of
+        // the CALLING class, not the DEFINING class. The class gen_server process sets
+        // `beamtalk_class_name`, `beamtalk_class_module`, and `beamtalk_class_is_abstract` in
+        // its process dictionary during init (beamtalk_object_class:init/1). When a subclass
+        // inherits a factory method and invokes it, the subclass gen_server process is running,
+        // so the process dictionary reflects the subclass, not the parent.
         let module = self.module_name.clone();
         match selector_atom.as_str() {
             "new" | "new:" => {
                 let args_doc = self.capture_argument_list_doc(arguments)?;
                 let doc = docvec![
-                    Document::String(format!(
-                        "call 'beamtalk_class_instantiation':'class_self_new'('{class_name}', '{module}', ["
-                    )),
+                    "call 'beamtalk_class_instantiation':'class_self_new'(",
+                    "call 'erlang':'get'('beamtalk_class_name'), ",
+                    "call 'erlang':'get'('beamtalk_class_module'), [",
                     args_doc,
                     "])"
                 ];
@@ -565,9 +572,10 @@ impl CoreErlangGenerator {
             "spawn" | "spawnWith:" => {
                 let args_doc = self.capture_argument_list_doc(arguments)?;
                 let doc = docvec![
-                    Document::String(format!(
-                        "call 'beamtalk_class_instantiation':'class_self_spawn'('{class_name}', '{module}', ["
-                    )),
+                    "call 'beamtalk_class_instantiation':'class_self_spawn'(",
+                    "call 'erlang':'get'('beamtalk_class_name'), ",
+                    "call 'erlang':'get'('beamtalk_class_module'), ",
+                    "call 'erlang':'get'('beamtalk_class_is_abstract'), [",
                     args_doc,
                     "])"
                 ];

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_instantiation.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_instantiation.erl
@@ -170,8 +170,13 @@ class_self_spawn(ClassName, Module, Args) ->
     class_self_spawn(ClassName, Module, false, Args).
 
 %% @doc Spawn with explicit abstract class flag (used by runtime self-instantiation).
--spec class_self_spawn(class_name(), atom(), boolean(), list()) -> term().
-class_self_spawn(ClassName, Module, IsAbstract, Args) ->
+%%
+%% BT-908: The IsAbstract parameter may come from erlang:get(beamtalk_class_is_abstract)
+%% in codegen-generated class methods. Normalize to boolean defensively — undefined or
+%% any non-true value is treated as false (non-abstract).
+-spec class_self_spawn(class_name(), atom(), boolean() | term(), list()) -> term().
+class_self_spawn(ClassName, Module, IsAbstract0, Args) ->
+    IsAbstract = IsAbstract0 =:= true,
     case handle_spawn(Args, ClassName, Module, IsAbstract) of
         {ok, Result} ->
             Result;

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 76
 expression: core_erlang
 ---
 module 'class_methods' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'/3, 'code_change'/3, 'terminate'/2, 'dispatch'/4, 'safe_dispatch'/3, 'method_table'/0, 'has_method'/1, 'spawn'/0, 'spawn'/1, 'new'/0, 'new'/1, 'superclass'/0, 'class_create'/2, 'class_getCount'/2, 'register_class'/0]
@@ -172,7 +173,7 @@ module 'class_methods' ['start_link'/1, 'init'/1, 'handle_cast'/2, 'handle_call'
 
 
 'class_create'/2 = fun (ClassSelf, ClassVars) ->
-    let _Val2 = call 'erlang':'+'(call 'beamtalk_future':'maybe_await'(call 'maps':'get'('instanceCount', ClassVars)), call 'beamtalk_future':'maybe_await'(1)) in let ClassVars1 = call 'maps':'put'('instanceCount', _Val2, ClassVars) in let _Ret3 = call 'beamtalk_class_instantiation':'class_self_spawn'('ClassVarCounter', 'class_methods', []) in {'class_var_result', _Ret3, ClassVars1}
+    let _Val2 = call 'erlang':'+'(call 'beamtalk_future':'maybe_await'(call 'maps':'get'('instanceCount', ClassVars)), call 'beamtalk_future':'maybe_await'(1)) in let ClassVars1 = call 'maps':'put'('instanceCount', _Val2, ClassVars) in let _Ret3 = call 'beamtalk_class_instantiation':'class_self_spawn'(call 'erlang':'get'('beamtalk_class_name'), call 'erlang':'get'('beamtalk_class_module'), call 'erlang':'get'('beamtalk_class_is_abstract'), []) in {'class_var_result', _Ret3, ClassVars1}
 
 'class_getCount'/2 = fun (ClassSelf, ClassVars) ->
     let _Ret4 = call 'maps':'get'('instanceCount', ClassVars) in _Ret4

--- a/tests/e2e/cases/beverage_test.bt
+++ b/tests/e2e/cases/beverage_test.bt
@@ -1,0 +1,52 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E tests for class method inheritance in file-compiled value-object subclasses (BT-908).
+//
+// Tests that `wrap:` — a class factory method defined in the parent class —
+// creates an instance of the CALLING class, not the DEFINING class.
+//
+// Root cause: BT-893 codegen for `self new:` in class methods hardcodes the
+// defining class name/module. When inherited by a subclass, this creates the
+// wrong type. Fix: use `erlang:get(beamtalk_class_name)` from the process
+// dictionary, which reflects the actual dispatching class.
+
+// @load tests/e2e/fixtures/beverage.bt
+// @load tests/e2e/fixtures/coffee.bt
+
+// ===========================================================================
+// BEVERAGE — DIRECT CLASS METHOD CALL (no inheritance)
+// ===========================================================================
+
+// Beverage wrap: creates a Beverage instance
+bev := Beverage wrap: "cold"
+// => _
+
+// The instance class must be Beverage, not Object
+bev class name
+// => Beverage
+
+// The value field is populated correctly
+bev value
+// => cold
+
+// ===========================================================================
+// COFFEE — INHERITED CLASS METHOD (wrap: from Beverage)
+// ===========================================================================
+
+// Coffee inherits wrap: from Beverage; must create a Coffee instance
+cof := Coffee wrap: "hot"
+// => _
+
+// Class must be Coffee, not Beverage (this was the bug: BT-893 codegen
+// hardcodes the defining class name, so Coffee wrap: returned a Beverage)
+cof class name
+// => Coffee
+
+// Inherited value field is accessible on the Coffee instance
+cof value
+// => hot
+
+// Coffee-specific flavor field has its default value
+cof flavor
+// => espresso

--- a/tests/e2e/fixtures/beverage.bt
+++ b/tests/e2e/fixtures/beverage.bt
@@ -1,0 +1,12 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Base value-object class for BT-908 fixture.
+// Defines a class method (wrap:) that subclasses should inherit correctly.
+
+Object subclass: Beverage
+  state: value = nil
+
+  class wrap: anObject => self new: #{value => anObject}
+
+  value => self.value

--- a/tests/e2e/fixtures/coffee.bt
+++ b/tests/e2e/fixtures/coffee.bt
@@ -1,0 +1,11 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Coffee value-object subclass of Beverage for BT-908 fixture.
+// Exercises class method inheritance: `wrap:` is defined in Beverage
+// but should create a Coffee instance when called as `Coffee wrap:`.
+
+Beverage subclass: Coffee
+  state: flavor = "espresso"
+
+  flavor => self.flavor


### PR DESCRIPTION
## Summary

Fixes [BT-908](https://linear.app/beamtalk/issue/BT-908): When a parent value-object class defines a class factory method (e.g. `class wrap: anObject => self new: #{value => anObject}`), and a subclass inherits it, `Coffee wrap: v` incorrectly created a Beverage instance instead of a Coffee instance.

**Root cause:** The BT-893 codegen for `self new:`/`self spawn` in class methods hardcoded the defining class name and module in the `class_self_new`/`class_self_spawn` call. When a subclass inherits and invokes the factory method, the hardcoded values point to the parent class.

**Fix:** Use `erlang:get(beamtalk_class_name)` and `erlang:get(beamtalk_class_module)` from the process dictionary instead of hardcoded values. The class gen_server process sets these during `init/1`, so when a subclass inherits a factory method, the process dictionary reflects the subclass.

## Key Changes

- **`dispatch_codegen.rs`** — Replace hardcoded class name/module with process dictionary lookups for `class_self_new` and `class_self_spawn` in class method codegen
- **`beamtalk_class_instantiation.erl`** — Add defensive normalization of `IsAbstract` parameter (undefined → false) in `class_self_spawn/4`
- **E2E test** — New `beverage_test.bt` with Beverage/Coffee fixtures verifying inherited `wrap:` creates the correct subclass instance

## Test plan

- [x] `just test` — all 525 BUnit + 2087 runtime tests pass
- [x] `just test-e2e` — all 611 E2E assertions pass (including new beverage_test.bt)
- [x] `just clippy` — no warnings
- [x] `just fmt-check` — all formatting checks pass
- [x] Snapshot updated for `class_methods_codegen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where inherited class factory methods would incorrectly instantiate the defining class instead of the calling class. Factory methods now correctly create instances of the appropriate subclass when invoked through an inheritance hierarchy.

* **Tests**
  * Added end-to-end test cases to validate that inherited factory methods correctly instantiate the calling class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->