### PR TITLE
Propagate `-> Never` through class-side dispatch fallback (BT-2037)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -14358,9 +14358,10 @@ typed Object subclass: WidgetFactory
 #[test]
 fn bt2037_block_self_error_infers_as_never() {
     // Mirrors the exdura reproduction: a typed instance method whose body
-    // sends a block-accepting selector to a receiver of unknown type
-    // (`looksUp` returns Dynamic). The block body's `self error:` must
-    // still resolve to Never via the enclosing instance-method `self`.
+    // sends `valueOrDo:` to `registry` (an Object-typed field), with a
+    // fallback block containing `self error:`. The block body's `self
+    // error:` must still resolve to Never via the enclosing instance-method
+    // `self`.
     let source = "
 typed Object subclass: ExduraWorker
   state: registry :: Object = nil

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -14308,3 +14308,86 @@ fn bt_2020_narrowed_if_true_is_kind_of_preserves_inner_sends() {
         "v unknownMethod outside narrowed block should produce DNU"
     );
 }
+
+// =====================================================================
+// BT-2037 — `self error:` should infer as Never inside typed classes,
+// both class-side and inside block arguments.
+// =====================================================================
+
+/// BT-2037: a class-side method that calls `self error: "..."` should
+/// not warn about Dynamic-in-typed-class. `error:` is declared
+/// `-> Never` on `Object`; the type checker must propagate that through
+/// the Class→Behaviour→Object→ProtoObject chain when no class-side
+/// override exists.
+#[test]
+fn bt2037_class_side_self_error_infers_as_never() {
+    let source = "
+typed Object subclass: WidgetFactory
+  class new: arg :: Object -> Nil =>
+    self error: \"use named constructors\"
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dynamic_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "class-side `self error:` should resolve to Never, not Dynamic; got: {:?}",
+        dynamic_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// BT-2037: an instance-side method that wraps `self error: "..."` in a
+/// block argument (e.g. as a fallback for `valueOrDo:`) should not warn
+/// about Dynamic-in-typed-class. `self` inside the block is the same
+/// instance type as in the enclosing method, and `error:` is `-> Never`.
+#[test]
+fn bt2037_block_self_error_infers_as_never() {
+    // Mirrors the exdura reproduction: a typed instance method whose body
+    // sends a block-accepting selector to a receiver of unknown type
+    // (`looksUp` returns Dynamic). The block body's `self error:` must
+    // still resolve to Never via the enclosing instance-method `self`.
+    let source = "
+typed Object subclass: ExduraWorker
+  state: registry :: Object = nil
+  doWork -> Nil =>
+    registry valueOrDo: [:e | self error: \"failed\"]
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dynamic_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "block-embedded `self error:` should resolve to Never, not Dynamic; got: {:?}",
+        dynamic_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -209,6 +209,30 @@ impl TypeChecker {
                 if let Some(ret_ty) = self.method_return_types.get(&key) {
                     return ret_ty.clone();
                 }
+                // BT-2037: When no class-side method exists, the runtime
+                // dispatches the message through the class object's instance
+                // chain (Class → Behaviour → Object → ProtoObject; ADR 0032
+                // Phase 0 fallthrough). Mirror that here for divergent
+                // selectors so a class-side `self error: "..."` carries the
+                // `-> Never` annotation from `Object#error:` instead of
+                // resolving to Dynamic.
+                //
+                // Limited to `-> Never` returns: other return types on this
+                // chain (e.g. `class -> Metaclass`) involve class-aware
+                // semantics that aren't modelled in the static hierarchy
+                // (e.g. `Metaclass` not knowing arbitrary class-side
+                // selectors), so propagating them would surface false DNUs.
+                if hierarchy.find_class_method(class_name, selector).is_none() {
+                    if let Some(method) = hierarchy.find_method("Class", selector) {
+                        if method
+                            .return_type
+                            .as_ref()
+                            .is_some_and(|ty| ty.as_str() == "Never")
+                        {
+                            return InferredType::Never;
+                        }
+                    }
+                }
                 InferredType::Dynamic(DynamicReason::UnannotatedReturn)
             }
         }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -222,7 +222,7 @@ impl TypeChecker {
                 // semantics that aren't modelled in the static hierarchy
                 // (e.g. `Metaclass` not knowing arbitrary class-side
                 // selectors), so propagating them would surface false DNUs.
-                if hierarchy.find_class_method(class_name, selector).is_none() {
+                if !has_class_method {
                     if let Some(method) = hierarchy.find_method("Class", selector) {
                         if method
                             .return_type


### PR DESCRIPTION
## Summary

`self error: "..."` inside a class-side method (e.g. the `class new:` guard pattern in DateTime/Random/Regex/Stream/Float) was inferred as `Dynamic (unannotated return)`, firing the BT-1914 typed-class warning.

`error:` is declared `-> Never` on `Object`. The runtime dispatches class-side sends through the class object's instance chain (Class→Behaviour→Object→ProtoObject), so the type checker should mirror that and surface the divergent return type rather than collapsing to Dynamic.

`check_class_side_send` now falls back to `find_method("Class", selector)` when no class-side method exists. Limited to `-> Never` returns to avoid regressions like `self class spawn` (`Class#class` returns `Metaclass`, which doesn't model arbitrary class-side selectors and would surface false DNUs).

The five `@expect type` directives in stdlib (DateTime/Random/Regex/Stream/Float) become stale with this fix; cleanup is tracked in BT-2036 per the issue.

## Test plan

- [x] New regression test `bt2037_class_side_self_error_infers_as_never` exercises the class-side path.
- [x] New companion test `bt2037_block_self_error_infers_as_never` pins the instance-side block case.
- [x] Full `cargo test -p beamtalk-core --lib` (3168 tests) green.
- [x] `just test` (stdlib + BUnit + runtime) green; pre-existing flaky TimerTest passed on retry.
- [x] `just clippy`, `just fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved class-side method resolution so `Never`-annotated returns are propagated through receiver chains instead of being inferred as `Dynamic`.

* **Tests**
  * Added regression tests that exercise typed method calls (including `self` inside blocks and class-side contexts) to ensure `Never` return types are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->