### PR TITLE
Revert "Update SICP example to ideal formatting (#1023)"

### DIFF
--- a/examples/sicp/src/scheme/env.bt
+++ b/examples/sicp/src/scheme/env.bt
@@ -20,7 +20,7 @@
 /// ```
 Actor subclass: SchemeEnv
   state: bindings = #{}
-  state: parent = nil
+  state: parent   = nil
 
   /// Look up `name` in this frame, then walk parent frames until found.
   /// Raises an error if the name is unbound in the entire chain, or if the
@@ -36,11 +36,8 @@ Actor subclass: SchemeEnv
 
   lookup: name depth: depth =>
     (depth > 1000) ifTrue: [^self error: "Environment chain exceeded maximum depth (cycle detected?)"]
-    
     (self.bindings includesKey: name) ifTrue: [^self.bindings at: name]
-    
     self.parent notNil ifTrue: [^(self.parent lookup: name depth: depth +1)]
-    
     self error: "Unbound variable: " ++ name
 
   /// Bind or rebind `name` to `val` in this frame.
@@ -72,13 +69,8 @@ Actor subclass: SchemeEnv
   /// ```
   extend: params values: vals =>
     (params size =:= vals size) ifFalse: [
-      ^self error: "Arity mismatch: expected " ++
-                   params size printString ++
-                   ", got " ++
-                   vals size printString
-    ]
-
-    newBindings := (params zip: vals) inject: #{} 
-      into: [:d :pair | d at: (pair at: "key") put: (pair at: "value")]
-
-      SchemeEnv spawnWith: #{#bindings => newBindings, #parent => self}
+      ^self error: "Arity mismatch: expected " ++ params size printString
+                   ++ ", got " ++ vals size printString]
+    newBindings := (params zip: vals) inject: #{} into: [:d :pair |
+      d at: (pair at: "key") put: (pair at: "value")]
+    SchemeEnv spawnWith: #{#bindings => newBindings, #parent => self}

--- a/examples/sicp/src/scheme/eval.bt
+++ b/examples/sicp/src/scheme/eval.bt
@@ -56,13 +56,11 @@ Object subclass: SchemeEval
         "cons"  => [:args | (#() add: (args at: 1)) ++ (args at: 2)],
         "list"  => [:args | args],
         "not"   => [:args | (args at: 1) not],
-        "null?" => [:args | 
+        "null?" => [:args |
           v := args at: 1
-          v isNil or: [v class =:= List and: [v isEmpty]]
-        ]
+          v isNil or: [v class =:= List and: [v isEmpty]]]
       },
-      #parent => nil
-    }
+      #parent => nil}
 
   /// Evaluate `expr` in `env` and return the result.
   ///
@@ -80,10 +78,10 @@ Object subclass: SchemeEval
   eval: expr in: env =>
     // Self-evaluating atomic types
     (expr class =:= Integer) ifTrue: [^expr]
-    (expr class =:= True) ifTrue: [^expr]
-    (expr class =:= False) ifTrue: [^expr]
-    (expr class =:= String) ifTrue: [^expr]
-    expr isNil ifTrue: [^expr]
+    (expr class =:= True)    ifTrue: [^expr]
+    (expr class =:= False)   ifTrue: [^expr]
+    (expr class =:= String)  ifTrue: [^expr]
+    expr isNil               ifTrue: [^expr]
 
     // Symbol: look up the name in the environment
     (expr class =:= SchemeSymbol) ifTrue: [
@@ -106,28 +104,22 @@ Object subclass: SchemeEval
       // (define name expr) — bind name in the current environment
       (sym =:= "define") ifTrue: [
         varName := (tail at: 1) name
-        val := self eval: (tail at: 2) in: env
+        val     := self eval: (tail at: 2) in: env
         env define: varName value: val
-        ^nil
-      ]
+        ^nil]
 
       // (lambda (params...) body) — create a closure
       (sym =:= "lambda") ifTrue: [
         params := (tail at: 1) collect: [:p | p name]
-        ^SchemeLambda withParams: params body: (tail at: 2) env: env
-      ]
+        ^SchemeLambda withParams: params body: (tail at: 2) env: env]
 
       // (if test then else?) — conditional branch
       (sym =:= "if") ifTrue: [
         condVal := self eval: (tail at: 1) in: env
-        (condVal == false or: [condVal isNil]) 
-          ifTrue: [
-            ^(tail size > 2) 
-              ifTrue: [self eval: (tail at: 3) in: env] 
-              ifFalse: [nil]
-          ] 
-          ifFalse: [^self eval: (tail at: 2) in: env]
-      ]
+        (condVal == false or: [condVal isNil]) ifTrue: [
+          ^(tail size > 2) ifTrue: [self eval: (tail at: 3) in: env] ifFalse: [nil]
+        ] ifFalse: [
+          ^self eval: (tail at: 2) in: env]]
 
       // (cond (test expr) ... (else expr))
       (sym =:= "cond") ifTrue: [^self evalCond: tail in: env]
@@ -145,9 +137,7 @@ Object subclass: SchemeEval
         params   := binds collect: [:b | (b at: 1) name]
         vals     := binds collect: [:b | self eval: (b at: 2) in: env]
         childEnv := env extend: params values: vals
-        ^self eval: body in: childEnv
-      ]
-    ]
+        ^self eval: body in: childEnv]]
 
     // Function application: evaluate head, evaluate all args, apply
     func     := self eval: head in: env
@@ -169,11 +159,9 @@ Object subclass: SchemeEval
   apply: func args: args in: _env =>
     (func class =:= SchemeLambda) ifTrue: [
       childEnv := func closureEnv extend: func params values: args
-      ^self eval: func body in: childEnv
-    ]
+      ^self eval: func body in: childEnv]
     (func class =:= Block) ifFalse: [
-      ^self error: "Not a procedure: " ++ func printString
-    ]
+      ^self error: "Not a procedure: " ++ func printString]
     // Built-in: block takes the full args list as its single argument
     func value: args
 
@@ -181,24 +169,20 @@ Object subclass: SchemeEval
   /// An `else` clause always matches. Returns `nil` if all tests fail.
   evalCond: clauses in: env =>
     clauses isEmpty ifTrue: [^nil]
-  
     clause := clauses first
-    ((clause first class =:= SchemeSymbol) and: [clause first name =:= "else"]) 
-      ifTrue: [^self eval: clause last in: env]
-
+    ((clause first class =:= SchemeSymbol) and: [clause first name =:= "else"]) ifTrue: [
+      ^self eval: clause last in: env]
     condVal := self eval: clause first in: env
-    (condVal == false or: [condVal isNil]) 
-      ifTrue: [self evalCond: clauses rest in: env] 
-      ifFalse: [self eval: clause last in: env]
+    (condVal == false or: [condVal isNil]) ifTrue: [
+      self evalCond: clauses rest in: env] ifFalse: [
+      self eval: clause last in: env]
 
   /// Evaluate `(and ...)` — return `false` on the first falsy value,
   /// otherwise return the last value.
   evalAnd: exprs in: env =>
     exprs isEmpty ifTrue: [^true]
-
     val := self eval: exprs first in: env
     (val == false or: [val isNil]) ifTrue: [^false]
-  
     exprs size =:= 1 ifTrue: [^val]
     self evalAnd: exprs rest in: env
 
@@ -206,8 +190,6 @@ Object subclass: SchemeEval
   /// or `false` if all expressions are falsy.
   evalOr: exprs in: env =>
     exprs isEmpty ifTrue: [^false]
-
     val := self eval: exprs first in: env
     (val == false or: [val isNil]) ifFalse: [^val]
-  
     self evalOr: exprs rest in: env

--- a/examples/sicp/src/scheme/lambda.bt
+++ b/examples/sicp/src/scheme/lambda.bt
@@ -16,8 +16,8 @@
 /// lam closureEnv   // => the SchemeEnv actor
 /// ```
 Object subclass: SchemeLambda
-  state: params = #()   // List of parameter name strings
-  state: body = nil   // Unevaluated body expression (AST)
+  state: params     = #()   // List of parameter name strings
+  state: body       = nil   // Unevaluated body expression (AST)
   state: closureEnv = nil   // SchemeEnv actor at point of definition
 
   /// Create a new lambda capturing `p` as parameter names, `b` as the body
@@ -31,10 +31,10 @@ Object subclass: SchemeLambda
     self new: #{#params => p, #body => b, #closureEnv => e}
 
   /// Return the list of parameter name strings.
-  params => self.params
+  params     => self.params
 
   /// Return the unevaluated body AST node.
-  body => self.body
+  body       => self.body
 
   /// Return the `SchemeEnv` actor captured at definition time.
   closureEnv => self.closureEnv

--- a/examples/sicp/src/scheme/printer.bt
+++ b/examples/sicp/src/scheme/printer.bt
@@ -32,10 +32,10 @@ Object subclass: SchemePrinter
   /// ```
   print: val =>
     val isNil ifTrue: [^"()"]
-    (val class =:= True) ifTrue: [^"#t"]
-    (val class =:= False) ifTrue: [^"#f"]
-    (val class =:= Integer) ifTrue: [^val printString]
-    (val class =:= String) ifTrue: [^"""" ++ val ++ """"]
+    (val class =:= True)         ifTrue: [^"#t"]
+    (val class =:= False)        ifTrue: [^"#f"]
+    (val class =:= Integer)      ifTrue: [^val printString]
+    (val class =:= String)       ifTrue: [^"""" ++ val ++ """"]
     (val class =:= SchemeSymbol) ifTrue: [^val name]
     (val class =:= SchemeLambda) ifTrue: [^"#<lambda>"]
     (val class =:= List) ifTrue: [^self printList: val]

--- a/examples/sicp/src/scheme/reader.bt
+++ b/examples/sicp/src/scheme/reader.bt
@@ -33,11 +33,9 @@ Object subclass: SchemeReader
   /// ```
   read: str =>
     chars := str asList
-    pair := self parseExpr: (self dropWs: chars)
-    rest := self dropWs: pair last
-    
+    pair  := self parseExpr: (self dropWs: chars)
+    rest  := self dropWs: pair last
     rest isEmpty ifFalse: [^self error: "Unexpected trailing input"]
-    
     pair first
 
   /// Return true if `ch` is a whitespace character (space, newline, tab, carriage return).
@@ -68,12 +66,10 @@ Object subclass: SchemeReader
   parseExpr: chars =>
     chars isEmpty ifTrue: [^self error: "Unexpected end of input"]
     ch := chars first
-  
     (ch =:= "(") ifTrue: [^self parseListElems: chars rest]
     (ch =:= "#") ifTrue: [^self parseBool: chars rest]
-    ch isDigit ifTrue: [^self parseNum: chars acc: ""]
-    (ch =:= """") ifTrue: [^self parseString: chars rest acc: ""]
-  
+    ch isDigit        ifTrue: [^self parseNum: chars acc: ""]
+    (ch =:= """")     ifTrue: [^self parseString: chars rest acc: ""]
     self parseSym: chars acc: ""
 
   /// Parse list elements after the opening `(` has been consumed.
@@ -81,13 +77,11 @@ Object subclass: SchemeReader
   parseListElems: chars =>
     trimmed := self dropWs: chars
     trimmed isEmpty ifTrue: [^self error: "Missing ')'"]
-
     (trimmed first =:= ")") ifTrue: [^self pairOf: #() rest: trimmed rest]
     headPair := self parseExpr: trimmed
-    head := headPair first
+    head     := headPair first
     tailPair := self parseListElems: (self dropWs: headPair last)
-    tail := tailPair first
-  
+    tail     := tailPair first
     self pairOf: ((#() add: head) ++ tail) rest: tailPair last
 
   /// Parse `#t` or `#f`; `chars` is positioned after the `#`.
@@ -111,8 +105,7 @@ Object subclass: SchemeReader
   /// ```
   parseNum: chars acc: acc =>
     (chars isEmpty or: [self isDelim: chars first]) ifTrue: [
-      ^self pairOf: acc asInteger rest: chars
-    ]
+      ^self pairOf: acc asInteger rest: chars]
     self parseNum: chars rest acc: acc ++ chars first
 
   /// Parse a string literal; `chars` is positioned after the opening `"`.
@@ -124,14 +117,10 @@ Object subclass: SchemeReader
   /// ```
   parseString: chars acc: acc =>
     chars isEmpty ifTrue: [^self error: "Unterminated string literal"]
-    
     (chars first =:= """") ifTrue: [
       (chars rest isEmpty not and: [chars rest first =:= """"]) ifTrue: [
-        ^self parseString: chars rest rest acc: acc ++ """"
-      ]
-      ^self pairOf: acc rest: chars rest
-    ]
-    
+        ^self parseString: chars rest rest acc: acc ++ """"]
+      ^self pairOf: acc rest: chars rest]
     self parseString: chars rest acc: acc ++ chars first
 
   /// Parse a symbol by accumulating non-delimiter characters.
@@ -143,7 +132,5 @@ Object subclass: SchemeReader
   /// ```
   parseSym: chars acc: acc =>
     (chars isEmpty or: [self isDelim: chars first]) ifTrue: [
-      ^self pairOf: (SchemeSymbol withName: acc) rest: chars
-    ]
-    
+      ^self pairOf: (SchemeSymbol withName: acc) rest: chars]
     self parseSym: chars rest acc: acc ++ chars first

--- a/examples/sicp/test/scheme_test.bt
+++ b/examples/sicp/test/scheme_test.bt
@@ -17,9 +17,9 @@ TestCase subclass: SchemeTest
 
   // Helpers shared across tests
   eval: str =>
-    reader := SchemeReader new
-    ev := SchemeEval new
-    env := ev defaultEnv
+    reader  := SchemeReader new
+    ev      := SchemeEval new
+    env     := ev defaultEnv
     ev eval: (reader read: str) in: env
 
   evalStr: str =>
@@ -33,7 +33,7 @@ TestCase subclass: SchemeTest
 
   testReaderSymbol =>
     reader := SchemeReader new
-    sym := reader read: "foo"
+    sym    := reader read: "foo"
     self assert: (sym class =:= SchemeSymbol)
 
   testReaderBoolTrue =>
@@ -92,8 +92,8 @@ TestCase subclass: SchemeTest
 
   testDefine =>
     reader := SchemeReader new
-    ev := SchemeEval new
-    env := ev defaultEnv
+    ev     := SchemeEval new
+    env    := ev defaultEnv
     ev eval: (reader read: "(define x 10)") in: env
     self assert: (ev eval: (reader read: "x") in: env) equals: 10
 
@@ -171,8 +171,8 @@ TestCase subclass: SchemeTest
 
   testClosure =>
     reader := SchemeReader new
-    ev := SchemeEval new
-    env := ev defaultEnv
+    ev     := SchemeEval new
+    env    := ev defaultEnv
     ev eval: (reader read: "(define make-adder (lambda (n) (lambda (x) (+ n x))))") in: env
     ev eval: (reader read: "(define add5 (make-adder 5))") in: env
     self assert: (ev eval: (reader read: "(add5 10)") in: env) equals: 15


### PR DESCRIPTION
## Summary
- Reverts commit 0bc5afb5 which broke Beamtalk code while reformatting SICP examples

## Test plan
- [ ] Verify SICP examples compile and run correctly after revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Aligned spacing and formatting across code examples for improved readability.

* **Refactor**
  * Simplified error handling logic in environment operations.
  * Reorganized control flow in parsing operations while maintaining equivalent behavior.

* **Tests**
  * Updated test code formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->