### PR TITLE
Warn when --timeout is ignored on existing workspace (BT-971)

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -521,6 +521,12 @@ pub fn run(
                      Stop the workspace first with `beamtalk workspace stop` to restart with TLS."
                 );
             }
+            if timeout.is_some() {
+                eprintln!(
+                    "  ⚠️  Workspace already running (timeout unchanged). \
+                     Use `beamtalk workspace stop` to restart with a new timeout."
+                );
+            }
             if workspace_name.is_some() {
                 println!("  Workspace: {workspace_id}");
             } else {
@@ -639,6 +645,35 @@ mod ephemeral_tests {
     #[test]
     fn not_stop_when_guard_present() {
         assert!(!should_stop_workspace(true, true));
+    }
+}
+
+#[cfg(test)]
+mod timeout_warning_tests {
+    /// Helper: returns true when timeout warning should be shown.
+    /// Warning is shown when timeout was explicitly provided AND workspace was already running.
+    fn should_warn_timeout(timeout: Option<u64>, is_new: bool) -> bool {
+        timeout.is_some() && !is_new
+    }
+
+    #[test]
+    fn warns_when_timeout_provided_and_workspace_existing() {
+        assert!(should_warn_timeout(Some(300), false));
+    }
+
+    #[test]
+    fn no_warn_when_timeout_not_provided() {
+        assert!(!should_warn_timeout(None, false));
+    }
+
+    #[test]
+    fn no_warn_when_new_workspace_started() {
+        assert!(!should_warn_timeout(Some(300), true));
+    }
+
+    #[test]
+    fn no_warn_when_new_workspace_and_no_timeout() {
+        assert!(!should_warn_timeout(None, true));
     }
 }
 


### PR DESCRIPTION
## Summary

- When `beamtalk repl --timeout N` reconnects to an already-running workspace, prints a warning to stderr: "Workspace already running (timeout unchanged). Use `beamtalk workspace stop` to restart with a new timeout."
- No warning when `--timeout` is not explicitly provided (default behavior)
- Follows the existing pattern used by `--tls` and `--web` warnings

## Changes

- `crates/beamtalk-cli/src/commands/repl/mod.rs`: Added timeout warning in the `!is_new` branch, plus unit tests for the warning condition logic

## Linear Issue

https://linear.app/beamtalk/issue/BT-971

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime warning when reconnecting to an existing workspace with a timeout value, informing users the timeout remains unchanged and suggesting to restart the workspace to apply a new timeout.

* **Tests**
  * Added unit tests validating timeout-warning behavior across various reconnection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->