### PR TITLE
Combine infer_method_return_types + infer_types into single TypeChecker pass (BT-1042)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker.rs
@@ -4086,7 +4086,11 @@ Object subclass: Foo
         }
     }
 
-    fn method_annotated(selector: &str, return_type: &str, body: Vec<Expression>) -> MethodDefinition {
+    fn method_annotated(
+        selector: &str,
+        return_type: &str,
+        body: Vec<Expression>,
+    ) -> MethodDefinition {
         MethodDefinition {
             selector: MessageSelector::Unary(selector.into()),
             parameters: vec![],
@@ -4220,8 +4224,14 @@ Object subclass: Foo
         let mut checker = TypeChecker::new();
         checker.check_module(&module, &hierarchy);
         let first = checker.take_method_return_types();
-        assert!(!first.is_empty(), "first take should have collected entries");
+        assert!(
+            !first.is_empty(),
+            "first take should have collected entries"
+        );
         let second = checker.take_method_return_types();
-        assert!(second.is_empty(), "second take should return empty map after drain");
+        assert!(
+            second.is_empty(),
+            "second take should return empty map after drain"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Move method return type collection into `TypeChecker.check_module` so both outputs (`TypeMap` + method return types) are produced in a single AST traversal
- Add `method_return_types` field to `TypeChecker` and `take_method_return_types()` accessor, mirroring the existing `type_map` pattern
- Reduce `infer_method_return_types` to a thin wrapper (like `infer_types`), eliminating ~80 lines of duplicated method traversal logic

Linear: https://linear.app/beamtalk/issue/BT-1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined type inference system architecture for improved maintainability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->