### PR TITLE
MCP complete op: send cursor field to enable chain completions (BT-1043)

### DIFF
--- a/crates/beamtalk-mcp/src/client.rs
+++ b/crates/beamtalk-mcp/src/client.rs
@@ -207,11 +207,12 @@ impl ReplClient {
 
     /// Send a complete operation.
     ///
-    /// `cursor` is the byte offset into `code` at which completion is requested.
-    /// Passing `code.len()` (end of input) is the standard default. The REPL
-    /// uses the presence of the `cursor` field to enable chain completion
-    /// (e.g. `"hello" size` → Integer methods); omitting it falls back to
-    /// bare-prefix completion only.
+    /// `code` must already be truncated to `cursor` (i.e. only the text the
+    /// user has typed up to the cursor position). `cursor` is included as a
+    /// field in the JSON request; its presence tells the REPL to use the
+    /// context-aware chain-completion path (`get_context_completions/2`)
+    /// rather than the legacy bare-prefix path. The cursor value itself is not
+    /// used by the current REPL handler — only its presence matters.
     pub async fn complete(&self, code: &str, cursor: usize) -> Result<ReplResponse, String> {
         let request = serde_json::json!({
             "op": "complete",

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -52,13 +52,18 @@ pub struct EvaluateParams {
 /// Parameters for the `complete` MCP tool.
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct CompleteParams {
-    /// Partial input to complete.
-    #[schemars(description = "Partial beamtalk input to get completions for")]
-    pub code: String,
-    /// Cursor position (byte offset). Defaults to end of `code` if absent.
-    /// When present, enables chain completion (e.g. `\"hello\" size` → Integer methods).
+    /// Beamtalk expression up to the cursor position to get completions for.
+    /// For chain completions (e.g. `"hello" size `) include the full expression
+    /// up to where the cursor is placed.
     #[schemars(
-        description = "Cursor position as byte offset into code. Omit to use end of input."
+        description = "Beamtalk expression up to the cursor position to get completions for"
+    )]
+    pub code: String,
+    /// Cursor position (byte offset into `code`). Defaults to `code.len()` if absent.
+    /// The `code` string is truncated to this offset before forwarding to the REPL,
+    /// enabling correct completions when the cursor is mid-expression.
+    #[schemars(
+        description = "Cursor position as byte offset into code. Omit to complete at end of input."
     )]
     pub cursor: Option<usize>,
 }
@@ -182,9 +187,12 @@ impl BeamtalkMcp {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let code_len = params.code.len();
         let cursor = params.cursor.unwrap_or(code_len).min(code_len);
+        // Truncate code to cursor: the REPL uses the code string as-is for
+        // completions, so only the text up to the cursor should be sent.
+        let code_up_to_cursor = &params.code[..cursor];
         let response = self
             .client
-            .complete(&params.code, cursor)
+            .complete(code_up_to_cursor, cursor)
             .await
             .map_err(|e| rmcp::ErrorData::internal_error(e, None))?;
 


### PR DESCRIPTION
## Summary
- Add optional cursor field to CompleteParams in MCP server (defaults to end of code string)
- Include cursor in ReplClient::complete JSON request so the REPL handler takes the chain-completion path
- Add test_complete_chain integration test verifying chain completions via MCP

## Linear Issue
https://linear.app/beamtalk/issue/BT-1043

## Test plan
- [x] just test passes
- [x] just clippy passes
- [x] just fmt-check passes
- [ ] just test-mcp — test_complete_chain integration test verifies chain completions via MCP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Code completion now supports cursor position specification, enabling more accurate suggestions based on where the cursor is positioned in your code. This improvement allows for better handling of chain completions.

* **Tests**
  * Added integration tests for chain completion validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->