### PR TITLE
Codegen: Tier 2 block StateAcc not threaded through stateful do: loop body in HOMs (BT-912)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -1567,6 +1567,17 @@ impl CoreErlangGenerator {
                             }
                             // Note: field_writes-only blocks are NOT yet supported
                             // for Tier 2 (requires different key scheme). See BT-852.
+                        } else if let Expression::Identifier(arg_id) = arg {
+                            // BT-912: If the argument is an identifier that is a known Tier 2
+                            // block parameter of the current method, treat it as a Tier 2 HOM
+                            // argument with no captured mutations. This handles nested HOMs where
+                            // one method delegates a Tier 2 block to another (e.g.
+                            // `outerEachItem: aBlock => self eachItem: aBlock`). The block was
+                            // already compiled as Tier 2 by the outer caller; we need to ensure
+                            // the returned state is threaded back through the delegation chain.
+                            if self.tier2_block_params.contains(arg_id.name.as_str()) {
+                                tier2_args.push((i, vec![]));
+                            }
                         }
                     }
                     if !tier2_args.is_empty() {

--- a/stdlib/test/hom_composability_test.bt
+++ b/stdlib/test/hom_composability_test.bt
@@ -3,17 +3,20 @@
 
 // BT-857: Tests for HOM composability (ADR 0041 Phase 5).
 //
-// What is tested here:
-// - Pure blocks passed to user-defined HOMs produce correct results (Tier 1 path)
+// BT-912: Tier 2 block StateAcc threading through stateful do: loop bodies.
 //
-// What requires BT-912 (Tier 2 block StateAcc threading through loop body):
-// - Mutating blocks via HOMs (testMutatingBlockViaMutatingHOM)
-// - Nested HOMs with mutating blocks (testNestedHOMsThreadState)
-// - Stored blocks passed to HOMs (testStoredBlockPassedToCustomHOM)
+// The BT-912 bug: when `last := aBlock value: each` is in a stateful do:
+// loop body, the Tier 2 block's NewStateAcc was discarded by codegen, so
+// mutations to captured variables (e.g., `count`) were not propagated back.
 //
-// The BT-912 scenario: when `last := aBlock value: each` is in a stateful do:
-// loop body, the Tier 2 block's NewStateAcc is discarded by codegen, so
-// mutations to captured variables (e.g., `count`) are not propagated back.
+// Fixed by:
+// 1. generate_local_var_assignment_in_loop: unpack {Result, NewStateAcc} from
+//    Tier 2 block calls and thread NewStateAcc into the maps:put.
+// 2. detect_tier2_self_send: treat identifier Tier 2 block parameters as Tier 2
+//    HOM arguments, enabling state threading through nested HOM delegation chains.
+//
+// Stored blocks passed to HOMs (testStoredBlockPassedToCustomHOM) require
+// type-level tracking of block variables (BT-909) and are not yet tested.
 
 TestCase subclass: HomComposabilityTest
 
@@ -22,4 +25,16 @@ TestCase subclass: HomComposabilityTest
   testPureBlockViaHOMCorrectResult =>
     actor := HomComposabilityActor spawn.
     self assert: ((actor testPureBlockViaHOM) await) equals: 30
+
+  // BT-912: Mutating block passed to user-defined HOM accumulates correctly.
+  // [:x | count := count + x] over 1..5 → count = 15.
+  testMutatingBlockViaMutatingHOM =>
+    actor := HomComposabilityActor spawn.
+    self assert: ((actor testMutatingBlockInCustomLoop) await) equals: 15
+
+  // BT-912: Nested HOMs — outer delegates to inner, state threads through both layers.
+  // Same block, same items, same expected result as above.
+  testNestedHOMsThreadState =>
+    actor := HomComposabilityActor spawn.
+    self assert: ((actor testNestedHOMsAccumulate) await) equals: 15
 


### PR DESCRIPTION
## Summary

Fixes [BT-912](https://linear.app/beamtalk/issue/BT-912/codegen-tier-2-block-stateacc-not-threaded-through-stateful-do-loop): When `last := aBlock value: each` appears in a stateful `do:` loop body, the Tier 2 block's `NewStateAcc` was discarded by codegen, so mutations to captured variables (e.g., `count`) were not propagated back.

## Key Changes

- **`generate_local_var_assignment_in_loop`**: When RHS is a Tier 2 block call returning `{Result, NewStateAcc}`, unpack the tuple so `Val` gets `Result` and `maps:put` uses `NewStateAcc` (preserving captured mutations) rather than the old `StateAcc`
- **`detect_tier2_self_send`**: Treat identifier arguments that are known Tier 2 block parameters as Tier 2 HOM arguments, enabling state threading through nested HOM delegation chains (e.g., `outerEachItem: aBlock => self eachItem: aBlock`)
- **Tests**: Added `testMutatingBlockViaMutatingHOM` and `testNestedHOMsThreadState` to verify both direct and nested HOM state threading

## Test plan

- [x] `just ci` passes (all 4662 tests)
- [x] New BUnit tests verify mutating block via direct HOM → count = 15
- [x] New BUnit tests verify nested HOM delegation → count = 15
- [x] Existing pure block HOM test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state preservation when executing blocks that return multiple values in nested operations, ensuring proper state threading across complex call chains.

* **Tests**
  * Added test coverage for state management in mutating blocks passed through higher-order functions and nested delegation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->