### PR TITLE
REPL: warn when a non-last module-level expression result is discarded (BT-979)

### DIFF
--- a/crates/beamtalk-cli/src/commands/test_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/test_stdlib.rs
@@ -369,6 +369,10 @@ fn compile_fixture(
         allow_primitives: false,
         workspace_mode: false,
         suppress_warnings,
+        // BT-979: Bootstrap-test fixtures use top-level expressions as test assertions
+        // paired with `// =>` comments. Skip the module-expression lint to avoid
+        // false positives on intentional assertion expressions.
+        skip_module_expression_lint: true,
     };
 
     crate::beam_compiler::compile_source(fixture_path, &module_name, &core_file, &options)

--- a/crates/beamtalk-cli/src/main.rs
+++ b/crates/beamtalk-cli/src/main.rs
@@ -315,6 +315,7 @@ fn run() -> Result<()> {
                 allow_primitives,
                 workspace_mode: false,
                 suppress_warnings: no_warnings,
+                ..Default::default()
             };
             commands::build::build(&path, &options)
         }

--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -382,6 +382,8 @@ fn handle_compile_expression(request: &Map) -> Term {
                 d.severity,
                 beamtalk_core::source_analysis::Severity::Warning
                     | beamtalk_core::source_analysis::Severity::Hint
+                    // BT-979: Include lint warnings so REPL users see effect-free statement hints.
+                    | beamtalk_core::source_analysis::Severity::Lint
             )
         })
         .map(|d| d.message.to_string())
@@ -556,6 +558,7 @@ fn handle_compile(request: &Map) -> Term {
         allow_primitives: false,
         workspace_mode,
         suppress_warnings: false,
+        ..Default::default()
     };
     let primitive_diags =
         beamtalk_core::semantic_analysis::primitive_validator::validate_primitives(

--- a/crates/beamtalk-core/src/lib.rs
+++ b/crates/beamtalk-core/src/lib.rs
@@ -63,4 +63,12 @@ pub struct CompilerOptions {
     /// When true, suppress warning diagnostics during compilation.
     /// Useful for test fixtures that intentionally trigger warnings.
     pub suppress_warnings: bool,
+
+    /// BT-979: When true, skip the effect-free lint check on `module.expressions`.
+    ///
+    /// Set this for bootstrap-test compilation, where top-level expressions are
+    /// intentional test assertions (paired with `// =>` comments) rather than
+    /// accidentally discarded values. Defaults to false so the REPL and normal
+    /// `beamtalk build` / `beamtalk lint` paths all get the check.
+    pub skip_module_expression_lint: bool,
 }


### PR DESCRIPTION
## Summary

- Enable the effect-free statement lint on `module.expressions` by default, so REPL users see warnings when expression results are silently discarded (e.g., `#{#x => 1} #{#y => 2}` where the first map literal is discarded)
- Add `skip_module_expression_lint` flag to `CompilerOptions` so bootstrap-test compilation can opt out (test fixtures intentionally use top-level expressions with `// =>` assertions)
- Expand REPL warning filter to include `Severity::Lint` diagnostics

**Linear issue:** https://linear.app/beamtalk/issue/BT-979

## Key Changes

- `CompilerOptions` gains `skip_module_expression_lint: bool` (default `false`)
- `check_effect_free_statements` now checks `module.expressions` unless the flag is set
- REPL compiler port surfaces `Severity::Lint` warnings to users
- Bootstrap-test compilation sets the flag to `true` to suppress false positives
- 4 new tests, 1 updated test, all 4,838 tests pass

## Test plan

- [x] Existing effect-free lint tests pass
- [x] New module-level lint tests verify detection and opt-out
- [x] Bootstrap-test compilation doesn't produce false positives
- [x] Full CI passes (`just ci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * REPL now displays linting hints for effect-free statements, providing enhanced feedback during interactive development.
  * Adjusted compiler linting behavior for module-level expressions in test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->