### PR TITLE
stdlib: List>>zip: returns 2-element Array pairs instead of maps (BT-1000)

### DIFF
--- a/examples/sicp/src/scheme/env.bt
+++ b/examples/sicp/src/scheme/env.bt
@@ -71,7 +71,6 @@ Actor subclass: SchemeEnv
     (params size =:= vals size) ifFalse: [
       ^self error: "Arity mismatch: expected " ++ params size printString
                    ++ ", got " ++ vals size printString]
-    // zip: returns #{"key" => param, "value" => val} maps
     newBindings := (params zip: vals) inject: #{} into: [:d :pair |
-      d at: (pair at: "key") put: (pair at: "value")]
+      d at: pair first put: pair last]
     SchemeEnv spawnWith: #{#bindings => newBindings, #parent => self}

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_list_ops.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_list_ops.erl
@@ -189,10 +189,10 @@ sort_with(_List, Block) ->
     Error2 = beamtalk_error:with_hint(Error1, Hint),
     beamtalk_error:raise(Error2).
 
-%% @doc Zip two lists into a list of maps #{key => K, value => V}.
+%% @doc Zip two lists into a list of 2-element List pairs [Elem1, Elem2].
 -spec zip(list(), list()) -> list().
 zip(List, Other) when is_list(List), is_list(Other) ->
-    zip_to_maps(List, Other);
+    zip_to_pairs(List, Other);
 zip(List, Other) when is_list(List) ->
     Error0 = beamtalk_error:new(type_error, 'List'),
     Error1 = beamtalk_error:with_selector(Error0, 'zip:'),
@@ -302,9 +302,9 @@ safe_nthtail(0, List) -> List;
 safe_nthtail(_, []) -> [];
 safe_nthtail(N, [_ | T]) -> safe_nthtail(N - 1, T).
 
-zip_to_maps([], _) -> [];
-zip_to_maps(_, []) -> [];
-zip_to_maps([H1 | T1], [H2 | T2]) -> [#{<<"key">> => H1, <<"value">> => H2} | zip_to_maps(T1, T2)].
+zip_to_pairs([], _) -> [];
+zip_to_pairs(_, []) -> [];
+zip_to_pairs([H1 | T1], [H2 | T2]) -> [[H1, H2] | zip_to_pairs(T1, T2)].
 
 %% @doc Return a human-readable description of a value for error messages.
 %%

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_list_ops_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_list_ops_tests.erl
@@ -425,23 +425,11 @@ sort_with_non_list_test() ->
 
 zip_equal_test() ->
     Result = beamtalk_list_ops:zip([a, b], [1, 2]),
-    ?assertEqual(
-        [
-            #{<<"key">> => a, <<"value">> => 1},
-            #{<<"key">> => b, <<"value">> => 2}
-        ],
-        Result
-    ).
+    ?assertEqual([[a, 1], [b, 2]], Result).
 
 zip_unequal_test() ->
     Result = beamtalk_list_ops:zip([a, b, c], [1, 2]),
-    ?assertEqual(
-        [
-            #{<<"key">> => a, <<"value">> => 1},
-            #{<<"key">> => b, <<"value">> => 2}
-        ],
-        Result
-    ).
+    ?assertEqual([[a, 1], [b, 2]], Result).
 
 zip_empty_test() ->
     ?assertEqual([], beamtalk_list_ops:zip([], [1, 2])).

--- a/stdlib/test/collections_test.bt
+++ b/stdlib/test/collections_test.bt
@@ -81,6 +81,9 @@ TestCase subclass: CollectionsTest
     // --- zip: ---
     zipped := #(1, 2, 3) zip: #(4, 5, 6)
     self assert: zipped size equals: 3
+    pair := zipped first
+    self assert: pair first equals: 1
+    self assert: pair last equals: 4
     // --- groupBy: ---
     grouped := #(1, 2, 3, 4, 5, 6) groupBy: [:x | x isEven]
     self assert: grouped size equals: 2


### PR DESCRIPTION
## Summary

Fixes `List>>zip:` to return 2-element Array pairs (`#(elem1, elem2)`) instead of Erlang maps with `<<"key">>` / `<<"value">>` string keys, matching the documented API.

**Linear issue:** https://linear.app/beamtalk/issue/BT-1000

## Changes

- **`beamtalk_list_ops.erl`** — Rename `zip_to_maps/2` → `zip_to_pairs/2`, return `[H1, H2]` lists
- **`beamtalk_list_ops_tests.erl`** — Update EUnit expectations from maps to 2-element lists
- **`collections_test.bt`** — Add `first`/`last` pair access assertions to verify the new shape
- **`examples/sicp/src/scheme/env.bt`** — Fix the only in-tree caller to use `pair first`/`pair last`

## Test plan

- [x] EUnit tests pass with new pair shape
- [x] Stdlib BUnit collections test verifies `first`/`last` on zip pairs
- [x] Full CI passes (`just ci`)
- [x] SICP example `env.bt` updated and compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated `zip` function output structure for consistency

* **Tests**
  * Aligned test expectations with updated `zip` function behavior

* **Documentation**
  * Updated to reflect `zip` function output changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->