### PR TITLE
Type checker: bind match-arm pattern variables into arm_env (BT-1946)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -613,6 +613,7 @@ impl TypeChecker {
                     .iter()
                     .map(|arm| {
                         let mut arm_env = env.child();
+                        Self::bind_pattern_vars(&arm.pattern, &mut arm_env);
                         if let Some(guard) = &arm.guard {
                             self.infer_expr(guard, hierarchy, &mut arm_env, in_abstract_method);
                         }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -578,66 +578,66 @@ fn test_match_returns_dynamic() {
 
 #[test]
 fn test_match_arm_pattern_vars_bound_in_body() {
-    // match x { n => n + 1 }
-    // `n` is pattern-bound — sending `+` to it should NOT produce a DNU warning
-    // because it should be Dynamic, not unknown.
-    let method = make_method(
-        "doMatch",
-        vec![Expression::Match {
-            value: Box::new(int_lit(42)),
-            arms: vec![MatchArm::new(
-                Pattern::Variable(ident("n")),
-                msg_send(
-                    var("n"),
-                    MessageSelector::Binary("+".into()),
-                    vec![int_lit(1)],
-                ),
-                span(),
-            )],
-            span: span(),
-        }],
-    );
-    let class = make_class_with_methods("Thing", vec![method]);
-    let module = make_module_with_classes(vec![], vec![class]);
-    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    // Outer env has `n :: Integer`. The match arm pattern binds `n` as Dynamic,
+    // which should shadow the outer binding. Sending a nonexistent selector to
+    // a Dynamic receiver produces no warning, but sending it to Integer would.
+    // This ensures the test fails if bind_pattern_vars is not called.
     let mut checker = TypeChecker::new();
-    checker.check_module(&module, &hierarchy);
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set("n", InferredType::known("Integer"));
+
+    let match_expr = Expression::Match {
+        value: Box::new(int_lit(42)),
+        arms: vec![MatchArm::new(
+            Pattern::Variable(ident("n")),
+            msg_send(
+                var("n"),
+                MessageSelector::Unary("definitelyMissing".into()),
+                vec![],
+            ),
+            span(),
+        )],
+        span: span(),
+    };
+
+    let _ = checker.infer_expr(&match_expr, &hierarchy, &mut env, false);
     assert!(
         checker.diagnostics().is_empty(),
-        "match-bound var `n` should be Dynamic — no DNU warnings: {:?}",
+        "match-bound var `n` should shadow outer Integer binding — no DNU warnings: {:?}",
         checker.diagnostics()
     );
 }
 
 #[test]
 fn test_match_arm_pattern_vars_bound_in_guard() {
-    // match x { n when n > 0 => n }
-    // `n` in the guard should also resolve as Dynamic, not produce a warning.
-    let method = make_method(
-        "doMatch",
-        vec![Expression::Match {
-            value: Box::new(int_lit(42)),
-            arms: vec![MatchArm::with_guard(
-                Pattern::Variable(ident("n")),
-                msg_send(
-                    var("n"),
-                    MessageSelector::Binary(">".into()),
-                    vec![int_lit(0)],
-                ),
-                var("n"),
-                span(),
-            )],
-            span: span(),
-        }],
-    );
-    let class = make_class_with_methods("Thing", vec![method]);
-    let module = make_module_with_classes(vec![], vec![class]);
-    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    // Same shadowing strategy: outer `n :: Integer`, pattern rebinds as Dynamic.
+    // Sending a nonexistent selector in the guard should produce no warning
+    // only if the pattern var is correctly bound.
     let mut checker = TypeChecker::new();
-    checker.check_module(&module, &hierarchy);
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set("n", InferredType::known("Integer"));
+
+    let match_expr = Expression::Match {
+        value: Box::new(int_lit(42)),
+        arms: vec![MatchArm::with_guard(
+            Pattern::Variable(ident("n")),
+            msg_send(
+                var("n"),
+                MessageSelector::Unary("definitelyMissing".into()),
+                vec![],
+            ),
+            var("n"),
+            span(),
+        )],
+        span: span(),
+    };
+
+    let _ = checker.infer_expr(&match_expr, &hierarchy, &mut env, false);
     assert!(
         checker.diagnostics().is_empty(),
-        "match-bound var `n` in guard should be Dynamic — no DNU warnings: {:?}",
+        "match-bound var `n` in guard should shadow outer Integer binding — no DNU warnings: {:?}",
         checker.diagnostics()
     );
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -5,7 +5,7 @@
 use super::*;
 use crate::ast::{
     Block, CascadeMessage, ClassDefinition, ClassKind, ClassModifiers, CommentAttachment,
-    ExpectCategory, Expression, ExpressionStatement, Identifier, KeywordPart, Literal,
+    ExpectCategory, Expression, ExpressionStatement, Identifier, KeywordPart, Literal, MatchArm,
     MessageSelector, MethodDefinition, MethodKind, Module, ParameterDefinition, Pattern,
     ProtocolDefinition, ProtocolMethodSignature, StateDeclaration, TypeAnnotation,
 };
@@ -574,6 +574,72 @@ fn test_match_returns_dynamic() {
         InferredType::Dynamic(reason) => assert_eq!(reason, DynamicReason::AmbiguousControlFlow),
         other => panic!("expected Dynamic(AmbiguousControlFlow), got {other:?}"),
     }
+}
+
+#[test]
+fn test_match_arm_pattern_vars_bound_in_body() {
+    // match x { n => n + 1 }
+    // `n` is pattern-bound — sending `+` to it should NOT produce a DNU warning
+    // because it should be Dynamic, not unknown.
+    let method = make_method(
+        "doMatch",
+        vec![Expression::Match {
+            value: Box::new(int_lit(42)),
+            arms: vec![MatchArm::new(
+                Pattern::Variable(ident("n")),
+                msg_send(
+                    var("n"),
+                    MessageSelector::Binary("+".into()),
+                    vec![int_lit(1)],
+                ),
+                span(),
+            )],
+            span: span(),
+        }],
+    );
+    let class = make_class_with_methods("Thing", vec![method]);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    assert!(
+        checker.diagnostics().is_empty(),
+        "match-bound var `n` should be Dynamic — no DNU warnings: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn test_match_arm_pattern_vars_bound_in_guard() {
+    // match x { n when n > 0 => n }
+    // `n` in the guard should also resolve as Dynamic, not produce a warning.
+    let method = make_method(
+        "doMatch",
+        vec![Expression::Match {
+            value: Box::new(int_lit(42)),
+            arms: vec![MatchArm::with_guard(
+                Pattern::Variable(ident("n")),
+                msg_send(
+                    var("n"),
+                    MessageSelector::Binary(">".into()),
+                    vec![int_lit(0)],
+                ),
+                var("n"),
+                span(),
+            )],
+            span: span(),
+        }],
+    );
+    let class = make_class_with_methods("Thing", vec![method]);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    assert!(
+        checker.diagnostics().is_empty(),
+        "match-bound var `n` in guard should be Dynamic — no DNU warnings: {:?}",
+        checker.diagnostics()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes [BT-1946](https://linear.app/beamtalk/issue/BT-1946/type-checker-bind-match-arm-pattern-variables-into-arm-env): match-arm pattern variables were not bound in the arm's type environment, causing references to them in guard/body expressions to infer as unknown instead of Dynamic.

- Call `bind_pattern_vars` on `arm.pattern` after creating `arm_env` in match expression inference
- Add tests for pattern variable resolution in both arm body and guard expressions

## Test plan

- [x] New unit test: `test_match_arm_pattern_vars_bound_in_body`
- [x] New unit test: `test_match_arm_pattern_vars_bound_in_guard`
- [x] Full CI passes (`just ci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type inference so variables introduced by match arm patterns are available during guard and arm-body analysis, preventing spurious “does not understand” diagnostics when sending messages to those variables.

* **Tests**
  * Added tests that validate correct type inference and ensure no diagnostics are produced for pattern-bound variables used in both guards and arm bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->