### PR TITLE
Warn when declared -> Never body returns a Known type (BT-2033)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -13028,6 +13028,92 @@ fn bt2022_generic_type_param_in_declared_args_not_warned() {
     );
 }
 
+// ---- BT-2033: `-> Never` with non-divergent body must warn ----
+
+/// BT-2033: A method declared `-> Never` with a `Known` body type (e.g. `42`)
+/// is not divergent — warn so the mislabelled declaration is caught.
+#[test]
+fn bt2033_never_return_with_known_body_warns() {
+    let hierarchy = ClassHierarchy::with_builtins();
+
+    let method = MethodDefinition {
+        selector: MessageSelector::Unary("diverge".into()),
+        parameters: vec![],
+        body: vec![bare(int_lit(42))],
+        return_type: Some(TypeAnnotation::Simple(ident("Never"))),
+        kind: MethodKind::Primary,
+        is_sealed: false,
+        is_internal: false,
+        span: span(),
+        doc_comment: None,
+        expect: None,
+        comments: CommentAttachment::default(),
+    };
+
+    // Body infers as Integer — clearly not divergent
+    let body_type = InferredType::known("Integer");
+    let mut checker = TypeChecker::new();
+    checker.check_return_type(&method, &body_type, &eco_string("NeverProbe"), &hierarchy);
+
+    let type_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("declares return type"))
+        .collect();
+    assert_eq!(
+        type_warnings.len(),
+        1,
+        "Declared -> Never with Integer body should produce one warning: {type_warnings:?}"
+    );
+    assert!(
+        type_warnings[0].message.contains("Never"),
+        "Warning should mention Never: {}",
+        type_warnings[0].message
+    );
+    assert!(
+        type_warnings[0].message.contains("Integer"),
+        "Warning should mention the actual Integer body type: {}",
+        type_warnings[0].message
+    );
+}
+
+/// BT-2033: A method declared `-> Never` whose body is truly divergent
+/// (inferred as `InferredType::Never`) must not warn — the declaration is
+/// honest.
+#[test]
+fn bt2033_never_return_with_never_body_no_warning() {
+    let hierarchy = ClassHierarchy::with_builtins();
+
+    let method = MethodDefinition {
+        selector: MessageSelector::Unary("diverge".into()),
+        parameters: vec![],
+        body: vec![bare(int_lit(42))],
+        return_type: Some(TypeAnnotation::Simple(ident("Never"))),
+        kind: MethodKind::Primary,
+        is_sealed: false,
+        is_internal: false,
+        span: span(),
+        doc_comment: None,
+        expect: None,
+        comments: CommentAttachment::default(),
+    };
+
+    // Body is divergent (e.g. always `self error: ...`)
+    let body_type = InferredType::Never;
+    let mut checker = TypeChecker::new();
+    checker.check_return_type(&method, &body_type, &eco_string("NeverProbe"), &hierarchy);
+
+    let type_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("declares return type"))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "Declared -> Never with Never body should not warn: {type_warnings:?}"
+    );
+}
+
 // =====================================================================
 // BT-2021 — Receiver type_args dropped for self / super in generic classes
 // =====================================================================

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -846,7 +846,34 @@ impl TypeChecker {
                     );
                 }
             }
-            InferredType::Dynamic(_) | InferredType::Never => {} // Can't check
+            InferredType::Never => {
+                // BT-2033: Declared `-> Never` means the method is divergent
+                // (never returns normally). The body must also be Never for the
+                // declaration to be honest. Any `Known` body reaching this arm
+                // means the method *does* return a value — warn.
+                //
+                // Note: `Never` body-types cause the early return on line ~753
+                // before this match, so we only reach this arm when the body
+                // has a non-Never `Known` type (the destructure above extracted
+                // `actual_ty`).
+                let selector = method.selector.name();
+                let actual_display = body_type
+                    .display_name()
+                    .unwrap_or_else(|| actual_ty.clone());
+                self.diagnostics.push(
+                    Diagnostic::warning(
+                        format!(
+                            "Method '{selector}' in {class_name} declares return type Never, but body returns {actual_display}"
+                        ),
+                        method.span,
+                    )
+                    .with_category(DiagnosticCategory::Type)
+                    .with_hint(format!(
+                        "`Never` means the method is divergent (throws or loops). Either remove `-> Never` or ensure the body always diverges (e.g. ends with `self error: ...`). Inferred body type is {actual_display}"
+                    )),
+                );
+            }
+            InferredType::Dynamic(_) => {} // Can't check
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes BT-2033: `check_return_type` grouped `Dynamic(_) | Never` into a single "skip" arm, so a method declared `-> Never` with a non-divergent body (e.g. `diverge -> Never => 42`) silently passed validation.

Linear: https://linear.app/beamtalk/issue/BT-2033
Follow-up to Copilot review on PR #2059 (BT-2022).

## Changes

- `crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs` — split the `Dynamic(_) | Never` arm; `Never` now emits a Type warning when the destructured body type is `Known`. Hint points the user at `self error: ...` or removing the `-> Never` annotation. Early-return above already handles the honest case (body is also `Never`), so the new arm only fires on the mismatch.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs` — regression tests for both cases (`Never` + non-Never body → warn; `Never` + divergent body → no warn).

## Test plan

- [x] `cargo test -p beamtalk-core --lib type_checker` — 614 pass
- [x] `just clippy` clean
- [x] `just fmt-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced type checker diagnostics to properly validate divergent return type declarations and emit warnings when the method body indicates a normal return instead of the declared divergent behavior.

* **Tests**
  * Added unit tests covering type checker validation for divergent return declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->