### PR TITLE
fix: REPL instance-method completions for bound variables

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/client.rs
+++ b/crates/beamtalk-cli/src/commands/repl/client.rs
@@ -95,6 +95,11 @@ impl ReplClient {
         }
     }
 
+    /// Returns the session ID assigned by the server, if known.
+    pub(crate) fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
+    }
+
     /// Send an eval request and receive the response.
     #[allow(dead_code)] // Used in non-interruptible mode or tests
     pub(crate) fn eval(&mut self, expression: &str) -> Result<ReplResponse> {

--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -693,7 +693,7 @@ pub(crate) fn repl_loop(
     let config = Config::builder()
         .completion_type(CompletionType::List)
         .build();
-    let helper = ReplHelper::new(host, port, cookie);
+    let helper = ReplHelper::new(host, port, cookie, client.session_id());
     let mut rl: Editor<ReplHelper, FileHistory> = Editor::with_config(config).into_diagnostic()?;
     rl.set_helper(Some(helper));
 
@@ -976,6 +976,10 @@ pub(crate) fn repl_loop(
                                     );
                                 } else {
                                     eprintln!("Reconnected (new session). Retrying evaluation...");
+                                }
+                                // Keep the completion helper's session ID in sync
+                                if let Some(h) = rl.helper() {
+                                    h.update_session_id(client.session_id());
                                 }
                                 // Reset interrupt flag for the retry attempt
                                 interrupted.store(false, Ordering::SeqCst);


### PR DESCRIPTION
## Summary

- REPL tab completion now works for instance methods on bound actor variables (e.g. `c := CommandHistory spawn` then `c b<TAB>` completes `buffer`)
- Root cause: the completion helper uses a separate WebSocket with its own empty session, so binding lookups always returned nothing
- Fix threads the main REPL session ID through to the completion request, and the Erlang handler resolves bindings from that session via the `beamtalk_sessions` ETS table

## Key Changes

- `client.rs`: Expose `session_id()` accessor on `ReplClient`
- `helper.rs`: Store main session ID, include in completion requests
- `mod.rs`: Pass session ID at construction and update on reconnect
- `beamtalk_repl_ops_dev.erl`: Add `resolve_binding_session/2` to look up the correct session's bindings

## Test plan

- [x] All 1279 Rust tests pass
- [x] All 589 BUnit tests pass
- [x] All 2201 Erlang runtime tests pass
- [x] Clippy clean, erlfmt clean
- [ ] Manual: start REPL, `c := CommandHistory spawn`, then `c b<TAB>` should show `buffer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * REPL completions are now context-aware, providing smarter suggestions based on the active session and bound actor variables.
  * Session identifiers are tracked and synchronized with the completion engine for enhanced accuracy.
  * Session context is automatically maintained during reconnections, ensuring consistent completion suggestions throughout your REPL workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->