### PR TITLE
Thread receiver type_args through super sends in generic classes (BT-2021)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -702,15 +702,28 @@ impl TypeChecker {
 
             // Super — resolve to parent class type for method validation.
             //
-            // BT-2025: Uses the central `receiver_type_for_class` helper so
-            // the parent receiver threads its declared type parameters (if
-            // any). Downstream substitution can then rewrite them to the
-            // concrete bindings inherited from the current receiver.
+            // BT-2025 / BT-2021: Uses `super_receiver_type` so the parent
+            // receiver threads the *child's* type-arg bindings into the
+            // parent's type-param positions, mapped via the child's
+            // `superclass_type_args` (`ParamRef` for `Sub(R) extends Base(R)`,
+            // `Concrete` for `IntBase extends Base(Integer)`). Falls back to
+            // the parent's symbolic placeholders when no extends-annotation
+            // mapping is recorded.
             Expression::Super(_) => {
-                if let Some(InferredType::Known { class_name, .. }) = env.get("self") {
+                if let Some(InferredType::Known {
+                    class_name,
+                    type_args,
+                    ..
+                }) = env.get("self")
+                {
                     if let Some(class_info) = hierarchy.get_class(&class_name) {
                         if let Some(ref parent) = class_info.superclass {
-                            super::type_resolver::receiver_type_for_class(parent, hierarchy)
+                            super::type_resolver::super_receiver_type(
+                                &class_name,
+                                &type_args,
+                                parent,
+                                hierarchy,
+                            )
                         } else {
                             InferredType::Dynamic(DynamicReason::Unknown)
                         }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -12956,3 +12956,322 @@ fn bt2022_generic_type_param_in_declared_args_not_warned() {
         "Type param T in declared type should not trigger a mismatch warning: {type_warnings:?}"
     );
 }
+
+// =====================================================================
+// BT-2021 — Receiver type_args dropped for self / super in generic classes
+// =====================================================================
+//
+// Sub-bug A (self): a method body inside a generic class `Box(T)` that
+// `self`-sends a `-> T` helper used to see `self` as `Known("Box", [])`,
+// dropping the symbolic type arg and resolving T to Dynamic. After
+// BT-2025's `receiver_type_for_class` migration, `self` carries
+// `[Known("T")]` placeholders so substitution can rewrite T correctly.
+//
+// Sub-bug B (super): from a child generic class `Sub(R)` extending
+// `Base(E)`, `super`-sending a `-> E`-returning method has to thread the
+// child's type-param placeholder (via `superclass_type_args`) into the
+// parent's `E` slot — otherwise the parent and child end up using
+// unrelated symbolic placeholders.
+//
+// Sub-bug C (Self class): intentionally still resolves to Dynamic. The
+// previous attempt to make it `Known(class_name, type_args)` broke four
+// narrowing tests (`x class = Integer` semantics) so full metatype
+// support stays deferred. The regression test below pins that contract
+// down so a future change can't silently flip it.
+
+/// BT-2021 sub-bug A: inside a generic class `Box(T)`, calling a self-send
+/// that returns `T` must yield the symbolic `T` placeholder rather than
+/// `Dynamic`. We probe the cached return type of the wrapper method —
+/// without the fix, the wrapper's return type was bare `Dynamic`.
+#[test]
+fn bt2021_self_send_in_generic_class_preserves_type_param() {
+    let source = "
+Object subclass: Box(T)
+  state: x :: T = nil
+  value -> T => x
+  wrapped -> T => self value
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    // The fix should produce no return-type-mismatch warnings — the wrapped
+    // method's body type must be the same `T` placeholder as its declared
+    // return type. Without the fix, `self value` resolves to Dynamic and
+    // the typed-class-context would warn.
+    let mismatches: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| {
+            d.message.contains("does not match declared")
+                || d.message.contains("does not understand")
+        })
+        .collect();
+    assert!(
+        mismatches.is_empty(),
+        "self-send in generic class should preserve T; got: {mismatches:?}"
+    );
+}
+
+/// BT-2021 sub-bug A direct check: probe the inferred type of `self value`
+/// inside a method of `Box(T)`. Must be `Known("T", [])`, never `Dynamic`.
+#[test]
+fn bt2021_self_send_inferred_type_is_symbolic_param() {
+    let source = "
+Object subclass: Box(T)
+  state: x :: T = nil
+  value -> T => x
+  wrapped -> T => self value
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let class = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "Box")
+        .expect("Box class");
+    let wrapped = class
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "wrapped")
+        .expect("wrapped method");
+    let stmt = wrapped.body.last().expect("wrapped has at least one stmt");
+    let expr = &stmt.expression;
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    // Mirror what `check_module` does: seed `self` with the receiver type
+    // produced by the centralised helper.
+    env.set(
+        "self",
+        super::type_resolver::receiver_type_for_class(&"Box".into(), &hierarchy),
+    );
+    let ty = checker.infer_expr(expr, &hierarchy, &mut env, false);
+
+    match &ty {
+        InferredType::Known { class_name, .. } => assert_eq!(
+            class_name.as_str(),
+            "T",
+            "expected `self value` to resolve to symbolic T placeholder, got {ty:?}"
+        ),
+        other => panic!("expected Known(T), got {other:?}"),
+    }
+}
+
+/// BT-2021 sub-bug A nested case: a multi-param generic class. Inside
+/// `Pair(K, V)`, calling `self second` (returning `V`) must resolve to
+/// the symbolic V placeholder, not Dynamic and not the wrong slot.
+#[test]
+fn bt2021_self_send_multi_param_generic_resolves_correct_slot() {
+    let source = "
+Object subclass: Pair(K, V)
+  state: k :: K = nil
+  state: v :: V = nil
+  first -> K => k
+  second -> V => v
+  rewrap -> V => self second
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let class = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "Pair")
+        .expect("Pair class");
+    let rewrap = class
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "rewrap")
+        .expect("rewrap method");
+    let stmt = rewrap.body.last().expect("rewrap has at least one stmt");
+    let expr = &stmt.expression;
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set(
+        "self",
+        super::type_resolver::receiver_type_for_class(&"Pair".into(), &hierarchy),
+    );
+    let ty = checker.infer_expr(expr, &hierarchy, &mut env, false);
+
+    match &ty {
+        InferredType::Known { class_name, .. } => assert_eq!(
+            class_name.as_str(),
+            "V",
+            "expected `self second` on Pair(K,V) to resolve to V, got {ty:?}"
+        ),
+        other => panic!("expected Known(V), got {other:?}"),
+    }
+}
+
+/// BT-2021 sub-bug B: a child generic class calling `super`-send on a
+/// parent method that returns the parent's type param must yield the
+/// child's matching type-param placeholder (mapped via
+/// `superclass_type_args`).
+///
+/// Source: `Base(E)` declares `peek -> E`; `Sub(R)` extends `Base(R)` —
+/// Sub's R is forwarded to Base's E. Inside a method on Sub, `super peek`
+/// should infer as `Known("R", [])`, not `Known("E", [])` and not Dynamic.
+#[test]
+fn bt2021_super_send_in_generic_class_threads_child_param() {
+    let source = "
+Object subclass: Base(E)
+  state: x :: E = nil
+  peek -> E => x
+
+Base(R) subclass: Sub(R)
+  borrow -> R => super peek
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let sub = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "Sub")
+        .expect("Sub class");
+    let borrow = sub
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "borrow")
+        .expect("borrow method");
+    let stmt = borrow.body.last().expect("borrow has at least one stmt");
+    let expr = &stmt.expression;
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set(
+        "self",
+        super::type_resolver::receiver_type_for_class(&"Sub".into(), &hierarchy),
+    );
+    let ty = checker.infer_expr(expr, &hierarchy, &mut env, false);
+
+    match &ty {
+        InferredType::Known { class_name, .. } => assert_eq!(
+            class_name.as_str(),
+            "R",
+            "expected `super peek` from Sub(R) extends Base(R) to resolve to R, got {ty:?}"
+        ),
+        other => panic!("expected Known(R), got {other:?}"),
+    }
+}
+
+/// BT-2021 sub-bug B with a *concrete* mapping: child binds parent's type
+/// param to a fixed type. `IntBase` extends `Base(Integer)`. Inside an
+/// `IntBase` method, `super peek` should resolve to `Integer`, not the
+/// parent's symbolic `E` placeholder.
+#[test]
+fn bt2021_super_send_with_concrete_superclass_arg_resolves_to_concrete() {
+    let source = "
+Object subclass: Base(E)
+  state: x :: E = nil
+  peek -> E => x
+
+Base(Integer) subclass: IntBase
+  borrow -> Integer => super peek
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let int_base = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "IntBase")
+        .expect("IntBase class");
+    let borrow = int_base
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "borrow")
+        .expect("borrow method");
+    let stmt = borrow.body.last().expect("borrow has at least one stmt");
+    let expr = &stmt.expression;
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set(
+        "self",
+        super::type_resolver::receiver_type_for_class(&"IntBase".into(), &hierarchy),
+    );
+    let ty = checker.infer_expr(expr, &hierarchy, &mut env, false);
+
+    match &ty {
+        InferredType::Known { class_name, .. } => assert_eq!(
+            class_name.as_str(),
+            "Integer",
+            "expected `super peek` from IntBase extends Base(Integer) to resolve to Integer, got {ty:?}"
+        ),
+        other => panic!("expected Known(Integer), got {other:?}"),
+    }
+}
+
+/// BT-2021 sub-bug C contract pin: `Self class` (as returned by `Object>>class`)
+/// stays `Dynamic`. Promoting it to `Known(class_name, type_args)` would
+/// regress narrowing tests like `x class = Integer` (BT-1952 constraint).
+/// Full metatype support is tracked separately.
+#[test]
+fn bt2021_self_class_remains_dynamic_for_factory_pattern() {
+    let source = "
+Object subclass: Box(T)
+  state: x :: T = nil
+  copy => self class new
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let class = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "Box")
+        .expect("Box class");
+    let copy = class
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "copy")
+        .expect("copy method");
+    let stmt = copy.body.last().expect("copy has at least one stmt");
+    let expr = &stmt.expression;
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set(
+        "self",
+        super::type_resolver::receiver_type_for_class(&"Box".into(), &hierarchy),
+    );
+    let ty = checker.infer_expr(expr, &hierarchy, &mut env, false);
+
+    // `self class new` on `Box(T)` resolves through `class -> Self class`
+    // (Object>>class) which intentionally returns Dynamic. The resulting
+    // `new` send on a Dynamic receiver also stays Dynamic.
+    assert!(
+        matches!(&ty, InferredType::Dynamic(_)),
+        "self class new should stay Dynamic (Self class metatype is deferred); got {ty:?}"
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -13234,10 +13234,13 @@ Base(Integer) subclass: IntBase
 /// Full metatype support is tracked separately.
 #[test]
 fn bt2021_self_class_remains_dynamic_for_factory_pattern() {
+    // Probe `self class` directly (not `self class new`) so a future change
+    // that resolves the metatype to a Known type but leaves `new` Dynamic
+    // would still cause this test to fail. CodeRabbit on PR #2064.
     let source = "
 Object subclass: Box(T)
   state: x :: T = nil
-  copy => self class new
+  metatype => self class
 ";
     let tokens = crate::source_analysis::lex_with_eof(source);
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
@@ -13251,12 +13254,12 @@ Object subclass: Box(T)
         .iter()
         .find(|c| c.name.name.as_str() == "Box")
         .expect("Box class");
-    let copy = class
+    let metatype = class
         .methods
         .iter()
-        .find(|m| m.selector.name() == "copy")
-        .expect("copy method");
-    let stmt = copy.body.last().expect("copy has at least one stmt");
+        .find(|m| m.selector.name() == "metatype")
+        .expect("metatype method");
+    let stmt = metatype.body.last().expect("metatype has at least one stmt");
     let expr = &stmt.expression;
 
     let mut checker = TypeChecker::new();
@@ -13267,11 +13270,10 @@ Object subclass: Box(T)
     );
     let ty = checker.infer_expr(expr, &hierarchy, &mut env, false);
 
-    // `self class new` on `Box(T)` resolves through `class -> Self class`
-    // (Object>>class) which intentionally returns Dynamic. The resulting
-    // `new` send on a Dynamic receiver also stays Dynamic.
+    // `self class` on `Box(T)` resolves through `class -> Self class`
+    // (Object>>class) which intentionally returns Dynamic per BT-1952.
     assert!(
         matches!(&ty, InferredType::Dynamic(_)),
-        "self class new should stay Dynamic (Self class metatype is deferred); got {ty:?}"
+        "self class should stay Dynamic (Self class metatype is deferred); got {ty:?}"
     );
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -13259,7 +13259,10 @@ Object subclass: Box(T)
         .iter()
         .find(|m| m.selector.name() == "metatype")
         .expect("metatype method");
-    let stmt = metatype.body.last().expect("metatype has at least one stmt");
+    let stmt = metatype
+        .body
+        .last()
+        .expect("metatype has at least one stmt");
     let expr = &stmt.expression;
 
     let mut checker = TypeChecker::new();

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -222,11 +222,13 @@ pub(in crate::semantic_analysis) fn super_receiver_type(
                 .get(*param_index)
                 .cloned()
                 .unwrap_or(InferredType::Dynamic(DynamicReason::Unknown)),
-            SuperclassTypeArg::Concrete { type_name } => InferredType::Known {
-                class_name: type_name.clone(),
-                type_args: vec![],
-                provenance: TypeProvenance::Inferred(crate::source_analysis::Span::default()),
-            },
+            // Copilot on PR #2064: parse the type-name string so concrete
+            // generics (`List(Integer)`), unions (`Integer | Nil`), and `Nil`
+            // keyword aliases canonicalise correctly instead of becoming an
+            // opaque `Known("List(Integer)")`.
+            SuperclassTypeArg::Concrete { type_name } => {
+                super::TypeChecker::resolve_type_name_string(type_name)
+            }
         })
         .collect();
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -174,6 +174,69 @@ pub(in crate::semantic_analysis) fn receiver_type_for_class(
     }
 }
 
+/// Build the [`InferredType`] for a `super` expression's receiver, threading
+/// the child class's type-arg bindings into the parent class's type-param
+/// positions.
+///
+/// Walks the child's `superclass_type_args` (the `Sub(R) extends Base(R)` /
+/// `IntBase extends Base(Integer)` mapping) and resolves each entry against
+/// the child's symbolic / concrete type args:
+///
+/// * [`SuperclassTypeArg::ParamRef`] — looks up the child's type arg at the
+///   given index, so `Sub(R) extends Base(R)` makes `super`'s receiver
+///   `Known("Base", [Known("R")])` (Sub's R, not Base's symbolic E).
+/// * [`SuperclassTypeArg::Concrete`] — substitutes a fixed type, so
+///   `IntBase extends Base(Integer)` makes `super`'s receiver
+///   `Known("Base", [Known("Integer")])`.
+///
+/// When the child has no `superclass_type_args` (no `extends Base(...)`
+/// annotation), falls back to [`receiver_type_for_class`] which emits the
+/// parent's symbolic type-param placeholders.
+///
+/// **References:** BT-2021 sub-bug B — `super` sends used to lose receiver
+/// `type_args` in generic classes.
+///
+/// [`SuperclassTypeArg::ParamRef`]: crate::semantic_analysis::class_hierarchy::SuperclassTypeArg::ParamRef
+/// [`SuperclassTypeArg::Concrete`]: crate::semantic_analysis::class_hierarchy::SuperclassTypeArg::Concrete
+pub(in crate::semantic_analysis) fn super_receiver_type(
+    child_class: &EcoString,
+    child_type_args: &[InferredType],
+    parent_class: &EcoString,
+    hierarchy: &ClassHierarchy,
+) -> InferredType {
+    use crate::semantic_analysis::class_hierarchy::SuperclassTypeArg;
+
+    let Some(child_info) = hierarchy.get_class(child_class) else {
+        return receiver_type_for_class(parent_class, hierarchy);
+    };
+
+    if child_info.superclass_type_args.is_empty() {
+        return receiver_type_for_class(parent_class, hierarchy);
+    }
+
+    let parent_type_args: Vec<InferredType> = child_info
+        .superclass_type_args
+        .iter()
+        .map(|sta| match sta {
+            SuperclassTypeArg::ParamRef { param_index } => child_type_args
+                .get(*param_index)
+                .cloned()
+                .unwrap_or(InferredType::Dynamic(DynamicReason::Unknown)),
+            SuperclassTypeArg::Concrete { type_name } => InferredType::Known {
+                class_name: type_name.clone(),
+                type_args: vec![],
+                provenance: TypeProvenance::Inferred(crate::source_analysis::Span::default()),
+            },
+        })
+        .collect();
+
+    InferredType::Known {
+        class_name: parent_class.clone(),
+        type_args: parent_type_args,
+        provenance: TypeProvenance::Inferred(crate::source_analysis::Span::default()),
+    }
+}
+
 /// Resolve type-position keywords to their class names.
 ///
 /// - `nil` / `Nil` → `UndefinedObject`
@@ -658,6 +721,89 @@ mod tests {
             assert_eq!(arg_name, param);
             assert!(inner_args.is_empty());
         }
+    }
+
+    // ---- super_receiver_type ----
+    //
+    // The tests below exercise BT-2021 sub-bug B's fix path: `super` sends
+    // must thread the *child's* type-arg bindings into the parent's
+    // type-param positions via `superclass_type_args` (`ParamRef` for
+    // forwarded type params, `Concrete` for fixed types).
+
+    fn parse_module(source: &str) -> (crate::ast::Module, ClassHierarchy) {
+        let tokens = crate::source_analysis::lex_with_eof(source);
+        let (module, diags) = crate::source_analysis::parse(tokens);
+        assert!(diags.is_empty(), "Parse failed: {diags:?}");
+        let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+        (module, hierarchy)
+    }
+
+    #[test]
+    fn super_receiver_threads_child_param_through_param_ref() {
+        // `Sub(R) extends Base(R)` — Sub's R forwards to Base's E.
+        // Calling super from inside Sub(R) with self typed as
+        // Known("Sub", [Known("R")]) should produce Known("Base", [Known("R")]).
+        let (_, hierarchy) = parse_module(
+            "Object subclass: Base(E)\n  state: x :: E = nil\n\nBase(R) subclass: Sub(R)\n",
+        );
+        let child_type_args = vec![InferredType::known("R")];
+        let result =
+            super_receiver_type(&"Sub".into(), &child_type_args, &"Base".into(), &hierarchy);
+        let InferredType::Known {
+            class_name,
+            type_args,
+            ..
+        } = result
+        else {
+            panic!("expected Known");
+        };
+        assert_eq!(class_name.as_str(), "Base");
+        assert_eq!(type_args, vec![InferredType::known("R")]);
+    }
+
+    #[test]
+    fn super_receiver_substitutes_concrete_superclass_arg() {
+        // `IntBase extends Base(Integer)` — Integer is fixed; Sub has no type
+        // params of its own. super's receiver must carry the concrete Integer.
+        let (_, hierarchy) = parse_module(
+            "Object subclass: Base(E)\n  state: x :: E = nil\n\nBase(Integer) subclass: IntBase\n",
+        );
+        let result = super_receiver_type(&"IntBase".into(), &[], &"Base".into(), &hierarchy);
+        let InferredType::Known {
+            class_name,
+            type_args,
+            ..
+        } = result
+        else {
+            panic!("expected Known");
+        };
+        assert_eq!(class_name.as_str(), "Base");
+        assert_eq!(type_args, vec![InferredType::known("Integer")]);
+    }
+
+    #[test]
+    fn super_receiver_falls_back_when_no_extends_annotation() {
+        // Non-generic child of non-generic parent — no superclass_type_args.
+        // super's receiver should match `receiver_type_for_class(parent)`.
+        let (_, hierarchy) = parse_module("Object subclass: Parent\n\nParent subclass: Child\n");
+        let result = super_receiver_type(&"Child".into(), &[], &"Parent".into(), &hierarchy);
+        let expected = receiver_type_for_class(&"Parent".into(), &hierarchy);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn super_receiver_unknown_child_falls_back_safely() {
+        // Child class not in hierarchy — must not panic; falls back to the
+        // parent's symbolic placeholders.
+        let (_, hierarchy) = parse_module("Object subclass: Base(E)\n");
+        let result = super_receiver_type(
+            &"NonExistentChild".into(),
+            &[InferredType::known("R")],
+            &"Base".into(),
+            &hierarchy,
+        );
+        let expected = receiver_type_for_class(&"Base".into(), &hierarchy);
+        assert_eq!(result, expected);
     }
 
     // ---- split_generic_base / base_name_of_string ----


### PR DESCRIPTION
## Summary

Fixes BT-2021: receiver `type_args` were dropped for `super` sends in generic classes, causing type parameters to silently resolve to Dynamic inside method bodies that call parent methods via `super`.

- **Sub-bug A (self):** Already fixed by BT-2025's `receiver_type_for_class` migration. Confirmed by 3 new regression tests.
- **Sub-bug B (super):** Added `super_receiver_type` helper that maps child type-arg bindings into parent type-param positions via `superclass_type_args` (`ParamRef` for forwarded params like `Sub(R) extends Base(R)`, `Concrete` for fixed types like `IntBase extends Base(Integer)`). Updated the `Expression::Super` handler to use it.
- **Sub-bug C (Self class):** Intentionally stays Dynamic per BT-1952 constraint (promoting to `Known(class_name, type_args)` breaks 4 narrowing tests). Pinned by a contract test.

### Files changed
- `inference.rs` — updated super handler to call `super_receiver_type` instead of bare `receiver_type_for_class`
- `type_resolver.rs` — new `super_receiver_type` helper + 4 unit tests
- `tests.rs` — 6 regression tests covering self (3), super (2), Self class (1)

Linear: https://linear.app/beamtalk/issue/BT-2021

## Test plan

- [x] 6 new regression tests in `tests.rs` (self single/multi-param, super ParamRef/Concrete, Self class contract)
- [x] 4 unit tests for `super_receiver_type` in `type_resolver.rs`
- [x] All 3139 existing tests pass (no regressions)
- [x] Clippy clean, fmt clean
- [x] E2E tests pass
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parent receiver type inference for `super` in generic inheritance so parent type-parameters are populated from child bindings, while preserving dynamic fallback when the child type is unknown.

* **Tests**
  * Added regression and unit tests covering generic type-argument threading, concrete superclass argument substitution, self-send behavior for generic helpers, `super`-send mapping across inheritance, and safe fallbacks when superclass info is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->