### PR TITLE
DiagnosticSummary accounting fixes (BT-2031)

### DIFF
--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -122,7 +122,6 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
     // Pass 2: Analyse each file with cross-file class context.
     let mut total_lint_count = 0usize;
     let mut all_diags: Vec<beamtalk_core::source_analysis::Diagnostic> = Vec::new();
-    let mut json_diags: Vec<serde_json::Value> = Vec::new();
 
     for (file, source, module, parse_diags) in parsed_files {
         let cross_file_classes =
@@ -141,6 +140,8 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
                     eprintln!("{:?}", miette::Report::new(compile_diag));
                 }
                 OutputFormat::Json => {
+                    // BT-2031: Stream each diagnostic as line-delimited JSON
+                    // instead of buffering all diagnostics in memory.
                     let notes: Vec<serde_json::Value> = diag
                         .notes
                         .iter()
@@ -161,7 +162,7 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
                         "hint": diag.hint.as_deref(),
                         "notes": notes,
                     });
-                    json_diags.push(json);
+                    println!("{json}");
                 }
             }
         }
@@ -181,11 +182,14 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
     // Lint native .erl files (BT-1909).
     total_lint_count += lint_erl_files(&erl_files, format)?;
 
-    // BT-2014: Build and print diagnostic summary.
-    let files_checked = source_files.len() + erl_files.len();
+    // BT-2014 / BT-2031: Build and print diagnostic summary.
+    // `all_diags` only contains `.bt` diagnostics, so `files_checked` must
+    // count only `.bt` files to keep the ratio consistent.
+    let bt_files_checked = source_files.len();
+    let total_files_checked = bt_files_checked + erl_files.len();
     let summary = beamtalk_core::source_analysis::DiagnosticSummary::from_diagnostics(
         &all_diags,
-        files_checked,
+        bt_files_checked,
     );
 
     match format {
@@ -196,10 +200,7 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
             }
         }
         OutputFormat::Json => {
-            // Emit per-diagnostic JSON lines first.
-            for json in &json_diags {
-                println!("{json}");
-            }
+            // Per-diagnostic JSON lines were already streamed above (BT-2031).
             // Emit the summary as a final JSON object.
             let summary_json = diagnostic_summary_to_json(&summary);
             println!("{summary_json}");
@@ -209,7 +210,7 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
     if total_lint_count > 0 {
         let plural = if total_lint_count == 1 { "" } else { "s" };
         miette::bail!(
-            "{total_lint_count} lint diagnostic{plural} found in {files_checked} file(s)"
+            "{total_lint_count} lint diagnostic{plural} found in {total_files_checked} file(s)"
         );
     }
 

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -520,7 +520,7 @@ pub struct PackageClassesParams {
 pub struct DiagnosticSummaryParams {
     /// Path to a `.bt` source file or directory. Defaults to the current directory.
     #[schemars(
-        description = "Path to a .bt source file or directory. Defaults to the current package root."
+        description = "Path to a .bt source file or directory. Defaults to the current directory."
     )]
     pub path: Option<String>,
 }
@@ -1797,16 +1797,26 @@ fn offset_to_line(source: &str, offset: usize) -> u32 {
 /// aggregates all diagnostics via the shared `DiagnosticSummary` type, and
 /// additionally computes type-coverage statistics. Returns a JSON-serializable
 /// value suitable for direct MCP tool output.
+#[allow(clippy::too_many_lines)] // Multi-pass pipeline is inherently sequential.
 fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
     use beamtalk_core::semantic_analysis::{ClassHierarchy, CoverageReport, infer_types};
     use beamtalk_core::source_analysis::{DiagnosticSummary, category_name};
 
-    let Ok(source_files) = resolve_source_files(path) else {
-        return serde_json::json!({
-            "error": format!("No .bt source files found in '{path}'"),
-            "files_checked": 0,
-            "total": 0,
-        });
+    let source_files = match resolve_source_files(path) {
+        Ok(files) => files,
+        Err(result) => {
+            // BT-2031: Surface the actual error (permission, IO, path-not-found)
+            // instead of collapsing to a generic "no files found" message.
+            let error_msg = result.errors.first().map_or_else(
+                || format!("No .bt source files found in '{path}'"),
+                |e| e.message.clone(),
+            );
+            return serde_json::json!({
+                "error": error_msg,
+                "files_checked": 0,
+                "total": 0,
+            });
+        }
     };
 
     // Pass 1: Parse all files and extract class metadata.
@@ -1871,7 +1881,9 @@ fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
         coverage.merge(file_report);
     }
 
-    let files_checked = source_files.len();
+    // BT-2031: Count only files that were actually read and analysed,
+    // not all resolved files (some may have been unreadable).
+    let files_checked = parsed_files.len();
     let summary = DiagnosticSummary::from_diagnostics(&all_diags, files_checked);
     let totals = summary.totals_by_severity();
 

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -1806,10 +1806,18 @@ fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
         Ok(files) => files,
         Err(result) => {
             // BT-2031: Surface the actual error (permission, IO, path-not-found)
-            // instead of collapsing to a generic "no files found" message.
+            // instead of collapsing to a generic "no files found" message. Include
+            // the file context from the diagnostic since the message alone may not
+            // name the offending path.
             let error_msg = result.errors.first().map_or_else(
                 || format!("No .bt source files found in '{path}'"),
-                |e| e.message.clone(),
+                |e| {
+                    if e.file.is_empty() {
+                        format!("{}: {}", path, e.message)
+                    } else {
+                        format!("{}: {}", e.file, e.message)
+                    }
+                },
             );
             return serde_json::json!({
                 "error": error_msg,

--- a/docs/beamtalk-tooling.md
+++ b/docs/beamtalk-tooling.md
@@ -92,8 +92,7 @@ At the end of a successful build, `beamtalk build` prints a summary of non-error
 Diagnostic summary (42 files):
   Type              12 warning
   Dnu                3 warning
-  UnresolvedClass    1 error
-  Total             16  (1 error, 15 warning)
+  Total             15  (15 warning)
 ```
 
 The summary is suppressed when `--no-warnings` is passed.


### PR DESCRIPTION
## Summary

Fixes several accounting bugs in `DiagnosticSummary` that were flagged during the BT-2014 PR but merged unresolved.

- **Error surfacing**: `compute_diagnostic_summary` now surfaces the actual `resolve_source_files` error (permission, IO, path-not-found) instead of always returning a generic "no files found" message
- **Accurate file counts**: MCP `files_checked` now reflects only files that were actually read and analysed (not all resolved files, some of which may have been unreadable)
- **Consistent lint counts**: `lint.rs` `files_checked` now uses only `.bt` file count for the `DiagnosticSummary` (matching `all_diags` which only contains `.bt` diagnostics), while the error message still reports total files checked
- **JSON streaming**: `--format json` now streams each diagnostic as line-delimited JSON directly instead of buffering all diagnostics in a `json_diags` Vec before emission
- **Doc fixes**: Removed error-severity diagnostic from the "successful build" summary example; aligned `path` field description between Rust doc and schemars schema

## Linear Issue

https://linear.app/beamtalk/issue/BT-2031

## Test plan

- [x] `just build` passes
- [x] `just clippy` passes (with new `#[allow(clippy::too_many_lines)]` on `compute_diagnostic_summary`)
- [x] `just fmt-check` passes
- [x] `just test` passes (250 stdlib, 1891 BUnit, 4727 runtime tests)
- [x] Verified `json_diags` buffer is fully removed with no remaining references
- [x] Verified `lint_erl_files` already streams JSON directly, consistent with the streaming change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages and handling when source files cannot be resolved or processed during linting and building.
  * Fixed diagnostic summary file count calculations to accurately reflect only files that were successfully processed.

* **Documentation**
  * Updated build command diagnostic output examples to reflect current behavior and file counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->