### PR TITLE
Dedup cascade receiver inference so inner DNU warnings fire once (BT-2035)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -589,6 +589,11 @@ impl TypeChecker {
                         env,
                         in_abstract_method,
                     );
+                    // The cascade's first-send node (the outer `MessageSend`
+                    // that is `receiver`) bypasses `infer_expr`, so record its
+                    // type in the LSP type map and run the BT-1914 Dynamic
+                    // warning for it here — mirroring `infer_expr`'s tail.
+                    self.post_process_expr_type(receiver, &send_ty);
                     (send_ty, inner.as_ref(), inner_ty)
                 } else {
                     // Non-MessageSend receiver (or a cast send, which short-circuits
@@ -765,6 +770,18 @@ impl TypeChecker {
             }
         };
 
+        self.post_process_expr_type(expr, &ty);
+        ty
+    }
+
+    /// Shared tail of [`Self::infer_expr`] — record the inferred type in the
+    /// LSP type map and emit the BT-1914 "Dynamic in typed class" warning.
+    ///
+    /// Factored out so the cascade fast-path (BT-2035) can apply the same
+    /// post-processing to the first-send `MessageSend` node, which it resolves
+    /// via `infer_message_send_with_receiver_ty` instead of routing through
+    /// `infer_expr`.
+    fn post_process_expr_type(&mut self, expr: &Expression, ty: &InferredType) {
         // Record inferred type for the expression's full span for LSP queries.
         // Dynamic types with a known reason (e.g., UnannotatedParam) are included
         // so that hover can display "Dynamic (reason)" — see BT-1912.
@@ -777,7 +794,7 @@ impl TypeChecker {
         // Only warn for root-cause Dynamic reasons (not DynamicReceiver, which is
         // propagated from a receiver that already produced its own warning).
         // Unknown is also skipped — no actionable message.
-        if let InferredType::Dynamic(reason) = &ty {
+        if let InferredType::Dynamic(reason) = ty {
             if !matches!(
                 reason,
                 DynamicReason::DynamicReceiver
@@ -800,8 +817,6 @@ impl TypeChecker {
                 }
             }
         }
-
-        ty
     }
 
     /// Bind all named variables in a destructuring `pattern` into `env` as `Dynamic`.

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -565,15 +565,37 @@ impl TypeChecker {
             Expression::Cascade {
                 receiver, messages, ..
             } => {
-                let send_ty = self.infer_expr(receiver, hierarchy, env, in_abstract_method);
-                let (cascade_target, dispatch_ty) = match receiver.as_ref() {
-                    Expression::MessageSend {
-                        receiver: inner, ..
-                    } => {
-                        let inner_ty = self.infer_expr(inner, hierarchy, env, in_abstract_method);
-                        (inner.as_ref(), inner_ty)
-                    }
-                    _ => (receiver.as_ref(), send_ty.clone()),
+                // BT-2035: to avoid walking the inner receiver subtree twice
+                // (which would double-emit any DNU / type diagnostics it
+                // produces), we infer the inner type once and thread it into
+                // the first send's inference via `infer_message_send_with_receiver_ty`.
+                let (send_ty, cascade_target, dispatch_ty) = if let Expression::MessageSend {
+                    receiver: inner,
+                    selector: inner_sel,
+                    arguments: inner_args,
+                    span: inner_span,
+                    is_cast: false,
+                    ..
+                } = receiver.as_ref()
+                {
+                    let inner_ty = self.infer_expr(inner, hierarchy, env, in_abstract_method);
+                    let send_ty = self.infer_message_send_with_receiver_ty(
+                        inner,
+                        inner_ty.clone(),
+                        inner_sel,
+                        inner_args,
+                        *inner_span,
+                        hierarchy,
+                        env,
+                        in_abstract_method,
+                    );
+                    (send_ty, inner.as_ref(), inner_ty)
+                } else {
+                    // Non-MessageSend receiver (or a cast send, which short-circuits
+                    // to Dynamic): fall back to a single infer_expr; the cascade
+                    // dispatches messages to that same type.
+                    let send_ty = self.infer_expr(receiver, hierarchy, env, in_abstract_method);
+                    (send_ty.clone(), receiver.as_ref(), send_ty)
                 };
                 let is_class_ref = matches!(cascade_target, Expression::ClassReference { .. });
                 for msg in messages {
@@ -797,7 +819,6 @@ impl TypeChecker {
 
     /// Infer the type of a message send and validate the selector.
     #[allow(clippy::too_many_arguments)] // hierarchy + env + flag needed for recursive checking
-    #[allow(clippy::too_many_lines)] // generic substitution adds necessary branches
     fn infer_message_send(
         &mut self,
         receiver: &Expression,
@@ -809,6 +830,40 @@ impl TypeChecker {
         in_abstract_method: bool,
     ) -> InferredType {
         let receiver_ty = self.infer_expr(receiver, hierarchy, env, in_abstract_method);
+        self.infer_message_send_with_receiver_ty(
+            receiver,
+            receiver_ty,
+            selector,
+            arguments,
+            span,
+            hierarchy,
+            env,
+            in_abstract_method,
+        )
+    }
+
+    /// Variant of [`Self::infer_message_send`] that takes a pre-computed receiver
+    /// type, avoiding a second walk of the receiver subtree.
+    ///
+    /// Used by the `Expression::Cascade` arm (BT-2035): the cascade's first send
+    /// is itself a `MessageSend`, whose inner receiver type is needed both to
+    /// resolve the first send and to dispatch the cascaded messages. Re-inferring
+    /// the inner subtree via `infer_expr` would re-emit any DNU / type warnings
+    /// it produces. By threading the receiver type through, we walk the inner
+    /// subtree exactly once.
+    #[allow(clippy::too_many_arguments)] // split from infer_message_send to share body
+    #[allow(clippy::too_many_lines)] // generic substitution adds necessary branches
+    fn infer_message_send_with_receiver_ty(
+        &mut self,
+        receiver: &Expression,
+        receiver_ty: InferredType,
+        selector: &MessageSelector,
+        arguments: &[Expression],
+        span: Span,
+        hierarchy: &ClassHierarchy,
+        env: &mut TypeEnv,
+        in_abstract_method: bool,
+    ) -> InferredType {
         let selector_name = selector.name();
 
         // Control-flow narrowing (ADR 0068 Phase 1g):

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -432,6 +432,51 @@ fn test_cascade_invalid_selector() {
 }
 
 #[test]
+fn test_cascade_complex_receiver_diagnostic_emitted_once() {
+    // BT-2035 regression: a cascade whose inner receiver subtree is itself
+    // a message send with a DNU must emit the DNU diagnostic exactly once.
+    // Previously the Cascade arm called `infer_expr` twice on the inner
+    // receiver — once via the outer MessageSend, once directly to extract
+    // the dispatch type — doubling any diagnostics produced by the subtree.
+    //
+    // AST for `(42 bogus) negated; abs`:
+    //   Cascade {
+    //     receiver: MessageSend { receiver: MessageSend(42, bogus),
+    //                             selector: negated, .. },
+    //     messages: [abs],
+    //   }
+    let inner_bad = msg_send(int_lit(42), MessageSelector::Unary("bogus".into()), vec![]);
+    let first_send = msg_send(inner_bad, MessageSelector::Unary("negated".into()), vec![]);
+    let module = make_module(vec![Expression::Cascade {
+        receiver: Box::new(first_send),
+        messages: vec![CascadeMessage::new(
+            MessageSelector::Unary("abs".into()),
+            vec![],
+            span(),
+        )],
+        span: span(),
+    }]);
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let bogus_diagnostics: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("bogus"))
+        .collect();
+    assert_eq!(
+        bogus_diagnostics.len(),
+        1,
+        "expected exactly one diagnostic for the DNU `bogus` on the inner cascade receiver, got {}: {:?}",
+        bogus_diagnostics.len(),
+        bogus_diagnostics
+            .iter()
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_string_methods() {
     // 'hello' length  ← String responds to length
     let module = make_module(vec![msg_send(


### PR DESCRIPTION
## Summary

Fixes BT-2035: the `Expression::Cascade` arm called `infer_expr` on the inner receiver twice — once as part of the first send, once to extract the dispatch type. For complex receivers like `(SomeClass new initialize) foo; bar` any DNU or type diagnostics emitted by the inner subtree fired twice.

Linear: https://linear.app/beamtalk/issue/BT-2035
Follow-up to CodeRabbit finding on PR #2060 (BT-2017).

## Changes

- `crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs`
  - Extract `infer_message_send_with_receiver_ty`: shares the whole body of `infer_message_send` but takes a pre-computed receiver type.
  - `infer_message_send` now calls `infer_expr(receiver, ...)` once and delegates to the new variant.
  - `Expression::Cascade` arm walks the inner receiver exactly once and threads the resulting type into both the first-send inference and the cascade dispatch. Non-`MessageSend` and `is_cast: true` receivers fall back to the single-`infer_expr` path.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs` — regression test: cascade on a complex receiver with a DNU-triggering inner send emits the diagnostic exactly once.

## Test plan

- [x] `cargo test -p beamtalk-core --lib type_checker` — 613 pass
- [x] `just clippy` clean
- [x] `just fmt-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized type inference for nested cascade expressions to avoid redundant receiver re-walking and consolidated post-processing so inferred types and related warnings are recorded consistently.

* **Tests**
  * Added a regression test ensuring a diagnostic from a complex cascade receiver is emitted exactly once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->