### PR TITLE
Test: classifier-vs-generated-exports assertion (BT-2029)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -1098,10 +1098,15 @@ impl CoreErlangGenerator {
 
         // BT-2007: Inherited class method — walk the hierarchy at runtime and
         // apply the defining module's class_<sel>(ClassSelf, ClassVars, Args...).
-        // Auto-generated 0-arity exports on every class module (superclass/0,
-        // methods/0, class_name/0) stay on the direct-call path because the
-        // chain walker only looks at user-defined class_methods. Anything else
-        // that falls through here — inherited or missing — routes through
+        // The two auto-generated 0-arity exports reachable via plain self-send
+        // (`superclass/0`, `class_name/0`) stay on the direct-call path because
+        // the chain walker only looks at user-defined class_methods. The other
+        // auto-exports (`method_table/0`, `has_method/1`, `register_class/0`,
+        // `__beamtalk_meta/0`) are codegen-internal reflection and metadata
+        // accessors without a stable user-level API, so they are deliberately
+        // NOT on the direct-call path — `is_class_auto_export_selector` must
+        // stay in sync with the actual reachable set. Anything else that falls
+        // through here — inherited or missing — routes through
         // class_self_dispatch/4, which raises a structured does_not_understand
         // error for genuine DNU.
         if is_class_auto_export_selector(&selector_atom, arguments.len()) {
@@ -2767,12 +2772,49 @@ pub(super) fn is_class_auto_export_selector(selector_atom: &str, arity: usize) -
 
 #[cfg(test)]
 mod tests {
+    use super::is_class_auto_export_selector;
     use crate::ast::{Expression, Identifier, KeywordPart, Literal, MessageSelector};
     use crate::codegen::core_erlang::CoreErlangGenerator;
     use crate::source_analysis::Span;
 
     fn s() -> Span {
         Span::new(0, 0)
+    }
+
+    /// BT-2029: the classifier must stay in sync with the actual reachable
+    /// auto-exports on generated class modules. Both `superclass/0` and
+    /// `class_name/0` are reachable via plain self-send and must short-circuit
+    /// to a direct call; `methods/0` does not exist on the current codegen
+    /// (an earlier mistaken inclusion); `method_table/0` and `has_method/1`
+    /// are codegen-internal reflection APIs with no Beamtalk surface and must
+    /// NOT be classified as auto-exports (they would compile to a direct call
+    /// that users cannot reach anyway, but including them would bypass the
+    /// structured DNU path that catches typos). Arity mismatches must also
+    /// return false so that, e.g., `self superclass: X` does not get hijacked
+    /// into a direct call to the 0-arity `superclass/0`.
+    #[test]
+    fn is_class_auto_export_selector_matches_reachable_exports() {
+        assert!(is_class_auto_export_selector("superclass", 0));
+        assert!(is_class_auto_export_selector("class_name", 0));
+
+        // Codegen-internal, not reachable via Beamtalk self-send.
+        assert!(!is_class_auto_export_selector("method_table", 0));
+        assert!(!is_class_auto_export_selector("has_method", 1));
+        assert!(!is_class_auto_export_selector("register_class", 0));
+        assert!(!is_class_auto_export_selector("__beamtalk_meta", 0));
+
+        // Historical mistake — `methods/0` is not emitted by the current
+        // codegen, so classifying it as auto-export would produce a call
+        // to a non-existent function.
+        assert!(!is_class_auto_export_selector("methods", 0));
+
+        // Arity mismatches must not match.
+        assert!(!is_class_auto_export_selector("superclass", 1));
+        assert!(!is_class_auto_export_selector("class_name", 1));
+
+        // Arbitrary user selectors must fall through to inherited dispatch.
+        assert!(!is_class_auto_export_selector("increment", 0));
+        assert!(!is_class_auto_export_selector("at:put:", 2));
     }
 
     #[test]

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -1096,6 +1096,38 @@ fn test_class_registration_generation() {
         code.contains("catch <CatchType, CatchError, CatchStack> -> primop 'raw_raise'(CatchType, CatchError, CatchStack)"),
         "register_class/0 catch clause must re-raise via primop 'raw_raise' (BT-998). Got:\n{code}"
     );
+
+    // BT-2029: every generated class module must export method_table/0 and
+    // has_method/1 — these are the reflection accessors that runtime dispatch
+    // (beamtalk_class_dispatch, method_table lookups, DNU chain walk) relies
+    // on. The classifier at dispatch_codegen.rs:is_class_auto_export_selector
+    // must stay aligned with this export set — see its unit test for the
+    // reverse direction.
+    assert!(
+        code.contains("'method_table'/0"),
+        "Generated class module must export method_table/0. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'has_method'/1"),
+        "Generated class module must export has_method/1. Got:\n{code}"
+    );
+    // And the classifier's reachable set (superclass/0, class_name/0) must
+    // match what the module actually exports — these are the two auto-exports
+    // reachable via plain Beamtalk self-send.
+    assert!(
+        code.contains("'superclass'/0"),
+        "Generated class module must export superclass/0. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'class_name'/0"),
+        "Generated class module must export class_name/0. Got:\n{code}"
+    );
+    // The old mistaken auto-export `methods/0` must NOT appear — it was
+    // removed from the classifier after BT-2007 and no codegen site emits it.
+    assert!(
+        !code.contains("'methods'/0"),
+        "Generated class module must NOT export methods/0 — removed after BT-2007. Got:\n{code}"
+    );
 }
 
 #[test]

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -35,6 +35,30 @@ fn extract_core_fn<'a>(code: &'a str, marker: &str) -> Option<&'a str> {
     Some(body)
 }
 
+/// Extract the module-header export list from generated Core Erlang.
+///
+/// A Core Erlang module header looks like:
+///   module 'Name' ['export1'/0, 'export2'/1, ...]
+///     attributes [...]
+///
+/// Returns the bracketed export list as a string (without the surrounding
+/// brackets), or an empty string if no header is found. Used by tests that
+/// want to assert on the exported API surface without false-positive matches
+/// against function definitions deeper in the module body.
+fn extract_module_exports(code: &str) -> String {
+    let Some(module_start) = code.find("module '") else {
+        return String::new();
+    };
+    let after_module = &code[module_start..];
+    let Some(bracket_open) = after_module.find('[') else {
+        return String::new();
+    };
+    let Some(bracket_close) = after_module[bracket_open..].find(']') else {
+        return String::new();
+    };
+    after_module[bracket_open + 1..bracket_open + bracket_close].to_string()
+}
+
 #[test]
 fn test_generate_empty_module() {
     let module = Module::new(Vec::new(), Span::new(0, 0));
@@ -1103,30 +1127,35 @@ fn test_class_registration_generation() {
     // on. The classifier at dispatch_codegen.rs:is_class_auto_export_selector
     // must stay aligned with this export set — see its unit test for the
     // reverse direction.
+    //
+    // Scope the assertions to the module header export list so we verify the
+    // API surface, not just a substring match that could pick up function
+    // definitions or other mentions.
+    let header_exports = extract_module_exports(&code);
     assert!(
-        code.contains("'method_table'/0"),
-        "Generated class module must export method_table/0. Got:\n{code}"
+        header_exports.contains("'method_table'/0"),
+        "Generated class module must export method_table/0 in header. Got header:\n{header_exports}\n\nFull code:\n{code}"
     );
     assert!(
-        code.contains("'has_method'/1"),
-        "Generated class module must export has_method/1. Got:\n{code}"
+        header_exports.contains("'has_method'/1"),
+        "Generated class module must export has_method/1 in header. Got header:\n{header_exports}"
     );
     // And the classifier's reachable set (superclass/0, class_name/0) must
     // match what the module actually exports — these are the two auto-exports
     // reachable via plain Beamtalk self-send.
     assert!(
-        code.contains("'superclass'/0"),
-        "Generated class module must export superclass/0. Got:\n{code}"
+        header_exports.contains("'superclass'/0"),
+        "Generated class module must export superclass/0 in header. Got header:\n{header_exports}"
     );
     assert!(
-        code.contains("'class_name'/0"),
-        "Generated class module must export class_name/0. Got:\n{code}"
+        header_exports.contains("'class_name'/0"),
+        "Generated class module must export class_name/0 in header. Got header:\n{header_exports}"
     );
     // The old mistaken auto-export `methods/0` must NOT appear — it was
     // removed from the classifier after BT-2007 and no codegen site emits it.
     assert!(
-        !code.contains("'methods'/0"),
-        "Generated class module must NOT export methods/0 — removed after BT-2007. Got:\n{code}"
+        !header_exports.contains("'methods'/0"),
+        "Generated class module must NOT export methods/0 in header — removed after BT-2007. Got header:\n{header_exports}"
     );
 }
 


### PR DESCRIPTION
## Summary

BT-2029 bundled five dispatch/runtime correctness findings from the BT-2003/2004/2005/2007 merge batch. On inspection, four of the five ACs were already fixed on main via the original PRs (#2033, #2035, #2038, #2040); only AC #4 lacked its called-for regression test.

This PR adds:

- A unit test for `is_class_auto_export_selector` verifying `superclass/0` and `class_name/0` are the only reachable auto-exports, and that historical mistakes (`methods/0`) and codegen-internal accessors (`method_table/0`, `has_method/1`, `register_class/0`, `__beamtalk_meta/0`) are correctly excluded.
- An integration test on the generated Counter class module asserting the actual export list contains `'method_table'/0`, `'has_method'/1`, `'superclass'/0`, `'class_name'/0`, and explicitly does NOT contain `'methods'/0`.
- A comment update at the self-send dispatch site so it reflects the current classifier (previously still named `methods/0` as an auto-export).

## Already fixed on main (no code change needed)

- **AC #1** `class_mod` unification — `apply_class_method_in_context/6` sets `class_mod = DefiningModule` for both the gen_server (`invoke_class_method/7`) and self-send (`class_self_dispatch/4`) entry paths.
- **AC #2** `handle_metaclass_self_named_spawn/3` undefined guard — current guards include `CN =/= undefined, Mod =/= undefined`.
- **AC #3** `raise_class_self_dnu/2` uses `~ts` with `atom_to_list/1`, not `~s` with atoms.
- **AC #5** `do_class_self_named_spawn/6` wraps non-structured errors via `generic_spawn_error/3` into a structured `instantiation_error`.

Linear: https://linear.app/beamtalk/issue/BT-2029

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — both new tests pass
- [x] `just build && just clippy && just fmt-check` — clean
- [x] `just test` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined class-method dispatch eligibility to ensure only the intended class-level selectors are reachable via direct dispatch and to exclude internal-only selectors for consistent behavior.

* **Tests**
  * Added targeted tests validating class registration, module export lists, dispatch matching, exclusion of legacy/internal selectors, and arity-mismatch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->