### PR TITLE
Fix REPL not displaying Transcript push output

### DIFF
--- a/crates/beamtalk-cli/src/commands/protocol.rs
+++ b/crates/beamtalk-cli/src/commands/protocol.rs
@@ -243,8 +243,13 @@ impl ProtocolClient {
             if let Some(text) = parsed.get("text").and_then(|v| v.as_str()) {
                 use std::io::Write;
                 let formatted = format_transcript_chunk(text, &mut self.transcript_bol);
-                let _ = std::io::stdout().lock().write_all(formatted.as_bytes());
-                let _ = std::io::stdout().flush();
+                let mut out = std::io::stdout().lock();
+                if let Err(err) = out
+                    .write_all(formatted.as_bytes())
+                    .and_then(|()| out.flush())
+                {
+                    eprintln!("warning: failed to write transcript output: {err}");
+                }
             }
         }
         true


### PR DESCRIPTION
## Summary

- The CLI was silently discarding all server-initiated push messages in three read loops in `protocol.rs`
- `Transcript show:` output was correctly subscribed and pushed by the workspace but thrown away client-side
- Added a `handle_push` method that prints transcript output inline with a `│ ` gutter prefix at each line start
- A `transcript_bol` field on `ProtocolClient` tracks cursor position so `show:` and `cr` arriving as separate chunks prefix correctly

## Test plan

- [ ] Start a workspace and REPL, run `Transcript show: "hello"; cr` — output should appear as `│ hello`
- [ ] Multi-line output via separate `show:` + `cr` calls should each get the `│ ` prefix
- [ ] Eval results (`=> ...`) are unaffected
- [ ] Actor lifecycle push messages remain silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcript output now prints inline with a gutter prefix at line starts for improved readability.

* **Bug Fixes**
  * Transcript prefixing state resets on reconnect so subsequent output is correctly formatted.
  * Non-transcript server pushes are ignored to reduce noise.

* **Refactor**
  * Push-message handling centralized for consistent processing.

* **Tests**
  * Added tests validating transcript prefixing and reconnect behavior.

* **Documentation**
  * Updated docs/comments to reflect inline transcript printing and push handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->