### PR TITLE
MCP: load_project should report which files failed (BT-1855)

### DIFF
--- a/crates/beamtalk-mcp/src/client.rs
+++ b/crates/beamtalk-mcp/src/client.rs
@@ -981,8 +981,10 @@ pub struct ReplResponse {
     /// Protocol and language versions (describe op).
     pub versions: Option<serde_json::Value>,
     /// Incremental load summary (load-project op, BT-1685).
-    /// E.g. "Reloaded 2 of 7 files (5 unchanged)"
+    /// E.g. "Reloaded 2 of 7 files (5 unchanged, 1 failed)"
     pub summary: Option<String>,
+    /// Number of unique files that failed to compile (load-project op, BT-1855).
+    pub error_count: Option<u32>,
 }
 
 impl ReplResponse {

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -636,11 +636,19 @@ impl BeamtalkMcp {
         let mut parts = Vec::new();
 
         if !errors.is_empty() {
+            // BT-1855: Count unique failed file paths (a file may have multiple
+            // diagnostics, but we report it as one failed file).
+            let failed_files: std::collections::BTreeSet<&str> = errors
+                .iter()
+                .filter_map(|e| e.get("path").and_then(|v| v.as_str()))
+                .collect();
+            let failed_count = failed_files.len().max(1); // at least 1 if errors exist
+
             // Lead with failure summary so agents detect errors immediately.
             parts.push(Content::text(format!(
-                "Load completed with errors: {} succeeded, {} failed",
+                "Load completed with errors: {} classes loaded, {} file(s) failed",
                 classes.len(),
-                errors.len()
+                failed_count
             )));
 
             // Report each failure with path, line, message, and hint.
@@ -675,6 +683,11 @@ impl BeamtalkMcp {
                     "Loaded classes: {}",
                     classes.join(", ")
                 )));
+            }
+
+            // BT-1855: Include incremental summary even on the error path.
+            if let Some(ref summary) = response.summary {
+                parts.push(Content::text(summary.clone()));
             }
 
             return Ok(CallToolResult::error(parts));

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
@@ -33,7 +33,8 @@
     extract_package_from_module/1,
     classify_files_by_change/2,
     get_file_mtime/1,
-    extract_native_refs/1
+    extract_native_refs/1,
+    build_incremental_summary/5
 ]).
 -endif.
 
@@ -221,17 +222,21 @@ do_sync_project(AbsPath, IncludeTests, Force, SessionPid) ->
     TotalFiles = length(AllFiles) + DeletedCount,
     ChangedCount = length(ChangedBt) + length(ChangedErl),
     UnchangedCount = length(UnchangedBt) + length(UnchangedErl),
+    %% BT-1855: Count unique files that failed (errors may have multiple
+    %% diagnostics per file, so deduplicate via sets).
+    ErrorFileCount = sets:size(sets:union(ErlErrorPaths, BtErrorPaths)),
     DepErrorMsgs = [format_dep_error(Mod, Reason) || {Mod, Reason} <- DepErrors],
     {ok, #{
         classes => ClassNames,
         errors => Errors,
         dep_errors => DepErrorMsgs,
         summary => build_incremental_summary(
-            ChangedCount, TotalFiles, UnchangedCount, DeletedCount
+            ChangedCount, TotalFiles, UnchangedCount, DeletedCount, ErrorFileCount
         ),
         changed_count => ChangedCount,
         unchanged_count => UnchangedCount,
         deleted_count => DeletedCount,
+        error_count => ErrorFileCount,
         total_files => TotalFiles
     }}.
 
@@ -1420,10 +1425,15 @@ unload_modules_for_path(Path, SessionPid, ModToClass, LoadedModules) ->
 %% @private
 %% @doc Build the incremental summary message.
 %% Format: "Reloaded 2 of 7 files (5 unchanged)" or "Reloaded 2 of 7 files (3 unchanged, 2 deleted)"
+%% When errors are present: "Reloaded 2 of 7 files (5 unchanged, 1 failed)"
 -spec build_incremental_summary(
-    non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer()
 ) -> binary().
-build_incremental_summary(ChangedCount, TotalFiles, UnchangedCount, DeletedCount) ->
+build_incremental_summary(ChangedCount, TotalFiles, UnchangedCount, DeletedCount, ErrorCount) ->
     BaseParts = [
         "Reloaded ",
         integer_to_list(ChangedCount),
@@ -1431,15 +1441,22 @@ build_incremental_summary(ChangedCount, TotalFiles, UnchangedCount, DeletedCount
         integer_to_list(TotalFiles),
         " files"
     ],
+    Details = lists:filter(
+        fun
+            ({_, 0}) -> false;
+            (_) -> true
+        end,
+        [{unchanged, UnchangedCount}, {deleted, DeletedCount}, {failed, ErrorCount}]
+    ),
     DetailParts =
-        case {UnchangedCount, DeletedCount} of
-            {0, 0} ->
+        case Details of
+            [] ->
                 [];
-            {U, 0} ->
-                [" (", integer_to_list(U), " unchanged)"];
-            {0, D} ->
-                [" (", integer_to_list(D), " deleted)"];
-            {U, D} ->
-                [" (", integer_to_list(U), " unchanged, ", integer_to_list(D), " deleted)"]
+            _ ->
+                Formatted = lists:join(", ", [
+                    [integer_to_list(N), " ", atom_to_list(Label)]
+                 || {Label, N} <- Details
+                ]),
+                [" ("] ++ Formatted ++ [")"]
         end,
     iolist_to_binary(BaseParts ++ DetailParts).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_load_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_load_tests.erl
@@ -832,3 +832,49 @@ activate_deps_adds_hex_ebin_paths_test() ->
 activate_dep_ebin_nonexistent_test() ->
     %% Non-existent dir should be a no-op (delegated to beamtalk_module_activation).
     ?assertEqual({ok, []}, beamtalk_module_activation:activate_ebin("/nonexistent/path")).
+
+%%====================================================================
+%% build_incremental_summary/5 (BT-1855)
+%%====================================================================
+
+build_incremental_summary_no_details_test() ->
+    ?assertEqual(
+        <<"Reloaded 5 of 5 files">>,
+        beamtalk_repl_ops_load:build_incremental_summary(5, 5, 0, 0, 0)
+    ).
+
+build_incremental_summary_unchanged_test() ->
+    ?assertEqual(
+        <<"Reloaded 2 of 7 files (5 unchanged)">>,
+        beamtalk_repl_ops_load:build_incremental_summary(2, 7, 5, 0, 0)
+    ).
+
+build_incremental_summary_deleted_test() ->
+    ?assertEqual(
+        <<"Reloaded 3 of 5 files (2 deleted)">>,
+        beamtalk_repl_ops_load:build_incremental_summary(3, 5, 0, 2, 0)
+    ).
+
+build_incremental_summary_unchanged_and_deleted_test() ->
+    ?assertEqual(
+        <<"Reloaded 2 of 10 files (5 unchanged, 3 deleted)">>,
+        beamtalk_repl_ops_load:build_incremental_summary(2, 10, 5, 3, 0)
+    ).
+
+build_incremental_summary_with_failures_test() ->
+    ?assertEqual(
+        <<"Reloaded 5 of 7 files (2 unchanged, 1 failed)">>,
+        beamtalk_repl_ops_load:build_incremental_summary(5, 7, 2, 0, 1)
+    ).
+
+build_incremental_summary_all_details_test() ->
+    ?assertEqual(
+        <<"Reloaded 3 of 10 files (4 unchanged, 1 deleted, 2 failed)">>,
+        beamtalk_repl_ops_load:build_incremental_summary(3, 10, 4, 1, 2)
+    ).
+
+build_incremental_summary_only_failures_test() ->
+    ?assertEqual(
+        <<"Reloaded 3 of 3 files (1 failed)">>,
+        beamtalk_repl_ops_load:build_incremental_summary(3, 3, 0, 0, 1)
+    ).


### PR DESCRIPTION
## Summary

- **Erlang**: Compute unique failed file count from deduplicated error path sets, include in `build_incremental_summary` so summary shows e.g. "Reloaded 5 of 7 files (2 unchanged, 1 failed)"
- **MCP server**: Count unique failed file paths (instead of raw diagnostic count), include REPL summary on the error response path
- **Protocol**: Add `error_count` field to load-project response

## Changes

- `beamtalk_repl_ops_load.erl`: Refactored `build_incremental_summary/5` to use data-driven filter/join instead of case explosion, added `error_count` to result map
- `beamtalk_repl_ops_load_tests.erl`: 7 new EUnit tests covering all summary format combinations
- `server.rs`: Deduplicate failed file paths via `BTreeSet`, improved error message wording, include summary on error path
- `client.rs`: Added `error_count` field to `ReplResponse`

## Test plan

- [x] 7 new EUnit tests for `build_incremental_summary/5` covering: no details, unchanged only, deleted only, unchanged+deleted, failures only, failures+unchanged, all three
- [x] Existing EUnit tests pass (2753 + 1073 tests)
- [x] BUnit tests pass (1737 tests)
- [x] Stdlib tests pass (250 tests)
- [x] MCP integration tests pass (20 tests)
- [x] E2E tests pass (3 tests)
- [x] Full CI passes

Linear: https://linear.app/beamtalk/issue/BT-1855

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project loading feedback now shows a failed-file count alongside the summary.

* **Bug Fixes**
  * Error summaries report unique failing files (deduplicated) and include summary content on error results for clearer incremental load failure messages.

* **Tests**
  * Added tests for human-readable load summaries verifying failed-file counts and breakdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->