### PR TITLE
fix: resolve Nil to UndefinedObject so isNil narrowing propagates (BT-2016)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -308,7 +308,10 @@ impl TypeChecker {
     /// - Everything else passes through unchanged.
     fn resolve_type_keyword(name: &EcoString) -> EcoString {
         match name.as_str() {
-            "nil" => "UndefinedObject".into(),
+            // BT-2016: Both `nil` (lowercase keyword) and `Nil` (class name) map
+            // to the canonical internal name `UndefinedObject` so narrowing,
+            // non_nil_type, and all downstream comparisons work consistently.
+            "nil" | "Nil" => "UndefinedObject".into(),
             "false" => "False".into(),
             "true" => "True".into(),
             _ => name.clone(),
@@ -2138,16 +2141,20 @@ impl TypeChecker {
 
     /// Remove `UndefinedObject` (nil) from a union type or convert a known type
     /// to itself if it is non-nil.
+    ///
+    /// BT-2016: Also matches `"Nil"` as a defensive measure — `resolve_type_keyword`
+    /// should canonicalize to `"UndefinedObject"`, but downstream callers may
+    /// encounter `"Nil"` from BEAM metadata or return-type strings.
     pub(super) fn non_nil_type(ty: &InferredType) -> InferredType {
         match ty {
             InferredType::Union {
                 members,
                 provenance,
             } => {
-                // Fast path: if no member is UndefinedObject, return unchanged.
+                // Fast path: if no member is UndefinedObject/Nil, return unchanged.
                 let has_nil = members.iter().any(|m| {
                     m.as_known()
-                        .is_some_and(|n| n.as_str() == "UndefinedObject")
+                        .is_some_and(|n| n.as_str() == "UndefinedObject" || n.as_str() == "Nil")
                 });
                 if !has_nil {
                     return ty.clone();
@@ -2155,8 +2162,9 @@ impl TypeChecker {
                 let non_nil: Vec<InferredType> = members
                     .iter()
                     .filter(|m| {
-                        m.as_known()
-                            .is_none_or(|name| name.as_str() != "UndefinedObject")
+                        m.as_known().is_none_or(|name| {
+                            name.as_str() != "UndefinedObject" && name.as_str() != "Nil"
+                        })
                     })
                     .cloned()
                     .collect();

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -302,10 +302,14 @@ impl TypeChecker {
 
     /// Resolves type-position keywords to their class names.
     ///
-    /// - `nil` → `UndefinedObject`
+    /// - `nil` / `Nil` → `UndefinedObject`
     /// - `false` → `False`
     /// - `true` → `True`
     /// - Everything else passes through unchanged.
+    ///
+    /// Both lowercase (`nil`) and capitalised (`Nil`) spellings map to
+    /// `UndefinedObject` so that `Integer | Nil` type annotations narrow
+    /// consistently under `isNil` guards (BT-2016).
     fn resolve_type_keyword(name: &EcoString) -> EcoString {
         match name.as_str() {
             // BT-2016: Both `nil` (lowercase keyword) and `Nil` (class name) map

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -12321,7 +12321,7 @@ fn annotated_assignment_compatible_type_no_warning() {
 /// keyword method that expects `Integer` must not produce a type mismatch.
 #[test]
 fn narrowing_isnil_propagates_to_keyword_arg_e2e() {
-    let source = r#"
+    let source = r"
 Object subclass: Receiver
   class process: ms :: Integer => ms
 
@@ -12329,7 +12329,7 @@ Object subclass: Caller
   run: ms :: Integer | Nil =>
     ms isNil ifTrue: [^nil]
     Receiver process: ms
-"#;
+";
     let tokens = crate::source_analysis::lex_with_eof(source);
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
@@ -12339,10 +12339,13 @@ Object subclass: Caller
         &crate::CompilerOptions::default(),
         vec![],
     );
+    // Filter by DiagnosticCategory::Type so argument-type warnings
+    // (formatted as "Argument ... expects ... got ...") are caught too,
+    // not only assignment-style "Type mismatch" messages.
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
-        .filter(|d| d.message.contains("Type mismatch"))
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
         .collect();
     assert!(
         type_warnings.is_empty(),
@@ -12354,13 +12357,13 @@ Object subclass: Caller
 /// to a typed local `local :: Integer := ms` must not produce a type mismatch.
 #[test]
 fn narrowing_isnil_propagates_to_typed_assignment_rhs_e2e() {
-    let source = r#"
+    let source = r"
 Object subclass: Caller
   run: ms :: Integer | Nil =>
     ms isNil ifTrue: [^nil]
     local :: Integer := ms
     local
-"#;
+";
     let tokens = crate::source_analysis::lex_with_eof(source);
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
@@ -12373,7 +12376,7 @@ Object subclass: Caller
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
-        .filter(|d| d.message.contains("Type mismatch"))
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
         .collect();
     assert!(
         type_warnings.is_empty(),
@@ -12385,8 +12388,11 @@ Object subclass: Caller
 /// an instance-side keyword method that expects `Integer` must not warn.
 #[test]
 fn narrowing_isnil_propagates_to_instance_send_arg_e2e() {
-    let source = r#"
-Object subclass: Receiver
+    // `Value subclass:` so the receiver can be `new`d — Object subclasses are
+    // not instantiable. The test focuses on the narrowing propagation into
+    // `r process: ms`, not on instantiation semantics.
+    let source = r"
+Value subclass: Receiver
   process: ms :: Integer => ms
 
 Object subclass: Caller
@@ -12394,7 +12400,7 @@ Object subclass: Caller
     r := Receiver new
     ms isNil ifTrue: [^nil]
     r process: ms
-"#;
+";
     let tokens = crate::source_analysis::lex_with_eof(source);
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
@@ -12407,7 +12413,7 @@ Object subclass: Caller
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
-        .filter(|d| d.message.contains("Type mismatch"))
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
         .collect();
     assert!(
         type_warnings.is_empty(),

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -12313,3 +12313,139 @@ fn annotated_assignment_compatible_type_no_warning() {
         "Integer assigned to Number should not warn, got: {type_warnings:?}"
     );
 }
+
+// ── BT-2016: isNil narrowing propagation into keyword args / typed assignment ──
+
+/// BT-2016: After `ms isNil ifTrue: [^nil]`, the narrowed type of `ms`
+/// should be `Integer` (not `Integer | Nil`), so passing it to a class-side
+/// keyword method that expects `Integer` must not produce a type mismatch.
+#[test]
+fn narrowing_isnil_propagates_to_keyword_arg_e2e() {
+    let source = r#"
+Object subclass: Receiver
+  class process: ms :: Integer => ms
+
+Object subclass: Caller
+  run: ms :: Integer | Nil =>
+    ms isNil ifTrue: [^nil]
+    Receiver process: ms
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let type_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.message.contains("Type mismatch"))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "Narrowed Integer should not warn as keyword arg, got: {type_warnings:?}"
+    );
+}
+
+/// BT-2016: After `ms isNil ifTrue: [^nil]`, assigning the narrowed value
+/// to a typed local `local :: Integer := ms` must not produce a type mismatch.
+#[test]
+fn narrowing_isnil_propagates_to_typed_assignment_rhs_e2e() {
+    let source = r#"
+Object subclass: Caller
+  run: ms :: Integer | Nil =>
+    ms isNil ifTrue: [^nil]
+    local :: Integer := ms
+    local
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let type_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.message.contains("Type mismatch"))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "Narrowed Integer in typed assignment should not warn, got: {type_warnings:?}"
+    );
+}
+
+/// BT-2016: After `ms isNil ifTrue: [^nil]`, passing the narrowed value to
+/// an instance-side keyword method that expects `Integer` must not warn.
+#[test]
+fn narrowing_isnil_propagates_to_instance_send_arg_e2e() {
+    let source = r#"
+Object subclass: Receiver
+  process: ms :: Integer => ms
+
+Object subclass: Caller
+  run: ms :: Integer | Nil =>
+    r := Receiver new
+    ms isNil ifTrue: [^nil]
+    r process: ms
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let type_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.message.contains("Type mismatch"))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "Narrowed Integer in instance send arg should not warn, got: {type_warnings:?}"
+    );
+}
+
+/// BT-2016: `non_nil_type` must strip `Known("Nil")` from unions, not just
+/// `Known("UndefinedObject")`. This ensures the defense-in-depth layer works
+/// even if a `"Nil"` member slips past `resolve_type_keyword`.
+#[test]
+fn non_nil_type_strips_capital_nil_from_union() {
+    // Union containing "Nil" (capital, as parser might produce from type annotations)
+    let union_with_nil = InferredType::simple_union(&["Integer", "Nil"]);
+    let narrowed = TypeChecker::non_nil_type(&union_with_nil);
+    assert_eq!(
+        narrowed,
+        InferredType::known("Integer"),
+        "non_nil_type should strip Nil from union"
+    );
+}
+
+/// BT-2016: `non_nil_type` must strip both `Known("UndefinedObject")` and
+/// `Known("Nil")` when both appear in the same union.
+#[test]
+fn non_nil_type_strips_both_nil_variants() {
+    let union = InferredType::Union {
+        members: vec![
+            InferredType::known("Integer"),
+            InferredType::known("UndefinedObject"),
+            InferredType::known("Nil"),
+        ],
+        provenance: TypeProvenance::Inferred(span()),
+    };
+    let narrowed = TypeChecker::non_nil_type(&union);
+    assert_eq!(
+        narrowed,
+        InferredType::known("Integer"),
+        "non_nil_type should strip both UndefinedObject and Nil"
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1226,7 +1226,8 @@ impl TypeChecker {
     /// Same as `resolve_type_keyword` but takes `&str` for use in validation contexts.
     fn resolve_type_keyword_static(name: &str) -> EcoString {
         match name {
-            "nil" => "UndefinedObject".into(),
+            // BT-2016: Match both `nil` and `Nil`, consistent with resolve_type_keyword.
+            "nil" | "Nil" => "UndefinedObject".into(),
             "false" => "False".into(),
             "true" => "True".into(),
             _ => EcoString::from(name),


### PR DESCRIPTION
## Summary

- `resolve_type_keyword` only mapped lowercase `nil` to `UndefinedObject`, but users write `Integer | Nil` (capital N) in type annotations. The parser preserves `Nil` as `Known("Nil")`, which `non_nil_type` didn't recognize, causing early-return narrowing (`ms isNil ifTrue: [^nil]`) to silently fail.
- Added `"Nil"` to both `resolve_type_keyword` (inference) and `resolve_type_keyword_static` (validation) so `Nil` canonicalizes to `UndefinedObject` consistently.
- Added `"Nil"` checks to `non_nil_type` as a defense-in-depth measure for any `"Nil"` values that bypass `resolve_type_keyword`.

## Test plan

- [x] 3 end-to-end regression tests parsing real Beamtalk source: keyword arg, typed assignment, instance send arg
- [x] 2 unit tests for `non_nil_type` directly: strip capital `Nil`, strip both `UndefinedObject` and `Nil`
- [x] All 3077 existing tests pass (0 failures)
- [x] Clippy clean

Closes BT-2016

https://claude.ai/code/session_01SfCmrkrALjxnUeSbunSsDy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently treat both `nil` and `Nil` as the same nil type, improving type resolution.
  * Non-nil type narrowing now correctly excludes nil members (including both representations), so narrowed types propagate through keyword args, local assignments, and method arguments.

* **Tests**
  * Added tests validating nil handling and type-narrowing behavior across the noted call/assignment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->