### PR TITLE
Runtime: named-registration intrinsics + process-dict marker + spawnAs (BT-1987)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -187,6 +187,18 @@ handle_getValue([], State) ->
 %% Internal dispatch
 -export([dispatch/4, make_self/1]).
 
+%% Named registration (ADR 0079, BT-1987)
+-export([
+    is_beamtalk_actor/1,
+    register_name/2,
+    unregister_name/1,
+    whereis_name/1,
+    all_registered/0,
+    'spawnAs'/2,
+    'spawnAs'/3,
+    reserved_name/1
+]).
+
 %% Lifecycle telemetry (BT-1638: called from compiled actor init/terminate)
 -export([maybe_execute_telemetry/3]).
 
@@ -1296,6 +1308,11 @@ init(State) when is_map(State) ->
         {ok, Class} when is_atom(Class) ->
             case maps:is_key('__methods__', State) of
                 true ->
+                    %% BT-1987 / ADR 0079: process-dict marker identifies
+                    %% every Beamtalk actor process so tooling and
+                    %% `all_registered/0` can filter them out of the
+                    %% flat OTP registry without needing a separate table.
+                    erlang:put('$beamtalk_actor', Class),
                     StateKeys = [
                         K
                      || K <- maps:keys(State),
@@ -1942,3 +1959,298 @@ object_fallback(Selector, Args, Self, State, ClassName) ->
         Result ->
             Result
     end.
+
+%%% =====================================================================
+%%% Named Actor Registration (ADR 0079, BT-1987)
+%%% =====================================================================
+%%%
+%%% These intrinsics wire Beamtalk actors into OTP's local process
+%%% registry (`erlang:register/2`). The `'$beamtalk_actor'` process
+%%% dictionary marker set in `init/1` lets us distinguish Beamtalk
+%%% actors from raw OTP processes when filtering `erlang:registered/0`.
+%%%
+%%% Errors use `#beamtalk_error{}` with kinds `name_registered`,
+%%% `type_error`, and `reserved_name` — these are translated to
+%%% `Result error: ...` at the stdlib boundary per ADR 0060/0076.
+
+-doc """
+Check whether a pid is a Beamtalk actor process.
+
+Returns `true` if the process has the `'$beamtalk_actor'` marker
+set in its process dictionary (set by `init/1` for every Beamtalk
+actor). Returns `false` for raw OTP processes (including kernel
+processes, gen_servers not built on beamtalk_actor, etc.) and for
+dead processes.
+""".
+-spec is_beamtalk_actor(pid()) -> boolean().
+is_beamtalk_actor(Pid) when is_pid(Pid) ->
+    case erlang:process_info(Pid, dictionary) of
+        {dictionary, Dict} when is_list(Dict) ->
+            lists:keymember('$beamtalk_actor', 1, Dict);
+        undefined ->
+            %% Process is dead
+            false
+    end;
+is_beamtalk_actor(_) ->
+    false.
+
+-doc """
+Register a pid under a name in the local atom registry.
+
+Returns `{ok, Name}` on success or `{error, #beamtalk_error{}}` on
+failure with `kind` one of:
+  - `type_error` — `Name` is not an atom or `Pid` is not a pid
+  - `reserved_name` — `Name` is in the reserved-name blocklist
+  - `name_registered` — another process is already registered
+    under `Name` (maps to `erlang:register/2` badarg when taken).
+""".
+-spec register_name(atom(), pid()) -> {ok, atom()} | {error, #beamtalk_error{}}.
+register_name(Name, Pid) when is_atom(Name), is_pid(Pid) ->
+    case reserved_name(Name) of
+        true ->
+            {error,
+                beamtalk_error:with_hint(
+                    beamtalk_error:new(reserved_name, 'Actor', registerAs),
+                    iolist_to_binary(
+                        io_lib:format(
+                            "Cannot register actor under reserved name '~ts'", [Name]
+                        )
+                    )
+                )};
+        false ->
+            try erlang:register(Name, Pid) of
+                true -> {ok, Name}
+            catch
+                error:badarg ->
+                    {error,
+                        beamtalk_error:with_hint(
+                            beamtalk_error:new(name_registered, 'Actor', registerAs),
+                            iolist_to_binary(
+                                io_lib:format(
+                                    "Name '~ts' is already registered", [Name]
+                                )
+                            )
+                        )}
+            end
+    end;
+register_name(Name, Pid) ->
+    {error,
+        beamtalk_error:with_hint(
+            beamtalk_error:new(type_error, 'Actor', registerAs),
+            iolist_to_binary(
+                io_lib:format(
+                    "register_name/2 expects (atom, pid), got (~tp, ~tp)", [Name, Pid]
+                )
+            )
+        )}.
+
+-doc """
+Unregister a name previously registered via `register_name/2`.
+
+Returns `ok` on success or `{error, #beamtalk_error{}}` if `Name`
+is not currently registered. Idempotent-friendly callers should
+check `whereis_name/1` first if they want "unregister-if-present"
+semantics.
+""".
+-spec unregister_name(atom()) -> ok | {error, #beamtalk_error{}}.
+unregister_name(Name) when is_atom(Name) ->
+    try erlang:unregister(Name) of
+        true -> ok
+    catch
+        error:badarg ->
+            {error,
+                beamtalk_error:with_hint(
+                    beamtalk_error:new(name_registered, 'Actor', unregister),
+                    iolist_to_binary(
+                        io_lib:format(
+                            "Name '~ts' is not registered", [Name]
+                        )
+                    )
+                )}
+    end;
+unregister_name(Name) ->
+    {error,
+        beamtalk_error:with_hint(
+            beamtalk_error:new(type_error, 'Actor', unregister),
+            iolist_to_binary(
+                io_lib:format(
+                    "unregister_name/1 expects atom, got ~tp", [Name]
+                )
+            )
+        )}.
+
+-doc """
+Look up the pid registered under `Name`.
+
+Returns `{ok, Pid}` if a process is registered, or `undefined` if
+no process is registered under that name. Non-atom input returns
+`{error, #beamtalk_error{kind = type_error}}`.
+""".
+-spec whereis_name(atom()) -> {ok, pid()} | undefined | {error, #beamtalk_error{}}.
+whereis_name(Name) when is_atom(Name) ->
+    case erlang:whereis(Name) of
+        undefined -> undefined;
+        Pid when is_pid(Pid) -> {ok, Pid}
+    end;
+whereis_name(Name) ->
+    {error,
+        beamtalk_error:with_hint(
+            beamtalk_error:new(type_error, 'Actor', whereisName),
+            iolist_to_binary(
+                io_lib:format(
+                    "whereis_name/1 expects atom, got ~tp", [Name]
+                )
+            )
+        )}.
+
+-doc """
+List all names currently registered to Beamtalk actors.
+
+Filters `erlang:registered/0` down to processes that carry the
+`'$beamtalk_actor'` process-dictionary marker, so kernel processes,
+gen_servers outside the Beamtalk runtime, and other raw OTP
+processes are excluded.
+""".
+-spec all_registered() -> [atom()].
+all_registered() ->
+    [
+        Name
+     || Name <- erlang:registered(),
+        case erlang:whereis(Name) of
+            undefined -> false;
+            Pid -> is_beamtalk_actor(Pid)
+        end
+    ].
+
+-doc """
+Spawn an actor under a registered name (arity 2).
+
+Equivalent to `start_link({local, Name}, Module, [])`. Returns
+`{ok, Pid}` on success or `{error, #beamtalk_error{}}` on
+name-related failures. Other errors (crash in init, etc.) pass
+through from `gen_server:start_link/4` as `{error, Reason}`.
+""".
+-spec 'spawnAs'(atom(), module()) -> {ok, pid()} | {error, term()}.
+'spawnAs'(Name, Module) ->
+    'spawnAs'(Name, Module, []).
+
+-doc """
+Spawn an actor under a registered name (arity 3).
+
+Thin delegate to `start_link({local, Name}, Module, Args)` that
+enforces the reserved-name blocklist and the atom type-check
+*before* the process is spawned. On `{already_started, _}` or
+`badarg` from the registry, returns a structured `#beamtalk_error{}`
+with kind `name_registered` so the stdlib boundary can translate
+to `Result error: ...`.
+""".
+-spec 'spawnAs'(atom(), module(), term()) -> {ok, pid()} | {error, term()}.
+'spawnAs'(Name, Module, Args) when is_atom(Name), is_atom(Module) ->
+    case reserved_name(Name) of
+        true ->
+            {error,
+                beamtalk_error:with_hint(
+                    beamtalk_error:new(reserved_name, 'Actor', spawnAs),
+                    iolist_to_binary(
+                        io_lib:format(
+                            "Cannot spawn actor under reserved name '~ts'", [Name]
+                        )
+                    )
+                )};
+        false ->
+            case gen_server:start_link({local, Name}, Module, Args, []) of
+                {ok, Pid} ->
+                    {ok, Pid};
+                {error, {already_started, _Other}} ->
+                    {error,
+                        beamtalk_error:with_hint(
+                            beamtalk_error:new(name_registered, 'Actor', spawnAs),
+                            iolist_to_binary(
+                                io_lib:format(
+                                    "Name '~ts' is already registered", [Name]
+                                )
+                            )
+                        )};
+                {error, Reason} ->
+                    {error, Reason};
+                ignore ->
+                    {error, ignore}
+            end
+    end;
+'spawnAs'(Name, Module, _Args) ->
+    {error,
+        beamtalk_error:with_hint(
+            beamtalk_error:new(type_error, 'Actor', spawnAs),
+            iolist_to_binary(
+                io_lib:format(
+                    "spawnAs expects (atom, module), got (~tp, ~tp)", [Name, Module]
+                )
+            )
+        )}.
+
+-doc """
+Check whether `Name` is on the reserved-name blocklist.
+
+Reserved names are:
+  - OTP kernel / stdlib registered process names that a user atom
+    collision with would be catastrophic (application_controller,
+    code_server, erl_prim_loader, erl_signal_server, error_logger,
+    erts_code_purger, file_server_2, global_group, global_group_check,
+    global_name_server, inet_db, init, kernel_refc, kernel_safe_sup,
+    kernel_sup, logger, logger_handler_watcher, logger_proxy,
+    logger_std_h_default, logger_sup, net_kernel, net_sup, rex,
+    socket_registry, standard_error, standard_error_sup,
+    standard_error_writer, user, user_drv, user_drv_reader,
+    user_drv_writer).
+  - Any atom whose textual form is prefixed `beamtalk_` — reserved
+    for internal runtime / supervision use.
+
+See ADR 0079 ("Reserved-name policy") for rationale.
+""".
+-spec reserved_name(atom()) -> boolean().
+reserved_name(Name) when is_atom(Name) ->
+    case is_kernel_reserved(Name) of
+        true ->
+            true;
+        false ->
+            NameStr = atom_to_list(Name),
+            lists:prefix("beamtalk_", NameStr)
+    end;
+reserved_name(_) ->
+    false.
+
+%% Static blocklist of OTP kernel / stdlib registered names.
+%% Kept as a function (not a macro) so dialyzer sees the pattern match.
+-spec is_kernel_reserved(atom()) -> boolean().
+is_kernel_reserved(application_controller) -> true;
+is_kernel_reserved(code_server) -> true;
+is_kernel_reserved(erl_prim_loader) -> true;
+is_kernel_reserved(erl_signal_server) -> true;
+is_kernel_reserved(error_logger) -> true;
+is_kernel_reserved(erts_code_purger) -> true;
+is_kernel_reserved(file_server_2) -> true;
+is_kernel_reserved(global_group) -> true;
+is_kernel_reserved(global_group_check) -> true;
+is_kernel_reserved(global_name_server) -> true;
+is_kernel_reserved(inet_db) -> true;
+is_kernel_reserved(init) -> true;
+is_kernel_reserved(kernel_refc) -> true;
+is_kernel_reserved(kernel_safe_sup) -> true;
+is_kernel_reserved(kernel_sup) -> true;
+is_kernel_reserved(logger) -> true;
+is_kernel_reserved(logger_handler_watcher) -> true;
+is_kernel_reserved(logger_proxy) -> true;
+is_kernel_reserved(logger_std_h_default) -> true;
+is_kernel_reserved(logger_sup) -> true;
+is_kernel_reserved(net_kernel) -> true;
+is_kernel_reserved(net_sup) -> true;
+is_kernel_reserved(rex) -> true;
+is_kernel_reserved(socket_registry) -> true;
+is_kernel_reserved(standard_error) -> true;
+is_kernel_reserved(standard_error_sup) -> true;
+is_kernel_reserved(standard_error_writer) -> true;
+is_kernel_reserved(user) -> true;
+is_kernel_reserved(user_drv) -> true;
+is_kernel_reserved(user_drv_reader) -> true;
+is_kernel_reserved(user_drv_writer) -> true;
+is_kernel_reserved(_) -> false.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -334,8 +334,31 @@ functions stay simple.
 """.
 -spec safe_spawn(module(), map()) -> {ok, pid()} | {error, term()}.
 safe_spawn(Module, InitArgs) ->
+    safe_spawn_internal(undefined, Module, InitArgs).
+
+-doc """
+BT-1987: Spawn a named actor with trap_exit + initialize synchronization.
+
+Same contract as `safe_spawn/2` but registers the actor under `Name`
+via `gen_server:start_link({local, Name}, ...)`. Reuses the same
+initialize-synchronization machinery so callers see `{ok, Pid}` only
+after `handle_continue(initialize, _)` has completed.
+""".
+-spec safe_spawn_named(atom(), module(), map()) -> {ok, pid()} | {error, term()}.
+safe_spawn_named(Name, Module, InitArgs) when is_atom(Name) ->
+    safe_spawn_internal({local, Name}, Module, InitArgs).
+
+-spec safe_spawn_internal(undefined | {local, atom()}, module(), term()) ->
+    {ok, pid()} | {error, term()}.
+safe_spawn_internal(ServerName, Module, InitArgs) ->
     OldTrap = erlang:process_flag(trap_exit, true),
-    Result = gen_server:start_link(Module, InitArgs, []),
+    Result =
+        case ServerName of
+            undefined ->
+                gen_server:start_link(Module, InitArgs, []);
+            {local, _} = SN ->
+                gen_server:start_link(SN, Module, InitArgs, [])
+        end,
     case Result of
         {ok, Pid} ->
             case await_initialize(Pid) of
@@ -1982,7 +2005,7 @@ actor). Returns `false` for raw OTP processes (including kernel
 processes, gen_servers not built on beamtalk_actor, etc.) and for
 dead processes.
 """.
--spec is_beamtalk_actor(pid()) -> boolean().
+-spec is_beamtalk_actor(term()) -> boolean().
 is_beamtalk_actor(Pid) when is_pid(Pid) ->
     case erlang:process_info(Pid, dictionary) of
         {dictionary, Dict} when is_list(Dict) ->
@@ -1999,12 +2022,20 @@ Register a pid under a name in the local atom registry.
 
 Returns `{ok, Name}` on success or `{error, #beamtalk_error{}}` on
 failure with `kind` one of:
-  - `type_error` — `Name` is not an atom or `Pid` is not a pid
+  - `type_error` — `Name` is not an atom or `Pid` is not a pid, or
+    the `Pid` is not registerable (dead, remote, or already has a
+    registered name).
   - `reserved_name` — `Name` is in the reserved-name blocklist
   - `name_registered` — another process is already registered
-    under `Name` (maps to `erlang:register/2` badarg when taken).
+    under `Name`.
+
+Note: `erlang:register/2` raises `badarg` for multiple reasons —
+duplicate name, dead pid, remote pid, pid already registered
+under another name. We disambiguate by checking
+`erlang:whereis(Name)` after `badarg`: if taken, it's a duplicate
+name; otherwise the Pid itself is unregisterable.
 """.
--spec register_name(atom(), pid()) -> {ok, atom()} | {error, #beamtalk_error{}}.
+-spec register_name(term(), term()) -> {ok, atom()} | {error, #beamtalk_error{}}.
 register_name(Name, Pid) when is_atom(Name), is_pid(Pid) ->
     case reserved_name(Name) of
         true ->
@@ -2022,15 +2053,35 @@ register_name(Name, Pid) when is_atom(Name), is_pid(Pid) ->
                 true -> {ok, Name}
             catch
                 error:badarg ->
-                    {error,
-                        beamtalk_error:with_hint(
-                            beamtalk_error:new(name_registered, 'Actor', registerAs),
-                            iolist_to_binary(
-                                io_lib:format(
-                                    "Name '~ts' is already registered", [Name]
-                                )
-                            )
-                        )}
+                    case erlang:whereis(Name) =/= undefined of
+                        true ->
+                            {error,
+                                beamtalk_error:with_hint(
+                                    beamtalk_error:new(
+                                        name_registered, 'Actor', registerAs
+                                    ),
+                                    iolist_to_binary(
+                                        io_lib:format(
+                                            "Name '~ts' is already registered", [Name]
+                                        )
+                                    )
+                                )};
+                        false ->
+                            {error,
+                                beamtalk_error:with_hint(
+                                    beamtalk_error:new(
+                                        type_error, 'Actor', registerAs
+                                    ),
+                                    iolist_to_binary(
+                                        io_lib:format(
+                                            "Pid ~tp is not registerable "
+                                            "(dead, remote, or already "
+                                            "registered under another name)",
+                                            [Pid]
+                                        )
+                                    )
+                                )}
+                    end
             end
     end;
 register_name(Name, Pid) ->
@@ -2052,21 +2103,36 @@ is not currently registered. Idempotent-friendly callers should
 check `whereis_name/1` first if they want "unregister-if-present"
 semantics.
 """.
--spec unregister_name(atom()) -> ok | {error, #beamtalk_error{}}.
+-spec unregister_name(term()) -> ok | {error, #beamtalk_error{}}.
 unregister_name(Name) when is_atom(Name) ->
-    try erlang:unregister(Name) of
-        true -> ok
-    catch
-        error:badarg ->
+    case reserved_name(Name) of
+        true ->
             {error,
                 beamtalk_error:with_hint(
-                    beamtalk_error:new(name_registered, 'Actor', unregister),
+                    beamtalk_error:new(reserved_name, 'Actor', unregister),
                     iolist_to_binary(
                         io_lib:format(
-                            "Name '~ts' is not registered", [Name]
+                            "Cannot unregister reserved name '~ts'", [Name]
                         )
                     )
-                )}
+                )};
+        false ->
+            try erlang:unregister(Name) of
+                true -> ok
+            catch
+                error:badarg ->
+                    {error,
+                        beamtalk_error:with_hint(
+                            beamtalk_error:new(
+                                name_registered, 'Actor', unregister
+                            ),
+                            iolist_to_binary(
+                                io_lib:format(
+                                    "Name '~ts' is not registered", [Name]
+                                )
+                            )
+                        )}
+            end
     end;
 unregister_name(Name) ->
     {error,
@@ -2086,7 +2152,7 @@ Returns `{ok, Pid}` if a process is registered, or `undefined` if
 no process is registered under that name. Non-atom input returns
 `{error, #beamtalk_error{kind = type_error}}`.
 """.
--spec whereis_name(atom()) -> {ok, pid()} | undefined | {error, #beamtalk_error{}}.
+-spec whereis_name(term()) -> {ok, pid()} | undefined | {error, #beamtalk_error{}}.
 whereis_name(Name) when is_atom(Name) ->
     case erlang:whereis(Name) of
         undefined -> undefined;
@@ -2130,21 +2196,22 @@ Equivalent to `start_link({local, Name}, Module, [])`. Returns
 name-related failures. Other errors (crash in init, etc.) pass
 through from `gen_server:start_link/4` as `{error, Reason}`.
 """.
--spec 'spawnAs'(atom(), module()) -> {ok, pid()} | {error, term()}.
+-spec 'spawnAs'(term(), term()) -> {ok, pid()} | {error, term()}.
 'spawnAs'(Name, Module) ->
     'spawnAs'(Name, Module, []).
 
 -doc """
 Spawn an actor under a registered name (arity 3).
 
-Thin delegate to `start_link({local, Name}, Module, Args)` that
-enforces the reserved-name blocklist and the atom type-check
-*before* the process is spawned. On `{already_started, _}` or
+Delegates to `safe_spawn_named/3` (which wraps
+`gen_server:start_link({local, Name}, ...)` with trap_exit and
+`initialize` synchronization) after enforcing the reserved-name
+blocklist and the atom type-check. On `{already_started, _}` or
 `badarg` from the registry, returns a structured `#beamtalk_error{}`
 with kind `name_registered` so the stdlib boundary can translate
 to `Result error: ...`.
 """.
--spec 'spawnAs'(atom(), module(), term()) -> {ok, pid()} | {error, term()}.
+-spec 'spawnAs'(term(), term(), term()) -> {ok, pid()} | {error, term()}.
 'spawnAs'(Name, Module, Args) when is_atom(Name), is_atom(Module) ->
     case reserved_name(Name) of
         true ->
@@ -2158,32 +2225,41 @@ to `Result error: ...`.
                     )
                 )};
         false ->
-            case gen_server:start_link({local, Name}, Module, Args, []) of
+            try safe_spawn_named(Name, Module, Args) of
                 {ok, Pid} ->
                     {ok, Pid};
                 {error, {already_started, _Other}} ->
-                    {error,
-                        beamtalk_error:with_hint(
-                            beamtalk_error:new(name_registered, 'Actor', spawnAs),
-                            iolist_to_binary(
-                                io_lib:format(
-                                    "Name '~ts' is already registered", [Name]
-                                )
-                            )
-                        )};
+                    name_registered_error(Name);
                 {error, Reason} ->
-                    {error, Reason};
-                ignore ->
-                    {error, ignore}
+                    {error, Reason}
+            catch
+                %% gen_server:start_link can raise badarg from the local
+                %% registry (e.g., name already taken at the moment of
+                %% registration). Translate to the structured error.
+                error:badarg ->
+                    name_registered_error(Name)
             end
     end;
-'spawnAs'(Name, Module, _Args) ->
+'spawnAs'(Name, Module, Args) ->
     {error,
         beamtalk_error:with_hint(
             beamtalk_error:new(type_error, 'Actor', spawnAs),
             iolist_to_binary(
                 io_lib:format(
-                    "spawnAs expects (atom, module), got (~tp, ~tp)", [Name, Module]
+                    "spawnAs/3 expects (atom, module, term), got (~tp, ~tp, ~tp)",
+                    [Name, Module, Args]
+                )
+            )
+        )}.
+
+-spec name_registered_error(atom()) -> {error, #beamtalk_error{}}.
+name_registered_error(Name) ->
+    {error,
+        beamtalk_error:with_hint(
+            beamtalk_error:new(name_registered, 'Actor', spawnAs),
+            iolist_to_binary(
+                io_lib:format(
+                    "Name '~ts' is already registered", [Name]
                 )
             )
         )}.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
@@ -2502,3 +2502,266 @@ sync_send_onExit_with_kill_reason_test() ->
     after 2000 ->
         ?assert(false)
     end.
+
+%%% ============================================================================
+%%% BT-1987 / ADR 0079: Named-registration intrinsics
+%%% ============================================================================
+%%%
+%%% Use per-test name suffixes to avoid cross-test collisions. The suffix
+%%% is the calling test name (bounded / compile-time) so we don't mint
+%%% unbounded new atoms at runtime.
+
+%% Helper: cleanup a name if registered (used in test teardown).
+cleanup_name(Name) ->
+    case erlang:whereis(Name) of
+        undefined -> ok;
+        _ -> catch erlang:unregister(Name)
+    end.
+
+is_beamtalk_actor_true_for_actor_test() ->
+    {ok, Counter} = test_counter:start_link(0),
+    ?assert(beamtalk_actor:is_beamtalk_actor(Counter)),
+    gen_server:stop(Counter).
+
+is_beamtalk_actor_false_for_raw_process_test() ->
+    %% Spawn a bare process that is NOT a beamtalk_actor
+    Self = self(),
+    Pid = spawn(fun() ->
+        Self ! ready,
+        receive
+            stop -> ok
+        end
+    end),
+    receive
+        ready -> ok
+    end,
+    ?assertNot(beamtalk_actor:is_beamtalk_actor(Pid)),
+    Pid ! stop.
+
+is_beamtalk_actor_false_for_kernel_process_test() ->
+    %% `init` is always running and is not a beamtalk actor.
+    InitPid = erlang:whereis(init),
+    ?assertNot(beamtalk_actor:is_beamtalk_actor(InitPid)).
+
+is_beamtalk_actor_false_for_dead_process_test() ->
+    Pid = spawn(fun() -> ok end),
+    %% Wait for the process to actually die.
+    MRef = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', MRef, process, Pid, _} -> ok
+    after 1000 ->
+        ?assert(false)
+    end,
+    ?assertNot(beamtalk_actor:is_beamtalk_actor(Pid)).
+
+is_beamtalk_actor_false_for_non_pid_test() ->
+    %% Guarded against non-pid input: must not crash.
+    ?assertNot(beamtalk_actor:is_beamtalk_actor(not_a_pid)).
+
+%%% register_name / unregister_name / whereis_name
+
+register_name_success_test() ->
+    Name = 'bt1987_test_register_success',
+    cleanup_name(Name),
+    {ok, Counter} = test_counter:start_link(0),
+    try
+        ?assertEqual({ok, Name}, beamtalk_actor:register_name(Name, Counter)),
+        ?assertEqual({ok, Counter}, beamtalk_actor:whereis_name(Name))
+    after
+        beamtalk_actor:unregister_name(Name),
+        gen_server:stop(Counter)
+    end.
+
+register_name_duplicate_test() ->
+    Name = 'bt1987_test_register_duplicate',
+    cleanup_name(Name),
+    {ok, A} = test_counter:start_link(0),
+    {ok, B} = test_counter:start_link(0),
+    try
+        ?assertEqual({ok, Name}, beamtalk_actor:register_name(Name, A)),
+        Result = beamtalk_actor:register_name(Name, B),
+        ?assertMatch({error, #beamtalk_error{kind = name_registered}}, Result)
+    after
+        beamtalk_actor:unregister_name(Name),
+        gen_server:stop(A),
+        gen_server:stop(B)
+    end.
+
+register_name_reserved_test() ->
+    {ok, Counter} = test_counter:start_link(0),
+    try
+        %% Reserved kernel name
+        R1 = beamtalk_actor:register_name(logger, Counter),
+        ?assertMatch({error, #beamtalk_error{kind = reserved_name}}, R1),
+        %% Reserved beamtalk_ prefix
+        R2 = beamtalk_actor:register_name(beamtalk_something_internal, Counter),
+        ?assertMatch({error, #beamtalk_error{kind = reserved_name}}, R2)
+    after
+        gen_server:stop(Counter)
+    end.
+
+register_name_non_atom_test() ->
+    {ok, Counter} = test_counter:start_link(0),
+    try
+        Result = beamtalk_actor:register_name(<<"not_atom">>, Counter),
+        ?assertMatch({error, #beamtalk_error{kind = type_error}}, Result)
+    after
+        gen_server:stop(Counter)
+    end.
+
+register_name_non_pid_test() ->
+    Result = beamtalk_actor:register_name(some_name, not_a_pid),
+    ?assertMatch({error, #beamtalk_error{kind = type_error}}, Result).
+
+unregister_name_success_test() ->
+    Name = 'bt1987_test_unregister_success',
+    cleanup_name(Name),
+    {ok, Counter} = test_counter:start_link(0),
+    try
+        {ok, Name} = beamtalk_actor:register_name(Name, Counter),
+        ?assertEqual(ok, beamtalk_actor:unregister_name(Name)),
+        ?assertEqual(undefined, beamtalk_actor:whereis_name(Name))
+    after
+        gen_server:stop(Counter)
+    end.
+
+unregister_name_not_registered_test() ->
+    Result = beamtalk_actor:unregister_name('bt1987_never_registered_name'),
+    ?assertMatch({error, #beamtalk_error{kind = name_registered}}, Result).
+
+unregister_name_non_atom_test() ->
+    Result = beamtalk_actor:unregister_name(<<"bin">>),
+    ?assertMatch({error, #beamtalk_error{kind = type_error}}, Result).
+
+whereis_name_undefined_test() ->
+    ?assertEqual(undefined, beamtalk_actor:whereis_name('bt1987_nonexistent_name')).
+
+whereis_name_non_atom_test() ->
+    Result = beamtalk_actor:whereis_name(<<"bin">>),
+    ?assertMatch({error, #beamtalk_error{kind = type_error}}, Result).
+
+%%% all_registered/0
+
+all_registered_filters_kernel_processes_test() ->
+    %% Kernel processes (e.g. `init`, `logger`) are registered but are not
+    %% beamtalk actors — they must be excluded.
+    All = beamtalk_actor:all_registered(),
+    ?assertNot(lists:member(init, All)),
+    ?assertNot(lists:member(logger, All)),
+    ?assertNot(lists:member(kernel_sup, All)).
+
+all_registered_includes_beamtalk_actor_test() ->
+    Name = 'bt1987_test_all_registered',
+    cleanup_name(Name),
+    {ok, Counter} = test_counter:start_link(0),
+    try
+        {ok, Name} = beamtalk_actor:register_name(Name, Counter),
+        All = beamtalk_actor:all_registered(),
+        ?assert(lists:member(Name, All))
+    after
+        beamtalk_actor:unregister_name(Name),
+        gen_server:stop(Counter)
+    end.
+
+%%% spawnAs/2,3
+
+spawnAs_success_test() ->
+    Name = 'bt1987_test_spawnas_success',
+    cleanup_name(Name),
+    try
+        {ok, Pid} = beamtalk_actor:'spawnAs'(Name, test_counter, 0),
+        ?assertEqual({ok, Pid}, beamtalk_actor:whereis_name(Name)),
+        ?assert(beamtalk_actor:is_beamtalk_actor(Pid)),
+        gen_server:stop(Pid)
+    after
+        cleanup_name(Name)
+    end.
+
+spawnAs_arity_2_uses_empty_args_test() ->
+    %% test_counter requires an initial value (treats atom() as numeric),
+    %% so use a spawn-capable module with [] args. Minimal check: arity-2
+    %% is a delegate to arity-3 with [] and does not crash on the shape.
+    %% We verify via reserved-name rejection which runs before start_link.
+    Result = beamtalk_actor:'spawnAs'(logger, test_counter),
+    ?assertMatch({error, #beamtalk_error{kind = reserved_name}}, Result).
+
+spawnAs_reserved_test() ->
+    R1 = beamtalk_actor:'spawnAs'(logger, test_counter, 0),
+    ?assertMatch({error, #beamtalk_error{kind = reserved_name}}, R1),
+    R2 = beamtalk_actor:'spawnAs'(beamtalk_foo, test_counter, 0),
+    ?assertMatch({error, #beamtalk_error{kind = reserved_name}}, R2).
+
+spawnAs_duplicate_test() ->
+    Name = 'bt1987_test_spawnas_duplicate',
+    cleanup_name(Name),
+    try
+        {ok, Pid1} = beamtalk_actor:'spawnAs'(Name, test_counter, 0),
+        Result = beamtalk_actor:'spawnAs'(Name, test_counter, 0),
+        ?assertMatch({error, #beamtalk_error{kind = name_registered}}, Result),
+        gen_server:stop(Pid1)
+    after
+        cleanup_name(Name)
+    end.
+
+spawnAs_non_atom_test() ->
+    R1 = beamtalk_actor:'spawnAs'(<<"not_atom">>, test_counter, 0),
+    ?assertMatch({error, #beamtalk_error{kind = type_error}}, R1),
+    R2 = beamtalk_actor:'spawnAs'(my_name, "not_module", 0),
+    ?assertMatch({error, #beamtalk_error{kind = type_error}}, R2).
+
+%%% Reserved-name policy
+
+reserved_name_kernel_test() ->
+    ?assert(beamtalk_actor:reserved_name(logger)),
+    ?assert(beamtalk_actor:reserved_name(kernel_sup)),
+    ?assert(beamtalk_actor:reserved_name(application_controller)),
+    ?assert(beamtalk_actor:reserved_name(code_server)),
+    ?assert(beamtalk_actor:reserved_name(init)),
+    ?assert(beamtalk_actor:reserved_name(error_logger)),
+    ?assert(beamtalk_actor:reserved_name(erl_prim_loader)),
+    ?assert(beamtalk_actor:reserved_name(erl_signal_server)),
+    ?assert(beamtalk_actor:reserved_name(erts_code_purger)),
+    ?assert(beamtalk_actor:reserved_name(file_server_2)),
+    ?assert(beamtalk_actor:reserved_name(global_name_server)),
+    ?assert(beamtalk_actor:reserved_name(inet_db)),
+    ?assert(beamtalk_actor:reserved_name(kernel_refc)),
+    ?assert(beamtalk_actor:reserved_name(kernel_safe_sup)),
+    ?assert(beamtalk_actor:reserved_name(logger_handler_watcher)),
+    ?assert(beamtalk_actor:reserved_name(logger_proxy)),
+    ?assert(beamtalk_actor:reserved_name(logger_std_h_default)),
+    ?assert(beamtalk_actor:reserved_name(logger_sup)),
+    ?assert(beamtalk_actor:reserved_name(net_kernel)),
+    ?assert(beamtalk_actor:reserved_name(net_sup)),
+    ?assert(beamtalk_actor:reserved_name(rex)),
+    ?assert(beamtalk_actor:reserved_name(socket_registry)),
+    ?assert(beamtalk_actor:reserved_name(standard_error)),
+    ?assert(beamtalk_actor:reserved_name(standard_error_sup)),
+    ?assert(beamtalk_actor:reserved_name(standard_error_writer)),
+    ?assert(beamtalk_actor:reserved_name(user)),
+    ?assert(beamtalk_actor:reserved_name(user_drv)),
+    ?assert(beamtalk_actor:reserved_name(user_drv_reader)),
+    ?assert(beamtalk_actor:reserved_name(user_drv_writer)).
+
+reserved_name_beamtalk_prefix_test() ->
+    ?assert(beamtalk_actor:reserved_name(beamtalk_runtime_sup)),
+    ?assert(beamtalk_actor:reserved_name(beamtalk_anything)),
+    ?assert(beamtalk_actor:reserved_name(beamtalk_)).
+
+reserved_name_allows_user_names_test() ->
+    ?assertNot(beamtalk_actor:reserved_name(counter)),
+    ?assertNot(beamtalk_actor:reserved_name(my_app_service)),
+    ?assertNot(beamtalk_actor:reserved_name('MyActor')),
+    %% A name that merely contains "beamtalk" but isn't prefixed:
+    ?assertNot(beamtalk_actor:reserved_name(my_beamtalk_app)).
+
+reserved_name_non_atom_test() ->
+    ?assertNot(beamtalk_actor:reserved_name(<<"logger">>)),
+    ?assertNot(beamtalk_actor:reserved_name("logger")).
+
+%%% Process-dict marker
+
+actor_carries_process_dict_marker_test() ->
+    {ok, Counter} = test_counter:start_link(0),
+    {dictionary, Dict} = erlang:process_info(Counter, dictionary),
+    ?assertEqual({'$beamtalk_actor', 'Counter'}, lists:keyfind('$beamtalk_actor', 1, Dict)),
+    gen_server:stop(Counter).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
@@ -2535,8 +2535,12 @@ is_beamtalk_actor_false_for_raw_process_test() ->
     receive
         ready -> ok
     end,
-    ?assertNot(beamtalk_actor:is_beamtalk_actor(Pid)),
-    Pid ! stop.
+    try
+        ?assertNot(beamtalk_actor:is_beamtalk_actor(Pid))
+    after
+        %% Ensure the spawned process is reaped even if the assertion fails.
+        exit(Pid, kill)
+    end.
 
 is_beamtalk_actor_false_for_kernel_process_test() ->
     %% `init` is always running and is not a beamtalk actor.
@@ -2632,6 +2636,37 @@ unregister_name_not_registered_test() ->
 unregister_name_non_atom_test() ->
     Result = beamtalk_actor:unregister_name(<<"bin">>),
     ?assertMatch({error, #beamtalk_error{kind = type_error}}, Result).
+
+unregister_name_reserved_test() ->
+    %% unregister_name/1 must reject reserved names before touching the
+    %% registry — otherwise `unregister_name(logger)` would silently
+    %% deregister the OTP logger process.
+    R1 = beamtalk_actor:unregister_name(logger),
+    ?assertMatch({error, #beamtalk_error{kind = reserved_name}}, R1),
+    R2 = beamtalk_actor:unregister_name(kernel_sup),
+    ?assertMatch({error, #beamtalk_error{kind = reserved_name}}, R2),
+    R3 = beamtalk_actor:unregister_name(beamtalk_something),
+    ?assertMatch({error, #beamtalk_error{kind = reserved_name}}, R3),
+    %% OTP logger must still be registered after the attempt.
+    ?assertNotEqual(undefined, erlang:whereis(logger)).
+
+register_name_dead_pid_test() ->
+    %% A `badarg` from erlang:register/2 can mean "dead pid", not just
+    %% "name already taken". The non-duplicate branch must surface as a
+    %% type_error with a useful hint rather than name_registered.
+    Name = 'bt1987_register_dead_pid',
+    cleanup_name(Name),
+    DeadPid = spawn(fun() -> ok end),
+    MRef = erlang:monitor(process, DeadPid),
+    receive
+        {'DOWN', MRef, process, DeadPid, _} -> ok
+    after 1000 ->
+        ?assert(false)
+    end,
+    Result = beamtalk_actor:register_name(Name, DeadPid),
+    ?assertMatch({error, #beamtalk_error{kind = type_error}}, Result),
+    %% And no ghost registration was left behind.
+    ?assertEqual(undefined, erlang:whereis(Name)).
 
 whereis_name_undefined_test() ->
     ?assertEqual(undefined, beamtalk_actor:whereis_name('bt1987_nonexistent_name')).


### PR DESCRIPTION
## Summary

Phase 1 of [ADR 0079 (Named Actor Registration)](https://linear.app/beamtalk/issue/BT-1987) — lays the runtime foundations that the stdlib API and proxy dispatch will build on.

Linear: https://linear.app/beamtalk/issue/BT-1987

## Changes

- **Process-dict marker**: `beamtalk_actor:init/1` now sets `erlang:put('$beamtalk_actor', ClassName)` so every Beamtalk actor process is identifiable from tooling without a separate registry.
- **`is_beamtalk_actor/1`**: fast marker lookup via `erlang:process_info(Pid, dictionary)`. Handles dead processes and non-pid input safely.
- **Named registration intrinsics**: `register_name/2`, `unregister_name/1`, `whereis_name/1`, `all_registered/0`.
- **`spawnAs/2,3`**: thin delegate over `gen_server:start_link({local, Name}, Module, Args, [])` that enforces reserved-name policy and atom type-checks *before* spawning the process.
- **Reserved-name policy**: static blocklist of OTP kernel / stdlib names (observed via `erlang:registered/0` on current OTP) plus any atom prefixed `beamtalk_`.
- **Structured errors**: all register/spawn paths return `{ok, ...} | {error, #beamtalk_error{}}` with `kind` ∈ `{name_registered, type_error, reserved_name}` — ready for translation to `Result error: ...` at the stdlib boundary per ADR 0060/0076.

## Test plan

- [x] EUnit: success path for register/unregister/whereis/spawnAs
- [x] EUnit: duplicate registration → `name_registered`
- [x] EUnit: reserved-name rejection (kernel names + `beamtalk_` prefix)
- [x] EUnit: type-error on non-atom / non-pid input
- [x] EUnit: `is_beamtalk_actor/1` true for actors, false for raw OTP / kernel / dead processes
- [x] EUnit: `all_registered/0` filters kernel processes, includes registered Beamtalk actors
- [x] Process-dict marker asserted on live actor
- [x] `just test` — all 209 actor tests pass
- [x] `rebar3 dialyzer` — clean
- [x] `just ci` — full CI passes

## Out of Scope

- Stdlib `Actor.bt` API (`spawnAs:`, `registerAs:`, `named:`) — Phase 2
- Proxy dispatch (`{registered, Name}` send-site recognition) — Phase 3
- Supervisor `childSpec` wiring — Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Named actor registration, lookup, enumeration, and unregistering (register_name, whereis_name, all_registered, unregister_name).
  * Actor identification API (is_beamtalk_actor) and process-marker for reliable detection.
  * Spawn-and-register helpers supporting reserved-name checks and clearer name-conflict/invalid-input errors ('spawnAs' variants).
  * Reserved-name policy blocking kernel/system and beamtalk_‑prefixed names.

* **Tests**
  * Extensive coverage for registration lifecycle, enumeration, spawn-with-name, reserved-name rules, and identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->