### PR TITLE
Accept class literals as args for Behaviour/Class params (BT-2038)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -9222,6 +9222,40 @@ fn class_literal_arg_rejected_for_unrelated_param() {
 }
 
 #[test]
+fn instance_identifier_still_rejected_for_class_param() {
+    // Regression guard (CodeRabbit on PR #2071): the BT-1877 `expected == "Class"`
+    // shortcut in `is_type_compatible` previously accepted any known class name
+    // unconditionally. With BT-2038's metaclass-tower check handling class
+    // literals, that shortcut must stay scoped to class-literal arguments —
+    // a plain identifier typed as `TestCase` is an instance, not a class,
+    // and should not satisfy a `:: Class` parameter.
+    let hierarchy = test_hierarchy_with_class_literal_arg("Class");
+    let mut checker = TypeChecker::new();
+    let ident_arg = var("aTestCase");
+    checker.check_argument_types(
+        &"ClassChecker".into(),
+        "accept:",
+        &[InferredType::known("TestCase")],
+        span(),
+        &hierarchy,
+        false,
+        Some(std::slice::from_ref(&ident_arg)),
+        None,
+    );
+    assert_eq!(
+        checker.diagnostics().len(),
+        1,
+        "A TestCase instance (not class literal) should not type-check as Class, got: {:?}",
+        checker.diagnostics()
+    );
+    assert!(
+        checker.diagnostics()[0].message.contains("expects Class"),
+        "got: {}",
+        checker.diagnostics()[0].message
+    );
+}
+
+#[test]
 fn instance_identifier_still_rejected_for_behaviour_param() {
     // Regression guard: the class-literal escape must NOT apply when the
     // argument is an identifier of a user class type — only class literals

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -9145,6 +9145,54 @@ fn class_literal_arg_accepted_for_class_param() {
 }
 
 #[test]
+fn class_literal_arg_accepted_for_object_param() {
+    // Object sits above Behaviour in the metaclass tower, so a class
+    // literal must satisfy an Object-typed parameter.
+    let hierarchy = test_hierarchy_with_class_literal_arg("Object");
+    let mut checker = TypeChecker::new();
+    let class_ref_arg = class_ref("TestCase");
+    checker.check_argument_types(
+        &"ClassChecker".into(),
+        "accept:",
+        &[InferredType::known("TestCase")],
+        span(),
+        &hierarchy,
+        false,
+        Some(std::slice::from_ref(&class_ref_arg)),
+        None,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "Class literal TestCase should type-check as Object, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn class_literal_arg_accepted_for_protoobject_param() {
+    // ProtoObject is the root of the metaclass tower — every class literal
+    // must satisfy it.
+    let hierarchy = test_hierarchy_with_class_literal_arg("ProtoObject");
+    let mut checker = TypeChecker::new();
+    let class_ref_arg = class_ref("TestCase");
+    checker.check_argument_types(
+        &"ClassChecker".into(),
+        "accept:",
+        &[InferredType::known("TestCase")],
+        span(),
+        &hierarchy,
+        false,
+        Some(std::slice::from_ref(&class_ref_arg)),
+        None,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "Class literal TestCase should type-check as ProtoObject, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
 fn class_literal_arg_rejected_for_unrelated_param() {
     // A class literal whose metaclass chain does NOT include the expected
     // type (e.g., expected Integer) should still warn.

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -9026,6 +9026,185 @@ fn union_arg_dynamic_still_skips() {
     );
 }
 
+// ── BT-2038: Class literal compatibility with Behaviour/Class/Object parameters ──
+//
+// A class reference like `TestCase` is a first-class class value whose runtime
+// type is `TestCase class` (a `Metaclass`, which inherits from `Class` →
+// `Behaviour` → `Object` → `ProtoObject`). When such a literal is passed to a
+// parameter declared as `Behaviour`, `Class`, `Object`, or `ProtoObject`, the
+// argument conformance check must accept it even though the class's *instance*
+// hierarchy (e.g., `TestCase` → `Value` → `Object`) does not pass through
+// `Behaviour`.
+
+fn test_hierarchy_with_class_literal_arg(
+    param_type: &str,
+) -> crate::semantic_analysis::class_hierarchy::ClassHierarchy {
+    use crate::semantic_analysis::class_hierarchy::{ClassInfo, MethodInfo};
+    let mut hierarchy = ClassHierarchy::with_builtins();
+    hierarchy.add_from_beam_meta(vec![
+        ClassInfo {
+            name: "TestCase".into(),
+            superclass: Some("Value".into()),
+            is_sealed: false,
+            is_abstract: false,
+            is_typed: false,
+            is_internal: false,
+            package: None,
+            is_value: true,
+            is_native: false,
+            state: vec![],
+            state_types: std::collections::HashMap::new(),
+            state_has_default: std::collections::HashMap::new(),
+            methods: vec![],
+            class_methods: vec![],
+            class_variables: vec![],
+            type_params: vec![],
+            type_param_bounds: vec![],
+            superclass_type_args: vec![],
+        },
+        ClassInfo {
+            name: "ClassChecker".into(),
+            superclass: Some("Object".into()),
+            is_sealed: false,
+            is_abstract: false,
+            is_typed: false,
+            is_internal: false,
+            package: None,
+            is_value: false,
+            is_native: false,
+            state: vec![],
+            state_types: std::collections::HashMap::new(),
+            state_has_default: std::collections::HashMap::new(),
+            methods: vec![MethodInfo {
+                selector: "accept:".into(),
+                arity: 1,
+                kind: MethodKind::Primary,
+                defined_in: "ClassChecker".into(),
+                is_sealed: false,
+                is_internal: false,
+                spawns_block: false,
+                return_type: Some("Boolean".into()),
+                param_types: vec![Some(param_type.into())],
+                doc: None,
+            }],
+            class_methods: vec![],
+            class_variables: vec![],
+            type_params: vec![],
+            type_param_bounds: vec![],
+            superclass_type_args: vec![],
+        },
+    ]);
+    hierarchy
+}
+
+#[test]
+fn class_literal_arg_accepted_for_behaviour_param() {
+    // BT-2038: Passing a class literal (TestCase) to a param expecting Behaviour
+    // should not warn — class objects flow through Metaclass → Class → Behaviour.
+    let hierarchy = test_hierarchy_with_class_literal_arg("Behaviour");
+    let mut checker = TypeChecker::new();
+    let class_ref_arg = class_ref("TestCase");
+    checker.check_argument_types(
+        &"ClassChecker".into(),
+        "accept:",
+        &[InferredType::known("TestCase")],
+        span(),
+        &hierarchy,
+        false,
+        Some(std::slice::from_ref(&class_ref_arg)),
+        None,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "Class literal TestCase should type-check as Behaviour, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn class_literal_arg_accepted_for_class_param() {
+    // A class literal should satisfy a Class-typed parameter.
+    let hierarchy = test_hierarchy_with_class_literal_arg("Class");
+    let mut checker = TypeChecker::new();
+    let class_ref_arg = class_ref("TestCase");
+    checker.check_argument_types(
+        &"ClassChecker".into(),
+        "accept:",
+        &[InferredType::known("TestCase")],
+        span(),
+        &hierarchy,
+        false,
+        Some(std::slice::from_ref(&class_ref_arg)),
+        None,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "Class literal TestCase should type-check as Class, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn class_literal_arg_rejected_for_unrelated_param() {
+    // A class literal whose metaclass chain does NOT include the expected
+    // type (e.g., expected Integer) should still warn.
+    let hierarchy = test_hierarchy_with_class_literal_arg("Integer");
+    let mut checker = TypeChecker::new();
+    let class_ref_arg = class_ref("TestCase");
+    checker.check_argument_types(
+        &"ClassChecker".into(),
+        "accept:",
+        &[InferredType::known("TestCase")],
+        span(),
+        &hierarchy,
+        false,
+        Some(std::slice::from_ref(&class_ref_arg)),
+        None,
+    );
+    assert_eq!(
+        checker.diagnostics().len(),
+        1,
+        "Class literal TestCase should NOT type-check as Integer"
+    );
+    assert!(
+        checker.diagnostics()[0].message.contains("expects Integer"),
+        "got: {}",
+        checker.diagnostics()[0].message
+    );
+}
+
+#[test]
+fn instance_identifier_still_rejected_for_behaviour_param() {
+    // Regression guard: the class-literal escape must NOT apply when the
+    // argument is an identifier of a user class type — only class literals
+    // carry the "is-a Behaviour" semantics.
+    let hierarchy = test_hierarchy_with_class_literal_arg("Behaviour");
+    let mut checker = TypeChecker::new();
+    let ident_arg = var("aTestCase");
+    checker.check_argument_types(
+        &"ClassChecker".into(),
+        "accept:",
+        &[InferredType::known("TestCase")],
+        span(),
+        &hierarchy,
+        false,
+        Some(std::slice::from_ref(&ident_arg)),
+        None,
+    );
+    assert_eq!(
+        checker.diagnostics().len(),
+        1,
+        "A TestCase instance (not class literal) should not type-check as Behaviour"
+    );
+    assert!(
+        checker.diagnostics()[0]
+            .message
+            .contains("expects Behaviour"),
+        "got: {}",
+        checker.diagnostics()[0].message
+    );
+}
+
 // --- Field assignment with unions ---
 
 #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -634,6 +634,15 @@ impl TypeChecker {
             return;
         }
 
+        // BT-2038: A class literal (e.g. `TestCase`) is a class value whose
+        // runtime type flows through the metaclass tower
+        // (Metaclass → Class → Behaviour → Object → ProtoObject). When the
+        // instance-side chain fails, re-check via `Metaclass` so parameters
+        // declared `:: Behaviour` / `:: Class` / `:: Object` / `:: ProtoObject`
+        // accept any class literal. Hoisted out of the loop since it's
+        // constant across all arguments.
+        let metaclass_name: EcoString = "Metaclass".into();
+
         for (i, (arg_ty, expected)) in arg_types.iter().zip(method.param_types.iter()).enumerate() {
             let Some(expected_ty) = expected else {
                 continue;
@@ -646,22 +655,16 @@ impl TypeChecker {
                     class_name: actual_ty,
                     ..
                 } => {
-                    // BT-2038: A class literal (e.g. `TestCase`) is a class value
-                    // whose runtime type flows through the metaclass tower
-                    // (Metaclass → Class → Behaviour → Object → ProtoObject).
-                    // Check that chain when the instance-side chain fails so
-                    // parameters declared `:: Behaviour` / `:: Class` accept
-                    // any class literal.
-                    let class_literal_compat = is_class_ref_arg
+                    // Short-circuit: only consult the metaclass chain when the
+                    // instance-side check fails. Keeps the hot path at one
+                    // `is_type_compatible` call per argument.
+                    let instance_compat =
+                        Self::is_type_compatible(actual_ty, expected_ty, hierarchy);
+                    let class_literal_compat = !instance_compat
+                        && is_class_ref_arg
                         && hierarchy.has_class(actual_ty)
-                        && Self::is_type_compatible(
-                            &EcoString::from("Metaclass"),
-                            expected_ty,
-                            hierarchy,
-                        );
-                    if !Self::is_type_compatible(actual_ty, expected_ty, hierarchy)
-                        && !class_literal_compat
-                    {
+                        && Self::is_type_compatible(&metaclass_name, expected_ty, hierarchy);
+                    if !instance_compat && !class_literal_compat {
                         let param_pos = i + 1;
                         // BT-1588: Use hint severity for generic type params (likely false positive)
                         let is_generic = super::is_generic_type_param(actual_ty);

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -658,8 +658,19 @@ impl TypeChecker {
                     // Short-circuit: only consult the metaclass chain when the
                     // instance-side check fails. Keeps the hot path at one
                     // `is_type_compatible` call per argument.
-                    let instance_compat =
-                        Self::is_type_compatible(actual_ty, expected_ty, hierarchy);
+                    //
+                    // CodeRabbit on PR #2071: `is_type_compatible` has a
+                    // pre-existing BT-1877 shortcut where `expected == "Class"`
+                    // accepts any known class name unconditionally. That was a
+                    // workaround for exactly the BT-2038 problem; with the
+                    // metaclass-tower check now handling class literals
+                    // properly, the shortcut must be scoped to class-literal
+                    // arguments here so a plain `TestCase` instance does not
+                    // satisfy a `:: Class` parameter.
+                    let class_shortcut_applies =
+                        expected_ty.as_str() == "Class" && !is_class_ref_arg;
+                    let instance_compat = !class_shortcut_applies
+                        && Self::is_type_compatible(actual_ty, expected_ty, hierarchy);
                     let class_literal_compat = !instance_compat
                         && is_class_ref_arg
                         && hierarchy.has_class(actual_ty)

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -612,6 +612,7 @@ impl TypeChecker {
 
     /// Check argument types against declared parameter types for a message send.
     #[allow(clippy::too_many_arguments)] // BT-1588: arg_exprs + env needed for origin tracing
+    #[allow(clippy::too_many_lines)] // BT-2038 adds class-literal subtyping arm
     pub(super) fn check_argument_types(
         &mut self,
         class_name: &EcoString,
@@ -637,12 +638,30 @@ impl TypeChecker {
             let Some(expected_ty) = expected else {
                 continue;
             };
+            let is_class_ref_arg = arg_exprs
+                .and_then(|exprs| exprs.get(i))
+                .is_some_and(|e| matches!(e, Expression::ClassReference { .. }));
             match arg_ty {
                 InferredType::Known {
                     class_name: actual_ty,
                     ..
                 } => {
-                    if !Self::is_type_compatible(actual_ty, expected_ty, hierarchy) {
+                    // BT-2038: A class literal (e.g. `TestCase`) is a class value
+                    // whose runtime type flows through the metaclass tower
+                    // (Metaclass → Class → Behaviour → Object → ProtoObject).
+                    // Check that chain when the instance-side chain fails so
+                    // parameters declared `:: Behaviour` / `:: Class` accept
+                    // any class literal.
+                    let class_literal_compat = is_class_ref_arg
+                        && hierarchy.has_class(actual_ty)
+                        && Self::is_type_compatible(
+                            &EcoString::from("Metaclass"),
+                            expected_ty,
+                            hierarchy,
+                        );
+                    if !Self::is_type_compatible(actual_ty, expected_ty, hierarchy)
+                        && !class_literal_compat
+                    {
                         let param_pos = i + 1;
                         // BT-1588: Use hint severity for generic type params (likely false positive)
                         let is_generic = super::is_generic_type_param(actual_ty);

--- a/stdlib/src/WorkspaceInterface.bt
+++ b/stdlib/src/WorkspaceInterface.bt
@@ -65,7 +65,6 @@ sealed typed Object subclass: WorkspaceInterface
   /// Workspace testClasses
   /// ```
   testClasses -> List(Behaviour) =>
-    @expect type
     self classes select: [:c | c inheritsFrom: TestCase]
 
   /// Return an immutable Dictionary snapshot of the project namespace.


### PR DESCRIPTION
## Summary
- A class reference like `TestCase` is a class value whose runtime type flows through the metaclass tower (Metaclass → Class → Behaviour → Object → ProtoObject), not through its own instance-type chain. The argument-conformance check only walked the instance chain, so `c inheritsFrom: TestCase` was flagged as "expects Behaviour, got TestCase" even though every class literal satisfies Behaviour at runtime.
- When an argument expression is `Expression::ClassReference`, additionally check compatibility via the Metaclass chain so parameters declared `:: Behaviour` / `:: Class` / `:: Object` accept any class literal. The escape only applies to class-literal arguments; identifiers typed as user classes still fail the check.
- Removes the `@expect type` at `stdlib/src/WorkspaceInterface.bt:68` — the fix makes it stale.

## Test plan
- [x] `just test` (rust + stdlib + BUnit + runtime) — all pass
- [x] `just test-e2e` — all pass
- [x] `just clippy` / `just fmt-check` — clean
- [x] 4 new regression tests in `type_checker/tests.rs` covering class-literal acceptance for Behaviour/Class, rejection for Integer, and identifier-based rejection.

Closes BT-2038.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument type checking so class literals are accepted where appropriate (including metaclass compatibility) while unchanged restrictions apply for unrelated types and instance identifiers.

* **Tests**
  * Added coverage for class-literal conformance and regression guards to prevent regressions.

* **Chores**
  * Minor cleanup in workspace selection logic (removed an unnecessary expectation directive).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->