### PR TITLE
Reclassify is_control_flow_selector() whitelist from correctness gate to Tier 1 optimization hint (BT-856)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/block_analyzer.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_analyzer.rs
@@ -83,22 +83,11 @@ impl Analyser {
                         ));
                     }
                 }
-                MutationKind::CapturedVariable { name } => {
-                    // Warning: Captured variable mutation in Stored blocks
-                    if matches!(context, BlockContext::Stored) {
-                        self.result.diagnostics.push(Diagnostic::warning(
-                            format!(
-                                "assignment to '{name}' has no effect on outer scope\n\
-                                 \n\
-                                 = help: closures capture variables by value\n\
-                                 = help: use control flow directly: `10 timesRepeat: [{name} := {name} + 1]`"
-                            ),
-                            mutation.span,
-                        ));
-                    }
-                }
-                MutationKind::LocalVariable { .. } => {
-                    // Local variable mutations are always allowed
+                MutationKind::CapturedVariable { .. } | MutationKind::LocalVariable { .. } => {
+                    // BT-856 (ADR 0041 Phase 3): Captured variable mutations in Stored/Passed
+                    // blocks are now supported via the Tier 2 stateful block protocol (BT-852).
+                    // State is threaded through StateAcc maps so mutations propagate correctly.
+                    // No diagnostic needed — this is valid and working behaviour.
                 }
             }
         }


### PR DESCRIPTION
## Summary

ADR 0041 Phase 3: reclassify the `is_control_flow_selector()` whitelist from a **correctness gate** to a **Tier 1 optimization hint**.

After BT-852/BT-853/BT-854, state threading is universal via the Tier 2 stateful block protocol. The whitelist no longer determines *whether* state threading happens — it only identifies sites where the compiler can generate optimized Tier 1 inline codegen.

**Linear:** https://linear.app/beamtalk/issue/BT-856

## Changes

- **`block_context.rs`**: Updated `is_control_flow_selector()` docs (optimization hint, not correctness gate), updated `classify_block()` docs (Tier 1/Tier 2 routing), added DDD Context module header
- **`mod.rs` (semantic_analysis)**: Updated `BlockContext` enum variant docs with Tier 1/Tier 2 annotations
- **`block_analyzer.rs`**: Removed stale `CapturedVariable` mutation warning for Stored blocks — Tier 2 now handles captured variable mutations correctly via StateAcc threading
- **`expressions.rs`**: Fixed misleading "Tier 1 optimization" comment on `generate_block()` plain fun path — Tier 1 refers only to whitelisted inline codegen
- **Tests**: Updated 2 tests from positive → negative assertion (verify warning is no longer emitted)

## Test plan

- [x] `just ci` passes (all Rust, stdlib, BUnit, E2E tests)
- [x] Existing Tier 2 block tests still pass (mixed_call_site_test, tier2_block_round_trip_test)
- [x] Captured variable mutation in stored blocks compiles without warning
- [x] Field mutation in stored blocks still correctly errors (BT-860 not yet done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed erroneous compiler warnings for captured variable mutations in stored blocks, which are now properly handled by the stateful block protocol.

* **Tests**
  * Updated diagnostic tests to reflect corrected behavior for captured variable mutations in stored contexts.

* **Documentation**
  * Clarified block categorization and codegen tier routing in semantic analysis modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->