### PR TITLE
Runtime: migrate startLink/1 to Result-shaped return (BT-1996)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_supervisor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_supervisor.erl
@@ -882,12 +882,15 @@ wrap_child(ChildClass, ChildModule, ChildPid) ->
 
 -doc """
 Execute Fun(), catching raw OTP process exits that indicate a stale
-supervisor handle ({noproc, _} when the process is dead) and converting
-them to a structured stale_handle error instead of letting the raw exit leak
-across the public API boundary.
+supervisor handle (the target process is dead) and converting them to a
+structured stale_handle error instead of letting the raw exit leak across
+the public API boundary.
 
-Both `supervisor:*` and `gen_server:stop` raise `exit:{noproc, MFA}` when
-the target process is not alive.
+Two distinct exit shapes are handled:
+
+* `supervisor:*` calls route through `gen_server:call`, which exits with
+  `{noproc, MFA}` (tuple) when the target process is not alive.
+* `gen_server:stop/1` exits with the bare atom `noproc` (no MFA wrapper).
 
 ADR 0080 Phase 1 (BT-1996): error kind changed from `runtime_error` to
 `stale_handle` so callers can distinguish stale-handle failures from other

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_supervisor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_supervisor.erl
@@ -883,11 +883,17 @@ wrap_child(ChildClass, ChildModule, ChildPid) ->
 -doc """
 Execute Fun(), catching raw OTP process exits that indicate a stale
 supervisor handle ({noproc, _} when the process is dead) and converting
-them to a structured runtime_error instead of letting the raw exit leak
+them to a structured stale_handle error instead of letting the raw exit leak
 across the public API boundary.
 
 Both `supervisor:*` and `gen_server:stop` raise `exit:{noproc, MFA}` when
 the target process is not alive.
+
+ADR 0080 Phase 1 (BT-1996): error kind changed from `runtime_error` to
+`stale_handle` so callers can distinguish stale-handle failures from other
+runtime errors. The error is still raised (not returned) because instance
+methods (`startChild`, `terminateChild:`, etc.) are not yet migrated to
+Result-shaped returns — that happens in Phase 2 (stdlib migration).
 """.
 -spec with_live_supervisor(atom(), atom(), fun(() -> term())) -> term().
 with_live_supervisor(ClassName, Selector, Fun) ->
@@ -903,7 +909,7 @@ with_live_supervisor(ClassName, Selector, Fun) ->
                 domain => [beamtalk, runtime]
             }),
             Error = beamtalk_error:new(
-                runtime_error,
+                stale_handle,
                 ClassName,
                 Selector,
                 <<"supervisor is not running — the handle is stale">>
@@ -917,7 +923,7 @@ with_live_supervisor(ClassName, Selector, Fun) ->
                 domain => [beamtalk, runtime]
             }),
             Error = beamtalk_error:new(
-                runtime_error,
+                stale_handle,
                 ClassName,
                 Selector,
                 <<"supervisor is not running — the handle is stale">>

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_test_helper.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_test_helper.erl
@@ -25,6 +25,8 @@ Function naming convention follows Beamtalk's `class_` prefix scheme:
     class_testRaise/2,
     'class_testTwoArgs:and:'/4,
     class_testSupervisorNew/2,
+    class_testAlreadyStarted/2,
+    class_testSupError/2,
     'class_initialize:'/3
 ]).
 
@@ -109,6 +111,41 @@ class_testSupervisorNew(_ClassSelf, _ClassVars) ->
     beamtalk_result:from_tagged_tuple(
         {ok, {beamtalk_supervisor_new, 'BT1981SupNewClass', ?MODULE, self()}}
     ).
+
+-doc """
+Zero-argument class method that returns a Result-wrapped
+`beamtalk_supervisor` tuple (the already_started / idempotent path).
+
+BT-1996 (ADR 0080 Phase 1): exercises the class_send_dispatch hook's
+pass-through behaviour for already-normalised supervisor tuples. The
+hook must NOT call run_initialize on this path — only the `_new` tag
+triggers initialization.
+""".
+-spec class_testAlreadyStarted(term(), map()) -> map().
+class_testAlreadyStarted(_ClassSelf, _ClassVars) ->
+    %% Use the ClassName from the class_send caller — it will match
+    %% whatever ClassName beamtalk_object_class was started with.
+    ClassName = get(beamtalk_class_name),
+    beamtalk_result:from_tagged_tuple(
+        {ok, {beamtalk_supervisor, ClassName, ?MODULE, self()}}
+    ).
+
+-doc """
+Zero-argument class method that returns a Result error tagged map.
+
+BT-1996 (ADR 0080 Phase 1): exercises the class_send_dispatch hook's
+pass-through behaviour for error Results. The hook must NOT call
+run_initialize on error paths.
+""".
+-spec class_testSupError(term(), map()) -> map().
+class_testSupError(_ClassSelf, _ClassVars) ->
+    BtError = beamtalk_error:new(
+        supervisor_start_failed,
+        'TestClass',
+        supervise,
+        <<"test error">>
+    ),
+    beamtalk_result:from_tagged_tuple({error, BtError}).
 
 -doc """
 Synchronous `class_initialize:` target for the supervisor-new rewrap test.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_supervisor_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_supervisor_tests.erl
@@ -18,7 +18,7 @@ Tests cover:
 - terminateChild/2 — dynamic path, stale handle, not_found error (BT-1960)
 - build_child_specs/1 with empty list
 - supervisor tuple structure
-- stale-handle error translation (noproc → beamtalk_error)
+- stale-handle error translation (noproc → beamtalk_error with stale_handle kind, BT-1996)
 - root registry — nil, roundtrip, overwrite, clear_root (BT-1960)
 - hierarchy walk — static_init/2, dynamic_init/2 via ETS (BT-1285, BT-1960)
 - hierarchy depth limit — call_inherited_class_method_direct error (BT-1960)
@@ -34,6 +34,8 @@ Tests cover:
 - wrap_child/3 supervisor and actor branches via whichChild (BT-1980)
 - build_child_specs/1 nested-supervisor OTP spec (BT-1980)
 - ensure_root_table concurrent creation safety (BT-1980)
+- stale_handle startChild/1 and /2 coverage (BT-1996)
+- class_dispatch hook: initialize: runs only on fresh start, not already_started or error (BT-1996)
 """.
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("beamtalk_runtime/include/beamtalk.hrl").
@@ -355,7 +357,7 @@ which_child_returns_nil_when_not_found_test() ->
     end.
 
 which_child_stale_handle_test() ->
-    %% BT-1960: whichChild/2 on a dead supervisor raises a structured runtime_error.
+    %% BT-1960 / BT-1996: whichChild/2 on a dead supervisor raises a structured stale_handle error.
     SupPid = start_anon_supervisor(),
     gen_server:stop(SupPid),
     timer:sleep(20),
@@ -374,7 +376,7 @@ which_child_stale_handle_test() ->
     try
         ClassArg = {beamtalk_object, 'X class', x_mod, FakeClassPid},
         ?assertError(
-            #{'$beamtalk_class' := _, error := #beamtalk_error{kind = runtime_error}},
+            #{'$beamtalk_class' := _, error := #beamtalk_error{kind = stale_handle}},
             beamtalk_supervisor:whichChild(Self, ClassArg)
         )
     after
@@ -508,14 +510,14 @@ terminate_child_not_found_dynamic_test() ->
     end.
 
 terminate_child_stale_handle_test() ->
-    %% BT-1960: terminateChild/2 on a dead supervisor raises structured runtime_error.
+    %% BT-1960 / BT-1996: terminateChild/2 on a dead supervisor raises structured stale_handle error.
     SupPid = start_anon_supervisor(),
     gen_server:stop(SupPid),
     timer:sleep(20),
     Self = make_supervisor_tuple('StaleSup4', stale_mod4, SupPid),
     ChildArg = {beamtalk_object, 'SomeActor', some_mod, self()},
     ?assertError(
-        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = runtime_error}},
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = stale_handle}},
         beamtalk_supervisor:terminateChild(Self, ChildArg)
     ).
 
@@ -549,35 +551,35 @@ supervisor_tuple_tag_test() ->
 %%====================================================================
 
 stale_handle_whichChildren_test() ->
-    %% whichChildren/1 on a dead supervisor raises a structured runtime_error.
+    %% BT-1996: whichChildren/1 on a dead supervisor raises a structured stale_handle error.
     SupPid = start_anon_supervisor(),
     gen_server:stop(SupPid),
     timer:sleep(20),
     Self = make_supervisor_tuple('StaleSup', stale_mod, SupPid),
     ?assertError(
-        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = runtime_error}},
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = stale_handle}},
         beamtalk_supervisor:whichChildren(Self)
     ).
 
 stale_handle_countChildren_test() ->
-    %% countChildren/1 on a dead supervisor raises a structured runtime_error.
+    %% BT-1996: countChildren/1 on a dead supervisor raises a structured stale_handle error.
     SupPid = start_anon_supervisor(),
     gen_server:stop(SupPid),
     timer:sleep(20),
     Self = make_supervisor_tuple('StaleSup2', stale_mod2, SupPid),
     ?assertError(
-        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = runtime_error}},
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = stale_handle}},
         beamtalk_supervisor:countChildren(Self)
     ).
 
 stale_handle_stop_test() ->
-    %% stop/1 on a dead supervisor raises a structured runtime_error.
+    %% BT-1996: stop/1 on a dead supervisor raises a structured stale_handle error.
     SupPid = start_anon_supervisor(),
     gen_server:stop(SupPid),
     timer:sleep(20),
     Self = make_supervisor_tuple('StaleSup3', stale_mod3, SupPid),
     ?assertError(
-        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = runtime_error}},
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = stale_handle}},
         beamtalk_supervisor:stop(Self)
     ).
 
@@ -1732,6 +1734,168 @@ startChild_arity1_error_raises_test() ->
 %% the root ETS table and races readers is removed because get_root/0 is not
 %% designed to handle a deleted table — ets:lookup_element raises badarg by
 %% design and the test proved flaky under CI load.
+
+%%====================================================================
+%% BT-1996 (ADR 0080 Phase 1): stale_handle error kind on startChild
+%%====================================================================
+
+stale_handle_startChild_arity1_test() ->
+    %% BT-1996: startChild/1 on a dead supervisor raises a structured stale_handle error.
+    SupPid = start_dynamic_supervisor_with_nullary_child(),
+    {ChildClassPid, ChildClassObj} = make_child_class_for_startchild('BT1996StaleChild'),
+    set_child_class(ChildClassObj),
+    gen_server:stop(SupPid),
+    timer:sleep(20),
+    try
+        Self = {beamtalk_supervisor, 'BT1996StaleSup', ?MODULE, SupPid},
+        ?assertError(
+            #{'$beamtalk_class' := _, error := #beamtalk_error{kind = stale_handle}},
+            beamtalk_supervisor:startChild(Self)
+        )
+    after
+        ChildClassPid ! stop
+    end.
+
+stale_handle_startChild_arity2_test() ->
+    %% BT-1996: startChild/2 on a dead supervisor raises a structured stale_handle error.
+    SupPid = start_dynamic_supervisor(),
+    {ChildClassPid, ChildClassObj} = make_child_class_for_startchild('BT1996StaleChild2'),
+    set_child_class(ChildClassObj),
+    gen_server:stop(SupPid),
+    timer:sleep(20),
+    try
+        Self = {beamtalk_supervisor, 'BT1996StaleSup2', ?MODULE, SupPid},
+        ?assertError(
+            #{'$beamtalk_class' := _, error := #beamtalk_error{kind = stale_handle}},
+            beamtalk_supervisor:startChild(Self, #{})
+        )
+    after
+        ChildClassPid ! stop
+    end.
+
+%%====================================================================
+%% BT-1996 (ADR 0080 Phase 1): class_dispatch hook — initialize: on
+%%   fresh start only (not on already_started or error paths)
+%%====================================================================
+
+%% These tests exercise the post-dispatch hook in
+%% beamtalk_class_dispatch:class_send_dispatch/3, verifying that
+%% run_initialize/1 runs exactly once on a fresh supervisor start and
+%% is NOT re-run on idempotent (already_started) or error paths.
+%%
+%% They use class_dispatch_test_helper's `class_testSupervisorNew`
+%% method for the fresh-start path, and hand-craft Result tagged maps
+%% for the already_started and error paths to drive through class_send.
+
+class_dispatch_hook_does_not_initialize_on_already_started_test_() ->
+    %% BT-1996: When class_send_dispatch receives a Result wrapping an
+    %% already-normalised {beamtalk_supervisor, ...} tuple (the
+    %% idempotent already_started path), it must NOT call run_initialize.
+    {setup,
+        fun() ->
+            setup_class_dispatch_runtime()
+        end,
+        fun(Ctx) ->
+            teardown_class_dispatch_runtime(Ctx)
+        end,
+        fun(_Ctx) ->
+            [
+                {"initialize: is not called on already_started path",
+                    fun test_no_initialize_on_already_started/0}
+            ]
+        end}.
+
+test_no_initialize_on_already_started() ->
+    ClassName = 'BT1996AlreadyStarted',
+    ClassInfo = #{
+        superclass => none,
+        module => beamtalk_class_dispatch_test_helper,
+        class_methods => #{testAlreadyStarted => <<>>, 'initialize:' => <<>>},
+        class_state => #{}
+    },
+    erase(bt1994_initialize_called),
+    {ok, Pid} = beamtalk_object_class:start_link(ClassName, ClassInfo),
+    try
+        Outcome = beamtalk_class_dispatch:class_send(Pid, testAlreadyStarted, []),
+        %% The Result wraps {beamtalk_supervisor, ...} (not _new), so
+        %% the hook must pass it through without calling initialize:.
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                isOk := true,
+                okValue := {beamtalk_supervisor, 'BT1996AlreadyStarted', _, _}
+            },
+            Outcome
+        ),
+        ?assertEqual(undefined, get(bt1994_initialize_called))
+    after
+        erase(bt1994_initialize_called),
+        (try
+            gen_server:stop(Pid, normal, 5000)
+        catch
+            _:_ -> ok
+        end)
+    end.
+
+class_dispatch_hook_does_not_initialize_on_error_test_() ->
+    %% BT-1996: When class_send_dispatch receives a Result error tagged
+    %% map, it must NOT call run_initialize.
+    {setup,
+        fun() ->
+            setup_class_dispatch_runtime()
+        end,
+        fun(Ctx) ->
+            teardown_class_dispatch_runtime(Ctx)
+        end,
+        fun(_Ctx) ->
+            [{"initialize: is not called on error path", fun test_no_initialize_on_error/0}]
+        end}.
+
+test_no_initialize_on_error() ->
+    ClassName = 'BT1996ErrorPath',
+    ClassInfo = #{
+        superclass => none,
+        module => beamtalk_class_dispatch_test_helper,
+        class_methods => #{testSupError => <<>>, 'initialize:' => <<>>},
+        class_state => #{}
+    },
+    erase(bt1994_initialize_called),
+    {ok, Pid} = beamtalk_object_class:start_link(ClassName, ClassInfo),
+    try
+        Outcome = beamtalk_class_dispatch:class_send(Pid, testSupError, []),
+        %% The Result wraps an error, so the hook must pass it through
+        %% without calling initialize:.
+        ?assertMatch(
+            #{
+                '$beamtalk_class' := 'Result',
+                isOk := false
+            },
+            Outcome
+        ),
+        ?assertEqual(undefined, get(bt1994_initialize_called))
+    after
+        erase(bt1994_initialize_called),
+        (try
+            gen_server:stop(Pid, normal, 5000)
+        catch
+            _:_ -> ok
+        end)
+    end.
+
+%%====================================================================
+%% BT-1996: Helpers for class_dispatch hook tests
+%%====================================================================
+
+%% Minimal runtime setup for class_dispatch tests that use beamtalk_object_class.
+%% Ensures ETS tables and registry are available.
+setup_class_dispatch_runtime() ->
+    beamtalk_class_hierarchy_table:new(),
+    beamtalk_class_module_table:new(),
+    %% Return an opaque context for teardown.
+    ok.
+
+teardown_class_dispatch_runtime(_Ctx) ->
+    ok.
 
 %%====================================================================
 %% BT-1990 / ADR 0079 Phase 3: named child specs + restart survival


### PR DESCRIPTION
## Summary

ADR 0080 Phase 1 implementation. Migrates `with_live_supervisor/3` error kind from `runtime_error` to `stale_handle` so callers can distinguish stale-handle failures from other runtime errors. Adds comprehensive EUnit tests verifying the class_dispatch initialize-hook invariant: `initialize:` runs only on fresh supervisor starts, never on already_started or error paths.

- Change `with_live_supervisor/3` error kind from `runtime_error` to `stale_handle` in both `exit:{noproc, _}` and `exit:noproc` catch clauses
- Add stale_handle tests for `startChild/1` and `startChild/2` (previously uncovered)
- Add class_dispatch hook tests verifying `initialize:` is NOT called on already_started or error Result paths
- Update 7 existing stale-handle test assertions to expect the new `stale_handle` error kind
- Add test helper methods `class_testAlreadyStarted/2` and `class_testSupError/2` to `beamtalk_class_dispatch_test_helper`

## Test plan

- [x] All 73 `beamtalk_supervisor_tests` pass (up from 69)
- [x] All 84 `beamtalk_class_dispatch_tests` pass
- [x] Full `just test` passes (stdlib, BUnit, runtime)
- [x] Full `just ci` passes (build, clippy, fmt, test, e2e)
- [x] Existing e2e supervisor tests unaffected (no stdlib changes)

Closes [BT-1996](https://linear.app/beamtalk/issue/BT-1996)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More specific handling for stale supervisor handles: invalid/stopped supervisor references now produce a distinct stale-handle error for clearer diagnostics and consistent behavior.

* **Tests**
  * Expanded test coverage for supervisor operations and startup paths, including cases where starting a supervisor yields a stale-handle error.
  * Added tests ensuring class initialization hooks are not invoked for already-started or error dispatch results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->