### PR TITLE
LSP: formatting via Beamtalk unparser (BT-1012)

### DIFF
--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -1180,9 +1180,13 @@ mod tests {
 
     #[test]
     fn format_source_returns_formatted_string() {
+        // An unformatted source must produce non-empty output, and that output
+        // must be stable (formatting the result again returns the same string).
         let source = "Object subclass: Foo\n  bar => 42\n";
-        let result = format_source(source);
-        assert!(result.is_some(), "valid source must be formatted");
+        let pass1 = format_source(source).expect("valid source must produce output");
+        assert!(!pass1.is_empty(), "formatted output must not be empty");
+        let pass2 = format_source(&pass1).expect("formatted output must be valid");
+        assert_eq!(pass1, pass2, "output must be canonical (idempotent)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Advertises `documentFormattingProvider` and `documentRangeFormattingProvider` in `initialize`
- Implements `textDocument/formatting` — formats the whole document using the Beamtalk unparser
- Implements `textDocument/rangeFormatting` — also formats the whole document (the unparser is file-scoped, like `rustfmt`)
- Skips formatting if the file has parse errors to prevent corrupting broken files
- Format-on-save and "Format Document" in VSCode work with no extra configuration

## Key Changes

- `Backend::format_document` — shared helper that formats a URI's in-memory source and returns a whole-document `TextEdit` (or an empty list if already formatted)
- `format_source` — thin wrapper around `lex_with_eof` + `parse` + `unparse_module`, same logic as `beamtalk fmt`
- 4 unit tests: parse error suppression, valid formatting, trailing newline, idempotency

## Links

https://linear.app/beamtalk/issue/BT-1012/lsp-formatting-via-beamtalk-fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document and range formatting support to the language server, enabling automatic code formatting for entire documents or selected ranges.

* **Tests**
  * Added comprehensive tests verifying formatting behavior, including proper error handling and idempotent formatting across multiple runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->