### PR TITLE
Tests: self.slot := in actor methods (BT-916)

### DIFF
--- a/stdlib/test/actor_slot_test.bt
+++ b/stdlib/test/actor_slot_test.bt
@@ -1,0 +1,133 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-916: Tests for self.slot := assignment in actor methods.
+// Verifies that state is correctly threaded through:
+//   - multiple slot assignments in one method
+//   - slot assignment inside ifTrue:ifFalse: conditional
+//   - slot assignment inside block (do:, collect:)
+//   - slot assignment with early return (^)
+//
+// Compile-time checks (value type error, withSlot: bypass warning) are
+// validated by Rust unit tests in semantic_analysis/validators.rs (BT-914)
+// and by the E2E @load-error test in tests/e2e/cases/actor_slot.bt.
+
+
+TestCase subclass: ActorSlotTest
+
+  testMultipleSlotAssignmentsInOneMethod =>
+    // Both count and total are updated and persist correctly
+    c := ActorSlotCounter spawn.
+    result := (c incrementBoth: 10) await.
+    self assert: result equals: #{#count => 1, #total => 10}.
+    result2 := (c incrementBoth: 5) await.
+    self assert: result2 equals: #{#count => 2, #total => 15}
+
+  testMultipleAssignmentsToSameSlot =>
+    // Three sequential assignments to the same slot accumulate correctly
+    c := ActorSlotCounter spawn.
+    self assert: ((c addThrice: 3) await) equals: 9.
+    self assert: ((c addThrice: 1) await) equals: 12
+
+  testSlotAssignmentInsideConditional =>
+    // Slot assignment inside ifTrue: is applied when condition is true
+    c := ConditionalMutationCounter spawn.
+    self assert: ((c conditionalIncrement: true) await) equals: 1.
+    self assert: ((c conditionalIncrement: true) await) equals: 2.
+    // Slot assignment is NOT applied when condition is false
+    self assert: ((c conditionalIncrement: false) await) equals: 2
+
+  testSlotAssignmentInsideIfTrueIfFalse =>
+    // Both branches of ifTrue:ifFalse: correctly thread state
+    c := ConditionalMutationCounter spawn.
+    self assert: ((c conditionalToggle: true) await) equals: 10.
+    (c reset) await.
+    self assert: ((c conditionalToggle: false) await) equals: -1
+
+  testSlotAssignmentInsideDoBlock =>
+    // do: with self.slot := accumulates correctly
+    c := ActorSlotCounter spawn.
+    self assert: ((c sumItems: #(1, 2, 3, 4, 5)) await) equals: 15.
+    // State persists after the method completes
+    self assert: (c getTotal await) equals: 15
+
+  testSlotAssignmentInsideDoBlockTwoSlots =>
+    // do: with mutations to two different slots both thread correctly
+    c := ActorSlotCounter spawn.
+    result := (c countAndSum: #(10, 20, 30)) await.
+    self assert: result equals: #{#count => 3, #total => 60}.
+    self assert: (c getCount await) equals: 3.
+    self assert: (c getTotal await) equals: 60
+
+  testSlotAssignmentInsideCollectBlock =>
+    // collect: with self.slot := in block: result is correct and state is updated
+    c := ActorSlotCounter spawn.
+    result := (c collectDoubled: #(1, 2, 3)) await.
+    self assert: result equals: #(2, 4, 6).
+    // count was incremented once per element
+    self assert: (c getCount await) equals: 3
+
+  testSlotAssignmentWithEarlyReturn =>
+    // Slot assignment before ifTrue:[^value] preserves the updated state
+    c := ActorSlotCounter spawn.
+    // count=0+1=1 >= 1, so early return fires
+    result := (c addAndCheckLimit: 1) await.
+    self assert: result equals: #reached.
+    self assert: (c getCount await) equals: 1
+
+  testSlotAssignmentWithEarlyReturnNotFired =>
+    // When the limit is not reached, normal path runs and state is still updated
+    c := ActorSlotCounter spawn.
+    // count=0+1=1 < 5, so early return does NOT fire
+    result := (c addAndCheckLimit: 5) await.
+    self assert: result equals: #not_yet.
+    self assert: (c getCount await) equals: 1.
+    // count=1+1=2 < 5, still not reached
+    result2 := (c addAndCheckLimit: 5) await.
+    self assert: result2 equals: #not_yet.
+    self assert: (c getCount await) equals: 2.
+    // count=2+1=3 < 5, still not reached
+    result3 := (c addAndCheckLimit: 5) await.
+    self assert: result3 equals: #not_yet.
+    self assert: (c getCount await) equals: 3.
+    // count=3+1=4 < 5, still not reached
+    result4 := (c addAndCheckLimit: 5) await.
+    self assert: result4 equals: #not_yet.
+    self assert: (c getCount await) equals: 4.
+    // count=4+1=5 >= 5, early return fires
+    result5 := (c addAndCheckLimit: 5) await.
+    self assert: result5 equals: #reached.
+    self assert: (c getCount await) equals: 5
+
+  testSlotAssignmentBeforeEarlyReturnValue =>
+    // total is incremented before the ^ so the returned value reflects the new state
+    c := ActorSlotCounter spawn.
+    // total=0+1=1 > 0, so returns total=1
+    result := (c addAndReturnIfAbove: 0) await.
+    self assert: result equals: 1.
+    self assert: (c getTotal await) equals: 1
+
+  testSlotAssignmentBeforeEarlyReturnFallthrough =>
+    // When threshold not exceeded, falls through to -1 but state is still updated
+    c := ActorSlotCounter spawn.
+    // total=0+1=1, 1 > 100? No, returns -1
+    result := (c addAndReturnIfAbove: 100) await.
+    self assert: result equals: -1.
+    self assert: (c getTotal await) equals: 1
+
+  testStatePersistedAcrossMultipleCalls =>
+    // State accumulates correctly across independent method calls
+    c := ActorSlotCounter spawn.
+    (c incrementBoth: 10) await.
+    (c incrementBoth: 20) await.
+    (c incrementBoth: 30) await.
+    self assert: (c getCount await) equals: 3.
+    self assert: (c getTotal await) equals: 60
+
+  testResetClearsBothSlots =>
+    // reset clears both slots back to 0
+    c := ActorSlotCounter spawn.
+    (c incrementBoth: 42) await.
+    (c reset) await.
+    self assert: (c getCount await) equals: 0.
+    self assert: (c getTotal await) equals: 0

--- a/stdlib/test/fixtures/actor_slot_fixture.bt
+++ b/stdlib/test/fixtures/actor_slot_fixture.bt
@@ -1,0 +1,64 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-916: Actor fixture for testing self.slot := assignment patterns.
+// Covers: multiple slots, do: blocks, collect: blocks, and early return (^).
+
+Actor subclass: ActorSlotCounter
+  state: count = 0
+  state: total = 0
+
+  getCount => self.count
+
+  getTotal => self.total
+
+  // Multiple slot assignments in one method
+  incrementBoth: n =>
+    self.count := self.count + 1.
+    self.total := self.total + n.
+    #{#count => self.count, #total => self.total}
+
+  // Multiple sequential assignments to same slot
+  addThrice: n =>
+    self.count := self.count + n.
+    self.count := self.count + n.
+    self.count := self.count + n.
+    self.count
+
+  // Slot assignment inside do: block
+  sumItems: items =>
+    items do: [:item | self.total := self.total + item].
+    self.total
+
+  // Slot assignment inside do: block with two slot mutations per iteration
+  countAndSum: items =>
+    items do: [:item |
+      self.count := self.count + 1.
+      self.total := self.total + item
+    ].
+    #{#count => self.count, #total => self.total}
+
+  // Slot assignment inside collect: block (count tracks each element processed)
+  collectDoubled: items =>
+    result := items collect: [:item |
+      self.count := self.count + 1.
+      item * 2
+    ].
+    result
+
+  // Slot assignment then early return (^) from method body via ifTrue:
+  // Pattern: mutate slot, check condition, return early if met
+  addAndCheckLimit: limit =>
+    self.count := self.count + 1.
+    self.count >= limit ifTrue: [^#reached].
+    #not_yet
+
+  // Slot assignment before an early return with a computed value
+  addAndReturnIfAbove: threshold =>
+    self.total := self.total + 1.
+    self.total > threshold ifTrue: [^self.total].
+    -1
+
+  reset =>
+    self.count := 0.
+    self.total := 0

--- a/tests/e2e/cases/actor_slot.bt
+++ b/tests/e2e/cases/actor_slot.bt
@@ -1,0 +1,88 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E tests for self.slot := assignment in actor methods (BT-916).
+//
+// These tests require E2E because:
+// - The @load-error directive (for compile-time error checking) is a REPL
+//   testing feature — BUnit tests execute already-compiled code and cannot
+//   trigger compile-time errors on new source files.
+// - REPL interaction tests (spawn, send, await) verify the full lifecycle
+//   including actor creation and stateful message dispatch.
+//
+// Compile-time warning for withSlot: bypass is covered by Rust unit tests
+// in semantic_analysis/validators.rs (BT-914) since compiler warnings are
+// not currently surfaced through the REPL load response.
+
+// ===========================================================================
+// VALUE TYPE: self.slot := IS A COMPILE ERROR
+// ===========================================================================
+
+// Loading a value type with self.slot := produces a clear compile error
+// @load-error tests/e2e/fixtures/actor_slot_value_error.bt => Cannot assign to slot
+
+// ===========================================================================
+// ACTOR SLOT ASSIGNMENT — REPL INTERACTION
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Basic slot assignment and retrieval
+// ---------------------------------------------------------------------------
+
+// @load tests/e2e/fixtures/counter.bt
+
+c := Counter spawn
+// => #Actor<Counter,_>
+
+c increment
+// => 1
+
+c increment
+// => 2
+
+c getValue
+// => 2
+
+// ---------------------------------------------------------------------------
+// Slot assignment persists across multiple messages
+// ---------------------------------------------------------------------------
+
+c2 := Counter spawn
+// => #Actor<Counter,_>
+
+c2 increment
+// => 1
+
+c2 increment
+// => 2
+
+c2 increment
+// => 3
+
+c2 getValue
+// => 3
+
+// ---------------------------------------------------------------------------
+// Each actor has independent state
+// ---------------------------------------------------------------------------
+
+a1 := Counter spawn
+// => #Actor<Counter,_>
+
+a2 := Counter spawn
+// => #Actor<Counter,_>
+
+a1 increment
+// => 1
+
+a1 increment
+// => 2
+
+a2 increment
+// => 1
+
+a1 getValue
+// => 2
+
+a2 getValue
+// => 1

--- a/tests/e2e/fixtures/actor_slot_value_error.bt
+++ b/tests/e2e/fixtures/actor_slot_value_error.bt
@@ -1,0 +1,13 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-916: Fixture that triggers a semantic compile error:
+// self.slot := inside a value type (Value subclass) method is not allowed.
+
+Value subclass: ImmutablePoint
+  state: x = 0
+  state: y = 0
+
+  // This should be a compile error: value types are immutable
+  badSetX: newX =>
+    self.x := newX


### PR DESCRIPTION
## Summary

Adds comprehensive BUnit and E2E tests for `self.slot :=` assignment in actor methods, completing Stage 1 Issue 3 of the ADR 0042 (Immutable Value Objects) epic.

- **13 BUnit tests** covering: multiple slot assignments in one method, conditional slot assignment (ifTrue:/ifFalse:), slot assignment inside do:/collect: blocks, and slot assignment with early return (^)
- **E2E test** verifying REPL interaction with actor slot assignment and `@load-error` for value type compile error
- **New fixtures**: `ActorSlotCounter` (actor with two slots) and `ImmutablePoint` (value type triggering compile error)

## Key Changes

- `stdlib/test/actor_slot_test.bt` — new BUnit test file (13 tests)
- `stdlib/test/fixtures/actor_slot_fixture.bt` — actor fixture with multiple slot assignment patterns
- `tests/e2e/cases/actor_slot.bt` — E2E test for REPL interaction + value type compile error
- `tests/e2e/fixtures/actor_slot_value_error.bt` — value type fixture triggering semantic error

## Notes

- Compiler warning for `withSlot:` bypass (acceptance criterion 6) is covered by Rust unit tests in `semantic_analysis/validators.rs` (BT-914). Compiler warnings are not currently surfaced through the REPL load response, so E2E testing of this warning is not possible.

Linear: https://linear.app/beamtalk/issue/BT-916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for actor slot assignment behavior across various control flows and state persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->