### PR TITLE
Tests: beamtalk_json + beamtalk_json_formatter coverage to 85% (BT-1968)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_json_formatter_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_json_formatter_tests.erl
@@ -345,6 +345,147 @@ format_extra_meta_excludes_standard_keys_test() ->
     ?assertNot(maps:is_key(<<"file">>, Decoded)),
     ?assertNot(maps:is_key(<<"line">>, Decoded)).
 
+format_time_missing_returns_unknown_test() ->
+    Event = #{
+        level => info,
+        msg => {string, "no time"},
+        meta => #{}
+    },
+    Decoded = decode_event(Event),
+    ?assertEqual(<<"unknown">>, maps:get(<<"time">>, Decoded)).
+
+format_supervisor_progress_proplist_report_test() ->
+    %% Supervisor progress with data nested in `report` key (OTP format)
+    Report = #{
+        label => {supervisor, progress},
+        report => [
+            {supervisor, {local, my_sup}},
+            {started, [{id, child_worker}, {pid, self()}]}
+        ]
+    },
+    Event = #{
+        level => info,
+        msg => {report, Report},
+        meta => #{time => erlang:system_time(microsecond)}
+    },
+    Decoded = decode_event(Event),
+    ?assertEqual(<<"supervisor_progress">>, maps:get(<<"report_type">>, Decoded)),
+    MsgBin = maps:get(<<"msg">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(MsgBin, <<"Supervisor">>)).
+
+format_supervisor_child_terminated_proplist_report_test() ->
+    %% Supervisor child_terminated with data nested in `report` key (OTP format)
+    Report = #{
+        label => {supervisor, child_terminated},
+        report => [
+            {supervisor, {local, test_sup}},
+            {reason, shutdown},
+            {offender, [{id, my_worker}, {pid, self()}]}
+        ]
+    },
+    Event = #{
+        level => error,
+        msg => {report, Report},
+        meta => #{time => erlang:system_time(microsecond)}
+    },
+    Decoded = decode_event(Event),
+    ?assertEqual(<<"supervisor_child_terminated">>, maps:get(<<"report_type">>, Decoded)),
+    MsgBin = maps:get(<<"msg">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(MsgBin, <<"test_sup">>)).
+
+format_supervisor_child_terminated_with_offender_test() ->
+    %% child_terminated with top-level offender key
+    Report = #{
+        label => {supervisor, child_terminated},
+        supervisor => {local, my_sup},
+        reason => normal,
+        offender => [{id, my_child}, {pid, self()}]
+    },
+    Event = #{
+        level => warning,
+        msg => {report, Report},
+        meta => #{time => erlang:system_time(microsecond)}
+    },
+    Decoded = decode_event(Event),
+    ?assertEqual(<<"supervisor_child_terminated">>, maps:get(<<"report_type">>, Decoded)),
+    MsgBin = maps:get(<<"msg">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(MsgBin, <<"my_child">>)).
+
+format_non_map_report_test() ->
+    %% Non-map report (e.g., a list) should be formatted via fallback
+    Event = #{
+        level => info,
+        msg => {report, [{key, value}]},
+        meta => #{time => erlang:system_time(microsecond)}
+    },
+    Decoded = decode_event(Event),
+    ?assert(is_binary(maps:get(<<"msg">>, Decoded))).
+
+format_report_with_arity2_callback_test() ->
+    %% report_cb as arity-2 function
+    Report = #{data => 42},
+    Event = #{
+        level => info,
+        msg => {report, Report},
+        meta => #{
+            time => erlang:system_time(microsecond),
+            report_cb => fun(_R, _Opts) -> <<"arity2 formatted">> end
+        }
+    },
+    Decoded = decode_event(Event),
+    ?assertEqual(<<"arity2 formatted">>, maps:get(<<"msg">>, Decoded)).
+
+format_extra_meta_pid_value_test() ->
+    Pid = self(),
+    Event = #{
+        level => info,
+        msg => {string, "pid meta"},
+        meta => #{
+            time => erlang:system_time(microsecond),
+            spawned_by => Pid
+        }
+    },
+    Decoded = decode_event(Event),
+    PidBin = maps:get(<<"spawned_by">>, Decoded),
+    ?assert(is_binary(PidBin)),
+    ?assertNotEqual(nomatch, binary:match(PidBin, <<"<">>)).
+
+format_extra_meta_integer_value_test() ->
+    Event = #{
+        level => info,
+        msg => {string, "integer meta"},
+        meta => #{
+            time => erlang:system_time(microsecond),
+            retry_count => 3
+        }
+    },
+    Decoded = decode_event(Event),
+    ?assertEqual(<<"3">>, maps:get(<<"retry_count">>, Decoded)).
+
+format_non_list_stacktrace_test() ->
+    %% Non-list stacktrace (e.g., from Core Erlang catch)
+    Event = #{
+        level => error,
+        msg => {string, "crash"},
+        meta => #{
+            time => erlang:system_time(microsecond),
+            stacktrace => {some, tuple, data}
+        }
+    },
+    Decoded = decode_event(Event),
+    StackBin = maps:get(<<"stacktrace">>, Decoded),
+    ?assert(is_binary(StackBin)).
+
+format_application_controller_domain_inference_test() ->
+    Report = #{label => {application_controller, progress}},
+    Event = #{
+        level => info,
+        msg => {report, Report},
+        meta => #{time => erlang:system_time(microsecond)}
+    },
+    Decoded = decode_event(Event),
+    ?assertEqual(<<"otp">>, maps:get(<<"domain">>, Decoded)).
+
 format_falls_back_to_plain_text_on_formatter_failure_test() ->
     %% Force the normal formatter path to fail so the catch branch is exercised.
     %% A binary in the domain list makes atom_to_list/1 crash inside format_domain.

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_json_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_json_tests.erl
@@ -53,6 +53,73 @@ parse_invalid_json_test() ->
     ).
 
 %%% ============================================================================
+%%% parse:/1 — additional coverage
+%%% ============================================================================
+
+parse_object_test() ->
+    R = beamtalk_json:'parse:'(<<"{\"a\":1,\"b\":2}">>),
+    ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true}, R),
+    #{okValue := Val} = R,
+    ?assertEqual(1, maps:get(<<"a">>, Val)),
+    ?assertEqual(2, maps:get(<<"b">>, Val)).
+
+parse_boolean_true_test() ->
+    R = beamtalk_json:'parse:'(<<"true">>),
+    ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true, 'okValue' := true}, R).
+
+parse_boolean_false_test() ->
+    R = beamtalk_json:'parse:'(<<"false">>),
+    ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true, 'okValue' := false}, R).
+
+parse_float_test() ->
+    R = beamtalk_json:'parse:'(<<"3.14">>),
+    ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true}, R),
+    #{okValue := Val} = R,
+    ?assert(is_float(Val)),
+    ?assert(abs(Val - 3.14) < 0.001).
+
+parse_nested_test() ->
+    Json = <<"{\"items\":[{\"name\":\"a\"},{\"name\":\"b\"}],\"count\":2}">>,
+    R = beamtalk_json:'parse:'(Json),
+    ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true}, R),
+    #{okValue := Val} = R,
+    ?assertEqual(2, maps:get(<<"count">>, Val)),
+    Items = maps:get(<<"items">>, Val),
+    ?assertEqual(2, length(Items)),
+    ?assertEqual(<<"a">>, maps:get(<<"name">>, hd(Items))).
+
+parse_unicode_string_test() ->
+    R = beamtalk_json:'parse:'(<<"\"caf\\u00e9\"">>),
+    ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true}, R),
+    #{okValue := Val} = R,
+    ?assertEqual(<<"café"/utf8>>, Val).
+
+parse_nested_null_test() ->
+    R = beamtalk_json:'parse:'(<<"[null,{\"x\":null}]">>),
+    ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true}, R),
+    #{okValue := [nil, Map]} = R,
+    ?assertEqual(nil, maps:get(<<"x">>, Map)).
+
+parse_empty_object_test() ->
+    R = beamtalk_json:'parse:'(<<"{}">>),
+    ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true, 'okValue' := #{}}, R).
+
+parse_empty_array_test() ->
+    R = beamtalk_json:'parse:'(<<"[]">>),
+    ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true, 'okValue' := []}, R).
+
+parse_unexpected_end_test() ->
+    R = beamtalk_json:'parse:'(<<"[1,2,">>),
+    ?assertMatch(
+        #{
+            '$beamtalk_class' := 'Result',
+            'isOk' := false,
+            'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{kind = parse_error}}
+        },
+        R
+    ).
+
+%%% ============================================================================
 %%% generate:/1
 %%% ============================================================================
 
@@ -65,6 +132,55 @@ generate_null_test() ->
 generate_list_test() ->
     ?assertEqual(<<"[1,2,3]">>, beamtalk_json:'generate:'([1, 2, 3])).
 
+generate_string_test() ->
+    ?assertEqual(<<"\"hello\"">>, beamtalk_json:'generate:'(<<"hello">>)).
+
+generate_boolean_test() ->
+    ?assertEqual(<<"true">>, beamtalk_json:'generate:'(true)),
+    ?assertEqual(<<"false">>, beamtalk_json:'generate:'(false)).
+
+generate_float_test() ->
+    Result = beamtalk_json:'generate:'(3.14),
+    ?assert(is_binary(Result)),
+    %% Round-trip: parse it back
+    Parsed = json:decode(Result),
+    ?assert(abs(Parsed - 3.14) < 0.001).
+
+generate_map_test() ->
+    Result = beamtalk_json:'generate:'(#{<<"key">> => <<"value">>}),
+    Decoded = json:decode(Result),
+    ?assertEqual(<<"value">>, maps:get(<<"key">>, Decoded)).
+
+generate_nested_test() ->
+    Value = #{<<"items">> => [1, 2, #{<<"nested">> => true}]},
+    Result = beamtalk_json:'generate:'(Value),
+    Decoded = json:decode(Result),
+    Items = maps:get(<<"items">>, Decoded),
+    ?assertEqual(3, length(Items)).
+
+generate_atom_to_string_test() ->
+    %% Atoms (symbols) should be converted to strings
+    Result = beamtalk_json:'generate:'(hello),
+    ?assertEqual(<<"\"hello\"">>, Result).
+
+generate_strips_beamtalk_class_test() ->
+    %% Maps with $beamtalk_class should have it stripped
+    Value = #{'$beamtalk_class' => 'Dictionary', <<"key">> => <<"val">>},
+    Result = beamtalk_json:'generate:'(Value),
+    Decoded = json:decode(Result),
+    ?assertNot(maps:is_key(<<"$beamtalk_class">>, Decoded)),
+    ?assertEqual(<<"val">>, maps:get(<<"key">>, Decoded)).
+
+generate_nil_in_list_test() ->
+    Result = beamtalk_json:'generate:'([1, nil, <<"a">>]),
+    ?assertEqual(<<"[1,null,\"a\"]">>, Result).
+
+generate_unsupported_type_test() ->
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = type_error}},
+        beamtalk_json:'generate:'({unsupported, tuple})
+    ).
+
 %%% ============================================================================
 %%% prettyPrint:/1
 %%% ============================================================================
@@ -72,6 +188,66 @@ generate_list_test() ->
 pretty_print_test() ->
     Result = beamtalk_json:'prettyPrint:'(42),
     ?assert(is_binary(Result)).
+
+pretty_print_object_test() ->
+    Result = beamtalk_json:'prettyPrint:'(#{<<"a">> => 1}),
+    ?assert(is_binary(Result)),
+    %% Should contain newlines (pretty-printed)
+    ?assertNotEqual(nomatch, binary:match(Result, <<"\n">>)),
+    %% Should be valid JSON
+    Decoded = json:decode(Result),
+    ?assertEqual(1, maps:get(<<"a">>, Decoded)).
+
+pretty_print_nested_test() ->
+    Value = #{<<"outer">> => #{<<"inner">> => [1, 2, 3]}},
+    Result = beamtalk_json:'prettyPrint:'(Value),
+    Decoded = json:decode(Result),
+    Inner = maps:get(<<"inner">>, maps:get(<<"outer">>, Decoded)),
+    ?assertEqual([1, 2, 3], Inner).
+
+pretty_print_unsupported_type_test() ->
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = type_error}},
+        beamtalk_json:'prettyPrint:'({unsupported, tuple})
+    ).
+
+%%% ============================================================================
+%%% prettify_term/1
+%%% ============================================================================
+
+prettify_term_test() ->
+    Result = beamtalk_json:prettify_term(#{<<"key">> => <<"value">>}),
+    ?assert(is_binary(Result)),
+    Decoded = json:decode(Result),
+    ?assertEqual(<<"value">>, maps:get(<<"key">>, Decoded)).
+
+%%% ============================================================================
+%%% Round-trip tests
+%%% ============================================================================
+
+round_trip_integer_test() ->
+    Original = 42,
+    Json = beamtalk_json:'generate:'(Original),
+    #{okValue := Decoded} = beamtalk_json:'parse:'(Json),
+    ?assertEqual(Original, Decoded).
+
+round_trip_string_test() ->
+    Original = <<"hello world">>,
+    Json = beamtalk_json:'generate:'(Original),
+    #{okValue := Decoded} = beamtalk_json:'parse:'(Json),
+    ?assertEqual(Original, Decoded).
+
+round_trip_list_test() ->
+    Original = [1, <<"two">>, true, false, nil],
+    Json = beamtalk_json:'generate:'(Original),
+    #{okValue := Decoded} = beamtalk_json:'parse:'(Json),
+    ?assertEqual([1, <<"two">>, true, false, nil], Decoded).
+
+round_trip_nested_map_test() ->
+    Original = #{<<"name">> => <<"test">>, <<"values">> => [1, 2, 3]},
+    Json = beamtalk_json:'generate:'(Original),
+    #{okValue := Decoded} = beamtalk_json:'parse:'(Json),
+    ?assertEqual(Original, Decoded).
 
 %%% ============================================================================
 %%% FFI no-colon aliases


### PR DESCRIPTION
## Summary

Adds ~39 new EUnit tests across both JSON modules to improve test coverage toward the 85% target.

- **beamtalk_json** (14 → 41 tests): parse round-trips for all JSON types (object, boolean, float, unicode, nested null), generate coverage (string, boolean, map, atom-to-string, `$beamtalk_class` stripping, unsupported type error), prettyPrint formatting verification, `prettify_term/1` direct usage, and encode/decode round-trip tests
- **beamtalk_json_formatter** (24 → 36 tests): missing time metadata fallback, OTP supervisor proplist report formats, child_terminated with offender key, non-map report fallback, arity-2 report callback, extra metadata type handling (pid, integer), non-list stacktrace, application_controller domain inference

## Linear Issue

https://linear.app/beamtalk/issue/BT-1968

## Test Plan

- [x] All 41 beamtalk_json_tests pass
- [x] All 36 beamtalk_json_formatter_tests pass
- [x] Full runtime EUnit suite: 0 failures
- [x] erlfmt formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)