### PR TITLE
docs: daily refresh 2026-04-22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Language
+
+- **Local variable type annotations** — `name :: Type := expr` syntax for type-checked variable bindings at type-erasure boundaries; supports simple, parametric, and union types; annotation is erased at codegen (BT-2012).
+- Accept narrowing RHS in local type annotations — `dict :: Dictionary := someMethodReturningObject` no longer warns when the declared type is more specific than the inferred type (BT-2015).
+- Fix `@expect` directives inside block bodies (`ifTrue: [...]`, `collect: [...]`, `whileTrue: [...]`) being silently ignored — they now correctly suppress diagnostics on the next statement within the block (BT-2010).
+- Typechecker warns when a non-Block value is passed to a `Block(T, R)` parameter — previously, parametric type annotations like `Block(T, R)` were treated as unknown classes and the warning was suppressed (BT-2002).
+
 ### Standard Library
 
 - **Named actor registration** ([ADR 0079](docs/ADR/0079-named-actor-registration.md)) — actors can now be registered under a `Symbol` name and looked up from anywhere via a name-resolving proxy that survives supervised restarts (BT-1985 epic, BT-1986..BT-1991):
@@ -10,6 +17,8 @@
   - `actor registerAs: name` / `actor unregister` / `actor registeredName` / `actor isRegistered` — post-spawn registration API.
   - `Actor allRegistered` — enumerate Beamtalk-registered actors (excludes raw OTP kernel processes via the `$beamtalk_actor` process-dict marker).
   - `SupervisionSpec withName:` — declaratively name a supervised child so the supervisor re-registers the name on every restart.
+- **Integer rounding methods** — `ceiling`, `floor`, `rounded`, and `truncated` on Integer return `self` (identity), so numeric code can call rounding methods on any `Number` without branching on type (BT-2011).
+- Tighter parametric type annotations across stdlib classes (`File`, `Subprocess`, `ReactiveSubprocess`, `Regex`, `Result`, `SupervisionSpec`) — `Result` return types now carry concrete `T`/`E` parameters for better type flow through `andThen:`/`map:` chains (#2032).
 
 ### Compiler
 
@@ -22,16 +31,28 @@
 - Fix `'spawnAs'/2` defaulting to `[]` instead of `#{}`, which crashed supervised named children in `init/1` with `{badmap, []}` (BT-1991).
 - Fix REPL JSON formatter crashing when displaying a name-resolving proxy: `#beamtalk_object{pid = {registered, Name}}` now renders as `#Actor<Class,registered,Name>` instead of calling `pid_to_list/1` on a non-pid term (BT-1991).
 - Supervisor `startLink` returns Result-shaped values internally (`{ok, ...}` / `{error, #beamtalk_error{kind = supervisor_start_failed}}`); `class supervise` unwraps to preserve the existing user-facing `Supervisor` return type — preparatory infrastructure for [ADR 0080](docs/ADR/0080-supervisor-lifecycle-result.md) Phase 1 (BT-1994).
+- **ADR 0080 Phase 1: supervisor lifecycle Result migration** — `startLink/1`, `startChild/1,2`, and `terminateChild/2` now return `{ok, V} | {error, #beamtalk_error{}}` internally; stdlib shims preserve existing user-facing signatures via `.unwrap` until Phase 2 (BT-1996, BT-1997, BT-1998).
+- `terminateChild` is now idempotent — terminating an already-terminated child returns `{ok, nil}` instead of raising (BT-1998).
+- Fix deadlock when calling `self class spawnAs:` / `self class spawnWith:as:` inside a class factory method — metaclass dispatch now short-circuits spawn selectors to avoid re-entering the class gen_server (BT-2005).
+- Fix `undef` crash for `self spawnAs:` / `self spawnWith:as:` in class methods — new runtime helpers read class metadata from the process dictionary to avoid the gen_server deadlock (BT-2004).
+- Fix `undef` crash for inherited class-method self-sends — a new `class_self_dispatch/4` runtime helper walks the superclass chain and threads class-var state correctly (BT-2007).
+
+### Tooling
+
+- **Diagnostic summary** — `beamtalk build` and `beamtalk lint` print an aggregated diagnostic summary (category × severity) at end of run; `beamtalk lint --format json` emits a `summary` JSON object for CI diffing; new `diagnostic_summary` MCP tool for agent use (BT-2014).
 
 ### Documentation
 
 - ADR 0079: Named Actor Registration.
 - Language features: new "Named Actor Registration" chapter covering the API surface, proxy semantics caveats (monitors don't re-arm across restarts; equality rules; unregister makes proxy dead), reserved-name policy, BEAM mapping, and a before/after migration example from `Supervisor which:` + `initialize:` to named registration (BT-1991).
+- Language features: new "Local Variable Type Annotations" section; updated `@expect` documentation to reflect block-body support.
 
 ### Internal
 
 - ADR 0080: Migrate Supervisor Lifecycle to Result — proposed and accepted with Phase 0 probe outcomes (BT-1977, BT-1994, BT-1995).
 - Typechecker probe confirms class-level type parameter substitution through `Result(C, Error)` works without extension (BT-1995).
+- Unified LSP and CLI diagnostic pipelines into shared `compute_project_diagnostics` function (BT-2009).
+- Thread fixture-defined protocols through BUnit compile path to eliminate false `Unresolved class` warnings (BT-2006).
 
 ## 0.3.1 — 2026-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   - `Actor allRegistered` — enumerate Beamtalk-registered actors (excludes raw OTP kernel processes via the `$beamtalk_actor` process-dict marker).
   - `SupervisionSpec withName:` — declaratively name a supervised child so the supervisor re-registers the name on every restart.
 - **Integer rounding methods** — `ceiling`, `floor`, `rounded`, and `truncated` on Integer return `self` (identity), so numeric code can call rounding methods on any `Number` without branching on type (BT-2011).
-- Tighter parametric type annotations across stdlib classes (`File`, `Subprocess`, `ReactiveSubprocess`, `Regex`, `Result`, `SupervisionSpec`) — `Result` return types now carry concrete `T`/`E` parameters for better type flow through `andThen:`/`map:` chains (#2032).
+- Tighter parametric type annotations across stdlib classes (`File`, `Subprocess`, `ReactiveSubprocess`, `Regex`, `Result`, `SupervisionSpec`) — `Result` return types now carry concrete `T`/`E` parameters for better type flow through `andThen:`/`map:` chains.
 
 ### Compiler
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -863,8 +863,24 @@ class -> Self class => @primitive "class"
 - Invalid annotation forms (e.g., `Self` in parameter position) are errors.
 - `typed` classes require parameter/return annotations on non-primitive methods.
 - Data annotations (`field: x :: Integer = 0` on Value, `state: x :: Integer = 0` on Actor) are checked for defaults and assignments. When a type annotation is present, the default value is optional (`field: x :: Integer` / `state: x :: Integer`) — the type annotation is the contract, and `nil` is used internally.
+- Local variable annotations (`name :: Type := expr`) declare the binding's type at type-erasure boundaries. See [Local Variable Type Annotations](#local-variable-type-annotations) below.
 - Complex annotations (e.g., unions/generics) are parsed and accepted; deeper checking is phased in.
 - `Self` in return position resolves to the static receiver class. Using `Self` as a parameter type is an error (unsound with subclassing).
+
+### Local Variable Type Annotations
+
+Local variables can carry a type annotation using `name :: Type := expr`. The declared type overrides the inferred type of the right-hand side, which is useful at type-erasure boundaries (FFI returns, deserialization, untyped APIs). The annotation is erased at codegen — there is no runtime effect.
+
+```beamtalk
+x :: Integer := 42
+dict :: Dictionary := Binary deserialize: content
+name :: String | nil := dictionary at: "name"
+r :: Result(Integer, Error) := computeSomething
+```
+
+Supported type forms: simple (`Integer`), parametric (`Result(T, E)`), and union (`String | nil`).
+
+**Type checking:** The compiler warns when the RHS type is unrelated to the declared type (e.g., `x :: Integer := "hello"`). Narrowing assertions — where the declared type is more specific than the inferred type — are accepted silently, since the annotation communicates that the runtime type is known to be more specific (BT-2015). Dynamic and Never RHS types are always accepted.
 
 ### Dynamic Type Visibility (ADR 0077)
 
@@ -3229,7 +3245,7 @@ Declaration-level `@expect` supports the same categories and stale-directive rul
 
 **Stale directives:** If `@expect` does not suppress any diagnostic (because no matching diagnostic exists on the following expression or declaration), the compiler emits a warning to prevent directives from silently becoming out of date.
 
-`@expect` works inside method bodies, on declarations in class definitions, and at module scope.
+`@expect` works inside method bodies, inside block bodies (e.g., `ifTrue: [...]`, `collect: [...]`, `whileTrue: [...]`), on declarations in class definitions, and at module scope (BT-2010).
 
 ### Pragma Annotations (`@primitive` and `@intrinsic`)
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -880,7 +880,7 @@ r :: Result(Integer, Error) := computeSomething
 
 Supported type forms: simple (`Integer`), parametric (`Result(T, E)`), and union (`String | nil`).
 
-**Type checking:** The compiler warns when the RHS type is unrelated to the declared type (e.g., `x :: Integer := "hello"`). Narrowing assertions — where the declared type is more specific than the inferred type — are accepted silently, since the annotation communicates that the runtime type is known to be more specific (BT-2015). Dynamic and Never RHS types are always accepted.
+**Type checking:** The compiler warns when the RHS type is unrelated to the declared type (e.g., `x :: Integer := "hello"`). Narrowing assertions — where the declared type is more specific than the inferred type — are accepted silently, since the annotation communicates that the runtime type is known to be more specific (BT-2015). `Dynamic` and `Never` RHS types are always accepted.
 
 ### Dynamic Type Visibility (ADR 0077)
 


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 17 commits merged to `main` in the last 24 hours.

### Docs updated

- **`docs/beamtalk-language-features.md`** — new "Local Variable Type Annotations" section documenting `name :: Type := expr` syntax (BT-2012, BT-2015); updated `@expect` section to reflect block-body support (BT-2010)
- **`CHANGELOG.md`** — added entries under Language, Standard Library, Runtime, Tooling, Documentation, and Internal sections

### Commits reviewed

| Commit | PR | Classification | Doc change |
|--------|-----|---------------|------------|
| `836328a` | #2045 | Language feature | New "Local Variable Type Annotations" section in language features + CHANGELOG "Language" |
| `6b7c472` | #2048 | Language feature (refinement) | Documented narrowing behavior in new section + CHANGELOG "Language" |
| `f5d8e4a` | #2043 | Bug fix | Updated `@expect` docs to mention block-body support + CHANGELOG "Language" |
| `7b76149` | #2034 | Type checker improvement | CHANGELOG "Language" |
| `4be20be` | #2042 | Stdlib API | CHANGELOG "Standard Library" |
| `69a66d2` | #2032 | Stdlib types | CHANGELOG "Standard Library" |
| `b3ccefb` | #2041 | Runtime (ADR 0080 Phase 1) | CHANGELOG "Runtime" |
| `0e72f73` | #2046 | Runtime (ADR 0080 Phase 1) | CHANGELOG "Runtime" |
| `7f52a81` | #2044 | Runtime (ADR 0080 Phase 1) | CHANGELOG "Runtime" |
| `abcb0dc` | #2038 | Runtime bug fix | CHANGELOG "Runtime" |
| `a7ca8c0` | #2033 | Runtime bug fix | CHANGELOG "Runtime" |
| `533f751` | #2040 | Runtime bug fix | CHANGELOG "Runtime" |
| `1c4ae72` | #2050 | Tooling | CHANGELOG "Tooling" (tooling doc already updated in commit) |
| `d0bbe22` | #2047 | Internal refactoring | CHANGELOG "Internal" |
| `076fab1` | #2039 | Internal bug fix | CHANGELOG "Internal" |

### Skipped

| Commit | Reason |
|--------|--------|
| `e66d95a` | CI deps bump (`actions/upload-pages-artifact`) — `.github/` only |
| `2288311` | #2035 — regression tests for BT-2004; no user-visible change beyond what BT-2004 already covers |

### Needs human judgment

None — all commits had clear user-visible semantics from their diffs and tests.

https://claude.ai/code/session_0144UfGoARYrMuPQgxCv5dYv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local variable type annotations for explicit type bindings
  * Aggregated diagnostic summary output in tooling

* **Bug Fixes**
  * Fixed runtime crashes and deadlocks; `terminateChild` now behaves idempotently

* **Improvements**
  * Standard Library: integer rounding methods return self; tighter parametric typing and improved typechecker warnings

* **Documentation**
  * Updated language-features docs, including annotation syntax and @expect in block bodies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->