### PR TITLE
Tests: beamtalk_hot_reload + beamtalk_class_instantiation coverage to 85% (BT-1971)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_instantiation_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_instantiation_tests.erl
@@ -55,7 +55,27 @@ instantiation_test_() ->
             {"Dictionary (value type) is registered as constructible",
                 fun test_dictionary_registered_constructible/0},
             %% abstract_class_error tests
-            {"abstract_class_error returns structured error", fun test_abstract_error_structure/0}
+            {"abstract_class_error returns structured error", fun test_abstract_error_structure/0},
+            {"abstract_class_error with spawnWith: selector", fun test_abstract_error_spawn_with/0},
+            {"abstract_class_error with new selector", fun test_abstract_error_new/0},
+            %% class_self_new tests (BT-893)
+            {"class_self_new succeeds for constructible class", fun test_class_self_new_success/0},
+            {"class_self_new raises for non-constructible class",
+                fun test_class_self_new_non_constructible/0},
+            %% class_self_spawn tests (BT-893)
+            {"class_self_spawn succeeds for non-abstract actor",
+                fun test_class_self_spawn_success/0},
+            {"class_self_spawn/4 raises for abstract class", fun test_class_self_spawn_abstract/0},
+            {"class_self_spawn/4 normalizes non-boolean IsAbstract",
+                fun test_class_self_spawn_normalize_abstract/0},
+            %% compute_is_constructible edge cases
+            {"module without new/0 is not constructible", fun test_compute_no_new_export/0},
+            %% handle_new with undefined IsConstructible
+            {"handle_new computes constructibility when undefined",
+                fun test_handle_new_undefined_constructible/0},
+            %% handle_spawn with abstract and spawnWith:
+            {"spawn abstract with spawnWith: returns instantiation_error",
+                fun test_spawn_abstract_spawn_with/0}
         ]
     end}.
 
@@ -222,6 +242,128 @@ test_abstract_error_structure() ->
         Error
     ),
     ?assert(is_binary(Error#beamtalk_error.hint)).
+
+%%====================================================================
+%% abstract_class_error with different selectors
+%%====================================================================
+
+test_abstract_error_spawn_with() ->
+    Error = beamtalk_class_instantiation:abstract_class_error('MyActor', 'spawnWith:'),
+    ?assertMatch(
+        #beamtalk_error{
+            kind = instantiation_error,
+            class = 'MyActor',
+            selector = 'spawnWith:'
+        },
+        Error
+    ),
+    ?assert(is_binary(Error#beamtalk_error.hint)).
+
+test_abstract_error_new() ->
+    Error = beamtalk_class_instantiation:abstract_class_error('Shape', new),
+    ?assertMatch(
+        #beamtalk_error{
+            kind = instantiation_error,
+            class = 'Shape',
+            selector = new
+        },
+        Error
+    ).
+
+%%====================================================================
+%% class_self_new tests (BT-893)
+%%====================================================================
+
+test_class_self_new_success() ->
+    %% Dictionary is constructible via new/0
+    code:ensure_loaded('bt@stdlib@dictionary'),
+    Result = beamtalk_class_instantiation:class_self_new(
+        'Dictionary', 'bt@stdlib@dictionary', []
+    ),
+    %% Should return the new instance directly (not wrapped in {ok, ...})
+    ?assert(is_map(Result)).
+
+test_class_self_new_non_constructible() ->
+    %% Integer's new/0 raises, so class_self_new should raise error
+    code:ensure_loaded(beamtalk_integer),
+    ?assertError(
+        _,
+        beamtalk_class_instantiation:class_self_new('Integer', beamtalk_integer, [])
+    ).
+
+%%====================================================================
+%% class_self_spawn tests (BT-893)
+%%====================================================================
+
+test_class_self_spawn_success() ->
+    ok = ensure_counter_loaded(),
+    Result = beamtalk_class_instantiation:class_self_spawn(
+        'Counter', 'bt@counter', []
+    ),
+    ?assertMatch(#beamtalk_object{class = 'Counter'}, Result),
+    gen_server:stop(Result#beamtalk_object.pid).
+
+test_class_self_spawn_abstract() ->
+    %% With IsAbstract=true, should raise instantiation_error
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = instantiation_error}},
+        beamtalk_class_instantiation:class_self_spawn(
+            'AbstractThing', some_mod, true, []
+        )
+    ).
+
+test_class_self_spawn_normalize_abstract() ->
+    %% undefined (from erlang:get) should be treated as false (non-abstract)
+    ok = ensure_counter_loaded(),
+    Result = beamtalk_class_instantiation:class_self_spawn(
+        'Counter', 'bt@counter', undefined, []
+    ),
+    ?assertMatch(#beamtalk_object{class = 'Counter'}, Result),
+    gen_server:stop(Result#beamtalk_object.pid).
+
+%%====================================================================
+%% compute_is_constructible edge cases
+%%====================================================================
+
+test_compute_no_new_export() ->
+    %% A module that doesn't export new/0 should not be constructible
+    %% Use the erlang module itself as it has no new/0
+    ?assertEqual(
+        false,
+        beamtalk_class_instantiation:compute_is_constructible(erlang, false)
+    ).
+
+%%====================================================================
+%% handle_new with undefined IsConstructible
+%%====================================================================
+
+test_handle_new_undefined_constructible() ->
+    %% When IsConstructible is undefined, handle_new should compute it
+    code:ensure_loaded('bt@stdlib@dictionary'),
+    Result = beamtalk_class_instantiation:handle_new(
+        [], 'Dictionary', 'bt@stdlib@dictionary', undefined
+    ),
+    ?assertMatch({ok, _, true}, Result),
+    {ok, Obj, _} = Result,
+    cleanup_if_process(Obj).
+
+%%====================================================================
+%% handle_spawn edge cases
+%%====================================================================
+
+test_spawn_abstract_spawn_with() ->
+    %% Abstract class with args should return error with spawnWith: selector
+    Result = beamtalk_class_instantiation:handle_spawn(
+        [#{value => 1}], 'AbstractThing', undefined, true
+    ),
+    ?assertMatch(
+        {error, #beamtalk_error{
+            kind = instantiation_error,
+            class = 'AbstractThing',
+            selector = 'spawnWith:'
+        }},
+        Result
+    ).
 
 %%====================================================================
 %% Helpers

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_hot_reload_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_hot_reload_tests.erl
@@ -166,3 +166,168 @@ trigger_code_change_dead_pid_test() ->
     {ok, 0, Failures} = beamtalk_hot_reload:trigger_code_change(test_module, [DeadPid]),
     ?assertEqual(1, length(Failures)),
     [{DeadPid, _Reason}] = Failures.
+
+trigger_code_change_multiple_dead_pids_test() ->
+    %% Multiple dead PIDs all produce failures
+    Pids = [spawn(fun() -> ok end) || _ <- lists:seq(1, 3)],
+    %% Wait for all to die
+    lists:foreach(
+        fun(Pid) ->
+            Ref = erlang:monitor(process, Pid),
+            receive
+                {'DOWN', Ref, process, Pid, _} -> ok
+            after 1000 ->
+                error(timeout_waiting_for_dead_pid)
+            end
+        end,
+        Pids
+    ),
+    {ok, 0, Failures} = beamtalk_hot_reload:trigger_code_change(test_module, Pids),
+    ?assertEqual(3, length(Failures)).
+
+%%====================================================================
+%% Tests for trigger_code_change/3 (with Extra)
+%%====================================================================
+
+trigger_code_change_3_empty_pids_test() ->
+    Extra = {[field1, field2], some_module},
+    {ok, Upgraded, Failures} = beamtalk_hot_reload:trigger_code_change(
+        test_module, [], Extra
+    ),
+    ?assertEqual(0, Upgraded),
+    ?assertEqual([], Failures).
+
+trigger_code_change_3_dead_pid_test() ->
+    DeadPid = spawn(fun() -> ok end),
+    Ref = erlang:monitor(process, DeadPid),
+    receive
+        {'DOWN', Ref, process, DeadPid, _} -> ok
+    after 1000 ->
+        error(timeout_waiting_for_dead_pid)
+    end,
+    Extra = {[field1], some_module},
+    {ok, 0, Failures} = beamtalk_hot_reload:trigger_code_change(
+        test_module, [DeadPid], Extra
+    ),
+    ?assertEqual(1, length(Failures)).
+
+%%====================================================================
+%% Tests for code_change/3 with field migration ({NewInstanceVars, Module})
+%%====================================================================
+
+field_migration_setup() ->
+    application:ensure_all_started(beamtalk_runtime),
+    beamtalk_stdlib:init(),
+    ok = ensure_counter_loaded(),
+    ok.
+
+field_migration_teardown(_) ->
+    ok.
+
+field_migration_test_() ->
+    {setup, fun field_migration_setup/0, fun field_migration_teardown/1, fun(_) ->
+        [
+            {"adds new fields with defaults", fun test_field_migration_adds_new_fields/0},
+            {"migrates legacy __class__ key during field migration",
+                fun test_field_migration_with_legacy_class_key/0},
+            {"init failure preserves state unchanged",
+                fun test_field_migration_init_failure_preserves_state/0},
+            {"drops removed fields", fun test_field_migration_drops_removed_fields/0},
+            {"preserves internal keys from new defaults",
+                fun test_field_migration_preserves_internal_keys/0}
+        ]
+    end}.
+
+test_field_migration_adds_new_fields() ->
+    OldState = #{'$beamtalk_class' => 'Counter', '__class_mod__' => 'bt@counter', value => 42},
+    {ok, Defaults} = 'bt@counter':init(#{}),
+    NewInstanceVars = [
+        K
+     || K <- maps:keys(Defaults),
+        not lists:member(K, beamtalk_tagged_map:internal_fields())
+    ],
+    {ok, NewState} = beamtalk_hot_reload:code_change(
+        v1, OldState, {NewInstanceVars, 'bt@counter'}
+    ),
+    %% Old value should be preserved
+    ?assertEqual(42, maps:get(value, NewState)),
+    %% Internal keys come from new defaults (init), not old state
+    ?assertEqual(maps:get('__class_mod__', Defaults), maps:get('__class_mod__', NewState)).
+
+test_field_migration_with_legacy_class_key() ->
+    {ok, Defaults} = 'bt@counter':init(#{}),
+    NewInstanceVars = [
+        K
+     || K <- maps:keys(Defaults),
+        not lists:member(K, beamtalk_tagged_map:internal_fields())
+    ],
+    OldState = #{'__class__' => 'Counter', '__class_mod__' => 'bt@counter', value => 10},
+    {ok, NewState} = beamtalk_hot_reload:code_change(
+        v1, OldState, {NewInstanceVars, 'bt@counter'}
+    ),
+    %% Legacy __class__ key should be removed (migrated by maybe_migrate_class_key)
+    ?assertNot(maps:is_key('__class__', NewState)),
+    %% Old user field value should be preserved
+    ?assertEqual(10, maps:get(value, NewState)),
+    %% Internal keys come from new defaults
+    ?assertEqual(maps:get('__class_mod__', Defaults), maps:get('__class_mod__', NewState)).
+
+test_field_migration_init_failure_preserves_state() ->
+    OldState = #{'$beamtalk_class' => 'Fake', value => 99},
+    {ok, NewState} = beamtalk_hot_reload:code_change(
+        v1, OldState, {[value, extra], nonexistent_module}
+    ),
+    ?assertEqual(OldState, NewState).
+
+test_field_migration_drops_removed_fields() ->
+    {ok, Defaults} = 'bt@counter':init(#{}),
+    NewInstanceVars = [
+        K
+     || K <- maps:keys(Defaults),
+        not lists:member(K, beamtalk_tagged_map:internal_fields())
+    ],
+    OldState = maps:merge(
+        #{'$beamtalk_class' => 'Counter', '__class_mod__' => 'bt@counter', value => 5},
+        #{obsolete_field => <<"should be dropped">>}
+    ),
+    {ok, NewState} = beamtalk_hot_reload:code_change(
+        v1, OldState, {NewInstanceVars, 'bt@counter'}
+    ),
+    ?assertNot(maps:is_key(obsolete_field, NewState)),
+    ?assertEqual(5, maps:get(value, NewState)).
+
+test_field_migration_preserves_internal_keys() ->
+    {ok, Defaults} = 'bt@counter':init(#{}),
+    NewInstanceVars = [
+        K
+     || K <- maps:keys(Defaults),
+        not lists:member(K, beamtalk_tagged_map:internal_fields())
+    ],
+    OldState = #{'$beamtalk_class' => 'Counter', '__class_mod__' => old_mod, value => 1},
+    {ok, NewState} = beamtalk_hot_reload:code_change(
+        v1, OldState, {NewInstanceVars, 'bt@counter'}
+    ),
+    ?assertEqual(maps:get('__class_mod__', Defaults), maps:get('__class_mod__', NewState)).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+ensure_counter_loaded() ->
+    case code:ensure_loaded('bt@counter') of
+        {module, 'bt@counter'} ->
+            case beamtalk_class_registry:whereis_class('Counter') of
+                undefined ->
+                    case erlang:function_exported('bt@counter', register_class, 0) of
+                        true ->
+                            'bt@counter':register_class(),
+                            ok;
+                        false ->
+                            ok
+                    end;
+                _Pid ->
+                    ok
+            end;
+        {error, Reason} ->
+            error({counter_module_not_found, Reason})
+    end.


### PR DESCRIPTION
## Summary

Adds ~18 new EUnit tests across two runtime modules to improve test coverage:

- **beamtalk_hot_reload_tests**: 8 new tests covering `trigger_code_change/2` with multiple dead pids, `trigger_code_change/3` with Extra data, and field migration via `{NewInstanceVars, Module}` Extra (add new fields, drop removed fields, legacy class key migration, init failure fallback, internal key preservation)
- **beamtalk_class_instantiation_tests**: 10 new tests covering `class_self_new/3` and `class_self_spawn/3,4` (BT-893 deadlock-prevention paths), `abstract_class_error` with different selectors, `IsAbstract` normalization from `undefined`, `compute_is_constructible` for modules without `new/0`, and `handle_new` with undefined constructibility

## Test plan

- [x] All 55 tests pass (28 hot_reload + 27 class_instantiation)
- [x] Full `just test` passes (1816 BUnit + 4029 EUnit, 0 failures)
- [x] Files formatted with erlfmt

Resolves [BT-1971](https://linear.app/beamtalk/issue/BT-1971)

🤖 Generated with [Claude Code](https://claude.com/claude-code)