### PR TITLE
Fix lint violations in tests/e2e/cases/ (BT-965)

### DIFF
--- a/tests/e2e/cases/hot_reload.bt
+++ b/tests/e2e/cases/hot_reload.bt
@@ -67,7 +67,7 @@ Actor subclass: LiveActor
   bump => self.count := self.count + 1
 // => _
 
-LiveActor >> getCount => ^self.count
+LiveActor >> getCount => self.count
 // => _
 
 la := LiveActor spawn

--- a/tests/e2e/cases/inline_class.bt
+++ b/tests/e2e/cases/inline_class.bt
@@ -29,7 +29,7 @@ Actor subclass: InlineCounter
 // Add more methods using Tonel-style standalone method defs
 // ---------------------------------------------------------------------------
 
-InlineCounter >> getValue => ^self.value
+InlineCounter >> getValue => self.value
 // => _
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e/cases/load_method_patch.bt
+++ b/tests/e2e/cases/load_method_patch.bt
@@ -60,7 +60,7 @@ c2 getValue
 // ===========================================================================
 
 // Add a new method that didn't exist in the original file
-Counter >> doubleValue => ^self.value * 2
+Counter >> doubleValue => self.value * 2
 // => _
 
 c3 := Counter spawn
@@ -82,4 +82,4 @@ c3 doubleValue
 
 // Source for newly added method should return its source
 (Counter >> #doubleValue) source
-// => doubleValue => ^self.value * 2
+// => doubleValue => self.value * 2


### PR DESCRIPTION
## Summary

Fixes 3 `trailing_caret` lint violations in e2e test files by removing redundant `^` from last expressions.

**Linear issue:** https://linear.app/beamtalk/issue/BT-965

### Changes
- `tests/e2e/cases/hot_reload.bt` — remove trailing `^` from `LiveActor >> getCount`
- `tests/e2e/cases/inline_class.bt` — remove trailing `^` from `InlineCounter >> getValue`
- `tests/e2e/cases/load_method_patch.bt` — remove trailing `^` from `Counter >> doubleValue` + update source-reflection assertion

### Verification
- `beamtalk lint tests/e2e/cases/` — 0 violations
- `just test-e2e` — 730/730 tests pass
- `just ci` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases to use implicit return expressions instead of explicit return syntax in methods.
  * Verified method behavior consistency across hot reload, inline class, and method patch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->