### PR TITLE
fix: suppress expected crash reports in safe_spawn error tests

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
@@ -2266,16 +2266,24 @@ handle_cast_fire_and_forget_with_propagated_context_test() ->
 safe_spawn_error_from_start_link_test() ->
     %% safe_spawn returns {error, Reason} when gen_server:start_link fails
     %% Use a module that doesn't exist to trigger an error
-    Result = beamtalk_actor:safe_spawn(nonexistent_module_bt1958, #{}),
-    ?assertMatch({error, _}, Result).
+    %% Suppress the expected crash report to avoid EUnit cancellation.
+    logger:set_primary_config(level, none),
+    try
+        Result = beamtalk_actor:safe_spawn(nonexistent_module_bt1958, #{}),
+        ?assertMatch({error, _}, Result)
+    after
+        logger:set_primary_config(level, all)
+    end.
 
 safe_spawn_restores_trap_exit_on_error_test() ->
     %% safe_spawn restores the original trap_exit flag even on error
     OldTrap = process_flag(trap_exit, false),
+    logger:set_primary_config(level, none),
     try
         _Result = beamtalk_actor:safe_spawn(nonexistent_module_bt1958, #{}),
         ?assertEqual(false, process_flag(trap_exit, false))
     after
+        logger:set_primary_config(level, all),
         process_flag(trap_exit, OldTrap)
     end.
 
@@ -2421,7 +2429,8 @@ code_change_preserves_state_unit_test() ->
 
 sync_send_to_shutdown_actor_raises_actor_dead_test() ->
     %% When an actor stops with shutdown reason during a call, we get actor_dead
-    {ok, Counter} = test_counter:start_link(0),
+    %% Use start (not start_link) so the test process isn't killed by the shutdown EXIT.
+    {ok, Counter} = gen_server:start(test_counter, 0, []),
     gen_server:stop(Counter, shutdown, 1000),
     timer:sleep(10),
     ?assertError(

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_stdlib_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_stdlib_tests.erl
@@ -431,8 +431,18 @@ start_link_test_() ->
 
 start_link_returns_pid_test() ->
     %% start_link spawns a proc_lib process
-    {ok, Pid} = beamtalk_stdlib:start_link(),
-    ?assert(is_pid(Pid)),
-    ?assert(is_process_alive(Pid)),
-    %% Cleanup
-    exit(Pid, shutdown).
+    %% Trap exits so the test process isn't killed when we clean up.
+    OldTrap = process_flag(trap_exit, true),
+    try
+        {ok, Pid} = beamtalk_stdlib:start_link(),
+        ?assert(is_pid(Pid)),
+        ?assert(is_process_alive(Pid)),
+        %% Cleanup
+        exit(Pid, shutdown),
+        receive
+            {'EXIT', Pid, _} -> ok
+        after 1000 -> ok
+        end
+    after
+        process_flag(trap_exit, OldTrap)
+    end.


### PR DESCRIPTION
## Summary
- The `nonexistent_module_bt1958` crash reports from BT-1958 actor tests were causing EUnit to cancel 6 unrelated tests
- Temporarily sets logger level to `none` during expected crashes, same pattern as #2005

## Test plan
- [ ] CI test-runtime passes with 0 cancelled tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Suppressed noisy logger output during certain test phases to keep test logs cleaner while restoring prior settings afterward.
  * Improved test reliability by adjusting actor startup/teardown and ensuring exit signals are observed and previous trap-exit state is restored.
  * General cleanup to reduce flakiness and ensure proper resource restoration after tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->