### PR TITLE
Wrap non-literal callable expressions at Erlang interop boundary (BT-909)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -994,6 +994,22 @@ impl CoreErlangGenerator {
         ));
     }
 
+    /// BT-909: Emits a warning for a non-literal callable at an Erlang call boundary.
+    pub(super) fn warn_non_literal_callable_at_erlang_boundary(
+        &mut self,
+        erlang_target: &str,
+        span: Span,
+    ) {
+        self.add_codegen_warning(Diagnostic::warning(
+            format!(
+                "non-literal callable passed to Erlang {erlang_target} — if this is a \
+                 stateful block, mutations inside the block will be silently dropped \
+                 (runtime arity check inserted to prevent badarity crash)"
+            ),
+            span,
+        ));
+    }
+
     /// BT-833: Resets the Self version to 0 (call at the start of each value type method).
     pub(super) fn reset_self_version(&mut self) {
         self.self_version = 0;

--- a/stdlib/test/fixtures/non_literal_callable_actor.bt
+++ b/stdlib/test/fixtures/non_literal_callable_actor.bt
@@ -1,0 +1,27 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-909: Actor that passes block variables (non-literal callables) to list ops.
+// This triggers the runtime arity normalization wrapper because the compiler
+// cannot statically determine the block's tier when it's referenced by identifier.
+
+Actor subclass: NonLiteralCallableActor
+
+  // collect: with a Tier-1 block stored in a variable
+  collectWithTier1Block =>
+    blk := [:x | x * 10].
+    #(1, 2, 3) collect: blk
+
+  // select: with a Tier-1 block stored in a variable
+  selectWithTier1Block =>
+    blk := [:x | x > 2].
+    #(1, 2, 3, 4, 5) select: blk
+
+  // do: with a Tier-2 (stateful) block stored in a variable.
+  // Mutations are silently dropped at the Erlang boundary (expected),
+  // but the call must not crash with badarity.
+  doWithTier2Block =>
+    total := 0.
+    blk := [:x | total := total + x].
+    #(1, 2, 3) do: blk.
+    "done"

--- a/stdlib/test/non_literal_callable_test.bt
+++ b/stdlib/test/non_literal_callable_test.bt
@@ -1,0 +1,23 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-909: Tests that non-literal callables (block variables) can be passed
+// to list ops without crashing with badarity. The runtime arity normalization
+// wrapper detects Tier-2 blocks at runtime and wraps them to arity 1.
+
+TestCase subclass: NonLiteralCallableTest
+
+  // Tier-1 block stored in a variable, passed to collect:
+  testCollectWithBlockVar =>
+    actor := NonLiteralCallableActor spawn.
+    self assert: ((actor collectWithTier1Block) await) equals: #(10, 20, 30)
+
+  // Tier-1 block stored in a variable, passed to select:
+  testSelectWithBlockVar =>
+    actor := NonLiteralCallableActor spawn.
+    self assert: ((actor selectWithTier1Block) await) equals: #(3, 4, 5)
+
+  // Tier-2 block stored in a variable, passed to do: — must not crash
+  testDoWithTier2BlockVar =>
+    actor := NonLiteralCallableActor spawn.
+    self assert: ((actor doWithTier2Block) await) equals: "done"


### PR DESCRIPTION
## Summary

- Add runtime arity normalization in `generate_simple_list_op` for non-literal callables (block variables) passed to `do:`, `collect:`, `select:`
- Use `erlang:is_function/2` to detect Tier-2 blocks at runtime and wrap them to arity 1, preventing `badarity` crashes from `lists:foreach/map/filter`
- Fix `generate_erlang_interop_wrapper` to use `erlang:element/2` instead of invalid tuple-pattern `let` in Core Erlang fun bodies
- Use `maps:get/3` with outer-scope fallback in `generate_block_stateful` so blocks remain callable when StateAcc lacks local state keys

**Linear issue:** https://linear.app/beamtalk/issue/BT-909

## Test plan

- [x] BUnit tests for block variables passed to list ops (`NonLiteralCallableTest`)
- [x] Updated unit test for `generate_erlang_interop_wrapper` to verify `element/2` pattern
- [x] All 4,944 existing tests pass (Rust + stdlib + BUnit + runtime)
- [x] All 666 E2E tests pass
- [x] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented runtime crashes when passing block variables to list operations by adding runtime arity normalization for non-literal callables.
  * Added arity validation at language/runtime boundaries to avoid badarity errors.

* **Tests**
  * Added end-to-end tests covering non-literal callable scenarios.

* **Chores**
  * Added a test fixture actor demonstrating non-literal block usage and surfaced a new warning for non-literal callables at the boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->