### PR TITLE
Parser: attach comments to ClassDefinition, MethodDefinition, StateDeclaration (BT-975)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -9,8 +9,8 @@
 //! - Method definitions with optional `sealed` modifier
 
 use crate::ast::{
-    ClassDefinition, CommentAttachment, Expression, ExpressionStatement, Identifier, KeywordPart,
-    MessageSelector, MethodDefinition, MethodKind, ParameterDefinition, StandaloneMethodDefinition,
+    ClassDefinition, Expression, ExpressionStatement, Identifier, KeywordPart, MessageSelector,
+    MethodDefinition, MethodKind, ParameterDefinition, StandaloneMethodDefinition,
     StateDeclaration, TypeAnnotation,
 };
 use crate::source_analysis::{Span, TokenKind};
@@ -41,6 +41,7 @@ impl Parser {
     pub(super) fn parse_class_definition(&mut self) -> ClassDefinition {
         let start = self.current_token().span();
         let doc_comment = self.collect_doc_comment();
+        let comments = self.collect_comment_attachment();
         let mut is_abstract = false;
         let mut is_sealed = false;
         let mut is_typed = false;
@@ -119,6 +120,7 @@ impl Parser {
         class_def.class_methods = class_methods;
         class_def.class_variables = class_variables;
         class_def.doc_comment = doc_comment;
+        class_def.comments = comments;
         class_def
     }
 
@@ -399,6 +401,8 @@ impl Parser {
     /// - `state: fieldName: TypeName = defaultValue`
     fn parse_state_declaration(&mut self) -> Option<StateDeclaration> {
         let start = self.current_token().span();
+        let doc_comment = self.collect_doc_comment();
+        let comments = self.collect_comment_attachment();
 
         // Consume `state:`
         if !matches!(self.current_kind(), TokenKind::Keyword(k) if k == "state:") {
@@ -462,8 +466,8 @@ impl Parser {
             name,
             type_annotation,
             default_value,
-            comments: CommentAttachment::default(),
-            doc_comment: None,
+            comments,
+            doc_comment,
             span,
         })
     }
@@ -477,6 +481,8 @@ impl Parser {
     /// - `classState: varName: TypeName = defaultValue`
     fn parse_classvar_declaration(&mut self) -> Option<StateDeclaration> {
         let start = self.current_token().span();
+        let doc_comment = self.collect_doc_comment();
+        let comments = self.collect_comment_attachment();
 
         // Consume `classState:`
         if !matches!(self.current_kind(), TokenKind::Keyword(k) if k == "classState:") {
@@ -529,8 +535,8 @@ impl Parser {
             name,
             type_annotation,
             default_value,
-            comments: CommentAttachment::default(),
-            doc_comment: None,
+            comments,
+            doc_comment,
             span,
         })
     }
@@ -593,6 +599,7 @@ impl Parser {
     fn parse_method_definition(&mut self) -> Option<MethodDefinition> {
         let start = self.current_token().span();
         let doc_comment = self.collect_doc_comment();
+        let comments = self.collect_comment_attachment();
         let method_kind = MethodKind::Primary;
         let mut method_is_sealed = false;
         let mut _is_class_method = false;
@@ -647,6 +654,7 @@ impl Parser {
             span,
         );
         method.doc_comment = doc_comment;
+        method.comments = comments;
         Some(method)
     }
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__abstract_class_spawn_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__abstract_class_spawn_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -78,7 +79,32 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 145,
+                            end: 153,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 145,
+                            end: 153,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test that instantiating an abstract class produces a diagnostic error.",
+                        span: Span {
+                            start: 145,
+                            end: 153,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_definition_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_definition_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -214,7 +215,32 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 104,
+                            end: 109,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 104,
+                            end: 109,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test class definition parsing",
+                        span: Span {
+                            start: 104,
+                            end: 109,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_methods_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_methods_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -411,7 +412,32 @@ Module {
                 },
             ],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 138,
+                            end: 143,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 138,
+                            end: 143,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test class method codegen (class-side methods, class variables)",
+                        span: Span {
+                            start: 138,
+                            end: 143,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -150,7 +151,48 @@ Module {
             ],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 244,
+                            end: 249,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 244,
+                            end: 249,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test empty method bodies (BT-859)",
+                        span: Span {
+                            start: 244,
+                            end: 249,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Empty method bodies are a compile-time error.",
+                        span: Span {
+                            start: 244,
+                            end: 249,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Developers must use `self notImplemented` or `self subclassResponsibility` instead.",
+                        span: Span {
+                            start: 244,
+                            end: 249,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_message_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_message_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -190,7 +191,40 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 186,
+                            end: 191,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 186,
+                            end: 191,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test error: message compilation",
+                        span: Span {
+                            start: 186,
+                            end: 191,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// The error: message should compile to erlang:error({beamtalk_error, Message})",
+                        span: Span {
+                            start: 186,
+                            end: 191,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__intrinsic_keyword_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__intrinsic_keyword_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -100,7 +101,40 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 204,
+                            end: 210,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 204,
+                            end: 210,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test that @intrinsic produces identical codegen to @primitive (BT-484).",
+                        span: Span {
+                            start: 204,
+                            end: 210,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Both keywords map to Expression::Primitive in the AST.",
+                        span: Span {
+                            start: 204,
+                            end: 210,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__method_lookup_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__method_lookup_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -79,7 +80,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Class literal: generates call with atom class name",
+                                span: Span {
+                                    start: 379,
+                                    end: 392,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -154,7 +164,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Variable receiver: generates call with evaluated receiver expression",
+                                span: Span {
+                                    start: 495,
+                                    end: 510,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -167,7 +186,64 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 286,
+                            end: 292,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 286,
+                            end: 292,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Compiler snapshot test for >> (method lookup) operator (BT-101, BT-323)",
+                        span: Span {
+                            start: 286,
+                            end: 292,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "//",
+                        span: Span {
+                            start: 286,
+                            end: 292,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Tests codegen for:",
+                        span: Span {
+                            start: 286,
+                            end: 292,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// - >> on class literal (compile-time optimized atom path)",
+                        span: Span {
+                            start: 286,
+                            end: 292,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// - >> on variable receiver (runtime resolution path)",
+                        span: Span {
+                            start: 286,
+                            end: 292,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__sealed_class_violation_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__sealed_class_violation_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -88,7 +89,40 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 179,
+                            end: 186,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 179,
+                            end: 186,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test that subclassing a sealed class produces a diagnostic error.",
+                        span: Span {
+                            start: 179,
+                            end: 186,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Integer is a built-in sealed class.",
+                        span: Span {
+                            start: 179,
+                            end: 186,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__sealed_method_override_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__sealed_method_override_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -67,7 +68,40 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 203,
+                            end: 209,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 203,
+                            end: 209,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test that overriding a sealed method produces a diagnostic error.",
+                        span: Span {
+                            start: 203,
+                            end: 209,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Parent defines a sealed method, Child tries to override it.",
+                        span: Span {
+                            start: 203,
+                            end: 209,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_dictionary_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_dictionary_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -53,7 +54,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Access",
+                                span: Span {
+                                    start: 297,
+                                    end: 301,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -420,7 +430,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Mutation (returns new dictionary)",
+                                span: Span {
+                                    start: 603,
+                                    end: 613,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -526,7 +545,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Iteration",
+                                span: Span {
+                                    start: 701,
+                                    end: 717,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -539,7 +567,48 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 247,
+                            end: 253,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 247,
+                            end: 253,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test Dictionary class compilation as a value type (not gen_server).",
+                        span: Span {
+                            start: 247,
+                            end: 253,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Dictionary is a sealed Object subclass backed by Erlang maps.",
+                        span: Span {
+                            start: 247,
+                            end: 253,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// new/0 should return #{} (empty map).",
+                        span: Span {
+                            start: 247,
+                            end: 253,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -53,7 +54,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Access",
+                                span: Span {
+                                    start: 251,
+                                    end: 255,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -329,7 +339,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Ordering",
+                                span: Span {
+                                    start: 489,
+                                    end: 493,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -503,7 +522,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Search",
+                                span: Span {
+                                    start: 639,
+                                    end: 646,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -626,7 +654,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Iteration — selector-based runtime dispatch",
+                                span: Span {
+                                    start: 794,
+                                    end: 797,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -908,7 +945,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Functional",
+                                span: Span {
+                                    start: 1024,
+                                    end: 1029,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -1252,7 +1298,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Concatenation",
+                                span: Span {
+                                    start: 1318,
+                                    end: 1320,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -1322,7 +1377,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Subsequence / Search",
+                                span: Span {
+                                    start: 1375,
+                                    end: 1380,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -1864,7 +1928,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Iteration with index",
+                                span: Span {
+                                    start: 1589,
+                                    end: 1603,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -1917,7 +1990,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Advanced",
+                                span: Span {
+                                    start: 1751,
+                                    end: 1755,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -2248,7 +2330,40 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 208,
+                            end: 214,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 208,
+                            end: 214,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test List class compilation as a value type (not gen_server).",
+                        span: Span {
+                            start: 208,
+                            end: 214,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Mirrors lib/List.bt exactly — new/0 should return [] (empty list).",
+                        span: Span {
+                            start: 208,
+                            end: 214,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_set_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_set_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -83,7 +84,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Size",
+                                span: Span {
+                                    start: 286,
+                                    end: 290,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -170,7 +180,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Membership",
+                                span: Span {
+                                    start: 365,
+                                    end: 374,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -223,7 +242,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Modification (returns new Set)",
+                                span: Span {
+                                    start: 448,
+                                    end: 452,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -329,7 +357,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Set operations (returns new Set)",
+                                span: Span {
+                                    start: 565,
+                                    end: 571,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -488,7 +525,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Predicates",
+                                span: Span {
+                                    start: 720,
+                                    end: 731,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -522,7 +568,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Conversion",
+                                span: Span {
+                                    start: 785,
+                                    end: 791,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -628,7 +683,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Iteration",
+                                span: Span {
+                                    start: 876,
+                                    end: 879,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -641,7 +705,40 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 221,
+                            end: 227,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 221,
+                            end: 227,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test Set class compilation as a value type (not gen_server).",
+                        span: Span {
+                            start: 221,
+                            end: 227,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Mirrors lib/Set.bt exactly — new/0 should return tagged map with empty elements.",
+                        span: Span {
+                            start: 221,
+                            end: 227,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_tuple_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_tuple_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -53,7 +54,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Size and access",
+                                span: Span {
+                                    start: 294,
+                                    end: 298,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -140,7 +150,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Pattern matching for Erlang result types",
+                                span: Span {
+                                    start: 401,
+                                    end: 405,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -208,7 +227,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Unwrapping",
+                                span: Span {
+                                    start: 480,
+                                    end: 486,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -348,7 +376,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Conversion",
+                                span: Span {
+                                    start: 627,
+                                    end: 635,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -361,7 +398,48 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 240,
+                            end: 246,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 240,
+                            end: 246,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Test Tuple class compilation as a value type (not gen_server).",
+                        span: Span {
+                            start: 240,
+                            end: 246,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Tuple is a sealed Object subclass backed by Erlang tuples.",
+                        span: Span {
+                            start: 240,
+                            end: 246,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// new/0 should return {} (empty tuple).",
+                        span: Span {
+                            start: 240,
+                            end: 246,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -118,7 +119,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Fully annotated — no warning expected",
+                                span: Span {
+                                    start: 386,
+                                    end: 394,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -243,7 +253,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Missing return type annotation — warning expected",
+                                span: Span {
+                                    start: 480,
+                                    end: 489,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -397,7 +416,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Missing parameter type annotation — warning expected",
+                                span: Span {
+                                    start: 605,
+                                    end: 609,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -410,7 +438,56 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 275,
+                            end: 280,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 275,
+                            end: 280,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Smoke test for typed class annotation warnings (BT-941).",
+                        span: Span {
+                            start: 275,
+                            end: 280,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "//",
+                        span: Span {
+                            start: 275,
+                            end: 280,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// A `typed` class with deliberately incomplete annotations, so we can",
+                        span: Span {
+                            start: 275,
+                            end: 280,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// verify the type checker surfaces warnings for missing annotations.",
+                        span: Span {
+                            start: 275,
+                            end: 280,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -118,7 +119,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Unary method with return type",
+                                span: Span {
+                                    start: 143,
+                                    end: 151,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -254,7 +264,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Keyword method with typed parameter and return type",
+                                span: Span {
+                                    start: 237,
+                                    end: 245,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -448,7 +467,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Method with union return type",
+                                span: Span {
+                                    start: 352,
+                                    end: 358,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -545,7 +573,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Untyped method (should not generate spec)",
+                                span: Span {
+                                    start: 486,
+                                    end: 495,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -558,7 +595,16 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Typed method definitions for spec generation",
+                        span: Span {
+                            start: 48,
+                            end: 53,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_value_type_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_value_type_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -158,7 +159,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Typed unary methods",
+                                span: Span {
+                                    start: 152,
+                                    end: 156,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -289,7 +299,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Typed keyword method",
+                                span: Span {
+                                    start: 235,
+                                    end: 246,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -323,7 +342,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Untyped method (no spec)",
+                                span: Span {
+                                    start: 339,
+                                    end: 350,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -336,7 +364,16 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Typed value type methods for spec generation",
+                        span: Span {
+                            start: 48,
+                            end: 54,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_type_multi_expr_method_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_type_multi_expr_method_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -142,7 +143,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Two-expression method: side effect then return value",
+                                span: Span {
+                                    start: 535,
+                                    end: 548,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -306,7 +316,16 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Three-expression method: multiple side effects then return",
+                                span: Span {
+                                    start: 654,
+                                    end: 665,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -319,7 +338,72 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 443,
+                            end: 449,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 443,
+                            end: 449,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Compiler snapshot test for BT-367: multi-expression value-type method sequencing",
+                        span: Span {
+                            start: 443,
+                            end: 449,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "//",
+                        span: Span {
+                            start: 443,
+                            end: 449,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Verifies that value-type methods with multiple expressions generate",
+                        span: Span {
+                            start: 443,
+                            end: 449,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// correct Core Erlang using `let ... in` to sequence non-last expressions.",
+                        span: Span {
+                            start: 443,
+                            end: 449,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// The first expression (side-effecting) should be wrapped in a let binding,",
+                        span: Span {
+                            start: 443,
+                            end: 449,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// and only the last expression should be returned directly.",
+                        span: Span {
+                            start: 443,
+                            end: 449,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -130,7 +131,40 @@ Module {
                     is_sealed: false,
                     kind: Primary,
                     comments: CommentAttachment {
-                        leading: [],
+                        leading: [
+                            Comment {
+                                content: "// Multi-expression method with a parameter named _seq0.",
+                                span: Span {
+                                    start: 758,
+                                    end: 766,
+                                },
+                                kind: Line,
+                            },
+                            Comment {
+                                content: "// Before BT-369, to_core_var kept \"_seq0\" verbatim while fresh_temp_var(\"seq\")",
+                                span: Span {
+                                    start: 758,
+                                    end: 766,
+                                },
+                                kind: Line,
+                            },
+                            Comment {
+                                content: "// could produce \"_seq1\", \"_seq2\" — a near-miss that could collide if naming",
+                                span: Span {
+                                    start: 758,
+                                    end: 766,
+                                },
+                                kind: Line,
+                            },
+                            Comment {
+                                content: "// conventions changed. Now both use the counter.",
+                                span: Span {
+                                    start: 758,
+                                    end: 766,
+                                },
+                                kind: Line,
+                            },
+                        ],
                         trailing: None,
                     },
                     doc_comment: None,
@@ -143,7 +177,72 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// Copyright 2026 James Casey",
+                        span: Span {
+                            start: 445,
+                            end: 451,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 445,
+                            end: 451,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Compiler snapshot test for BT-369: value-type temp var collision avoidance",
+                        span: Span {
+                            start: 445,
+                            end: 451,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "//",
+                        span: Span {
+                            start: 445,
+                            end: 451,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Verifies that method parameters with underscore-prefixed names (e.g., _seq0)",
+                        span: Span {
+                            start: 445,
+                            end: 451,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// don't collide with codegen-internal temp vars used for expression sequencing.",
+                        span: Span {
+                            start: 445,
+                            end: 451,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Both parameter binding and sequencing temp vars go through the fresh_var",
+                        span: Span {
+                            start: 445,
+                            end: 451,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// counter, ensuring unique Core Erlang variable names.",
+                        span: Span {
+                            start: 445,
+                            end: 451,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -146,7 +147,24 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// BT-374: Workspace binding cascade dispatch.",
+                        span: Span {
+                            start: 130,
+                            end: 135,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Cascade messages to a workspace binding should use persistent_term PID lookup.",
+                        span: Span {
+                            start: 130,
+                            end: 135,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_parser.snap
@@ -1,5 +1,6 @@
 ---
 source: test-package-compiler/tests/compiler_tests.rs
+assertion_line: 70
 expression: output
 ---
 AST:
@@ -100,7 +101,24 @@ Module {
             class_methods: [],
             class_variables: [],
             comments: CommentAttachment {
-                leading: [],
+                leading: [
+                    Comment {
+                        content: "// BT-374: Workspace binding dispatch via persistent_term.",
+                        span: Span {
+                            start: 148,
+                            end: 153,
+                        },
+                        kind: Line,
+                    },
+                    Comment {
+                        content: "// Transcript is a workspace binding — generates persistent_term lookup + actor send.",
+                        span: Span {
+                            start: 148,
+                            end: 153,
+                        },
+                        kind: Line,
+                    },
+                ],
                 trailing: None,
             },
             doc_comment: None,


### PR DESCRIPTION
## Summary

Implements Phase 2, Issue 3 of ADR 0044 (Comments as First-Class AST Nodes).

- Adds `collect_comment_attachment()` to the parser that collects `//` and `/* */` trivia into `CommentAttachment.leading`, skipping `///` doc comments
- Wires comment collection at all parse sites: `parse_class_definition`, `parse_method_definition`, `parse_state_declaration`, `parse_classvar_declaration`
- Wires `collect_doc_comment()` for `StateDeclaration` (previously missing)
- Adds 5 focused parser tests covering all acceptance criteria
- Updates 20 parser snapshots to reflect populated `comments` fields

**Linear:** https://linear.app/beamtalk/issue/BT-975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced source code parser to properly collect and associate comments with code elements (classes, methods, and state declarations), ensuring improved documentation preservation during analysis.

* **Tests**
  * Added test coverage validating comment attachment and documentation handling across multiple code element types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->