### PR TITLE
Tests and documentation: Value subclass:, with*:, construction forms (BT-926)

### DIFF
--- a/examples/getting-started/src/point.bt
+++ b/examples/getting-started/src/point.bt
@@ -1,0 +1,36 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Point — a 2D point value object (BT-926 example).
+//
+// Demonstrates the `Value subclass:` pattern (ADR 0042):
+//   - Three construction forms: new, new:, keyword constructor
+//   - Auto-generated getters and with*: functional setters
+//   - Immutability: originals are never modified
+//   - Value equality: two Points with the same coordinates are ==
+//   - User-defined methods on a value type
+//   - Usage in collections (collect:, select:, inject:into:)
+//
+// Try it in the REPL:
+//   $ beamtalk repl
+//   > :load src/point.bt
+//   > p := Point x: 3 y: 4
+//   > p distanceSquared          => 25
+//   > (p withX: 0) distanceSquared     => 16
+//   > (Point x: 3 y: 4) == (Point x: 3 y: 4)   => true
+
+Value subclass: Point
+  state: x = 0
+  state: y = 0
+
+  // Euclidean distance squared from the origin (avoids a Float sqrt dependency)
+  distanceSquared => (self.x * self.x) + (self.y * self.y)
+
+  // Translate by a delta in each axis, returning a new Point
+  translateX: dx y: dy => Point x: self.x + dx y: self.y + dy
+
+  // Return a Point whose coordinates are negated
+  negated => Point x: self.x negated y: self.y negated
+
+  // Human-readable representation
+  printString => "Point({self.x}, {self.y})"

--- a/stdlib/test/value_object_test.bt
+++ b/stdlib/test/value_object_test.bt
@@ -1,0 +1,186 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-926: Comprehensive BUnit tests for Value subclass: construction forms,
+// with*: functional setters, immutability enforcement, value equality,
+// and value objects in collections.
+//
+// Fixture: stdlib/test/fixtures/value_point.bt (ValuePoint — x, y slots)
+//
+// See also:
+//   value_subclass_test.bt — auto-generated getter/setter/reflection tests
+//   value_type_update_test.bt — multi-field update semantics
+
+
+TestCase subclass: ValueObjectTest
+
+  // =========================================================================
+  // CONSTRUCTION FORMS
+  // =========================================================================
+
+  // new — default-initialises all slots to their declared defaults
+  testNewDefaultValues =>
+    p := ValuePoint new.
+    self assert: p x equals: 0.
+    self assert: p y equals: 0
+
+  // new: — initialises from a map; missing keys keep defaults
+  testNewWithMap =>
+    p := ValuePoint new: #{#x => 5, #y => 10}.
+    self assert: p x equals: 5.
+    self assert: p y equals: 10
+
+  testNewWithPartialMap =>
+    p := ValuePoint new: #{#x => 7}.
+    self assert: p x equals: 7.
+    // y keeps its declared default
+    self assert: p y equals: 0
+
+  // Keyword constructor — auto-generated from slot names
+  testKeywordConstructor =>
+    p := ValuePoint x: 3 y: 4.
+    self assert: p x equals: 3.
+    self assert: p y equals: 4
+
+  testKeywordConstructorZeroValues =>
+    p := ValuePoint x: 0 y: 0.
+    self assert: p x equals: 0.
+    self assert: p y equals: 0
+
+  // =========================================================================
+  // with*: FUNCTIONAL SETTERS
+  // =========================================================================
+
+  // with*: returns a new instance with one field changed
+  testWithXReturnsNewInstance =>
+    p := ValuePoint x: 1 y: 2.
+    p2 := p withX: 99.
+    self assert: p2 x equals: 99.
+    // y is preserved from the original
+    self assert: p2 y equals: 2
+
+  testWithYReturnsNewInstance =>
+    p := ValuePoint x: 1 y: 2.
+    p2 := p withY: 99.
+    // x is preserved from the original
+    self assert: p2 x equals: 1.
+    self assert: p2 y equals: 99
+
+  // Original object is unchanged after with*:
+  testWithSetterDoesNotMutateOriginal =>
+    p := ValuePoint x: 10 y: 20.
+    p withX: 999.
+    self assert: p x equals: 10.
+    self assert: p y equals: 20
+
+  // Chaining with*: calls produces cumulative result
+  testChainedWithSetters =>
+    p := ValuePoint new.
+    p2 := (p withX: 5) withY: 7.
+    self assert: p2 x equals: 5.
+    self assert: p2 y equals: 7
+
+  // with*: preserves class identity
+  testWithSetterPreservesClass =>
+    p := ValuePoint x: 1 y: 2.
+    p2 := p withX: 99.
+    self assert: p2 class equals: ValuePoint
+
+  // User-defined methods coexist with auto-generated ones
+  testUserDefinedMethodWithAutoGetters =>
+    p := ValuePoint x: 3 y: 4.
+    self assert: p distanceSquared equals: 25
+
+  // =========================================================================
+  // IMMUTABILITY ENFORCEMENT
+  // =========================================================================
+
+  // fieldAt:put: raises immutable_value — direct slot mutation is rejected
+  testFieldAtPutRaisesImmutableValue =>
+    p := ValuePoint x: 1 y: 2.
+    self should: [p fieldAt: #x put: 99] raise: #immutable_value
+
+  testFieldAtPutRaisesForAnySlot =>
+    p := ValuePoint x: 0 y: 0.
+    self should: [p fieldAt: #y put: 42] raise: #immutable_value
+
+  // self.slot := is rejected at compile time (tested in E2E via @load-error)
+
+  // =========================================================================
+  // VALUE EQUALITY
+  // =========================================================================
+
+  // Two value objects with identical field values are equal (structural equality)
+  testTwoPointsWithSameFieldsAreEqual =>
+    p1 := ValuePoint x: 3 y: 4.
+    p2 := ValuePoint x: 3 y: 4.
+    self assert: (p1 == p2)
+
+  // Two value objects with different field values are not equal
+  testTwoPointsWithDifferentFieldsAreNotEqual =>
+    p1 := ValuePoint x: 1 y: 2.
+    p2 := ValuePoint x: 9 y: 9.
+    self deny: (p1 == p2)
+
+  // Inequality operator agrees with equality
+  testInequalityOperator =>
+    p1 := ValuePoint x: 1 y: 2.
+    p2 := ValuePoint x: 1 y: 2.
+    p3 := ValuePoint x: 5 y: 6.
+    self deny: (p1 /= p2).
+    self assert: (p1 /= p3)
+
+  // with*: result equals a fresh object with the same values
+  testWithSetterResultEqualsManualConstruct =>
+    p := ValuePoint x: 1 y: 2.
+    p2 := p withX: 10.
+    p3 := ValuePoint x: 10 y: 2.
+    self assert: (p2 == p3)
+
+  // Default (new) equals keyword constructor with zeros
+  testNewEqualsKeywordConstructorWithDefaults =>
+    p1 := ValuePoint new.
+    p2 := ValuePoint x: 0 y: 0.
+    self assert: (p1 == p2)
+
+  // =========================================================================
+  // VALUE OBJECTS IN COLLECTIONS
+  // =========================================================================
+
+  // collect: transforms a collection of value objects
+  testCollectOnValueObjects =>
+    points := #((ValuePoint x: 1 y: 1), (ValuePoint x: 2 y: 2), (ValuePoint x: 3 y: 3)).
+    xs := points collect: [:p | p x].
+    self assert: xs equals: #(1, 2, 3)
+
+  // collect: can produce new value objects from old ones
+  testCollectProducesNewValueObjects =>
+    points := #((ValuePoint x: 1 y: 10), (ValuePoint x: 2 y: 20)).
+    doubled := points collect: [:p | p withX: p x * 2].
+    self assert: (doubled at: 1) x equals: 2.
+    self assert: (doubled at: 2) x equals: 4
+
+  // select: filters a collection of value objects by a predicate
+  testSelectOnValueObjects =>
+    points := #((ValuePoint x: 1 y: 1), (ValuePoint x: 5 y: 5), (ValuePoint x: 2 y: 2)).
+    big := points select: [:p | p x > 2].
+    self assert: big size equals: 1.
+    self assert: (big at: 1) x equals: 5
+
+  // inject:into: folds over a collection of value objects
+  testInjectIntoOnValueObjects =>
+    points := #((ValuePoint x: 1 y: 0), (ValuePoint x: 2 y: 0), (ValuePoint x: 3 y: 0)).
+    total := points inject: 0 into: [:sum :p | sum + p x].
+    self assert: total equals: 6
+
+  // Size of a collection of value objects
+  testCollectionSizeWithValueObjects =>
+    points := #((ValuePoint x: 0 y: 0), (ValuePoint x: 1 y: 1)).
+    self assert: points size equals: 2
+
+  // Value objects can be used as elements in detect:
+  testDetectOnValueObjects =>
+    points := #((ValuePoint x: 1 y: 1), (ValuePoint x: 7 y: 3), (ValuePoint x: 2 y: 2)).
+    found := points detect: [:p | p x == 7].
+    self assert: found x equals: 7.
+    self assert: found y equals: 3

--- a/tests/e2e/cases/value_objects.bt
+++ b/tests/e2e/cases/value_objects.bt
@@ -1,0 +1,153 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E tests for Value subclass: construction, with*: setters, immutability,
+// and equality in the REPL (BT-926).
+//
+// These tests require E2E because:
+// - The @load-error directive (compile-time error checking) is a REPL feature.
+// - REPL interaction validates the full load-compile-eval-print cycle.
+//
+// Compile-time rejection of self.slot := in value types is already
+// verified by actor_slot.bt (@load-error on fixtures/actor_slot_value_error.bt).
+
+// @load tests/e2e/fixtures/value_point.bt
+
+// ===========================================================================
+// CONSTRUCTION FORMS
+// ===========================================================================
+
+// new — default-initialises all slots
+p := ValuePoint new
+// => _
+
+p x
+// => 0
+
+p y
+// => 0
+
+// new: — initialise from map
+p2 := ValuePoint new: #{#x => 3, #y => 4}
+// => _
+
+p2 x
+// => 3
+
+p2 y
+// => 4
+
+// Keyword constructor
+p3 := ValuePoint x: 10 y: 20
+// => _
+
+p3 x
+// => 10
+
+p3 y
+// => 20
+
+// ===========================================================================
+// with*: FUNCTIONAL SETTERS
+// ===========================================================================
+
+// with*: returns a new instance — original unchanged
+orig := ValuePoint x: 1 y: 2
+// => _
+
+moved := orig withX: 99
+// => _
+
+orig x
+// => 1
+
+moved x
+// => 99
+
+moved y
+// => 2
+
+// Chaining with*: setters
+chained := (ValuePoint new withX: 5) withY: 7
+// => _
+
+chained x
+// => 5
+
+chained y
+// => 7
+
+// ===========================================================================
+// IMMUTABILITY ENFORCEMENT
+// ===========================================================================
+
+// compile-time: self.slot := inside a Value subclass is rejected
+// @load-error tests/e2e/fixtures/actor_slot_value_error.bt => Cannot assign to slot
+
+// runtime: fieldAt:put: raises immutable_value
+immPt := ValuePoint x: 1 y: 2
+// => _
+
+immPt fieldAt: #x put: 99
+// => ERROR: immutable value
+
+// ===========================================================================
+// VALUE EQUALITY
+// ===========================================================================
+
+// Two value objects with the same fields are equal
+a := ValuePoint x: 3 y: 4
+// => _
+
+b := ValuePoint x: 3 y: 4
+// => _
+
+a == b
+// => true
+
+// Different values are not equal
+c := ValuePoint x: 9 y: 9
+// => _
+
+a == c
+// => false
+
+// with*: result equals a fresh object with the same values
+withResult := a withX: 10
+// => _
+
+fresh := ValuePoint x: 10 y: 4
+// => _
+
+withResult == fresh
+// => true
+
+// ===========================================================================
+// REFLECTION
+// ===========================================================================
+
+// fieldAt: reads slot by name
+reflPt := ValuePoint x: 7 y: 8
+// => _
+
+reflPt fieldAt: #x
+// => 7
+
+reflPt fieldAt: #y
+// => 8
+
+// fieldNames returns the slot count (exact order is implementation-defined)
+reflPt fieldNames size
+// => 2
+
+// ===========================================================================
+// CLASS MEMBERSHIP
+// ===========================================================================
+
+// class returns ValuePoint, not an actor class
+(ValuePoint x: 1 y: 2) class name
+// => ValuePoint
+
+// ValuePoint is a subclass of Value
+ValuePoint superclass name
+// => Value

--- a/tests/e2e/fixtures/value_point.bt
+++ b/tests/e2e/fixtures/value_point.bt
@@ -1,0 +1,13 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// ValuePoint — a Point value object used in E2E tests (BT-926).
+// Exercises Value subclass: auto-generated getters, with*: setters,
+// keyword constructor, and value equality.
+
+Value subclass: ValuePoint
+  state: x = 0
+  state: y = 0
+
+  // User-defined method: Euclidean distance squared from origin
+  distanceSquared => (self.x * self.x) + (self.y * self.y)


### PR DESCRIPTION
## Summary

Comprehensive tests and documentation for Value subclass: (ADR 0042, Stage 3 — final issue of the epic).

- **BUnit tests** (`stdlib/test/value_object_test.bt`): 24 tests covering all three construction forms (new, new:, keyword constructor), with*: functional setters, immutability enforcement, value equality, and value objects in collections (collect:, select:, inject:into:, detect:)
- **E2E tests** (`tests/e2e/cases/value_objects.bt`): REPL interaction with value objects, runtime immutability error messages, reflection, and class membership
- **Documentation** (`docs/beamtalk-language-features.md`): New "Value subclass: in Depth" section with construction forms, with*: setters, immutability enforcement, value equality, collections usage, and reflection
- **Example** (`examples/getting-started/src/point.bt`): Point value object example demonstrating the full Value subclass: API

**Linear:** https://linear.app/beamtalk/issue/BT-926

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide on Value subclass construction, immutability, equality, and functional setters with examples.

* **New Features**
  * Included Point value object example demonstrating immutability, value equality, and functional-style operations.

* **Tests**
  * Added extensive test coverage for Value subclass behavior including construction forms, immutability enforcement, equality semantics, and collection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->