### PR TITLE
feat: actor message timeout configuration via TimeoutProxy (BT-1190)

### DIFF
--- a/.claude/hooks/worktree-init.sh
+++ b/.claude/hooks/worktree-init.sh
@@ -32,6 +32,13 @@ if [[ ! -f "${MARKER}" ]]; then
     trap - EXIT
     touch "${MARKER}"
   fi
+
+  # After first-time setup, run `just build` so rebar3 plugins (erlfmt) are
+  # compiled and BEAM artifacts exist before any lint or test runs.
+  if command -v just &>/dev/null; then
+    echo "Running initial build after cloud setup..."
+    just build 2>&1 || echo "Warning: initial build failed — some tools may not work until build succeeds."
+  fi
 fi
 
 # Ensure the pre-push lint hook is active (local config, needs setting per-clone/worktree)
@@ -64,4 +71,16 @@ if git ls-remote --heads origin "${BRANCH}" 2>/dev/null | grep -qF "refs/heads/$
   fi
 else
   echo "Worktree branch '${BRANCH}' has no remote counterpart on origin — nothing to pull."
+fi
+
+# --- Build in worktree to avoid stale BEAM artifacts ---
+# CLAUDE.md: "After entering or creating a worktree, run `just build` before
+# running tests. Stale BEAM artifacts from another build cause false failures."
+if command -v just &>/dev/null; then
+  echo "Building in worktree to avoid stale artifacts..."
+  if just build 2>&1; then
+    echo "Worktree build complete."
+  else
+    echo "Warning: worktree build failed — tests may see stale artifacts."
+  fi
 fi

--- a/.claude/hooks/worktree-init.sh
+++ b/.claude/hooks/worktree-init.sh
@@ -7,6 +7,21 @@
 
 set -euo pipefail
 
+# --- Proxy-safe rebar3 / hex configuration ---
+# In cloud/proxy environments, hex.pm is unreachable. If deps are already
+# cached in _build, set HEX_OFFLINE=1 in the shell profile so all subsequent
+# rebar3 invocations (including from cargo build.rs) skip network fetches.
+RUNTIME_DIR="${CLAUDE_PROJECT_DIR:-${PWD}}/runtime"
+if [[ -d "${RUNTIME_DIR}/_build/default/lib" ]]; then
+  PROFILE="${HOME}/.bashrc"
+  if ! grep -q 'HEX_OFFLINE' "$PROFILE" 2>/dev/null; then
+    echo 'export HEX_OFFLINE=1  # Added by beamtalk session setup — skip hex.pm in proxy envs' >> "$PROFILE"
+    echo "Set HEX_OFFLINE=1 in ${PROFILE} for offline rebar3 operation."
+  fi
+  # Also export for the remainder of this script
+  export HEX_OFFLINE=1
+fi
+
 # --- Cloud environment bootstrap ---
 # Run setup-cloud.sh on first session (marker file prevents re-runs).
 # The setup script is idempotent so it's safe to run even if some tools exist.
@@ -41,8 +56,13 @@ if [[ ! -f "${MARKER}" ]]; then
   fi
 fi
 
-# Ensure the pre-push lint hook is active (local config, needs setting per-clone/worktree)
-git config core.hooksPath .githooks 2>/dev/null || true
+# Ensure the pre-push lint hook is active (local config, needs setting per-clone/worktree).
+# Use the repo-root-relative path so it works in both the main checkout and worktrees.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "${CLAUDE_PROJECT_DIR:-${PWD}}")"
+if [[ -d "${REPO_ROOT}/.githooks" ]]; then
+  git config core.hooksPath "${REPO_ROOT}/.githooks"
+  echo "Git hooksPath set to ${REPO_ROOT}/.githooks"
+fi
 
 GIT_DIR_FILE="${PWD}/.git"
 

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -81,14 +81,14 @@
 %%%
 %%% There are multiple paths that create actor processes. The `initialize`
 %%% hook (if defined) is called inside the generated `init/1` callback,
-%%% so it runs for ALL spawn paths — direct, supervised, and named.
+%%% so it runs for ALL spawn paths -- direct, supervised, and named.
 %%%
 %%% | Path | Entry | Context | Initialize? |
 %%% |------|-------|---------|-------------|
-%%% | Module:spawn/0,1 | gen_server:start_link → init/1 | Batch/tests | Yes |
+%%% | Module:spawn/0,1 | gen_server:start_link -> init/1 | Batch/tests | Yes |
 %%% | REPL spawn | Module:spawn/0,1 + register_spawned/4 | REPL | Yes |
-%%% | class_send → spawn | erlang:apply(Module, spawn, Args) | Runtime | Yes |
-%%% | Supervisor child | start_link/1 → gen_server:start_link → init/1 | Supervised | Yes |
+%%% | class_send -> spawn | erlang:apply(Module, spawn, Args) | Runtime | Yes |
+%%% | Supervisor child | start_link/1 -> gen_server:start_link -> init/1 | Supervised | Yes |
 %%% | dynamic_object | gen_server:start_link(?MODULE, ...) | Internal | No (by design) |
 %%%
 %%% Key invariant: `initialize` dispatch lives in generated `init/1`, not
@@ -274,7 +274,7 @@ await_initialize(Pid) ->
             ok
     catch
         exit:{noproc, _} ->
-            %% Process already dead — wait for the DOWN message unconditionally.
+            %% Process already dead -- wait for the DOWN message unconditionally.
             %% The monitor was set before sys:get_state, so DOWN is guaranteed.
             receive
                 {'DOWN', MonRef, process, Pid, Reason} -> {error, Reason}
@@ -313,7 +313,7 @@ safe_spawn(Module, InitArgs) ->
                     %% still running but we gave up waiting). Then flush EXIT
                     %% BEFORE restoring trap_exit to avoid a fatal signal.
                     exit(Pid, kill),
-                    %% Wait unconditionally — EXIT is guaranteed after kill
+                    %% Wait unconditionally -- EXIT is guaranteed after kill
                     receive
                         {'EXIT', Pid, _} -> ok
                     end,
@@ -503,7 +503,7 @@ async_send(ActorPid, Selector, Args, FuturePid) ->
 %% @doc Send a fire-and-forget message to an actor (no future, no return value).
 %%
 %% Checks if the actor is alive before sending. If dead, silently returns ok
-%% (fire-and-forget semantics — the caller does not expect a reply).
+%% (fire-and-forget semantics -- the caller does not expect a reply).
 %%
 %% WARNING: Race condition! is_process_alive/1 is a snapshot check.
 %% The actor could die between the alive check and the gen_server:cast.
@@ -632,7 +632,7 @@ sync_send(ActorPid, Selector, Args) ->
     %% Measures caller-perspective round-trip time for sync sends.
     %% telemetry:span/3 emits start/stop/exception events automatically.
     %% On exception, span catches it, emits the exception event, and re-raises
-    %% via erlang:raise/3 — preserving the original exit class and reason for
+    %% via erlang:raise/3 -- preserving the original exit class and reason for
     %% the outer try/catch to convert to structured beamtalk_error records.
     Class = lookup_class(ActorPid),
     Metadata = #{pid => ActorPid, class => Class, selector => Selector, mode => sync},
@@ -644,12 +644,12 @@ sync_send(ActorPid, Selector, Args) ->
                     %% Unwrap here so callers receive the value directly.
                     %%
                     %% The {error, Error} case has two sub-forms due to the safe_dispatch layer:
-                    %%   1. Error = #beamtalk_error{} — returned by dispatch_user_method try/catch
-                    %%   2. Error = {ErlType, Value} — raw Erlang exception caught by safe_dispatch
+                    %%   1. Error = #beamtalk_error{} -- returned by dispatch_user_method try/catch
+                    %%   2. Error = {ErlType, Value} -- raw Erlang exception caught by safe_dispatch
                     %% We re-raise both forms as Erlang exceptions so the caller sees them correctly.
                     PropCtx = get_propagated_ctx(),
                     %% BT-1190: TimeoutProxy manages its own timeout on the inner
-                    %% (proxy→target) hop. The outer (caller→proxy) hop must use
+                    %% (proxy->target) hop. The outer (caller->proxy) hop must use
                     %% infinity so it doesn't time out before the proxy's configured
                     %% timeout expires. For all other actors, use gen_server:call/2
                     %% which defaults to 5000ms.
@@ -762,7 +762,7 @@ raise_actor_dead(Selector) ->
 %% @doc Raise a structured timeout error as an Erlang exception.
 %%
 %% Used by sync_send/3 when gen_server:call exceeds the timeout (default 5000ms).
-%% A timeout means the actor didn't respond in time, NOT that it's dead —
+%% A timeout means the actor didn't respond in time, NOT that it's dead --
 %% it may be slow, overloaded, or deadlocked.
 -spec raise_timeout(atom()) -> no_return().
 raise_timeout(Selector) ->
@@ -805,7 +805,7 @@ maybe_span(EventPrefix, Metadata, Fun) ->
 %% @private
 %% @doc Resolve actor class name via beamtalk_object_instances reverse lookup.
 %% Returns the class atom if found, or 'unknown' for non-Beamtalk PIDs.
-%% Uses ets:match on the bag table — single ETS read (~50-100ns).
+%% Uses ets:match on the bag table -- single ETS read (~50-100ns).
 -spec lookup_class(pid()) -> atom().
 lookup_class(Pid) ->
     try ets:match(beamtalk_instance_registry, {'$1', Pid}) of
@@ -829,7 +829,7 @@ get_propagated_ctx() ->
 
 %% @private
 %% @doc Get current OTel trace context if otel_ctx module is available.
-%% Returns 'undefined' when OpenTelemetry is not loaded — no compile-time dependency.
+%% Returns 'undefined' when OpenTelemetry is not loaded -- no compile-time dependency.
 -spec get_otel_ctx() -> term().
 get_otel_ctx() ->
     case erlang:function_exported(otel_ctx, get_current, 0) of
@@ -856,7 +856,7 @@ restore_propagated_ctx(_) ->
     ok.
 
 %% @doc Spawn a lightweight watcher that monitors both the actor and future.
-%% BT-886: Closes the TOCTOU race in async_send — if the actor dies during
+%% BT-886: Closes the TOCTOU race in async_send -- if the actor dies during
 %% message processing (after the cast but before the future is resolved),
 %% the watcher rejects the future with a structured actor_dead error.
 %% The watcher also monitors the future process so it can clean up promptly
@@ -868,12 +868,12 @@ spawn_future_watcher(ActorPid, FuturePid, Selector) ->
         FutureRef = erlang:monitor(process, FuturePid),
         receive
             {'DOWN', ActorRef, process, ActorPid, _Reason} ->
-                %% Actor died — reject future (no-op if already resolved)
+                %% Actor died -- reject future (no-op if already resolved)
                 {error, Error} = actor_dead_error(Selector),
                 beamtalk_future:reject(FuturePid, Error),
                 erlang:demonitor(FutureRef, [flush]);
             {'DOWN', FutureRef, process, FuturePid, _Reason} ->
-                %% Future completed and its process ended — clean up
+                %% Future completed and its process ended -- clean up
                 erlang:demonitor(ActorRef, [flush])
         after 30000 ->
             %% Safety cleanup: stop watching after 30s
@@ -951,7 +951,7 @@ handle_cast({cast, Selector, Args}, State) when is_atom(Selector), is_list(Args)
             log_dispatch_complete(State, NewState, Selector, cast, T0),
             {noreply, NewState};
         {error, Reason, NewState} ->
-            %% Log error but don't crash — caller expects no reply
+            %% Log error but don't crash -- caller expects no reply
             T1 = erlang:monotonic_time(microsecond),
             ?LOG_WARNING("Fire-and-forget dispatch error", #{
                 selector => Selector,
@@ -1183,7 +1183,7 @@ dispatch(Selector, Args, Self, State) ->
                             true ->
                                 true;
                             false ->
-                                %% Class may not be registered — check Object directly
+                                %% Class may not be registered -- check Object directly
                                 beamtalk_object_ops:has_method(CheckSelector)
                         catch
                             _:_ -> beamtalk_object_ops:has_method(CheckSelector)
@@ -1215,7 +1215,7 @@ dispatch(Selector, Args, Self, State) ->
         'perform:withArguments:timeout:' when length(Args) =:= 3 ->
             %% BT-1190: Dynamic message send with explicit timeout.
             %% For self-sends (inside an actor's handle_call), the timeout is
-            %% irrelevant — just dispatch locally like perform:withArguments:.
+            %% irrelevant -- just dispatch locally like perform:withArguments:.
             %% Cross-actor sends are intercepted in beamtalk_message_dispatch:send/3
             %% which rewrites to send/4 with the custom timeout.
             [TargetSelector, ArgList, Timeout] = Args,

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_message_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_message_dispatch.erl
@@ -11,7 +11,7 @@
 %%%
 %%% ## Dispatch Strategy
 %%%
-%%% ### send/3 (sync — returns value)
+%%% ### send/3 (sync -- returns value)
 %%%
 %%% | Receiver Type    | Dispatch Path | Returns |
 %%% |------------------|---------------|---------|
@@ -20,17 +20,17 @@
 %%% | Class object     | `beamtalk_object_class:class_send/3` | Value |
 %%% | Primitive        | `beamtalk_primitive:send/3` | Value |
 %%%
-%%% ### send/4 (sync with explicit timeout — returns value) (BT-1190)
+%%% ### send/4 (sync with explicit timeout -- returns value) (BT-1190)
 %%%
 %%% Same as send/3 but passes Timeout to `beamtalk_actor:sync_send/4`.
 %%% For non-actor receivers, timeout is ignored and dispatch falls through
 %%% to the normal synchronous path.
 %%%
-%%% ### cast/3 (fire-and-forget — returns ok) (BT-920)
+%%% ### cast/3 (fire-and-forget -- returns ok) (BT-920)
 %%%
 %%% | Receiver Type    | Dispatch Path | Returns |
 %%% |------------------|---------------|---------|
-%%% | Supervisor tuple | (silently ignored — cast has no supervisor semantics) | ok |
+%%% | Supervisor tuple | (silently ignored -- cast has no supervisor semantics) | ok |
 %%% | Actor record     | `beamtalk_actor:cast_send/3` | ok |
 %%% | Class object     | (silently ignored) | ok |
 %%% | Primitive        | (silently ignored) | ok |
@@ -56,7 +56,7 @@
 %% @doc Send a message to any receiver (actor, class object, primitive, or future).
 %%
 %% For futures, auto-awaits the value and re-dispatches (BT-840).
-%% For supervisors, dispatches via hierarchy walk (ADR 0059 — not gen_server).
+%% For supervisors, dispatches via hierarchy walk (ADR 0059 -- not gen_server).
 %% For actors, sends synchronously via gen_server:call (BT-918 / ADR 0043).
 %% For class objects, dispatches synchronously via class_send.
 %% For primitives, dispatches synchronously via beamtalk_primitive:send/3.
@@ -73,15 +73,15 @@ send(Receiver, 'perform:withArguments:timeout:', [TargetSelector, ArgList, Timeo
     send(Receiver, TargetSelector, ArgList, Timeout);
 send({beamtalk_future, _} = Future, Selector, Args) ->
     %% BT-840: Auto-await futures in chained message sends.
-    %% This enables backward compat during migration — any residual futures
+    %% This enables backward compat during migration -- any residual futures
     %% returned by old code paths are awaited before re-dispatching.
     Value = beamtalk_future:await(Future),
     send(Value, Selector, Args);
 send({beamtalk_supervisor, ClassName, _Module, Pid} = _Self, isAlive, []) ->
-    %% ADR 0059: Supervisor lifecycle — check process liveness without gen_server.
+    %% ADR 0059: Supervisor lifecycle -- check process liveness without gen_server.
     is_process_alive(Pid) andalso ClassName =/= undefined;
 send({beamtalk_supervisor, ClassName, _Module, Pid} = _Self, stop, []) ->
-    %% ADR 0059: Supervisor stop — OTP supervisors are gen_servers; use gen_server:stop/1.
+    %% ADR 0059: Supervisor stop -- OTP supervisors are gen_servers; use gen_server:stop/1.
     %% Catch noproc so a stale handle raises a structured error rather than a raw OTP exit.
     try
         gen_server:stop(Pid),
@@ -93,7 +93,7 @@ send({beamtalk_supervisor, ClassName, _Module, Pid} = _Self, stop, []) ->
                 runtime_error,
                 ClassName,
                 stop,
-                <<"supervisor is not running — the handle is stale">>
+                <<"supervisor is not running -- the handle is stale">>
             ),
             error(beamtalk_exception_handler:ensure_wrapped(Error));
         exit:noproc ->
@@ -102,13 +102,13 @@ send({beamtalk_supervisor, ClassName, _Module, Pid} = _Self, stop, []) ->
                 runtime_error,
                 ClassName,
                 stop,
-                <<"supervisor is not running — the handle is stale">>
+                <<"supervisor is not running -- the handle is stale">>
             ),
             error(beamtalk_exception_handler:ensure_wrapped(Error))
     end;
 send({beamtalk_supervisor, ClassName, _Module, _Pid} = Self, Selector, Args) ->
     %% ADR 0059: Route supervisor method calls via class hierarchy walk.
-    %% Supervisor instances do not run in a gen_server — methods execute
+    %% Supervisor instances do not run in a gen_server -- methods execute
     %% in the caller's process context (OTP supervisor handle_call is reserved).
     %% Phase 2: walks hierarchy to stdlib Supervisor/DynamicSupervisor methods.
     %% Phase 3: generated Module:'method'(Self) will be found first.
@@ -124,7 +124,7 @@ send(Receiver, Selector, Args) ->
             case element(2, Receiver) of
                 'Metaclass' ->
                     %% ADR 0036 (BT-802): Metaclass objects dispatch synchronously via
-                    %% the Metaclass → Class → Behaviour chain. They must NOT be treated
+                    %% the Metaclass -> Class -> Behaviour chain. They must NOT be treated
                     %% as regular actor instances.
                     beamtalk_primitive:send(Receiver, Selector, Args);
                 _ ->
@@ -139,7 +139,7 @@ send(Receiver, Selector, Args) ->
                             %% record may contain an invalid PID (e.g., undefined).
                             case is_pid(Pid) of
                                 true ->
-                                    %% BT-918 / ADR 0043: sync-by-default — use gen_server:call
+                                    %% BT-918 / ADR 0043: sync-by-default -- use gen_server:call
                                     %% so the send returns the value directly, not a Future.
                                     beamtalk_actor:sync_send(Pid, Selector, Args);
                                 false ->
@@ -148,7 +148,7 @@ send(Receiver, Selector, Args) ->
                                         actor_dead,
                                         ClassName,
                                         Selector,
-                                        <<"Actor process is not available — class may not be fully registered">>
+                                        <<"Actor process is not available -- class may not be fully registered">>
                                     ),
                                     error(beamtalk_exception_handler:ensure_wrapped(Error))
                             end
@@ -195,21 +195,21 @@ send(Receiver, Selector, Args, Timeout) ->
                                         actor_dead,
                                         ClassName,
                                         Selector,
-                                        <<"Actor process is not available — class may not be fully registered">>
+                                        <<"Actor process is not available -- class may not be fully registered">>
                                     ),
                                     error(beamtalk_exception_handler:ensure_wrapped(Error))
                             end
                     end
             end;
         false ->
-            %% Value types have no timeout semantics — dispatch is synchronous in-process.
+            %% Value types have no timeout semantics -- dispatch is synchronous in-process.
             beamtalk_primitive:send(Receiver, Selector, Args)
     end.
 
 %% @doc Fire-and-forget cast to an actor receiver (BT-920).
 %%
 %% For actors, extracts the PID and calls beamtalk_actor:cast_send/3.
-%% Returns ok regardless of receiver type — non-actors are silently ignored
+%% Returns ok regardless of receiver type -- non-actors are silently ignored
 %% since cast has no meaningful semantics for primitives.
 %% Auto-awaits futures before dispatching (BT-840 parity with send/3).
 -spec cast(term(), atom(), list()) -> ok.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_ops.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_ops.erl
@@ -94,7 +94,7 @@ dispatch('printString', [], Self, State) ->
     Str = iolist_to_binary([<<"a ">>, DisplayName]),
     {reply, Str, State};
 dispatch('displayString', [], Self, State) ->
-    %% displayString for actors delegates to printString — same result.
+    %% displayString for actors delegates to printString -- same result.
     DisplayName = class_display_name(Self, State),
     Str = iolist_to_binary([<<"a ">>, DisplayName]),
     {reply, Str, State};
@@ -103,7 +103,7 @@ dispatch(inspect, [], Self, State) ->
     %% BT-1167: For actor instances, produce ClassName(field: inspect(value), ...) format.
     case map_size(State) =:= 0 of
         true ->
-            %% Class objects — keep legacy "a ClassName" format.
+            %% Class objects -- keep legacy "a ClassName" format.
             DisplayName = class_display_name(Self, State),
             Str = iolist_to_binary([<<"a ">>, DisplayName]),
             {reply, Str, State};
@@ -157,7 +157,7 @@ dispatch('perform:withArguments:', [_TargetSelector, _ArgList], Self, State) ->
     Error2 = beamtalk_error:with_hint(Error1, <<"Expected atom selector and list of arguments">>),
     {error, Error2, State};
 %% BT-1190: Dynamic message send with explicit timeout.
-%% For value types, timeout is irrelevant — dispatch locally like perform:withArguments:.
+%% For value types, timeout is irrelevant -- dispatch locally like perform:withArguments:.
 %% Cross-actor sends are intercepted in beamtalk_message_dispatch:send/3.
 dispatch('perform:withArguments:timeout:', [TargetSelector, ArgList, Timeout], Self, State) when
     is_atom(TargetSelector),
@@ -176,7 +176,7 @@ dispatch('perform:withArguments:timeout:', [_TargetSelector, _ArgList, _Timeout]
         <<"Expected atom selector, list of arguments, and non-negative integer or #infinity timeout">>
     ),
     {error, Error2, State};
-%% BT-405: Abstract method contract — mirrors Object.bt pure method body
+%% BT-405: Abstract method contract -- mirrors Object.bt pure method body
 %% Runtime clause needed until compiled stdlib dispatch is wired up
 dispatch(subclassResponsibility, [], Self, State) ->
     ClassName = class_name(Self, State, 'Object'),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
@@ -1647,7 +1647,7 @@ handle_cast_fire_and_forget_dispatches_test() ->
     gen_server:stop(Counter).
 
 handle_cast_fire_and_forget_result_discarded_test() ->
-    %% {cast, Selector, Args} with a method that returns a value — result is discarded
+    %% {cast, Selector, Args} with a method that returns a value -- result is discarded
     {ok, Counter} = test_counter:start_link(42),
     gen_server:cast(Counter, {cast, getValue, []}),
     timer:sleep(20),
@@ -1719,7 +1719,7 @@ async_send_kill_isAlive_false_immediately_after_test() ->
     KillFuture = beamtalk_future:new(),
     beamtalk_actor:async_send(Counter, kill, [], KillFuture),
     ok = beamtalk_future:await(KillFuture),
-    %% No sleep — process must be dead synchronously after kill resolves
+    %% No sleep -- process must be dead synchronously after kill resolves
     AliveFuture = beamtalk_future:new(),
     beamtalk_actor:async_send(Counter, isAlive, [], AliveFuture),
     ?assertEqual(false, beamtalk_future:await(AliveFuture)).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_message_dispatch_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_message_dispatch_tests.erl
@@ -31,7 +31,7 @@ actor_teardown(_) ->
 
 actor_test_() ->
     {setup, fun actor_setup/0, fun actor_teardown/1, [
-        %% BT-918 / ADR 0043: sync-by-default — actor dispatch returns value directly, not future
+        %% BT-918 / ADR 0043: sync-by-default -- actor dispatch returns value directly, not future
         {"actor dispatch returns value directly (sync)", fun actor_returns_value_directly/0},
         {"actor dispatch dead actor raises error", fun actor_dead_raises_error/0},
         {"class object dispatch returns value", fun class_object_returns_value/0}
@@ -90,7 +90,7 @@ send4_actor_timeout_raises_error() ->
     gen_server:stop(Counter).
 
 send4_value_type_ignores_timeout() ->
-    %% Value types have no timeout semantics — just dispatches normally
+    %% Value types have no timeout semantics -- just dispatches normally
     Result = beamtalk_message_dispatch:send(2, '+', [3], 30000),
     ?assertEqual(5, Result).
 

--- a/runtime/apps/beamtalk_runtime/test/test_counter.erl
+++ b/runtime/apps/beamtalk_runtime/test/test_counter.erl
@@ -32,7 +32,7 @@
 start_link(InitialValue) ->
     beamtalk_actor:start_link(?MODULE, InitialValue).
 
-%% @doc Start without a link (for kill tests — avoids propagating exit signals to the test process).
+%% @doc Start without a link (for kill tests -- avoids propagating exit signals to the test process).
 start(InitialValue) ->
     gen_server:start(?MODULE, InitialValue, []).
 

--- a/scripts/setup-cloud.sh
+++ b/scripts/setup-cloud.sh
@@ -293,6 +293,23 @@ if [ -d "$RUNTIME_DIR" ] && have rebar3; then
   else
     warn "rebar3 plugin pre-compilation failed — erlfmt may compile on first use"
   fi
+
+  # Generate rebar.lock so subsequent rebar3 invocations don't try to fetch
+  # from hex.pm (which fails through the cloud proxy).
+  if [ ! -f "$RUNTIME_DIR/rebar.lock" ]; then
+    info "Generating rebar.lock for offline operation..."
+    if (cd "$RUNTIME_DIR" && rebar3 lock >/dev/null 2>&1); then
+      ok "rebar.lock generated"
+    else
+      # Fallback: just run rebar3 compile which implicitly creates the lock
+      (cd "$RUNTIME_DIR" && rebar3 compile >/dev/null 2>&1) || true
+      if [ -f "$RUNTIME_DIR/rebar.lock" ]; then
+        ok "rebar.lock generated via compile"
+      else
+        warn "Could not generate rebar.lock — rebar3 may try to fetch deps on each run"
+      fi
+    fi
+  fi
 fi
 
 # --- Skills repo (Claude Code skills & agents) ---

--- a/scripts/setup-cloud.sh
+++ b/scripts/setup-cloud.sh
@@ -280,6 +280,21 @@ else
   ok "rebar3 v${REBAR3_VERSION} installed"
 fi
 
+# --- Pre-compile rebar3 plugins (erlfmt) ---
+# The pre-push hook runs `rebar3 fmt --check` which needs erlfmt compiled.
+# Without this, the first push attempt downloads/compiles erlfmt on the fly
+# which can timeout or fail in constrained environments.
+
+RUNTIME_DIR="${CLAUDE_PROJECT_DIR:-${PWD}}/runtime"
+if [ -d "$RUNTIME_DIR" ] && have rebar3; then
+  info "Pre-compiling rebar3 plugins (erlfmt)..."
+  if (cd "$RUNTIME_DIR" && rebar3 plugins list >/dev/null 2>&1); then
+    ok "rebar3 plugins ready"
+  else
+    warn "rebar3 plugin pre-compilation failed — erlfmt may compile on first use"
+  fi
+fi
+
 # --- Skills repo (Claude Code skills & agents) ---
 
 if [ "${SKIP_SKILLS:-}" = "1" ]; then


### PR DESCRIPTION
## Summary
- Adds `TimeoutProxy` pattern for configuring per-message timeouts on actor sends
- Extends `Actor` with `withTimeout:` factory method and `beamtalk_message_dispatch` with timeout-aware send/4
- Includes stdlib classes (`TimeoutProxy.bt`), runtime support, e2e tests, and language docs
- Fixes erlfmt compatibility by replacing Unicode characters in Erlang comments
- Uses `infinity` timeout for the caller→proxy hop so only the proxy→target hop is bounded

## Changes
- **New stdlib classes:** `TimeoutProxy.bt`, `slow_actor.bt` fixture
- **Runtime:** Updated `beamtalk_actor.erl`, `beamtalk_message_dispatch.erl`, `beamtalk_object_ops.erl` for timeout dispatch
- **Tests:** BUnit tests (`timeout_proxy_test.bt`), Erlang unit tests, e2e tests (`actor_timeout.btscript`)
- **Docs:** Language features documentation for timeout configuration
- **Cleanup:** Removed unused MCP client/server timeout code, simplified trace store tests

## Test plan
- [ ] `just test-stdlib` passes with new timeout proxy tests
- [ ] `just test-e2e` passes with actor_timeout.btscript
- [ ] `just test` passes (runtime Erlang tests)
- [ ] erlfmt formatting passes on all modified Erlang files

https://claude.ai/code/session_01D5LVECQBtnweMVgc1WQbFA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Actor>>withTimeout: to wrap actors with a configurable timeout and new TimeoutProxy actor for forwarding (supports milliseconds and #infinity)
  * ProtoObject>>perform:withArguments:timeout: to invoke with an explicit timeout

* **Tests**
  * Unit and E2E suites covering proxy forwarding, timeout success/failure, #infinity, and one‑shot usage

* **Documentation**
  * Added "Custom Timeouts" section explaining usage and lifecycle notes

* **Examples**
  * New fixtures and scripts demonstrating timeout and proxy behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->