### PR TITLE
Language Feature: classState declaration and codegen for Actor subclasses (BT-927)

### DIFF
--- a/stdlib/test/class_state_test.bt
+++ b/stdlib/test/class_state_test.bt
@@ -41,8 +41,10 @@ TestCase subclass: ClassStateTest
     self assert: ClassStateActor label equals: "hello"
 
   testClassStateIsolatedFromInstanceState =>
-    // Class state does not depend on actor instances being spawned.
+    // Mutating instance state on a spawned actor does not affect class state.
     ClassStateActor counter: 55.
+    actor := ClassStateActor spawn.
+    actor increment.
     self assert: ClassStateActor counter equals: 55
 
   testResetRestoresDefaultValues =>

--- a/stdlib/test/fixtures/class_state_actor.bt
+++ b/stdlib/test/fixtures/class_state_actor.bt
@@ -4,11 +4,13 @@
 // BT-927: Test fixture for classState declaration and codegen.
 //
 // Provides an Actor subclass with classState variables for round-trip testing.
-// Tests: initial value, setter, getter, multiple independent class variables.
+// Tests: initial value, setter, getter, multiple independent class variables,
+// and independence from instance-level state mutations.
 
 Actor subclass: ClassStateActor
   classState: counter = 0
   classState: label = "unset"
+  state: value = 0
 
   /// Return the class-level counter value.
   class counter => self.counter
@@ -21,6 +23,9 @@ Actor subclass: ClassStateActor
 
   /// Set the class-level label.
   class label: s => self.label := s
+
+  /// Increment the instance-level value (independent from class state).
+  increment => self.value := self.value + 1
 
   /// Reset all class state to defaults.
   class reset =>


### PR DESCRIPTION
## Summary

- Add `ClassStateActor` fixture (`stdlib/test/fixtures/class_state_actor.bt`): an `Actor` subclass with two `classState:` variables (`counter = 0`, `label = "unset"`) and class-side getter/setter/reset methods
- Add `ClassStateTest` BUnit test (`stdlib/test/class_state_test.bt`): 6 tests verifying classState read/write round-trip

Closes https://linear.app/beamtalk/issue/BT-927

## What this verifies

The `classState:` declaration, codegen (ClassVars threading, field access/assignment via `maps:get`/`maps:put`, `{class_var_result,...}` tuple protocol), and runtime dispatch (`beamtalk_class_dispatch`, `beamtalk_object_class` gen_server) already existed and were used by the three stdlib singletons. This PR adds explicit BUnit test coverage for the full lifecycle:

- Default value initialization at class registration time
- Getter/setter round-trip
- Setter overwrite semantics
- Multiple independent classState variables
- Isolation from instance state
- Reset restoring declared defaults

## Test plan

- [x] `just test` — 576 tests, 576 passed (6 new tests)
- [x] `just build && just clippy && just fmt-check` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for class-level state management covering initialization, persistence across calls, isolation from instance state, reset behavior, and multi-variable interactions.
  * Included a test fixture to exercise class-side getters/setters, resets, and cross-variable scenarios to ensure correct round-trip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->