### PR TITLE
fix: prevent calling_self on module_name/class_name during class method dispatch

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -298,7 +298,9 @@ find_class_method_in_ancestors(Selector, AncestorName, Depth) ->
                 true ->
                     AncestorModule =
                         try
-                            gen_server:call(AncestorPid, module_name, 5000)
+                            %% BT-893: Use module_name/1 (not gen_server:call directly) so
+                            %% the self-call guard fires if AncestorPid happens to be self().
+                            beamtalk_object_class:module_name(AncestorPid)
                         catch
                             Class2:Reason2 ->
                                 ?LOG_WARNING(

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -152,12 +152,22 @@ superclass(ClassPid) ->
     gen_server:call(ClassPid, superclass).
 
 %% @doc Get the class name.
+%%
+%% BT-893: If called from within the class gen_server itself (self-call), read
+%% from the process dictionary instead of gen_server:call to avoid calling_self.
 -spec class_name(pid()) -> class_name().
+class_name(ClassPid) when ClassPid =:= self() ->
+    get(beamtalk_class_name);
 class_name(ClassPid) ->
     gen_server:call(ClassPid, class_name).
 
 %% @doc Get the module name.
+%%
+%% BT-893: If called from within the class gen_server itself (self-call), read
+%% from the process dictionary instead of gen_server:call to avoid calling_self.
 -spec module_name(pid()) -> atom().
+module_name(ClassPid) when ClassPid =:= self() ->
+    get(beamtalk_class_module);
 module_name(ClassPid) ->
     gen_server:call(ClassPid, module_name).
 


### PR DESCRIPTION
## Summary

- Add self-call guards to `module_name/1` and `class_name/1` in `beamtalk_object_class.erl`: when `ClassPid =:= self()`, read class metadata from the process dictionary (already populated by `init/1` as part of the BT-893 approach) instead of calling `gen_server:call(self(), ...)`.
- Use `beamtalk_object_class:module_name/1` in `find_class_method_in_ancestors` instead of a bare `gen_server:call(AncestorPid, module_name, 5000)` so the self-call guard is applied consistently.

## Root Cause

When a class gen_server executes a class method (e.g. `class run => self new run` from the default project template), the instance dispatch path calls `class_name_to_module('Main')` in `beamtalk_primitive`. If the `bt@main` module isn't loaded yet, this falls back to `beamtalk_object_class:module_name(MainClassPid)`. Since the dispatch is running inside the Main class gen_server handler, `MainClassPid == self()`, causing `{calling_self,{gen_server,call,[...,module_name]}}` at workspace startup.

## Test plan

- [x] `just test` — all tests pass
- [x] `just test-stdlib` — all stdlib + BUnit tests pass
- [x] `just build && just clippy && just fmt-check` — all static checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency of method dispatch and class name resolution.
  * Enhanced fallback mechanisms for increased reliability in method lookup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->