### PR TITLE
ADR: REPL expression-level completion via gradual type inference (BT-989)

### DIFF
--- a/docs/ADR/0045-repl-expression-completion-type-inference.md
+++ b/docs/ADR/0045-repl-expression-completion-type-inference.md
@@ -1,7 +1,7 @@
 # ADR 0045: REPL Expression-Level Completion via Gradual Type Inference
 
 ## Status
-Proposed 2026-03-01
+Accepted 2026-03-01
 
 ## Context
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -71,7 +71,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0042](0042-immutable-value-objects-actor-mutable-state.md) | Immutable Value Objects and Actor-Only Mutable State | Accepted | 2026-02-26 |
 | [0043](0043-sync-by-default-actor-messaging.md) | Sync-by-Default Actor Messaging | Accepted | 2026-02-26 |
 | [0044](0044-comments-as-first-class-ast-nodes.md) | Comments as First-Class AST Nodes | Accepted | 2026-02-28 |
-| [0045](0045-repl-expression-completion-type-inference.md) | REPL Expression-Level Completion via Gradual Type Inference | Proposed | 2026-03-01 |
+| [0045](0045-repl-expression-completion-type-inference.md) | REPL Expression-Level Completion via Gradual Type Inference | Accepted | 2026-03-01 |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## Summary

Adds ADR 0045 documenting the architecture for expression-level REPL completion without evaluation.

**Decision**: Erlang-side chain resolution using a new `method_return_types` map stored on each class in `class_state`. The completion engine walks unary send chains one hop at a time, looking up return types from the runtime class registry. No IPC, no port dependency, full visibility of user-defined REPL classes.

## Key design decisions

- `method_return_types :: #{selector() => atom()}` stored separately from `method_signatures` display strings — follows Elixir's `@spec` vs `@doc` separation
- Only `TypeAnnotation::Simple` annotations produce return-type entries; Union/Generic/Singleton treated as dynamic (acceptable initial scope)
- Initial scope: unary send chains only; keyword sends mid-chain deferred to follow-up
- `walk_chain_class/2` handles class→instance transition for class-side send chains
- Return-type lookup must walk the superclass chain (same as method dispatch)
- `apply_class_info/2` and `put_method/3` must thread the new fields
- Option C (compiler fallback for unannotated methods) is the natural upgrade path, built on top of this Option A foundation — tracked in BT-993

## Changes

- `docs/ADR/0045-repl-expression-completion-type-inference.md` — new ADR
- `docs/ADR/README.md` — index entry

## Linear

https://linear.app/beamtalk/issue/BT-989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved REPL expression-level completion with chain-aware type inference for multi-token receivers, enabling more accurate suggestions.

* **Public API**
  * Expanded runtime/query surface to expose return-type lookups for improved completion workflows.

* **Documentation**
  * Added ADR describing the inference design, integration phases, edge cases, and migration notes; updated ADR index.

* **Tests**
  * Added tests covering chain-resolution and return-type inference behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->