### PR TITLE
Bug: fix class references to subdirectory-loaded classes

### DIFF
--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -187,6 +187,8 @@ do_compile(Port, Source, Options) ->
     SourcePath = maps:get(source_path, Options, undefined),
     %% BT-905: Optional class superclass index for cross-file value-object inheritance
     ClassSuperclassIndex = maps:get(class_superclass_index, Options, #{}),
+    %% Optional class module index for correct cross-directory module names
+    ClassModuleIndex = maps:get(class_module_index, Options, #{}),
     Request0 = #{
         command => compile,
         source => Source,
@@ -203,10 +205,15 @@ do_compile(Port, Source, Options) ->
             undefined -> Request1;
             _ -> Request1#{source_path => SourcePath}
         end,
-    Request =
+    Request3 =
         case map_size(ClassSuperclassIndex) of
             0 -> Request2;
             _ -> Request2#{class_superclass_index => ClassSuperclassIndex}
+        end,
+    Request =
+        case map_size(ClassModuleIndex) of
+            0 -> Request3;
+            _ -> Request3#{class_module_index => ClassModuleIndex}
         end,
     RequestBin = term_to_binary(Request),
     try port_command(Port, RequestBin) of

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -438,10 +438,17 @@ recompile_with_method(ClassSource, ClassNameBin, SelectorBin, Expression, Warnin
     %% BT-907: Include superclass index so cross-file inheritance resolves correctly.
     SuperclassIndex = beamtalk_repl_compiler:build_class_superclass_index(),
     Options0 = #{stdlib_mode => false, workspace_mode => true},
-    Options =
+    Options1 =
         case map_size(SuperclassIndex) of
             0 -> Options0;
             _ -> Options0#{class_superclass_index => SuperclassIndex}
+        end,
+    %% Include module index for correct cross-directory class references.
+    ModuleIndex = beamtalk_repl_compiler:build_class_module_index(),
+    Options =
+        case map_size(ModuleIndex) of
+            0 -> Options1;
+            _ -> Options1#{class_module_index => ModuleIndex}
         end,
     case beamtalk_repl_compiler:compile_for_method_reload(SourceBin, Options) of
         {ok, Binary, ModName, Classes, RecompileWarnings} ->

--- a/tests/e2e/cases/load_nested_directory.bt
+++ b/tests/e2e/cases/load_nested_directory.bt
@@ -1,0 +1,52 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression test: :load with files in subdirectories generates correct module names.
+//
+// Before the fix, actor classes in subdirectories (e.g. workers/task_worker.bt)
+// had their path component stripped by user_package_prefix in the Rust compiler.
+// The compiler generated spawn calls to bt@...@task_worker:spawn/0, but the
+// loaded BEAM module was registered as bt@...@workers@task_worker — so spawn
+// failed with {undef, bt@...@task_worker:spawn/0}.
+//
+// The fix: build_class_module_index/0 queries all registered class gen-servers
+// for their actual module names and passes the full class→module map to the
+// compiler, so references use the correct name (bt@...@workers@task_worker).
+
+// ===========================================================================
+// :load <directory with subdirectory>
+// ===========================================================================
+
+// Load a directory containing tag.bt (root) and workers/task_worker.bt (subdir)
+:load tests/e2e/fixtures/nested_dir/
+// => Loaded 2 files from tests/e2e/fixtures/nested_dir/
+
+// ===========================================================================
+// ROOT-LEVEL CLASS — VALUE TYPE WORKS AS BEFORE
+// ===========================================================================
+
+t := Tag new
+// => _
+
+t id
+// => 42
+
+// ===========================================================================
+// SUBDIRECTORY ACTOR CLASS — SPAWN WORKS (regression for subdir module naming)
+// ===========================================================================
+
+// Before the fix: Error: undef — spawn/0 called wrong module name
+w := TaskWorker spawn
+// => #Actor<TaskWorker,_>
+
+w getCount
+// => 0
+
+w increment
+// => 1
+
+w getCount
+// => 1
+
+w stop
+// => ok

--- a/tests/e2e/fixtures/nested_dir/tag.bt
+++ b/tests/e2e/fixtures/nested_dir/tag.bt
@@ -1,0 +1,11 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Tag - value type at the root level of a nested fixture directory.
+// Used by load_nested_directory.bt to verify that root-level classes still
+// load correctly when a directory also contains subdirectory files.
+
+Object subclass: Tag
+  state: id = 42
+
+  id => self.id

--- a/tests/e2e/fixtures/nested_dir/workers/task_worker.bt
+++ b/tests/e2e/fixtures/nested_dir/workers/task_worker.bt
@@ -1,0 +1,13 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// TaskWorker - actor in a subdirectory of a nested fixture directory.
+// Used by load_nested_directory.bt to regression-test that actors loaded
+// from subdirectories generate the correct BEAM module name so that
+// spawn/0 resolves correctly (bt@...@workers@task_worker, not bt@...@task_worker).
+
+Actor subclass: TaskWorker
+  state: count = 0
+
+  increment => self.count := self.count + 1
+  getCount => self.count


### PR DESCRIPTION
## Summary

- Classes loaded from subdirectories (e.g. `src/singleton/app_logger.bt`) had the subdirectory path stripped when referenced by other files — `bt@pkg@singleton@app_logger` was resolved as `bt@pkg@app_logger`, causing `undef` on `spawn` and method calls
- Root cause: Rust compiler's `user_package_prefix` only kept the top-level package segment, discarding subdirectory components
- Fix: build `class_module_index` (class name → full module name) from registered class gen-servers and pass it through all three REPL compilation paths (file, expression, method reload)
- The Rust compiler's `compiled_module_name` already checks this index before falling back to `user_package_prefix` — the index just was never populated from the Erlang side

## Test plan

- [x] New E2E regression test: `load_nested_directory.bt` — loads directory with actor in `workers/` subdirectory, spawns it, sends messages
- [x] All existing tests pass (`just test`, `just test-stdlib`, `just test-e2e`)
- [x] Dialyzer and erlfmt pass
- [ ] Manual verification: load a workspace project with subdirectory classes and confirm cross-file references resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced module name resolution for classes in subdirectories, ensuring correct actor spawning from nested locations.

* **Improvements**
  * Compiler now maintains a complete class-to-module mapping, fixing issues with module path resolution for nested classes.

* **Tests**
  * Added regression tests for nested directory class loading and actor instantiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->