### PR TITLE
Tests: file + JSON + stdlib + collection coverage to 90% (BT-1983)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_stdlib.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_stdlib.erl
@@ -46,8 +46,15 @@ No Erlang code changes needed.
 -export([topo_sort/1]).
 
 -ifdef(TEST).
-%% Export internal helpers for EUnit coverage (BT-1975)
--export([format_bt_module/1, class_entry_module/1, find_stdlib_ebin/0]).
+%% Export internal helpers for EUnit coverage (BT-1975, BT-1983)
+-export([
+    format_bt_module/1,
+    class_entry_module/1,
+    find_stdlib_ebin/0,
+    discover_and_load_fallback/1,
+    load_protocol_modules/0,
+    stdlib_loop/0
+]).
 -endif.
 
 -doc """

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_stdlib_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_stdlib_tests.erl
@@ -446,3 +446,110 @@ start_link_returns_pid_test() ->
     after
         process_flag(trap_exit, OldTrap)
     end.
+
+%%% ============================================================================
+%%% stdlib_loop/0 Tests (BT-1983)
+%%% ============================================================================
+
+start_link_stays_alive_on_message_test_() ->
+    {setup, fun stdlib_setup/0, fun stdlib_teardown/1, [
+        fun start_link_handles_unknown_message_test/0
+    ]}.
+
+start_link_handles_unknown_message_test() ->
+    %% The idle loop drains arbitrary messages and keeps running.
+    OldTrap = process_flag(trap_exit, true),
+    try
+        {ok, Pid} = beamtalk_stdlib:start_link(),
+        %% Send an arbitrary message — the loop should consume it and continue.
+        Pid ! {arbitrary, message, 123},
+        Pid ! another_message,
+        %% Yield so the loop has a chance to process the messages.
+        timer:sleep(50),
+        ?assert(is_process_alive(Pid)),
+        exit(Pid, shutdown),
+        receive
+            {'EXIT', Pid, _} -> ok
+        after 1000 -> ok
+        end
+    after
+        process_flag(trap_exit, OldTrap)
+    end.
+
+%%% ============================================================================
+%%% load_protocol_modules/0 Tests (BT-1983)
+%%% ============================================================================
+
+load_protocol_modules_test_() ->
+    {setup, fun stdlib_setup/0, fun stdlib_teardown/1, [
+        fun load_protocol_modules_idempotent_test/0,
+        fun load_protocol_modules_missing_module_test/0,
+        fun load_protocol_modules_unset_env_test/0
+    ]}.
+
+load_protocol_modules_idempotent_test() ->
+    %% Calling load_protocol_modules/0 after stdlib init should be a no-op
+    %% that successfully re-loads the already-loaded protocol modules.
+    ?assertEqual(ok, beamtalk_stdlib:load_protocol_modules()).
+
+load_protocol_modules_missing_module_test() ->
+    %% Inject a non-existent module name and verify the warning path runs
+    %% without crashing the loader.
+    Original = application:get_env(beamtalk_stdlib, protocol_modules),
+    try
+        application:set_env(
+            beamtalk_stdlib, protocol_modules, [nonexistent_bt_module_xyz]
+        ),
+        ?assertEqual(ok, beamtalk_stdlib:load_protocol_modules())
+    after
+        case Original of
+            {ok, Value} -> application:set_env(beamtalk_stdlib, protocol_modules, Value);
+            undefined -> application:unset_env(beamtalk_stdlib, protocol_modules)
+        end
+    end.
+
+load_protocol_modules_unset_env_test() ->
+    %% Temporarily unset protocol_modules env — should return ok without crashing.
+    Original = application:get_env(beamtalk_stdlib, protocol_modules),
+    try
+        application:unset_env(beamtalk_stdlib, protocol_modules),
+        ?assertEqual(ok, beamtalk_stdlib:load_protocol_modules())
+    after
+        case Original of
+            {ok, Value} -> application:set_env(beamtalk_stdlib, protocol_modules, Value);
+            undefined -> ok
+        end
+    end.
+
+%%% ============================================================================
+%%% discover_and_load_fallback/1 Tests (BT-1983)
+%%% ============================================================================
+
+discover_and_load_fallback_missing_dir_test() ->
+    %% Non-existent directory should log a warning but not crash.
+    ?assertEqual(
+        ok, beamtalk_stdlib:discover_and_load_fallback("_bt_nonexistent_ebin_dir_for_test")
+    ).
+
+discover_and_load_fallback_empty_dir_test() ->
+    %% Create an empty temp directory — should list it successfully with no modules.
+    TmpDir = filename:join(
+        "_bt_eunit_stdlib_fallback", integer_to_list(erlang:unique_integer([positive]))
+    ),
+    try
+        ok = filelib:ensure_path(TmpDir),
+        ?assertEqual(ok, beamtalk_stdlib:discover_and_load_fallback(TmpDir))
+    after
+        file:del_dir_r("_bt_eunit_stdlib_fallback")
+    end.
+
+discover_and_load_fallback_with_beam_files_test() ->
+    %% Directory with a valid .beam file (use the stdlib ebin itself).
+    EbinDir = beamtalk_stdlib:find_stdlib_ebin(),
+    case filelib:is_dir(EbinDir) of
+        true ->
+            ?assertEqual(ok, beamtalk_stdlib:discover_and_load_fallback(EbinDir));
+        false ->
+            %% Stdlib not built — skip
+            ok
+    end.

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_collection_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_collection_tests.erl
@@ -14,6 +14,26 @@ Tests inject_into/3 and to_list/1 for list inputs.
 -include_lib("eunit/include/eunit.hrl").
 
 %%% ============================================================================
+%%% Test Fixtures (BT-1983)
+%%% ============================================================================
+
+%% Load stdlib so non-list Collection classes (e.g. Interval) can dispatch do:.
+stdlib_setup() ->
+    case whereis(pg) of
+        undefined -> pg:start_link();
+        _ -> ok
+    end,
+    beamtalk_extensions:init(),
+    case whereis(beamtalk_bootstrap) of
+        undefined -> {ok, _} = beamtalk_bootstrap:start_link();
+        _ -> ok
+    end,
+    beamtalk_stdlib:init(),
+    ok.
+
+stdlib_teardown(_) -> ok.
+
+%%% ============================================================================
 %%% inject_into/3
 %%% ============================================================================
 
@@ -84,3 +104,39 @@ inject_into_count_test() ->
     %% Count elements
     Result = beamtalk_collection:inject_into([x, y, z], 0, fun(Acc, _E) -> Acc + 1 end),
     ?assertEqual(3, Result).
+
+%%% ============================================================================
+%%% to_list/1 — non-list collection path (BT-1983)
+%%% ============================================================================
+%%%
+%%% These tests exercise the non-list branch of to_list/1, which dispatches
+%%% `do:` on the receiver via beamtalk_primitive:send/3. Requires stdlib to
+%%% be loaded so that Interval (a Collection subclass) can respond to do:.
+
+to_list_non_list_test_() ->
+    {setup, fun stdlib_setup/0, fun stdlib_teardown/1, [
+        {"to_list on Interval yields integers in range", fun to_list_interval_test/0},
+        {"to_list on empty Interval yields empty list", fun to_list_empty_interval_test/0},
+        {"inject_into on Interval sums the range", fun inject_into_interval_test/0}
+    ]}.
+
+%% Build an Interval via direct map construction (matches stdlib/src/Interval.bt).
+make_interval(From, To) ->
+    #{'$beamtalk_class' => 'Interval', from => From, to => To, step => 1}.
+
+to_list_interval_test() ->
+    Interval = make_interval(1, 5),
+    Result = beamtalk_collection:to_list(Interval),
+    ?assertEqual([1, 2, 3, 4, 5], Result).
+
+to_list_empty_interval_test() ->
+    %% from > to with step 1 → empty
+    Interval = make_interval(5, 1),
+    Result = beamtalk_collection:to_list(Interval),
+    ?assertEqual([], Result).
+
+inject_into_interval_test() ->
+    Interval = make_interval(1, 10),
+    %% Sum 1..10 = 55
+    Sum = beamtalk_collection:inject_into(Interval, 0, fun(Acc, E) -> Acc + E end),
+    ?assertEqual(55, Sum).

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_file_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_file_tests.erl
@@ -2010,3 +2010,343 @@ open_do_handle_lines_success_test() ->
             R
         )
     end).
+
+%%% ============================================================================
+%%% BT-1983 — additional error path coverage
+%%% ============================================================================
+
+%% Attempting to read/write a directory (as if it were a file) exercises
+%% the catch-all io_error branches: file:read_file/write_file/open on a
+%% directory returns {error, eisdir} (not enoent, not eacces).
+
+readAll_eisdir_test() ->
+    Dir = "_bt_eunit_readAll_eisdir",
+    try
+        ok = filelib:ensure_path(Dir),
+        R = beamtalk_file:'readAll:'(list_to_binary(Dir)),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{kind = io_error}}
+            },
+            R
+        )
+    after
+        file:del_dir_r(Dir)
+    end.
+
+readBinary_eisdir_test() ->
+    Dir = "_bt_eunit_readBinary_eisdir",
+    try
+        ok = filelib:ensure_path(Dir),
+        R = beamtalk_file:'readBinary:'(list_to_binary(Dir)),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{kind = io_error}}
+            },
+            R
+        )
+    after
+        file:del_dir_r(Dir)
+    end.
+
+writeAll_eisdir_test() ->
+    Dir = "_bt_eunit_writeAll_eisdir",
+    try
+        ok = filelib:ensure_path(Dir),
+        R = beamtalk_file:'writeAll:contents:'(list_to_binary(Dir), <<"x">>),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{kind = io_error}}
+            },
+            R
+        )
+    after
+        file:del_dir_r(Dir)
+    end.
+
+writeBinary_eisdir_test() ->
+    Dir = "_bt_eunit_writeBinary_eisdir",
+    try
+        ok = filelib:ensure_path(Dir),
+        R = beamtalk_file:'writeBinary:contents:'(list_to_binary(Dir), <<"x">>),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{kind = io_error}}
+            },
+            R
+        )
+    after
+        file:del_dir_r(Dir)
+    end.
+
+appendBinary_eisdir_test() ->
+    Dir = "_bt_eunit_appendBinary_eisdir",
+    try
+        ok = filelib:ensure_path(Dir),
+        R = beamtalk_file:'appendBinary:contents:'(list_to_binary(Dir), <<"x">>),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{kind = io_error}}
+            },
+            R
+        )
+    after
+        file:del_dir_r(Dir)
+    end.
+
+lines_eisdir_test() ->
+    Dir = "_bt_eunit_lines_eisdir",
+    try
+        ok = filelib:ensure_path(Dir),
+        R = beamtalk_file:'lines:'(list_to_binary(Dir)),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{kind = io_error}}
+            },
+            R
+        )
+    after
+        file:del_dir_r(Dir)
+    end.
+
+open_do_eisdir_test() ->
+    Dir = "_bt_eunit_open_eisdir",
+    try
+        ok = filelib:ensure_path(Dir),
+        R = beamtalk_file:'open:do:'(
+            list_to_binary(Dir), fun(_) -> error(callback_should_not_run) end
+        ),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{kind = io_error}}
+            },
+            R
+        )
+    after
+        file:del_dir_r(Dir)
+    end.
+
+%%% ----------------------------------------------------------------------------
+%%% mkdir / mkdirAll / listDirectory / delete / deleteAll / rename catch-alls
+%%% ----------------------------------------------------------------------------
+
+mkdir_already_exists_as_file_test() ->
+    %% mkdir on a path that exists as a regular file → {error, eexist}
+    %% (covers the eexist branch, which is distinct from directory_not_found)
+    FileName = "_bt_eunit_mkdir_eexist.txt",
+    try
+        ok = file:write_file(FileName, <<"x">>),
+        R = beamtalk_file:'mkdir:'(list_to_binary(FileName)),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{
+                    '$beamtalk_class' := _, error := #beamtalk_error{kind = already_exists}
+                }
+            },
+            R
+        )
+    after
+        file:delete(FileName)
+    end.
+
+mkdirAll_parent_is_file_test() ->
+    %% mkdirAll when a path component is a regular file → io_error
+    Parent = "_bt_eunit_mkdirAll_parent_file.txt",
+    try
+        ok = file:write_file(Parent, <<"x">>),
+        R = beamtalk_file:'mkdirAll:'(list_to_binary(Parent ++ "/child")),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{}}
+            },
+            R
+        )
+    after
+        file:delete(Parent)
+    end.
+
+listDirectory_missing_dir_test() ->
+    R = beamtalk_file:'listDirectory:'(<<"_bt_eunit_listdir_missing">>),
+    ?assertMatch(
+        #{
+            '$beamtalk_class' := 'Result',
+            'isOk' := false,
+            'errReason' := #{
+                '$beamtalk_class' := _, error := #beamtalk_error{kind = directory_not_found}
+            }
+        },
+        R
+    ).
+
+listDirectory_upfront_file_check_test() ->
+    %% listDirectory on a regular file → not_a_directory (upfront check)
+    FileName = "_bt_eunit_listdir_file.txt",
+    try
+        ok = file:write_file(FileName, <<"x">>),
+        R = beamtalk_file:'listDirectory:'(list_to_binary(FileName)),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{
+                    '$beamtalk_class' := _, error := #beamtalk_error{kind = not_a_directory}
+                }
+            },
+            R
+        )
+    after
+        file:delete(FileName)
+    end.
+
+rename_to_destination_is_directory_test() ->
+    %% rename a file to a target that is an existing, non-empty directory
+    Src = "_bt_eunit_rename_src_file.txt",
+    Dst = "_bt_eunit_rename_dst_dir",
+    DstChild = Dst ++ "/child.txt",
+    try
+        ok = file:write_file(Src, <<"x">>),
+        ok = filelib:ensure_path(Dst),
+        ok = file:write_file(DstChild, <<"y">>),
+        R = beamtalk_file:'rename:to:'(list_to_binary(Src), list_to_binary(Dst)),
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                'isOk' := false,
+                'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{}}
+            },
+            R
+        )
+    after
+        file:delete(Src),
+        file:del_dir_r(Dst)
+    end.
+
+%%% ----------------------------------------------------------------------------
+%%% strip_newline edge cases — exercised through lines:/1
+%%% ----------------------------------------------------------------------------
+
+lines_empty_trailing_newline_only_test() ->
+    with_temp_file("_bt_eunit_lines_empty_newline.txt", <<"\n">>, fun() ->
+        R = beamtalk_file:'lines:'(<<"_bt_eunit_lines_empty_newline.txt">>),
+        ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true}, R),
+        #{okValue := Stream} = R,
+        Lines = beamtalk_stream:as_list(Stream),
+        %% Expect a single empty line
+        ?assertEqual([<<>>], Lines)
+    end).
+
+lines_bare_cr_in_middle_test() ->
+    %% A bare \r inside a line is preserved (only trailing \r\n is stripped)
+    with_temp_file("_bt_eunit_lines_bare_cr.txt", <<"ab\rcd\nef\n">>, fun() ->
+        R = beamtalk_file:'lines:'(<<"_bt_eunit_lines_bare_cr.txt">>),
+        #{okValue := Stream} = R,
+        Lines = beamtalk_stream:as_list(Stream),
+        ?assertEqual([<<"ab\rcd">>, <<"ef">>], Lines)
+    end).
+
+%%% ----------------------------------------------------------------------------
+%%% tempDirectory: exercise the os:getenv fallback branches
+%%% ----------------------------------------------------------------------------
+
+temp_directory_respects_TMPDIR_test() ->
+    %% Set TMPDIR to a known value and verify it is returned.
+    OrigTmpdir = os:getenv("TMPDIR"),
+    try
+        os:putenv("TMPDIR", "/custom/tmp/path"),
+        ?assertEqual(<<"/custom/tmp/path">>, beamtalk_file:'tempDirectory'())
+    after
+        case OrigTmpdir of
+            false -> os:unsetenv("TMPDIR");
+            V -> os:putenv("TMPDIR", V)
+        end
+    end.
+
+temp_directory_falls_back_to_TMP_test() ->
+    %% Unset TMPDIR, set TMP, expect TMP's value.
+    OrigTmpdir = os:getenv("TMPDIR"),
+    OrigTmp = os:getenv("TMP"),
+    try
+        os:unsetenv("TMPDIR"),
+        os:putenv("TMP", "/tmp-fallback"),
+        ?assertEqual(<<"/tmp-fallback">>, beamtalk_file:'tempDirectory'())
+    after
+        case OrigTmp of
+            false -> os:unsetenv("TMP");
+            V -> os:putenv("TMP", V)
+        end,
+        case OrigTmpdir of
+            false -> ok;
+            V2 -> os:putenv("TMPDIR", V2)
+        end
+    end.
+
+temp_directory_falls_back_to_TEMP_test() ->
+    %% Unset TMPDIR and TMP, set TEMP.
+    OrigTmpdir = os:getenv("TMPDIR"),
+    OrigTmp = os:getenv("TMP"),
+    OrigTemp = os:getenv("TEMP"),
+    try
+        os:unsetenv("TMPDIR"),
+        os:unsetenv("TMP"),
+        os:putenv("TEMP", "/temp-fallback"),
+        ?assertEqual(<<"/temp-fallback">>, beamtalk_file:'tempDirectory'())
+    after
+        case OrigTemp of
+            false -> os:unsetenv("TEMP");
+            V -> os:putenv("TEMP", V)
+        end,
+        case OrigTmp of
+            false -> ok;
+            V2 -> os:putenv("TMP", V2)
+        end,
+        case OrigTmpdir of
+            false -> ok;
+            V3 -> os:putenv("TMPDIR", V3)
+        end
+    end.
+
+temp_directory_platform_default_test() ->
+    %% Unset all three env vars; the function must still return a platform-
+    %% appropriate default ("/tmp" on Unix, "C:\\Windows\\Temp" on Windows).
+    OrigTmpdir = os:getenv("TMPDIR"),
+    OrigTmp = os:getenv("TMP"),
+    OrigTemp = os:getenv("TEMP"),
+    try
+        os:unsetenv("TMPDIR"),
+        os:unsetenv("TMP"),
+        os:unsetenv("TEMP"),
+        Result = beamtalk_file:'tempDirectory'(),
+        ?assert(is_binary(Result)),
+        ?assert(byte_size(Result) > 0)
+    after
+        case OrigTmpdir of
+            false -> ok;
+            V1 -> os:putenv("TMPDIR", V1)
+        end,
+        case OrigTmp of
+            false -> ok;
+            V2 -> os:putenv("TMP", V2)
+        end,
+        case OrigTemp of
+            false -> ok;
+            V3 -> os:putenv("TEMP", V3)
+        end
+    end.

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_json_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_json_tests.erl
@@ -269,3 +269,131 @@ generate_alias_test() ->
 pretty_print_alias_test() ->
     Result = beamtalk_json:prettyPrint(42),
     ?assert(is_binary(Result)).
+
+%%% ============================================================================
+%%% Additional coverage — prettify/4 edge cases (BT-1983)
+%%% ============================================================================
+
+pretty_print_empty_object_test() ->
+    %% Covers the empty-object branch (L233-234): the pretty-printer skips
+    %% inserting a newline after the opening brace when it sees `}` next.
+    Result = beamtalk_json:'prettyPrint:'(#{}),
+    ?assertEqual(<<"{\n}">>, Result),
+    %% Should still decode back to an empty map
+    ?assertEqual(#{}, json:decode(Result)).
+
+pretty_print_empty_array_test() ->
+    %% Covers the empty-array branch (L241-242).
+    Result = beamtalk_json:'prettyPrint:'([]),
+    ?assertEqual(<<"[\n]">>, Result),
+    ?assertEqual([], json:decode(Result)).
+
+pretty_print_nested_empty_collections_test() ->
+    %% Empty inside non-empty container
+    Result = beamtalk_json:'prettyPrint:'(#{<<"a">> => #{}, <<"b">> => []}),
+    ?assert(is_binary(Result)),
+    Decoded = json:decode(Result),
+    ?assertEqual(#{}, maps:get(<<"a">>, Decoded)),
+    ?assertEqual([], maps:get(<<"b">>, Decoded)).
+
+pretty_print_escaped_backslash_test() ->
+    %% Covers the in-string escape branch (L224-225): prettify sees \" inside string
+    %% The encoded JSON contains \\" sequences (backslash + quote) inside string literals.
+    Result = beamtalk_json:'prettyPrint:'(<<"quote\"backslash\\end">>),
+    ?assert(is_binary(Result)),
+    Decoded = json:decode(Result),
+    ?assertEqual(<<"quote\"backslash\\end">>, Decoded).
+
+prettify_term_empty_object_test() ->
+    %% Direct exercise of prettify_term helper with empty map.
+    %% Same behaviour as prettyPrint:/1 — newline before the closing brace.
+    ?assertEqual(<<"{\n}">>, beamtalk_json:prettify_term(#{})).
+
+%%% ============================================================================
+%%% Additional coverage — parse error catch-all (BT-1983)
+%%% ============================================================================
+
+parse_unexpected_sequence_test() ->
+    %% Lone garbage tokens raise {unexpected_sequence, _} from json:decode
+    R = beamtalk_json:'parse:'(<<"xyz">>),
+    ?assertMatch(
+        #{
+            '$beamtalk_class' := 'Result',
+            'isOk' := false,
+            'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{kind = parse_error}}
+        },
+        R
+    ).
+
+parse_trailing_garbage_test() ->
+    R = beamtalk_json:'parse:'(<<"{\"a\":1}junk">>),
+    ?assertMatch(
+        #{
+            '$beamtalk_class' := 'Result',
+            'isOk' := false,
+            'errReason' := #{'$beamtalk_class' := _, error := #beamtalk_error{kind = parse_error}}
+        },
+        R
+    ).
+
+%%% ============================================================================
+%%% Additional coverage — generate/prettyPrint error paths (BT-1983)
+%%% ============================================================================
+
+generate_nested_unsupported_type_test() ->
+    %% Covers prepare_for_encode raising inside the recursive list walk,
+    %% hitting the #beamtalk_error{} re-raise branch in generate:/1 (L95-96).
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = type_error, class = 'Json'}},
+        beamtalk_json:'generate:'([1, {oops, bad}, 3])
+    ).
+
+generate_unsupported_in_map_test() ->
+    %% Tuple as map value triggers prepare_for_encode error from inside map walk
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = type_error, class = 'Json'}},
+        beamtalk_json:'generate:'(#{<<"k">> => {oops, bad}})
+    ).
+
+pretty_print_nested_unsupported_type_test() ->
+    %% Covers the #beamtalk_error{} re-raise branch in prettyPrint:/1 (L117-118).
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = type_error, class = 'Json'}},
+        beamtalk_json:'prettyPrint:'([1, {oops, bad}, 3])
+    ).
+
+%%% ============================================================================
+%%% Additional coverage — large / deeply nested structures (BT-1983)
+%%% ============================================================================
+
+parse_deeply_nested_array_test() ->
+    %% Build [[[[[[[[[[42]]]]]]]]]] and round-trip it.
+    Depth = 20,
+    Json = iolist_to_binary([
+        binary:copy(<<"[">>, Depth),
+        <<"42">>,
+        binary:copy(<<"]">>, Depth)
+    ]),
+    R = beamtalk_json:'parse:'(Json),
+    ?assertMatch(#{'$beamtalk_class' := 'Result', 'isOk' := true}, R),
+    #{okValue := Decoded} = R,
+    %% Unwrap back to integer
+    Unwrap = fun
+        U(X) when is_list(X) -> U(hd(X));
+        U(N) -> N
+    end,
+    ?assertEqual(42, Unwrap(Decoded)).
+
+generate_deeply_nested_map_test() ->
+    %% Build {"k": {"k": ... {"k": 1}}} at depth 10
+    Depth = 10,
+    Nested = lists:foldl(
+        fun(_, Acc) -> #{<<"k">> => Acc} end,
+        1,
+        lists:seq(1, Depth)
+    ),
+    Json = beamtalk_json:'generate:'(Nested),
+    ?assert(is_binary(Json)),
+    %% Round-trip
+    #{okValue := Decoded} = beamtalk_json:'parse:'(Json),
+    ?assertEqual(Nested, Decoded).


### PR DESCRIPTION
## Summary

Add ~25 EUnit tests across four stdlib modules to raise coverage:

- **beamtalk_collection**: 33% → 100%. Cover the non-list `to_list/1` dispatch path by exercising an Interval receiver (requires the stdlib class registry to be up; new `stdlib_setup/0` fixture).
- **beamtalk_file**: 74% → 83%. Cover the catch-all io_error branches of `readAll`/`readBinary`/`writeAll`/`writeBinary`/`appendBinary`/`lines`/`open:do:` by passing a directory where a file is expected. Add `listDirectory` not_found/not_a_directory, `mkdir` eexist, `mkdirAll` enotdir, `rename` onto an existing non-empty directory, `strip_newline` edge cases, and the `tempDirectory` TMPDIR/TMP/TEMP fallback chain.
- **beamtalk_json**: 68% → 72%. Cover prettify empty-object/array, the in-string backslash escape branch, the `#beamtalk_error{}` re-raise path in `generate:`/`prettyPrint:` when `prepare_for_encode` raises from inside a nested list or map, and round-trip for deeply nested structures. (Remaining uncovered lines are defensive catch-alls for json module failure modes that don't occur in practice.)
- **beamtalk_stdlib** (runtime): 28% → 82%. Exercise `stdlib_loop/0` via an arbitrary message, `load_protocol_modules/0` with a missing module name and an unset env key, and `discover_and_load_fallback/1` with missing / empty / valid directories. Expose three private helpers (`discover_and_load_fallback`, `load_protocol_modules`, `stdlib_loop`) via a TEST-only export so EUnit can drive them directly.

## Test plan

- [x] All new tests pass (`rebar3 eunit --module beamtalk_collection_tests,beamtalk_json_tests,beamtalk_file_tests,beamtalk_stdlib_tests`)
- [x] `just test` passes end-to-end
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 dialyzer` clean
- [x] No hardcoded `/tmp/` paths — tests use `_bt_eunit_` prefixed relative names and clean up in `after` blocks
- [x] Environment variable mutations (tempDirectory tests) are properly restored

## Linear
https://linear.app/beamtalk/issue/BT-1983

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Significantly expanded test coverage across the standard library with new test suites for protocol module loading and initialization, comprehensive file operation error scenarios (directory handling, missing paths, file conflicts), JSON formatting and parsing edge cases (empty structures, deep nesting, escape sequences), and collection operations on interval data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->