### PR TITLE
Formatter: emit canonical blank lines between class sections and methods (BT-985)

### DIFF
--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -193,6 +193,11 @@ pub(crate) fn unparse_class_definition(class: &ClassDefinition) -> Document<'sta
         docs.push(nest(2, docvec![line(), unparse_method_definition(method)]));
     }
 
+    // Blank line between last instance method and first class-side method
+    if !class.methods.is_empty() && !class.class_methods.is_empty() {
+        docs.push(line());
+    }
+
     // Class-side methods
     for (i, method) in class.class_methods.iter().enumerate() {
         if i > 0 {


### PR DESCRIPTION
## Summary

- Always emit a blank line between class leading comments (e.g. license block) and the doc comment/class header
- Always emit a blank line before the first method in a class body, regardless of whether state declarations exist
- Emit a blank line between consecutive methods within a class

Fixes: https://linear.app/beamtalk/issue/BT-985

## Test plan

- [x] `beamtalk fmt-check examples/getting-started/src/hello.bt` reports no diff
- [x] All idempotency tests pass (hello.bt, hanoi.bt, point.bt)
- [x] `just ci` passes (2371 Rust tests, 886 stdlib/BUnit, 2208 Erlang tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated-code formatting: ensures a blank line between leading comments and doc headers.
  * Consistently inserts blank lines between consecutive instance methods, between consecutive class-side methods, and between the last instance method and the first class-side method when both exist.
  * No public or exported signatures were added, removed, or changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->