### PR TITLE
Idiomatic improvements to examples, trace:/traceCr: return self

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
@@ -1532,6 +1532,7 @@ pub(super) fn generated_builtin_classes() -> HashMap<EcoString, ClassInfo> {
             class_methods: vec![
                 MethodInfo { selector: "current".into(), arity: 0, kind: MethodKind::Primary, defined_in: "TranscriptStream".into(), is_sealed: false, return_type: Some("TranscriptStream".into()), param_types: vec![] },
                 MethodInfo { selector: "current:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "TranscriptStream".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![Some("TranscriptStream".into())] },
+                MethodInfo { selector: "resetCurrent".into(), arity: 0, kind: MethodKind::Primary, defined_in: "TranscriptStream".into(), is_sealed: false, return_type: Some("Nil".into()), param_types: vec![] },
             ],
             class_variables: vec!["current".into()],
         },

--- a/examples/getting-started/src/logging_counter.bt
+++ b/examples/getting-started/src/logging_counter.bt
@@ -3,9 +3,8 @@
 
 /// LoggingCounter demonstrates the "super" keyword for calling superclass methods
 ///
-/// This class extends Counter and adds logging functionality.
-/// When increment is called, it logs the action and then delegates
-/// to the superclass implementation using "super".
+/// This class extends Counter and adds logging via `traceCr:` before
+/// delegating to the superclass implementation using "super".
 ///
 /// IMPORTANT: Load counter.bt first to define the Counter class:
 ///   > :load examples/counter.bt
@@ -14,7 +13,6 @@ Counter subclass: LoggingCounter
   
   // Override increment to add logging before delegating to superclass
   // The "super" keyword calls Counter's increment method
-  increment => 
-    // TODO: Add actual logging when we have IO/logging support
-    // For now, just delegate to super
+  increment =>
+    self traceCr: "increment called"
     super increment

--- a/examples/getting-started/test/hello_test.bt
+++ b/examples/getting-started/test/hello_test.bt
@@ -10,12 +10,26 @@
 
 TestCase subclass: HelloTest
 
+  setUp =>
+    self.ts := TranscriptStream spawn
+    TranscriptStream current: self.ts
+    self
+
+  tearDown =>
+    TranscriptStream current ifNotNil: [:t | t stop]
+    TranscriptStream resetCurrent
+    self
+
   testGreeting =>
-    self assert: Hello new greeting equals: "Hello, World!"
+    // greeting outputs "Hello, World!" via traceCr: and returns self
+    Hello new greeting
+    self assert: (self.ts recent includes: "Hello, World!")
 
   testTwoInstancesHaveSameGreeting =>
-    // Value types have no shared state — both instances return the same greeting
-    self assert: Hello new greeting equals: Hello new greeting
+    // Both instances output the same text
+    Hello new greeting
+    Hello new greeting
+    self assert: (self.ts recent includes: "Hello, World!")
 
   testClassIsHello =>
     // Hello is a value type — class name is the symbol #Hello

--- a/examples/getting-started/test/logging_counter_test.bt
+++ b/examples/getting-started/test/logging_counter_test.bt
@@ -13,13 +13,31 @@
 
 TestCase subclass: LoggingCounterTest
 
+  setUp =>
+    self.ts := TranscriptStream spawn
+    TranscriptStream current: self.ts
+    self
+
+  tearDown =>
+    TranscriptStream current ifNotNil: [:t | t stop]
+    TranscriptStream resetCurrent
+    self
+
   testInitialValueIsZero =>
     // Inherits Counter's initial state
     self assert: LoggingCounter spawn getValue equals: 0
 
   testIncrementDelegatesToSuper =>
-    // LoggingCounter#increment calls super increment — returns new value
+    // LoggingCounter#increment logs then delegates to super — returns new value
     self assert: LoggingCounter spawn increment equals: 1
+    self assert: (self.ts recent includes: "increment called")
+
+  testIncrementLogs =>
+    // Each increment call produces a log message
+    lc := LoggingCounter spawn
+    lc increment
+    lc increment
+    self assert: (self.ts recent includes: "increment called")
 
   testDecrementIsInherited =>
     // decrement is inherited from Counter unchanged

--- a/examples/sicp/src/scheme/env.bt
+++ b/examples/sicp/src/scheme/env.bt
@@ -71,6 +71,7 @@ Actor subclass: SchemeEnv
     (params size =:= vals size) ifFalse: [
       ^self error: "Arity mismatch: expected " ++ params size printString
                    ++ ", got " ++ vals size printString]
+    // zip: returns #{"key" => param, "value" => val} maps
     newBindings := (params zip: vals) inject: #{} into: [:d :pair |
       d at: (pair at: "key") put: (pair at: "value")]
     SchemeEnv spawnWith: #{#bindings => newBindings, #parent => self}

--- a/examples/sicp/src/scheme/eval.bt
+++ b/examples/sicp/src/scheme/eval.bt
@@ -77,11 +77,7 @@ Object subclass: SchemeEval
   /// ```
   eval: expr in: env =>
     // Self-evaluating atomic types
-    (expr class =:= Integer) ifTrue: [^expr]
-    (expr class =:= True)    ifTrue: [^expr]
-    (expr class =:= False)   ifTrue: [^expr]
-    (expr class =:= String)  ifTrue: [^expr]
-    expr isNil               ifTrue: [^expr]
+    (expr isNil or: [#(Integer, True, False, String) includes: expr class]) ifTrue: [^expr]
 
     // Symbol: look up the name in the environment
     (expr class =:= SchemeSymbol) ifTrue: [
@@ -122,7 +118,7 @@ Object subclass: SchemeEval
       // (if test then else?) — conditional branch
       "if" -> [
         condVal := self eval: (tail at: 1) in: env
-        isFalsy := condVal == false or: [condVal isNil]
+        isFalsy := self isFalsy: condVal
         isFalsy ifTrue: [
           (tail size > 2) ifTrue: [self eval: (tail at: 3) in: env] ifFalse: [nil]] ifFalse: [
           self eval: (tail at: 2) in: env]] value;
@@ -164,7 +160,7 @@ Object subclass: SchemeEval
   ///
   /// ## Examples
   /// ```beamtalk
-  /// ev apply: [:a | (a at: 1) + (a at: 2)] args: #(3 4) in: env   // => 7
+  /// ev apply: [:a | (a at: 1) + (a at: 2)] args: #(3, 4) in: env   // => 7
   /// ```
   apply: func args: args in: _env =>
     (func class =:= SchemeLambda) ifTrue: [
@@ -175,6 +171,10 @@ Object subclass: SchemeEval
     // Built-in: block takes the full args list as its single argument
     func value: args
 
+  /// Return true if `val` is Scheme-falsy (i.e. `false` or `nil`).
+  isFalsy: val =>
+    val == false or: [val isNil]
+
   /// Evaluate `cond` clauses in order; return the first truthy branch.
   /// An `else` clause always matches. Returns `nil` if all tests fail.
   evalCond: clauses in: env =>
@@ -183,7 +183,7 @@ Object subclass: SchemeEval
     ((clause first class =:= SchemeSymbol) and: [clause first name =:= "else"]) ifTrue: [
       ^self eval: clause last in: env]
     condVal := self eval: clause first in: env
-    (condVal == false or: [condVal isNil]) ifTrue: [
+    (self isFalsy: condVal) ifTrue: [
       self evalCond: clauses rest in: env] ifFalse: [
       self eval: clause last in: env]
 
@@ -192,7 +192,7 @@ Object subclass: SchemeEval
   evalAnd: exprs in: env =>
     exprs isEmpty ifTrue: [^true]
     val := self eval: exprs first in: env
-    (val == false or: [val isNil]) ifTrue: [^false]
+    (self isFalsy: val) ifTrue: [^false]
     exprs size =:= 1 ifTrue: [^val]
     self evalAnd: exprs rest in: env
 
@@ -201,5 +201,5 @@ Object subclass: SchemeEval
   evalOr: exprs in: env =>
     exprs isEmpty ifTrue: [^false]
     val := self eval: exprs first in: env
-    (val == false or: [val isNil]) ifFalse: [^val]
+    (self isFalsy: val) ifFalse: [^val]
     self evalOr: exprs rest in: env

--- a/examples/sicp/src/scheme/lambda.bt
+++ b/examples/sicp/src/scheme/lambda.bt
@@ -28,4 +28,4 @@ Value subclass: SchemeLambda
   /// SchemeLambda withParams: #("x") body: ast env: env
   /// ```
   class withParams: p body: b env: e =>
-    SchemeLambda params: p body: b closureEnv: e
+    SchemeLambda new: #{#params => p, #body => b, #closureEnv => e}

--- a/examples/sicp/src/scheme/printer.bt
+++ b/examples/sicp/src/scheme/printer.bt
@@ -14,7 +14,7 @@
 /// printer print: true        // => "#t"
 /// printer print: false       // => "#f"
 /// printer print: nil         // => "()"
-/// printer print: #(1 2 3)    // => "(1 2 3)"
+/// printer print: #(1, 2, 3)    // => "(1 2 3)"
 /// ```
 Object subclass: SchemePrinter
 
@@ -46,7 +46,7 @@ Object subclass: SchemePrinter
   /// ## Examples
   /// ```beamtalk
   /// SchemePrinter new printList: #()        // => "()"
-  /// SchemePrinter new printList: #(1 2 3)   // => "(1 2 3)"
+  /// SchemePrinter new printList: #(1, 2, 3)   // => "(1 2 3)"
   /// ```
   printList: lst =>
     lst isEmpty ifTrue: [^"()"]

--- a/examples/sicp/src/scheme/reader.bt
+++ b/examples/sicp/src/scheme/reader.bt
@@ -40,7 +40,7 @@ Object subclass: SchemeReader
 
   /// Return true if `ch` is a whitespace character (space, newline, tab, carriage return).
   isWs: ch =>
-    (ch =:= " ") or: [(ch =:= "\n") or: [(ch =:= "\t") or: [ch =:= "\r"]]]
+    #(" ", "\n", "\t", "\r") includes: ch
 
   /// Drop leading whitespace characters from a char list.
   dropWs: chars =>
@@ -54,7 +54,7 @@ Object subclass: SchemeReader
 
   /// Return true if `ch` is a token delimiter (whitespace, `(`, or `)`).
   isDelim: ch =>
-    (self isWs: ch) or: [(ch =:= "(") or: [ch =:= ")"]]
+    (self isWs: ch) or: [#("(", ")") includes: ch]
 
   /// Dispatch to the appropriate sub-parser based on the leading character.
   ///
@@ -113,7 +113,7 @@ Object subclass: SchemeReader
   ///
   /// ## Examples
   /// ```beamtalk
-  /// SchemeReader new read: '"hello"'     // => "hello"
+  /// SchemeReader new read: """hello"""     // => "hello"
   /// ```
   parseString: chars acc: acc =>
     chars isEmpty ifTrue: [^self error: "Unterminated string literal"]

--- a/examples/sicp/src/scheme/symbol.bt
+++ b/examples/sicp/src/scheme/symbol.bt
@@ -15,7 +15,7 @@
 /// sym == (SchemeSymbol withName: "lambda")  // => false
 /// ```
 Value subclass: SchemeSymbol
-  state: name = ""
+  state: symName = ""
 
   /// Create a new symbol with the given name string.
   ///
@@ -23,7 +23,15 @@ Value subclass: SchemeSymbol
   /// ```beamtalk
   /// SchemeSymbol withName: "car"   // => a SchemeSymbol
   /// ```
-  class withName: n => SchemeSymbol name: n
+  class withName: n => SchemeSymbol new: #{#symName => n}
+
+  /// Return the symbol name string.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// (SchemeSymbol withName: "cons") name   // => "cons"
+  /// ```
+  name => self.symName
 
   /// Return the symbol name as a string (same as `name`).
   ///
@@ -31,4 +39,4 @@ Value subclass: SchemeSymbol
   /// ```beamtalk
   /// (SchemeSymbol withName: "cons") printString   // => "cons"
   /// ```
-  printString => self.name
+  printString => self.symName

--- a/stdlib/src/Object.bt
+++ b/stdlib/src/Object.bt
@@ -224,7 +224,9 @@ ProtoObject subclass: Object
   /// ```beamtalk
   /// 42 trace: "value: "
   /// ```
-  trace: aValue => TranscriptStream current ifNotNil: [:t | t show: aValue]
+  trace: aValue =>
+    TranscriptStream current ifNotNil: [:t | t show: aValue]
+    self
 
   /// Send aValue to the current transcript followed by a newline.
   ///
@@ -234,7 +236,9 @@ ProtoObject subclass: Object
   /// ```beamtalk
   /// 42 traceCr: "hello world"
   /// ```
-  traceCr: aValue => TranscriptStream current ifNotNil: [:t | t show: aValue; cr]
+  traceCr: aValue =>
+    TranscriptStream current ifNotNil: [:t | t show: aValue; cr]
+    self
 
   /// Raise an error with the given message.
   ///

--- a/stdlib/src/TranscriptStream.bt
+++ b/stdlib/src/TranscriptStream.bt
@@ -23,6 +23,9 @@ Actor subclass: TranscriptStream
   /// Set the current singleton instance.
   class current: instance: TranscriptStream -> Nil => self.current := instance
 
+  /// Clear the current singleton instance (reset to nil).
+  class resetCurrent -> Nil => self.current := nil
+
   /// Write a value to the transcript.
   ///
   /// ## Examples

--- a/stdlib/test/trace_cr_test.bt
+++ b/stdlib/test/trace_cr_test.bt
@@ -11,25 +11,25 @@ TestCase subclass: TraceCrTest
 
   setUp =>
     // Ensure current is nil before each test (default in test environment)
-    TranscriptStream current: nil
+    TranscriptStream resetCurrent
     self
 
   tearDown =>
     // Stop per-test transcript actor when one was set
     TranscriptStream current ifNotNil: [:t | t stop]
     // Restore nil state after each test
-    TranscriptStream current: nil
+    TranscriptStream resetCurrent
     self
 
   testTraceCrNilSafeWhenNoTranscript =>
-    // When TranscriptStream current is nil, traceCr: should be a no-op (returns nil)
-    TranscriptStream current: nil
-    self assert: (42 traceCr: "hello") equals: nil
+    // When TranscriptStream current is nil, traceCr: is a no-op and returns self
+    TranscriptStream resetCurrent
+    self assert: (42 traceCr: "hello") equals: 42
 
   testTraceNilSafeWhenNoTranscript =>
-    // When TranscriptStream current is nil, trace: should be a no-op (returns nil)
-    TranscriptStream current: nil
-    self assert: (42 trace: "hello") equals: nil
+    // When TranscriptStream current is nil, trace: is a no-op and returns self
+    TranscriptStream resetCurrent
+    self assert: (42 trace: "hello") equals: 42
 
   testTraceCrRoutesOutputWhenTranscriptSet =>
     // When a TranscriptStream is set as current, traceCr: routes output to it


### PR DESCRIPTION
## Summary

- **SICP examples**: Use `includes:` for membership checks, extract `isFalsy:` helper, fix doc comment syntax errors (missing commas, single-quoted strings), work around BT-996 getter/constructor collision in `SchemeSymbol` and `SchemeLambda`
- **Stdlib**: `trace:`/`traceCr:` now return `self` (idiomatic Smalltalk), added `TranscriptStream>>resetCurrent` to avoid type warning
- **Getting-started**: `LoggingCounter` implements actual logging via `traceCr:` (was TODO), test coverage for transcript output in `HelloTest` and `LoggingCounterTest`

## Issues discovered during this work

- BT-996: Codegen resolves `ClassName field: value` to instance getter instead of keyword constructor
- BT-997: "Failed to load stdlib module" should name the specific module
- BT-998: `register_class/0` silently swallows errors
- BT-999: Class dispatch should raise structured error on `undef`
- BT-1000: `zip:` returns maps not Arrays as documented

## Test plan

- [x] `just test` — all pass
- [x] `just test-stdlib` — all pass
- [x] `just clippy` — clean
- [x] `just fmt` — clean
- [x] `beamtalk test` in `examples/getting-started` — 21/21 pass
- [ ] `beamtalk test` in `examples/sicp` — 36/40 pass (4 lambda failures are BT-996, not this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `resetCurrent()` method to TranscriptStream for clearing the current transcript instance.
  * Implemented test lifecycle support with setUp/tearDown methods in test classes.
  * Added new test for logging increment operations.

* **Bug Fixes**
  * Fixed trace and traceCr methods to return self instead of the transcript stream value.
  * Improved Scheme symbol evaluation to properly look up symbol values in the environment.

* **Tests**
  * Enhanced test infrastructure with proper setup and teardown lifecycle management.
  * Updated test assertions to verify logging output via transcript streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->