### PR TITLE
Warn on self capture in block passed to actor method (BT-953)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -271,6 +271,8 @@ fn analyse_full(module: &Module, known_vars: &[&str], stdlib_mode: bool) -> Anal
     validators::check_cast_on_value_type(module, &result.class_hierarchy, &mut result.diagnostics);
     // BT-950: Warn on redundant assignment (x := x)
     validators::check_redundant_assignment(module, &mut result.diagnostics);
+    // BT-953: Hint on self capture in collection HOF blocks (deadlock risk)
+    validators::check_self_capture_in_actor_block(module, &mut result.diagnostics);
 
     // Phase 6: Module-level validation (BT-349)
     let module_diags = module_validator::validate_single_class(module);

--- a/crates/beamtalk-core/src/semantic_analysis/validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators.rs
@@ -13,11 +13,12 @@
 //! - Class variable access (BT-563)
 //! - Empty method bodies (BT-631)
 
-use crate::ast::{Expression, Identifier, Module};
-use crate::semantic_analysis::ClassHierarchy;
+use crate::ast::{Block, Expression, Identifier, Module};
+use crate::semantic_analysis::block_context::{classify_block, is_collection_hof_selector};
+use crate::semantic_analysis::{BlockContext, ClassHierarchy};
 #[cfg(test)]
 use crate::source_analysis::lex_with_eof;
-use crate::source_analysis::{Diagnostic, DiagnosticCategory};
+use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
 use ecow::EcoString;
 
 /// BT-105: Check for attempts to instantiate abstract classes.
@@ -758,6 +759,109 @@ fn visit_redundant_assignment(expr: &Expression, diagnostics: &mut Vec<Diagnosti
     }
 }
 
+// ── BT-953: Self capture in collection HOF blocks ─────────────────────────────
+
+/// BT-953: Warn when `self` is referenced inside a literal block passed to a
+/// collection higher-order method (collect:, do:, select:, reject:, inject:into:,
+/// detect:, detect:ifNone:).
+///
+/// These methods pass the block to Erlang-side iteration. If the block body
+/// references `self` as a message receiver, the re-entrant self-send goes
+/// through the `calling_self` mechanism and can deadlock at runtime.
+///
+/// Example: `items collect: [:x | self process: x]`  ← deadlock risk
+pub(crate) fn check_self_capture_in_actor_block(
+    module: &Module,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for expr in &module.expressions {
+        visit_self_capture_in_block(expr, diagnostics);
+    }
+    for class in &module.classes {
+        for method in class.methods.iter().chain(class.class_methods.iter()) {
+            for expr in &method.body {
+                visit_self_capture_in_block(expr, diagnostics);
+            }
+        }
+    }
+    for standalone in &module.method_definitions {
+        for expr in &standalone.method.body {
+            visit_self_capture_in_block(expr, diagnostics);
+        }
+    }
+}
+
+/// Recursively searches an expression tree for any reference to `self`.
+///
+/// Returns the `Span` of the first `self` identifier found, or `None`.
+/// Uses `child_expressions` to traverse all expression variants consistently.
+fn find_self_reference(expr: &Expression) -> Option<Span> {
+    // Check current node
+    if let Expression::Identifier(Identifier { name, span, .. }) = expr {
+        if name == "self" {
+            return Some(*span);
+        }
+    }
+    // Recurse into children (covers all expression variants)
+    child_expressions(expr)
+        .into_iter()
+        .find_map(find_self_reference)
+}
+
+/// Searches a block's body for any `self` reference.
+fn find_self_reference_in_block(block: &Block) -> Option<Span> {
+    block.body.iter().find_map(find_self_reference)
+}
+
+/// Walks expressions looking for literal blocks in collection HOF positions
+/// that reference `self`. Emits a hint diagnostic for each such occurrence.
+///
+/// Uses `classify_block` to confirm the argument is a literal block in a
+/// control-flow position (Tier 1 codegen site), then additionally checks that
+/// the selector is one of the dangerous collection iteration methods.
+fn visit_self_capture_in_block(expr: &Expression, diagnostics: &mut Vec<Diagnostic>) {
+    if let Expression::MessageSend {
+        selector,
+        arguments,
+        span,
+        ..
+    } = expr
+    {
+        let selector_str = selector.name();
+        for (i, arg) in arguments.iter().enumerate() {
+            if !is_collection_hof_selector(&selector_str, i) {
+                continue;
+            }
+            // Use classify_block to confirm this is a literal block in a control-flow
+            // position (not a block variable). This is the production wiring of the
+            // block_context infrastructure (BT-953).
+            let ctx = classify_block(arg.span(), expr, false);
+            if !matches!(ctx, BlockContext::ControlFlow) {
+                continue;
+            }
+            if let Expression::Block(block) = arg {
+                if find_self_reference_in_block(block).is_some() {
+                    let mut diag = Diagnostic::hint(
+                        format!("`self` capture in block passed to `{selector_str}` may deadlock"),
+                        *span,
+                    );
+                    diag.hint = Some(
+                        "Sending `self` from within a collection block re-enters the \
+                         `calling_self` dispatch and can deadlock. \
+                         Inline the logic or bind the result to a local variable before \
+                         entering the block."
+                            .into(),
+                    );
+                    diagnostics.push(diag);
+                }
+            }
+        }
+    }
+    for child in child_expressions(expr) {
+        visit_self_capture_in_block(child, diagnostics);
+    }
+}
+
 /// BT-859: Error on empty method bodies.
 ///
 /// Methods declared with `=>` but no body expressions are a compile error.
@@ -1184,5 +1288,147 @@ mod tests {
             "Expected 1 warning for redundant assignment in standalone method, got: {diagnostics:?}"
         );
         assert_eq!(diagnostics[0].severity, Severity::Warning);
+    }
+
+    // ── BT-953: Self capture in collection HOF blocks ─────────────────────────
+
+    /// `self` inside a `collect:` block emits a hint.
+    #[test]
+    fn self_capture_in_collect_block_hints() {
+        let src =
+            "Actor subclass: Processor\n  process: items => items collect: [:x | self handle: x]";
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+        let mut diagnostics = Vec::new();
+        check_self_capture_in_actor_block(&module, &mut diagnostics);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Expected 1 hint for self capture in collect:, got: {diagnostics:?}"
+        );
+        assert_eq!(diagnostics[0].severity, Severity::Hint);
+        assert!(
+            diagnostics[0].message.contains("collect:"),
+            "Expected 'collect:' in message, got: {}",
+            diagnostics[0].message
+        );
+    }
+
+    /// `self` inside an `inject:into:` block emits a hint.
+    #[test]
+    fn self_capture_in_inject_into_block_hints() {
+        let src = "Actor subclass: Processor\n  run: items => items inject: 0 into: [:acc :x | self transform: x]";
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+        let mut diagnostics = Vec::new();
+        check_self_capture_in_actor_block(&module, &mut diagnostics);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Expected 1 hint for self capture in inject:into:, got: {diagnostics:?}"
+        );
+        assert_eq!(diagnostics[0].severity, Severity::Hint);
+        assert!(diagnostics[0].message.contains("inject:into:"));
+    }
+
+    /// No `self` in the block — no hint.
+    #[test]
+    fn no_self_in_collect_block_no_hint() {
+        let src = "Actor subclass: Processor\n  process: items => items collect: [:x | x * 2]";
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+        let mut diagnostics = Vec::new();
+        check_self_capture_in_actor_block(&module, &mut diagnostics);
+        assert!(
+            diagnostics.is_empty(),
+            "Expected no hints when self is not in block, got: {diagnostics:?}"
+        );
+    }
+
+    /// `self` in an `ifTrue:` block is safe — no hint.
+    #[test]
+    fn self_in_if_true_block_no_hint() {
+        let src = "Actor subclass: Worker\n  run => (x > 0) ifTrue: [self doWork]";
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+        let mut diagnostics = Vec::new();
+        check_self_capture_in_actor_block(&module, &mut diagnostics);
+        assert!(
+            diagnostics.is_empty(),
+            "Expected no hints for self in ifTrue: block, got: {diagnostics:?}"
+        );
+    }
+
+    /// Value-object class (not Actor) also gets the hint — the deadlock risk
+    /// exists for any class using the `calling_self` mechanism.
+    #[test]
+    fn self_capture_in_value_object_collect_hints() {
+        let src = "Object subclass: Formatter\n  format: rows => rows collect: [:row | self formatRow: row]";
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+        let mut diagnostics = Vec::new();
+        check_self_capture_in_actor_block(&module, &mut diagnostics);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Expected 1 hint for self capture in value-object collect:, got: {diagnostics:?}"
+        );
+        assert_eq!(diagnostics[0].severity, Severity::Hint);
+    }
+
+    /// `self` inside a `do:` block emits a hint.
+    #[test]
+    fn self_capture_in_do_block_hints() {
+        let src = "Object subclass: Runner\n  run: items => items do: [:x | self process: x]";
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+        let mut diagnostics = Vec::new();
+        check_self_capture_in_actor_block(&module, &mut diagnostics);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Expected 1 hint for self capture in do:, got: {diagnostics:?}"
+        );
+        assert_eq!(diagnostics[0].severity, Severity::Hint);
+    }
+
+    /// `self` inside a map literal within a collect: block still triggers.
+    #[test]
+    fn self_capture_nested_in_map_literal_hints() {
+        let src =
+            "Object subclass: Foo\n  run: items => items collect: [:x | #{key => self value}]";
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+        let mut diagnostics = Vec::new();
+        check_self_capture_in_actor_block(&module, &mut diagnostics);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Expected 1 hint for self nested in map literal, got: {diagnostics:?}"
+        );
+        assert_eq!(diagnostics[0].severity, Severity::Hint);
+    }
+
+    /// A block variable (not a literal block) passed to collect: does NOT trigger
+    /// the hint — we only flag literal blocks.
+    #[test]
+    fn block_variable_in_collect_no_hint() {
+        let src = "Object subclass: Foo\n  run: items with: blk => items collect: blk";
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+        let mut diagnostics = Vec::new();
+        check_self_capture_in_actor_block(&module, &mut diagnostics);
+        assert!(
+            diagnostics.is_empty(),
+            "Expected no hints for block variable (not literal), got: {diagnostics:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds a compile-time hint diagnostic when `self` is referenced inside a literal block passed to a collection higher-order method (`collect:`, `do:`, `select:`, `reject:`, `detect:`, `inject:into:`, `detect:ifNone:`). These patterns risk deadlock via the `calling_self` re-entrancy mechanism.

**Linear:** https://linear.app/beamtalk/issue/BT-953

## Changes

- **`block_context.rs`**: Add `is_collection_hof_selector()` to identify dangerous iteration selectors (subset of control-flow selectors, excluding safe conditionals like `ifTrue:`). Remove `#[allow(dead_code)]` from `classify_block`, `is_literal_block`, `is_block_variable` — these are now wired to production.
- **`validators.rs`**: Add `check_self_capture_in_actor_block` validator that walks all class method bodies, uses `classify_block` to confirm literal block in control-flow position, then checks for `self` references via `find_self_reference` (reuses `child_expressions` for complete expression traversal). Emits `Severity::Hint` diagnostic.
- **`mod.rs`**: Wire the new check into the semantic analysis pipeline.

## Test plan

- [x] 8 new unit tests covering: collect:, inject:into:, do: (positive), ifTrue: (safe — no hint), no-self (no hint), value-object class, block variable (no hint), self nested in map literal
- [x] `just clippy` passes
- [x] `just test-stdlib` passes (237/237)
- [x] `just build && just fmt-check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced semantic analysis to detect and warn about potential deadlock risks when self is captured in collection iteration blocks within actor constructs.

* **Tests**
  * Introduced comprehensive test coverage for the new validation logic, including edge cases and various iteration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->