### PR TITLE
Protocol define: fails to load via MCP load_project (BT-1950)

### DIFF
--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -753,6 +753,7 @@ fn handle_compile_expression(request: &Map) -> Term {
             class_module_index,
             pre_class_hierarchy,
             module_name_override.as_deref(),
+            false, // REPL expressions are never stdlib
         );
     }
 
@@ -989,6 +990,7 @@ fn handle_inline_class_definition(
 /// with protocol registration via BT-1610), then returns a `protocol_definition`
 /// response so the Erlang side can load and execute the module.
 /// BT-1670: Accepts optional `module_name_override` for package-mode consistency.
+#[allow(clippy::too_many_arguments)]
 fn handle_inline_protocol_definition(
     module: &beamtalk_core::ast::Module,
     source: &str,
@@ -997,10 +999,11 @@ fn handle_inline_protocol_definition(
     class_module_index: std::collections::HashMap<String, String>,
     pre_class_hierarchy: Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
     module_name_override: Option<&str>,
+    stdlib_mode: bool,
 ) -> Term {
     let first_protocol_name = &module.protocols[0].name.name;
     let protocol_module_name =
-        derive_class_module_name(first_protocol_name, module_name_override, false);
+        derive_class_module_name(first_protocol_name, module_name_override, stdlib_mode);
 
     let protocol_names: Vec<String> = module
         .protocols
@@ -1163,6 +1166,7 @@ fn handle_compile(request: &Map) -> Term {
             class_module_index,
             pre_class_hierarchy,
             module_name_override.as_deref(),
+            stdlib_mode,
         );
     }
 

--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -1139,13 +1139,6 @@ fn handle_compile(request: &Map) -> Term {
         }
     };
 
-    // Extract class info
-    let classes: Vec<(String, String)> = module
-        .classes
-        .iter()
-        .map(|c| (c.name.name.to_string(), c.superclass_name().to_string()))
-        .collect();
-
     let class_module_index = match extract_optional_string_map(request, "class_module_index") {
         Ok(map) => map,
         Err(resp) => return resp,
@@ -1155,6 +1148,30 @@ fn handle_compile(request: &Map) -> Term {
             Ok(map) => map,
             Err(resp) => return resp,
         };
+
+    // BT-1950: Protocol-only files need the same early-return path as
+    // handle_compile_expression (BT-1612). generate_module assumes at least
+    // one class exists and errors with "Value type module has no class" for
+    // protocol-only files. Route through the protocol codegen instead.
+    if !module.protocols.is_empty() && module.classes.is_empty() {
+        let warning_msgs: Vec<String> = warnings.iter().map(|w| w.message.clone()).collect();
+        return handle_inline_protocol_definition(
+            &module,
+            &source,
+            &warning_msgs,
+            &class_superclass_index,
+            class_module_index,
+            pre_class_hierarchy,
+            module_name_override.as_deref(),
+        );
+    }
+
+    // Extract class info
+    let classes: Vec<(String, String)> = module
+        .classes
+        .iter()
+        .map(|c| (c.name.name.to_string(), c.superclass_name().to_string()))
+        .collect();
 
     // BT-845/BT-860: Extract optional source file path to embed as beamtalk_source attribute.
     let source_path = map_get(request, "source_path").and_then(term_to_string);
@@ -1843,17 +1860,32 @@ mod tests {
             "Protocol-only file should compile successfully"
         );
 
+        // BT-1950: Protocol-only files now return a protocol_definition response
+        let kind = map_get(m, "kind").and_then(term_to_atom);
+        assert_eq!(
+            kind.as_deref(),
+            Some("protocol_definition"),
+            "Protocol-only file should return protocol_definition kind"
+        );
+
         let module_name = map_get(m, "module_name").and_then(term_to_string);
         assert_eq!(module_name.as_deref(), Some("bt@awaitable"));
 
-        // Classes list should be present and empty for protocol-only files
-        let classes = map_get(m, "classes").expect("response should include 'classes' key");
-        let Term::List(list) = classes else {
-            panic!("Expected classes to be a list, got: {classes:?}");
+        // Protocols list should contain the protocol name
+        let protocols = map_get(m, "protocols").expect("response should include 'protocols' key");
+        let Term::List(list) = protocols else {
+            panic!("Expected protocols to be a list, got: {protocols:?}");
         };
+        assert_eq!(list.elements.len(), 1, "Should have one protocol");
+        assert_eq!(
+            term_to_string(&list.elements[0]).as_deref(),
+            Some("Awaitable")
+        );
+
+        // core_erlang should be present
         assert!(
-            list.elements.is_empty(),
-            "Protocol-only file should have no classes"
+            map_get(m, "core_erlang").is_some(),
+            "Protocol response should include core_erlang"
         );
     }
 
@@ -1873,6 +1905,10 @@ mod tests {
 
         let status = map_get(m, "status").and_then(term_to_atom);
         assert_eq!(status.as_deref(), Some("ok"));
+
+        // BT-1950: Protocol-only files return protocol_definition kind
+        let kind = map_get(m, "kind").and_then(term_to_atom);
+        assert_eq!(kind.as_deref(), Some("protocol_definition"));
 
         let module_name = map_get(m, "module_name").and_then(term_to_string);
         assert_eq!(module_name.as_deref(), Some("bt@exdura@awaitable"));

--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -431,29 +431,17 @@
       "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
-        "Actor",
         "Collection",
         "Object",
-        "Orchestrator",
-        "actor",
-        "async",
         "beamtalk-language-features",
-        "concurrent",
         "extends",
-        "field",
         "first",
-        "gen_server",
-        "genserver",
         "inherit",
         "inheritance",
-        "instance variable",
-        "member",
         "object",
-        "process",
-        "property",
         "subclassing"
       ],
-      "source": "Actor subclass: Orchestrator\n  @expect type\n  state: deps :: OrchestratorDeps    // factory-required, no sensible default — suppress uninitialized warning\n\ntyped Object subclass: Collection(E)\n  @expect type\n  first => (Erlang erlang) hd: self asErlangList   // polymorphic return — suppress missing-annotation warning",
+      "source": "typed Object subclass: Collection(E)\n  @expect type\n  first => (Erlang erlang) hd: self asErlangList   // polymorphic return — suppress missing-annotation warning",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -24116,6 +24104,16 @@
       ],
       "source": "// Point - a simple value type for testing BT-213\n\nValue subclass: Point\n  field: x = 0\n  field: y = 0\n\n  // Get x coordinate\n  getX => self.x\n\n  // Get y coordinate\n  getY => self.y",
       "explanation": "Point - a simple value type for testing BT-213"
+    },
+    {
+      "id": "tests-e2e-fixtures-protocol-loadable",
+      "title": "Protocol Loadable",
+      "category": "e2e-fixtures",
+      "tags": [
+        "protocol_loadable"
+      ],
+      "source": "// Test protocol definition for load-file e2e test (BT-1950).\nProtocol define: LoadableProtocol\n  doSomething -> String",
+      "explanation": "Test protocol definition for load-file e2e test (BT-1950)."
     },
     {
       "id": "tests-e2e-fixtures-rectangle",

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler.erl
@@ -96,7 +96,7 @@ Returns `{ok, #{core_erlang, module_name, classes, warnings}}' or
 `{error, Diagnostics}'.
 """.
 -spec compile(binary(), map()) ->
-    {ok, map()} | {error, [map()]}.
+    {ok, map()} | {ok, protocol_definition, map()} | {error, [map()]}.
 compile(Source, Options) ->
     beamtalk_compiler_server:compile(Source, Options).
 

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler.erl
@@ -92,8 +92,9 @@ Compile a file/class definition.
   - `stdlib_mode' (boolean, default false) — enable `@primitive' pragmas
   - `workspace_mode' (boolean, default true) — REPL workspace context
 
-Returns `{ok, #{core_erlang, module_name, classes, warnings}}' or
-`{error, Diagnostics}'.
+Returns `{ok, #{core_erlang, module_name, classes, warnings}}',
+`{ok, protocol_definition, #{core_erlang, module_name, protocols, warnings}}',
+or `{error, Diagnostics}'.
 """.
 -spec compile(binary(), map()) ->
     {ok, map()} | {ok, protocol_definition, map()} | {error, [map()]}.

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -117,7 +117,7 @@ Options: #{path => binary(), stdlib_mode => boolean(), workspace_mode => boolean
 Returns `{ok, #{core_erlang, module_name, classes, warnings}}' or `{error, Diagnostics}'.
 """.
 -spec compile(binary(), map()) ->
-    {ok, map()} | {error, [map()]}.
+    {ok, map()} | {ok, protocol_definition, map()} | {error, [map()]}.
 compile(Source, Options) ->
     gen_server:call(?MODULE, {compile, Source, Options}, 30000).
 
@@ -524,6 +524,22 @@ handle_compile_response(#{
         core_erlang => CoreErlang,
         module_name => ModuleName,
         classes => Classes,
+        warnings => Warnings
+    }};
+%% BT-1950: Protocol definitions use a different response shape (kind := protocol_definition)
+%% and have no `classes` key — they have `protocols` instead.
+handle_compile_response(#{
+    status := ok,
+    kind := protocol_definition,
+    core_erlang := CoreErlang,
+    module_name := ModuleName,
+    protocols := Protocols,
+    warnings := Warnings
+}) ->
+    {ok, protocol_definition, #{
+        core_erlang => CoreErlang,
+        module_name => ModuleName,
+        protocols => Protocols,
         warnings => Warnings
     }};
 handle_compile_response(#{status := error, diagnostics := Diagnostics}) ->

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -114,7 +114,9 @@ compile_expression_trace(Source, ModuleName, KnownVars, Options) ->
 -doc """
 Compile a file/class definition.
 Options: #{path => binary(), stdlib_mode => boolean(), workspace_mode => boolean()}
-Returns `{ok, #{core_erlang, module_name, classes, warnings}}' or `{error, Diagnostics}'.
+Returns `{ok, #{core_erlang, module_name, classes, warnings}}',
+`{ok, protocol_definition, #{core_erlang, module_name, protocols, warnings}}',
+or `{error, Diagnostics}'.
 """.
 -spec compile(binary(), map()) ->
     {ok, map()} | {ok, protocol_definition, map()} | {error, [map()]}.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
@@ -92,7 +92,9 @@ compile_expression_trace(Expression, ModuleName, Bindings) ->
 
 -doc "Compile a Beamtalk file to bytecode.".
 -spec compile_file(string(), string(), boolean(), binary() | undefined) ->
-    {ok, binary(), [#{name := string(), superclass := string()}], atom()} | {error, term()}.
+    {ok, binary(), [#{name := string(), superclass := string()}], atom()}
+    | {ok, protocol_definition, map(), [binary()]}
+    | {error, term()}.
 compile_file(Source, Path, StdlibMode, ModuleNameOverride) ->
     compile_file_via_port(Source, Path, StdlibMode, ModuleNameOverride).
 
@@ -103,7 +105,9 @@ Like `compile_file/4' but accepts pre-built class indexes to avoid
 redundant class registry scans during batch loads.
 """.
 -spec compile_file(string(), string(), boolean(), binary() | undefined, map()) ->
-    {ok, binary(), [#{name := string(), superclass := string()}], atom()} | {error, term()}.
+    {ok, binary(), [#{name := string(), superclass := string()}], atom()}
+    | {ok, protocol_definition, map(), [binary()]}
+    | {error, term()}.
 compile_file(Source, Path, StdlibMode, ModuleNameOverride, PrebuiltIndexes) ->
     compile_file_via_port(Source, Path, StdlibMode, ModuleNameOverride, PrebuiltIndexes).
 
@@ -463,6 +467,10 @@ compile_file_via_port(Source, Path, StdlibMode, ModuleNameOverride, PrebuiltInde
                     % elp:fixme W0023 intentional atom creation
                     ModuleName = binary_to_atom(ModNameBin, utf8),
                     compile_file_core(CoreErlang, ModuleName, Classes);
+                %% BT-1950: Protocol definitions from the compile path — compile
+                %% Core Erlang to BEAM and return a protocol_definition result.
+                {ok, protocol_definition, ProtocolInfo} ->
+                    compile_protocol_definition_result(ProtocolInfo);
                 {error, Diagnostics} ->
                     {error, {compile_error, format_formatted_diagnostics(Diagnostics)}}
             end

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -340,6 +340,10 @@ load_compiled_module(Binary, ClassNames, ModuleName, Source, SourcePath, State) 
     {ok, [map()], beamtalk_repl_state:state()} | {error, term(), beamtalk_repl_state:state()}.
 load_protocol_module(ProtocolInfo, Path, State) ->
     #{binary := Binary, module_name := ModuleName, protocols := Protocols} = ProtocolInfo,
+    ProtocolClassNames = [
+        #{name => binary_to_list(P), superclass => "Object"}
+     || P <- Protocols
+    ],
     LoadPath =
         case Path of
             undefined -> "";
@@ -348,16 +352,18 @@ load_protocol_module(ProtocolInfo, Path, State) ->
     case code:load_binary(ModuleName, LoadPath, Binary) of
         {module, ModuleName} ->
             %% activate_module calls register_class/0 which registers the protocol
-            ProtocolClassNames = [
-                #{name => binary_to_list(P), superclass => "Object"}
-             || P <- Protocols
-            ],
             activate_module(ModuleName, ProtocolClassNames, Path),
             NewState1 = maybe_add_loaded_module(ModuleName, State),
             NewState2 = track_module_source(ModuleName, Path, NewState1),
             {ok, ProtocolClassNames, NewState2};
         {error, Reason} ->
-            {error, {load_error, Reason}, State}
+            ClassAtoms = class_name_atoms(ProtocolClassNames),
+            case beamtalk_runtime_api:drain_pending_load_errors_by_names(ClassAtoms) of
+                [{_ClassName, StructuredError} | _] ->
+                    {error, StructuredError, State};
+                [] ->
+                    {error, {load_error, Reason}, State}
+            end
     end.
 
 %% BT-1950: Load a protocol module without session state (stateless path).
@@ -365,16 +371,22 @@ load_protocol_module(ProtocolInfo, Path, State) ->
 -spec load_protocol_module_stateless(map(), string()) -> {ok, [map()]} | {error, term()}.
 load_protocol_module_stateless(ProtocolInfo, Path) ->
     #{binary := Binary, module_name := ModuleName, protocols := Protocols} = ProtocolInfo,
+    ProtocolClassNames = [
+        #{name => binary_to_list(P), superclass => "Object"}
+     || P <- Protocols
+    ],
     case code:load_binary(ModuleName, Path, Binary) of
         {module, ModuleName} ->
-            ProtocolClassNames = [
-                #{name => binary_to_list(P), superclass => "Object"}
-             || P <- Protocols
-            ],
             activate_module(ModuleName, ProtocolClassNames, Path),
             {ok, ProtocolClassNames};
         {error, Reason} ->
-            {error, {load_error, Reason}}
+            ClassAtoms = class_name_atoms(ProtocolClassNames),
+            case beamtalk_runtime_api:drain_pending_load_errors_by_names(ClassAtoms) of
+                [{_ClassName, StructuredError} | _] ->
+                    {error, StructuredError};
+                [] ->
+                    {error, {load_error, Reason}}
+            end
     end.
 
 %% Add a module to the loaded modules list if not already present.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -71,6 +71,12 @@ handle_load(Path, State) ->
                             Source, Path, StdlibMode, ModuleNameOverride
                         )
                     of
+                        %% BT-1950: Protocol definition from file compilation.
+                        %% Must be matched before the generic 4-tuple to avoid
+                        %% {ok, protocol_definition, Info, Warnings} binding to
+                        %% {ok, Binary, ClassNames, ModuleName}.
+                        {ok, protocol_definition, ProtocolInfo, _Warnings} ->
+                            load_protocol_module(ProtocolInfo, Path, State);
                         {ok, Binary, ClassNames, ModuleName} ->
                             load_compiled_module(
                                 Binary, ClassNames, ModuleName, Source, Path, State
@@ -106,6 +112,9 @@ handle_load(Path, State, PrebuiltIndexes) ->
                             Source, Path, StdlibMode, ModuleNameOverride, PrebuiltIndexes
                         )
                     of
+                        %% BT-1950: Protocol definition — must match before generic 4-tuple.
+                        {ok, protocol_definition, ProtocolInfo, _Warnings} ->
+                            load_protocol_module(ProtocolInfo, Path, State);
                         {ok, Binary, ClassNames, ModuleName} ->
                             load_compiled_module(
                                 Binary, ClassNames, ModuleName, Source, Path, State
@@ -122,6 +131,9 @@ handle_load(Path, State, PrebuiltIndexes) ->
 handle_load_source(SourceBin, Label, State) ->
     Source = binary_to_list(SourceBin),
     case beamtalk_repl_compiler:compile_file(Source, Label, false, undefined) of
+        %% BT-1950: Protocol definition — must match before generic 4-tuple.
+        {ok, protocol_definition, ProtocolInfo, _Warnings} ->
+            load_protocol_module(ProtocolInfo, undefined, State);
         {ok, Binary, ClassNames, ModuleName} ->
             load_compiled_module(Binary, ClassNames, ModuleName, Source, undefined, State);
         {error, Reason} ->
@@ -322,6 +334,49 @@ load_compiled_module(Binary, ClassNames, ModuleName, Source, SourcePath, State) 
             end
     end.
 
+%% BT-1950: Load a protocol module into BEAM, register it, and update REPL state.
+%% Used by handle_load/2, handle_load/3, and handle_load_source.
+-spec load_protocol_module(map(), string() | undefined, beamtalk_repl_state:state()) ->
+    {ok, [map()], beamtalk_repl_state:state()} | {error, term(), beamtalk_repl_state:state()}.
+load_protocol_module(ProtocolInfo, Path, State) ->
+    #{binary := Binary, module_name := ModuleName, protocols := Protocols} = ProtocolInfo,
+    LoadPath =
+        case Path of
+            undefined -> "";
+            _ -> Path
+        end,
+    case code:load_binary(ModuleName, LoadPath, Binary) of
+        {module, ModuleName} ->
+            %% activate_module calls register_class/0 which registers the protocol
+            ProtocolClassNames = [
+                #{name => binary_to_list(P), superclass => "Object"}
+             || P <- Protocols
+            ],
+            activate_module(ModuleName, ProtocolClassNames, Path),
+            NewState1 = maybe_add_loaded_module(ModuleName, State),
+            NewState2 = track_module_source(ModuleName, Path, NewState1),
+            {ok, ProtocolClassNames, NewState2};
+        {error, Reason} ->
+            {error, {load_error, Reason}, State}
+    end.
+
+%% BT-1950: Load a protocol module without session state (stateless path).
+%% Used by reload_compile_and_load for load_files_stateless.
+-spec load_protocol_module_stateless(map(), string()) -> {ok, [map()]} | {error, term()}.
+load_protocol_module_stateless(ProtocolInfo, Path) ->
+    #{binary := Binary, module_name := ModuleName, protocols := Protocols} = ProtocolInfo,
+    case code:load_binary(ModuleName, Path, Binary) of
+        {module, ModuleName} ->
+            ProtocolClassNames = [
+                #{name => binary_to_list(P), superclass => "Object"}
+             || P <- Protocols
+            ],
+            activate_module(ModuleName, ProtocolClassNames, Path),
+            {ok, ProtocolClassNames};
+        {error, Reason} ->
+            {error, {load_error, Reason}}
+    end.
+
 %% Add a module to the loaded modules list if not already present.
 -spec maybe_add_loaded_module(atom(), beamtalk_repl_state:state()) -> beamtalk_repl_state:state().
 maybe_add_loaded_module(ModuleName, State) ->
@@ -481,6 +536,9 @@ reload_class_file_impl(Path, ExpectedClassName) ->
 reload_compile_and_load(Source, Path, ModuleNameOverride, ExpectedClassName) ->
     StdlibMode = is_stdlib_path(Path),
     case beamtalk_repl_compiler:compile_file(Source, Path, StdlibMode, ModuleNameOverride) of
+        %% BT-1950: Protocol definition — must match before generic 4-tuple.
+        {ok, protocol_definition, ProtocolInfo, _Warnings} ->
+            load_protocol_module_stateless(ProtocolInfo, Path);
         {ok, Binary, ClassNames, ModuleName} ->
             case verify_class_present(ExpectedClassName, ClassNames, Path) of
                 ok ->

--- a/tests/e2e/cases/protocol_load_file.btscript
+++ b/tests/e2e/cases/protocol_load_file.btscript
@@ -1,0 +1,22 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E tests for loading Protocol define: files via :load (BT-1950)
+//
+// Verifies that Protocol definitions can be loaded from files,
+// not just defined inline in the REPL. This was broken because the
+// file compilation path didn't handle protocol_definition responses.
+
+// ===========================================================================
+// Load a protocol file
+// ===========================================================================
+
+:load tests/e2e/fixtures/protocol_loadable.bt
+// => Loaded: LoadableProtocol
+
+// ===========================================================================
+// Verify the protocol is registered after file load
+// ===========================================================================
+
+Protocol isProtocol: #LoadableProtocol
+// => true

--- a/tests/e2e/fixtures/protocol_loadable.bt
+++ b/tests/e2e/fixtures/protocol_loadable.bt
@@ -1,0 +1,6 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Test protocol definition for load-file e2e test (BT-1950).
+Protocol define: LoadableProtocol
+  doSomething -> String


### PR DESCRIPTION
## Summary

Fixes BT-1950: `Protocol define:` files failed silently when loaded via MCP `load_project` or `load_file` because the file compilation path (`handle_compile` in the Rust compiler port) didn't handle protocol-only modules — it fell through to `generate_value_type_module` which errored with "Value type module has no class".

**Root cause:** The `compile` command in the Rust port lacked the early return for protocol definitions that the `compile_expression` command already had (BT-1612). The fix routes protocol-only files through `handle_inline_protocol_definition`, and plumbs the `protocol_definition` response through the Erlang compiler server, REPL compiler, and REPL loader.

## Changes

- **Rust port** (`beamtalk-compiler-port/main.rs`): Add protocol early return in `handle_compile` for files with protocols but no classes
- **Erlang compiler server** (`beamtalk_compiler_server.erl`): Add `handle_compile_response` clause for `protocol_definition` kind
- **REPL compiler** (`beamtalk_repl_compiler.erl`): Handle `protocol_definition` result in `compile_file_via_port`; update specs
- **REPL loader** (`beamtalk_repl_loader.erl`): Add `load_protocol_module/3` and `load_protocol_module_stateless/2`; fix Erlang pattern match ordering (protocol clause before generic 4-tuple)
- **Tests**: E2E test for `:load` of protocol files + updated Rust port unit tests

[Linear: BT-1950](https://linear.app/beamtalk/issue/BT-1950)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compile protocol-only files independently as protocol definitions.
  * Load and register protocol modules at runtime via the :load command.
  * Compiler and runtime APIs now return and handle a distinct protocol-definition success shape.

* **Tests**
  * Added end-to-end fixtures and a test case validating protocol loading and registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->