### PR TITLE
CLI: print session ID to stdout on REPL connect (BT-1021)

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -565,6 +565,12 @@ pub fn run(
     println!("Connected to REPL backend on port {connect_port}.");
     if let Some(session_id) = client.session_id() {
         println!("[beamtalk] session: {session_id}");
+    } else {
+        eprintln!(
+            "[beamtalk] warning: REPL backend did not provide a session id; \
+             editor integrations (e.g., VS Code) may not function correctly."
+        );
+        warn!("REPL backend connected without session id; stdout session contract not satisfied");
     }
 
     // BT-689: Print browser workspace URL when --web flag is used
@@ -1014,6 +1020,11 @@ pub(crate) fn repl_loop(
                                     );
                                 } else {
                                     eprintln!("Reconnected (new session). Retrying evaluation...");
+                                    // BT-1021: Emit updated session line so external consumers
+                                    // (e.g. VS Code) can track the new session ID.
+                                    if let Some(session_id) = client.session_id() {
+                                        println!("[beamtalk] session: {session_id}");
+                                    }
                                 }
                                 // Keep the completion helper's session ID in sync
                                 if let Some(h) = rl.helper() {


### PR DESCRIPTION
## Summary

- Print `[beamtalk] session: <id>` to stdout immediately after connecting to the workspace
- Enables VSCode extension to capture the session ID for querying bindings (ADR 0046 Phase 0)
- Printed once on connect, not on reconnect

## Changes

- `crates/beamtalk-cli/src/commands/repl/mod.rs`: Added 3 lines after `connect_with_retries` to print session ID

## Linear Issue

https://linear.app/beamtalk/issue/BT-1021/cli-print-session-id-to-stdout-on-repl-connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REPL now displays the active session identifier on connection and after reconnection, so users can identify their current interactive session.
* **Bug Fixes / UX**
  * Adds a user-facing warning when no session identifier is available, clarifying potential limitations for editor integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->