### PR TITLE
Auto-chain initialize across hierarchy + validate inherited fields (BT-1951)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -11,8 +11,32 @@
 
 use super::super::document::{Document, INDENT, line, nest};
 use super::super::{CoreErlangGenerator, Result};
-use crate::ast::{ClassDefinition, Module, TypeAnnotation};
+use crate::ast::{ClassDefinition, Module, StateDeclaration, TypeAnnotation};
 use crate::docvec;
+
+/// BT-1951 (ADR 0078): Identifies a single class's `initialize` method in the
+/// auto-chained dispatch sequence emitted by `generate_handle_continue`.
+#[derive(Debug, Clone)]
+pub(in crate::codegen::core_erlang) struct InitializeChainEntry {
+    /// Beamtalk class name (e.g. `"CachingDatabaseActor"`). Used for diagnostics.
+    #[allow(dead_code)] // reserved for future diagnostic output
+    pub class_name: String,
+    /// Compiled Erlang module name for this class (e.g. `"bt@caching_database_actor"`).
+    /// The `safe_dispatch` call targets this module so dispatch starts at the
+    /// class's own table rather than walking from the leaf.
+    pub module_name: String,
+}
+
+/// BT-1951 (ADR 0078): A typed-no-default state field annotated with the class
+/// that declared it, so post-initialize diagnostics can name the owning class
+/// rather than always the leaf.
+#[derive(Debug, Clone)]
+pub(in crate::codegen::core_erlang) struct InheritedTypedField<'a> {
+    /// Beamtalk class name that declared this field.
+    pub owning_class: String,
+    /// The state declaration from the class's AST.
+    pub state: &'a StateDeclaration,
+}
 
 impl CoreErlangGenerator {
     /// Generates the `init/1` callback for `gen_server`.
@@ -86,11 +110,19 @@ impl CoreErlangGenerator {
         // If so, dispatch it at the end of init/1 — but only when not called
         // as a parent state-building helper. The __skip_initialize__ flag in
         // InitArgs suppresses dispatch when a child's init calls us as a helper.
-        let has_initialize = current_class.is_some_and(|c| {
-            self.semantic_facts
-                .class_facts(&c.name.name)
-                .is_some_and(|cf| cf.has_instance_method("initialize"))
+        //
+        // BT-1951 (ADR 0078): Also defer to handle_continue when any *ancestor*
+        // class defines initialize — handle_continue auto-chains each ancestor's
+        // initialize parent-first. And defer when any class in the chain has
+        // typed-no-default fields so the post-initialize validation runs.
+        let chain_has_initialize = current_class
+            .is_some_and(|c| !self.user_defined_initialize_chain(&c.name.name).is_empty());
+        let chain_has_typed_no_default = current_class.is_some_and(|c| {
+            !self
+                .inherited_typed_no_default_fields(module, &c.name.name)
+                .is_empty()
         });
+        let has_initialize = chain_has_initialize || chain_has_typed_no_default;
 
         let module_name = self.module_name.clone();
 
@@ -359,31 +391,30 @@ impl CoreErlangGenerator {
         ]
     }
 
-    /// BT-1949: Generates the success body for `handle_continue` after initialize.
+    /// BT-1949/BT-1951: Generates the success body for `handle_continue` after
+    /// the auto-chained initialize sequence.
     ///
-    /// If the class has typed-no-default state fields (type annotation but no `= default`),
-    /// emits a check that each such field is no longer nil. If any are still nil,
-    /// raises `UninitializedStateError` with the class name, field name, and expected type.
-    /// If there are no such fields, returns a plain `{'noreply', InitNewState}`.
+    /// Collects typed-no-default state fields from the full inheritance chain
+    /// (ADR 0078). For each such field that is still `nil` after the chain
+    /// completes, raises `UninitializedStateError` with the owning class name,
+    /// field name, and expected type. If no such fields exist, returns a plain
+    /// `{'noreply', InitNewState}`.
     #[allow(clippy::too_many_lines)]
     fn generate_post_initialize_check(
         &self,
         current_class: Option<&ClassDefinition>,
-        class_name: &ecow::EcoString,
+        module: &Module,
+        // Reserved for future log-metadata enrichment that names the leaf
+        // spawning class in addition to the field's owning class.
+        _leaf_class_name: &ecow::EcoString,
     ) -> Document<'static> {
-        // Collect typed-no-default fields: have type annotation, no default value,
-        // and the type is NOT nilable (a union containing Nil — nil is a valid value).
-        let typed_no_default: Vec<_> = current_class
-            .map(|c| {
-                c.state
-                    .iter()
-                    .filter(|s| {
-                        s.type_annotation.is_some()
-                            && s.default_value.is_none()
-                            && !Self::is_nilable_type(s.type_annotation.as_ref())
-                    })
-                    .collect::<Vec<_>>()
-            })
+        // BT-1951: Collect typed-no-default fields from the full inheritance
+        // chain (leaf + ancestors), not just the current class. For ancestors
+        // defined outside this module (cross-file), the AST is unavailable and
+        // their fields are skipped; same-file ancestors are walked via the AST
+        // (matching the limitation in `collect_inherited_fields` in state.rs).
+        let typed_no_default: Vec<InheritedTypedField<'_>> = current_class
+            .map(|c| self.inherited_typed_no_default_fields(module, &c.name.name))
             .unwrap_or_default();
 
         if typed_no_default.is_empty() {
@@ -395,19 +426,25 @@ impl CoreErlangGenerator {
         let mut body: Document<'static> = docvec!["{'noreply', InitNewState}"];
 
         for (i, field) in typed_no_default.iter().enumerate().rev() {
-            let field_name = field.name.name.to_string();
+            let field_name = field.state.name.name.to_string();
             let type_name = field
+                .state
                 .type_annotation
                 .as_ref()
                 .map_or_else(|| "Unknown".to_string(), Self::type_annotation_display);
+            // BT-1951: Use the owning class name (which may be an ancestor)
+            // in the diagnostic, while keeping the leaf class in logger metadata
+            // so operators see which actor failed to start.
+            let owning_class = field.owning_class.as_str();
             let idx = i.to_string();
             let check_var = format!("_ChkVal{idx}");
             let err_var0 = format!("_UErr{idx}a");
             let err_var1 = format!("_UErr{idx}b");
             let err_msg_var = format!("_UErrMsg{idx}");
             let class_name_var = format!("_UErrClass{idx}");
-            let hint_msg =
-                format!("{class_name} field '{field_name}' (:: {type_name}) was not initialized",);
+            let hint_msg = format!(
+                "{owning_class} field '{field_name}' (:: {type_name}) was not initialized",
+            );
             let hint_binary = Self::binary_string_literal(&hint_msg);
 
             body = docvec![
@@ -432,7 +469,7 @@ impl CoreErlangGenerator {
                                 "let ",
                                 Document::String(err_var0.clone()),
                                 " = call 'beamtalk_error':'new'('uninitialized_state_error', '",
-                                Document::String(class_name.to_string()),
+                                Document::String(owning_class.to_string()),
                                 "') in",
                                 line(),
                                 "let ",
@@ -486,7 +523,7 @@ impl CoreErlangGenerator {
 
         docvec![
             line(),
-            "%% BT-1949: Verify typed-no-default fields were initialized",
+            "%% BT-1949/BT-1951: Verify typed-no-default fields (including inherited) were initialized",
             line(),
             body,
         ]
@@ -530,48 +567,439 @@ impl CoreErlangGenerator {
         }
     }
 
-    /// Generates the `handle_continue/2` callback (BT-1541).
+    /// BT-1951 (ADR 0078): Returns the list of user-defined initializers to run
+    /// for a class, parent-first.
     ///
-    /// Dispatches `initialize` via `safe_dispatch` when the continuation token
-    /// `{continue, initialize}` arrives. This runs after `init/1` returns, so
-    /// the `gen_server` message loop is active and self-sends work without deadlock.
+    /// Each entry identifies a class in the inheritance chain (leaf last) that
+    /// defines its own `initialize` method. Root classes (`Actor`, `Object`,
+    /// `ProtoObject`) are excluded because their `initialize` is a no-op default
+    /// — running them would generate unnecessary dispatch calls.
     ///
-    /// OTP guarantees no other messages are processed before `handle_continue`.
+    /// Uses the compile-time `ClassHierarchy` snapshot so cross-file ancestors
+    /// are visible. When the hierarchy is unavailable (e.g. generator
+    /// constructed standalone without `generate_module_with_warnings`), returns
+    /// an empty list — callers fall back to the single-class dispatch path.
+    pub(in crate::codegen::core_erlang) fn user_defined_initialize_chain(
+        &self,
+        leaf_class: &str,
+    ) -> Vec<InitializeChainEntry> {
+        let Some(hierarchy) = self.class_hierarchy.as_ref() else {
+            return Vec::new();
+        };
+
+        // Build the chain parent-first: leaf's superclass_chain returns
+        // immediate ancestors first (Actor, Object, ProtoObject at the end
+        // after user classes). Reverse to put the root ancestor first, then
+        // append the leaf.
+        let mut ordered: Vec<ecow::EcoString> = hierarchy
+            .superclass_chain(leaf_class)
+            .into_iter()
+            .rev()
+            .collect();
+        ordered.push(ecow::EcoString::from(leaf_class));
+
+        let mut out = Vec::new();
+        for name in ordered {
+            // Skip root no-op initialize owners — Actor's `initialize` is a
+            // no-op per ADR 0078 and we don't generate a dispatch for it.
+            if matches!(name.as_str(), "Actor" | "Object" | "ProtoObject") {
+                continue;
+            }
+            let defines_initialize = hierarchy
+                .classes()
+                .get(name.as_str())
+                .is_some_and(|info| info.methods.iter().any(|m| m.selector == "initialize"));
+            if !defines_initialize {
+                continue;
+            }
+            let module_name = self.compiled_module_name(name.as_str());
+            out.push(InitializeChainEntry {
+                class_name: name.to_string(),
+                module_name,
+            });
+        }
+        out
+    }
+
+    /// BT-1951 (ADR 0078): Collect typed-no-default state fields across the
+    /// inheritance chain for post-initialize validation.
     ///
-    /// # Generated Code
+    /// Returns fields in parent-first order (ancestors first, then the leaf's
+    /// own fields), annotated with the owning class name so diagnostics can
+    /// point at the class that declared the field.
+    ///
+    /// Only walks classes whose AST is present in the current `Module`. This
+    /// matches the existing limitation of `collect_inherited_fields` in
+    /// `state.rs` — cross-file ancestor fields are not included. Extending to
+    /// cross-file parents is future work (needs default-value metadata on
+    /// `ClassInfo`).
+    pub(in crate::codegen::core_erlang) fn inherited_typed_no_default_fields<'a>(
+        &self,
+        module: &'a Module,
+        leaf_class: &str,
+    ) -> Vec<InheritedTypedField<'a>> {
+        let Some(hierarchy) = self.class_hierarchy.as_ref() else {
+            // Fallback: AST only, leaf class fields.
+            return module
+                .classes
+                .iter()
+                .find(|c| c.name.name == leaf_class)
+                .map(|c| {
+                    c.state
+                        .iter()
+                        .filter(|s| {
+                            s.type_annotation.is_some()
+                                && s.default_value.is_none()
+                                && !Self::is_nilable_type(s.type_annotation.as_ref())
+                        })
+                        .map(|s| InheritedTypedField {
+                            owning_class: c.name.name.to_string(),
+                            state: s,
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+        };
+
+        let mut ordered: Vec<ecow::EcoString> = hierarchy
+            .superclass_chain(leaf_class)
+            .into_iter()
+            .rev()
+            .collect();
+        ordered.push(ecow::EcoString::from(leaf_class));
+
+        let mut out = Vec::new();
+        for name in ordered {
+            if matches!(name.as_str(), "Actor" | "Object" | "ProtoObject") {
+                continue;
+            }
+            // Find the class in the current module's AST so we can read default_value.
+            let Some(class) = module.classes.iter().find(|c| c.name.name == name) else {
+                // Cross-file ancestor — AST not available in this compilation.
+                // Skip its typed-no-default fields (limitation documented on
+                // this function). A future extension could derive the list
+                // from `ClassInfo.state_types` once defaults are tracked.
+                continue;
+            };
+            for s in &class.state {
+                if s.type_annotation.is_some()
+                    && s.default_value.is_none()
+                    && !Self::is_nilable_type(s.type_annotation.as_ref())
+                {
+                    out.push(InheritedTypedField {
+                        owning_class: class.name.name.to_string(),
+                        state: s,
+                    });
+                }
+            }
+        }
+        out
+    }
+
+    /// Generates the `handle_continue/2` callback (BT-1541, BT-1951).
+    ///
+    /// BT-1951 (ADR 0078): Auto-chains `initialize` methods parent-first across
+    /// the full inheritance hierarchy. For each ancestor class that defines its
+    /// own `initialize`, we emit a `safe_dispatch` call, threading the state
+    /// from one initializer to the next. After the chain completes, the
+    /// post-initialize check (BT-1949) validates that every typed-no-default
+    /// field (from any class in the chain) was set.
+    ///
+    /// Dispatches run via `beamtalk_dispatch:lookup/5` with each class's own
+    /// compiled module name so that dispatch starts *at* that class and walks
+    /// upward — which finds the class's own `initialize` if present, bypassing
+    /// any overriding subclass method (this is `super`-like semantics).
+    ///
+    /// This runs after `init/1` returns, so the `gen_server` message loop is
+    /// active and self-sends do not deadlock. OTP guarantees no other messages
+    /// are processed before `handle_continue`.
+    ///
+    /// # Generated Code (single-class — no user ancestors)
     ///
     /// ```erlang
     /// 'handle_continue'/2 = fun (Continue, State) ->
     ///     case Continue of
     ///         <'initialize'> when 'true' ->
-    ///             case call 'module':'safe_dispatch'('initialize', [], State) of
-    ///                 <{'reply', _InitResult, InitNewState}> when 'true' ->
-    ///                     {'noreply', InitNewState}
-    ///                 <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-    ///                     let _ = call 'logger':'error'(Msg, #{stacktrace => ...}) in
-    ///                     {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-    ///                 <{'error', InitError, InitErrState2}> when 'true' ->
-    ///                     let _ = call 'logger':'error'(Msg, #{...}) in
-    ///                     {'stop', InitError, InitErrState2}
+    ///             <stash State> in
+    ///             let _InitResult0 = call 'module':'safe_dispatch'('initialize', [], State) in
+    ///             <restore State> in
+    ///             case _InitResult0 of
+    ///                 <{'reply', _InitRet0, InitNewState}> when 'true' ->
+    ///                     <post-init check on InitNewState>
+    ///                 ...errors...
     ///             end
     ///         <_> when 'true' -> {'noreply', State}
     ///     end
     /// ```
+    ///
+    /// # Generated Code (with ancestor chain `Grandparent -> Parent -> Child`)
+    ///
+    /// Grandparent runs first, its output state feeds Parent, whose output
+    /// feeds Child, whose output is validated.
     #[allow(clippy::unnecessary_wraps)] // uniform Result<Document> codegen interface
+    #[allow(clippy::too_many_lines)] // chain dispatch + error arms grow with hierarchy depth
     pub(in crate::codegen::core_erlang) fn generate_handle_continue(
         &self,
         module: &Module,
     ) -> Result<Document<'static>> {
         let module_name = self.module_name.clone();
-        let module_name_for_log = module_name.clone();
 
-        // BT-1949: Find typed-no-default fields for post-initialize validation.
+        // BT-1949/BT-1951: Find typed-no-default fields (leaf + ancestors) for
+        // post-initialize validation.
         let current_class = module.classes.iter().find(|c| {
             use super::super::util::module_matches_class;
             module_matches_class(&self.module_name, &c.name.name)
         });
-        let class_name = current_class.map_or_else(|| module_name.clone(), |c| c.name.name.clone());
-        let success_body = self.generate_post_initialize_check(current_class, &class_name);
+        let leaf_class_name =
+            current_class.map_or_else(|| module_name.clone(), |c| c.name.name.clone());
+        let success_body =
+            self.generate_post_initialize_check(current_class, module, &leaf_class_name);
+
+        // BT-1951 (ADR 0078): Walk the user-defined initialize chain (parent-first).
+        // Each entry is the (class_name, compiled_module_name) for a class that
+        // defines its own `initialize`. Root classes (Actor/Object/ProtoObject)
+        // are filtered out since their `initialize` is a no-op default.
+        let chain = current_class
+            .map(|c| self.user_defined_initialize_chain(&c.name.name))
+            .unwrap_or_default();
+
+        // Body that runs after the dispatch chain: the post-initialize check.
+        // If the chain is empty (e.g. only typed-no-default fields exist with no
+        // initialize method), the post-init check runs directly against the
+        // inbound `State` by binding it to `InitNewState`.
+        let inner = if chain.is_empty() {
+            docvec![line(), "let InitNewState = State in", success_body,]
+        } else {
+            // Build the dispatch chain from last to first so each step can nest
+            // inside the previous one's success arm.
+            let mut inner: Document<'static> = success_body;
+            let n = chain.len();
+            for (i, class) in chain.iter().enumerate().rev() {
+                let idx = i.to_string();
+                let is_last = i + 1 == n;
+                let in_state_var = if i == 0 {
+                    "State".to_string()
+                } else {
+                    format!("InitState{i}")
+                };
+                let result_var = format!("_InitResult{idx}");
+                let reply_ret_var = format!("_InitRet{idx}");
+                let next_state_var = if is_last {
+                    "InitNewState".to_string()
+                } else {
+                    let next = i + 1;
+                    format!("InitState{next}")
+                };
+                let err_state_var = format!("_InitErrState{idx}");
+                let err_state_var2 = format!("_InitErrState{idx}b");
+                let err_triple_type = format!("_InitType{idx}");
+                let err_triple_reason = format!("_InitReason{idx}");
+                let err_triple_stack = format!("_InitStack{idx}");
+                let err_plain = format!("_InitError{idx}");
+                let err_msg = format!("_InitErrMsg{idx}");
+                let err_msg2 = format!("_InitErrMsg{idx}b");
+                let err_class_name_var = format!("_InitErrClass{idx}");
+                let err_class_name_var2 = format!("_InitErrClass{idx}b");
+
+                let old_state_var = format!("_OldPdict{idx}");
+                let put_ok_var = format!("_PutPdict{idx}");
+                let restore_ok_var = format!("_RestorePdict{idx}");
+                let clear_stack_var = format!("_ClearStack{idx}");
+
+                inner = docvec![
+                    line(),
+                    docvec![
+                        "let ",
+                        Document::String(old_state_var.clone()),
+                        " = call 'erlang':'get'('$bt_actor_state') in",
+                    ],
+                    line(),
+                    docvec![
+                        "let ",
+                        Document::String(put_ok_var),
+                        " = call 'erlang':'put'('$bt_actor_state', ",
+                        Document::String(in_state_var.clone()),
+                        ") in",
+                    ],
+                    line(),
+                    docvec![
+                        "let ",
+                        Document::String(result_var.clone()),
+                        " = call '",
+                        Document::String(class.module_name.clone()),
+                        "':'safe_dispatch'('initialize', [], ",
+                        Document::String(in_state_var),
+                        ") in",
+                    ],
+                    line(),
+                    docvec![
+                        "let ",
+                        Document::String(restore_ok_var.clone()),
+                        " = case ",
+                        Document::String(old_state_var.clone()),
+                        " of",
+                    ],
+                    nest(
+                        INDENT,
+                        docvec![
+                            line(),
+                            "<'undefined'> when 'true' ->",
+                            nest(
+                                INDENT,
+                                docvec![line(), "call 'erlang':'erase'('$bt_actor_state')"]
+                            ),
+                            line(),
+                            "<_Prev> when 'true' ->",
+                            nest(
+                                INDENT,
+                                docvec![line(), "call 'erlang':'put'('$bt_actor_state', _Prev)"]
+                            ),
+                        ]
+                    ),
+                    line(),
+                    "end in",
+                    line(),
+                    docvec![
+                        "let ",
+                        Document::String(clear_stack_var),
+                        " = call 'erlang':'erase'('$bt_call_stack') in",
+                    ],
+                    line(),
+                    "case ",
+                    Document::String(result_var),
+                    " of",
+                    nest(
+                        INDENT,
+                        docvec![
+                            line(),
+                            docvec![
+                                "<{'reply', ",
+                                Document::String(reply_ret_var),
+                                ", ",
+                                Document::String(next_state_var),
+                                "}> when 'true' ->",
+                            ],
+                            nest(INDENT, inner),
+                            line(),
+                            // BT-1822: Destructure error triple to capture stacktrace
+                            docvec![
+                                "<{'error', {",
+                                Document::String(err_triple_type.clone()),
+                                ", ",
+                                Document::String(err_triple_reason.clone()),
+                                ", ",
+                                Document::String(err_triple_stack.clone()),
+                                "}, ",
+                                Document::String(err_state_var.clone()),
+                                "}> when 'true' ->",
+                            ],
+                            nest(
+                                INDENT,
+                                docvec![
+                                    line(),
+                                    docvec![
+                                        "let ",
+                                        Document::String(err_msg.clone()),
+                                        " = call 'beamtalk_error':'format_safe'({",
+                                        Document::String(err_triple_type.clone()),
+                                        ", ",
+                                        Document::String(err_triple_reason.clone()),
+                                        "}, ",
+                                        Document::String(err_triple_stack.clone()),
+                                        ") in",
+                                    ],
+                                    line(),
+                                    docvec![
+                                        "let ",
+                                        Document::String(err_class_name_var.clone()),
+                                        " = call '",
+                                        Document::Eco(module_name.clone()),
+                                        "':'class_name'() in",
+                                    ],
+                                    line(),
+                                    docvec![
+                                        "let _ = call 'logger':'error'(",
+                                        Document::String(err_msg),
+                                        ", ~{'class' => ",
+                                        Document::String(err_class_name_var),
+                                        ", 'reason' => {",
+                                        Document::String(err_triple_type.clone()),
+                                        ", ",
+                                        Document::String(err_triple_reason.clone()),
+                                        "}, 'stacktrace' => ",
+                                        Document::String(err_triple_stack.clone()),
+                                        ", 'domain' => ['beamtalk'|['runtime'|[]]]}~) in",
+                                    ],
+                                    line(),
+                                    docvec![
+                                        "{'stop', {",
+                                        Document::String(err_triple_type),
+                                        ", ",
+                                        Document::String(err_triple_reason),
+                                        ", ",
+                                        Document::String(err_triple_stack),
+                                        "}, ",
+                                        Document::String(err_state_var),
+                                        "}",
+                                    ],
+                                ]
+                            ),
+                            line(),
+                            // Fallback: plain {error, Error, State} from dispatch (DNU, #beamtalk_error{}, etc.)
+                            docvec![
+                                "<{'error', ",
+                                Document::String(err_plain.clone()),
+                                ", ",
+                                Document::String(err_state_var2.clone()),
+                                "}> when 'true' ->",
+                            ],
+                            nest(
+                                INDENT,
+                                docvec![
+                                    line(),
+                                    docvec![
+                                        "let ",
+                                        Document::String(err_msg2.clone()),
+                                        " = call 'beamtalk_error':'format_safe'(",
+                                        Document::String(err_plain.clone()),
+                                        ") in",
+                                    ],
+                                    line(),
+                                    docvec![
+                                        "let ",
+                                        Document::String(err_class_name_var2.clone()),
+                                        " = call '",
+                                        Document::Eco(module_name.clone()),
+                                        "':'class_name'() in",
+                                    ],
+                                    line(),
+                                    docvec![
+                                        "let _ = call 'logger':'error'(",
+                                        Document::String(err_msg2),
+                                        ", ~{'class' => ",
+                                        Document::String(err_class_name_var2),
+                                        ", 'reason' => ",
+                                        Document::String(err_plain.clone()),
+                                        ", 'domain' => ['beamtalk'|['runtime'|[]]]}~) in",
+                                    ],
+                                    line(),
+                                    docvec![
+                                        "{'stop', ",
+                                        Document::String(err_plain),
+                                        ", ",
+                                        Document::String(err_state_var2),
+                                        "}",
+                                    ],
+                                ]
+                            ),
+                        ]
+                    ),
+                    line(),
+                    "end",
+                ];
+            }
+            inner
+        };
 
         let doc = docvec![
             "'handle_continue'/2 = fun (Continue, State) ->",
@@ -587,65 +1015,11 @@ impl CoreErlangGenerator {
                             "<'initialize'> when 'true' ->",
                             nest(
                                 INDENT,
-                                docvec![
-                                    // BT-1325: Stash State for re-entrant self-sends
-                                    Self::pdict_stash_preamble(),
-                                    line(),
-                                    docvec![
-                                        "let _InitDispatchResult = call '",
-                                        Document::Eco(module_name),
-                                        "':'safe_dispatch'('initialize', [], State) in",
-                                    ],
-                                    Self::pdict_restore_epilogue(),
-                                    line(),
-                                    "case _InitDispatchResult of",
-                                    nest(
-                                        INDENT,
-                                        docvec![
-                                            line(),
-                                            "<{'reply', _InitResult, InitNewState}> when 'true' ->",
-                                            nest(INDENT, success_body,),
-                                            line(),
-                                            // BT-1822: Destructure error triple to capture stacktrace
-                                            "<{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->",
-                                            nest(
-                                                INDENT,
-                                                docvec![
-                                                    line(),
-                                                    "let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in",
-                                                    line(),
-                                                    "let InitClassName = call '",
-                                                    Document::Eco(module_name_for_log.clone()),
-                                                    "':'class_name'() in",
-                                                    line(),
-                                                    "let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in",
-                                                    line(),
-                                                    "{'stop', {InitType, InitReason, InitStacktrace}, InitErrState}",
-                                                ]
-                                            ),
-                                            line(),
-                                            // Fallback: plain {error, Error, State} from dispatch (DNU, #beamtalk_error{}, etc.)
-                                            "<{'error', InitError, InitErrState2}> when 'true' ->",
-                                            nest(
-                                                INDENT,
-                                                docvec![
-                                                    line(),
-                                                    "let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in",
-                                                    line(),
-                                                    "let InitClassName2 = call '",
-                                                    Document::Eco(module_name_for_log),
-                                                    "':'class_name'() in",
-                                                    line(),
-                                                    "let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in",
-                                                    line(),
-                                                    "{'stop', InitError, InitErrState2}",
-                                                ]
-                                            ),
-                                        ]
-                                    ),
-                                    line(),
-                                    "end",
-                                ]
+                                // BT-1951: The auto-chained dispatch body. Each
+                                // class's initialize is bracketed by its own
+                                // pdict stash/restore pair to preserve BT-1325
+                                // re-entrant self-send semantics.
+                                inner,
                             ),
                             line(),
                             "<_> when 'true' -> {'noreply', State}",

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -115,8 +115,11 @@ impl CoreErlangGenerator {
         // class defines initialize — handle_continue auto-chains each ancestor's
         // initialize parent-first. And defer when any class in the chain has
         // typed-no-default fields so the post-initialize validation runs.
-        let chain_has_initialize = current_class
-            .is_some_and(|c| !self.user_defined_initialize_chain(&c.name.name).is_empty());
+        let chain_has_initialize = current_class.is_some_and(|c| {
+            !self
+                .user_defined_initialize_chain(module, &c.name.name)
+                .is_empty()
+        });
         let chain_has_typed_no_default = current_class.is_some_and(|c| {
             !self
                 .inherited_typed_no_default_fields(module, &c.name.name)
@@ -577,14 +580,28 @@ impl CoreErlangGenerator {
     ///
     /// Uses the compile-time `ClassHierarchy` snapshot so cross-file ancestors
     /// are visible. When the hierarchy is unavailable (e.g. generator
-    /// constructed standalone without `generate_module_with_warnings`), returns
-    /// an empty list — callers fall back to the single-class dispatch path.
+    /// constructed standalone without `generate_module_with_warnings`), falls
+    /// back to the leaf class's own `initialize` method if the AST defines one
+    /// so single-class initialization still runs.
     pub(in crate::codegen::core_erlang) fn user_defined_initialize_chain(
         &self,
+        module: &Module,
         leaf_class: &str,
     ) -> Vec<InitializeChainEntry> {
         let Some(hierarchy) = self.class_hierarchy.as_ref() else {
-            return Vec::new();
+            // Fallback: AST only, leaf class initialize.
+            return module
+                .classes
+                .iter()
+                .find(|c| c.name.name == leaf_class)
+                .filter(|c| c.methods.iter().any(|m| m.selector.name() == "initialize"))
+                .map(|c| {
+                    vec![InitializeChainEntry {
+                        class_name: c.name.name.to_string(),
+                        module_name: self.compiled_module_name(&c.name.name),
+                    }]
+                })
+                .unwrap_or_default();
         };
 
         // Build the chain parent-first: leaf's superclass_chain returns
@@ -760,7 +777,7 @@ impl CoreErlangGenerator {
         // defines its own `initialize`. Root classes (Actor/Object/ProtoObject)
         // are filtered out since their `initialize` is a no-op default.
         let chain = current_class
-            .map(|c| self.user_defined_initialize_chain(&c.name.name))
+            .map(|c| self.user_defined_initialize_chain(module, &c.name.name))
             .unwrap_or_default();
 
         // Body that runs after the dispatch chain: the post-initialize check.
@@ -913,7 +930,7 @@ impl CoreErlangGenerator {
                                         "let ",
                                         Document::String(err_class_name_var.clone()),
                                         " = call '",
-                                        Document::Eco(module_name.clone()),
+                                        Document::String(class.module_name.clone()),
                                         "':'class_name'() in",
                                     ],
                                     line(),
@@ -969,7 +986,7 @@ impl CoreErlangGenerator {
                                         "let ",
                                         Document::String(err_class_name_var2.clone()),
                                         " = call '",
-                                        Document::Eco(module_name.clone()),
+                                        Document::String(class.module_name.clone()),
                                         "':'class_name'() in",
                                     ],
                                     line(),

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -564,6 +564,11 @@ pub fn generate_module_with_warnings(
     generator.direct_call_eligible =
         CoreErlangGenerator::compute_direct_call_eligible(&hierarchy, &generator);
 
+    // BT-1951: Stash the hierarchy for use by actor callback generation
+    // (auto-chained initialize dispatch in handle_continue and inherited
+    // typed-no-default field validation).
+    generator.class_hierarchy = Some(hierarchy.clone());
+
     // BT-213: Route based on whether class is actor or value type
     let doc = if CoreErlangGenerator::is_actor_class(module, &hierarchy) {
         generator.generate_actor_module(module)?
@@ -1107,6 +1112,13 @@ pub(crate) struct CoreErlangGenerator {
     class_context: Option<ClassContext>,
     /// BT-1461: Value-type-specific codegen state. `Some` when compiling value types.
     value_type_context: Option<ValueTypeContext>,
+    /// BT-1951: Snapshot of the class hierarchy for this generation (ADR 0078).
+    ///
+    /// Populated by `generate_module_with_warnings` before codegen begins. Used by
+    /// actor `handle_continue` generation to walk the superclass chain and emit
+    /// parent-first `initialize` dispatches, and by the post-initialize validation
+    /// check to collect inherited typed-no-default fields.
+    pub(super) class_hierarchy: Option<crate::semantic_analysis::class_hierarchy::ClassHierarchy>,
 }
 
 impl CoreErlangGenerator {
@@ -1142,6 +1154,7 @@ impl CoreErlangGenerator {
             repl_context: Some(ReplContext::new()),
             class_context: Some(ClassContext::new()),
             value_type_context: Some(ValueTypeContext::new()),
+            class_hierarchy: None,
         }
     }
 

--- a/stdlib/test/fixtures/deep_hierarchy_a.bt
+++ b/stdlib/test/fixtures/deep_hierarchy_a.bt
@@ -1,0 +1,12 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-1951 / ADR 0078 — Phase 1 fixture (deep hierarchy test).
+// Root of a 3-level hierarchy. `initialize` records execution order in a log.
+
+Actor subclass: DeepHierarchyA
+  state: log = ""
+
+  initialize => self.log := self.log ++ "A"
+
+  getLog => self.log

--- a/stdlib/test/fixtures/deep_hierarchy_b.bt
+++ b/stdlib/test/fixtures/deep_hierarchy_b.bt
@@ -1,0 +1,9 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-1951 / ADR 0078 — Phase 1 fixture (deep hierarchy test).
+// Middle class. Its `initialize` appends "B" after A's has appended "A".
+
+DeepHierarchyA subclass: DeepHierarchyB
+
+  initialize => self.log := self.log ++ "B"

--- a/stdlib/test/fixtures/deep_hierarchy_c.bt
+++ b/stdlib/test/fixtures/deep_hierarchy_c.bt
@@ -1,0 +1,9 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-1951 / ADR 0078 — Phase 1 fixture (deep hierarchy test).
+// Leaf class. Final log should be "ABC" after the auto-chain runs.
+
+DeepHierarchyB subclass: DeepHierarchyC
+
+  initialize => self.log := self.log ++ "C"

--- a/stdlib/test/fixtures/inherited_initialize_base.bt
+++ b/stdlib/test/fixtures/inherited_initialize_base.bt
@@ -1,0 +1,21 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-1951 / ADR 0078 — Phase 1 fixture.
+// Parent actor class that sets a typed-no-default field in its own
+// `initialize` method. Subclasses that do not override `initialize`
+// should inherit the initialization by virtue of the auto-chain.
+
+typed Actor subclass: InheritedInitializeBase
+  state: label :: String
+  state: count :: Integer = 0
+
+  initialize -> String => self.label := "parent-initialized"
+
+  getLabel -> String => self.label
+
+  getCount -> Integer => self.count
+
+  increment -> Integer =>
+    self.count := self.count + 1
+    self.count

--- a/stdlib/test/fixtures/inherited_initialize_child_adds.bt
+++ b/stdlib/test/fixtures/inherited_initialize_child_adds.bt
@@ -1,0 +1,17 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-1951 / ADR 0078 — Phase 1 fixture.
+// Child actor class that defines its own `initialize` which only touches its
+// own typed-no-default field. Parent's `initialize` should run first (via
+// auto-chain), setting `label`, before the child's `initialize` runs and
+// sets `cache`.
+
+typed InheritedInitializeBase subclass: InheritedInitializeChildAdds
+  state: cache :: String
+
+  initialize -> String =>
+    // parent's initialize already ran; self.label is set
+    self.cache := "cache-" ++ self.label
+
+  getCache -> String => self.cache

--- a/stdlib/test/fixtures/inherited_initialize_child_no_override.bt
+++ b/stdlib/test/fixtures/inherited_initialize_child_no_override.bt
@@ -1,0 +1,12 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-1951 / ADR 0078 — Phase 1 fixture.
+// Child actor class with no `initialize` of its own. The auto-chain should
+// still run the parent's `initialize`, setting `label` to
+// "parent-initialized".
+
+InheritedInitializeBase subclass: InheritedInitializeChildNoOverride
+  state: extra :: Integer = 0
+
+  getExtra -> Integer => self.extra

--- a/stdlib/test/fixtures/inherited_initialize_parent_forgets.bt
+++ b/stdlib/test/fixtures/inherited_initialize_parent_forgets.bt
@@ -1,0 +1,19 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-1951 / ADR 0078 — Phase 1 fixture.
+// Parent actor class whose `initialize` forgets to set its own typed-no-default
+// field. Spawning any subclass should fail with UninitializedStateError
+// because the post-initialize check validates the inherited field too.
+
+typed Actor subclass: InheritedInitializeParentForgets
+  state: missing :: String
+  state: count :: Integer = 0
+
+  initialize -> Integer =>
+    // Deliberately does NOT set self.missing
+    self.count := 1
+
+  getMissing -> String => self.missing
+
+  getCount -> Integer => self.count

--- a/stdlib/test/inherited_initialize_test.bt
+++ b/stdlib/test/inherited_initialize_test.bt
@@ -11,7 +11,6 @@
 //   fixtures/inherited_initialize_child_no_override.bt
 //   fixtures/inherited_initialize_child_adds.bt
 //   fixtures/inherited_initialize_parent_forgets.bt
-//   fixtures/inherited_initialize_parent_forgets_child.bt
 //   fixtures/deep_hierarchy_a.bt
 //   fixtures/deep_hierarchy_b.bt
 //   fixtures/deep_hierarchy_c.bt

--- a/stdlib/test/inherited_initialize_test.bt
+++ b/stdlib/test/inherited_initialize_test.bt
@@ -1,0 +1,75 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for BT-1951 / ADR 0078 Phase 1:
+//   - handle_continue walks the class hierarchy and dispatches
+//     `initialize` parent-first.
+//   - Post-initialize check validates inherited typed-no-default fields.
+//
+// Fixtures:
+//   fixtures/inherited_initialize_base.bt
+//   fixtures/inherited_initialize_child_no_override.bt
+//   fixtures/inherited_initialize_child_adds.bt
+//   fixtures/inherited_initialize_parent_forgets.bt
+//   fixtures/inherited_initialize_parent_forgets_child.bt
+//   fixtures/deep_hierarchy_a.bt
+//   fixtures/deep_hierarchy_b.bt
+//   fixtures/deep_hierarchy_c.bt
+
+TestCase subclass: InheritedInitializeTest
+
+  // === Parent sets typed-no-default, child has no initialize ===
+  testChildWithNoInitializeInheritsParentInitialize =>
+    a := InheritedInitializeChildNoOverride spawn
+    self assert: a getLabel equals: "parent-initialized"
+
+  testChildWithNoInitializeInheritsParentCount =>
+    a := InheritedInitializeChildNoOverride spawn
+    self assert: a getCount equals: 0
+
+  testChildWithNoInitializeCanUseOwnState =>
+    a := InheritedInitializeChildNoOverride spawn
+    self assert: a getExtra equals: 0
+
+  // === Parent sets typed-no-default, child adds its own initialize ===
+  testChildWithInitializeSeesParentState =>
+    a := InheritedInitializeChildAdds spawn
+    // child's initialize reads self.label set by parent's initialize
+    self assert: a getCache equals: "cache-parent-initialized"
+
+  testChildWithInitializeKeepsParentLabel =>
+    a := InheritedInitializeChildAdds spawn
+    self assert: a getLabel equals: "parent-initialized"
+
+  // === Parent forgets its own typed-no-default field ===
+  testParentForgetsOwnFieldRaisesError =>
+    self should: [
+      InheritedInitializeParentForgets spawn
+    ] raise: #instantiation_error
+
+  testForgottenFieldErrorMentionsFieldName =>
+    hint := [
+      InheritedInitializeParentForgets spawn
+    ] on: Exception do: [:e | e hint]
+    self assert: (hint includesSubstring: "missing")
+
+  testForgottenFieldErrorNamesOwningClass =>
+    hint := [
+      InheritedInitializeParentForgets spawn
+    ] on: Exception do: [:e | e hint]
+    // Diagnostic must name the class that declared the field.
+    self assert: (hint includesSubstring: "InheritedInitializeParentForgets")
+
+  // NOTE: A subclass inheriting a typed-no-default field from a cross-file
+  // parent whose `initialize` forgets to set that field is a known Phase 1
+  // limitation — the child's codegen cannot see the parent's AST to collect
+  // the inherited field into its own post-initialize check. The auto-chain
+  // itself still runs the parent's initialize (cross-file aware via
+  // ClassHierarchy); only the inherited field validation is limited.
+  // See ADR 0078 — a follow-up can embed default-value metadata on
+  // `ClassInfo` to lift this restriction.
+
+  // === Deep hierarchy — initialize runs parent-first across 3 levels ===
+  testDeepHierarchyRunsAllInitializersInOrder =>
+    c := DeepHierarchyC spawn
+    self assert: c getLog equals: "ABC"

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_codegen.snap
@@ -91,30 +91,8 @@ module 'actor_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'actor_spawn':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'actor_spawn':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'actor_spawn':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_codegen.snap
@@ -91,30 +91,8 @@ module 'actor_spawn_with_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'actor_spawn_with_args':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'actor_spawn_with_args':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'actor_spawn_with_args':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_codegen.snap
@@ -91,30 +91,8 @@ module 'actor_state_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'actor_state_mutation':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'actor_state_mutation':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'actor_state_mutation':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_codegen.snap
@@ -90,30 +90,8 @@ module 'async_keyword_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'async_keyword_message':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'async_keyword_message':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'async_keyword_message':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_codegen.snap
@@ -90,30 +90,8 @@ module 'async_unary_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'async_unary_message':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'async_unary_message':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'async_unary_message':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_codegen.snap
@@ -90,30 +90,8 @@ module 'async_with_await' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'async_with_await':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'async_with_await':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'async_with_await':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_codegen.snap
@@ -92,30 +92,8 @@ module 'binary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'binary_operators':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'binary_operators':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'binary_operators':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_codegen.snap
@@ -91,30 +91,8 @@ module 'blocks_no_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'blocks_no_args':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'blocks_no_args':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'blocks_no_args':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_codegen.snap
@@ -90,30 +90,8 @@ module 'boundary_deeply_nested' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'boundary_deeply_nested':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'boundary_deeply_nested':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'boundary_deeply_nested':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_codegen.snap
@@ -92,30 +92,8 @@ module 'boundary_long_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'boundary_long_identifiers':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'boundary_long_identifiers':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'boundary_long_identifiers':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_codegen.snap
@@ -90,30 +90,8 @@ module 'boundary_mixed_errors' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'boundary_mixed_errors':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'boundary_mixed_errors':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'boundary_mixed_errors':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_codegen.snap
@@ -90,30 +90,8 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1,
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'boundary_unicode_identifiers':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'boundary_unicode_identifiers':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'boundary_unicode_identifiers':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_codegen.snap
@@ -90,30 +90,8 @@ module 'cascade_complex' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'cascade_complex':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'cascade_complex':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'cascade_complex':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascades_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascades_codegen.snap
@@ -90,30 +90,8 @@ module 'cascades' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'cascades':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'cascades':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'cascades':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__character_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__character_literals_codegen.snap
@@ -94,30 +94,8 @@ module 'character_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'character_literals':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'character_literals':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'character_literals':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_definition_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_definition_codegen.snap
@@ -92,30 +92,8 @@ module 'class_definition' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'class_definition':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'class_definition':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'class_definition':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
@@ -94,30 +94,8 @@ module 'class_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'class_methods':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'class_methods':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'class_methods':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_codegen.snap
@@ -94,30 +94,8 @@ module 'comment_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'comment_handling':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'comment_handling':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'comment_handling':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_codegen.snap
@@ -99,30 +99,8 @@ module 'control_flow_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'control_flow_mutations':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'control_flow_mutations':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'control_flow_mutations':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_codegen.snap
@@ -90,30 +90,8 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'start_link'/2, 'init'/1
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'control_flow_mutations_errors':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'control_flow_mutations_errors':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'control_flow_mutations_errors':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_codegen.snap
@@ -90,30 +90,8 @@ module 'empty_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'empty_blocks':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'empty_blocks':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'empty_blocks':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_codegen.snap
@@ -92,30 +92,8 @@ module 'empty_method_body' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'empty_method_body':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'empty_method_body':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'empty_method_body':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_message_codegen.snap
@@ -91,30 +91,8 @@ module 'error_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'error_message':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'error_message':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'error_message':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_codegen.snap
@@ -90,30 +90,8 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'start_link'/2, 'init'/1
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'error_recovery_invalid_syntax':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'error_recovery_invalid_syntax':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'error_recovery_invalid_syntax':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_codegen.snap
@@ -90,30 +90,8 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'start_link'/2, 'init
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'error_recovery_malformed_message':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'error_recovery_malformed_message':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'error_recovery_malformed_message':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_codegen.snap
@@ -90,30 +90,8 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'start_link'/2, 'in
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'error_recovery_unterminated_string':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'error_recovery_unterminated_string':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'error_recovery_unterminated_string':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_codegen.snap
@@ -91,30 +91,8 @@ module 'expect_directive' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'expect_directive':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'expect_directive':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'expect_directive':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_codegen.snap
@@ -90,30 +90,8 @@ module 'future_pattern_matching' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'future_pattern_matching':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'future_pattern_matching':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'future_pattern_matching':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_codegen.snap
@@ -97,30 +97,8 @@ module 'future_string_interpolation' ['start_link'/1, 'start_link'/2, 'init'/1, 
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'future_string_interpolation':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'future_string_interpolation':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'future_string_interpolation':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__hello_world_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__hello_world_codegen.snap
@@ -90,30 +90,8 @@ module 'hello_world' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'hello_world':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'hello_world':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'hello_world':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__map_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__map_literals_codegen.snap
@@ -90,30 +90,8 @@ module 'map_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'map_literals':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'map_literals':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'map_literals':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_codegen.snap
@@ -90,30 +90,8 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'start_link'/2, 'init'/1, '
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'multi_keyword_complex_args':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'multi_keyword_complex_args':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'multi_keyword_complex_args':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_codegen.snap
@@ -90,30 +90,8 @@ module 'nested_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'nested_blocks':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'nested_blocks':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'nested_blocks':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_codegen.snap
@@ -90,30 +90,8 @@ module 'nested_keyword_messages' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'nested_keyword_messages':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'nested_keyword_messages':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'nested_keyword_messages':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__string_operations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__string_operations_codegen.snap
@@ -95,30 +95,8 @@ module 'string_operations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'string_operations':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'string_operations':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'string_operations':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_codegen.snap
@@ -92,30 +92,8 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'typed_class_warnings':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'typed_class_warnings':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'typed_class_warnings':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_codegen.snap
@@ -92,30 +92,8 @@ module 'typed_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'typed_methods':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'typed_methods':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'typed_methods':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_codegen.snap
@@ -91,30 +91,8 @@ module 'unary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'unary_operators':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'unary_operators':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'unary_operators':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_codegen.snap
@@ -94,30 +94,8 @@ module 'unicode_string_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'unicode_string_literals':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'unicode_string_literals':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'unicode_string_literals':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_codegen.snap
@@ -90,30 +90,8 @@ module 'while_true_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'while_true_simple':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'while_true_simple':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'while_true_simple':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_codegen.snap
@@ -92,30 +92,8 @@ module 'whitespace_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'whitespace_handling':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'whitespace_handling':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'whitespace_handling':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_codegen.snap
@@ -91,30 +91,8 @@ module 'workspace_binding_cascade' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'workspace_binding_cascade':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'workspace_binding_cascade':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'workspace_binding_cascade':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_codegen.snap
@@ -91,30 +91,8 @@ module 'workspace_binding_send' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'workspace_binding_send':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'workspace_binding_send':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'workspace_binding_send':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_codegen.snap
@@ -90,30 +90,8 @@ module 'ws_stdlib_array' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'ws_stdlib_array':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'ws_stdlib_array':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'ws_stdlib_array':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_codegen.snap
@@ -92,30 +92,8 @@ module 'ws_stdlib_block' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'ws_stdlib_block':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'ws_stdlib_block':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'ws_stdlib_block':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_codegen.snap
@@ -90,30 +90,8 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'ws_stdlib_boolean':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'ws_stdlib_boolean':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'ws_stdlib_boolean':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_codegen.snap
@@ -90,30 +90,8 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'ws_stdlib_dictionary':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'ws_stdlib_dictionary':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'ws_stdlib_dictionary':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_codegen.snap
@@ -92,30 +92,8 @@ module 'ws_stdlib_integer' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'ws_stdlib_integer':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'ws_stdlib_integer':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'ws_stdlib_integer':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_codegen.snap
@@ -90,30 +90,8 @@ module 'ws_stdlib_list' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'ws_stdlib_list':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'ws_stdlib_list':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'ws_stdlib_list':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_codegen.snap
@@ -90,30 +90,8 @@ module 'ws_stdlib_nil' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'ws_stdlib_nil':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'ws_stdlib_nil':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'ws_stdlib_nil':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_codegen.snap
@@ -95,30 +95,8 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'ws_stdlib_nil_object':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'ws_stdlib_nil_object':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'ws_stdlib_nil_object':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_codegen.snap
@@ -90,30 +90,8 @@ module 'ws_stdlib_set' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'ws_stdlib_set':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'ws_stdlib_set':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'ws_stdlib_set':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_codegen.snap
@@ -92,30 +92,8 @@ module 'ws_stdlib_string' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
 'handle_continue'/2 = fun (Continue, State) ->
     case Continue of
         <'initialize'> when 'true' ->
-            let _OldState = call 'erlang':'get'('$bt_actor_state') in
-            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
-            let _InitDispatchResult = call 'ws_stdlib_string':'safe_dispatch'('initialize', [], State) in
-            let _RestoreOk = case _OldState of
-                <'undefined'> when 'true' ->
-                    call 'erlang':'erase'('$bt_actor_state')
-                <_Prev> when 'true' ->
-                    call 'erlang':'put'('$bt_actor_state', _Prev)
-            end in
-            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
-            case _InitDispatchResult of
-                <{'reply', _InitResult, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
-                <{'error', {InitType, InitReason, InitStacktrace}, InitErrState}> when 'true' ->
-                    let InitErrorMsg = call 'beamtalk_error':'format_safe'({InitType, InitReason}, InitStacktrace) in
-                    let InitClassName = call 'ws_stdlib_string':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg, ~{'class' => InitClassName, 'reason' => {InitType, InitReason}, 'stacktrace' => InitStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', {InitType, InitReason, InitStacktrace}, InitErrState}
-                <{'error', InitError, InitErrState2}> when 'true' ->
-                    let InitErrorMsg2 = call 'beamtalk_error':'format_safe'(InitError) in
-                    let InitClassName2 = call 'ws_stdlib_string':'class_name'() in
-                    let _ = call 'logger':'error'(InitErrorMsg2, ~{'class' => InitClassName2, 'reason' => InitError, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
-                    {'stop', InitError, InitErrState2}
-            end
+            let InitNewState = State in
+            {'noreply', InitNewState}
         <_> when 'true' -> {'noreply', State}
     end
 


### PR DESCRIPTION
Phase 1 of [ADR 0078](../blob/main/docs/ADR/0078-actor-initialize-inheritance.md): auto-chain `initialize` up the actor class hierarchy and extend the post-initialize check to cover inherited typed-no-default fields.

Linear: https://linear.app/beamtalk/issue/BT-1951

## Summary

- `handle_continue` now walks the superclass chain (via `ClassHierarchy`) and emits a `safe_dispatch` call for each class that defines its own `initialize`, parent-first — state threads through so child initializers see parent's mutations.
- Post-initialize check validates typed-no-default fields from the full AST-visible inheritance chain and names the owning class in diagnostics.
- `init/1` defers to `handle_continue` whenever any ancestor defines `initialize` OR any class in the chain has typed-no-default fields.
- `CoreErlangGenerator` stashes a `ClassHierarchy` snapshot so callback codegen can reach cross-file ancestors.
- Each dispatch is bracketed by its own pdict stash/restore pair to preserve BT-1325 re-entrant self-send semantics.

## Acceptance Criteria

- [x] `handle_continue` walks class hierarchy and dispatches `initialize` parent-first
- [x] Post-initialize check validates inherited typed-no-default fields (AST-visible ancestors)
- [x] BUnit test: parent sets typed-no-default field in initialize, child doesn't mention it — works
- [x] BUnit test: parent forgets its own field — `UninitializedStateError`
- [x] BUnit test: deep hierarchy (3 levels) — all initializers run in order
- [x] BUnit test: child with no initialize, parent has initialize — parent's runs
- [x] Existing actor tests still pass (no regression across 1825 BUnit / 3900 runtime / 332 compiler-snapshot tests)

## Known limitation

Cross-file parent classes whose typed-no-default fields are declared outside the current compilation unit are skipped by the post-initialize check (the auto-chain itself IS cross-file aware via `ClassHierarchy`). Tracked in BT-1976 as a Phase 2 follow-up that adds default-value metadata to `ClassInfo`.

## Test plan

- [x] `just test` — Rust unit + stdlib + BUnit + runtime suites
- [x] `just clippy` — zero warnings
- [x] `just fmt-check` — formatted
- [x] Snapshot regressions reviewed & accepted (the only semantic change is simplifying `handle_continue` when no class in the chain defines `initialize`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Actors now automatically chain initialization methods through inheritance hierarchies, ensuring parent initialization completes before child initialization.
  * Added validation for typed fields across all inherited classes to catch missing initializations early.

* **Tests**
  * Added comprehensive test suite for inherited initialization behavior, covering deep hierarchies and field validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->