### PR TITLE
LSP diagnostic parity regressions from BT-2009 (BT-2027)

### DIFF
--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -88,35 +88,21 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
     // type/DNU diagnostics in Pass 2 match what `build` emits. Without this,
     // `@expect` annotations that suppress real cross-file diagnostics during
     // build would be reported as stale by lint.
-    let mut all_class_infos = Vec::new();
-    let mut parsed_files: Vec<(
-        Utf8PathBuf,
-        String,
-        beamtalk_core::ast::Module,
-        Vec<beamtalk_core::source_analysis::Diagnostic>,
-    )> = Vec::new();
-
-    for file in &source_files {
-        let source = std::fs::read_to_string(file)
-            .into_diagnostic()
-            .map_err(|e| miette::miette!("Failed to read '{}': {e}", file))?;
-
-        let tokens = lex_with_eof(&source);
-        let (module, parse_diags) = parse(tokens);
-
-        all_class_infos
-            .extend(beamtalk_core::semantic_analysis::ClassHierarchy::extract_class_infos(&module));
-
-        parsed_files.push((file.clone(), source, module, parse_diags));
-    }
+    //
+    // BT-2027: When the lint target is a subset of a package (e.g. `test/` or a
+    // single file), extraction must still cover the full package source set so
+    // classes defined in sibling directories (`src/` from `test/`, etc.) are
+    // visible. Otherwise a test file that references a `src/` class produces
+    // spurious `Unresolved class` diagnostics.
+    let package_root = find_package_root(&source_path);
+    let (mut all_class_infos, parsed_files) =
+        parse_and_extract_class_infos(&source_files, package_root.as_deref())?;
 
     // Resolve dependency class metadata so lint sees the same class hierarchy
     // as build. Without this, @expect annotations that suppress real cross-package
     // diagnostics would be reported as stale.
-    // Walk ancestors to find the package root (directory containing beamtalk.toml),
-    // since the lint target may be a subdirectory or single file.
-    if let Some(project_root) = find_package_root(&source_path) {
-        resolve_dep_class_infos(&project_root, &mut all_class_infos);
+    if let Some(ref project_root) = package_root {
+        resolve_dep_class_infos(project_root, &mut all_class_infos);
     }
 
     // Pass 2: Analyse each file with cross-file class context.
@@ -295,14 +281,117 @@ fn lint_erl_files(erl_files: &[Utf8PathBuf], format: OutputFormat) -> Result<usi
     Ok(count)
 }
 
+/// Collect all `.bt` files in the package's conventional source directories
+/// (`src/` and `test/`) plus any explicitly-targeted lint files that fall
+/// outside those directories.
+///
+/// BT-2027: Used so that `beamtalk lint test/` or `beamtalk lint src/foo.bt`
+/// extracts class metadata from the full package source set, not just the
+/// path the user passed. Without this, a test file that references a `src/`
+/// class produces spurious `Unresolved class` diagnostics.
+fn collect_package_class_files(
+    package_root: &Utf8Path,
+    target_files: &[Utf8PathBuf],
+) -> Vec<Utf8PathBuf> {
+    use std::collections::HashSet;
+    let mut seen: HashSet<Utf8PathBuf> = HashSet::new();
+    let mut out: Vec<Utf8PathBuf> = Vec::new();
+
+    for subdir in ["src", "test"] {
+        let dir = package_root.join(subdir);
+        if dir.is_dir() {
+            match FileWalker::source_files().walk(&dir) {
+                Ok(files) => {
+                    for f in files {
+                        if seen.insert(f.clone()) {
+                            out.push(f);
+                        }
+                    }
+                }
+                Err(e) => warn!("failed to walk '{dir}' for cross-file class extraction: {e}"),
+            }
+        }
+    }
+
+    // Ensure explicitly-targeted files are always included, even if they live
+    // outside `src/`/`test/` (e.g. a one-off file at the package root).
+    for f in target_files {
+        if seen.insert(f.clone()) {
+            out.push(f.clone());
+        }
+    }
+
+    out
+}
+
+/// Parse each lint target and collect class-info metadata from the package's
+/// full source set (src/ + test/) so cross-file class resolution works for
+/// partial-path lint targets (BT-2027).
+///
+/// Returns `(all_class_infos, parsed_files)` where `parsed_files` contains only
+/// the files the user asked to lint; sibling files walked purely for
+/// class-info extraction are dropped.
+type ParsedLintFile = (
+    Utf8PathBuf,
+    String,
+    beamtalk_core::ast::Module,
+    Vec<beamtalk_core::source_analysis::Diagnostic>,
+);
+
+fn parse_and_extract_class_infos(
+    source_files: &[Utf8PathBuf],
+    package_root: Option<&Utf8Path>,
+) -> Result<(
+    Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
+    Vec<ParsedLintFile>,
+)> {
+    let extraction_files = match package_root {
+        Some(root) => collect_package_class_files(root, source_files),
+        None => source_files.to_vec(),
+    };
+
+    let source_file_set: std::collections::HashSet<&Utf8PathBuf> = source_files.iter().collect();
+    let mut all_class_infos = Vec::new();
+    let mut parsed_files: Vec<ParsedLintFile> = Vec::new();
+
+    for file in &extraction_files {
+        let source = std::fs::read_to_string(file)
+            .into_diagnostic()
+            .map_err(|e| miette::miette!("Failed to read '{}': {e}", file))?;
+
+        let tokens = lex_with_eof(&source);
+        let (module, parse_diags) = parse(tokens);
+
+        all_class_infos
+            .extend(beamtalk_core::semantic_analysis::ClassHierarchy::extract_class_infos(&module));
+
+        if source_file_set.contains(file) {
+            parsed_files.push((file.clone(), source, module, parse_diags));
+        }
+    }
+
+    Ok((all_class_infos, parsed_files))
+}
+
 /// Walk ancestors from the given path to find the package root (containing `beamtalk.toml`).
 ///
 /// Returns `None` if no `beamtalk.toml` is found in any ancestor directory.
+///
+/// BT-2027: Relative paths like `test/` or `src/foo.bt` are canonicalized
+/// before ancestor walking so that the search reaches the real package root
+/// rather than bailing out when the short relative path runs out of parents.
 pub(crate) fn find_package_root(start: &Utf8Path) -> Option<Utf8PathBuf> {
-    let start_dir = if start.is_file() {
-        start.parent()?
+    // Canonicalize so relative paths (e.g. `test/` invoked from the package
+    // root) have enough ancestors to walk up to the manifest.
+    let canonical: Utf8PathBuf = std::fs::canonicalize(start.as_std_path())
+        .ok()
+        .and_then(|p| Utf8PathBuf::from_path_buf(p).ok())
+        .unwrap_or_else(|| start.to_path_buf());
+
+    let start_dir: &Utf8Path = if canonical.is_file() {
+        canonical.parent()?
     } else {
-        start
+        canonical.as_path()
     };
 
     let mut dir = start_dir;
@@ -626,5 +715,101 @@ mod tests {
             text.contains(&format!("Total{:>15}", summary.total())),
             "Text should contain total count, got: {text}"
         );
+    }
+
+    /// BT-2027: Regression — linting `test/` in a package must pull class
+    /// infos from sibling `src/` so references to src-defined classes resolve.
+    #[test]
+    fn lint_on_test_dir_resolves_sibling_src_classes() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::write(
+            root.join("beamtalk.toml"),
+            "[package]\nname = \"xpkg\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let src = root.join("src");
+        let test = root.join("test");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&test).unwrap();
+        std::fs::write(
+            src.join("foo.bt"),
+            "Object subclass: Foo\n  class demo => 42\n",
+        )
+        .unwrap();
+        std::fs::write(
+            test.join("foo_test.bt"),
+            "Object subclass: FooTest\n  class run =>\n    Foo demo\n",
+        )
+        .unwrap();
+
+        // Emulate what run_lint does: walk the `test/` directory, but extract
+        // class infos from the full package source set (src/ + test/).
+        let test_utf8 = camino::Utf8PathBuf::from_path_buf(test.clone()).unwrap();
+        let test_files = collect_source_files_from_dir(&test_utf8).unwrap();
+        let pkg_root = find_package_root(&test_utf8).expect("package root must be found");
+        let extraction_files = collect_package_class_files(&pkg_root, &test_files);
+
+        let mut all_class_infos = Vec::new();
+        for file in &extraction_files {
+            let source = std::fs::read_to_string(file).unwrap();
+            let tokens = lex_with_eof(&source);
+            let (module, _) = parse(tokens);
+            all_class_infos.extend(
+                beamtalk_core::semantic_analysis::ClassHierarchy::extract_class_infos(&module),
+            );
+        }
+
+        // Now lint-analyse the test file with the full class info set.
+        let test_source = std::fs::read_to_string(test.join("foo_test.bt")).unwrap();
+        let tokens = lex_with_eof(&test_source);
+        let (module, parse_diags) = parse(tokens);
+        let cross_file_classes =
+            beamtalk_core::semantic_analysis::ClassHierarchy::cross_file_class_infos(
+                &all_class_infos,
+                &module,
+            );
+        let diags = collect_diagnostics(&module, parse_diags, cross_file_classes);
+
+        let unresolved: Vec<_> = diags
+            .iter()
+            .filter(|d| {
+                d.category
+                    == Some(beamtalk_core::source_analysis::DiagnosticCategory::UnresolvedClass)
+            })
+            .collect();
+        assert!(
+            unresolved.is_empty(),
+            "test/ file should resolve src/ classes, got unresolved: {unresolved:?}"
+        );
+    }
+
+    /// BT-2027: `find_package_root` must work for relative paths like `test/`
+    /// by canonicalizing the start path.
+    ///
+    /// Serialized on `cwd` because it temporarily mutates the process working
+    /// directory, matching the convention used by tests in `run.rs` / `test.rs`.
+    #[test]
+    #[serial_test::serial(cwd)]
+    fn find_package_root_canonicalizes_relative_paths() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::write(
+            root.join("beamtalk.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let test_dir = root.join("test");
+        std::fs::create_dir_all(&test_dir).unwrap();
+
+        // Run the check from the package root with a relative argument.
+        let prev_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(root).unwrap();
+        let relative = camino::Utf8PathBuf::from("test");
+        let found = find_package_root(&relative);
+        std::env::set_current_dir(prev_cwd).unwrap();
+
+        let expected = camino::Utf8PathBuf::from_path_buf(root.canonicalize().unwrap()).unwrap();
+        assert_eq!(found, Some(expected));
     }
 }

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -294,6 +294,10 @@ fn collect_package_class_files(
     target_files: &[Utf8PathBuf],
 ) -> Vec<Utf8PathBuf> {
     use std::collections::HashSet;
+    // Dedup by canonical form: walked paths are absolute (`package_root` is
+    // canonicalized upstream) but `target_files` often arrive as relative
+    // user-typed paths (e.g. `test/Foo.bt`). Comparing raw `Utf8PathBuf`
+    // would let the same file appear twice and get parsed twice.
     let mut seen: HashSet<Utf8PathBuf> = HashSet::new();
     let mut out: Vec<Utf8PathBuf> = Vec::new();
 
@@ -303,7 +307,7 @@ fn collect_package_class_files(
             match FileWalker::source_files().walk(&dir) {
                 Ok(files) => {
                     for f in files {
-                        if seen.insert(f.clone()) {
+                        if seen.insert(canonicalize_or_clone(&f)) {
                             out.push(f);
                         }
                     }
@@ -316,12 +320,22 @@ fn collect_package_class_files(
     // Ensure explicitly-targeted files are always included, even if they live
     // outside `src/`/`test/` (e.g. a one-off file at the package root).
     for f in target_files {
-        if seen.insert(f.clone()) {
+        if seen.insert(canonicalize_or_clone(f)) {
             out.push(f.clone());
         }
     }
 
     out
+}
+
+/// Returns the canonical filesystem form of `path`, falling back to a clone
+/// when the path cannot be canonicalized (e.g. it does not yet exist). Used
+/// as a normalized key for path-based deduplication.
+fn canonicalize_or_clone(path: &Utf8Path) -> Utf8PathBuf {
+    std::fs::canonicalize(path.as_std_path())
+        .ok()
+        .and_then(|p| Utf8PathBuf::from_path_buf(p).ok())
+        .unwrap_or_else(|| path.to_path_buf())
 }
 
 /// Parse each lint target and collect class-info metadata from the package's
@@ -350,7 +364,14 @@ fn parse_and_extract_class_infos(
         None => source_files.to_vec(),
     };
 
-    let source_file_set: std::collections::HashSet<&Utf8PathBuf> = source_files.iter().collect();
+    // Match by canonical form: `source_files` may be user-typed relative
+    // paths while `extraction_files` contains absolute paths from the package
+    // walk. Comparing raw `Utf8PathBuf` would drop relative targets from
+    // `parsed_files` after dedup canonicalized them into walked form.
+    let source_file_set: std::collections::HashSet<Utf8PathBuf> = source_files
+        .iter()
+        .map(|p| canonicalize_or_clone(p))
+        .collect();
     let mut all_class_infos = Vec::new();
     let mut parsed_files: Vec<ParsedLintFile> = Vec::new();
 
@@ -365,7 +386,7 @@ fn parse_and_extract_class_infos(
         all_class_infos
             .extend(beamtalk_core::semantic_analysis::ClassHierarchy::extract_class_infos(&module));
 
-        if source_file_set.contains(file) {
+        if source_file_set.contains(&canonicalize_or_clone(file)) {
             parsed_files.push((file.clone(), source, module, parse_diags));
         }
     }
@@ -606,8 +627,14 @@ mod tests {
         let src = root.join("src");
         std::fs::create_dir_all(&src).unwrap();
 
-        let root_utf8 = camino::Utf8PathBuf::from_path_buf(root.to_path_buf()).unwrap();
-        let src_utf8 = camino::Utf8PathBuf::from_path_buf(src.clone()).unwrap();
+        // Use the canonical form of root for the expected value: on macOS
+        // `/tmp` resolves to `/private/tmp`; on Windows short/long path names
+        // differ. `find_package_root` canonicalises internally, so the expected
+        // value must do the same to match.
+        let root_utf8 =
+            camino::Utf8PathBuf::from_path_buf(std::fs::canonicalize(root).unwrap()).unwrap();
+        let src_utf8 =
+            camino::Utf8PathBuf::from_path_buf(std::fs::canonicalize(&src).unwrap()).unwrap();
 
         // From subdir, should find parent
         assert_eq!(find_package_root(&src_utf8), Some(root_utf8.clone()));
@@ -630,7 +657,9 @@ mod tests {
         std::fs::write(src.join("foo.bt"), "Object subclass: Foo\n").unwrap();
 
         let file_utf8 = camino::Utf8PathBuf::from_path_buf(src.join("foo.bt")).unwrap();
-        let root_utf8 = camino::Utf8PathBuf::from_path_buf(root.to_path_buf()).unwrap();
+        // Canonicalise root — see find_package_root_from_subdir for rationale.
+        let root_utf8 =
+            camino::Utf8PathBuf::from_path_buf(std::fs::canonicalize(root).unwrap()).unwrap();
 
         assert_eq!(find_package_root(&file_utf8), Some(root_utf8));
     }
@@ -781,6 +810,43 @@ mod tests {
         assert!(
             unresolved.is_empty(),
             "test/ file should resolve src/ classes, got unresolved: {unresolved:?}"
+        );
+    }
+
+    /// BT-2027: `collect_package_class_files` must dedup across the absolute
+    /// paths produced by walking `src/`/`test/` and the relative paths a user
+    /// may pass as explicit lint targets. Without canonical-form dedup the
+    /// same file would appear twice in the extraction list and be parsed
+    /// twice downstream.
+    #[test]
+    #[serial_test::serial(cwd)]
+    fn collect_package_class_files_dedups_absolute_and_relative() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::write(
+            root.join("beamtalk.toml"),
+            "[package]\nname = \"dp\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let test = root.join("test");
+        std::fs::create_dir_all(&test).unwrap();
+        std::fs::write(test.join("foo.bt"), "Object subclass: Foo\n").unwrap();
+
+        let prev_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(root).unwrap();
+
+        // Walked form is absolute (under canonical package_root); user-typed
+        // target is relative. Both refer to the same file.
+        let pkg_root = find_package_root(&camino::Utf8PathBuf::from("test")).expect("package root");
+        let relative_target = camino::Utf8PathBuf::from("test/foo.bt");
+        let out = collect_package_class_files(&pkg_root, std::slice::from_ref(&relative_target));
+
+        std::env::set_current_dir(prev_cwd).unwrap();
+
+        assert_eq!(
+            out.len(),
+            1,
+            "expected single entry after canonical-form dedup, got {out:?}"
         );
     }
 

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -912,7 +912,16 @@ impl LanguageService for SimpleLanguageService {
                 // the ProjectIndex are passed so type checking, @expect
                 // directives, and all post-analysis passes run identically.
                 let cross_file_classes = self.project_index.cross_file_class_infos_for(file);
+                // BT-2027: Stdlib source files must be analysed with
+                // `stdlib_mode = true` so the "conflicts with a stdlib class"
+                // shadowing check (BT-738) doesn't flag every class the file
+                // legitimately defines.
+                let mut options = crate::CompilerOptions::default();
+                if self.project_index.is_stdlib_file(file) {
+                    options.stdlib_mode = true;
+                }
                 let ctx = crate::queries::diagnostic_provider::ProjectDiagnosticContext {
+                    options,
                     cross_file_classes,
                     native_type_registry: self.native_types.clone(),
                     ..Default::default()
@@ -2782,5 +2791,67 @@ mod tests {
         assert!(refs.iter().any(|r| r.file == file_proto));
         assert!(refs.iter().any(|r| r.file == file_logger));
         assert!(refs.iter().any(|r| r.file == file_sortable));
+    }
+
+    /// BT-2027: `SimpleLanguageService::diagnostics` must hand off the
+    /// cross-file class set from the `ProjectIndex` to the unified diagnostic
+    /// pipeline, so that a file referencing a class defined elsewhere does
+    /// not produce a spurious `UnresolvedClass` diagnostic.
+    #[test]
+    fn diagnostics_resolve_cross_file_class_via_project_index() {
+        use crate::source_analysis::DiagnosticCategory;
+
+        let mut service = SimpleLanguageService::new();
+        let src_file = Utf8PathBuf::from("src/Foo.bt");
+        let test_file = Utf8PathBuf::from("test/FooTest.bt");
+
+        service.update_file(
+            src_file.clone(),
+            "Object subclass: Foo\n  class demo => 42\n".to_string(),
+        );
+        service.update_file(
+            test_file.clone(),
+            "Object subclass: FooTest\n  class run =>\n    Foo demo\n".to_string(),
+        );
+
+        let diags = service.diagnostics(&test_file);
+        let unresolved: Vec<_> = diags
+            .iter()
+            .filter(|d| d.category == Some(DiagnosticCategory::UnresolvedClass))
+            .collect();
+        assert!(
+            unresolved.is_empty(),
+            "cross-file class `Foo` should resolve via ProjectIndex, got: {unresolved:?}"
+        );
+    }
+
+    /// BT-2027: Opening a stdlib source file must not emit "conflicts with
+    /// stdlib class" diagnostics for every class the file defines. The
+    /// language service now sets `stdlib_mode = true` for files tracked as
+    /// stdlib in the `ProjectIndex`.
+    #[test]
+    fn diagnostics_skip_stdlib_shadowing_for_stdlib_files() {
+        use crate::language_service::project_index::ProjectIndex;
+
+        // Pre-index a stdlib file defining `Counter`.
+        let stdlib_path = Utf8PathBuf::from("stdlib/src/Counter.bt");
+        let stdlib_source = "Object subclass: Counter\n  class zero => 0\n".to_string();
+        let (index_result, _) =
+            ProjectIndex::with_stdlib(&[(stdlib_path.clone(), stdlib_source.clone())]);
+        let index = index_result.unwrap();
+
+        let mut service = SimpleLanguageService::with_project_index(index);
+        // Re-register through update_file so `files` has an entry for it.
+        service.update_file(stdlib_path.clone(), stdlib_source);
+
+        let diags = service.diagnostics(&stdlib_path);
+        let shadowing: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("conflicts with a stdlib class"))
+            .collect();
+        assert!(
+            shadowing.is_empty(),
+            "stdlib files should not emit stdlib-shadowing diagnostics, got: {shadowing:?}"
+        );
     }
 }

--- a/crates/beamtalk-core/src/language_service/project_index.rs
+++ b/crates/beamtalk-core/src/language_service/project_index.rs
@@ -200,6 +200,16 @@ impl ProjectIndex {
         self.file_classes.get(file).map(Vec::as_slice)
     }
 
+    /// Returns `true` if `file` was loaded as part of the stdlib source set.
+    ///
+    /// BT-2027: `SimpleLanguageService::diagnostics` uses this to suppress the
+    /// "conflicts with a stdlib class" shadowing check for stdlib files
+    /// themselves (which would otherwise flag every class they define).
+    #[must_use]
+    pub fn is_stdlib_file(&self, file: &Utf8PathBuf) -> bool {
+        self.stdlib_files.contains(file)
+    }
+
     /// Returns cross-file `ClassInfo` entries for diagnostic computation (BT-2009).
     ///
     /// Returns all `ClassInfo` entries from the merged hierarchy that were NOT

--- a/crates/beamtalk-core/src/queries/diagnostic_provider.rs
+++ b/crates/beamtalk-core/src/queries/diagnostic_provider.rs
@@ -71,7 +71,9 @@ pub struct ProjectDiagnosticContext<'a> {
 /// # Arguments
 ///
 /// * `module` - The parsed AST
-/// * `parse_diagnostics` - Diagnostics from the parser
+/// * `initial_diagnostics` - Pre-analysis diagnostics (parse + any earlier passes,
+///   e.g. `@primitive` validation from the CLI compiler); the function appends
+///   semantic and post-analysis diagnostics to this list.
 /// * `ctx` - Project-level context bundling all optional inputs
 ///
 /// # Returns
@@ -80,10 +82,10 @@ pub struct ProjectDiagnosticContext<'a> {
 #[must_use]
 pub fn compute_project_diagnostics(
     module: &Module,
-    parse_diagnostics: Vec<Diagnostic>,
+    initial_diagnostics: Vec<Diagnostic>,
     ctx: &ProjectDiagnosticContext<'_>,
 ) -> Vec<Diagnostic> {
-    let mut diagnostics = parse_diagnostics;
+    let mut diagnostics = initial_diagnostics;
 
     // Run semantic analysis with the richest available entry point.
     let analysis_result = crate::semantic_analysis::analyse_with_natives_and_protocols(

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -467,6 +467,24 @@ impl Backend {
         }])
     }
 
+    /// Republishes diagnostics for every currently-open file.
+    ///
+    /// BT-2027: Called once preload completes so that any file opened before
+    /// the project index was fully populated has its diagnostics recomputed
+    /// against the complete hierarchy. Stale `unresolved_class` warnings
+    /// against now-indexed classes self-heal without user intervention.
+    async fn republish_open_diagnostics(&self) {
+        let paths: Vec<Utf8PathBuf> = {
+            let versions = self.versions.lock().expect("versions lock poisoned");
+            versions.keys().cloned().collect()
+        };
+        for path in paths {
+            if let Ok(uri) = Url::from_file_path(path.as_std_path()) {
+                self.publish_diagnostics(&uri).await;
+            }
+        }
+    }
+
     /// Publishes diagnostics for a file after every change.
     async fn publish_diagnostics(&self, uri: &Url) {
         // Stdlib virtual documents have no user-facing diagnostics.
@@ -558,6 +576,14 @@ impl LanguageServer for Backend {
             self.preload_workspace_source_files(config.clone()).await;
             // ADR 0075: Load type cache from _build/type_cache/ for typed completions.
             self.load_type_cache(&config.roots).await;
+
+            // BT-2027: Re-publish diagnostics for every open file after preload
+            // completes. If a file was opened via `did_open` before preload
+            // finished (or against an incomplete project index), its initial
+            // diagnostics may contain stale `unresolved_class` warnings against
+            // classes that have since been indexed. Republishing self-heals
+            // those without requiring the user to touch the file.
+            self.republish_open_diagnostics().await;
         }
 
         // Resolve OTP lib dir for FFI goto-definition.
@@ -1162,19 +1188,25 @@ fn collect_preload_files(config: PreloadConfig) -> PreloadedFiles {
 
     let preload_walker = FileWalker::preload_files(remaining_budget);
 
+    // BT-2027: Preload both `src/` and `test/` so that opening a file in
+    // `test/` immediately sees classes defined in `src/` (and vice versa).
+    // Before this, the LSP would report spurious `Unresolved class` for every
+    // test-to-src reference until the user touched the src file manually.
     for root in &roots {
-        if remaining_budget == 0 {
-            break;
-        }
-        let src_dir = root.join("src");
-        if src_dir.is_dir() {
-            if let Ok(found) = preload_walker
-                .clone()
-                .max_files(remaining_budget)
-                .walk_pathbuf(&src_dir)
-            {
-                remaining_budget = remaining_budget.saturating_sub(found.len());
-                user_paths.extend(found);
+        for subdir in ["src", "test"] {
+            if remaining_budget == 0 {
+                break;
+            }
+            let dir = root.join(subdir);
+            if dir.is_dir() {
+                if let Ok(found) = preload_walker
+                    .clone()
+                    .max_files(remaining_budget)
+                    .walk_pathbuf(&dir)
+                {
+                    remaining_budget = remaining_budget.saturating_sub(found.len());
+                    user_paths.extend(found);
+                }
             }
         }
     }
@@ -1989,6 +2021,41 @@ mod tests {
         assert_eq!(loaded.stdlib_files.len(), 1);
         assert!(loaded.user_files[0].0.ends_with("User.bt"));
         assert!(loaded.stdlib_files[0].0.ends_with("Integer.bt"));
+
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    /// BT-2027: Preload must walk both `src/` and `test/`. Before this fix,
+    /// opening a `test/` file in the LSP reported spurious `Unresolved class`
+    /// for every reference to a `src/` class.
+    #[test]
+    fn collect_preload_files_walks_src_and_test() {
+        let temp = unique_temp_dir("beamtalk_lsp_preload_test_dir");
+        let project_root = temp.join("project");
+        let src_dir = project_root.join("src");
+        let test_dir = project_root.join("test");
+
+        fs::create_dir_all(&src_dir).expect("create src dir");
+        fs::create_dir_all(&test_dir).expect("create test dir");
+
+        fs::write(src_dir.join("Foo.bt"), "Object subclass: Foo").expect("write src file");
+        fs::write(test_dir.join("FooTest.bt"), "Object subclass: FooTest")
+            .expect("write test file");
+
+        let config = PreloadConfig {
+            roots: vec![project_root],
+            stdlib_dirs: vec![],
+        };
+        let loaded = collect_preload_files(config);
+
+        assert_eq!(loaded.user_files.len(), 2);
+        assert!(loaded.user_files.iter().any(|(p, _)| p.ends_with("Foo.bt")));
+        assert!(
+            loaded
+                .user_files
+                .iter()
+                .any(|(p, _)| p.ends_with("FooTest.bt"))
+        );
 
         let _ = fs::remove_dir_all(&temp);
     }

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -473,13 +473,34 @@ impl Backend {
     /// the project index was fully populated has its diagnostics recomputed
     /// against the complete hierarchy. Stale `unresolved_class` warnings
     /// against now-indexed classes self-heal without user intervention.
+    ///
+    /// `versions` is keyed by the internal path returned by
+    /// `resolve_path_for_uri`, so paths may represent `file://`, `untitled:`
+    /// (via the `__untitled__/` prefix), or `beamtalk-stdlib://` virtual docs
+    /// (real stdlib paths stored in `stdlib_paths`). The URI reconstructed
+    /// here must match the original scheme so `publish_diagnostics` routes
+    /// correctly — in particular, stdlib docs must not be republished under
+    /// `file://`, which would bypass the stdlib early-return and leak
+    /// diagnostics for sources the user never opened.
     async fn republish_open_diagnostics(&self) {
         let paths: Vec<Utf8PathBuf> = {
             let versions = self.versions.lock().expect("versions lock poisoned");
             versions.keys().cloned().collect()
         };
         for path in paths {
-            if let Ok(uri) = Url::from_file_path(path.as_std_path()) {
+            let is_stdlib = {
+                let stdlib_paths = self
+                    .stdlib_paths
+                    .lock()
+                    .expect("stdlib_paths lock poisoned");
+                stdlib_paths.contains(&path)
+            };
+            let uri = if is_stdlib {
+                path_to_stdlib_uri(&path)
+            } else {
+                path_to_uri(&path)
+            };
+            if let Some(uri) = uri {
                 self.publish_diagnostics(&uri).await;
             }
         }


### PR DESCRIPTION
## Summary

Fixes the user-reported regression where `beamtalk lint test/` (and opening `test/*.bt` files in the LSP) produced spurious `Unresolved class` diagnostics for every reference to a class defined in sibling `src/`. Also fixes the separate Copilot-flagged regression where opening any stdlib `.bt` file in the LSP flagged every class with "conflicts with a stdlib class".

Linear issue: https://linear.app/beamtalk/issue/BT-2027

## Changes

- **CLI `lint`**: When the target is a subset of a package (e.g. `test/`), class-info extraction now walks the full package source set (`src/` + `test/`) instead of just the passed path. Files are only lint-analysed if the user asked for them; sibling files are loaded purely for cross-file class resolution. The Pass 1 loop is factored into `parse_and_extract_class_infos`.
- **`find_package_root`**: Now canonicalizes relative paths so `beamtalk lint test/` reaches the real package root instead of bailing out when the short relative path runs out of parents.
- **LSP preload**: `collect_preload_files` walks both `src/` and `test/` under each workspace root.
- **LSP post-preload**: `initialized` now calls `republish_open_diagnostics` so files opened before preload finished have their diagnostics recomputed against the complete `ProjectIndex` — stale `unresolved_class` warnings self-heal.
- **`SimpleLanguageService::diagnostics`**: Sets `stdlib_mode = true` when the target file is tracked as stdlib in `ProjectIndex`. Adds `ProjectIndex::is_stdlib_file`.
- **Copilot nits**: Renamed `parse_diagnostics` → `initial_diagnostics` in `compute_project_diagnostics` and updated its docstring to describe what callers actually pass.

Deferred as follow-ups (out of scope for this fix): `Arc<[ClassInfo]>` clone-pressure reduction (pure perf, touches many callers); duplicate relative-path bug in `commands/test.rs::find_package_root`.

## Test plan

- [x] `cargo test -p beamtalk-cli --bin beamtalk lint::` — 36 pass (includes new `lint_on_test_dir_resolves_sibling_src_classes`, `find_package_root_canonicalizes_relative_paths`)
- [x] `cargo test -p beamtalk-core --lib` — includes new `diagnostics_resolve_cross_file_class_via_project_index`, `diagnostics_skip_stdlib_shadowing_for_stdlib_files`
- [x] `cargo test -p beamtalk-lsp collect_preload` — includes new `collect_preload_files_walks_src_and_test`
- [x] `just test`, `just test-e2e`, `just test-integration`, `just test-mcp`, `just clippy`, `just fmt-check` — all green
- [x] User repro: `cd ~/source/beamtalk-exdura && beamtalk lint test/ | grep "Unresolved class" | wc -l` — now `0` (was 100+ before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language server now republishes diagnostics for already-open files after workspace preload.
  * Workspace preload covers both src/ and test/ directories for fuller analysis.

* **Bug Fixes**
  * Linting now discovers and resolves class references between src/ and test/ reliably.
  * Diagnostics no longer emit false unresolved or stdlib-conflict warnings; relative path package-root detection corrected.

* **Chores**
  * Added regression tests for multi-directory resolution and diagnostic republishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->