### PR TITLE
SchemeEnv lookup: add cycle guard for self-parent loops (BT-945)

### DIFF
--- a/examples/sicp/src/scheme/env.bt
+++ b/examples/sicp/src/scheme/env.bt
@@ -23,7 +23,8 @@ Actor subclass: SchemeEnv
   state: parent   = nil
 
   /// Look up `name` in this frame, then walk parent frames until found.
-  /// Raises an error if the name is unbound in the entire chain.
+  /// Raises an error if the name is unbound in the entire chain, or if the
+  /// parent chain exceeds 1000 frames (cycle guard).
   ///
   /// ## Examples
   /// ```beamtalk
@@ -31,8 +32,12 @@ Actor subclass: SchemeEnv
   /// (env lookup: "z") await    // raises "Unbound variable: z"
   /// ```
   lookup: name =>
+    self lookup: name depth: 0
+
+  lookup: name depth: depth =>
+    (depth > 1000) ifTrue: [^self error: "Environment chain exceeded maximum depth (cycle detected?)"]
     (self.bindings includesKey: name) ifTrue: [^self.bindings at: name]
-    self.parent notNil ifTrue: [^(self.parent lookup: name) await]
+    self.parent notNil ifTrue: [^(self.parent lookup: name depth: depth + 1) await]
     self error: "Unbound variable: " ++ name
 
   /// Bind or rebind `name` to `val` in this frame.
@@ -47,7 +52,9 @@ Actor subclass: SchemeEnv
     nil
 
   /// Set this frame's parent environment (used during construction).
+  /// Raises an error if `p` is `self` to prevent self-parent loops.
   setParent: p =>
+    (p =:= self) ifTrue: [^self error: "Cycle detected: environment cannot be its own parent"]
     self.parent := p
 
   /// Create a child environment that binds each name in `params` to the

--- a/examples/sicp/test/scheme_test.bt
+++ b/examples/sicp/test/scheme_test.bt
@@ -187,6 +187,14 @@ TestCase subclass: SchemeTest
     result := [self eval: "(42 1 2)"] on: Error do: [:e | e message]
     self assert: result equals: "Not a procedure: 42"
 
+  // --- Cycle guard ---
+
+  testSetParentCycleGuard =>
+    ev  := SchemeEval new
+    env := ev defaultEnv
+    result := [env setParent: env] on: Error do: [:e | e message]
+    self assert: result equals: "Cycle detected: environment cannot be its own parent"
+
   // --- Recursion ---
 
   testFactorial =>

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_codegen.snap
@@ -88,8 +88,9 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             case call 'typed_class_warnings':'safe_dispatch'(CastSelector, CastArgs, State) of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
                     {'noreply', CastNewState}
-                <{'error', _CastError, _CastState}> when 'true' ->
-                    {'noreply', State}
+                <{'error', CastError, _CastState}> when 'true' ->
+                    let _ = call 'logger':'warning'(~{'selector' => CastSelector, 'reason' => CastError}~)
+                    in {'noreply', State}
             end
         <{Selector, Args, FuturePid}> when 'true' ->
             let _ = call 'erlang':'put'('$bt_future_pid', FuturePid)


### PR DESCRIPTION
## Summary

Adds defensive guards to `SchemeEnv` in the SICP example to prevent infinite loops when parent chains contain cycles:

- `setParent:` raises an error if called with `self`, preventing direct self-parent loops
- `lookup:` delegates to a depth-limited `lookup:depth:` that raises an error after 1000 frames, catching longer multi-actor cycles
- New `testSetParentCycleGuard` test verifies the `setParent:` guard
- Accepts pre-existing snapshot update for `typed_class_warnings_codegen` (BT-943 logging change)

**Linear issue:** https://linear.app/beamtalk/issue/BT-945

## Test plan

- [x] `testSetParentCycleGuard` verifies `env setParent: env` raises the expected error
- [x] All existing `SchemeTest` tests pass (closures, recursion, env lookup)
- [x] `just test` — 5,173 tests pass
- [x] `just build && just clippy && just fmt-check` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Environment variable lookup now includes cycle detection with a maximum recursion depth guard to safely handle complex environment chains without stack overflows.
  * Environments can no longer be set as their own parent, preventing self-referential loops.

* **Tests**
  * Added test case to verify self-reference cycle detection works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->