### PR TITLE
Preserve type_args on concrete parametric instance-method returns (BT-2019)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1081,28 +1081,19 @@ impl TypeChecker {
                         return InferredType::Dynamic(DynamicReason::Unknown);
                     }
 
-                    // BT-1576: If the return type is a generic like "Array(R)",
-                    // extract the base class name so completion/chain
-                    // resolution works.
+                    // BT-2019: Resolve the return type through the centralised
+                    // string-form parser, which preserves the full
+                    // parameterised type — `List(String)` becomes
+                    // `Known("List", [Known("String")])` rather than the
+                    // pre-fix bare `Known("List", [])` that silently dropped
+                    // the element type.
                     //
-                    // BT-2025 preserves current (buggy — type_args dropped)
-                    // behaviour here. The fix lives in the follow-up PRs
-                    // (BT-2018..BT-2023); this commit only introduces the
-                    // resolver framework, it does not flip behaviour at the
-                    // call sites. See the parent epic BT-2024. The
-                    // `base_name_of_string` helper keeps the
-                    // `no .find('(')` grep clean without altering the
-                    // (deliberately preserved) type-args-dropping behaviour.
-                    let base = super::type_resolver::base_name_of_string(ret_ty);
-                    if base.len() < ret_ty.len() {
-                        return InferredType::known(EcoString::from(base));
-                    }
-                    // BT-2017: Use resolve_type_name_string to properly parse
-                    // union return types like "Integer | Nil" into
-                    // InferredType::Union instead of Known("Integer | Nil").
-                    // Without this, locals bound from method calls that return
-                    // union types get a flat Known type, which prevents
-                    // narrowing and causes false operand-type warnings.
+                    // Also handles:
+                    //  * BT-2017: union return types like `"Integer | Nil"`
+                    //    parse into `InferredType::Union`, enabling narrowing.
+                    //  * Plain class names — pass through to `Known(name, [])`.
+                    //  * Nested generics — `Result(List(String), Error)`
+                    //    keeps both layers.
                     return Self::resolve_type_name_string(ret_ty);
                 }
             }
@@ -1575,19 +1566,12 @@ impl TypeChecker {
                             {
                                 return_types.push(InferredType::Dynamic(DynamicReason::Unknown));
                             } else {
-                                // BT-1576 / BT-2025: preserve the existing
-                                // (type_args-dropping) behaviour but route
-                                // through the `base_name_of_string` helper
-                                // to satisfy the `no .find('(')` grep check.
-                                let base = super::type_resolver::base_name_of_string(ret_ty);
-                                if base.len() < ret_ty.len() {
-                                    return_types.push(InferredType::known(EcoString::from(base)));
-                                } else {
-                                    // BT-2017: Use resolve_type_name_string to
-                                    // properly parse union return types (e.g.
-                                    // "Integer | Nil") into InferredType::Union.
-                                    return_types.push(Self::resolve_type_name_string(ret_ty));
-                                }
+                                // BT-2019 / BT-2017: Resolve through the
+                                // centralised string-form parser to preserve
+                                // parametric type args (`List(String)` keeps
+                                // its element type) and parse union return
+                                // types into `InferredType::Union`.
+                                return_types.push(Self::resolve_type_name_string(ret_ty));
                             }
                         }
                     } else {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -13487,3 +13487,327 @@ fn assert_full_result_list_string_error(ty: &InferredType) {
         type_args[1]
     );
 }
+
+// ---- BT-2019: Concrete parametric return types preserve type_args on
+// instance-method sends from non-generic receivers ----
+//
+// When a non-generic class declares an instance or class method returning a
+// concrete parametric type such as `-> List(String)` or `-> List(MyThing)`,
+// the call-site result must preserve the inner type arguments so downstream
+// generic resolution (`first`, `do:`, etc.) sees the element type.
+//
+// Pre-fix the path in `inference.rs` that handled instance-method return
+// types stripped the `(...)` portion off, so callers saw `Known("List", [])`
+// instead of `Known("List", [Known("MyThing")])`. Every downstream send then
+// fell back to Object/Dynamic.
+
+/// BT-2019 (b): instance method on a non-generic receiver returning a
+/// concrete parametric type. The call-site result must preserve the
+/// inner element type so `events first` resolves to `MyThing`, not bare
+/// `Object`/`Dynamic`.
+#[test]
+fn instance_method_concrete_parametric_return_preserves_type_args() {
+    let source = "
+typed Value subclass: MyThing
+  field: v :: Integer = 0
+
+typed Object subclass: Store
+  readEvents -> List(MyThing) =>
+    #()
+
+typed Object subclass: Driver
+  probe: store :: Store -> Nil =>
+    events := store readEvents
+    events
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let driver = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "Driver")
+        .expect("Driver class");
+    let probe = driver
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "probe:")
+        .expect("probe: method");
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set("self", InferredType::known("Driver"));
+    env.set("store", InferredType::known("Store"));
+    // Walk the body so each binding is recorded in env.
+    for stmt in &probe.body {
+        let _ = checker.infer_expr(&stmt.expression, &hierarchy, &mut env, false);
+    }
+    let events_ty = checker.infer_expr(
+        &probe.body.last().expect("probe body non-empty").expression,
+        &hierarchy,
+        &mut env,
+        false,
+    );
+    let InferredType::Known {
+        class_name,
+        type_args,
+        ..
+    } = events_ty
+    else {
+        panic!("expected Known(List, [MyThing]), got {events_ty:?}");
+    };
+    assert_eq!(class_name.as_str(), "List");
+    assert_eq!(
+        type_args.len(),
+        1,
+        "List should preserve its element type arg, got {type_args:?}"
+    );
+    assert_eq!(
+        type_args[0].as_known().map(EcoString::as_str),
+        Some("MyThing"),
+        "List element type should be MyThing, got {:?}",
+        type_args[0]
+    );
+}
+
+/// BT-2019: end-to-end DNU check. After the fix, sending a non-existent
+/// selector to the element of a `List(MyThing)` returned by an instance
+/// method must produce a "`MyThing` does not understand 'xyzzyNonsense'"
+/// warning. Pre-fix the warning was silently lost (element type was
+/// Dynamic).
+#[test]
+fn instance_method_concrete_parametric_return_drives_element_dnu() {
+    let source = "
+typed Value subclass: MyThing
+  field: v :: Integer = 0
+
+typed Object subclass: Store
+  readEvents -> List(MyThing) =>
+    #()
+
+typed Object subclass: Driver
+  probe: store :: Store -> Nil =>
+    events := store readEvents
+    first := events first
+    first xyzzyNonsense
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dnu: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| {
+            d.message.contains("does not understand") && d.message.contains("xyzzyNonsense")
+        })
+        .collect();
+    assert!(
+        !dnu.is_empty(),
+        "expected `xyzzyNonsense` DNU on MyThing element from List(MyThing) \
+         instance-method return; diagnostics: {:?}",
+        checker.diagnostics()
+    );
+}
+
+/// BT-2019: class-method case. `ExduraSupervisor class >> children -> List(Actor)`
+/// — the call-site result of `Sup children` must be `List(Actor)`, not
+/// bare `List`.
+#[test]
+fn class_method_concrete_parametric_return_preserves_type_args() {
+    let source = "
+typed Object subclass: Actor
+  field: name :: String = \"\"
+
+typed Object subclass: Sup
+  class children -> List(Actor) =>
+    #()
+
+typed Object subclass: Driver
+  probe -> Nil =>
+    kids := Sup children
+    kids
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let driver = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "Driver")
+        .expect("Driver class");
+    let probe = driver
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "probe")
+        .expect("probe method");
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set("self", InferredType::known("Driver"));
+    for stmt in &probe.body {
+        let _ = checker.infer_expr(&stmt.expression, &hierarchy, &mut env, false);
+    }
+    let kids_ty = checker.infer_expr(
+        &probe.body.last().expect("probe body non-empty").expression,
+        &hierarchy,
+        &mut env,
+        false,
+    );
+    let InferredType::Known {
+        class_name,
+        type_args,
+        ..
+    } = kids_ty
+    else {
+        panic!("expected Known(List, [Actor]), got {kids_ty:?}");
+    };
+    assert_eq!(class_name.as_str(), "List");
+    assert_eq!(
+        type_args.len(),
+        1,
+        "List should preserve its element type arg"
+    );
+    assert_eq!(
+        type_args[0].as_known().map(EcoString::as_str),
+        Some("Actor")
+    );
+}
+
+/// BT-2019: Dictionary(K, V) — two type args must be preserved.
+#[test]
+fn instance_method_dictionary_return_preserves_both_type_args() {
+    let source = "
+typed Object subclass: Store
+  readMap -> Dictionary(String, Integer) =>
+    Dictionary new
+
+typed Object subclass: Driver
+  probe: store :: Store -> Nil =>
+    m := store readMap
+    m
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let driver = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "Driver")
+        .expect("Driver class");
+    let probe = driver
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "probe:")
+        .expect("probe: method");
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set("self", InferredType::known("Driver"));
+    env.set("store", InferredType::known("Store"));
+    for stmt in &probe.body {
+        let _ = checker.infer_expr(&stmt.expression, &hierarchy, &mut env, false);
+    }
+    let m_ty = checker.infer_expr(
+        &probe.body.last().expect("probe body non-empty").expression,
+        &hierarchy,
+        &mut env,
+        false,
+    );
+    let InferredType::Known {
+        class_name,
+        type_args,
+        ..
+    } = m_ty
+    else {
+        panic!("expected Known(Dictionary, [String, Integer]), got {m_ty:?}");
+    };
+    assert_eq!(class_name.as_str(), "Dictionary");
+    assert_eq!(type_args.len(), 2);
+    assert_eq!(
+        type_args[0].as_known().map(EcoString::as_str),
+        Some("String")
+    );
+    assert_eq!(
+        type_args[1].as_known().map(EcoString::as_str),
+        Some("Integer")
+    );
+}
+
+/// BT-2019: Set(T) — single-arg generic, instance-method return.
+#[test]
+fn instance_method_set_return_preserves_type_arg() {
+    let source = "
+typed Object subclass: Store
+  readSet -> Set(String) =>
+    Set new
+
+typed Object subclass: Driver
+  probe: store :: Store -> Nil =>
+    s := store readSet
+    s
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let driver = module
+        .classes
+        .iter()
+        .find(|c| c.name.name.as_str() == "Driver")
+        .expect("Driver class");
+    let probe = driver
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == "probe:")
+        .expect("probe: method");
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set("self", InferredType::known("Driver"));
+    env.set("store", InferredType::known("Store"));
+    for stmt in &probe.body {
+        let _ = checker.infer_expr(&stmt.expression, &hierarchy, &mut env, false);
+    }
+    let s_ty = checker.infer_expr(
+        &probe.body.last().expect("probe body non-empty").expression,
+        &hierarchy,
+        &mut env,
+        false,
+    );
+    let InferredType::Known {
+        class_name,
+        type_args,
+        ..
+    } = s_ty
+    else {
+        panic!("expected Known(Set, [String]), got {s_ty:?}");
+    };
+    assert_eq!(class_name.as_str(), "Set");
+    assert_eq!(type_args.len(), 1);
+    assert_eq!(
+        type_args[0].as_known().map(EcoString::as_str),
+        Some("String")
+    );
+}

--- a/stdlib/src/WorkspaceInterface.bt
+++ b/stdlib/src/WorkspaceInterface.bt
@@ -47,7 +47,6 @@ sealed typed Object subclass: WorkspaceInterface
   /// Workspace actorsOf: Counter
   /// ```
   actorsOf: aClass :: Class -> List(Actor) =>
-    @expect type
     self actors select: [:a | a class includesBehaviour: aClass]
 
   /// Return a list of loaded user classes with source file info.


### PR DESCRIPTION
## Summary

Fixes BT-2019: when a non-generic class declares a method returning a concrete parametric type like `-> List(String)` or `-> List(MyThing)`, the type checker was stripping the type arguments at the call site. A local like `events := store readEvents` became `Known("List", [])` instead of `Known("List", [Known("MyThing")])`, so `events first` fell back to Dynamic and every downstream method send lost its element type.

Root cause was in `crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs` — two paths (single-return near L1081, multi-return union near L1566) routed the return-type string through the `base_name_of_string` helper, which truncated at `(`. That helper was scaffolded under BT-1576 / BT-2025 to deliberately preserve the buggy behaviour until follow-up issues landed (BT-2017, BT-2018, BT-2021, BT-2022 all shipped; this is the last of the series).

Linear: https://linear.app/beamtalk/issue/BT-2019

## Changes

- `inference.rs` — both return-type paths now call `Self::resolve_type_name_string(ret_ty)` unconditionally. This preserves parametric type args (`List(String)` keeps its element), nested generics (`Result(List(String), Error)`), and union returns (`Integer | Nil` parses to `InferredType::Union`). The `base_name_of_string` helper remains in use in `validation.rs` where it's still correct behaviour.
- `type_checker/tests.rs` — 5 new regression tests:
  - `instance_method_concrete_parametric_return_preserves_type_args` (bug fixture)
  - `instance_method_concrete_parametric_return_drives_element_dnu` (end-to-end DNU on element type)
  - `class_method_concrete_parametric_return_preserves_type_args`
  - `instance_method_dictionary_return_preserves_both_type_args` (two type args)
  - `instance_method_set_return_preserves_type_arg`
- `stdlib/src/WorkspaceInterface.bt` — remove an `@expect type` directive on `actorsOf:` that was silencing a false warning produced by the old buggy inference. With the fix the warning is gone at the source.

## Test plan

- [x] New regression tests in `type_checker/tests.rs` (all 5 pass)
- [x] `cargo test -p beamtalk-core --lib type_checker` — 610 pass / 0 fail
- [x] `just test` — Rust, stdlib, BUnit, runtime all green
- [x] `just clippy` — clean
- [x] `just fmt-check` — clean (Rust, Erlang, JS/TS, Beamtalk)

## Known flakes

- `just ci` fails locally on `dialyzer-specs` because the mise toolchain points at an uninstalled Erlang (`28.4.2` missing; only `28.4.3` is installed). Reproduces on an unmodified baseline — unrelated to this change. GitHub Actions CI should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved type inference to properly preserve generic type parameters in method return types (e.g., `List(String)` now correctly retains element type information).

* **Tests**
  * Added comprehensive regression tests for generic type parameter preservation on method call sites.

* **Chores**
  * Removed unnecessary internal type annotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->