### PR TITLE
Type checker: Warn on type args for classes with no type params (BT-1861)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -177,6 +177,9 @@ impl TypeChecker {
             }
         }
 
+        // BT-1861: Warn when type arguments are provided for classes with no type params.
+        self.check_type_annotation_arity_in_module(module, hierarchy);
+
         // Check top-level expressions last — method return types are now available.
         self.infer_stmts(&module.expressions, hierarchy, &mut env, false);
     }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -9193,3 +9193,272 @@ fn test_ffi_member_returns_boolean() {
         "member should return Boolean"
     );
 }
+
+// ---- BT-1861: Warn on type args for classes with no type params ----
+
+#[test]
+fn test_type_annotation_arity_integer_with_args_warns() {
+    // state: x :: Integer(String) → warning: Integer has no type params
+    let state = vec![StateDeclaration::with_type(
+        ident("x"),
+        TypeAnnotation::Generic {
+            base: ident("Integer"),
+            parameters: vec![TypeAnnotation::Simple(ident("String"))],
+            span: span(),
+        },
+        span(),
+    )];
+    let class = counter_class_with_typed_state(vec![], state);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("no type parameters"))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "Expected 1 arity warning, got: {:?}",
+        checker.diagnostics()
+    );
+    assert!(warnings[0].message.contains("Integer"));
+}
+
+#[test]
+fn test_type_annotation_arity_dictionary_with_args_no_warn() {
+    // state: x :: Dictionary(Symbol, Integer) → no warning (Dictionary has K, V)
+    let state = vec![StateDeclaration::with_type(
+        ident("x"),
+        TypeAnnotation::Generic {
+            base: ident("Dictionary"),
+            parameters: vec![
+                TypeAnnotation::Simple(ident("Symbol")),
+                TypeAnnotation::Simple(ident("Integer")),
+            ],
+            span: span(),
+        },
+        span(),
+    )];
+    let class = counter_class_with_typed_state(vec![], state);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("no type parameters"))
+        .collect();
+    assert!(
+        warnings.is_empty(),
+        "No arity warnings expected for Dictionary(K, V), got: {warnings:?}"
+    );
+}
+
+#[test]
+fn test_type_annotation_arity_result_with_args_no_warn() {
+    // state: x :: Result(Integer, Error) → no warning (Result has T, E)
+    let state = vec![StateDeclaration::with_type(
+        ident("x"),
+        TypeAnnotation::Generic {
+            base: ident("Result"),
+            parameters: vec![
+                TypeAnnotation::Simple(ident("Integer")),
+                TypeAnnotation::Simple(ident("Error")),
+            ],
+            span: span(),
+        },
+        span(),
+    )];
+    let class = counter_class_with_typed_state(vec![], state);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("no type parameters"))
+        .collect();
+    assert!(
+        warnings.is_empty(),
+        "No arity warnings expected for Result(T, E), got: {warnings:?}"
+    );
+}
+
+#[test]
+fn test_type_annotation_arity_boolean_with_args_warns() {
+    // state: flag :: Boolean(Integer) → warning: Boolean has no type params
+    let state = vec![StateDeclaration::with_type(
+        ident("flag"),
+        TypeAnnotation::Generic {
+            base: ident("Boolean"),
+            parameters: vec![TypeAnnotation::Simple(ident("Integer"))],
+            span: span(),
+        },
+        span(),
+    )];
+    let class = counter_class_with_typed_state(vec![], state);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("no type parameters"))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "Expected 1 arity warning for Boolean(Integer), got: {:?}",
+        checker.diagnostics()
+    );
+    assert!(warnings[0].message.contains("Boolean"));
+}
+
+#[test]
+fn test_type_annotation_arity_nested_warns() {
+    // state: x :: Result(Integer(String), Error) → warning for Integer(String)
+    // Result(T, E) is fine, but Integer(String) nested inside it should warn
+    let state = vec![StateDeclaration::with_type(
+        ident("x"),
+        TypeAnnotation::Generic {
+            base: ident("Result"),
+            parameters: vec![
+                TypeAnnotation::Generic {
+                    base: ident("Integer"),
+                    parameters: vec![TypeAnnotation::Simple(ident("String"))],
+                    span: span(),
+                },
+                TypeAnnotation::Simple(ident("Error")),
+            ],
+            span: span(),
+        },
+        span(),
+    )];
+    let class = counter_class_with_typed_state(vec![], state);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("no type parameters"))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "Expected 1 nested arity warning, got: {warnings:?}"
+    );
+    assert!(warnings[0].message.contains("Integer"));
+}
+
+#[test]
+fn test_type_annotation_arity_unknown_class_no_warn() {
+    // state: x :: UnknownClass(String) → no arity warning (class is unknown)
+    let state = vec![StateDeclaration::with_type(
+        ident("x"),
+        TypeAnnotation::Generic {
+            base: ident("UnknownClass"),
+            parameters: vec![TypeAnnotation::Simple(ident("String"))],
+            span: span(),
+        },
+        span(),
+    )];
+    let class = counter_class_with_typed_state(vec![], state);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("no type parameters"))
+        .collect();
+    assert!(
+        warnings.is_empty(),
+        "No arity warnings expected for unknown class, got: {warnings:?}"
+    );
+}
+
+#[test]
+fn test_type_annotation_arity_method_param_warns() {
+    // Method param x :: Integer(String) → should also warn
+    let method = MethodDefinition {
+        selector: MessageSelector::Keyword(vec![KeywordPart {
+            keyword: "doWith:".into(),
+            span: span(),
+        }]),
+        parameters: vec![ParameterDefinition::with_type(
+            ident("x"),
+            TypeAnnotation::Generic {
+                base: ident("Integer"),
+                parameters: vec![TypeAnnotation::Simple(ident("String"))],
+                span: span(),
+            },
+        )],
+        body: vec![bare(int_lit(0))],
+        return_type: None,
+        is_sealed: false,
+        kind: MethodKind::Primary,
+        is_internal: false,
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        span: span(),
+    };
+    let class = counter_class_with_typed_state(vec![method], vec![]);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("no type parameters"))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "Expected 1 arity warning for method param, got: {:?}",
+        checker.diagnostics()
+    );
+    assert!(warnings[0].message.contains("Integer"));
+}
+
+#[test]
+fn test_type_annotation_arity_return_type_warns() {
+    // Method -> Integer(String) → should also warn
+    let method = MethodDefinition::with_return_type(
+        MessageSelector::Unary("compute".into()),
+        vec![],
+        vec![bare(int_lit(42))],
+        TypeAnnotation::Generic {
+            base: ident("Integer"),
+            parameters: vec![TypeAnnotation::Simple(ident("String"))],
+            span: span(),
+        },
+        span(),
+    );
+    let class = counter_class_with_typed_state(vec![method], vec![]);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("no type parameters"))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "Expected 1 arity warning for return type, got: {:?}",
+        checker.diagnostics()
+    );
+    assert!(warnings[0].message.contains("Integer"));
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1509,4 +1509,144 @@ impl TypeChecker {
             }
         }
     }
+
+    /// Walk all type annotations in a module and warn when type arguments are
+    /// provided for a class that declares no type parameters.
+    ///
+    /// For example, `state: x :: Integer(String)` is almost certainly a mistake
+    /// since `Integer` has no type parameters — the `(String)` is silently
+    /// discarded. Emitting a warning prevents this footgun (BT-1861).
+    pub(super) fn check_type_annotation_arity_in_module(
+        &mut self,
+        module: &crate::ast::Module,
+        hierarchy: &ClassHierarchy,
+    ) {
+        for class in &module.classes {
+            // Collect the class's own type parameter names so we skip them
+            let class_type_params: Vec<&str> = class
+                .type_params
+                .iter()
+                .map(|tp| tp.name.name.as_str())
+                .collect();
+
+            // Check state field type annotations
+            for state_decl in &class.state {
+                if let Some(ref ann) = state_decl.type_annotation {
+                    self.check_type_annotation_arity(ann, hierarchy, &class_type_params);
+                }
+            }
+
+            // Check method parameter and return type annotations
+            for method in class.methods.iter().chain(class.class_methods.iter()) {
+                for param in &method.parameters {
+                    if let Some(ref ann) = param.type_annotation {
+                        self.check_type_annotation_arity(ann, hierarchy, &class_type_params);
+                    }
+                }
+                if let Some(ref ann) = method.return_type {
+                    self.check_type_annotation_arity(ann, hierarchy, &class_type_params);
+                }
+            }
+
+            // Check superclass type args
+            for arg in &class.superclass_type_args {
+                self.check_type_annotation_arity(arg, hierarchy, &class_type_params);
+            }
+        }
+
+        // Check standalone method definitions
+        for standalone in &module.method_definitions {
+            let class_type_params: Vec<&str> = hierarchy
+                .get_class(&standalone.class_name.name)
+                .map(|info| info.type_params.iter().map(EcoString::as_str).collect())
+                .unwrap_or_default();
+
+            for param in &standalone.method.parameters {
+                if let Some(ref ann) = param.type_annotation {
+                    self.check_type_annotation_arity(ann, hierarchy, &class_type_params);
+                }
+            }
+            if let Some(ref ann) = standalone.method.return_type {
+                self.check_type_annotation_arity(ann, hierarchy, &class_type_params);
+            }
+        }
+    }
+
+    /// Check a single type annotation for arity mismatches.
+    ///
+    /// Warns when a `Generic` annotation names a class that has no type
+    /// parameters. Recurses into nested annotations (union members, generic
+    /// args, false-or inner) so that e.g. `Result(Integer(String), Error)` is
+    /// also caught.
+    fn check_type_annotation_arity(
+        &mut self,
+        ann: &TypeAnnotation,
+        hierarchy: &ClassHierarchy,
+        class_type_params: &[&str],
+    ) {
+        match ann {
+            TypeAnnotation::Generic {
+                base,
+                parameters,
+                span,
+            } => {
+                let base_name = &base.name;
+
+                // Skip if the base is a type parameter of the enclosing class
+                // (e.g., `T(Integer)` where T is a class type param — unusual
+                // but not something we can validate statically).
+                if class_type_params.contains(&base_name.as_str()) {
+                    return;
+                }
+
+                // Skip single-letter uppercase names (generic type params like T, E, K, V)
+                if super::is_generic_type_param(base_name) {
+                    return;
+                }
+
+                // Block uses type args as function signature documentation
+                // (e.g., Block(Integer, String) for a block taking Integer and
+                // returning String) even though Block has no formal type params.
+                if base_name == "Block" {
+                    return;
+                }
+
+                // Only warn if the class is known in the hierarchy and has no type params.
+                // Unknown classes are handled elsewhere (unknown-class warnings).
+                if let Some(class_info) = hierarchy.get_class(base_name) {
+                    if class_info.type_params.is_empty() {
+                        self.diagnostics.push(
+                            Diagnostic::warning(
+                                format!(
+                                    "{base_name} has no type parameters, but type arguments were provided"
+                                ),
+                                *span,
+                            )
+                            .with_category(DiagnosticCategory::Type)
+                            .with_hint(format!(
+                                "Remove the type arguments: use `{base_name}` instead of `{base_name}(...)`"
+                            )),
+                        );
+                    }
+                }
+
+                // Recurse into the type arguments themselves
+                for param in parameters {
+                    self.check_type_annotation_arity(param, hierarchy, class_type_params);
+                }
+            }
+            TypeAnnotation::Union { types, .. } => {
+                for ty in types {
+                    self.check_type_annotation_arity(ty, hierarchy, class_type_params);
+                }
+            }
+            TypeAnnotation::FalseOr { inner, .. } => {
+                self.check_type_annotation_arity(inner, hierarchy, class_type_params);
+            }
+            // Simple, SelfType, Singleton — no type args to check
+            TypeAnnotation::Simple(_)
+            | TypeAnnotation::SelfType { .. }
+            | TypeAnnotation::Singleton { .. } => {}
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Emit a compiler warning when a type annotation provides type arguments to a class that declares no type parameters (e.g., `Integer(String)`, `Boolean(X)`)
- Warning message names the class and states it has no type parameters, with a hint to remove the type arguments
- No false positives for classes that do have type params (Dictionary, List, Result, Ets, etc.) or for Block (which uses type args as function signature documentation)
- Recurses into nested annotations so `Result(Integer(String), Error)` catches the nested `Integer(String)`

## Test plan

- [x] 8 unit tests covering: state fields, method params, return types, nested generics, unknown classes, and classes with real type params
- [x] Full stdlib build produces no false positive warnings
- [x] `just ci` passes (clippy, fmt, all test suites)

Closes [BT-1861](https://linear.app/beamtalk/issue/BT-1861/type-checker-warn-on-type-args-for-classes-with-no-type-params)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Type checker now validates type argument counts in type annotations. Warnings are emitted when type arguments are supplied to classes that don't accept type parameters (e.g., `Integer(String)`).
  * Validation applies to class state declarations, method parameters, return types, and superclass annotations.

* **Tests**
  * Comprehensive test coverage added for type annotation arity validation across various contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->