### PR TITLE
Tests: small stdlib modules coverage to 85% (BT-1975)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_stdlib.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_stdlib.erl
@@ -45,6 +45,11 @@ No Erlang code changes needed.
 %% Re-export for backwards compatibility (tests reference beamtalk_stdlib:topo_sort/1)
 -export([topo_sort/1]).
 
+-ifdef(TEST).
+%% Export internal helpers for EUnit coverage (BT-1975)
+-export([format_bt_module/1, class_entry_module/1, find_stdlib_ebin/0]).
+-endif.
+
 -doc """
 Start the stdlib initializer as a supervised process.
 

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_actor_sup_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_actor_sup_tests.erl
@@ -92,3 +92,35 @@ supervisor_count_children_test() ->
 
     %% Cleanup
     exit(Pid, normal).
+
+%%% BT-1975: Additional coverage tests
+
+init_child_spec_shutdown_test() ->
+    {ok, {_SupFlags, [ChildSpec]}} = beamtalk_actor_sup:init([]),
+    %% Should have a 5 second shutdown timeout
+    ?assertEqual(5000, maps:get(shutdown, ChildSpec)).
+
+init_child_spec_modules_test() ->
+    {ok, {_SupFlags, [ChildSpec]}} = beamtalk_actor_sup:init([]),
+    %% Modules list should contain beamtalk_actor
+    ?assertEqual([beamtalk_actor], maps:get(modules, ChildSpec)).
+
+init_child_spec_id_test() ->
+    {ok, {_SupFlags, [ChildSpec]}} = beamtalk_actor_sup:init([]),
+    %% Child id should be beamtalk_actor
+    ?assertEqual(beamtalk_actor, maps:get(id, ChildSpec)).
+
+supervisor_registered_name_test() ->
+    %% Start the supervisor — it registers under beamtalk_actor_sup
+    {ok, Pid} = beamtalk_actor_sup:start_link(),
+    ?assertEqual(Pid, whereis(beamtalk_actor_sup)),
+    %% Cleanup
+    exit(Pid, normal).
+
+start_actor_function_exported_test() ->
+    %% Verify start_actor/3 is exported with correct arity
+    ?assert(erlang:function_exported(beamtalk_actor_sup, start_actor, 3)).
+
+start_link_function_exported_test() ->
+    %% Verify start_link/0 is exported
+    ?assert(erlang:function_exported(beamtalk_actor_sup, start_link, 0)).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_metaclass_bt_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_metaclass_bt_tests.erl
@@ -1,0 +1,114 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_metaclass_bt_tests).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+EUnit tests for beamtalk_metaclass_bt module (BT-1975).
+
+Tests metaclass identity predicates, dispatch error handling,
+has_method/1 queries, and class registration.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include("beamtalk.hrl").
+
+%%% ============================================================================
+%%% dispatch/4 — identity predicates
+%%% ============================================================================
+
+dispatch_is_meta_test() ->
+    State = #{},
+    ?assertEqual({reply, true, State}, beamtalk_metaclass_bt:dispatch('isMeta', [], self(), State)).
+
+dispatch_is_class_test() ->
+    State = #{},
+    ?assertEqual(
+        {reply, false, State}, beamtalk_metaclass_bt:dispatch('isClass', [], self(), State)
+    ).
+
+dispatch_is_metaclass_test() ->
+    State = #{},
+    ?assertEqual(
+        {reply, true, State}, beamtalk_metaclass_bt:dispatch('isMetaclass', [], self(), State)
+    ).
+
+dispatch_preserves_state_test() ->
+    %% State map should pass through unchanged
+    State = #{foo => bar, count => 42},
+    {reply, true, RetState} = beamtalk_metaclass_bt:dispatch('isMeta', [], self(), State),
+    ?assertEqual(State, RetState).
+
+%%% ============================================================================
+%%% dispatch/4 — unknown selectors
+%%% ============================================================================
+
+dispatch_unknown_selector_test() ->
+    State = #{},
+    {error, Error, RetState} = beamtalk_metaclass_bt:dispatch(
+        'unknownMethod', [], self(), State
+    ),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind),
+    ?assertEqual('Metaclass', Error#beamtalk_error.class),
+    ?assertEqual(State, RetState).
+
+dispatch_unknown_with_args_test() ->
+    State = #{},
+    {error, Error, _} = beamtalk_metaclass_bt:dispatch('foo:', [42], self(), State),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind).
+
+%%% ============================================================================
+%%% has_method/1
+%%% ============================================================================
+
+has_method_known_selectors_test() ->
+    ?assert(beamtalk_metaclass_bt:has_method('isMeta')),
+    ?assert(beamtalk_metaclass_bt:has_method('isClass')),
+    ?assert(beamtalk_metaclass_bt:has_method('isMetaclass')).
+
+has_method_unknown_selectors_test() ->
+    ?assertNot(beamtalk_metaclass_bt:has_method('unknownMethod')),
+    ?assertNot(beamtalk_metaclass_bt:has_method('new')),
+    ?assertNot(beamtalk_metaclass_bt:has_method('name')),
+    ?assertNot(beamtalk_metaclass_bt:has_method('superclass')).
+
+%%% ============================================================================
+%%% register_class/0 (requires bootstrap)
+%%% ============================================================================
+
+register_class_test_() ->
+    {setup, fun setup_bootstrap/0, fun teardown_bootstrap/1, [
+        {"register_class creates Metaclass", fun register_class_creates_test/0},
+        {"register_class is idempotent", fun register_class_idempotent_test/0},
+        {"registered Metaclass has correct superclass", fun register_class_superclass_test/0}
+    ]}.
+
+setup_bootstrap() ->
+    case whereis(pg) of
+        undefined -> pg:start_link();
+        _ -> ok
+    end,
+    beamtalk_extensions:init(),
+    {ok, _} = beamtalk_bootstrap:start_link(),
+    ok.
+
+teardown_bootstrap(_) ->
+    ok.
+
+register_class_creates_test() ->
+    %% Bootstrap already registered Metaclass; verify it's there
+    Pid = beamtalk_class_registry:whereis_class('Metaclass'),
+    ?assertNotEqual(undefined, Pid),
+    ?assertEqual('Metaclass', beamtalk_object_class:class_name(Pid)).
+
+register_class_idempotent_test() ->
+    %% Calling register_class again should not crash
+    ok = beamtalk_metaclass_bt:register_class(),
+    Pid = beamtalk_class_registry:whereis_class('Metaclass'),
+    ?assertNotEqual(undefined, Pid).
+
+register_class_superclass_test() ->
+    Pid = beamtalk_class_registry:whereis_class('Metaclass'),
+    ?assertEqual('Class', beamtalk_object_class:superclass(Pid)).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_metaclass_bt_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_metaclass_bt_tests.erl
@@ -91,7 +91,10 @@ setup_bootstrap() ->
         _ -> ok
     end,
     beamtalk_extensions:init(),
-    {ok, _} = beamtalk_bootstrap:start_link(),
+    case beamtalk_bootstrap:start_link() of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
     ok.
 
 teardown_bootstrap(_) ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_stdlib_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_stdlib_tests.erl
@@ -369,3 +369,70 @@ dispatch_unknown_selector_test() ->
         },
         beamtalk_stdlib:dispatch(nonExistentMethod, [], 'Beamtalk')
     ).
+
+%%% ============================================================================
+%%% format_bt_module/1 Tests (BT-1975)
+%%% ============================================================================
+
+format_bt_module_test_() ->
+    [
+        {"dotted module path",
+            ?_assertEqual(
+                "bt.stdlib.integer", beamtalk_stdlib:format_bt_module('bt@stdlib@integer')
+            )},
+        {"single segment module",
+            ?_assertEqual("beamtalk_runtime", beamtalk_stdlib:format_bt_module(beamtalk_runtime))},
+        {"deeply nested module",
+            ?_assertEqual(
+                "bt.sicp.scheme.lambda",
+                beamtalk_stdlib:format_bt_module('bt@sicp@scheme@lambda')
+            )},
+        {"no @ signs", ?_assertEqual("simple", beamtalk_stdlib:format_bt_module(simple))}
+    ].
+
+%%% ============================================================================
+%%% class_entry_module/1 Tests (BT-1975)
+%%% ============================================================================
+
+class_entry_module_map_test() ->
+    Entry = #{
+        name => 'Integer',
+        module => 'bt@stdlib@integer',
+        parent => 'Number',
+        package => stdlib,
+        kind => value,
+        type_params => []
+    },
+    ?assertEqual('bt@stdlib@integer', beamtalk_stdlib:class_entry_module(Entry)).
+
+class_entry_module_tuple_test() ->
+    Entry = {mod_a, 'A', 'Object'},
+    ?assertEqual(mod_a, beamtalk_stdlib:class_entry_module(Entry)).
+
+%%% ============================================================================
+%%% find_stdlib_ebin/0 Tests (BT-1975)
+%%% ============================================================================
+
+find_stdlib_ebin_test() ->
+    %% After build, stdlib should be loaded and ebin should exist
+    Dir = beamtalk_stdlib:find_stdlib_ebin(),
+    ?assert(is_list(Dir)),
+    %% Should end with "ebin"
+    ?assertEqual("ebin", filename:basename(Dir)).
+
+%%% ============================================================================
+%%% start_link/0 Tests (BT-1975)
+%%% ============================================================================
+
+start_link_test_() ->
+    {setup, fun stdlib_setup/0, fun stdlib_teardown/1, [
+        {"start_link returns pid", fun start_link_returns_pid_test/0}
+    ]}.
+
+start_link_returns_pid_test() ->
+    %% start_link spawns a proc_lib process
+    {ok, Pid} = beamtalk_stdlib:start_link(),
+    ?assert(is_pid(Pid)),
+    ?assert(is_process_alive(Pid)),
+    %% Cleanup
+    exit(Pid, shutdown).

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_collection_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_collection_tests.erl
@@ -51,3 +51,36 @@ to_list_empty_list_test() ->
 
 to_list_single_element_test() ->
     ?assertEqual([x], beamtalk_collection:to_list([x])).
+
+to_list_nested_list_test() ->
+    ?assertEqual([[1, 2], [3, 4]], beamtalk_collection:to_list([[1, 2], [3, 4]])).
+
+to_list_mixed_types_test() ->
+    ?assertEqual([1, a, <<"str">>], beamtalk_collection:to_list([1, a, <<"str">>])).
+
+%%% ============================================================================
+%%% inject_into/3 — additional coverage
+%%% ============================================================================
+
+inject_into_string_accumulator_test() ->
+    %% Build a string by accumulating elements
+    Result = beamtalk_collection:inject_into(
+        [<<"a">>, <<"b">>, <<"c">>],
+        <<>>,
+        fun(Acc, E) -> <<Acc/binary, E/binary>> end
+    ),
+    ?assertEqual(<<"abc">>, Result).
+
+inject_into_map_accumulator_test() ->
+    %% Build a map by accumulating key-value pairs
+    Result = beamtalk_collection:inject_into(
+        [{a, 1}, {b, 2}],
+        #{},
+        fun(Acc, {K, V}) -> maps:put(K, V, Acc) end
+    ),
+    ?assertEqual(#{a => 1, b => 2}, Result).
+
+inject_into_count_test() ->
+    %% Count elements
+    Result = beamtalk_collection:inject_into([x, y, z], 0, fun(Acc, _E) -> Acc + 1 end),
+    ?assertEqual(3, Result).

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_map_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_map_tests.erl
@@ -23,6 +23,89 @@ at_if_absent_missing_test() ->
 at_if_absent_empty_map_test() ->
     ?assertEqual(42, beamtalk_map:at_if_absent(#{}, x, fun() -> 42 end)).
 
+at_if_absent_block_not_called_when_present_test() ->
+    %% Block should NOT be called when key is present
+    ?assertEqual(
+        1,
+        beamtalk_map:at_if_absent(#{a => 1}, a, fun() -> error(should_not_be_called) end)
+    ).
+
+%%% ============================================================================
+%%% do/2
+%%% ============================================================================
+
+do_iterates_values_test() ->
+    Self = self(),
+    beamtalk_map:do(#{a => 1, b => 2}, fun(V) -> Self ! {value, V} end),
+    Values = collect_messages([]),
+    ?assertEqual(lists:sort([1, 2]), lists:sort(Values)).
+
+do_empty_map_test() ->
+    ?assertEqual(nil, beamtalk_map:do(#{}, fun(_V) -> ok end)).
+
+do_returns_nil_test() ->
+    ?assertEqual(nil, beamtalk_map:do(#{a => 1}, fun(_V) -> ok end)).
+
+%%% ============================================================================
+%%% do_with_key/2
+%%% ============================================================================
+
+do_with_key_iterates_pairs_test() ->
+    Self = self(),
+    beamtalk_map:do_with_key(#{a => 1, b => 2}, fun(K, V) -> Self ! {pair, K, V} end),
+    Pairs = collect_pair_messages([]),
+    ?assertEqual(lists:sort([{a, 1}, {b, 2}]), lists:sort(Pairs)).
+
+do_with_key_empty_map_test() ->
+    ?assertEqual(nil, beamtalk_map:do_with_key(#{}, fun(_K, _V) -> ok end)).
+
+do_with_key_returns_nil_test() ->
+    ?assertEqual(nil, beamtalk_map:do_with_key(#{x => y}, fun(_K, _V) -> ok end)).
+
+%%% ============================================================================
+%%% includes/2
+%%% ============================================================================
+
+includes_present_value_test() ->
+    ?assert(beamtalk_map:includes(#{a => 1, b => 2}, 1)).
+
+includes_absent_value_test() ->
+    ?assertNot(beamtalk_map:includes(#{a => 1, b => 2}, 3)).
+
+includes_empty_map_test() ->
+    ?assertNot(beamtalk_map:includes(#{}, anything)).
+
+includes_checks_values_not_keys_test() ->
+    %% includes/2 checks values, not keys
+    ?assertNot(beamtalk_map:includes(#{a => 1}, a)),
+    ?assert(beamtalk_map:includes(#{a => 1}, 1)).
+
+%%% ============================================================================
+%%% print_string/1
+%%% ============================================================================
+
+print_string_empty_map_test() ->
+    ?assertEqual(<<"#{}">>, beamtalk_map:print_string(#{})).
+
+print_string_single_entry_test() ->
+    Result = beamtalk_map:print_string(#{1 => 2}),
+    ?assertEqual(<<"#{1 => 2}">>, Result).
+
+print_string_strips_beamtalk_class_tag_test() ->
+    %% $beamtalk_class tag should be stripped from output
+    Result = beamtalk_map:print_string(#{'$beamtalk_class' => 'Dictionary', a => 1}),
+    %% Should only show the 'a => 1' pair, not $beamtalk_class
+    ?assertNotEqual(nomatch, binary:match(Result, <<"a">>)),
+    ?assertEqual(nomatch, binary:match(Result, <<"$beamtalk_class">>)).
+
+print_string_sorted_keys_test() ->
+    %% Keys should be sorted for deterministic output
+    Result = beamtalk_map:print_string(#{b => 2, a => 1}),
+    %% 'a' should appear before 'b'
+    {PosA, _} = binary:match(Result, <<"a">>),
+    {PosB, _} = binary:match(Result, <<"b">>),
+    ?assert(PosA < PosB).
+
 %%% ============================================================================
 %%% Compiled bt@stdlib@dictionary dispatch/3
 %%% ============================================================================
@@ -145,3 +228,19 @@ primitive_send_at_put_test() ->
 primitive_send_includes_key_test() ->
     ?assertEqual(true, beamtalk_primitive:send(#{a => 1}, 'includesKey:', [a])),
     ?assertEqual(false, beamtalk_primitive:send(#{a => 1}, 'includesKey:', [b])).
+
+%%% ============================================================================
+%%% Helpers
+%%% ============================================================================
+
+collect_messages(Acc) ->
+    receive
+        {value, V} -> collect_messages([V | Acc])
+    after 100 -> lists:reverse(Acc)
+    end.
+
+collect_pair_messages(Acc) ->
+    receive
+        {pair, K, V} -> collect_pair_messages([{K, V} | Acc])
+    after 100 -> lists:reverse(Acc)
+    end.


### PR DESCRIPTION
## Summary

Add ~30 EUnit tests covering five smaller runtime/stdlib modules to improve coverage toward 85%:

- **beamtalk_metaclass_bt** (new file): dispatch identity predicates (isMeta, isClass, isMetaclass), unknown selector DNU errors, has_method queries, register_class with bootstrap fixture
- **beamtalk_map**: do/2, do_with_key/2, includes/2, print_string/1 (empty, single entry, class tag stripping, sorted keys), at_if_absent block-not-called guard
- **beamtalk_collection**: nested/mixed to_list variants, string/map/count accumulator variants for inject_into
- **beamtalk_stdlib**: format_bt_module (dotted paths, single segment, deeply nested), class_entry_module (map + tuple formats), find_stdlib_ebin, start_link
- **beamtalk_actor_sup**: child spec fields (shutdown, modules, id), registered name verification, function export checks

Also adds `-ifdef(TEST)` exports for three internal helpers in `beamtalk_stdlib.erl` to enable direct unit testing.

Linear: https://linear.app/beamtalk/issue/BT-1975

## Test plan

- [x] All new tests pass individually (`rebar3 eunit --module=<module>`)
- [x] Full `just test` passes with 0 failures
- [x] `just clippy` and `just fmt-check` pass
- [x] No production code changes beyond `-ifdef(TEST)` export guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added EUnit coverage for supervisor child specifications and registration validation in `beamtalk_actor_sup`.
  * Added test suite for `beamtalk_metaclass_bt` covering dispatch operations, method verification, and class registration.
  * Expanded test coverage for `beamtalk_stdlib` including module formatting, class entry handling, and process initialization.
  * Added tests for `beamtalk_collection` covering list conversion and fold operations.
  * Expanded `beamtalk_map` tests including value iteration, conditional blocks, and output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->