### PR TITLE
Runtime: short-circuit `self class spawn*` metaclass self-call (BT-2005)

### DIFF
--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -13721,7 +13721,7 @@
         "to_string",
         "where"
       ],
-      "source": "// File streaming tests (BT-513)\n\nTestCase subclass: FileStreamTest\n\n  testFileLinesBasicReading =>\n    self assert: (File lines: \"test/fixtures/stream_test.txt\") isOk\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:h |\n        h lines asList size\n      ]) unwrap\n      equals: 3\n    self assert: (File lines: \"test/fixtures/stream_single.txt\") isOk\n    self assert: (File lines: \"test/fixtures/stream_no_trailing.txt\") isOk\n\n  testEmptyFile =>\n    // Empty file returns empty stream\n    self assert: (File lines: \"test/fixtures/stream_empty.txt\") isOk\n    self assert: (File open: \"test/fixtures/stream_empty.txt\" do: [:h |\n      h lines asList\n    ]) unwrap equals: #()\n\n  testStreamPipelineComposition =>\n    // Pipeline operations are verified through open:do: (see testFileOpenDoBlockScopedHandle)\n    self assert: (File lines: \"test/fixtures/stream_test.txt\") isOk\n\n  testFileOpenDoBlockScopedHandle =>\n    // Read lines through handle\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:handle |\n        handle lines asList\n      ]) unwrap\n      equals: #(\"line one\", \"line two\", \"line three\")\n    // Take lines through handle\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:handle |\n        handle lines take: 1\n      ]) unwrap\n      equals: #(\"line one\")\n    // Pipeline through handle\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:handle |\n        (handle lines select: [:l | l includesSubstring: \"two\"]) asList\n      ]) unwrap\n      equals: #(\"line two\")\n    // Block returns result\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:handle |\n        handle lines inject: 0 into: [:count :line | count + 1]\n      ]) unwrap\n      equals: 3\n    // Empty file through handle\n    self\n      assert: (File open: \"test/fixtures/stream_empty.txt\" do: [:handle |\n        handle lines asList\n      ]) unwrap\n      equals: #()\n\n  testLazyEvaluationConstantMemory =>\n    // Lazy take: reads only N lines from a large file; count with inject:into:\n    self\n      assert: (File open: \"test/fixtures/stream_large.txt\" do: [:h |\n        (h lines take: 3) inject: 0 into: [:count :_ | count + 1]\n      ]) unwrap\n      equals: 3\n\n  testDoSideEffects =>\n    // do: iterates all lines; verify count via inject:into:\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:h |\n        h lines inject: 0 into: [:count :line | count + 1]\n      ]) unwrap\n      equals: 3\n\n  testPrintstringStreamDescription =>\n    // Stream printString returns a non-empty description\n    stream := (File lines: \"test/fixtures/stream_test.txt\") unwrap\n    self assert: ((stream printString size) > 0)\n\n  testStreamFinalizerPartialConsumption =>\n    // Partial consumption via open:do: returns only the taken lines\n    self assert: (File open: \"test/fixtures/stream_test.txt\" do: [:h |\n      h lines take: 1\n    ]) unwrap equals: #(\"line one\")\n    self assert: (File lines: \"test/fixtures/stream_large.txt\") isOk\n\n  testErrorPaths =>\n    // File not found returns file_not_found error\n    notFound := File lines: \"test/fixtures/nonexistent.txt\"\n    self assert: notFound isError\n    self assert: (notFound error printString includesSubstring: \"file not found\")\n    // Type error: non-string path\n    @expect type\n    self should: [File lines: 42] raise: #type_error\n    // File not found with open:do:\n    self assert: (File open: \"test/fixtures/nonexistent.txt\" do: [:h |\n      h lines asList\n    ]) isError\n\n  testErrorPathsTypeErrors =>\n    // Type errors that produce compile-time warnings but still run correctly\n    @expect type\n    self should: [File open: 42 do: [:h | h lines asList]] raise: #type_error\n    self should: [\n      File open: \"test/fixtures/stream_test.txt\" do: \"not a block\"\n    ] raise: #type_error\n\n  testWindowsStyleLineEndingsRN =>\n    // Windows CRLF line endings are stripped correctly\n    self assert: (File lines: \"test/fixtures/stream_crlf.txt\") isOk\n\n  testUnicodeFileContent =>\n    // Unicode content (multi-byte UTF-8) reads correctly through streams\n    self assert: (File lines: \"test/fixtures/stream_unicode.txt\") isOk\n\n  testOpenDoConcreteReturnValueCheck =>\n    // BT-1273: File open:do: returns Result; unwrap gives the block value.\n    // BT-1576: With generic Result(T, E), unwrap returns Dynamic for\n    // unparameterized Results — no DNU hint, no @expect type needed.\n    result := (File open: \"test/fixtures/stream_test.txt\" do: [:handle |\n      handle lines asList\n    ]) unwrap\n    self assert: result size equals: 3",
+      "source": "// File streaming tests (BT-513)\n\nTestCase subclass: FileStreamTest\n\n  testFileLinesBasicReading =>\n    self assert: (File lines: \"test/fixtures/stream_test.txt\") isOk\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:h |\n        h lines asList size\n      ]) unwrap\n      equals: 3\n    self assert: (File lines: \"test/fixtures/stream_single.txt\") isOk\n    self assert: (File lines: \"test/fixtures/stream_no_trailing.txt\") isOk\n\n  testEmptyFile =>\n    // Empty file returns empty stream\n    self assert: (File lines: \"test/fixtures/stream_empty.txt\") isOk\n    self assert: (File open: \"test/fixtures/stream_empty.txt\" do: [:h |\n      h lines asList\n    ]) unwrap equals: #()\n\n  testStreamPipelineComposition =>\n    // Pipeline operations are verified through open:do: (see testFileOpenDoBlockScopedHandle)\n    self assert: (File lines: \"test/fixtures/stream_test.txt\") isOk\n\n  testFileOpenDoBlockScopedHandle =>\n    // Read lines through handle\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:handle |\n        handle lines asList\n      ]) unwrap\n      equals: #(\"line one\", \"line two\", \"line three\")\n    // Take lines through handle\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:handle |\n        handle lines take: 1\n      ]) unwrap\n      equals: #(\"line one\")\n    // Pipeline through handle\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:handle |\n        (handle lines select: [:l | l includesSubstring: \"two\"]) asList\n      ]) unwrap\n      equals: #(\"line two\")\n    // Block returns result\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:handle |\n        handle lines inject: 0 into: [:count :line | count + 1]\n      ]) unwrap\n      equals: 3\n    // Empty file through handle\n    self\n      assert: (File open: \"test/fixtures/stream_empty.txt\" do: [:handle |\n        handle lines asList\n      ]) unwrap\n      equals: #()\n\n  testLazyEvaluationConstantMemory =>\n    // Lazy take: reads only N lines from a large file; count with inject:into:\n    self\n      assert: (File open: \"test/fixtures/stream_large.txt\" do: [:h |\n        (h lines take: 3) inject: 0 into: [:count :_ | count + 1]\n      ]) unwrap\n      equals: 3\n\n  testDoSideEffects =>\n    // do: iterates all lines; verify count via inject:into:\n    self\n      assert: (File open: \"test/fixtures/stream_test.txt\" do: [:h |\n        h lines inject: 0 into: [:count :line | count + 1]\n      ]) unwrap\n      equals: 3\n\n  testPrintstringStreamDescription =>\n    // Stream printString returns a non-empty description\n    stream := (File lines: \"test/fixtures/stream_test.txt\") unwrap\n    self assert: ((stream printString size) > 0)\n\n  testStreamFinalizerPartialConsumption =>\n    // Partial consumption via open:do: returns only the taken lines\n    self assert: (File open: \"test/fixtures/stream_test.txt\" do: [:h |\n      h lines take: 1\n    ]) unwrap equals: #(\"line one\")\n    self assert: (File lines: \"test/fixtures/stream_large.txt\") isOk\n\n  testErrorPaths =>\n    // File not found returns file_not_found error\n    notFound := File lines: \"test/fixtures/nonexistent.txt\"\n    self assert: notFound isError\n    self assert: (notFound error printString includesSubstring: \"file not found\")\n    // Type error: non-string path\n    @expect type\n    self should: [File lines: 42] raise: #type_error\n    // File not found with open:do:\n    self assert: (File open: \"test/fixtures/nonexistent.txt\" do: [:h |\n      h lines asList\n    ]) isError\n\n  testErrorPathsTypeErrors =>\n    // Type errors that produce compile-time warnings but still run correctly\n    @expect type\n    self should: [File open: 42 do: [:h | h lines asList]] raise: #type_error\n    @expect type\n    self should: [\n      File open: \"test/fixtures/stream_test.txt\" do: \"not a block\"\n    ] raise: #type_error\n\n  testWindowsStyleLineEndingsRN =>\n    // Windows CRLF line endings are stripped correctly\n    self assert: (File lines: \"test/fixtures/stream_crlf.txt\") isOk\n\n  testUnicodeFileContent =>\n    // Unicode content (multi-byte UTF-8) reads correctly through streams\n    self assert: (File lines: \"test/fixtures/stream_unicode.txt\") isOk\n\n  testOpenDoConcreteReturnValueCheck =>\n    // BT-1273: File open:do: returns Result; unwrap gives the block value.\n    // BT-1576: With generic Result(T, E), unwrap returns Dynamic for\n    // unparameterized Results — no DNU hint, no @expect type needed.\n    result := (File open: \"test/fixtures/stream_test.txt\" do: [:handle |\n      handle lines asList\n    ]) unwrap\n    self assert: result size equals: 3",
       "explanation": "File streaming tests (BT-513)"
     },
     {
@@ -18246,6 +18246,37 @@
       "explanation": "BT-1420: Fixture for testing that self-call state mutations are visible to the caller after the self-call returns."
     },
     {
+      "id": "stdlib-test-fixtures-self-class-named-factory-actor",
+      "title": "SelfClassNamedFactoryActor",
+      "category": "stdlib-fixtures",
+      "tags": [
+        "Actor",
+        "SelfClassNamedFactoryActor",
+        "actor",
+        "async",
+        "concurrent",
+        "extends",
+        "field",
+        "gen_server",
+        "genserver",
+        "getValue",
+        "inherit",
+        "inheritance",
+        "instance variable",
+        "member",
+        "process",
+        "property",
+        "self_class_named_factory_actor",
+        "startViaClassAs:",
+        "startViaClassPlain",
+        "startViaClassWith:as:",
+        "startViaClassWithMap:",
+        "subclassing"
+      ],
+      "source": "// BT-2005: Test fixture — actor with class factory methods that call\n// `self class spawnAs:` / `self class spawnWith:as:` to register the spawned\n// process under a symbolic name. Before BT-2005 these forms deadlocked at\n// runtime because `self class` resolves to the same metaclass process that is\n// currently executing the class method, and the dispatch was routed through\n// `gen_server:call` to self.\n\nActor subclass: SelfClassNamedFactoryActor\n  state: value = 0\n\n  class startViaClassAs: name :: Symbol -> Result(SelfClassNamedFactoryActor, Error) =>\n    self class spawnAs: name\n\n  class startViaClassWith: initArgs :: Dictionary as: name :: Symbol -> Result(SelfClassNamedFactoryActor, Error) =>\n    self class spawnWith: initArgs as: name\n\n  class startViaClassPlain -> SelfClassNamedFactoryActor => self class spawn\n\n  class startViaClassWithMap: initArgs :: Dictionary -> SelfClassNamedFactoryActor =>\n    self class spawnWith: initArgs\n\n  getValue => self.value",
+      "explanation": "BT-2005: Test fixture — actor with class factory methods that call `self class spawnAs:` / `self class spawnWith:as:` to register the spawned process under a symbolic name. Before BT-2005 these forms deadlocked at runtime because `self class` resolves to the same metaclass process that is currently executing the class method, and the dispatch was routed through `gen_server:call` to self."
+    },
+    {
       "id": "stdlib-test-fixtures-self-ref-actor",
       "title": "SelfRefActor",
       "category": "stdlib-fixtures",
@@ -21350,6 +21381,39 @@
       ],
       "source": "// BT-403: Tests sealed class codegen — sealed actor methods are compiled to\n// direct __sealed_* calls instead of dynamic dispatch, verified by exercising\n// external calls, internal self-sends, and state persistence\n\nTestCase subclass: SealedClassTest\n\n  testSealedClassOperations =>\n    c := SealedCounter spawn\n    // Basic read: getValue (uses __sealed_getValue direct call internally)\n    self assert: c getValue equals: 0\n    // Mutation via external call: increment\n    self assert: c increment equals: 1\n    // Verify state persisted after increment\n    self assert: c getValue equals: 1\n    // Second increment\n    self assert: c increment equals: 2\n    // Decrement\n    self assert: c decrement equals: 1\n    // Parentheses needed: unary messages bind tighter than keyword messages\n    self assert: (c addAmount: 10) equals: 11\n    // Internal self-send: getValuePlusTen calls self getValue (tests __sealed_* direct call)\n    self assert: c getValuePlusTen equals: 21\n    // Final state verification\n    self assert: c getValue equals: 11",
       "explanation": "BT-403: Tests sealed class codegen — sealed actor methods are compiled to direct __sealed_* calls instead of dynamic dispatch, verified by exercising external calls, internal self-sends, and state persistence"
+    },
+    {
+      "id": "stdlib-test-self-class-spawn-test",
+      "title": "SelfClassSpawnTest",
+      "category": "stdlib-tests",
+      "tags": [
+        "SelfClassSpawnTest",
+        "TestCase",
+        "assign",
+        "assignment",
+        "async",
+        "concurrent",
+        "extends",
+        "gen_server",
+        "genserver",
+        "inherit",
+        "inheritance",
+        "mutate",
+        "mutation",
+        "object",
+        "process",
+        "self_class_spawn_test",
+        "set",
+        "subclassing",
+        "testSelfClassSpawnAsRegistersName",
+        "testSelfClassSpawnAsReservedNameReturnsError",
+        "testSelfClassSpawnPlain",
+        "testSelfClassSpawnWithAsDuplicateReturnsError",
+        "testSelfClassSpawnWithAsRegistersName",
+        "testSelfClassSpawnWithMap"
+      ],
+      "source": "// BT-2005: Regression tests for `self class spawnWith:as:` /\n// `self class spawnAs:` inside a class factory method. Before the fix, the\n// metaclass dispatch path routed through `gen_server:call` on the class\n// process, which is the *same* process executing the class method — the call\n// deadlocked with `{calling_self, gen_server:call([...])}`.\n//\n// Fixture: stdlib/test/fixtures/self_class_named_factory_actor.bt\n\nTestCase subclass: SelfClassSpawnTest\n\n  testSelfClassSpawnAsRegistersName =>\n    name := #bt2005_self_class_spawnas_success\n    result := SelfClassNamedFactoryActor startViaClassAs: name\n    self assert: result isOk\n    actor := result unwrap\n    self assert: actor registeredName equals: name\n    self assert: actor isRegistered\n    actor stop\n\n  testSelfClassSpawnWithAsRegistersName =>\n    name := #bt2005_self_class_spawnwithas_success\n    result := SelfClassNamedFactoryActor startViaClassWith: #{\n      #value => 42\n    } as: name\n    self assert: result isOk\n    actor := result unwrap\n    self assert: actor getValue equals: 42\n    self assert: actor registeredName equals: name\n    actor stop\n\n  testSelfClassSpawnWithAsDuplicateReturnsError =>\n    name := #bt2005_self_class_spawnwithas_dup\n    first := (SelfClassNamedFactoryActor startViaClassWith: #{\n      #value => 1\n    } as: name) unwrap\n    second := SelfClassNamedFactoryActor startViaClassWith: #{\n      #value => 2\n    } as: name\n    self assert: second isError\n    self assert: second error kind equals: #name_registered\n    first stop\n\n  testSelfClassSpawnAsReservedNameReturnsError =>\n    result := SelfClassNamedFactoryActor startViaClassAs: #logger\n    self assert: result isError\n    self assert: result error kind equals: #reserved_name\n\n  testSelfClassSpawnPlain =>\n    actor := SelfClassNamedFactoryActor startViaClassPlain\n    self assert: actor getValue equals: 0\n    actor stop\n\n  testSelfClassSpawnWithMap =>\n    actor := SelfClassNamedFactoryActor startViaClassWithMap: #{#value => 7}\n    self assert: actor getValue equals: 7\n    actor stop",
+      "explanation": "BT-2005: Regression tests for `self class spawnWith:as:` / `self class spawnAs:` inside a class factory method. Before the fix, the metaclass dispatch path routed through `gen_server:call` on the class process, which is the *same* process executing the class method — the call deadlocked with `{calling_self, gen_server:call([...])}`.  Fixture: stdlib/test/fixtures/self_class_named_factory_actor.bt"
     },
     {
       "id": "stdlib-test-self-reference-test",

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -196,6 +196,13 @@ The class pid is the same as the described class (virtual tag approach, ADR 0013
 Self carries `class='Metaclass'` so method dispatch receives the correct receiver.
 """.
 -spec metaclass_send(pid(), atom(), list(), #beamtalk_object{}) -> term().
+%% BT-2005: `self class <msg>` inside a class method routes here with
+%% Pid =:= self() (the class gen_server calling itself). A plain
+%% gen_server:call on the instantiation selectors would deadlock; short-circuit
+%% the spawn/new family via the process-dictionary-backed helpers used by
+%% BT-893 / BT-2004, and raise a clear error for everything else.
+metaclass_send(Pid, Selector, Args, _Self) when Pid =:= self() ->
+    handle_metaclass_self_call(Selector, Args);
 metaclass_send(Pid, Selector, Args, Self) ->
     %% BT-1768: Wrap in crash recovery, same as class_send.
     %% Update Self's pid on recovery so downstream dispatch uses the new process.
@@ -676,6 +683,77 @@ handle_self_instantiation(Type, Selector, Args) ->
             end;
         {_, _, _} ->
             %% Corrupt/invalid is_abstract metadata — fail fast with structured error.
+            handle_self_instantiation_error(Selector)
+    end.
+
+-doc """
+Handle `self class <selector>` self-calls from within a class method (BT-2005).
+
+The class gen_server cannot `gen_server:call(self(), ...)` — the metaclass
+dispatch path would deadlock. Short-circuit the spawn/new family to the same
+helpers used by BT-893 (`self new`) and BT-2004 (`self spawnAs:`), and raise a
+clear, structured error for any other selector so callers see a useful
+diagnostic rather than an opaque `calling_self` timeout.
+""".
+-spec handle_metaclass_self_call(selector(), list()) -> term().
+handle_metaclass_self_call('new', []) ->
+    handle_self_instantiation(new, 'new', []);
+handle_metaclass_self_call('new:', [Map]) ->
+    handle_self_instantiation(new, 'new:', [Map]);
+handle_metaclass_self_call(spawn, []) ->
+    handle_self_instantiation(spawn, spawn, []);
+handle_metaclass_self_call('spawnWith:', [Map]) ->
+    handle_self_instantiation(spawn, 'spawnWith:', [Map]);
+handle_metaclass_self_call('spawnAs:', [Name]) ->
+    handle_metaclass_self_named_spawn('spawnAs:', #{}, Name);
+handle_metaclass_self_call('spawnWith:as:', [InitArgs, Name]) ->
+    handle_metaclass_self_named_spawn('spawnWith:as:', InitArgs, Name);
+handle_metaclass_self_call(Selector, _Args) ->
+    ClassName =
+        case get(beamtalk_class_name) of
+            undefined -> class_name_from_pid(self());
+            CN -> CN
+        end,
+    Error0 = beamtalk_error:new(dispatch_error, ClassName, Selector),
+    Error1 = beamtalk_error:with_hint(
+        Error0,
+        iolist_to_binary(
+            io_lib:format(
+                "'self class ~ts' inside a class method of '~ts' would deadlock "
+                "(gen_server:call to self). Only spawn/new selectors can be "
+                "short-circuited from the class process. Send this message "
+                "from outside the class, or use `self ~ts` directly if the "
+                "method is defined on the instance side.",
+                [Selector, ClassName, Selector]
+            )
+        )
+    ),
+    beamtalk_error:raise(Error1).
+
+-doc """
+Perform a named spawn directly from within a class method (BT-2005 / BT-2004).
+
+Mirrors `handle_self_instantiation/3` but routes to `class_self_spawn_as` /
+`class_self_spawn_with`, which return a Beamtalk `Result` rather than raising.
+""".
+-spec handle_metaclass_self_named_spawn('spawnAs:' | 'spawnWith:as:', term(), term()) -> term().
+handle_metaclass_self_named_spawn(Selector, InitArgs, Name) ->
+    ClassName = get(beamtalk_class_name),
+    Module = get(beamtalk_class_module),
+    IsAbstract0 = get(beamtalk_class_is_abstract),
+    case {ClassName, Module, IsAbstract0} of
+        {CN, Mod, IsAbstract} when
+            is_atom(CN), is_atom(Mod), is_boolean(IsAbstract), CN =/= undefined
+        ->
+            case Selector of
+                'spawnAs:' ->
+                    beamtalk_class_instantiation:class_self_spawn_as(CN, Mod, IsAbstract, Name);
+                'spawnWith:as:' ->
+                    beamtalk_class_instantiation:class_self_spawn_with(
+                        CN, Mod, IsAbstract, InitArgs, Name
+                    )
+            end;
+        _ ->
             handle_self_instantiation_error(Selector)
     end.
 

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -743,7 +743,11 @@ handle_metaclass_self_named_spawn(Selector, InitArgs, Name) ->
     IsAbstract0 = get(beamtalk_class_is_abstract),
     case {ClassName, Module, IsAbstract0} of
         {CN, Mod, IsAbstract} when
-            is_atom(CN), is_atom(Mod), is_boolean(IsAbstract), CN =/= undefined
+            is_atom(CN),
+            is_atom(Mod),
+            is_boolean(IsAbstract),
+            CN =/= undefined,
+            Mod =/= undefined
         ->
             case Selector of
                 'spawnAs:' ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_tests.erl
@@ -1210,6 +1210,41 @@ class_send_self_instantiation_spawn_with_test() ->
         beamtalk_class_dispatch:class_send(self(), 'spawnWith:', [#{}])
     ).
 
+%% BT-2005: `self class <selector>` inside a class method routes through
+%% metaclass_send with Pid =:= self(). The previous implementation issued a
+%% `gen_server:call(self(), {metaclass_method_call, ...})` and deadlocked with
+%% `{calling_self, ...}`. The self-call branch now short-circuits spawn/new
+%% selectors to the process-dictionary-backed helpers and raises a structured
+%% dispatch_error for anything else.
+metaclass_send_self_call_spawn_missing_metadata_test() ->
+    Self = #beamtalk_object{
+        class = 'Metaclass', class_mod = undefined, pid = self()
+    },
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = instantiation_error}},
+        beamtalk_class_dispatch:metaclass_send(self(), 'spawnWith:', [#{}], Self)
+    ).
+
+metaclass_send_self_call_spawn_with_as_missing_metadata_test() ->
+    Self = #beamtalk_object{
+        class = 'Metaclass', class_mod = undefined, pid = self()
+    },
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = instantiation_error}},
+        beamtalk_class_dispatch:metaclass_send(
+            self(), 'spawnWith:as:', [#{}, anyName], Self
+        )
+    ).
+
+metaclass_send_self_call_unknown_selector_raises_dispatch_error_test() ->
+    Self = #beamtalk_object{
+        class = 'Metaclass', class_mod = undefined, pid = self()
+    },
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = dispatch_error}},
+        beamtalk_class_dispatch:metaclass_send(self(), someUserSelector, [], Self)
+    ).
+
 %% is_test_execution_selector branches — exhaustively cover each test selector.
 is_test_execution_selector_exhaustive_test() ->
     ?assert(beamtalk_class_dispatch:is_test_execution_selector(runAll)),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_tests.erl
@@ -1245,6 +1245,33 @@ metaclass_send_self_call_unknown_selector_raises_dispatch_error_test() ->
         beamtalk_class_dispatch:metaclass_send(self(), someUserSelector, [], Self)
     ).
 
+%% BT-2005 review: guard in handle_metaclass_self_named_spawn/3 must reject
+%% `Module = undefined` explicitly — `is_atom(undefined)` returns true, so a
+%% process dictionary with the name/is_abstract keys set but the module key
+%% missing would otherwise slip through into `class_self_spawn_*` and crash.
+metaclass_send_self_call_named_spawn_missing_module_metadata_test() ->
+    Self = #beamtalk_object{
+        class = 'Metaclass', class_mod = undefined, pid = self()
+    },
+    OldName = put(beamtalk_class_name, 'BT2005GuardTestClass'),
+    OldModule = erase(beamtalk_class_module),
+    OldAbs = put(beamtalk_class_is_abstract, false),
+    try
+        ?assertError(
+            #{'$beamtalk_class' := _, error := #beamtalk_error{kind = instantiation_error}},
+            beamtalk_class_dispatch:metaclass_send(
+                self(), 'spawnWith:as:', [#{}, anyName], Self
+            )
+        )
+    after
+        restore_pd_key(beamtalk_class_name, OldName),
+        restore_pd_key(beamtalk_class_module, OldModule),
+        restore_pd_key(beamtalk_class_is_abstract, OldAbs)
+    end.
+
+restore_pd_key(Key, undefined) -> erase(Key);
+restore_pd_key(Key, Value) -> put(Key, Value).
+
 %% is_test_execution_selector branches — exhaustively cover each test selector.
 is_test_execution_selector_exhaustive_test() ->
     ?assert(beamtalk_class_dispatch:is_test_execution_selector(runAll)),

--- a/stdlib/test/fixtures/self_class_named_factory_actor.bt
+++ b/stdlib/test/fixtures/self_class_named_factory_actor.bt
@@ -1,0 +1,25 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2005: Test fixture — actor with class factory methods that call
+// `self class spawnAs:` / `self class spawnWith:as:` to register the spawned
+// process under a symbolic name. Before BT-2005 these forms deadlocked at
+// runtime because `self class` resolves to the same metaclass process that is
+// currently executing the class method, and the dispatch was routed through
+// `gen_server:call` to self.
+
+Actor subclass: SelfClassNamedFactoryActor
+  state: value = 0
+
+  class startViaClassAs: name :: Symbol -> Result(SelfClassNamedFactoryActor, Error) =>
+    self class spawnAs: name
+
+  class startViaClassWith: initArgs :: Dictionary as: name :: Symbol -> Result(SelfClassNamedFactoryActor, Error) =>
+    self class spawnWith: initArgs as: name
+
+  class startViaClassPlain -> SelfClassNamedFactoryActor => self class spawn
+
+  class startViaClassWithMap: initArgs :: Dictionary -> SelfClassNamedFactoryActor =>
+    self class spawnWith: initArgs
+
+  getValue => self.value

--- a/stdlib/test/self_class_spawn_test.bt
+++ b/stdlib/test/self_class_spawn_test.bt
@@ -1,0 +1,59 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2005: Regression tests for `self class spawnWith:as:` /
+// `self class spawnAs:` inside a class factory method. Before the fix, the
+// metaclass dispatch path routed through `gen_server:call` on the class
+// process, which is the *same* process executing the class method — the call
+// deadlocked with `{calling_self, gen_server:call([...])}`.
+//
+// Fixture: stdlib/test/fixtures/self_class_named_factory_actor.bt
+
+TestCase subclass: SelfClassSpawnTest
+
+  testSelfClassSpawnAsRegistersName =>
+    name := #bt2005_self_class_spawnas_success
+    result := SelfClassNamedFactoryActor startViaClassAs: name
+    self assert: result isOk
+    actor := result unwrap
+    self assert: actor registeredName equals: name
+    self assert: actor isRegistered
+    actor stop
+
+  testSelfClassSpawnWithAsRegistersName =>
+    name := #bt2005_self_class_spawnwithas_success
+    result := SelfClassNamedFactoryActor startViaClassWith: #{
+      #value => 42
+    } as: name
+    self assert: result isOk
+    actor := result unwrap
+    self assert: actor getValue equals: 42
+    self assert: actor registeredName equals: name
+    actor stop
+
+  testSelfClassSpawnWithAsDuplicateReturnsError =>
+    name := #bt2005_self_class_spawnwithas_dup
+    first := (SelfClassNamedFactoryActor startViaClassWith: #{
+      #value => 1
+    } as: name) unwrap
+    second := SelfClassNamedFactoryActor startViaClassWith: #{
+      #value => 2
+    } as: name
+    self assert: second isError
+    self assert: second error kind equals: #name_registered
+    first stop
+
+  testSelfClassSpawnAsReservedNameReturnsError =>
+    result := SelfClassNamedFactoryActor startViaClassAs: #logger
+    self assert: result isError
+    self assert: result error kind equals: #reserved_name
+
+  testSelfClassSpawnPlain =>
+    actor := SelfClassNamedFactoryActor startViaClassPlain
+    self assert: actor getValue equals: 0
+    actor stop
+
+  testSelfClassSpawnWithMap =>
+    actor := SelfClassNamedFactoryActor startViaClassWithMap: #{#value => 7}
+    self assert: actor getValue equals: 7
+    actor stop


### PR DESCRIPTION
## Summary

- Fixes BT-2005: `self class spawnWith:X as:#name` inside a class method deadlocked at runtime with `{calling_self, gen_server:call([...])}` because the metaclass dispatch routed through `gen_server:call` on the same class process that was executing the method.
- `beamtalk_class_dispatch:metaclass_send/4` now guards the `Pid =:= self()` case and short-circuits the spawn/new family (`new`, `new:`, `spawn`, `spawnWith:`, `spawnAs:`, `spawnWith:as:`) to the process-dictionary-backed helpers used by BT-893 / BT-2004. Any other selector self-sent through the metaclass raises a structured `dispatch_error` naming the self-call problem instead of hanging.
- Adds a BUnit regression test (`stdlib/test/self_class_spawn_test.bt` + fixture) covering `self class spawnAs:`, `self class spawnWith:as:`, the reserved-name / duplicate-name error paths, and the bare `self class spawn` / `self class spawnWith:` variants, plus three EUnit tests for the missing-metadata and unknown-selector branches.

## Test plan
- [x] `just test` (1873 BUnit tests, 3474 + 1242 runtime EUnit tests passing)
- [x] `just ci` (all checks green; corpus.json regenerated and committed)
- [x] `cargo run --bin beamtalk -- test stdlib/test/self_class_spawn_test.bt` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a deadlock when spawning actors from within class-level factory methods.

* **New Features**
  * Added class-level factory methods to create and register named actor instances.
  * Added variants to spawn actors with or without initial state.

* **Tests**
  * Added tests covering named registration, duplicate-name errors, reserved-name rejection, and plain/stateful spawn behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->