### PR TITLE
Lint: warn on unattached /// doc comments (BT-980)

### DIFF
--- a/stdlib/src/Actor.bt
+++ b/stdlib/src/Actor.bt
@@ -14,7 +14,6 @@
 ///   increment => self.count := self.count + 1
 ///   count => self.count
 /// ```
-
 Object subclass: Actor
   /// Spawn a new actor process with default state.
   ///

--- a/stdlib/src/TestCase.bt
+++ b/stdlib/src/TestCase.bt
@@ -15,7 +15,6 @@
 ///   testIncrement =>
 ///     self assert: (self.counter getValue await) equals: 1
 /// ```
-
 Object subclass: TestCase
 
   /// Prepare the test fixture. Called before each test method.


### PR DESCRIPTION
## Summary

- Detect `///` doc comment trivia that is never captured by an AST node and emit a `Warning` diagnostic
- Two detection paths: cleared doc comments in `collect_doc_comment()` (blank line or `//` break), and pre-scanned doc comments before non-declaration tokens (post-parse sweep)
- Fix existing unattached doc comments in `Actor.bt` and `TestCase.bt`

Resolves: https://linear.app/beamtalk/issue/BT-980

## Key Changes

- **`parser/mod.rs`**: Added `unattached_doc_comment_indices: HashSet<usize>` to `Parser` struct, pre-scanned in `new()`. `collect_doc_comment()` changed to `&mut self` to emit warnings when doc comments are cleared. Post-parse sweep warns for remaining unscanned indices.
- **`Actor.bt`, `TestCase.bt`**: Removed blank lines between `///` doc comment blocks and class definitions (the exact pattern now warned about).
- **Tests**: 3 new tests + 2 updated existing tests covering blank line, `//` comment, before-expression, and no-warning cases.

## Test plan

- [x] `unattached_doc_comment_blank_line_before_class_emits_warning` — `///` + blank line + class → warning
- [x] `attached_doc_comment_no_blank_line_no_warning` — `///` immediately before class → no warning
- [x] `unattached_doc_comment_before_expression_emits_warning` — `///` before expression → warning
- [x] `parse_doc_comment_resets_on_regular_comment` — updated to verify warning
- [x] `parse_doc_comment_blank_line_resets` — updated to verify warning
- [x] `just build` — no warnings from stdlib
- [x] `just ci` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Parser now emits warnings when doc comments (///) are unattached to any declaration, helping developers identify misplaced documentation and ensure proper association with classes, methods, or state variables.

* **Style**
  * Removed unnecessary blank lines from standard library files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->