### PR TITLE
Warn on redundant assignment (x := x) (BT-950)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -269,6 +269,8 @@ fn analyse_full(module: &Module, known_vars: &[&str], stdlib_mode: bool) -> Anal
     );
     // BT-919: Reject cast (!) on value types
     validators::check_cast_on_value_type(module, &result.class_hierarchy, &mut result.diagnostics);
+    // BT-950: Warn on redundant assignment (x := x)
+    validators::check_redundant_assignment(module, &mut result.diagnostics);
 
     // Phase 6: Module-level validation (BT-349)
     let module_diags = module_validator::validate_single_class(module);


### PR DESCRIPTION
## Summary

- Add `check_redundant_assignment` validator that detects `x := x` (same identifier on both sides of `:=`) and emits a warning
- Walk top-level expressions, class methods, and standalone method definitions recursively
- 7 unit tests covering: top-level, method body, block nesting, standalone methods, different names (no false positive), and field access (no false positive)

Closes [BT-950](https://linear.app/beamtalk/issue/BT-950/warn-on-redundant-assignment-x-x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation warnings to detect redundant assignments in code analysis.

* **Tests**
  * Added comprehensive test coverage for redundant assignment detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->