### PR TITLE
Refactor: Continue splitting beamtalk_repl_server.erl (<500 LOC target) (BT-865)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_errors.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_errors.erl
@@ -1,0 +1,157 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%%% @doc Error utilities for the Beamtalk REPL.
+%%%
+%%% **DDD Context:** REPL
+%%%
+%%% Provides helpers for wrapping raw error terms into structured
+%%% #beamtalk_error{} records, safe atom conversion, and name formatting.
+%%% Used by protocol handlers and op modules.
+
+-module(beamtalk_repl_errors).
+
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+-export([
+    ensure_structured_error/1,
+    ensure_structured_error/2,
+    format_name/1,
+    safe_to_existing_atom/1
+]).
+
+%%% Public API
+
+%% @doc Safely convert a binary to an existing atom, returning error instead of creating new atoms.
+-spec safe_to_existing_atom(binary()) -> {ok, atom()} | {error, badarg}.
+safe_to_existing_atom(<<>>) ->
+    {error, badarg};
+safe_to_existing_atom(Bin) when is_binary(Bin) ->
+    try binary_to_existing_atom(Bin, utf8) of
+        Atom -> {ok, Atom}
+    catch
+        error:badarg -> {error, badarg}
+    end;
+safe_to_existing_atom(_) ->
+    {error, badarg}.
+
+%% @doc Ensure an error reason is a structured #beamtalk_error{} record.
+%% If already structured (or a wrapped exception), passes through unchanged.
+%% Handles known bare tuple error patterns from the compile pipeline.
+%% Otherwise wraps the raw term in an internal_error.
+-spec ensure_structured_error(term()) -> #beamtalk_error{}.
+ensure_structured_error(#beamtalk_error{} = Err) ->
+    Err;
+ensure_structured_error(#{'$beamtalk_class' := _, error := #beamtalk_error{} = Err}) ->
+    Err;
+ensure_structured_error(
+    {eval_error, _Class, #{'$beamtalk_class' := _, error := #beamtalk_error{} = Err}}
+) ->
+    Err;
+ensure_structured_error({eval_error, _Class, #beamtalk_error{} = Err}) ->
+    Err;
+ensure_structured_error({eval_error, _Class, Reason}) ->
+    %% Delegate to /1 for known tuple patterns; fall back to generic wrapper.
+    ensure_structured_error(Reason);
+ensure_structured_error({compile_error, Msg}) when is_binary(Msg) ->
+    Err0 = beamtalk_error:new(compile_error, 'Compiler'),
+    beamtalk_error:with_message(Err0, Msg);
+ensure_structured_error({compile_error, Msg}) when is_list(Msg) ->
+    Err0 = beamtalk_error:new(compile_error, 'Compiler'),
+    beamtalk_error:with_message(Err0, list_to_binary(Msg));
+ensure_structured_error({compile_error, Reason}) ->
+    Err0 = beamtalk_error:new(compile_error, 'Compiler'),
+    beamtalk_error:with_message(
+        Err0,
+        iolist_to_binary([<<"Compile error: ">>, format_name(Reason)])
+    );
+ensure_structured_error({undefined_variable, Name}) ->
+    Err0 = beamtalk_error:new(undefined_variable, 'REPL'),
+    beamtalk_error:with_message(
+        Err0,
+        iolist_to_binary([<<"Undefined variable: ">>, format_name(Name)])
+    );
+ensure_structured_error({file_not_found, Path}) ->
+    Err0 = beamtalk_error:new(file_not_found, 'File'),
+    beamtalk_error:with_message(
+        Err0,
+        iolist_to_binary([<<"File not found: ">>, format_name(Path)])
+    );
+ensure_structured_error({read_error, Reason}) ->
+    Err0 = beamtalk_error:new(io_error, 'File'),
+    beamtalk_error:with_message(
+        Err0,
+        iolist_to_binary([<<"Failed to read file: ">>, format_name(Reason)])
+    );
+ensure_structured_error({load_error, Reason}) ->
+    Err0 = beamtalk_error:new(io_error, 'File'),
+    beamtalk_error:with_message(
+        Err0,
+        iolist_to_binary([<<"Failed to load bytecode: ">>, format_name(Reason)])
+    );
+ensure_structured_error({parse_error, Details}) ->
+    Err0 = beamtalk_error:new(compile_error, 'Compiler'),
+    beamtalk_error:with_message(
+        Err0,
+        iolist_to_binary([<<"Parse error: ">>, format_name(Details)])
+    );
+ensure_structured_error({invalid_request, Reason}) ->
+    Err0 = beamtalk_error:new(internal_error, 'REPL'),
+    beamtalk_error:with_message(
+        Err0,
+        iolist_to_binary([<<"Invalid request: ">>, format_name(Reason)])
+    );
+ensure_structured_error(empty_expression) ->
+    Err0 = beamtalk_error:new(empty_expression, 'REPL'),
+    beamtalk_error:with_message(Err0, <<"Empty expression">>);
+ensure_structured_error(timeout) ->
+    Err0 = beamtalk_error:new(timeout, 'REPL'),
+    beamtalk_error:with_message(Err0, <<"Request timed out">>);
+ensure_structured_error(Reason) ->
+    Err0 = beamtalk_error:new(internal_error, 'REPL'),
+    beamtalk_error:with_message(
+        Err0,
+        iolist_to_binary(io_lib:format("~p", [Reason]))
+    ).
+
+%% @doc Ensure an error reason is structured, with exception class context.
+%% Delegates known tuple patterns to ensure_structured_error/1 to preserve
+%% specific error kinds, only falling back to generic wrapper for unknown terms.
+-spec ensure_structured_error(term(), atom()) -> #beamtalk_error{}.
+ensure_structured_error(#beamtalk_error{} = Err, _Class) ->
+    Err;
+ensure_structured_error(#{'$beamtalk_class' := _, error := #beamtalk_error{} = Err}, _Class) ->
+    Err;
+ensure_structured_error({compile_error, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({eval_error, _, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({undefined_variable, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({file_not_found, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({read_error, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({load_error, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({parse_error, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({invalid_request, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error(Reason, Class) ->
+    Err0 = beamtalk_error:new(internal_error, 'REPL'),
+    beamtalk_error:with_message(
+        Err0,
+        iolist_to_binary([
+            atom_to_binary(Class, utf8),
+            <<": ">>,
+            io_lib:format("~p", [Reason])
+        ])
+    ).
+
+%% @doc Format a name for error messages.
+-spec format_name(term()) -> binary().
+format_name(Name) when is_atom(Name) -> atom_to_binary(Name, utf8);
+format_name(Name) when is_binary(Name) -> Name;
+format_name(Name) when is_list(Name) -> list_to_binary(Name);
+format_name(Name) -> iolist_to_binary(io_lib:format("~p", [Name])).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
@@ -1197,12 +1197,12 @@ class_name_atoms(Classes) ->
     lists:filtermap(
         fun
             (#{name := Name}) when is_list(Name) ->
-                case beamtalk_repl_server:safe_to_existing_atom(list_to_binary(Name)) of
+                case beamtalk_repl_errors:safe_to_existing_atom(list_to_binary(Name)) of
                     {ok, Atom} -> {true, Atom};
                     {error, badarg} -> false
                 end;
             (#{name := Name}) when is_binary(Name) ->
-                case beamtalk_repl_server:safe_to_existing_atom(Name) of
+                case beamtalk_repl_errors:safe_to_existing_atom(Name) of
                     {ok, Atom} -> {true, Atom};
                     {error, badarg} -> false
                 end;

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -47,7 +47,7 @@ handle(<<"complete">>, Params, Msg, SessionPid) ->
     end;
 handle(<<"docs">>, Params, Msg, _SessionPid) ->
     ClassBin = maps:get(<<"class">>, Params, <<>>),
-    case beamtalk_repl_server:safe_to_existing_atom(ClassBin) of
+    case beamtalk_repl_errors:safe_to_existing_atom(ClassBin) of
         {error, badarg} ->
             beamtalk_repl_protocol:encode_error(
                 make_class_not_found_error(ClassBin),
@@ -125,7 +125,7 @@ handle(<<"show-codegen">>, Params, Msg, SessionPid) ->
                         end,
                     jsx:encode(Result1);
                 {error, ErrorReason, Warnings} ->
-                    WrappedReason = beamtalk_repl_server:ensure_structured_error(ErrorReason),
+                    WrappedReason = beamtalk_repl_errors:ensure_structured_error(ErrorReason),
                     beamtalk_repl_protocol:encode_error(
                         WrappedReason,
                         Msg,
@@ -314,7 +314,7 @@ classify_receiver(<<>>, _Bindings) ->
     undefined;
 classify_receiver(<<H, _/binary>> = Receiver, _Bindings) when H >= $A, H =< $Z ->
     %% Starts with uppercase — treat as a class object; complete class-side methods
-    case beamtalk_repl_server:safe_to_existing_atom(Receiver) of
+    case beamtalk_repl_errors:safe_to_existing_atom(Receiver) of
         {ok, ClassName} ->
             case
                 try
@@ -349,7 +349,7 @@ classify_receiver(<<$", _/binary>>, _Bindings) ->
     end;
 classify_receiver(Receiver, Bindings) ->
     %% Lowercase identifier — look up in session bindings to find the class
-    case beamtalk_repl_server:safe_to_existing_atom(Receiver) of
+    case beamtalk_repl_errors:safe_to_existing_atom(Receiver) of
         {ok, VarAtom} ->
             case maps:find(VarAtom, Bindings) of
                 {ok, #beamtalk_object{class = ClassName}} ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
@@ -32,7 +32,7 @@ handle(<<"eval">>, Params, Msg, SessionPid) ->
                         Result, Msg, fun beamtalk_repl_json:term_to_json/1, Output, Warnings
                     );
                 {error, ErrorReason, Output, Warnings} ->
-                    WrappedReason = beamtalk_repl_server:ensure_structured_error(ErrorReason),
+                    WrappedReason = beamtalk_repl_errors:ensure_structured_error(ErrorReason),
                     beamtalk_repl_protocol:encode_error(
                         WrappedReason,
                         Msg,

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
@@ -25,7 +25,7 @@ handle(<<"load-file">>, Params, Msg, SessionPid) ->
                 Classes, Msg, fun beamtalk_repl_json:term_to_json/1, Warnings
             );
         {error, Reason} ->
-            WrappedReason = beamtalk_repl_server:ensure_structured_error(Reason),
+            WrappedReason = beamtalk_repl_errors:ensure_structured_error(Reason),
             beamtalk_repl_protocol:encode_error(
                 WrappedReason, Msg, fun beamtalk_repl_json:format_error_message/1
             )
@@ -48,7 +48,7 @@ handle(<<"load-source">>, Params, Msg, SessionPid) ->
                         Classes, Msg, fun beamtalk_repl_json:term_to_json/1, Warnings
                     );
                 {error, Reason} ->
-                    WrappedReason = beamtalk_repl_server:ensure_structured_error(Reason),
+                    WrappedReason = beamtalk_repl_errors:ensure_structured_error(Reason),
                     beamtalk_repl_protocol:encode_error(
                         WrappedReason, Msg, fun beamtalk_repl_json:format_error_message/1
                     )
@@ -58,7 +58,7 @@ handle(<<"reload">>, Params, Msg, SessionPid) ->
     ModuleBin = maps:get(<<"module">>, Params, <<>>),
     case maps:get(<<"path">>, Params, undefined) of
         undefined when ModuleBin =/= <<>> ->
-            case beamtalk_repl_server:safe_to_existing_atom(ModuleBin) of
+            case beamtalk_repl_errors:safe_to_existing_atom(ModuleBin) of
                 {ok, ModuleAtom} ->
                     {ok, Tracker} = beamtalk_repl_shell:get_module_tracker(SessionPid),
                     case beamtalk_repl_modules:get_module_info(ModuleAtom, Tracker) of
@@ -163,7 +163,7 @@ collect_load_warnings(Classes) ->
     ClassNames = lists:filtermap(
         fun
             (#{name := N}) when N =/= "" ->
-                case beamtalk_repl_server:safe_to_existing_atom(list_to_binary(N)) of
+                case beamtalk_repl_errors:safe_to_existing_atom(list_to_binary(N)) of
                     {ok, Atom} -> {true, Atom};
                     {error, badarg} -> false
                 end;
@@ -205,7 +205,7 @@ do_reload(Path, ModuleAtom, Msg, SessionPid) ->
                 Classes, ActorCount, MigrationFailures, Msg, Warnings
             );
         {error, Reason} ->
-            WrappedReason = beamtalk_repl_server:ensure_structured_error(Reason),
+            WrappedReason = beamtalk_repl_errors:ensure_structured_error(Reason),
             beamtalk_repl_protocol:encode_error(
                 WrappedReason, Msg, fun beamtalk_repl_json:format_error_message/1
             )
@@ -253,12 +253,12 @@ resolve_module_atoms(undefined, Classes) ->
                 "" ->
                     false;
                 Name when is_list(Name) ->
-                    case beamtalk_repl_server:safe_to_existing_atom(list_to_binary(Name)) of
+                    case beamtalk_repl_errors:safe_to_existing_atom(list_to_binary(Name)) of
                         {ok, Atom} -> {true, Atom};
                         {error, badarg} -> false
                     end;
                 Name when is_binary(Name) ->
-                    case beamtalk_repl_server:safe_to_existing_atom(Name) of
+                    case beamtalk_repl_errors:safe_to_existing_atom(Name) of
                         {ok, Atom} -> {true, Atom};
                         {error, badarg} -> false
                     end;

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
@@ -118,7 +118,7 @@ websocket_info(
 ) when
     Msg =/= undefined
 ->
-    WrappedReason = beamtalk_repl_server:ensure_structured_error(Reason),
+    WrappedReason = beamtalk_repl_errors:ensure_structured_error(Reason),
     Response = beamtalk_repl_protocol:encode_error(
         WrappedReason, Msg, fun beamtalk_repl_json:format_error_message/1, Output, Warnings
     ),


### PR DESCRIPTION
## Summary

Reduces `beamtalk_repl_server.erl` from 685 to 480 LOC (under the 500 LOC target) by extracting error utilities and legacy request parsing into focused modules.

### Changes

- **New `beamtalk_repl_errors.erl`** (157 LOC): Extracts `ensure_structured_error/1,2`, `format_name/1`, and `safe_to_existing_atom/1` — error wrapping utilities used across REPL ops modules
- **Extended `beamtalk_repl_protocol.erl`**: Adds `parse_request/1` and `op_to_request/2` (legacy request parsing, deprecated in favor of `decode/1`)
- **Slimmed `beamtalk_repl_server.erl`**: Retains thin delegates so existing tests and callers work without modification
- **Updated 5 caller modules** (`beamtalk_repl_ops_load`, `beamtalk_repl_ops_eval`, `beamtalk_repl_ops_dev`, `beamtalk_repl_eval`, `beamtalk_ws_handler`) to call new modules directly

### Linear Issue

https://linear.app/beamtalk/issue/BT-865/refactor-continue-splitting-beamtalk-repl-servererl-500-loc-target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for legacy JSON-based CLI request parsing with enhanced protocol handling.

* **Refactor**
  * Reorganized error handling utilities into a dedicated module for improved error structuring and normalization across the REPL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->