### PR TITLE
Completion: filter class-side methods and hide Object meta-protocol (BT-1049)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -28,6 +28,28 @@
 
 -include_lib("kernel/include/logger.hrl").
 
+%% Methods inherited from Object that are internal implementation protocol and
+%% should not appear in user-facing completions. Long-term, reflection methods
+%% (fieldNames, fieldAt:, fieldAt:put:) should move to Mirror classes (BT-1049).
+-define(COMPLETION_HIDDEN_METHODS, [
+    %% Abstract-class stubs — only meaningful inside a class body
+    subclassResponsibility,
+    notImplemented,
+    %% Message-not-understood handler — internal dispatch protocol
+    'doesNotUnderstand:args:',
+    %% Reflection intrinsics — long-term these should move to a Mirror class
+    fieldNames,
+    'fieldAt:',
+    'fieldAt:put:',
+    %% Object constructors — valid on class objects but confusing on instances
+    %% ("foo" new dispatches via basicNew which most classes don't support directly)
+    new,
+    'new:',
+    %% Dynamic dispatch — advanced/meta protocol, rarely called directly
+    'perform:',
+    'perform:withArguments:'
+]).
+
 %% @doc Handle complete/docs/describe ops.
 -spec handle(binary(), map(), beamtalk_repl_protocol:protocol_msg(), pid()) -> binary().
 handle(<<"complete">>, Params, Msg, SessionPid) ->
@@ -526,9 +548,17 @@ walk_chain(ClassName, [Selector | Rest], Depth) ->
 %%
 %% The first hop uses `class_method_return_types`; subsequent hops transition to the
 %% instance side via `walk_chain/2`.
+%%
+%% Special case: `class` is an instance method on ProtoObject (not annotated with a
+%% return type). When a class object receives `class`, it returns its metaclass, which
+%% has the same class-side methods for completion purposes. We stay on the class side
+%% rather than failing the chain.
 -spec walk_chain_class(atom(), [atom()]) -> {ok, atom()} | undefined.
 walk_chain_class(ClassName, []) ->
     {ok, ClassName};
+walk_chain_class(ClassName, [class | Rest]) ->
+    %% `ClassName class` → metaclass; for completions treat as still on the class side.
+    walk_chain_class(ClassName, Rest);
 walk_chain_class(ClassName, [Selector | Rest]) ->
     case beamtalk_class_registry:get_class_method_return_type(ClassName, Selector) of
         {ok, NextClass} -> walk_chain(NextClass, Rest, 1);
@@ -536,10 +566,18 @@ walk_chain_class(ClassName, [Selector | Rest]) ->
     end.
 
 %% @private
+%% @doc Remove methods that are internal Object protocol and should not appear
+%% in user-facing completions. See ?COMPLETION_HIDDEN_METHODS.
+-spec filter_hidden_methods([atom()]) -> [atom()].
+filter_hidden_methods(Selectors) ->
+    Hidden = sets:from_list(?COMPLETION_HIDDEN_METHODS, [{version, 2}]),
+    [S || S <- Selectors, not sets:is_element(S, Hidden)].
+
+%% @private
 %% @doc Return all instance methods of a class filtered by the given prefix.
 -spec complete_instance_methods(atom(), binary()) -> [binary()].
 complete_instance_methods(ClassName, Prefix) ->
-    MethodSelectors = collect_all_methods(ClassName, 0),
+    MethodSelectors = filter_hidden_methods(collect_all_methods(ClassName, 0)),
     All = [atom_to_binary(S, utf8) || S <- MethodSelectors],
     case Prefix of
         <<>> ->
@@ -554,8 +592,8 @@ complete_instance_methods(ClassName, Prefix) ->
 
 %% @private
 %% @doc Get method selectors for a given receiver token.
-%% For class-name receivers (uppercase), returns class-side methods (via hierarchy
-%% walk) and instance methods (what instances of that class respond to).
+%% For class-name receivers (uppercase), returns only class-side methods (via hierarchy
+%% walk). Instance methods are excluded — they cannot be called on the class object.
 %% For instance receivers (literals, bindings), returns instance methods.
 -spec get_methods_for_receiver(binary(), map()) -> [atom()].
 get_methods_for_receiver(Receiver, Bindings) when is_binary(Receiver) ->
@@ -563,12 +601,16 @@ get_methods_for_receiver(Receiver, Bindings) when is_binary(Receiver) ->
         undefined ->
             [];
         {class, ClassName} ->
-            %% Class-object receiver: class-side methods (via hierarchy walk) and
-            %% instance methods (users commonly want to see what instances respond to).
-            collect_all_class_methods(ClassName, 0) ++
-                collect_all_methods(ClassName, 0);
+            %% Class-object receiver: class-side methods plus the ProtoObject instance
+            %% methods that are genuinely callable on any object (including class objects).
+            %% Most instance methods are excluded — they can't be called on the class object
+            %% and would cause misleading completions that always error.
+            %% ProtoObject methods (e.g. `class`) are included because class objects ARE
+            %% objects and `ClassName class` is meaningful (returns the metaclass).
+            ProtoObjMethods = filter_hidden_methods(collect_all_methods('ProtoObject', 0)),
+            collect_all_class_methods(ClassName, 0) ++ ProtoObjMethods;
         {instance, ClassName} ->
-            collect_all_methods(ClassName, 0)
+            filter_hidden_methods(collect_all_methods(ClassName, 0))
     end.
 
 %% @private

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_server_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_server_tests.erl
@@ -1226,8 +1226,8 @@ context_completions_class_receiver_returns_class_methods_test() ->
         cleanup_mock_class('TestCompletionClassA', Pid)
     end.
 
-%% BT-1044: Class receiver also shows instance methods when prefix matches
-context_completions_class_receiver_includes_instance_methods_test() ->
+%% Class receiver must NOT show instance methods — they can't be called on the class object.
+context_completions_class_receiver_excludes_instance_methods_test() ->
     Pid = spawn_mock_class('TestCompletionClassA2', #{spawn => ok}, [
         increment, inspect, decrement
     ]),
@@ -1235,10 +1235,9 @@ context_completions_class_receiver_includes_instance_methods_test() ->
         Result = beamtalk_repl_ops_dev:get_context_completions(
             <<"TestCompletionClassA2 in">>, #{}
         ),
-        %% Instance methods matching "in" should appear for class-name receivers
-        ?assert(lists:member(<<"increment">>, Result)),
-        ?assert(lists:member(<<"inspect">>, Result)),
-        %% Non-matching instance methods must not appear
+        %% Instance methods must NOT appear for class-name receivers
+        ?assertNot(lists:member(<<"increment">>, Result)),
+        ?assertNot(lists:member(<<"inspect">>, Result)),
         ?assertNot(lists:member(<<"decrement">>, Result))
     after
         cleanup_mock_class('TestCompletionClassA2', Pid)
@@ -1263,6 +1262,37 @@ context_completions_instance_binding_returns_instance_methods_test() ->
         ?assertNot(lists:member(<<"spawnWith:">>, Result))
     after
         cleanup_mock_class('TestCompletionClassB', Pid)
+    end.
+
+%% Hidden meta-protocol methods (subclassResponsibility, notImplemented, fieldNames, etc.)
+%% must not appear in instance completions regardless of prefix.
+context_completions_instance_hides_meta_protocol_methods_test() ->
+    Bindings = #{i => 42},
+    ResultAll = beamtalk_repl_ops_dev:get_context_completions(<<"i ">>, Bindings),
+    ?assertNot(lists:member(<<"subclassResponsibility">>, ResultAll)),
+    ?assertNot(lists:member(<<"notImplemented">>, ResultAll)),
+    ?assertNot(lists:member(<<"doesNotUnderstand:args:">>, ResultAll)),
+    ?assertNot(lists:member(<<"fieldNames">>, ResultAll)),
+    ?assertNot(lists:member(<<"fieldAt:">>, ResultAll)),
+    ?assertNot(lists:member(<<"fieldAt:put:">>, ResultAll)),
+    %% new/new: are also hidden on instances (they error via basicNew for most classes)
+    ?assertNot(lists:member(<<"new">>, ResultAll)),
+    ?assertNot(lists:member(<<"new:">>, ResultAll)),
+    %% perform:/perform:withArguments: — dynamic dispatch meta-protocol
+    ?assertNot(lists:member(<<"perform:">>, ResultAll)),
+    ?assertNot(lists:member(<<"perform:withArguments:">>, ResultAll)).
+
+%% new/new: must still appear for class-name receivers (they ARE the constructors there).
+context_completions_class_receiver_new_methods_visible_test() ->
+    Pid = spawn_mock_class('TestCompletionNewClass', #{'new' => ok, 'new:' => ok}, []),
+    try
+        Result = beamtalk_repl_ops_dev:get_context_completions(
+            <<"TestCompletionNewClass n">>, #{}
+        ),
+        ?assert(lists:member(<<"new">>, Result)),
+        ?assert(lists:member(<<"new:">>, Result))
+    after
+        cleanup_mock_class('TestCompletionNewClass', Pid)
     end.
 
 %% BT: Uppercase global binding (e.g. Transcript) falls back to binding lookup
@@ -1490,6 +1520,27 @@ walk_chain_class_single_hop_found_test() ->
         )
     after
         cleanup_mock_class('WalkChainClassTestA', Pid)
+    end.
+
+%% BT-1048: `ClassName class` chain — `class` is an instance method on ProtoObject
+%% (no class-side return-type annotation), but sending it to a class object returns
+%% the metaclass, which has the same class-side methods. The chain should stay on the
+%% class side rather than returning undefined.
+walk_chain_class_class_selector_stays_on_class_side_test() ->
+    ?assertEqual({ok, 'Integer'}, beamtalk_repl_ops_dev:walk_chain_class('Integer', [class])).
+
+walk_chain_class_class_then_method_test() ->
+    Pid = spawn_mock_class_with_return_types(
+        'WalkChainClassB', #{}, #{new => 'WalkChainClassB'}
+    ),
+    try
+        %% `WalkChainClassB class new` — `class` stays on class side, then `new` resolves
+        ?assertEqual(
+            {ok, 'WalkChainClassB'},
+            beamtalk_repl_ops_dev:walk_chain_class('WalkChainClassB', [class, new])
+        )
+    after
+        cleanup_mock_class('WalkChainClassB', Pid)
     end.
 
 walk_chain_multi_hop_test() ->


### PR DESCRIPTION
## Summary

Fixes misleading REPL completions in two areas:

- **Class-name receivers** (`Integer`, `Actor`) now show only class-side methods. Instance methods removed — they can't be called on the class object and always error.
- **Instance receivers** (`"foo"`, `42`) no longer show Object-level meta-protocol that clutters completions: `subclassResponsibility`, `notImplemented`, `doesNotUnderstand:args:`, `fieldNames`, `fieldAt:`, `fieldAt:put:`, `new`, `new:`, `perform:`, `perform:withArguments:`.
- **`class` selector** added back for class receivers via ProtoObject — `Actor class` is meaningful and now appears as a completion.
- **`walk_chain_class`** special-cases the `class` selector to stay on the class side, fixing `Actor class <TAB>` chain completion (BT-1048).

## Key changes

- `get_methods_for_receiver`: `{class, ClassName}` returns class methods + ProtoObject instance methods only
- `?COMPLETION_HIDDEN_METHODS` define + `filter_hidden_methods/1` applied to all instance completion paths
- `walk_chain_class/2`: new clause for `class` selector that continues chain resolution on the class side
- Tests updated/added for all new filtering behaviour

## Linear

https://linear.app/beamtalk/issue/BT-1049

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Code completion now correctly filters out internal protocol methods from suggestions
  * Class-side completions improved to exclude instance methods for class receivers
  * Constructor suggestions now accurately display for appropriate contexts

* **Tests**
  * Enhanced test coverage for method visibility filtering and class receiver completions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->