### PR TITLE
docs: fix precedence example + split migration subsections

### DIFF
--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -610,7 +610,7 @@
       "tags": [
         "beamtalk-language-features"
       ],
-      "source": "// Unary message\ncounter increment\n\n// Binary message (standard math precedence: 2 + 3 * 4 = 14)\n3 + 4\n\n// Keyword message\ndict at: #name put: \"hello\"\n\n// Cascade - multiple messages to same receiver\nTranscript show: \"Hello\"; cr; show: \"World\"",
+      "source": "// Unary message\ncounter increment\n\n// Binary message (standard math precedence: 2 + 3 * 4 = 14)\n2 + 3 * 4\n\n// Keyword message\ndict at: #name put: \"hello\"\n\n// Cascade - multiple messages to same receiver\nTranscript show: \"Hello\"; cr; show: \"World\"",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -1857,7 +1857,7 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-89",
-      "title": "Worked Example — Migrating from Supervisor which: (beamtalk-language-features)",
+      "title": "Before named registration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
         "ExduraSupervisor",
@@ -1903,7 +1903,7 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-90",
-      "title": "Worked Example — Migrating from Supervisor which: (beamtalk-language-features)",
+      "title": "After named registration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
         "ExduraSupervisor",

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -415,7 +415,7 @@ Point superclass       // => Value
 counter increment
 
 // Binary message (standard math precedence: 2 + 3 * 4 = 14)
-3 + 4
+2 + 3 * 4
 
 // Keyword message
 dict at: #name put: "hello"
@@ -1892,7 +1892,9 @@ The asymmetry is deliberate: `named:` returns a Result because name-absence is a
 
 ### Worked Example — Migrating from `Supervisor which:`
 
-Before — the pre-ADR pattern uses a supervisor-local lookup (`which:`) and an `initialize:` hook to re-wire dependencies after each restart:
+#### Before named registration
+
+The pre-ADR pattern uses a supervisor-local lookup (`which:`) and an `initialize:` hook to re-wire dependencies after each restart:
 
 ```beamtalk
 typed Supervisor subclass: ExduraSupervisor
@@ -1912,7 +1914,9 @@ typed Supervisor subclass: ExduraSupervisor
     nil
 ```
 
-After — naming each child eliminates the `initialize:` hook, and the supervisor strategy is freed from the rewire-on-restart constraint:
+#### After named registration
+
+Naming each child eliminates the `initialize:` hook, and the supervisor strategy is freed from the rewire-on-restart constraint:
 
 ```beamtalk
 typed Supervisor subclass: ExduraSupervisor


### PR DESCRIPTION
## Summary
- Correct binary-message precedence example in `docs/beamtalk-language-features.md`: snippet now shows `2 + 3 * 4` to match its comment (previously showed `3 + 4`).
- Split the named-registration "Worked Example — Migrating from Supervisor which:" section into `#### Before named registration` / `#### After named registration` subheadings so the corpus indexes each variant under a unique title.

Follow-up to CodeRabbit nits on PR #2025 (BT-1991) that were deferred as out-of-scope at the time.

## Test plan
- [x] \`just test\` (fast tests green)
- [x] \`just build-corpus\` regenerates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated arithmetic examples to clearly demonstrate operator precedence handling
  * Reorganized migration guide with improved section structure for better clarity and comparison of registration approaches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->