### PR TITLE
docs: daily refresh 2026-04-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased
+
+### Language
+
+- **`Self class` metatype return type** — class-side methods can declare `-> Self class`; resolves to the receiver's metaclass at call sites so `self class` narrows correctly through subclasses ([BT-1952](https://linear.app/beamtalk/issue/BT-1952))
+- **Auto-chained actor `initialize`** — `Actor` subclasses inherit parent `initialize` methods automatically; the hierarchy is walked parent-first before the child's own `initialize` runs. State threads through so each child sees the parent's mutations. Writing an explicit `super initialize` is now a compiler warning ([ADR 0078](docs/ADR/0078-actor-initialize-inheritance.md); [BT-1951](https://linear.app/beamtalk/issue/BT-1951), [BT-1955](https://linear.app/beamtalk/issue/BT-1955))
+- **Post-initialize field check spans the full hierarchy** — typed-no-default `state:` fields declared on any ancestor (including cross-file parents) are validated after `initialize` runs; the diagnostic names the owning class ([BT-1951](https://linear.app/beamtalk/issue/BT-1951), [BT-1976](https://linear.app/beamtalk/issue/BT-1976))
+
+### Standard Library
+
+- **Actor named registration** — new sealed API on `Actor`: class-side `spawnAs:`, `spawnWith:as:`, `named:`, `allRegistered`; instance-side `registerAs:`, `unregister`, `registeredName`, `isRegistered`. `named:` returns `Result(Self, Error)` so subclass lookups narrow (`Counter named: #c` → `Result(Counter, Error)`). See [ADR 0079](docs/ADR/0079-named-actor-registration.md) ([BT-1988](https://linear.app/beamtalk/issue/BT-1988))
+- **`SupervisionSpec withName:` combinators** — new `name :: Symbol | Nil` field plus `withName:`, `withName:withRestart:`, `withName:withArgs:`, and `withName:withRestart:withArgs:` fluent builders; named specs emit `#spawnAs:` / `#spawnWith:as:` startFns so supervised actors re-register atomically on each restart. `name` and `classMethod` are mutually exclusive ([BT-1989](https://linear.app/beamtalk/issue/BT-1989))
+- **`Beamtalk allClasses` returns class objects** — previously returned Symbol class names; now returns the class objects directly so callers can send messages (`superclass`, `methods`, `respondsTo:`) without a `classNamed:` lookup ([BT-1953](https://linear.app/beamtalk/issue/BT-1953))
+
+### Compiler
+
+- **`Self` substitutes inside generic return types** — `-> Result(Self, Error)` and similar nested positions now narrow to the static receiver class; previously left as a bogus `Known("Self")` ([BT-1986](https://linear.app/beamtalk/issue/BT-1986))
+- **Warning: redundant `super initialize` in Actor `initialize`** — paired with auto-chaining; emitted only for unary `super initialize` sends inside Actor `initialize` methods (including nested in blocks and cascades) ([BT-1955](https://linear.app/beamtalk/issue/BT-1955))
+
+### Runtime
+
+- **Named-registration intrinsics** — `beamtalk_actor:spawnAs/2,3`, `registerAs/2`, `unregister/1`, `registeredName/1`, `isRegistered/1`, `named/2`, `allRegistered/1` FFI shims; compiled actors write a `'$beamtalk_actor' => ClassName` process-dictionary marker in `init/1` so `Actor allRegistered` can distinguish Beamtalk actors from plain Erlang-registered processes ([BT-1987](https://linear.app/beamtalk/issue/BT-1987))
+- **Name-resolving proxy dispatch** — `#beamtalk_object{}` carries `{registered, Name}` alongside raw pids; sends route via `gen_server:call(Name, ...)` so held references survive supervisor restarts. Supervisor child specs translate `#spawnAs:` / `#spawnWith:as:` into `beamtalk_actor:spawnAs` MFAs so restarts re-register atomically. Sends to a vanished name raise `#beamtalk_error{kind = no_such_process}` (distinct from the `actor_dead` raised for stale pids) ([BT-1990](https://linear.app/beamtalk/issue/BT-1990))
+
+### Documentation
+
+- [ADR 0079: Named Actor Registration](docs/ADR/0079-named-actor-registration.md) ([#2010](https://github.com/jamesc/beamtalk/pull/2010))
+
+### Internal
+
+- Test-coverage ramp-up: `beamtalk_actor`, `beamtalk_supervisor`, `beamtalk_behaviour_intrinsics`, `beamtalk_primitive`, `beamtalk_message_dispatch`, `beamtalk_dispatch`, `beamtalk_class_dispatch`, `beamtalk_class_builder`, `beamtalk_file`, `beamtalk_json`, `beamtalk_json_formatter`, `beamtalk_hot_reload`, `beamtalk_class_instantiation`, `beamtalk_stream`, `beamtalk_future`, `beamtalk_module_activation`, `beamtalk_logging_config`, class/protocol registry, object ops, reflection, native docs, file/JSON/stdlib/collection paths, and the actor system supervisor (85%+, several at 90%) ([BT-1958](https://linear.app/beamtalk/issue/BT-1958)–[BT-1984](https://linear.app/beamtalk/issue/BT-1984))
+- E2E test for auto-chained actor initialization ([BT-1956](https://linear.app/beamtalk/issue/BT-1956))
+- Suppress expected crash reports in `safe_spawn` and `gen_server` error tests ([#2005](https://github.com/jamesc/beamtalk/pull/2005), [#2009](https://github.com/jamesc/beamtalk/pull/2009))
+- Bump `actions/github-script` from 8 to 9 ([#1987](https://github.com/jamesc/beamtalk/pull/1987))
+
 ## 0.3.1 — 2026-03-26
 
 ### Language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@
 
 ### Runtime
 
-- **Named-registration intrinsics and supervisor wiring** — `beamtalk_actor:spawnAs/2,3`, `registerAs/2`, `unregister/1`, `named/2`, `allRegistered/1`, name-resolving `{registered, Name}` proxy dispatch, and supervisor routing of `SupervisionSpec withName:` through `beamtalk_actor:spawnAs/2,3` so supervised restarts re-register atomically (BT-1987, BT-1988, BT-1990).
+- **Named-registration intrinsics and supervisor wiring** — `beamtalk_actor:'spawnAs'/2,3`, `registerAs/2`, `unregister/1`, `named/2`, `allRegistered/1`, name-resolving `{registered, Name}` proxy dispatch, and supervisor routing of `SupervisionSpec withName:` through `beamtalk_actor:'spawnAs'/2,3` so supervised restarts re-register atomically (BT-1987, BT-1988, BT-1990).
 - Reserved-name blocklist at registration time for OTP kernel/stdlib atoms and the `beamtalk_` prefix; returns `Result error: (beamtalk_error reserved_name)`.
-- Fix `spawnAs/2` defaulting to `[]` instead of `#{}`, which crashed supervised named children in `init/1` with `{badmap, []}` (BT-1991).
+- Fix `'spawnAs'/2` defaulting to `[]` instead of `#{}`, which crashed supervised named children in `init/1` with `{badmap, []}` (BT-1991).
 - Fix REPL JSON formatter crashing when displaying a name-resolving proxy: `#beamtalk_object{pid = {registered, Name}}` now renders as `#Actor<Class,registered,Name>` instead of calling `pid_to_list/1` on a non-pid term (BT-1991).
 
 ### Documentation

--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -53,6 +53,37 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-100",
+      "title": "Type annotations on extensions (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "async",
+        "beamtalk-language-features",
+        "branch",
+        "concurrent",
+        "conditional",
+        "gen_server",
+        "genserver",
+        "if",
+        "if not",
+        "negation",
+        "process",
+        "unless"
+      ],
+      "source": "// Standard return type syntax (same as inside a class)\nString >> reversed -> String => self reverse\n\n// Extension-style: `:: ->` separates selector from return type\nInteger >> factorial :: -> Integer =>\n  self <= 1\n    ifTrue: [1]\n    ifFalse: [self * (self - 1) factorial]\n\nString >> words :: -> Array => self split: \" \"\n\n// Typed parameters with :: -> return type\nMap >> at: key :: String put: value :: Integer :: -> Map => // ...",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-101",
+      "title": "Beamtalk — System reflection (BeamtalkInterface) (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features"
+      ],
+      "source": "Beamtalk version\n// => \"0.3.1\"\n\nBeamtalk allClasses includes: Integer\n// => true\n\nBeamtalk classNamed: #Counter\n// => Counter (or nil if not loaded)\n\n(Beamtalk globals) at: #Integer\n// => Integer\n\n(Beamtalk help: Integer)\n// => \"== Integer < Number ==\\n...\"\n\n(Beamtalk help: Integer selector: #+)\n// => \"Integer >> +\\n...\"",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-102",
       "title": "Workspace — Project operations (WorkspaceInterface) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -67,7 +98,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-101",
+      "id": "docs-beamtalk-language-features-block-103",
       "title": "Class-based reload via Behaviour >> reload (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -80,7 +111,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-102",
+      "id": "docs-beamtalk-language-features-block-104",
       "title": "Tracing Lifecycle (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -90,7 +121,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-103",
+      "id": "docs-beamtalk-language-features-block-105",
       "title": "Aggregate Stats (Always-On) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -105,7 +136,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-104",
+      "id": "docs-beamtalk-language-features-block-106",
       "title": "Trace Event Queries (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -123,7 +154,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-105",
+      "id": "docs-beamtalk-language-features-block-107",
       "title": "Analysis Methods (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -138,7 +169,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-106",
+      "id": "docs-beamtalk-language-features-block-108",
       "title": "Live Health (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -153,7 +184,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-107",
+      "id": "docs-beamtalk-language-features-block-109",
       "title": "Configuration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -163,7 +194,22 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-108",
+      "id": "docs-beamtalk-language-features-block-11",
+      "title": "Value equality (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "assign",
+        "assignment",
+        "beamtalk-language-features",
+        "mutate",
+        "mutation",
+        "set"
+      ],
+      "source": "p1 := Point x: 3 y: 4\np2 := Point x: 3 y: 4\np1 == p2    // => true\n\np3 := Point x: 9 y: 9\np1 == p3    // => false\n\n// with*: result equals a freshly constructed object\n(p1 withX: 10) == (Point x: 10 y: 4)   // => true",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-110",
       "title": "Typical Workflow (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -183,22 +229,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-11",
-      "title": "Value equality (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "assign",
-        "assignment",
-        "beamtalk-language-features",
-        "mutate",
-        "mutation",
-        "set"
-      ],
-      "source": "p1 := Point x: 3 y: 4\np2 := Point x: 3 y: 4\np1 == p2    // => true\n\np3 := Point x: 9 y: 9\np1 == p3    // => false\n\n// with*: result equals a freshly constructed object\n(p1 withX: 10) == (Point x: 10 y: 4)   // => true",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-111",
+      "id": "docs-beamtalk-language-features-block-113",
       "title": "Protected stdlib class names (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -219,7 +250,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-112",
+      "id": "docs-beamtalk-language-features-block-114",
       "title": "Protected stdlib class names (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -240,7 +271,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-117",
+      "id": "docs-beamtalk-language-features-block-119",
       "title": "Binary — Byte-Level Data (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -258,46 +289,6 @@
         "where"
       ],
       "source": "// Construction\nbin := Binary fromBytes: #(104, 101, 108, 108, 111)\nbin := Binary fromIolist: #(\"hello\", \" \", \"world\")\n\n// Byte access (1-based, Collection protocol)\nbin := Binary fromBytes: #(104, 101, 108)\nbin at: 1                    // => \"h\" (grapheme — runtime dispatches via String)\nbin size                     // => 3\n\n// Byte access (0-based, Erlang-compatible)\nbin byteAt: 0                // => 104 (byte value)\nbin byteSize                 // => 3 (byte count)\n\n// Zero-copy slicing\nbin := Binary fromBytes: #(1, 2, 3, 4, 5)\nbin part: 1 size: 3          // => Binary (bytes 2, 3, 4)\n\n// Concatenation\na := Binary fromBytes: #(1, 2)\nb := Binary fromBytes: #(3, 4)\na concat: b                  // => Binary (1, 2, 3, 4)\n\n// Byte list conversion\nbin toBytes                   // => #(1, 2, 3, 4, 5)\nBinary fromBytes: #(65, 66)  // => Binary\n\n// UTF-8 decoding (Binary → String)\n(Binary fromBytes: #(104, 101, 108, 108, 111)) asString           // => \"hello\"\n(Binary fromBytes: #(104, 101, 108, 108, 111)) asStringUnchecked  // => \"hello\"\n\n// Serialization (class methods)\netf := Binary serialize: #(1, 2, 3)\nBinary deserialize: etf               // => #(1, 2, 3)\nBinary deserializeWithUsed: etf       // => #(value, bytesConsumed)\n\n// Collection protocol — Binary is a collection of bytes\nbin := Binary fromBytes: #(65, 66, 67, 68, 69)\nbin collect: [:ch | ch]       // => \"ABCDE\" (via String species)\nbin select: [:ch | ch /= \"C\"]  // => \"ABDE\"\nbin includes: \"B\"             // => true\nbin isEmpty                   // => false",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-118",
-      "title": "Interval — Arithmetic Sequences (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features",
-        "filter",
-        "filtering",
-        "map",
-        "mapping",
-        "transform",
-        "where"
-      ],
-      "source": "1 to: 10                    // => (1 to: 10) — 10 elements: 1, 2, ..., 10\n1 to: 10 by: 2             // => (1 to: 10 by: 2) — 5 elements: 1, 3, 5, 7, 9\n10 to: 1 by: -1            // => (10 to: 1 by: -1) — 10 elements: 10, 9, ..., 1\n\n(1 to: 10) size            // => 10\n(1 to: 10) first           // => 1\n(1 to: 10) last            // => 10\n(1 to: 10) includes: 5     // => true\n\n// Interval supports the full Collection protocol:\n(1 to: 5) inject: 0 into: [:sum :x | sum + x]   // => 15\n(1 to: 10) select: [:x | x isEven]              // => #(2, 4, 6, 8, 10)\n(1 to: 5) collect: [:x | x * x]                 // => #(1, 4, 9, 16, 25)",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-119",
-      "title": "Bag — Multisets (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "assign",
-        "assignment",
-        "beamtalk-language-features",
-        "constructor",
-        "create",
-        "for each",
-        "for-each",
-        "forEach",
-        "instantiate",
-        "iterate",
-        "iteration",
-        "loop",
-        "mutate",
-        "mutation",
-        "set"
-      ],
-      "source": "Bag new class                           // => Bag\n(Bag new add: 1) occurrencesOf: 1      // => 1\n\nb := Bag withAll: #(1, 2, 1, 3, 1)\nb size                                  // => 5 (total occurrences)\nb occurrencesOf: 1                      // => 3\nb includes: 2                           // => true\nb includes: 9                           // => false\n\n// Bag mutating operations return new Bags:\nb2 := b add: 2                         // one more occurrence of 2\nb2 occurrencesOf: 2                    // => 2\nb3 := b add: 4 withCount: 5           // add 5 occurrences of 4\nb4 := b remove: 1                      // remove one occurrence of 1\nb4 occurrencesOf: 1                    // => 2\n\n// do: iterates each element once per occurrence:\n(Bag withAll: #(1, 1, 2)) inject: 0 into: [:sum :x | sum + x]  // => 4",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -327,6 +318,46 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-120",
+      "title": "Interval — Arithmetic Sequences (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features",
+        "filter",
+        "filtering",
+        "map",
+        "mapping",
+        "transform",
+        "where"
+      ],
+      "source": "1 to: 10                    // => (1 to: 10) — 10 elements: 1, 2, ..., 10\n1 to: 10 by: 2             // => (1 to: 10 by: 2) — 5 elements: 1, 3, 5, 7, 9\n10 to: 1 by: -1            // => (10 to: 1 by: -1) — 10 elements: 10, 9, ..., 1\n\n(1 to: 10) size            // => 10\n(1 to: 10) first           // => 1\n(1 to: 10) last            // => 10\n(1 to: 10) includes: 5     // => true\n\n// Interval supports the full Collection protocol:\n(1 to: 5) inject: 0 into: [:sum :x | sum + x]   // => 15\n(1 to: 10) select: [:x | x isEven]              // => #(2, 4, 6, 8, 10)\n(1 to: 5) collect: [:x | x * x]                 // => #(1, 4, 9, 16, 25)",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-121",
+      "title": "Bag — Multisets (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "assign",
+        "assignment",
+        "beamtalk-language-features",
+        "constructor",
+        "create",
+        "for each",
+        "for-each",
+        "forEach",
+        "instantiate",
+        "iterate",
+        "iteration",
+        "loop",
+        "mutate",
+        "mutation",
+        "set"
+      ],
+      "source": "Bag new class                           // => Bag\n(Bag new add: 1) occurrencesOf: 1      // => 1\n\nb := Bag withAll: #(1, 2, 1, 3, 1)\nb size                                  // => 5 (total occurrences)\nb occurrencesOf: 1                      // => 3\nb includes: 2                           // => true\nb includes: 9                           // => false\n\n// Bag mutating operations return new Bags:\nb2 := b add: 2                         // one more occurrence of 2\nb2 occurrencesOf: 2                    // => 2\nb3 := b add: 4 withCount: 5           // add 5 occurrences of 4\nb4 := b remove: 1                      // remove one occurrence of 1\nb4 occurrencesOf: 1                    // => 2\n\n// do: iterates each element once per occurrence:\n(Bag withAll: #(1, 1, 2)) inject: 0 into: [:sum :x | sum + x]  // => 4",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-122",
       "title": "Constructors (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -345,7 +376,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-121",
+      "id": "docs-beamtalk-language-features-block-123",
       "title": "Lazy Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -366,7 +397,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-122",
+      "id": "docs-beamtalk-language-features-block-124",
       "title": "Terminal Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -379,7 +410,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-123",
+      "id": "docs-beamtalk-language-features-block-125",
       "title": "printString — Pipeline Inspection (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -395,7 +426,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-124",
+      "id": "docs-beamtalk-language-features-block-126",
       "title": "Eager vs Lazy — The Boundary (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -408,7 +439,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-125",
+      "id": "docs-beamtalk-language-features-block-127",
       "title": "File Streaming (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -427,7 +458,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-126",
+      "id": "docs-beamtalk-language-features-block-128",
       "title": "File I/O and Directory Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -437,7 +468,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-127",
+      "id": "docs-beamtalk-language-features-block-129",
       "title": "Side-Effect Timing ⚠️ (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -452,31 +483,6 @@
         "transform"
       ],
       "source": "// This prints NOTHING — the pipeline is just a recipe\ns := (Stream on: #(1, 2, 3)) collect: [:n | Transcript show: n. n * 2]\n\n// This is when printing actually happens\ns asList\n// Transcript shows: 1, 2, 3\n// => [2,4,6]",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-128",
-      "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "assign",
-        "assignment",
-        "beamtalk-language-features",
-        "mutate",
-        "mutation",
-        "set"
-      ],
-      "source": "@expect dnu\nsomeObject unknownMessage   // DNU hint suppressed\n\n@expect type\n42 + \"hello\"                // type warning suppressed\n\n@expect type\n42 unknownMethod            // also suppresses method-not-found (DNU) hints\n\n@expect unused\nx := computeSomething       // unused-variable warning suppressed\n\n@expect all\nanything                    // any diagnostic suppressed (discouraged — use a specific category)",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-129",
-      "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features"
-      ],
-      "source": "// Result.unwrap returns Object — the type system cannot verify 'size' exists\n@expect type\nself assert: someResult unwrap size equals: 10",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -499,6 +505,31 @@
       "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
+        "assign",
+        "assignment",
+        "beamtalk-language-features",
+        "mutate",
+        "mutation",
+        "set"
+      ],
+      "source": "@expect dnu\nsomeObject unknownMessage   // DNU hint suppressed\n\n@expect type\n42 + \"hello\"                // type warning suppressed\n\n@expect type\n42 unknownMethod            // also suppresses method-not-found (DNU) hints\n\n@expect unused\nx := computeSomething       // unused-variable warning suppressed\n\n@expect all\nanything                    // any diagnostic suppressed (discouraged — use a specific category)",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-131",
+      "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features"
+      ],
+      "source": "// Result.unwrap returns Object — the type system cannot verify 'size' exists\n@expect type\nself assert: someResult unwrap size equals: 10",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-132",
+      "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
         "Collection",
         "Object",
         "beamtalk-language-features",
@@ -513,7 +544,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-133",
+      "id": "docs-beamtalk-language-features-block-135",
       "title": "Creating a Table (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -536,7 +567,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-134",
+      "id": "docs-beamtalk-language-features-block-136",
       "title": "Reading and Writing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -546,7 +577,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-135",
+      "id": "docs-beamtalk-language-features-block-137",
       "title": "Other Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -556,7 +587,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-136",
+      "id": "docs-beamtalk-language-features-block-138",
       "title": "Cross-Actor Sharing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -579,7 +610,17 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-138",
+      "id": "docs-beamtalk-language-features-block-14",
+      "title": "Message Sends (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features"
+      ],
+      "source": "// Unary message\ncounter increment\n\n// Binary message (standard math precedence: 2 + 3 * 4 = 14)\n2 + 3 * 4\n\n// Keyword message\ndict at: #name put: \"hello\"\n\n// Cascade - multiple messages to same receiver\nTranscript show: \"Hello\"; cr; show: \"World\"",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-140",
       "title": "Enqueueing and Dequeueing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -594,7 +635,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-139",
+      "id": "docs-beamtalk-language-features-block-141",
       "title": "Other Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -604,17 +645,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-14",
-      "title": "Message Sends (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features"
-      ],
-      "source": "// Unary message\ncounter increment\n\n// Binary message (standard math precedence: 2 + 3 * 4 = 14)\n2 + 3 * 4\n\n// Keyword message\ndict at: #name put: \"hello\"\n\n// Cascade - multiple messages to same receiver\nTranscript show: \"Hello\"; cr; show: \"World\"",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-141",
+      "id": "docs-beamtalk-language-features-block-143",
       "title": "Atomic Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -627,7 +658,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-142",
+      "id": "docs-beamtalk-language-features-block-144",
       "title": "Cross-Actor Sharing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -650,7 +681,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-143",
+      "id": "docs-beamtalk-language-features-block-145",
       "title": "TestCase — BUnit Testing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -673,7 +704,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-144",
+      "id": "docs-beamtalk-language-features-block-146",
       "title": "TestCase — BUnit Testing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -696,7 +727,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-145",
+      "id": "docs-beamtalk-language-features-block-147",
       "title": "Suite-Level Setup — setUpOnce / tearDownOnce (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -727,7 +758,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-146",
+      "id": "docs-beamtalk-language-features-block-148",
       "title": "Parallel Test Execution (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1815,7 +1846,28 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-85",
+      "id": "docs-beamtalk-language-features-block-84",
+      "title": "SupervisionSpec — Per-Child Overrides (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "Supervisor",
+        "WebApp",
+        "beamtalk-language-features",
+        "children",
+        "extends",
+        "fault tolerance",
+        "inherit",
+        "inheritance",
+        "object",
+        "restart",
+        "subclassing",
+        "supervision"
+      ],
+      "source": "Supervisor subclass: WebApp\n  class children =>\n    #((Counter supervisionSpec withName: #counter withRestart: #permanent))",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-86",
       "title": "Dynamic Supervisor (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1838,7 +1890,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-87",
+      "id": "docs-beamtalk-language-features-block-88",
       "title": "Nested Supervisors (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1857,6 +1909,47 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-89",
+      "title": "Actor Named Registration (ADR 0079) (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "assign",
+        "assignment",
+        "async",
+        "beamtalk-language-features",
+        "concurrent",
+        "exception",
+        "gen_server",
+        "genserver",
+        "mutate",
+        "mutation",
+        "process",
+        "raise",
+        "set",
+        "throw"
+      ],
+      "source": "// Atomic spawn + register — prefer this when the name is known up front\nc := (Counter spawnAs: #counter) unwrap\nc := (Counter spawnWith: #{#count => 10} as: #counter) unwrap\n\n// Register an already-spawned actor (not atomic w.r.t. spawn)\n(counter registerAs: #counter) onSuccess: [:c | c increment]\n\n// Typed lookup — Result(Self, Error), so `Counter named:` narrows to Counter\nengine := (WorkflowEngine named: #engine) unwrap\n(Logger named: #counter)   // => Result error: (beamtalk_error wrong_class)\n\n// Instance queries\ncounter registeredName    // => #counter  (or nil if unnamed)\ncounter isRegistered      // => true\n\n// Idempotent release\ncounter unregister        // => #ok\n\n// Discover all currently-registered Beamtalk actors\nActor allRegistered       // => #(an Actor(Counter), an Actor(Logger))",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-9",
+      "title": "with*: functional setters (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "assign",
+        "assignment",
+        "beamtalk-language-features",
+        "constructor",
+        "create",
+        "instantiate",
+        "mutate",
+        "mutation",
+        "set"
+      ],
+      "source": "p  := Point x: 1 y: 2\np2 := p withX: 10       // new object: x=10, y=2\np  x                     // => 1   (original unchanged)\np2 x                     // => 10\np2 y                     // => 2\n\n// Chaining\np3 := (Point new withX: 5) withY: 7   // x=5, y=7",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-91",
       "title": "Before named registration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1884,25 +1977,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-9",
-      "title": "with*: functional setters (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "assign",
-        "assignment",
-        "beamtalk-language-features",
-        "constructor",
-        "create",
-        "instantiate",
-        "mutate",
-        "mutation",
-        "set"
-      ],
-      "source": "p  := Point x: 1 y: 2\np2 := p withX: 10       // new object: x=10, y=2\np  x                     // => 1   (original unchanged)\np2 x                     // => 10\np2 y                     // => 2\n\n// Chaining\np3 := (Point new withX: 5) withY: 7   // x=5, y=7",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-90",
+      "id": "docs-beamtalk-language-features-block-92",
       "title": "After named registration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1924,7 +1999,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-91",
+      "id": "docs-beamtalk-language-features-block-93",
       "title": "Proxy Semantics (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1945,7 +2020,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-92",
+      "id": "docs-beamtalk-language-features-block-94",
       "title": "Match Expression (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1958,7 +2033,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-93",
+      "id": "docs-beamtalk-language-features-block-95",
       "title": "Match Expression (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1971,7 +2046,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-94",
+      "id": "docs-beamtalk-language-features-block-96",
       "title": "Destructuring in Match Arms (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1986,7 +2061,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-95",
+      "id": "docs-beamtalk-language-features-block-97",
       "title": "Rest Patterns in Destructuring (BT-1251) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2001,7 +2076,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-96",
+      "id": "docs-beamtalk-language-features-block-98",
       "title": "Live Patching (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2037,7 +2112,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-97",
+      "id": "docs-beamtalk-language-features-block-99",
       "title": "Extension Methods (Open Classes) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2048,37 +2123,6 @@
         "string join"
       ],
       "source": "// Instance method\nString >> shout => self uppercase ++ \"!\"\n\n// Class-side method\nString class >> fromJson: s => // ...parse JSON string\n\n// Keyword method with typed parameter\nArray >> chunksOf: n :: Integer => // ...split into n-sized chunks\n\n// Binary method\nPoint >> + other :: Point => Point x: self x + other x y: self y + other y",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-98",
-      "title": "Type annotations on extensions (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "async",
-        "beamtalk-language-features",
-        "branch",
-        "concurrent",
-        "conditional",
-        "gen_server",
-        "genserver",
-        "if",
-        "if not",
-        "negation",
-        "process",
-        "unless"
-      ],
-      "source": "// Standard return type syntax (same as inside a class)\nString >> reversed -> String => self reverse\n\n// Extension-style: `:: ->` separates selector from return type\nInteger >> factorial :: -> Integer =>\n  self <= 1\n    ifTrue: [1]\n    ifFalse: [self * (self - 1) factorial]\n\nString >> words :: -> Array => self split: \" \"\n\n// Typed parameters with :: -> return type\nMap >> at: key :: String put: value :: Integer :: -> Map => // ...",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-99",
-      "title": "Beamtalk — System reflection (BeamtalkInterface) (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features"
-      ],
-      "source": "Beamtalk version\n// => \"0.3.1\"\n\nBeamtalk allClasses includes: Integer\n// => true\n\nBeamtalk classNamed: #Counter\n// => Counter (or nil if not loaded)\n\n(Beamtalk globals) at: #Integer\n// => Integer\n\n(Beamtalk help: Integer)\n// => \"== Integer < Number ==\\n...\"\n\n(Beamtalk help: Integer selector: #+)\n// => \"Integer >> +\\n...\"",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -1801,7 +1801,7 @@ Use `withShutdown:` to set a graceful shutdown timeout (in milliseconds) for chi
 HttpServer supervisionSpec withShutdown: 30000   // 30s graceful shutdown
 ```
 
-Use `withName:` (and the `withName:withRestart:` / `withName:withArgs:` / `withName:withRestart:withArgs:` combinators) to have the supervisor register the child atomically under a Symbol name on each restart. Named specs emit a `#spawnAs:` / `#spawnWith:as:` startFn so re-registration happens in the same OTP call that starts the process — held `Actor named:` references survive restarts (see [ADR 0079](ADR/0078-actor-initialize-inheritance.md) and the Actor Named Registration section below). `name` and `classMethod` cannot be combined on the same spec.
+Use `withName:` (and the `withName:withRestart:` / `withName:withArgs:` / `withName:withRestart:withArgs:` combinators) to have the supervisor register the child atomically under a Symbol name on each restart. Named specs emit a `#spawnAs:` / `#spawnWith:as:` startFn so re-registration happens in the same OTP call that starts the process — held `Actor named:` references survive restarts (see [ADR 0079](ADR/0079-named-actor-registration.md) and the Actor Named Registration section below). `name` and `classMethod` cannot be combined on the same spec.
 
 ```beamtalk
 Supervisor subclass: WebApp
@@ -1869,7 +1869,7 @@ root which: DatabaseSupervisor      // => #Supervisor<DatabaseSupervisor,_>
 
 ### Actor Named Registration (ADR 0079)
 
-Actors can be registered under a Symbol name so they can be looked up without passing a reference around, and so supervised restarts stay addressable. Named lookups are **class-checked** — `Counter named: #c` only returns the registered process if it is a `Counter` (or subclass).
+Actors can be registered under a Symbol name so they can be looked up without passing a reference around, and so supervised restarts stay addressable. Named lookups are **class-checked** — `Counter named: #counter` only returns the registered process if it is a `Counter` (or subclass).
 
 ```beamtalk
 // Atomic spawn + register — prefer this when the name is known up front
@@ -1877,24 +1877,24 @@ c := (Counter spawnAs: #counter) unwrap
 c := (Counter spawnWith: #{#count => 10} as: #counter) unwrap
 
 // Register an already-spawned actor (not atomic w.r.t. spawn)
-(counter registerAs: #counter) onSuccess: [:c | c increment]
+(c registerAs: #counter) onSuccess: [:c | c increment]
 
 // Typed lookup — Result(Self, Error), so `Counter named:` narrows to Counter
 engine := (WorkflowEngine named: #engine) unwrap
 (Logger named: #counter)   // => Result error: (beamtalk_error wrong_class)
 
 // Instance queries
-counter registeredName    // => #counter  (or nil if unnamed)
-counter isRegistered      // => true
+c registeredName    // => #counter  (or nil if unnamed)
+c isRegistered      // => true
 
 // Idempotent release
-counter unregister        // => #ok
+c unregister        // => #ok
 
 // Discover all currently-registered Beamtalk actors
 Actor allRegistered       // => #(an Actor(Counter), an Actor(Logger))
 ```
 
-**Restart survival.** When a named actor is started under a supervisor (via `SupervisionSpec withName:`), the runtime dispatches sends through the registered name, not the snapshot pid. Held `Counter named: #c` references continue to work after a supervisor restart because the name is re-registered atomically in the restarted process's `gen_server:start_link({local, Name}, ...)` call.
+**Restart survival.** When a named actor is started under a supervisor (via `SupervisionSpec withName:`), the runtime dispatches sends through the registered name, not the snapshot pid. Held `Counter named: #counter` references continue to work after a supervisor restart because the name is re-registered atomically in the restarted process's `gen_server:start_link({local, Name}, ...)` call.
 
 Errors are surfaced as `Result` values (or raised as `#beamtalk_error{}` on direct send):
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -184,6 +184,8 @@ Actor subclass: ResourceActor
 
 Both hooks are optional — actors without them work normally.
 
+**Initialization chaining** — `initialize` methods defined on ancestors run automatically, parent-first, before the child's own `initialize`. State threads through each call so the child sees the parent's mutations. Do **not** write `super initialize` yourself — the compiler warns on redundant `super initialize` sends inside an Actor's `initialize`. After the full chain runs, any typed `state:` field without a default (on the child or any ancestor, including cross-file parents) must have been assigned, or the actor crashes with `UninitializedStateError` naming the owning class. See [ADR 0078](ADR/0078-actor-initialize-inheritance.md).
+
 ### Three Class Kinds (ADR 0067)
 
 Beamtalk has three class kinds with distinct data keywords and construction protocols:
@@ -839,6 +841,15 @@ collect: block :: Block -> Self =>
 // At call sites, Self resolves to the static receiver type:
 // (List new collect: [:each | each])  — inferred return type: List
 // (Set new collect: [:each | each])   — inferred return type: Set
+
+// Self also substitutes inside nested generic return types
+class named: name :: Symbol -> Result(Self, Error) => ...
+// (Counter named: #c) — inferred return type: Result(Counter, Error)
+
+// Self class — the receiver's metaclass (return position only)
+class -> Self class => @primitive "class"
+// (Counter new) class — inferred type: Counter's metaclass, so
+// `self class instanceCount` type-checks against class-side methods
 ```
 
 ### Current Semantics
@@ -1789,6 +1800,14 @@ Use `withShutdown:` to set a graceful shutdown timeout (in milliseconds) for chi
 HttpServer supervisionSpec withShutdown: 30000   // 30s graceful shutdown
 ```
 
+Use `withName:` (and the `withName:withRestart:` / `withName:withArgs:` / `withName:withRestart:withArgs:` combinators) to have the supervisor register the child atomically under a Symbol name on each restart. Named specs emit a `#spawnAs:` / `#spawnWith:as:` startFn so re-registration happens in the same OTP call that starts the process — held `Actor named:` references survive restarts (see [ADR 0079](ADR/0078-actor-initialize-inheritance.md) and the Actor Named Registration section below). `name` and `classMethod` cannot be combined on the same spec.
+
+```beamtalk
+Supervisor subclass: WebApp
+  class children =>
+    #((Counter supervisionSpec withName: #counter withRestart: #permanent))
+```
+
 ### Dynamic Supervisor
 
 Subclass `DynamicSupervisor` to manage pools of actors started at runtime. Override `class childClass` to declare which actor class the pool manages.
@@ -1846,6 +1865,47 @@ root which: DatabaseSupervisor      // => #Supervisor<DatabaseSupervisor,_>
 | `which: Class` | find child by module in `which_children` result |
 | `withShutdown:` | `shutdown` field in child spec (default 5000ms workers, infinity supervisors) |
 | `stop` | `gen_server:stop/1` |
+
+### Actor Named Registration (ADR 0079)
+
+Actors can be registered under a Symbol name so they can be looked up without passing a reference around, and so supervised restarts stay addressable. Named lookups are **class-checked** — `Counter named: #c` only returns the registered process if it is a `Counter` (or subclass).
+
+```beamtalk
+// Atomic spawn + register — prefer this when the name is known up front
+c := (Counter spawnAs: #counter) unwrap
+c := (Counter spawnWith: #{#count => 10} as: #counter) unwrap
+
+// Register an already-spawned actor (not atomic w.r.t. spawn)
+(counter registerAs: #counter) onSuccess: [:c | c increment]
+
+// Typed lookup — Result(Self, Error), so `Counter named:` narrows to Counter
+engine := (WorkflowEngine named: #engine) unwrap
+(Logger named: #counter)   // => Result error: (beamtalk_error wrong_class)
+
+// Instance queries
+counter registeredName    // => #counter  (or nil if unnamed)
+counter isRegistered      // => true
+
+// Idempotent release
+counter unregister        // => #ok
+
+// Discover all currently-registered Beamtalk actors
+Actor allRegistered       // => #(an Actor(Counter), an Actor(Logger))
+```
+
+**Restart survival.** When a named actor is started under a supervisor (via `SupervisionSpec withName:`), the runtime dispatches sends through the registered name, not the snapshot pid. Held `Counter named: #c` references continue to work after a supervisor restart because the name is re-registered atomically in the restarted process's `gen_server:start_link({local, Name}, ...)` call.
+
+Errors are surfaced as `Result` values (or raised as `#beamtalk_error{}` on direct send):
+
+| Kind | When |
+|------|------|
+| `name_registered` | another process is already registered under the name |
+| `name_not_registered` | `named:` lookup found nothing |
+| `wrong_class` | `named:` lookup found a process of a different class |
+| `reserved_name` | name is in the OTP kernel / stdlib blocklist |
+| `no_such_process` | send through a `{registered, Name}` proxy whose name has vanished |
+
+See [ADR 0079](ADR/0079-named-actor-registration.md) for the full design and exposure table.
 
 ---
 


### PR DESCRIPTION
## Summary

Daily documentation refresh for commits merged in the 24 hours ending 2026-04-16. Adds an `Unreleased` section to `CHANGELOG.md` and documents the new user-facing features in `docs/beamtalk-language-features.md`.

> **Branch note:** The task prompt suggested `docs/daily-refresh-2026-04-16`, but the session harness pinned this work to `claude/clever-pascal-f9TPj`. Pushed there to comply with the harness's "never push to a different branch without explicit permission" rule. Please rename/rebase if the docs-branch convention should be enforced.

## Commits reviewed (39)

### Documented — user-visible

| Commit | Area | Doc change |
|---|---|---|
| `105cc92` Runtime: name-resolving proxy dispatch + supervisor wiring (BT-1990) | Runtime | CHANGELOG Runtime; Actor Named Registration section |
| `f50c204` Stdlib: Actor.bt named-registration API (BT-1988) | Stdlib | CHANGELOG Standard Library; new Actor Named Registration section with full API example |
| `c65261d` Stdlib: SupervisionSpec withName: combinators (BT-1989) | Stdlib | CHANGELOG Standard Library; SupervisionSpec section extended |
| `1c5c650` Typechecker: Result(Self, Error) in generic position (BT-1986) | Compiler | CHANGELOG Compiler; Self-in-generic-return example in types section |
| `f28920b` Cross-file inherited typed-no-default field validation (BT-1976) | Language | CHANGELOG Language; Actor Lifecycle Hooks extended |
| `0506529` Runtime: named-registration intrinsics + spawnAs (BT-1987) | Runtime | CHANGELOG Runtime |
| `3975b98` Self class metatype (BT-1952) | Language | CHANGELOG Language; Self class example in types section |
| `2808a05` Warning for redundant super initialize (BT-1955) | Compiler | CHANGELOG Compiler; referenced in Actor Lifecycle Hooks |
| `6f0cda2` Auto-chain initialize + validate inherited fields (BT-1951) | Language | CHANGELOG Language; Actor Lifecycle Hooks extended with Initialization chaining paragraph |
| `489e857` Beamtalk allClasses returns class objects (BT-1953) | Stdlib | CHANGELOG Standard Library (docs already updated in-commit) |
| `9c9fae3` ADR 0079: Named Actor Registration | Docs | CHANGELOG Documentation |

### Skipped — internal / test-only

All "Tests: … coverage to 85%/90%" commits (`0ce55e7`, `d9f4017`, `d0ce719`, `5bec0e1`, `c4669f2`, `83ce469`, `6543c0f`, `3a3a524`, `1fdf045`, `c343afa`, `fbe72e7`, `1658363`, `484250a`, `c90712b`, `a4aee93`, `9e11d26`, `d956755`, `e602a81`, `cff40be`, `33d0e64`, `94c0d3e`, `1078891`, `1fc6bcc`, `70d1bcf`) — listed in CHANGELOG Internal as a single line with issue-range reference.

`b8c9747` E2E test for auto-chained actor init — noted in CHANGELOG Internal.

`8c3a628`, `fb816df` — crash-report suppression in tests; CHANGELOG Internal.

`fe747cd` — `actions/github-script` dep bump; CHANGELOG Internal.

### Flagged "needs human judgment"

None. Every user-visible change had a clear diff and BT issue reference, so semantics were unambiguous.

## Test plan

- [x] `git diff` reviewed; CHANGELOG and language features doc consistent with stdlib source and ADRs 0078/0079
- [ ] Human review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for Actor initialization inheritance (ancestor-first execution, threaded state visibility, compiler warnings, runtime UninitializedStateError).
  * Expanded Gradual Typing `Self` semantics, including nested-generic substitution and `Self class` meaning.
  * Documented Supervisor child naming/combinators and Actor Named Registration APIs (atomic spawn+register, lookups, discovery, errors, restart behavior).

* **Changelog**
  * Clarified named-registration intrinsic notation and corrected default-argument bugfix description.

* **Examples**
  * Added and reorganized language-reference examples covering typing, reflection, equality, messaging, and named registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->