### PR TITLE
LSP: handle beamtalk-stdlib:// URIs for full virtual document support (BT-1029)

### DIFF
--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -1747,12 +1747,24 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn resolve_path_for_uri_file_uri_still_works() {
         let (service, _socket) = tower_lsp::LspService::new(Backend::new);
         let backend: &Backend = service.inner();
 
         let uri = Url::parse("file:///some/project/main.bt").expect("valid URI");
         let result = backend.resolve_path_for_uri(&uri);
-        assert_eq!(result, Some(Utf8PathBuf::from("/some/project/main.bt")),);
+        assert_eq!(result, Some(Utf8PathBuf::from("/some/project/main.bt")));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn resolve_path_for_uri_file_uri_still_works() {
+        let (service, _socket) = tower_lsp::LspService::new(Backend::new);
+        let backend: &Backend = service.inner();
+
+        let uri = Url::parse("file:///C:/project/main.bt").expect("valid URI");
+        let result = backend.resolve_path_for_uri(&uri);
+        assert_eq!(result, Some(Utf8PathBuf::from("C:/project/main.bt")));
     }
 }


### PR DESCRIPTION
## Summary

Resolves [BT-1029](https://linear.app/beamtalk/issue/BT-1029)

When a user navigates to a stdlib class definition, VSCode opens a `beamtalk-stdlib:///ClassName.bt` virtual document and sends standard LSP requests against it. Previously, `uri_to_path` only handled `file://` and `untitled:` URIs, so all features (hover, completion, goto_definition, etc.) were silently disabled for stdlib virtual documents.

- Add `Backend::resolve_path_for_uri()` that maps `beamtalk-stdlib:///ClassName.bt` URIs to real filesystem paths via `stdlib_paths` lookup
- Update all LSP handlers to use `resolve_path_for_uri` instead of `uri_to_path`
- `did_open` skips `svc.update_file` for stdlib (already pre-loaded at startup)
- `did_change` ignores stdlib URIs (read-only virtual documents)
- `did_close` preserves stdlib content in index across editor open/close cycles
- `formatting` and `publish_diagnostics` are no-ops for stdlib URIs
- Add unit tests for `resolve_path_for_uri` covering: stdlib resolves to real path, unknown class returns None, invalid URI form returns None, ambiguous filenames return None, file:// URIs still work

## Test plan

- [x] All existing LSP tests pass
- [x] New unit tests for `resolve_path_for_uri` edge cases
- [x] `just build && just clippy && just fmt-check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added proper URI resolution for standard library references so the language server accurately distinguishes stdlib vs user files across features.

* **Bug Fixes**
  * Ensured formatting, diagnostics, indexing, and code-intelligence skip or treat stdlib as read-only to avoid edits, false diagnostics, and incorrect reindexing.

* **Tests**
  * Added comprehensive tests covering URI resolution, malformed/ambiguous stdlib URIs, platform file-URI behaviors, and related formatting/idempotence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->