### PR TITLE
WorkspaceInterface: offload classes/testClasses, DRY spawn pattern (BT-879)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface.erl
@@ -486,7 +486,10 @@ spawn_call_worker(From, Op, Fun, State) ->
                     From,
                     {error,
                         beamtalk_error:with_message(
-                            Err, iolist_to_binary([<<"Internal error in ">>, atom_to_binary(Op)])
+                            Err,
+                            iolist_to_binary([
+                                <<"Internal error in ">>, atom_to_binary(Op, utf8)
+                            ])
                         )}
                 )
         end
@@ -511,7 +514,10 @@ spawn_cast_worker(FuturePid, Op, Fun, State) ->
                 beamtalk_future:reject(
                     FuturePid,
                     beamtalk_error:with_message(
-                        Err, iolist_to_binary([<<"Internal error in ">>, atom_to_binary(Op)])
+                        Err,
+                        iolist_to_binary([
+                            <<"Internal error in ">>, atom_to_binary(Op, utf8)
+                        ])
                     )
                 )
         end


### PR DESCRIPTION
## Summary

Addresses [BT-879](https://linear.app/beamtalk/issue/BT-879): expensive ops blocking the WorkspaceInterface gen_server mailbox.

- **Offload `classes` and `testClasses`** to spawned workers in both `handle_call` and `handle_cast` paths — these iterate all class PIDs with O(n) gen_server round-trips
- **Extract `spawn_call_worker/4` and `spawn_cast_worker/4`** helpers to DRY the repeated spawn/try/catch/reply boilerplate (12 sites collapsed into 2 helpers, net -54 lines)
- **Unify cast error handling**: `spawn_cast_worker` consistently rejects futures on `{error, Err}` results — fixes `test`/`test:` cast handlers silently resolving error tuples

### What was already done (BT-882)
- `load:` call/cast paths — offloaded in PR #937
- `test`/`test:` call/cast paths — already spawned

### What this PR adds
- `classes` call/cast — now spawned
- `testClasses` call/cast — now spawned  
- DRY helpers replacing all inline spawn blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Offloaded blocking workspace operations to background worker processes to keep the main handler responsive and reduce latency under concurrency.
  * Asynchronous request paths now return/resolve futures so callers get nonblocking responses while work runs in workers.
  * Improved crash/error logging to reference workspace context for clearer diagnostics.
  * No changes to public API surface or exported function signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->