### PR TITLE
Chore: add dedicated unit tests for repl_compiler and repl_loader

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
@@ -27,7 +27,14 @@
 -ifdef(TEST).
 -export([
     compile_expression_via_port/3,
-    compile_file_via_port/4
+    compile_file_via_port/4,
+    apply_module_name_override/2,
+    apply_source_path/2,
+    assemble_class_result/5,
+    compile_trailing_expressions/2,
+    compile_standard_expression/2,
+    compile_file_core/3,
+    format_core_error/1
 ]).
 -endif.
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
@@ -22,23 +22,12 @@
 -ifdef(TEST).
 -export([
     extract_assignment/1,
-    format_formatted_diagnostics/1,
     maybe_await_future/1,
     should_purge_module/2,
     strip_internal_bindings/1,
-    is_stdlib_path/1,
-    compute_package_module_name/1,
-    to_snake_case/1,
     inject_output/3,
-    is_internal_key/1,
-    activate_module/2,
-    register_classes/2,
-    trigger_hot_reload/2,
     handle_class_definition/7,
-    handle_method_definition/4,
-    compile_expression_via_port/3,
-    compile_file_via_port/4,
-    verify_class_present/3
+    handle_method_definition/4
 ]).
 -endif.
 
@@ -339,54 +328,3 @@ inject_output({ok, Result, State}, Output, Warnings) ->
     {ok, Result, Output, Warnings, State};
 inject_output({error, Reason, State}, Output, Warnings) ->
     {error, Reason, Output, Warnings, State}.
-
-%%% Delegate functions for backward compatibility (tests call these on beamtalk_repl_eval)
-
--ifdef(TEST).
-
--spec format_formatted_diagnostics(list()) -> binary().
-format_formatted_diagnostics(Diagnostics) ->
-    beamtalk_repl_compiler:format_formatted_diagnostics(Diagnostics).
-
--spec is_internal_key(atom()) -> boolean().
-is_internal_key(Key) ->
-    beamtalk_repl_compiler:is_internal_key(Key).
-
--spec activate_module(atom(), [map()]) -> ok.
-activate_module(ModuleName, Classes) ->
-    beamtalk_repl_loader:activate_module(ModuleName, Classes).
-
--spec register_classes([map()], atom()) -> ok.
-register_classes(ClassInfoList, ModuleName) ->
-    beamtalk_repl_loader:register_classes(ClassInfoList, ModuleName).
-
--spec trigger_hot_reload(atom(), [map()]) -> ok.
-trigger_hot_reload(ModuleName, Classes) ->
-    beamtalk_repl_loader:trigger_hot_reload(ModuleName, Classes).
-
--spec compile_expression_via_port(string(), atom(), map()) -> term().
-compile_expression_via_port(Expression, ModuleName, Bindings) ->
-    beamtalk_repl_compiler:compile_expression_via_port(Expression, ModuleName, Bindings).
-
--spec compile_file_via_port(string(), string(), boolean(), binary() | undefined) -> term().
-compile_file_via_port(Source, Path, StdlibMode, ModuleNameOverride) ->
-    beamtalk_repl_compiler:compile_file_via_port(Source, Path, StdlibMode, ModuleNameOverride).
-
--spec to_snake_case(string()) -> string().
-to_snake_case(Str) ->
-    beamtalk_repl_loader:to_snake_case(Str).
-
--spec is_stdlib_path(string()) -> boolean().
-is_stdlib_path(Path) ->
-    beamtalk_repl_loader:is_stdlib_path(Path).
-
--spec verify_class_present(atom() | undefined, [#{name := string()}], string()) ->
-    ok | {error, term()}.
-verify_class_present(ExpectedClassName, ClassNames, Path) ->
-    beamtalk_repl_loader:verify_class_present(ExpectedClassName, ClassNames, Path).
-
--spec compute_package_module_name(string()) -> binary() | undefined.
-compute_package_module_name(Path) ->
-    beamtalk_repl_loader:compute_package_module_name(Path).
-
--endif.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -32,7 +32,18 @@
 %% Exported for testing (only in test builds)
 -ifdef(TEST).
 -export([
-    load_compiled_module/6
+    load_compiled_module/6,
+    normalize_class_source_key/1,
+    extract_trailing_info/1,
+    resolve_class_name/1,
+    safe_binary_to_atom/1,
+    safe_list_to_atom/1,
+    safe_atom_result/1,
+    resolve_package_module/3,
+    try_package_relative/3,
+    maybe_add_loaded_module/2,
+    store_file_class_sources/3,
+    store_class_sources/4
 ]).
 -endif.
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_compiler_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_compiler_tests.erl
@@ -1,0 +1,279 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%%% @doc Unit tests for beamtalk_repl_compiler module
+
+-module(beamtalk_repl_compiler_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% format_formatted_diagnostics/1
+%%====================================================================
+
+format_diagnostics_empty_test() ->
+    ?assertEqual(<<"Compilation failed">>, beamtalk_repl_compiler:format_formatted_diagnostics([])).
+
+format_diagnostics_single_test() ->
+    ?assertEqual(
+        <<"Unexpected token">>,
+        beamtalk_repl_compiler:format_formatted_diagnostics([<<"Unexpected token">>])
+    ).
+
+format_diagnostics_multiple_test() ->
+    Result = beamtalk_repl_compiler:format_formatted_diagnostics([<<"Error 1">>, <<"Error 2">>]),
+    ?assertEqual(<<"Error 1\n\nError 2">>, Result).
+
+format_diagnostics_three_test() ->
+    Result = beamtalk_repl_compiler:format_formatted_diagnostics([<<"A">>, <<"B">>, <<"C">>]),
+    ?assert(binary:match(Result, <<"A">>) =/= nomatch),
+    ?assert(binary:match(Result, <<"B">>) =/= nomatch),
+    ?assert(binary:match(Result, <<"C">>) =/= nomatch).
+
+%%====================================================================
+%% is_internal_key/1
+%%====================================================================
+
+is_internal_key_double_underscore_test() ->
+    ?assert(beamtalk_repl_compiler:is_internal_key('__repl_actor_registry__')).
+
+is_internal_key_double_underscore_prefix_only_test() ->
+    ?assert(beamtalk_repl_compiler:is_internal_key('__workspace_user_bindings__')).
+
+is_internal_key_single_underscore_test() ->
+    ?assertNot(beamtalk_repl_compiler:is_internal_key('_error')).
+
+is_internal_key_regular_atom_test() ->
+    ?assertNot(beamtalk_repl_compiler:is_internal_key(x)).
+
+is_internal_key_empty_atom_test() ->
+    ?assertNot(beamtalk_repl_compiler:is_internal_key('')).
+
+is_internal_key_normal_name_test() ->
+    ?assertNot(beamtalk_repl_compiler:is_internal_key(myVar)).
+
+%%====================================================================
+%% build_class_superclass_index/0
+%%====================================================================
+
+build_class_superclass_index_missing_table_test() ->
+    %% When the ETS table doesn't exist, returns empty map
+    Result = beamtalk_repl_compiler:build_class_superclass_index(),
+    ?assert(is_map(Result)).
+
+%%====================================================================
+%% format_core_error/1
+%%====================================================================
+
+format_core_error_atom_test() ->
+    Result = beamtalk_repl_compiler:format_core_error(badarg),
+    ?assert(is_binary(Result)),
+    ?assert(binary:match(Result, <<"Core Erlang compile error">>) =/= nomatch).
+
+format_core_error_tuple_test() ->
+    Result = beamtalk_repl_compiler:format_core_error({error, some_reason}),
+    ?assert(is_binary(Result)).
+
+format_core_error_string_test() ->
+    Result = beamtalk_repl_compiler:format_core_error("something went wrong"),
+    ?assert(is_binary(Result)).
+
+%%====================================================================
+%% apply_module_name_override/2
+%%====================================================================
+
+apply_module_name_override_undefined_test() ->
+    Opts = #{stdlib_mode => false},
+    ?assertEqual(Opts, beamtalk_repl_compiler:apply_module_name_override(Opts, undefined)).
+
+apply_module_name_override_with_name_test() ->
+    Opts = #{stdlib_mode => false},
+    Result = beamtalk_repl_compiler:apply_module_name_override(Opts, <<"my_module">>),
+    ?assertEqual(<<"my_module">>, maps:get(module_name, Result)).
+
+apply_module_name_override_preserves_existing_test() ->
+    Opts = #{stdlib_mode => true, other => value},
+    Result = beamtalk_repl_compiler:apply_module_name_override(Opts, <<"override">>),
+    ?assertEqual(true, maps:get(stdlib_mode, Result)),
+    ?assertEqual(value, maps:get(other, Result)),
+    ?assertEqual(<<"override">>, maps:get(module_name, Result)).
+
+%%====================================================================
+%% apply_source_path/2
+%%====================================================================
+
+apply_source_path_undefined_test() ->
+    Opts = #{stdlib_mode => false},
+    ?assertEqual(Opts, beamtalk_repl_compiler:apply_source_path(Opts, undefined)).
+
+apply_source_path_with_slash_test() ->
+    Opts = #{},
+    Result = beamtalk_repl_compiler:apply_source_path(Opts, "/home/user/src/Foo.bt"),
+    ?assertEqual(<<"/home/user/src/Foo.bt">>, maps:get(source_path, Result)).
+
+apply_source_path_with_bt_extension_test() ->
+    Opts = #{},
+    Result = beamtalk_repl_compiler:apply_source_path(Opts, "Foo.bt"),
+    ?assertEqual(<<"Foo.bt">>, maps:get(source_path, Result)).
+
+apply_source_path_plain_expression_test() ->
+    %% "1 + 1" has no path markers, should not add source_path
+    Opts = #{},
+    Result = beamtalk_repl_compiler:apply_source_path(Opts, "1 + 1"),
+    ?assertNot(maps:is_key(source_path, Result)).
+
+apply_source_path_windows_path_test() ->
+    Opts = #{},
+    Result = beamtalk_repl_compiler:apply_source_path(Opts, "C:\\Users\\src\\Foo.bt"),
+    ?assertEqual(<<"C:\\Users\\src\\Foo.bt">>, maps:get(source_path, Result)).
+
+apply_source_path_non_list_ignored_test() ->
+    Opts = #{},
+    Result = beamtalk_repl_compiler:apply_source_path(Opts, 42),
+    ?assertEqual(Opts, Result).
+
+%%====================================================================
+%% assemble_class_result/5
+%%====================================================================
+
+assemble_class_result_error_trailing_test() ->
+    %% When trailing result is an error, returns the error
+    Result = beamtalk_repl_compiler:assemble_class_result(
+        <<"binary">>, my_module, [], [], {error, <<"trailing failed">>}
+    ),
+    ?assertEqual({error, <<"trailing failed">>}, Result).
+
+assemble_class_result_no_trailing_test() ->
+    %% With trailing=none, produces base info
+    Result = beamtalk_repl_compiler:assemble_class_result(
+        <<"bin">>, my_mod, [#{name => <<"Foo">>}], [<<"warn">>], none
+    ),
+    ?assertMatch(
+        {ok, class_definition, #{binary := <<"bin">>, module_name := my_mod}, [<<"warn">>]}, Result
+    ).
+
+assemble_class_result_with_trailing_test() ->
+    %% With trailing={ok, TrailingBin, ModName}, adds trailing keys
+    Result = beamtalk_repl_compiler:assemble_class_result(
+        <<"bin">>, my_mod, [], [], {ok, <<"trailing">>, trail_mod}
+    ),
+    ?assertMatch(
+        {ok, class_definition,
+            #{trailing_binary := <<"trailing">>, trailing_module_name := trail_mod}, []},
+        Result
+    ).
+
+assemble_class_result_warnings_preserved_test() ->
+    Warnings = [<<"w1">>, <<"w2">>],
+    {ok, class_definition, _Info, ResultWarnings} = beamtalk_repl_compiler:assemble_class_result(
+        <<"bin">>, m, [], Warnings, none
+    ),
+    ?assertEqual(Warnings, ResultWarnings).
+
+%%====================================================================
+%% compile_trailing_expressions/2
+%%====================================================================
+
+compile_trailing_expressions_none_test() ->
+    %% No trailing_core_erlang key → returns none
+    ClassInfo = #{core_erlang => <<"...">>, module_name => <<"m">>, classes => [], warnings => []},
+    Result = beamtalk_repl_compiler:compile_trailing_expressions(ClassInfo, my_mod),
+    ?assertEqual(none, Result).
+
+%%====================================================================
+%% compile_expression_via_port/3 — error paths (no compiler running)
+%%====================================================================
+
+compile_expression_via_port_noproc_test() ->
+    %% With no compiler server, hits exit:{noproc,_} → {error, _}
+    Result = beamtalk_repl_compiler:compile_expression_via_port("1 + 1", test_mod, #{}),
+    ?assertMatch({error, _}, Result).
+
+compile_expression_via_port_with_bindings_test() ->
+    %% Bindings are filtered; still hits noproc
+    Result = beamtalk_repl_compiler:compile_expression_via_port(
+        "x + 1", test_mod, #{x => 42, '__internal__' => true}
+    ),
+    ?assertMatch({error, _}, Result).
+
+compile_expression_via_port_error_message_test() ->
+    {error, Msg} = beamtalk_repl_compiler:compile_expression_via_port("1", m, #{}),
+    ?assert(is_binary(Msg)).
+
+%%====================================================================
+%% compile_file_via_port/4 — error paths (no compiler running)
+%%====================================================================
+
+compile_file_via_port_noproc_test() ->
+    Result = beamtalk_repl_compiler:compile_file_via_port("x := 1", "/test.bt", false, undefined),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+compile_file_via_port_stdlib_mode_test() ->
+    Result = beamtalk_repl_compiler:compile_file_via_port(
+        "Object subclass: Foo [\n]\n", "/stdlib/src/Foo.bt", true, undefined
+    ),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+compile_file_via_port_with_override_test() ->
+    Result = beamtalk_repl_compiler:compile_file_via_port(
+        "Object subclass: Bar [\n]\n", "/src/Bar.bt", false, <<"bt@pkg@bar">>
+    ),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+%%====================================================================
+%% compile_expression/3 (public API — same error path as via_port)
+%%====================================================================
+
+compile_expression_noproc_test() ->
+    Result = beamtalk_repl_compiler:compile_expression("1 + 1", some_mod, #{}),
+    ?assertMatch({error, _}, Result).
+
+%%====================================================================
+%% compile_file/4 (public API — same error path as via_port)
+%%====================================================================
+
+compile_file_noproc_test() ->
+    Result = beamtalk_repl_compiler:compile_file(
+        "Object subclass: X [\n]\n", "/x.bt", false, undefined
+    ),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+%%====================================================================
+%% compile_for_codegen/3 (public API)
+%%====================================================================
+
+compile_for_codegen_noproc_test() ->
+    Result = beamtalk_repl_compiler:compile_for_codegen(<<"1 + 1">>, <<"test_mod">>, []),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+%%====================================================================
+%% compile_for_method_reload/2 (public API)
+%%====================================================================
+
+compile_for_method_reload_noproc_test() ->
+    Result = beamtalk_repl_compiler:compile_for_method_reload(<<"Object subclass: X [\n]\n">>, #{}),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+%%====================================================================
+%% compile_standard_expression/2
+%%====================================================================
+
+compile_standard_expression_bad_core_test() ->
+    %% Invalid core erlang → compile_core_erlang fails → {error, _}
+    Result = beamtalk_repl_compiler:compile_standard_expression(<<"not valid core erlang">>, []),
+    ?assertMatch({error, _}, Result).
+
+%%====================================================================
+%% compile_file_core/3
+%%====================================================================
+
+compile_file_core_bad_core_test() ->
+    Result = beamtalk_repl_compiler:compile_file_core(<<"not core erlang">>, my_mod, []),
+    ?assertMatch({error, {core_compile_error, _}}, Result).
+
+compile_file_core_class_extraction_test() ->
+    %% Even if compile fails, the class list transform logic is pure — test error path
+    Result = beamtalk_repl_compiler:compile_file_core(<<"garbage">>, my_mod, [
+        #{name => <<"Foo">>, superclass => <<"Object">>}
+    ]),
+    %% Core erlang compile will fail, but we're just verifying it handles the error
+    ?assertMatch({error, _}, Result).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
@@ -53,18 +53,18 @@ extract_assignment_invalid_variable_name_test() ->
 %%% Diagnostics formatting tests
 
 format_formatted_diagnostics_empty_test() ->
-    ?assertEqual(<<"Compilation failed">>, beamtalk_repl_eval:format_formatted_diagnostics([])).
+    ?assertEqual(<<"Compilation failed">>, beamtalk_repl_compiler:format_formatted_diagnostics([])).
 
 format_formatted_diagnostics_single_test() ->
     FormattedDiagnostics = [<<"Unexpected token">>],
     ?assertEqual(
         <<"Unexpected token">>,
-        beamtalk_repl_eval:format_formatted_diagnostics(FormattedDiagnostics)
+        beamtalk_repl_compiler:format_formatted_diagnostics(FormattedDiagnostics)
     ).
 
 format_formatted_diagnostics_multiple_test() ->
     FormattedDiagnostics = [<<"Error 1">>, <<"Error 2">>, <<"Error 3">>],
-    Result = beamtalk_repl_eval:format_formatted_diagnostics(FormattedDiagnostics),
+    Result = beamtalk_repl_compiler:format_formatted_diagnostics(FormattedDiagnostics),
     ?assert(binary:match(Result, <<"Error 1">>) =/= nomatch),
     ?assert(binary:match(Result, <<"Error 2">>) =/= nomatch),
     ?assert(binary:match(Result, <<"Error 3">>) =/= nomatch).
@@ -257,31 +257,33 @@ io_capture_reset_does_not_affect_unrelated_processes_test() ->
 %% === is_stdlib_path tests ===
 
 is_stdlib_path_relative_lib_test() ->
-    ?assert(beamtalk_repl_eval:is_stdlib_path("stdlib/src/Integer.bt")).
+    ?assert(beamtalk_repl_loader:is_stdlib_path("stdlib/src/Integer.bt")).
 
 is_stdlib_path_absolute_test() ->
-    ?assert(beamtalk_repl_eval:is_stdlib_path("/workspace/project/stdlib/src/Integer.bt")).
+    ?assert(beamtalk_repl_loader:is_stdlib_path("/workspace/project/stdlib/src/Integer.bt")).
 
 is_stdlib_path_non_lib_test() ->
-    ?assertNot(beamtalk_repl_eval:is_stdlib_path("src/MyClass.bt")).
+    ?assertNot(beamtalk_repl_loader:is_stdlib_path("src/MyClass.bt")).
 
 is_stdlib_path_non_lib_absolute_test() ->
-    ?assertNot(beamtalk_repl_eval:is_stdlib_path("/workspace/project/src/MyClass.bt")).
+    ?assertNot(beamtalk_repl_loader:is_stdlib_path("/workspace/project/src/MyClass.bt")).
 
 is_stdlib_path_lib_without_trailing_slash_test() ->
     %% "stdlib/src" alone (no trailing slash) is NOT a stdlib path
-    ?assertNot(beamtalk_repl_eval:is_stdlib_path("stdlib/src")).
+    ?assertNot(beamtalk_repl_loader:is_stdlib_path("stdlib/src")).
 
 is_stdlib_path_libs_prefix_test() ->
     %% "stdlib/srcs/" is NOT the same as "stdlib/src/"
-    ?assertNot(beamtalk_repl_eval:is_stdlib_path("stdlib/srcs/Integer.bt")).
+    ?assertNot(beamtalk_repl_loader:is_stdlib_path("stdlib/srcs/Integer.bt")).
 
 is_stdlib_path_embedded_lib_test() ->
     %% Path with /stdlib/src/ deeper in the tree
-    ?assert(beamtalk_repl_eval:is_stdlib_path("/home/user/projects/beamtalk/stdlib/src/String.bt")).
+    ?assert(
+        beamtalk_repl_loader:is_stdlib_path("/home/user/projects/beamtalk/stdlib/src/String.bt")
+    ).
 
 is_stdlib_path_empty_test() ->
-    ?assertNot(beamtalk_repl_eval:is_stdlib_path("")).
+    ?assertNot(beamtalk_repl_loader:is_stdlib_path("")).
 
 %%% strip_internal_bindings tests
 
@@ -499,7 +501,7 @@ inject_output_multiple_warnings_test() ->
 
 format_formatted_diagnostics_single_binary_with_newlines_test() ->
     FormattedDiagnostics = [<<"Line 1\nLine 2\nLine 3">>],
-    Result = beamtalk_repl_eval:format_formatted_diagnostics(FormattedDiagnostics),
+    Result = beamtalk_repl_compiler:format_formatted_diagnostics(FormattedDiagnostics),
     ?assertEqual(<<"Line 1\nLine 2\nLine 3">>, Result).
 
 %%% do_eval error edge cases
@@ -545,51 +547,51 @@ handle_load_empty_file_test() ->
 %%% is_internal_key/1 tests
 
 is_internal_key_double_underscore_test() ->
-    ?assert(beamtalk_repl_eval:is_internal_key('__repl_actor_registry__')).
+    ?assert(beamtalk_repl_compiler:is_internal_key('__repl_actor_registry__')).
 
 is_internal_key_single_underscore_test() ->
-    ?assertNot(beamtalk_repl_eval:is_internal_key('_error')).
+    ?assertNot(beamtalk_repl_compiler:is_internal_key('_error')).
 
 is_internal_key_regular_atom_test() ->
-    ?assertNot(beamtalk_repl_eval:is_internal_key(x)).
+    ?assertNot(beamtalk_repl_compiler:is_internal_key(x)).
 
 is_internal_key_empty_atom_test() ->
-    ?assertNot(beamtalk_repl_eval:is_internal_key('')).
+    ?assertNot(beamtalk_repl_compiler:is_internal_key('')).
 
 %%% register_classes/2 tests
 
 register_classes_no_function_test() ->
-    ?assertEqual(ok, beamtalk_repl_eval:register_classes([], lists)).
+    ?assertEqual(ok, beamtalk_repl_loader:register_classes([], lists)).
 
 %%% trigger_hot_reload/2 tests
 
 trigger_hot_reload_empty_classes_test() ->
-    ?assertEqual(ok, beamtalk_repl_eval:trigger_hot_reload(some_module, [])).
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, [])).
 
 trigger_hot_reload_unknown_class_test() ->
     Classes = [#{name => <<"xyzzy_nonexistent_class_99999">>}],
-    ?assertEqual(ok, beamtalk_repl_eval:trigger_hot_reload(some_module, Classes)).
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
 
 trigger_hot_reload_undefined_name_test() ->
     Classes = [#{name => undefined}],
-    ?assertEqual(ok, beamtalk_repl_eval:trigger_hot_reload(some_module, Classes)).
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
 
 trigger_hot_reload_no_name_key_test() ->
     Classes = [#{}],
-    ?assertEqual(ok, beamtalk_repl_eval:trigger_hot_reload(some_module, Classes)).
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
 
 trigger_hot_reload_list_name_test() ->
     Classes = [#{name => "xyzzy_nonexistent_class_88888"}],
-    ?assertEqual(ok, beamtalk_repl_eval:trigger_hot_reload(some_module, Classes)).
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
 
 trigger_hot_reload_atom_name_test() ->
     Classes = [#{name => xyzzy_nonexistent_class_77777}],
-    ?assertEqual(ok, beamtalk_repl_eval:trigger_hot_reload(some_module, Classes)).
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
 
 %%% activate_module/2 tests
 
 activate_module_nonexistent_test() ->
-    ?assertEqual(ok, beamtalk_repl_eval:activate_module(lists, [])).
+    ?assertEqual(ok, beamtalk_repl_loader:activate_module(lists, [])).
 
 %%% io_passthrough_loop tests
 
@@ -656,7 +658,7 @@ do_eval_with_registry_no_compiler_test() ->
 %%% format_formatted_diagnostics edge cases
 
 format_formatted_diagnostics_two_items_test() ->
-    Result = beamtalk_repl_eval:format_formatted_diagnostics([<<"A">>, <<"B">>]),
+    Result = beamtalk_repl_compiler:format_formatted_diagnostics([<<"A">>, <<"B">>]),
     ?assertEqual(<<"A\n\nB">>, Result).
 
 %%% extract_assignment edge cases
@@ -673,14 +675,14 @@ extract_assignment_no_space_v2_test() ->
 
 compile_expr_noproc_test() ->
     %% Covers exit:{noproc, _} clause (line 341-342)
-    Result = beamtalk_repl_eval:compile_expression_via_port("1+2", test_mod, #{}),
+    Result = beamtalk_repl_compiler:compile_expression_via_port("1+2", test_mod, #{}),
     ?assertMatch({error, _}, Result).
 
 compile_expr_noproc_with_env_test() ->
     %% compile_expression_via_port calls beamtalk_compiler which isn't started,
     %% so it hits exit:{noproc, _} rather than the timeout path.
     %% This test verifies the function handles a missing compiler gracefully.
-    Result = beamtalk_repl_eval:compile_expression_via_port("hello", test_mod2, #{x => 1}),
+    Result = beamtalk_repl_compiler:compile_expression_via_port("hello", test_mod2, #{x => 1}),
     ?assertMatch({error, _}, Result).
 
 %% ===================================================================
@@ -689,12 +691,12 @@ compile_expr_noproc_with_env_test() ->
 
 compile_file_noproc_test() ->
     %% Covers exit:{noproc, _} clause (line 380-381)
-    Result = beamtalk_repl_eval:compile_file_via_port("x := 1", "/test.bt", false, undefined),
+    Result = beamtalk_repl_compiler:compile_file_via_port("x := 1", "/test.bt", false, undefined),
     ?assertMatch({error, _}, Result).
 
 compile_file_noproc_stdlib_test() ->
     %% Covers stdlib_mode path too
-    Result = beamtalk_repl_eval:compile_file_via_port(
+    Result = beamtalk_repl_compiler:compile_file_via_port(
         "Object subclass: Foo", "/stdlib/src/Foo.bt", true, undefined
     ),
     ?assertMatch({error, _}, Result).
@@ -704,29 +706,29 @@ compile_file_noproc_stdlib_test() ->
 %% ===================================================================
 
 to_snake_case_simple_test() ->
-    ?assertEqual("counter", beamtalk_repl_eval:to_snake_case("counter")).
+    ?assertEqual("counter", beamtalk_repl_loader:to_snake_case("counter")).
 
 to_snake_case_camel_test() ->
-    ?assertEqual("counter", beamtalk_repl_eval:to_snake_case("Counter")).
+    ?assertEqual("counter", beamtalk_repl_loader:to_snake_case("Counter")).
 
 to_snake_case_multi_word_test() ->
-    ?assertEqual("scheme_symbol", beamtalk_repl_eval:to_snake_case("SchemeSymbol")).
+    ?assertEqual("scheme_symbol", beamtalk_repl_loader:to_snake_case("SchemeSymbol")).
 
 to_snake_case_three_words_test() ->
-    ?assertEqual("my_counter_actor", beamtalk_repl_eval:to_snake_case("MyCounterActor")).
+    ?assertEqual("my_counter_actor", beamtalk_repl_loader:to_snake_case("MyCounterActor")).
 
 to_snake_case_acronym_test() ->
     %% Acronyms: no underscores within consecutive uppercase
-    ?assertEqual("httprouter", beamtalk_repl_eval:to_snake_case("HTTPRouter")).
+    ?assertEqual("httprouter", beamtalk_repl_loader:to_snake_case("HTTPRouter")).
 
 to_snake_case_already_snake_test() ->
-    ?assertEqual("already_snake", beamtalk_repl_eval:to_snake_case("already_snake")).
+    ?assertEqual("already_snake", beamtalk_repl_loader:to_snake_case("already_snake")).
 
 to_snake_case_empty_test() ->
-    ?assertEqual([], beamtalk_repl_eval:to_snake_case([])).
+    ?assertEqual([], beamtalk_repl_loader:to_snake_case([])).
 
 to_snake_case_with_digits_test() ->
-    ?assertEqual("app2", beamtalk_repl_eval:to_snake_case("App2")).
+    ?assertEqual("app2", beamtalk_repl_loader:to_snake_case("App2")).
 
 %% ===================================================================
 %% handle_class_definition (BT-627)
@@ -952,23 +954,23 @@ trigger_hot_reload_with_list_name_test() ->
     %% Test the is_list(N) branch in trigger_hot_reload (line 455-457)
     %% Use a class name that doesn't exist as an atom to hit the badarg catch
     Classes = [#{name => "nonexistent_class_xyz_12345"}],
-    ?assertEqual(ok, beamtalk_repl_eval:trigger_hot_reload(some_mod, Classes)).
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_mod, Classes)).
 
 trigger_hot_reload_undefined_name_v2_test() ->
     %% Test the undefined name branch (line 459)
     Classes = [#{name => undefined}],
-    ?assertEqual(ok, beamtalk_repl_eval:trigger_hot_reload(some_mod, Classes)).
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_mod, Classes)).
 
 trigger_hot_reload_no_name_key_v2_test() ->
     %% Test when name key is missing (maps:get returns undefined)
     Classes = [#{}],
-    ?assertEqual(ok, beamtalk_repl_eval:trigger_hot_reload(some_mod, Classes)).
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_mod, Classes)).
 
 trigger_hot_reload_atom_name_v2_test() ->
     %% Test the is_atom(N) branch (line 454)
     %% Use an atom that exists but has no instances
     Classes = [#{name => test_atom_class}],
-    ?assertEqual(ok, beamtalk_repl_eval:trigger_hot_reload(some_mod, Classes)).
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_mod, Classes)).
 
 %% ===================================================================
 %% is_stdlib_path edge cases (BT-627)
@@ -976,14 +978,14 @@ trigger_hot_reload_atom_name_v2_test() ->
 
 is_stdlib_path_abs_v2_test() ->
     ?assertEqual(
-        true, beamtalk_repl_eval:is_stdlib_path("/home/user/project/stdlib/src/Integer.bt")
+        true, beamtalk_repl_loader:is_stdlib_path("/home/user/project/stdlib/src/Integer.bt")
     ).
 
 is_stdlib_path_not_stdlib_test() ->
-    ?assertEqual(false, beamtalk_repl_eval:is_stdlib_path("/home/user/src/main.bt")).
+    ?assertEqual(false, beamtalk_repl_loader:is_stdlib_path("/home/user/src/main.bt")).
 
 is_stdlib_path_rel_lib_v2_test() ->
-    ?assertEqual(true, beamtalk_repl_eval:is_stdlib_path("stdlib/src/String.bt")).
+    ?assertEqual(true, beamtalk_repl_loader:is_stdlib_path("stdlib/src/String.bt")).
 
 %% ===================================================================
 %% should_purge_module edge cases (BT-627)
@@ -1195,7 +1197,7 @@ verify_class_present_undefined_skips_check_test() ->
     %% undefined means no verification needed (e.g., handle_load path)
     ?assertEqual(
         ok,
-        beamtalk_repl_eval:verify_class_present(
+        beamtalk_repl_loader:verify_class_present(
             undefined, [#{name => "Foo"}], "/some/path.bt"
         )
     ).
@@ -1204,14 +1206,14 @@ verify_class_present_found_test() ->
     ClassNames = [#{name => "Counter"}, #{name => "Timer"}],
     ?assertEqual(
         ok,
-        beamtalk_repl_eval:verify_class_present(
+        beamtalk_repl_loader:verify_class_present(
             'Counter', ClassNames, "/some/path.bt"
         )
     ).
 
 verify_class_present_not_found_test() ->
     ClassNames = [#{name => "OtherClass"}],
-    Result = beamtalk_repl_eval:verify_class_present(
+    Result = beamtalk_repl_loader:verify_class_present(
         'Counter', ClassNames, "/some/path.bt"
     ),
     ?assertEqual(
@@ -1220,7 +1222,7 @@ verify_class_present_not_found_test() ->
     ).
 
 verify_class_present_empty_classes_test() ->
-    Result = beamtalk_repl_eval:verify_class_present(
+    Result = beamtalk_repl_loader:verify_class_present(
         'Counter', [], "/some/path.bt"
     ),
     ?assertEqual(

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
@@ -1,0 +1,445 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%%% @doc Unit tests for beamtalk_repl_loader module
+
+-module(beamtalk_repl_loader_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+temp_dir() ->
+    case os:getenv("TMPDIR") of
+        false ->
+            case os:getenv("TEMP") of
+                false -> "/tmp";
+                Dir -> Dir
+            end;
+        Dir ->
+            Dir
+    end.
+
+%%====================================================================
+%% is_stdlib_path/1
+%%====================================================================
+
+is_stdlib_path_relative_test() ->
+    ?assert(beamtalk_repl_loader:is_stdlib_path("stdlib/src/Integer.bt")).
+
+is_stdlib_path_relative_nested_test() ->
+    ?assert(beamtalk_repl_loader:is_stdlib_path("stdlib/src/collections/Array.bt")).
+
+is_stdlib_path_absolute_test() ->
+    ?assert(beamtalk_repl_loader:is_stdlib_path("/workspace/project/stdlib/src/Integer.bt")).
+
+is_stdlib_path_not_stdlib_src_test() ->
+    ?assertNot(beamtalk_repl_loader:is_stdlib_path("src/MyClass.bt")).
+
+is_stdlib_path_absolute_not_stdlib_test() ->
+    ?assertNot(beamtalk_repl_loader:is_stdlib_path("/workspace/project/src/MyClass.bt")).
+
+is_stdlib_path_no_trailing_slash_test() ->
+    ?assertNot(beamtalk_repl_loader:is_stdlib_path("stdlib/src")).
+
+is_stdlib_path_wrong_subdir_test() ->
+    ?assertNot(beamtalk_repl_loader:is_stdlib_path("stdlib/srcs/Integer.bt")).
+
+is_stdlib_path_empty_test() ->
+    ?assertNot(beamtalk_repl_loader:is_stdlib_path("")).
+
+is_stdlib_path_deep_absolute_test() ->
+    ?assert(beamtalk_repl_loader:is_stdlib_path("/home/user/beamtalk/stdlib/src/String.bt")).
+
+%%====================================================================
+%% to_snake_case/1
+%%====================================================================
+
+to_snake_case_empty_test() ->
+    ?assertEqual([], beamtalk_repl_loader:to_snake_case([])).
+
+to_snake_case_lowercase_test() ->
+    ?assertEqual("counter", beamtalk_repl_loader:to_snake_case("counter")).
+
+to_snake_case_uppercase_first_test() ->
+    ?assertEqual("counter", beamtalk_repl_loader:to_snake_case("Counter")).
+
+to_snake_case_two_words_test() ->
+    ?assertEqual("scheme_symbol", beamtalk_repl_loader:to_snake_case("SchemeSymbol")).
+
+to_snake_case_three_words_test() ->
+    ?assertEqual("my_counter_actor", beamtalk_repl_loader:to_snake_case("MyCounterActor")).
+
+to_snake_case_acronym_no_underscore_test() ->
+    %% Consecutive uppercase → no underscore inserted within them
+    ?assertEqual("httprouter", beamtalk_repl_loader:to_snake_case("HTTPRouter")).
+
+to_snake_case_already_snake_test() ->
+    ?assertEqual("already_snake", beamtalk_repl_loader:to_snake_case("already_snake")).
+
+to_snake_case_with_digits_test() ->
+    ?assertEqual("app2", beamtalk_repl_loader:to_snake_case("App2")).
+
+to_snake_case_all_uppercase_test() ->
+    ?assertEqual("abc", beamtalk_repl_loader:to_snake_case("ABC")).
+
+%%====================================================================
+%% verify_class_present/3
+%%====================================================================
+
+verify_class_present_undefined_test() ->
+    ?assertEqual(
+        ok, beamtalk_repl_loader:verify_class_present(undefined, [#{name => "Foo"}], "/path.bt")
+    ).
+
+verify_class_present_found_test() ->
+    Classes = [#{name => "Counter"}, #{name => "Timer"}],
+    ?assertEqual(ok, beamtalk_repl_loader:verify_class_present('Counter', Classes, "/path.bt")).
+
+verify_class_present_not_found_test() ->
+    Classes = [#{name => "OtherClass"}],
+    Result = beamtalk_repl_loader:verify_class_present('Counter', Classes, "/path.bt"),
+    ?assertEqual({error, {class_not_found, 'Counter', "/path.bt", ["OtherClass"]}}, Result).
+
+verify_class_present_empty_list_test() ->
+    Result = beamtalk_repl_loader:verify_class_present('Foo', [], "/path.bt"),
+    ?assertEqual({error, {class_not_found, 'Foo', "/path.bt", []}}, Result).
+
+verify_class_present_multiple_classes_test() ->
+    Classes = [#{name => "A"}, #{name => "B"}, #{name => "C"}],
+    ?assertEqual(ok, beamtalk_repl_loader:verify_class_present('B', Classes, "/path.bt")).
+
+%%====================================================================
+%% normalize_class_source_key/1
+%%====================================================================
+
+normalize_class_source_key_binary_test() ->
+    ?assertEqual(<<"Foo">>, beamtalk_repl_loader:normalize_class_source_key(<<"Foo">>)).
+
+normalize_class_source_key_atom_test() ->
+    ?assertEqual(<<"counter">>, beamtalk_repl_loader:normalize_class_source_key(counter)).
+
+normalize_class_source_key_list_test() ->
+    ?assertEqual(<<"Counter">>, beamtalk_repl_loader:normalize_class_source_key("Counter")).
+
+%%====================================================================
+%% extract_trailing_info/1
+%%====================================================================
+
+extract_trailing_info_no_trailing_test() ->
+    ClassInfo = #{binary => <<"bin">>, module_name => my_mod, classes => []},
+    ?assertEqual(no_trailing, beamtalk_repl_loader:extract_trailing_info(ClassInfo)).
+
+extract_trailing_info_with_trailing_test() ->
+    ClassInfo = #{
+        binary => <<"bin">>,
+        module_name => my_mod,
+        trailing_binary => <<"trail_bin">>,
+        trailing_module_name => trail_mod
+    },
+    Result = beamtalk_repl_loader:extract_trailing_info(ClassInfo),
+    ?assertEqual({trailing, trail_mod, <<"trail_bin">>}, Result).
+
+%%====================================================================
+%% resolve_class_name/1
+%%====================================================================
+
+resolve_class_name_binary_existing_test() ->
+    %% 'lists' is a known atom
+    Result = beamtalk_repl_loader:resolve_class_name(#{name => <<"lists">>}),
+    ?assertEqual(lists, Result).
+
+resolve_class_name_binary_unknown_test() ->
+    Result = beamtalk_repl_loader:resolve_class_name(#{name => <<"xyzzy_nonexistent_class_99991">>}),
+    ?assertEqual(undefined, Result).
+
+resolve_class_name_atom_test() ->
+    Result = beamtalk_repl_loader:resolve_class_name(#{name => lists}),
+    ?assertEqual(lists, Result).
+
+resolve_class_name_list_existing_test() ->
+    Result = beamtalk_repl_loader:resolve_class_name(#{name => "lists"}),
+    ?assertEqual(lists, Result).
+
+resolve_class_name_list_unknown_test() ->
+    Result = beamtalk_repl_loader:resolve_class_name(#{name => "xyzzy_nonexistent_9999"}),
+    ?assertEqual(undefined, Result).
+
+resolve_class_name_no_name_key_test() ->
+    Result = beamtalk_repl_loader:resolve_class_name(#{}),
+    ?assertEqual(undefined, Result).
+
+resolve_class_name_undefined_name_test() ->
+    Result = beamtalk_repl_loader:resolve_class_name(#{name => undefined}),
+    ?assertEqual(undefined, Result).
+
+%%====================================================================
+%% safe_binary_to_atom/1
+%%====================================================================
+
+safe_binary_to_atom_known_test() ->
+    ?assertEqual(lists, beamtalk_repl_loader:safe_binary_to_atom(<<"lists">>)).
+
+safe_binary_to_atom_unknown_test() ->
+    ?assertEqual(
+        undefined, beamtalk_repl_loader:safe_binary_to_atom(<<"xyzzy_nonexistent_atom_111">>)
+    ).
+
+%%====================================================================
+%% safe_list_to_atom/1
+%%====================================================================
+
+safe_list_to_atom_known_test() ->
+    ?assertEqual(lists, beamtalk_repl_loader:safe_list_to_atom("lists")).
+
+safe_list_to_atom_unknown_test() ->
+    ?assertEqual(undefined, beamtalk_repl_loader:safe_list_to_atom("xyzzy_nonexistent_atom_222")).
+
+%%====================================================================
+%% safe_atom_result/1
+%%====================================================================
+
+safe_atom_result_ok_test() ->
+    ?assertEqual({true, lists}, beamtalk_repl_loader:safe_atom_result({ok, lists})).
+
+safe_atom_result_error_test() ->
+    ?assertEqual(false, beamtalk_repl_loader:safe_atom_result({error, badarg})).
+
+%%====================================================================
+%% register_classes/2
+%%====================================================================
+
+register_classes_no_function_exported_test() ->
+    %% lists module has no register_class/0 → ok
+    ?assertEqual(ok, beamtalk_repl_loader:register_classes([], lists)).
+
+register_classes_empty_classes_test() ->
+    ?assertEqual(ok, beamtalk_repl_loader:register_classes([], some_nonexistent_module)).
+
+%%====================================================================
+%% trigger_hot_reload/2
+%%====================================================================
+
+trigger_hot_reload_empty_test() ->
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, [])).
+
+trigger_hot_reload_unknown_class_binary_test() ->
+    Classes = [#{name => <<"xyzzy_nonexistent_class_88881">>}],
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
+
+trigger_hot_reload_unknown_class_list_test() ->
+    Classes = [#{name => "xyzzy_nonexistent_class_88882"}],
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
+
+trigger_hot_reload_unknown_class_atom_test() ->
+    Classes = [#{name => xyzzy_nonexistent_class_88883}],
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
+
+trigger_hot_reload_undefined_name_test() ->
+    Classes = [#{name => undefined}],
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
+
+trigger_hot_reload_no_name_key_test() ->
+    Classes = [#{}],
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
+
+trigger_hot_reload_multiple_classes_test() ->
+    Classes = [
+        #{name => <<"xyzzy_class_a_1">>},
+        #{name => "xyzzy_class_b_1"},
+        #{}
+    ],
+    ?assertEqual(ok, beamtalk_repl_loader:trigger_hot_reload(some_module, Classes)).
+
+%%====================================================================
+%% activate_module/2
+%%====================================================================
+
+activate_module_existing_module_test() ->
+    %% lists has no register_class/0, no hot reload needed — should complete ok
+    ?assertEqual(ok, beamtalk_repl_loader:activate_module(lists, [])).
+
+%%====================================================================
+%% handle_load/2 — error paths
+%%====================================================================
+
+handle_load_not_found_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    ?assertMatch(
+        {error, {file_not_found, _}, _},
+        beamtalk_repl_loader:handle_load("/nonexistent/x.bt", State)
+    ).
+
+handle_load_directory_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    ?assertMatch({error, {read_error, _}, _}, beamtalk_repl_loader:handle_load(temp_dir(), State)).
+
+handle_load_compile_error_test() ->
+    UniqueId = erlang:unique_integer([positive]),
+    TempFile = filename:join(temp_dir(), io_lib:format("loader_test_~p.bt", [UniqueId])),
+    ok = file:write_file(TempFile, <<"invalid syntax @@@">>),
+    State = beamtalk_repl_state:new(undefined, 0),
+    Result = beamtalk_repl_loader:handle_load(TempFile, State),
+    file:delete(TempFile),
+    ?assertMatch({error, {compile_error, _}, _}, Result).
+
+%%====================================================================
+%% reload_class_file/1,2 — error paths
+%%====================================================================
+
+reload_class_file_not_found_test() ->
+    ?assertEqual(
+        {error, {file_not_found, "/nonexistent/x.bt"}},
+        beamtalk_repl_loader:reload_class_file("/nonexistent/x.bt")
+    ).
+
+reload_class_file_2_not_found_test() ->
+    ?assertEqual(
+        {error, {file_not_found, "/nonexistent/x.bt"}},
+        beamtalk_repl_loader:reload_class_file("/nonexistent/x.bt", 'MyClass')
+    ).
+
+reload_class_file_directory_test() ->
+    ?assertMatch({error, {read_error, _}}, beamtalk_repl_loader:reload_class_file(temp_dir())).
+
+reload_class_file_compile_error_test() ->
+    UniqueId = erlang:unique_integer([positive]),
+    TempFile = filename:join(temp_dir(), io_lib:format("loader_reload_~p.bt", [UniqueId])),
+    ok = file:write_file(TempFile, <<"invalid @@@ syntax">>),
+    Result = beamtalk_repl_loader:reload_class_file(TempFile),
+    file:delete(TempFile),
+    ?assertMatch({error, _}, Result).
+
+%%====================================================================
+%% compute_package_module_name/1
+%%====================================================================
+
+compute_package_module_name_no_metadata_test() ->
+    %% Without workspace_meta started, returns undefined
+    Result = beamtalk_repl_loader:compute_package_module_name("/some/path/src/Foo.bt"),
+    ?assertEqual(undefined, Result).
+
+%%====================================================================
+%% resolve_package_module/3
+%%====================================================================
+
+resolve_package_module_src_match_test() ->
+    %% File under ProjectRoot/src → bt@pkg@module
+    %% Use file:get_cwd() as the root so paths are drive-letter-consistent on Windows.
+    {ok, Cwd} = file:get_cwd(),
+    ProjectRoot = filename:join(Cwd, "myproject"),
+    AbsPath = filename:join([ProjectRoot, "src", "Counter.bt"]),
+    Result = beamtalk_repl_loader:resolve_package_module(AbsPath, ProjectRoot, <<"mypkg">>),
+    ?assertEqual(<<"bt@mypkg@counter">>, Result).
+
+resolve_package_module_test_match_test() ->
+    {ok, Cwd} = file:get_cwd(),
+    ProjectRoot = filename:join(Cwd, "myproject"),
+    AbsPath = filename:join([ProjectRoot, "test", "CounterTest.bt"]),
+    Result = beamtalk_repl_loader:resolve_package_module(AbsPath, ProjectRoot, <<"mypkg">>),
+    ?assertEqual(<<"bt@mypkg@test@counter_test">>, Result).
+
+resolve_package_module_no_match_test() ->
+    {ok, Cwd} = file:get_cwd(),
+    ProjectRoot = filename:join(Cwd, "myproject"),
+    AbsPath = filename:join([Cwd, "other", "project", "Foo.bt"]),
+    Result = beamtalk_repl_loader:resolve_package_module(AbsPath, ProjectRoot, <<"pkg">>),
+    ?assertEqual(undefined, Result).
+
+%%====================================================================
+%% try_package_relative/3
+%%====================================================================
+
+try_package_relative_match_test() ->
+    {ok, Cwd} = file:get_cwd(),
+    ProjectRoot = filename:join(Cwd, "project"),
+    AbsPath = filename:join([ProjectRoot, "src", "collections", "Array.bt"]),
+    Result = beamtalk_repl_loader:try_package_relative(AbsPath, ProjectRoot, "src"),
+    ?assertMatch({ok, _}, Result),
+    {ok, Parts} = Result,
+    ?assertEqual(iolist_to_binary(Parts), <<"collections@array">>).
+
+try_package_relative_no_match_test() ->
+    {ok, Cwd} = file:get_cwd(),
+    ProjectRoot = filename:join(Cwd, "project"),
+    AbsPath = filename:join([Cwd, "other", "src", "Foo.bt"]),
+    Result = beamtalk_repl_loader:try_package_relative(AbsPath, ProjectRoot, "src"),
+    ?assertEqual(undefined, Result).
+
+try_package_relative_simple_file_test() ->
+    {ok, Cwd} = file:get_cwd(),
+    ProjectRoot = filename:join(Cwd, "project"),
+    AbsPath = filename:join([ProjectRoot, "src", "MyClass.bt"]),
+    Result = beamtalk_repl_loader:try_package_relative(AbsPath, ProjectRoot, "src"),
+    ?assertMatch({ok, _}, Result),
+    {ok, Parts} = Result,
+    ?assertEqual(iolist_to_binary(Parts), <<"my_class">>).
+
+%%====================================================================
+%% maybe_add_loaded_module/2
+%%====================================================================
+
+maybe_add_loaded_module_not_present_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    NewState = beamtalk_repl_loader:maybe_add_loaded_module(lists, State),
+    ?assert(lists:member(lists, beamtalk_repl_state:get_loaded_modules(NewState))).
+
+maybe_add_loaded_module_already_present_test() ->
+    State0 = beamtalk_repl_state:new(undefined, 0),
+    State1 = beamtalk_repl_loader:maybe_add_loaded_module(lists, State0),
+    State2 = beamtalk_repl_loader:maybe_add_loaded_module(lists, State1),
+    %% Should appear exactly once
+    Modules = beamtalk_repl_state:get_loaded_modules(State2),
+    ?assertEqual(1, length([M || M <- Modules, M =:= lists])).
+
+%%====================================================================
+%% store_file_class_sources/3
+%%====================================================================
+
+store_file_class_sources_single_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    Classes = [#{name => "MyClass", superclass => "Object"}],
+    NewState = beamtalk_repl_loader:store_file_class_sources(
+        Classes, "Object subclass: MyClass [\n]\n", State
+    ),
+    ?assertNotEqual(undefined, beamtalk_repl_state:get_class_source(<<"MyClass">>, NewState)).
+
+store_file_class_sources_multiple_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    Classes = [#{name => "A", superclass => "Object"}, #{name => "B", superclass => "Object"}],
+    NewState = beamtalk_repl_loader:store_file_class_sources(Classes, "source", State),
+    ?assertNotEqual(undefined, beamtalk_repl_state:get_class_source(<<"A">>, NewState)),
+    ?assertNotEqual(undefined, beamtalk_repl_state:get_class_source(<<"B">>, NewState)).
+
+store_file_class_sources_empty_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    NewState = beamtalk_repl_loader:store_file_class_sources([], "source", State),
+    ?assertEqual(State, NewState).
+
+%%====================================================================
+%% store_class_sources/4
+%%====================================================================
+
+store_class_sources_empty_classes_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    {Name, NewState} = beamtalk_repl_loader:store_class_sources([], my_fallback_mod, "expr", State),
+    %% Falls back to module name as class name
+    ?assertEqual(<<"my_fallback_mod">>, Name),
+    ?assertNotEqual(
+        undefined, beamtalk_repl_state:get_class_source(<<"my_fallback_mod">>, NewState)
+    ).
+
+store_class_sources_with_classes_binary_name_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    Classes = [#{name => <<"Counter">>, superclass => <<"Object">>}],
+    {Name, NewState} = beamtalk_repl_loader:store_class_sources(Classes, some_mod, "expr", State),
+    ?assertEqual(<<"Counter">>, Name),
+    ?assertNotEqual(undefined, beamtalk_repl_state:get_class_source(<<"Counter">>, NewState)).
+
+store_class_sources_with_classes_list_name_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    Classes = [#{name => "MyActor", superclass => "Actor"}],
+    {Name, NewState} = beamtalk_repl_loader:store_class_sources(Classes, some_mod, "expr", State),
+    ?assertEqual(<<"MyActor">>, Name),
+    ?assertNotEqual(undefined, beamtalk_repl_state:get_class_source(<<"MyActor">>, NewState)).


### PR DESCRIPTION
## Summary
- Removes test-only backward-compat delegate functions from `beamtalk_repl_eval` that were left by the BT-863 refactor
- Creates dedicated test files for `beamtalk_repl_compiler` (~36 tests) and `beamtalk_repl_loader` (~60 tests) to restore coverage lost when BT-863 split the eval module into three
- Fixes `class_not_found` → `does_not_understand` error conversion in `beamtalk_workspace_interface` for unit test environments without full runtime hierarchy

## Test plan
- [x] All 1004 eunit tests pass
- [x] erlfmt clean
- [x] Dialyzer passes
- [x] Pre-push lint hooks pass (Rust, Erlang, JS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit test suites covering compilation, loading, evaluation, error handling, hot-reload, path/package resolution, formatting, and many edge cases to improve reliability.

* **Refactor**
  * Rebalanced responsibilities between runtime components and exposed additional test-only entry points in test builds to simplify testing and verify internal flows more directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->