### PR TITLE
Generic return type args lost when assigned to a local from a class method call (BT-2018)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2570,7 +2570,7 @@ impl TypeChecker {
     /// passes through as a class-named `Known("Self")`, which is wrong but
     /// matches historic behaviour for call sites that don't know the
     /// receiver).
-    fn substitute_return_type_with_self(
+    pub(super) fn substitute_return_type_with_self(
         ret_ty: &str,
         subst: &HashMap<EcoString, InferredType>,
         method_local_subst: &HashMap<EcoString, InferredType>,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -12625,3 +12625,210 @@ fn param_passthrough_local_no_false_binary_warning() {
          binary operand warning, got: {binary_warnings:?}"
     );
 }
+
+// ---- BT-2018: Generic return type args preserved on class-method assignment ----
+//
+// When a class method declares a parameterised return type like
+// `Result(List(String), Error)`, callers that bind the result to a local
+// must see the full nested type — not a flattened `Known("Result(...)")`.
+// Pre-fix the call site dropped the inner generics, which made downstream
+// `result unwrap` resolve to `Dynamic` and cascaded into block-parameter
+// inference (every `[:f | ...]` after that became Dynamic).
+//
+// These tests cover the three reproducer variants from the issue plus a
+// chained-assignment case and an instance-method case.
+
+/// BT-2018 (a): explicit annotation on the LHS already worked pre-fix —
+/// keep it as a baseline so a regression here is loud.
+#[test]
+fn class_method_return_with_explicit_annotation_preserves_type_args() {
+    let source = "
+typed Object subclass: Box
+  class wrap: v :: List(String) -> Result(List(String), Error) =>
+    Result ok: v
+
+typed Object subclass: Driver
+  probe -> Nil =>
+    r :: Result(List(String), Error) := Box wrap: #()
+    r
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let driver = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "Driver")
+        .expect("Driver class");
+    let probe = driver
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "probe")
+        .expect("probe method");
+    // Last expression is `r` — its type should be Result(List(String), Error).
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set("self", InferredType::known("Driver"));
+    let _ = checker.infer_expr(&probe.body[0].expression, &hierarchy, &mut env, false);
+    let last_stmt = probe.body.last().expect("probe body non-empty");
+    let r_ty = checker.infer_expr(&last_stmt.expression, &hierarchy, &mut env, false);
+    assert_full_result_list_string_error(&r_ty);
+}
+
+/// BT-2018 (b): the bug — RHS is a class-method send returning the same
+/// concrete generic. Pre-fix, `r` lost its inner `type_args` and
+/// `r unwrap` collapsed to `Dynamic`.
+#[test]
+fn class_method_return_preserves_nested_type_args_on_assignment() {
+    let source = "
+typed Object subclass: Box
+  class wrap: v :: List(String) -> Result(List(String), Error) =>
+    Result ok: v
+
+typed Object subclass: Driver
+  probe -> Nil =>
+    r := Box wrap: #()
+    r
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let driver = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "Driver")
+        .expect("Driver class");
+    let probe = driver
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "probe")
+        .expect("probe method");
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set("self", InferredType::known("Driver"));
+    let _ = checker.infer_expr(&probe.body[0].expression, &hierarchy, &mut env, false);
+    let r_ty = checker.infer_expr(
+        &probe.body.last().expect("probe body non-empty").expression,
+        &hierarchy,
+        &mut env,
+        false,
+    );
+    assert_full_result_list_string_error(&r_ty);
+}
+
+/// BT-2018 chained: `a := ClassMethod`, `b := a instanceMethod` — type args
+/// on `a` must flow through to `b` so `b` resolves to the concrete type.
+#[test]
+fn class_method_return_type_args_flow_through_chained_assignment() {
+    let source = "
+typed Object subclass: Box
+  class wrap: v :: List(String) -> Result(List(String), Error) =>
+    Result ok: v
+
+typed Object subclass: Driver
+  probe -> Nil =>
+    r := Box wrap: #()
+    files := r unwrap
+    files frobnicate
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    // Pre-fix: `files` was Dynamic, so `frobnicate` was silently accepted.
+    // Post-fix: `files` is `List(String)` and `List` does not understand
+    // `frobnicate`, so we expect a DNU warning. (We assert *some* DNU
+    // warning naming `frobnicate` rather than pinning the exact wording —
+    // the receiver class hint format may evolve.)
+    let dnu: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not understand") && d.message.contains("frobnicate"))
+        .collect();
+    assert!(
+        !dnu.is_empty(),
+        "expected `frobnicate` DNU after chained assignment from class-method \
+         result; diagnostics: {:?}",
+        checker.diagnostics()
+    );
+}
+
+// BT-2018 instance-method case via chained assignment: the chained-flow
+// test above (`class_method_return_type_args_flow_through_chained_assignment`)
+// already exercises the instance-method substitution path: after
+// `r := Box wrap: #()` gives `r :: Result(List(String), Error)`, the
+// `r unwrap` send is an instance-method call whose return type `T`
+// substitutes through to `List(String)`. The DNU on `files frobnicate`
+// proves the instance-method substitution preserved the generics.
+// (Pure instance-method *concrete* return-type preservation — e.g.
+// `-> List(String)` on a non-generic receiver — is the sibling BT-2019,
+// not in scope here.)
+
+/// Helper: assert the type is the fully-nested
+/// `Known("Result", [Known("List", [Known("String")]), Known("Error")])`.
+fn assert_full_result_list_string_error(ty: &InferredType) {
+    let InferredType::Known {
+        class_name,
+        type_args,
+        ..
+    } = ty
+    else {
+        panic!("expected Known(Result, ...), got {ty:?}");
+    };
+    assert_eq!(
+        class_name.as_str(),
+        "Result",
+        "outer class should be Result, got {class_name}"
+    );
+    assert_eq!(
+        type_args.len(),
+        2,
+        "Result should have 2 type args, got {type_args:?}"
+    );
+    let InferredType::Known {
+        class_name: inner_name,
+        type_args: inner_args,
+        ..
+    } = &type_args[0]
+    else {
+        panic!(
+            "expected first type_arg to be Known(List, [String]), got {:?}",
+            type_args[0]
+        );
+    };
+    assert_eq!(
+        inner_name.as_str(),
+        "List",
+        "first type_arg should be List, got {inner_name}"
+    );
+    assert_eq!(
+        inner_args.len(),
+        1,
+        "List should have 1 type_arg, got {inner_args:?}"
+    );
+    assert_eq!(
+        inner_args[0].as_known().map(EcoString::as_str),
+        Some("String"),
+        "List inner type_arg should be String, got {:?}",
+        inner_args[0]
+    );
+    assert_eq!(
+        type_args[1].as_known().map(EcoString::as_str),
+        Some("Error"),
+        "second type_arg should be Error, got {:?}",
+        type_args[1]
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -163,10 +163,38 @@ impl TypeChecker {
                         let class_subst = Self::class_method_substitution(
                             class_name, hierarchy, &method, arg_types,
                         );
-                        // Self resolves to the receiver class (no inferred
-                        // type args at the class-method call site — the
-                        // substitution map carries them via the named params).
-                        let self_type = InferredType::known(class_name.clone());
+                        // Self resolves to the receiver class. For a generic
+                        // receiver (e.g. `Box(T)`) we thread the inferred
+                        // type args through `self_type` so nested `Self` in
+                        // the return type — `-> Result(Self, Error)` —
+                        // resolves to `Result(Box(Integer), Error)` rather
+                        // than the erased `Result(Box, Error)`. CodeRabbit
+                        // on PR #2065.
+                        let self_type_args: Vec<InferredType> = hierarchy
+                            .get_class(class_name)
+                            .map(|info| {
+                                info.type_params
+                                    .iter()
+                                    .map(|param| {
+                                        class_subst
+                                            .get(param)
+                                            .cloned()
+                                            .unwrap_or_else(|| InferredType::known(param.clone()))
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        let self_type = if self_type_args.is_empty() {
+                            InferredType::known(class_name.clone())
+                        } else {
+                            InferredType::Known {
+                                class_name: class_name.clone(),
+                                type_args: self_type_args,
+                                provenance: crate::semantic_analysis::TypeProvenance::Inferred(
+                                    crate::source_analysis::Span::default(),
+                                ),
+                            }
+                        };
                         return super::TypeChecker::substitute_return_type_with_self(
                             ret_ty,
                             &class_subst,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -146,40 +146,33 @@ impl TypeChecker {
                                 class_name, hierarchy, selector, arg_types,
                             );
                         }
-                        // BT-1836: Parse parameterized return types like "Stream(Integer)"
-                        // into Known { class_name: "Stream", type_args: [Known("Integer")] }
-                        // so downstream method resolution works correctly.
+                        // BT-1836 / BT-2018: Parse parameterised return types like
+                        // `Result(List(String), Error)` into a fully-nested
+                        // `Known { class_name, type_args }` so that downstream
+                        // sends on the bound local resolve correctly.
                         //
                         // BT-1986: `Self` appearing as a (nested) type argument —
                         // e.g. `class named: -> Result(Self, Error)` on Actor —
                         // resolves to the static receiver class. This powers
                         // ADR 0079's typed-lookup API where `Counter named: #c`
                         // should infer as `Result(Counter, Error)`.
-                        let (base, args_slice) = super::type_resolver::split_generic_base(ret_ty);
-                        if let Some(inner) = args_slice {
-                            let params = super::TypeChecker::split_type_params(inner);
-                            let resolved_args: Vec<super::InferredType> = params
-                                .iter()
-                                .map(|p| {
-                                    let p_eco: EcoString = (*p).into();
-                                    if p_eco.as_str() == "Self" {
-                                        super::InferredType::known(class_name.clone())
-                                    } else if super::is_generic_type_param(&p_eco) {
-                                        super::InferredType::Dynamic(DynamicReason::Unknown)
-                                    } else {
-                                        super::InferredType::known(p_eco)
-                                    }
-                                })
-                                .collect();
-                            return super::InferredType::Known {
-                                class_name: base.into(),
-                                type_args: resolved_args,
-                                provenance: super::TypeProvenance::Substituted(
-                                    crate::source_analysis::Span::default(),
-                                ),
-                            };
-                        }
-                        return InferredType::known(ret_ty.clone());
+                        //
+                        // Build the class-level substitution map (for generic
+                        // class methods like `class wrap: v :: T -> Box(T)`)
+                        // by mapping declared param types to argument types.
+                        let class_subst = Self::class_method_substitution(
+                            class_name, hierarchy, &method, arg_types,
+                        );
+                        // Self resolves to the receiver class (no inferred
+                        // type args at the class-method call site — the
+                        // substitution map carries them via the named params).
+                        let self_type = InferredType::known(class_name.clone());
+                        return super::TypeChecker::substitute_return_type_with_self(
+                            ret_ty,
+                            &class_subst,
+                            &HashMap::new(),
+                            Some(&self_type),
+                        );
                     }
                 }
                 // BT-1047: Fall back to return types inferred earlier in this pass.
@@ -190,6 +183,43 @@ impl TypeChecker {
                 InferredType::Dynamic(DynamicReason::UnannotatedReturn)
             }
         }
+    }
+
+    /// Build the class-level substitution map for a class-method call.
+    ///
+    /// Walks the method's declared parameter types and, for each parameter
+    /// whose declared type is one of the class's type parameters (e.g. `T`
+    /// in `Box(T)`), records the mapping `T -> arg_type`. The resulting map
+    /// is threaded into [`super::TypeChecker::substitute_return_type_with_self`]
+    /// so the return type's references to those params resolve to the
+    /// concrete inferred types.
+    ///
+    /// For non-generic classes (or classes with no class-method type
+    /// substitution to do), the returned map is empty.
+    ///
+    /// **References:** BT-2018 (preserve generic return types on class-method
+    /// assignments), ADR 0068 Phase 1c.
+    fn class_method_substitution(
+        class_name: &EcoString,
+        hierarchy: &ClassHierarchy,
+        method: &crate::semantic_analysis::class_hierarchy::MethodInfo,
+        arg_types: &[InferredType],
+    ) -> HashMap<EcoString, InferredType> {
+        let mut subst: HashMap<EcoString, InferredType> = HashMap::new();
+        let Some(class_info) = hierarchy.get_class(class_name) else {
+            return subst;
+        };
+        if class_info.type_params.is_empty() {
+            return subst;
+        }
+        for (param_ty_opt, arg_ty) in method.param_types.iter().zip(arg_types.iter()) {
+            if let Some(param_ty) = param_ty_opt {
+                if class_info.type_params.contains(param_ty) {
+                    subst.insert(param_ty.clone(), arg_ty.clone());
+                }
+            }
+        }
+        subst
     }
 
     /// Infer the constructor return type for a generic class (ADR 0068 Phase 1c).
@@ -215,18 +245,12 @@ impl TypeChecker {
         }
 
         // Build inference map from class method param types → argument types
-        let mut inferred: HashMap<EcoString, InferredType> = HashMap::new();
-
-        if let Some(method) = hierarchy.find_class_method(class_name, selector) {
-            for (param_ty_opt, arg_ty) in method.param_types.iter().zip(arg_types.iter()) {
-                if let Some(param_ty) = param_ty_opt {
-                    // If param type is a class type param (e.g., "T"), map it to the arg type
-                    if class_info.type_params.contains(param_ty) {
-                        inferred.insert(param_ty.clone(), arg_ty.clone());
-                    }
-                }
-            }
-        }
+        // (shared with non-`Self` returns via `class_method_substitution`).
+        let mut inferred = if let Some(method) = hierarchy.find_class_method(class_name, selector) {
+            Self::class_method_substitution(class_name, hierarchy, &method, arg_types)
+        } else {
+            HashMap::new()
+        };
 
         // Build type_args in class param order, defaulting unresolved to Dynamic
         let type_args: Vec<InferredType> = class_info


### PR DESCRIPTION
## Summary

When a class method declares a parameterised return type like
`Result(List(String), Error)`, the call site previously parsed only the
outer generic and stored each inner argument as an opaque
`Known("List(String)")` — nested type args were dropped at the boundary.
Downstream sends on a local bound from such a call collapsed to Dynamic,
which cascaded into block-parameter inference and silently masked DNU
warnings.

- Replace shallow EcoString parsing in `check_class_side_send` with the
  existing recursive `substitute_return_type_with_self` helper
- Extract `class_method_substitution` so `infer_constructor_type` and
  the new code share the param→arg mapping logic
- Add regression tests for the three reproducer variants from the issue
  (explicit annotation, class-method call, chained assignment)

Linear: https://linear.app/beamtalk/issue/BT-2018

## Test plan

- [x] `cargo test -p beamtalk-core --lib` (3125 tests pass)
- [x] `just test` (Rust + stdlib + BUnit + runtime)
- [x] `just clippy` clean
- [x] `just fmt-check` clean
- [ ] `just test-e2e` — passed before commit; rerun in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generic return type arguments not being preserved when assigning class methods with parameterized return types (e.g., `Result(List(String), Error)`) to local variables.
  * Improved type inference consistency for chained method calls on parameterized return types, preventing unwanted type degradation to `Dynamic`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->