### PR TITLE
E2E + examples: migrate otp-tree to Result-shaped API (BT-2000)

### DIFF
--- a/examples/otp-tree/.github/copilot-instructions.md
+++ b/examples/otp-tree/.github/copilot-instructions.md
@@ -16,9 +16,10 @@ This is a [Beamtalk](https://jamesc.github.io/beamtalk) workspace demonstrating 
 - `class supervisionPolicy =>` — per-actor restart strategy (`#permanent`, `#transient`, `#temporary`)
 - `class children =>` — returns the list of child classes for the supervisor
 - `class childClass =>` — the worker class for a DynamicSupervisor
-- `supervise` — starts the supervisor (or returns the running instance)
+- `supervise` — starts the supervisor (or returns the running instance); returns `Result(Self, Error)` — use `unwrap` for boot-style call sites or `ifOk:ifError:` / `andThen:` to handle failures
 - `current` — returns the running supervisor instance by class name (Supervisor/DynamicSupervisor only)
-- `startChild` — spawns a new dynamic child
+- `startChild` / `startChild:` — spawns a new dynamic child; returns `Result(C, Error)` (child type narrowed via the `DynamicSupervisor(C)` parameter)
+- `terminate:` / `terminateChild:` — returns `Result(Nil, Error)` and is idempotent on `not_found`
 
 ## Beamtalk Syntax
 

--- a/examples/otp-tree/AGENTS.md
+++ b/examples/otp-tree/AGENTS.md
@@ -38,11 +38,18 @@ All source files in `src/` load automatically when you start the REPL.
 - **`Supervisor subclass:`** — static supervision tree; children are known at
   startup and declared by overriding `class children`.
 - **`DynamicSupervisor subclass:`** — dynamic pool; children are added at
-  runtime via `pool startChild` / `pool startChild: args`.
+  runtime via `pool startChild unwrap` / `(pool startChild: args) unwrap`.
 - **`class supervisionPolicy`** — per-actor restart strategy (`#permanent`,
   `#transient`, `#temporary`). Read by the supervisor when building child specs.
-- **`supervise`** — starts the supervisor process (or returns the already-running
-  instance if called again).
+- **`supervise`** — starts the supervisor process (or returns the
+  already-running instance if called again). Returns `Result(Self, Error)`
+  (ADR 0080); use `unwrap` for boot-style "crash on failure", or
+  `ifOk:ifError:` / `andThen:` for recoverable start flows.
+- **`startChild`** / **`startChild:`** — spawns a new child on a
+  `DynamicSupervisor`. Returns `Result(C, Error)` (the child type is narrowed
+  via the `DynamicSupervisor(C)` parameter).
+- **`terminate:`** / **`terminateChild:`** — returns `Result(Nil, Error)` and
+  is idempotent on `not_found` (already-gone children yield `Result ok: nil`).
 - **`current`** — returns the running supervisor instance looked up by class
   name. Available on `Supervisor` and `DynamicSupervisor` subclasses. Regular
   actors do not have `current`; reach them via the supervisor using `which:`.
@@ -94,8 +101,14 @@ whether code is correct, evaluate it directly rather than inferring from source.
 ## Common Pitfalls
 
 - `current` returns `nil` if the supervisor has not been started yet.
-  Always call `supervise` before `current`. Note: `current` is only available
-  on `Supervisor`/`DynamicSupervisor` subclasses, not on plain `Actor` subclasses.
+  Always call `supervise` (and `unwrap` the Result, or branch on it) before
+  `current`. Note: `current` is only available on `Supervisor` /
+  `DynamicSupervisor` subclasses, not on plain `Actor` subclasses.
+- `supervise`, `startChild`, `startChild:`, `terminate:`, and `terminateChild:`
+  all return `Result` (ADR 0080). Chaining sends directly on the return value
+  — e.g. `AppSupervisor supervise stop` — is a bug; the receiver is a
+  `Result`, not the supervisor. Insert `unwrap` (or branch with `ifOk:ifError:`)
+  before the chained send: `(AppSupervisor supervise) unwrap stop`.
 - `DynamicSupervisor` has no `class children` — only `class childClass`.
   Defining `children` on a `DynamicSupervisor` subclass has no effect.
 - A `#temporary` worker that crashes is **not restarted** — that is intentional.

--- a/examples/otp-tree/README.md
+++ b/examples/otp-tree/README.md
@@ -50,15 +50,26 @@ All source files in `src/` load automatically.
 ### 1. Start the supervision tree
 
 ```text
-> sup := AppSupervisor supervise
+> sup := (AppSupervisor supervise) unwrap
 ```
 
-`supervise` starts `AppSupervisor` as a named OTP supervisor process.
-Its two children — `EventLogger` and `WorkerPool` — start automatically.
+`supervise` starts `AppSupervisor` as a named OTP supervisor process and
+returns `Result(Self, Error)` (ADR 0080). Use `unwrap` at application boot
+/ REPL exploration where a start failure should propagate as an exception;
+use `ifOk:ifError:` / `andThen:` for recoverable flows. Its two children —
+`EventLogger` and `WorkerPool` — start automatically.
 
 ```text
 > sup count
 2
+```
+
+If you would rather branch on the result, the recoverable form reads:
+
+```text
+> (AppSupervisor supervise)
+    ifOk:    [:app | app count]
+    ifError: [:e | Logger warn: e message]
 ```
 
 ### 2. Reach named supervisors without a direct reference
@@ -82,13 +93,23 @@ reach a worker actor managed by the supervisor:
 
 ### 4. Spawn workers dynamically
 
-`startChild` asks `WorkerPool` to start a new `TaskWorker` and returns it:
+`startChild` asks `WorkerPool` to start a new `TaskWorker` and returns
+`Result(TaskWorker, Error)` (ADR 0080). `unwrap` is the boot-style path;
+`ifOk:ifError:` is the recoverable form:
 
 ```text
-> w1 := pool startChild
-> w2 := pool startChild
+> w1 := pool startChild unwrap
+> w2 := pool startChild unwrap
 > pool count
 2
+```
+
+If a start might fail at runtime, branch on the Result instead:
+
+```text
+> pool startChild
+    ifOk:    [:w | w process: 21]
+    ifError: [:e | Logger warn: e message]
 ```
 
 ### 5. Process tasks
@@ -205,9 +226,11 @@ live root supervisor instance.
 - **`DynamicSupervisor subclass:`** for pools — children added and removed at
   runtime
 - **`supervisionPolicy`** on each actor class controls restart behaviour
-- **`supervise`** starts the supervisor; **`current`** finds the live supervisor
-  instance (Supervisor/DynamicSupervisor only); **`which:`** reaches a specific
-  child actor managed by the supervisor
+- **`supervise`** starts the supervisor and returns `Result(Self, Error)`;
+  **`current`** finds the live supervisor instance (Supervisor/DynamicSupervisor
+  only); **`which:`** reaches a specific child actor managed by the supervisor.
+  Use `unwrap` for the happy-path/boot flow or `ifOk:ifError:` / `andThen:`
+  when you want to handle start failures explicitly (ADR 0080)
 - **Fault isolation is automatic** — OTP's one_for_one strategy contains crashes
   to the failing child only
 - **`[application] supervisor`** in `beamtalk.toml` wires the tree into the OTP


### PR DESCRIPTION
## Summary

Migrates the `examples/otp-tree` documentation to the Result-shaped supervisor API (ADR 0080, Phase 3).

- **README.md**: REPL walkthrough now uses `unwrap` on `supervise` / `startChild`, adds recoverable `ifOk:ifError:` examples, and updates the Key Takeaways section
- **AGENTS.md**: Documents Result return types for all lifecycle methods (`supervise`, `startChild`, `startChild:`, `terminate:`, `terminateChild:`), adds a common pitfall about chaining sends directly on Result values
- **copilot-instructions.md**: Adds Result type signatures and `terminate:` / `terminateChild:` entries

E2E btscripts and fixtures were already migrated in BT-1999 (commit f9c59c32) because CI required them to pass before that PR could merge. This PR completes the remaining BT-2000 scope.

**Linear:** https://linear.app/beamtalk/issue/BT-2000

## Test plan

- [x] `just test-e2e` passes (no e2e code changes, verified locally)
- [x] `examples/otp-tree` build + tests pass (`beamtalk build && beamtalk test`)
- [x] `just test` passes (250 stdlib + 1893 BUnit + 4727 runtime tests)
- [ ] Verify REPL walkthrough examples in README match actual REPL output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OTP supervision-tree API documentation to clarify return types and error handling patterns
  * Added examples demonstrating proper error handling with Result-based operations
  * Enhanced guidance for supervision initialization and dynamic child management
  * Clarified idempotent behavior for termination operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->