### PR TITLE
Accept narrowing RHS for local type annotations (BT-2015)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -478,14 +478,23 @@ impl TypeChecker {
                     // Dynamic RHS (the primary use case for annotations) is accepted silently.
                     // Never RHS (diverging expressions like `self error:`) is compatible
                     // with any declared type (bottom of the type lattice).
+                    // A narrowing assignment (declared type is a subtype of RHS type, e.g.
+                    // `Dictionary := <Object>`) is the type-erasure escape hatch the annotation
+                    // is designed for — the user is asserting the runtime type is more specific.
                     if let Some(inferred_name) = inferred_ty.display_name() {
                         if !matches!(inferred_ty, InferredType::Dynamic(_) | InferredType::Never) {
                             if let Some(declared_name) = declared.display_name() {
-                                if !Self::is_assignable_to(
+                                let rhs_assignable_to_declared = Self::is_assignable_to(
                                     &inferred_name,
                                     &declared_name,
                                     hierarchy,
-                                ) {
+                                );
+                                let declared_assignable_to_rhs = Self::is_assignable_to(
+                                    &declared_name,
+                                    &inferred_name,
+                                    hierarchy,
+                                );
+                                if !rhs_assignable_to_declared && !declared_assignable_to_rhs {
                                     self.diagnostics.push(
                                         Diagnostic::warning(
                                             format!(

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -12193,6 +12193,74 @@ fn annotated_assignment_dynamic_rhs_no_warning() {
 }
 
 #[test]
+fn annotated_assignment_narrowing_from_object_no_warning() {
+    // `x :: Dictionary := <Object>` is the primary type-erasure use case:
+    // callees like `Binary deserialize:` return Object, and the annotation is
+    // the user's explicit assertion that the runtime type is more specific.
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    let hierarchy = ClassHierarchy::with_builtins();
+
+    // Seed someVar with inferred type Object in the env
+    env.set("someVar", InferredType::known("Object"));
+
+    let expr = Expression::Assignment {
+        target: Box::new(var("x")),
+        value: Box::new(Expression::Identifier(Identifier::new("someVar", span()))),
+        type_annotation: Some(TypeAnnotation::simple("Dictionary", span())),
+        span: span(),
+    };
+    checker.infer_expr(&expr, &hierarchy, &mut env, false);
+
+    let type_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("Type mismatch"))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "Narrowing from Object to Dictionary should not warn, got: {type_warnings:?}"
+    );
+}
+
+#[test]
+fn annotated_assignment_narrowing_to_parametric_type_no_warning() {
+    // `dict :: Dictionary(Symbol, String) := <Object>` — narrowing to a
+    // parametric type should also be silently accepted.
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    let hierarchy = ClassHierarchy::with_builtins();
+
+    env.set("someVar", InferredType::known("Object"));
+
+    let dict_ann = TypeAnnotation::Generic {
+        base: Identifier::new("Dictionary", span()),
+        parameters: vec![
+            TypeAnnotation::simple("Symbol", span()),
+            TypeAnnotation::simple("String", span()),
+        ],
+        span: span(),
+    };
+    let expr = Expression::Assignment {
+        target: Box::new(var("dict")),
+        value: Box::new(Expression::Identifier(Identifier::new("someVar", span()))),
+        type_annotation: Some(dict_ann),
+        span: span(),
+    };
+    checker.infer_expr(&expr, &hierarchy, &mut env, false);
+
+    let type_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("Type mismatch"))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "Narrowing Object to Dictionary(Symbol, String) should not warn, got: {type_warnings:?}"
+    );
+}
+
+#[test]
 fn annotated_assignment_mismatch_warns() {
     // Known incompatible type should emit a warning
     let mut checker = TypeChecker::new();


### PR DESCRIPTION
## Summary

Fixes BT-2015: local type annotations (`name :: Type := expr`) were only accepting widening or `Dynamic`/`Never` RHS silently. The primary type-erasure use case from BT-2012's issue description — `dict :: Dictionary := Binary deserialize: content` where the callee returns `Object` — fired a spurious warning.

Change: accept **any narrowing** (declared type is a subtype of inferred type) silently. The user using `::` is asserting the runtime type is more specific than the static type.

- RHS ≤ declared (widening/exact) → OK (already handled)
- declared ≤ RHS (narrowing — explicit assertion) → **OK (new)**
- Otherwise (unrelated types) → warn

Covers `Object → Dictionary`, `Object → Dictionary(Symbol, String)`, `Dictionary(Symbol, Object) → Dictionary(Symbol, String)` (base-class stripping handles parametric), and hierarchy downcasts. Still warns on `Integer := \"hello\"` etc.

## Test plan

- [x] `cargo test -p beamtalk-core --lib annotated_assignment` — 14/14 pass
- [x] New test: `annotated_assignment_narrowing_from_object_no_warning`
- [x] New test: `annotated_assignment_narrowing_to_parametric_type_no_warning`
- [x] Existing `annotated_assignment_mismatch_warns` unchanged (still catches real mismatches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved type checking to eliminate false warnings when assigning broader types to narrower type annotations.

* **Tests**
  * Added test coverage for annotated type assignments with both simple and generic type parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->