### PR TITLE
docs: daily refresh 2026-04-17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,27 @@
   - `Actor allRegistered` — enumerate Beamtalk-registered actors (excludes raw OTP kernel processes via the `$beamtalk_actor` process-dict marker).
   - `SupervisionSpec withName:` — declaratively name a supervised child so the supervisor re-registers the name on every restart.
 
+### Compiler
+
+- Fix `Self` type substitution in generic return types on parameterised receivers — e.g., `Result(Self, Error)` on `Box(Integer)` now correctly resolves to `Result(Box(Integer), Error)` instead of bare `Result(Box, Error)` (BT-1992).
+
 ### Runtime
 
 - **Named-registration intrinsics and supervisor wiring** — `beamtalk_actor:'spawnAs'/2,3`, `registerAs/2`, `unregister/1`, `named/2`, `allRegistered/1`, name-resolving `{registered, Name}` proxy dispatch, and supervisor routing of `SupervisionSpec withName:` through `beamtalk_actor:'spawnAs'/2,3` so supervised restarts re-register atomically (BT-1987, BT-1988, BT-1990).
 - Reserved-name blocklist at registration time for OTP kernel/stdlib atoms and the `beamtalk_` prefix; returns `Result error: (beamtalk_error reserved_name)`.
 - Fix `'spawnAs'/2` defaulting to `[]` instead of `#{}`, which crashed supervised named children in `init/1` with `{badmap, []}` (BT-1991).
 - Fix REPL JSON formatter crashing when displaying a name-resolving proxy: `#beamtalk_object{pid = {registered, Name}}` now renders as `#Actor<Class,registered,Name>` instead of calling `pid_to_list/1` on a non-pid term (BT-1991).
+- Supervisor `startLink` returns Result-shaped values internally (`{ok, ...}` / `{error, #beamtalk_error{kind = supervisor_start_failed}}`); `class supervise` unwraps to preserve the existing user-facing `Supervisor` return type — preparatory infrastructure for [ADR 0080](docs/ADR/0080-supervisor-lifecycle-result.md) Phase 1 (BT-1994).
 
 ### Documentation
 
 - ADR 0079: Named Actor Registration.
 - Language features: new "Named Actor Registration" chapter covering the API surface, proxy semantics caveats (monitors don't re-arm across restarts; equality rules; unregister makes proxy dead), reserved-name policy, BEAM mapping, and a before/after migration example from `Supervisor which:` + `initialize:` to named registration (BT-1991).
+
+### Internal
+
+- ADR 0080: Migrate Supervisor Lifecycle to Result — proposed and accepted with Phase 0 probe outcomes (BT-1977, BT-1994, BT-1995).
+- Typechecker probe confirms class-level type parameter substitution through `Result(C, Error)` works without extension (BT-1995).
 
 ## 0.3.1 — 2026-03-26
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -847,6 +847,10 @@ collect: block :: Block -> Self =>
 class named: name :: Symbol -> Result(Self, Error) => ...
 // (Counter named: #c) — inferred return type: Result(Counter, Error)
 
+// On parameterised receivers, Self preserves type arguments:
+// (Box(Integer) new) someMethod — where someMethod -> Result(Self, Error)
+//   inferred return type: Result(Box(Integer), Error)
+
 // Self class — the receiver's metaclass (return position only)
 class -> Self class => @primitive "class"
 // (Counter new) class — inferred type: Counter's metaclass, so


### PR DESCRIPTION
## Summary

Daily documentation refresh for commits merged in the 24 hours ending 2026-04-17. 7 commits reviewed, 2 produced doc changes, 3 skipped as already-documented or doc-only, 2 excluded (ADR/test-only).

### Documented — user-visible

| Commit | Area | Doc change |
|---|---|---|
| `a1bf5bb` Typechecker: thread receiver type arguments through Self substitution (BT-1992) | Compiler | CHANGELOG Compiler; language-features Self-in-generic example for parameterised receivers |
| `a108cdb` Probe FFI coercion vs supervisor_new hook (BT-1994) | Runtime | CHANGELOG Runtime (internal Result infrastructure for ADR 0080 Phase 1) |
| `e292593` Probe Result(C, Error) typechecker substitution (BT-1995) | Internal | CHANGELOG Internal |
| `e185089` ADR 0080: Migrate Supervisor Lifecycle to Result (BT-1977) | Internal | CHANGELOG Internal |

### Skipped

| Commit | Reason |
|---|---|
| `867c7da` docs: daily refresh 2026-04-16 | Already a docs commit |
| `1280ce1` docs: fix precedence example + split migration subsections | Already a docs fix commit |
| `523a278` E2E + docs for named actor registration (BT-1991) | Self-documented — CHANGELOG and language-features updated in the commit itself |

### Flagged "needs human judgment"

None.

## Test plan

- [ ] Human review of CHANGELOG entries and language-features addition

https://claude.ai/code/session_015dTiYZWhuN6kE2yU56iXns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how `Self` type resolves when receiver types include generic type parameters, with examples showing the distinction between parameterised and non-parameterised receiver cases.

* **Chores**
  * Updated changelog with compiler, runtime, and internal changes including supervisor lifecycle behavior adjustments and type substitution improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->