### PR TITLE
fix: apply timesRepeat: body closure on simple path

### DIFF
--- a/stdlib/test/times_repeat_simple_test.bt
+++ b/stdlib/test/times_repeat_simple_test.bt
@@ -1,0 +1,32 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression tests for timesRepeat: simple path.
+//
+// The simple path (no local mutations, no self-sends, no field writes)
+// previously generated `let _ = body_code in ...` without ever applying the
+// body closure, so the block body silently never executed.
+//
+// The mutation path (local writes / self-sends) was unaffected.
+
+TestCase subclass: TimesRepeatSimpleTest
+
+  testZeroTimesIsNoOp =>
+    c := Counter spawn.
+    0 timesRepeat: [c increment await].
+    self assert: (c getValue await) equals: 0
+
+  testOneTimeRunsBlockOnce =>
+    c := Counter spawn.
+    1 timesRepeat: [c increment await].
+    self assert: (c getValue await) equals: 1
+
+  testThreeTimesRunsBlockThreeTimes =>
+    c := Counter spawn.
+    3 timesRepeat: [c increment await].
+    self assert: (c getValue await) equals: 3
+
+  testFiveTimesRunsBlockFiveTimes =>
+    c := Counter spawn.
+    5 timesRepeat: [c increment await].
+    self assert: (c getValue await) equals: 5


### PR DESCRIPTION
## Summary

- `generate_times_repeat_simple` emitted `let _ = body_code in ...` where `body_code` is a `fun () -> ...` closure that was **never applied** — block body silently executed zero times on every iteration
- Fix: hoist body closure binding outside the `letrec` (matching `generate_to_do_simple`), then `apply BodyFun ()` inside the loop branch
- All other loop constructs (`to:do:`, `to:by:do:`, `whileTrue:`, `whileFalse:`, `do:`, `collect:`, etc.) were audited and unaffected

## Root cause

The simple path is taken when the block has no local mutations, self-sends, or field writes. The mutation path (which inlines body expressions directly) was never affected.

## Test plan

- [x] `stdlib/test/times_repeat_simple_test.bt` — 4 regression tests: zero, one, three, five iterations on the simple path (external actor as observable side-effect)
- [x] Existing `stdlib/test/fixtures/local_mutation_actor.bt:countToN:` — mutation path regression
- [x] `just clippy && just test` — 4,547 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `timesRepeat` loop execution to properly handle body function evaluation.

* **Tests**
  * Added comprehensive test coverage for the `timesRepeat` simple path, validating correct iteration counts from zero to multiple executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->