### PR TITLE
docs: daily refresh 2026-04-23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@
 - Accept narrowing RHS in local type annotations — `dict :: Dictionary := someMethodReturningObject` no longer warns when the declared type is more specific than the inferred type (BT-2015).
 - Fix `@expect` directives inside block bodies (`ifTrue: [...]`, `collect: [...]`, `whileTrue: [...]`) being silently ignored — they now correctly suppress diagnostics on the next statement within the block (BT-2010).
 - Typechecker warns when a non-Block value is passed to a `Block(T, R)` parameter — previously, parametric type annotations like `Block(T, R)` were treated as unknown classes and the warning was suppressed (BT-2002).
+- **`<ClassName> class` metatype annotation** — `Actor class`, `MyService class`, etc. can now appear in any type position (fields, parameters, return types, locals) to denote a class object in the named hierarchy. Class-side methods on that class resolve without false DNU warnings after nil-check narrowing. Resolves to `Dynamic` at runtime (BT-2034).
+- **Conditional return type inference** — `ifTrue:ifFalse:` now declares `Block(R), Block(R) -> R`, so the type checker unifies both arms to a common return type instead of collapsing to `Dynamic` (BT-2020).
+- Typechecker warns when a method declared `-> Never` has a body that returns a known type (BT-2033).
+- Fix generic return type inner arg validation — the type checker now correctly warns when inner type args of a generic return type mismatch (e.g., `-> Result(Integer, Error)` with body returning `Result(String, Error)`) (BT-2022).
 
 ### Standard Library
 
-- **BREAKING: Supervisor lifecycle methods now return `Result`** ([ADR 0080](docs/ADR/0080-supervisor-lifecycle-result.md), BT-1993 epic) — `Supervisor class>>supervise` and `Supervisor>>terminate:` on the static path, plus `DynamicSupervisor class>>supervise`, `DynamicSupervisor>>startChild`, `DynamicSupervisor>>startChild:`, and `DynamicSupervisor>>terminateChild:` on the dynamic path, all return `Result` values instead of raising. `stop`, `current`, `which:`, `children`, and `count` are unchanged.
+- **BREAKING: Supervisor lifecycle methods now return `Result`** ([ADR 0080](docs/ADR/0080-supervisor-lifecycle-result.md), BT-1993 epic) — `Supervisor class>>supervise` and `Supervisor>>terminate:` on the static path, plus `DynamicSupervisor class>>supervise`, `DynamicSupervisor>>startChild`, `DynamicSupervisor>>startChild:`, and `DynamicSupervisor>>terminateChild:` on the dynamic path, all return `Result` values instead of raising. `stop`, `current`, `children`, and `count` are unchanged.
   - Adopts the **idempotent-startup convention**: an operation succeeds (returns `Result ok: ...`) when the caller's target end state already holds — `supervise` on an already-running supervisor returns `Result ok: sup` (preserved from the prior runtime), and `terminate:` / `terminateChild:` on a child that is already gone returns `Result ok: nil` (new on the static path — previously raised).
   - **Mechanical migration.** Boot-style call sites add `unwrap`: `app := WebApp supervise` becomes `app := (WebApp supervise) unwrap`. Recoverable flows use `ifOk:ifError:` / `andThen:`. Call sites that were swallowing the raise to express "stop it if it's running" — e.g. `[app terminate: Child] on: Error do: [:_e | nil]` — can now be written as `(app terminate: Child) unwrap` (idempotent by construction — `Ok` whether the child was alive or already gone). See ADR 0080 §Migration Path for the full rewrite guide.
   - Structured `beamtalk_error` kinds (`kind` field): `#supervisor_start_failed`, `#child_start_failed`, `#terminate_failed`, `#stale_handle` — greppable in logs (BT-1999, BT-2000, BT-2001).
@@ -23,6 +27,9 @@
   - `SupervisionSpec withName:` — declaratively name a supervised child so the supervisor re-registers the name on every restart.
 - **Integer rounding methods** — `ceiling`, `floor`, `rounded`, and `truncated` on Integer return `self` (identity), so numeric code can call rounding methods on any `Number` without branching on type (BT-2011).
 - Tighter parametric type annotations across stdlib classes (`File`, `Subprocess`, `ReactiveSubprocess`, `Regex`, `Result`, `SupervisionSpec`) — `Result` return types now carry concrete `T`/`E` parameters for better type flow through `andThen:`/`map:` chains.
+- **`Supervisor>>which:` now returns `Result(Object, Error)`** — migrated to ADR 0080 Phase 2 Result signature, consistent with `supervise` and `terminate:`. Callers must `unwrap` or use Result combinators; returns `Result ok: nil` when the class is not in the supervision tree, `Result error: (beamtalk_error stale_handle)` when the supervisor is stopped (BT-2041).
+- **`Collection(E)` parametrized** — `Collection` is now `Collection(E)` with typed block parameters on `do:`, `collect:`, `select:`, `reject:`, `detect:`, `inject:into:`, `anySatisfy:`, `allSatisfy:`, and `includes:`. `Bag` is now `Bag(E)` with typed `add:`, `remove:`, `occurrencesOf:`. Enables type-safe iteration and better IDE support (BT-2036).
+- `Float>>min:/max:` and `Integer>>min:/max:` return type corrected from `Float`/`Integer` to `Number` (BT-2020).
 
 ### Compiler
 
@@ -43,6 +50,8 @@
 ### Tooling
 
 - **Diagnostic summary** — `beamtalk build` and `beamtalk lint` print an aggregated diagnostic summary (category × severity) at end of run; `beamtalk lint --format json` emits a `summary` JSON object for CI diffing; new `diagnostic_summary` MCP tool for agent use (BT-2014).
+- Fix `beamtalk lint` diagnostic summary accounting — `files_checked` count, error surfacing, and `--format json` buffered output now report correctly (BT-2031).
+- Fix `beamtalk lint test/` emitting spurious `Unresolved class` diagnostics for classes defined in the package's `src/`; fix LSP falsely flagging every class as "conflicts with a stdlib class" when opening stdlib `.bt` files (BT-2027).
 
 ### Documentation
 
@@ -58,6 +67,18 @@
 - Typechecker probe confirms class-level type parameter substitution through `Result(C, Error)` works without extension (BT-1995).
 - Unified LSP and CLI diagnostic pipelines into shared `compute_project_diagnostics` function (BT-2009).
 - Thread fixture-defined protocols through BUnit compile path to eliminate false `Unresolved class` warnings (BT-2006).
+- Centralised parametric type resolution into shared `type_resolver` submodule — infrastructure for BT-2018..BT-2023 bug fixes (BT-2025).
+- Fix generic return type args lost when assigned to a local from a class method call (BT-2018).
+- Fix receiver type_args not threaded through super sends in generic classes (BT-2021).
+- Fix generic unification failures on nested, union, and FFI type shapes (BT-2023).
+- Fix union return types stored as flat `Known` instead of proper `Union`, causing false numeric-operand warnings (BT-2017).
+- Fix `Nil` in type annotations not canonicalized to `UndefinedObject`, causing `isNil` narrowing to silently fail (BT-2016).
+- Preserve type_args on concrete parametric instance-method returns (BT-2019).
+- Propagate `-> Never` through class-side dispatch fallback so `self error:` infers as Never (BT-2037).
+- Accept class literals as valid arguments for `Behaviour`/`Class` typed parameters (BT-2038).
+- Dedup cascade receiver inference so inner DNU warnings fire once instead of duplicating (BT-2035).
+- Fix spurious untyped-FFI warning on narrowing-path blocks in Result.bt (BT-2039).
+- Remove 11+ stale `@expect type` directives across stdlib following type checker improvements (#2076).
 
 ## 0.3.1 — 2026-03-26
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -242,8 +242,8 @@ ProtoObject (minimal — identity, DNU)
        ├─ Integer, String (primitives)
        ├─ Value (immutable value objects — field:)
        │    ├─ Point, Color (value types)
-       │    ├─ Collection (abstract)
-       │    │    └─ Set, Bag, Interval
+       │    ├─ Collection(E) (abstract)
+       │    │    └─ Set(E), Bag(E), Interval
        │    └─ TestCase (BUnit test base)
        └─ Actor (process-based — state: + spawn)
             └─ Counter, Server (actors)
@@ -834,7 +834,7 @@ maybeName: flag :: Boolean -> Integer | String =>
 
 // Self return type — resolves to the static receiver class at call sites
 // (only valid in return position, not parameters)
-collect: block :: Block -> Self =>
+collect: block :: Block(E, R) -> Self =>
   self species withAll: (self inject: #() into: [:acc :each |
     acc addFirst: (block value: each)
   ]) reversed
@@ -855,6 +855,15 @@ class named: name :: Symbol -> Result(Self, Error) => ...
 class -> Self class => @primitive "class"
 // (Counter new) class — inferred type: Counter's metaclass, so
 // `self class instanceCount` type-checks against class-side methods
+
+// <ClassName> class — a named class metatype annotation
+// Valid in any type position (fields, parameters, return types, locals).
+// Tells the type checker the value is a class object in the named class
+// hierarchy, so class-side methods on that class resolve without false DNU
+// warnings. Resolves to Dynamic at runtime (type-erased).
+field: actorClass :: Actor class | Nil = nil
+// After `actorClass isNil ifTrue: [^nil]`, actorClass is narrowed to
+// `Actor class` — class-side methods like `isSupervisor` type-check.
 ```
 
 ### Current Semantics
@@ -1334,6 +1343,18 @@ validate: x :: Object =>
 | `x isNil ifTrue: [^...]` | `x` is non-nil after the statement | Rest of method |
 | `x isNil ifTrue: [^...] ifFalse: [...]` | `x` is non-nil in false block | False block |
 
+### Conditional Return Type Inference
+
+`ifTrue:ifFalse:` on `Boolean` (and `True`/`False`) is declared as `Block(R), Block(R) -> R` — the type checker unifies both arms to a common return type. The result of a conditional expression is now statically typed rather than `Dynamic`:
+
+```beamtalk
+x := condition ifTrue: [42] ifFalse: [0]
+// x is inferred as Integer (not Dynamic)
+
+result isOk ifTrue: [result unwrap] ifFalse: [default]
+// inferred as the common type of both arms
+```
+
 ### Union + Narrowing Compose
 
 ```beamtalk
@@ -1771,7 +1792,7 @@ Inspect and manage children:
 ```beamtalk
 app count                                 // => 3  (number of running children)
 app children                              // => ["DatabasePool","HTTPRouter","MetricsCollector"]  (child ids)
-app which: DatabasePool                   // => #Actor<DatabasePool,_>  (running child instance)
+(app which: DatabasePool) unwrap           // => #Actor<DatabasePool,_>  (running child instance)
 (app terminate: HTTPRouter) unwrap        // gracefully stop a single child; Result(Nil, Error)
 app stop                                  // stop the supervisor and all children (unchanged — Nil)
 
@@ -1886,7 +1907,7 @@ Nested supervisor children are identified by `isSupervisor => true` and started 
 ```beamtalk
 root := (AppRoot supervise) unwrap
 root count                          // => 3
-root which: DatabaseSupervisor      // => #Supervisor<DatabaseSupervisor,_>
+(root which: DatabaseSupervisor) unwrap  // => #Supervisor<DatabaseSupervisor,_>
 ```
 
 ### Lifecycle API returns Result (ADR 0080)
@@ -1897,11 +1918,12 @@ Supervisor lifecycle methods that can fail at a startup / registry boundary retu
 |--------|-----------|---------------|
 | `Supervisor class>>supervise` | `-> Result(Self, Error)` | `#supervisor_start_failed`, `#stale_handle` |
 | `Supervisor>>terminate: aClass` | `-> Result(Nil, Error)` | `#terminate_failed`, `#stale_handle` |
+| `Supervisor>>which: aClass` | `-> Result(Object, Error)` | `#stale_handle` |
 | `DynamicSupervisor class>>supervise` | `-> Result(Self, Error)` | `#supervisor_start_failed`, `#stale_handle` |
 | `DynamicSupervisor>>startChild` / `startChild: args` | `-> Result(C, Error)` | `#child_start_failed`, `#stale_handle` |
 | `DynamicSupervisor>>terminateChild: child` | `-> Result(Nil, Error)` | `#terminate_failed`, `#stale_handle` |
 
-`stop`, `current`, `which:`, `children`, and `count` are **unchanged** — they are teardown / lookup / inspection operations over an already-valid handle and follow let-it-crash semantics (teardown) or nil-on-miss (lookup), matching the rules established in [ADR 0079](ADR/0079-named-actor-registration.md) for the parallel `Actor` surface.
+`stop`, `current`, `children`, and `count` are **unchanged** — they are teardown / lookup / inspection operations over an already-valid handle and follow let-it-crash semantics (teardown) or nil-on-miss (lookup), matching the rules established in [ADR 0079](ADR/0079-named-actor-registration.md) for the parallel `Actor` surface.
 
 This mirrors `Actor spawnAs:` / `Class named:` from the [Actor Named Registration](#actor-named-registration-adr-0079) section — both APIs speak `Result` at registry / lifecycle boundaries so call sites that chain actor spawns and supervisor operations stay on a single error idiom.
 
@@ -2077,9 +2099,9 @@ typed Supervisor subclass: ExduraSupervisor
 
   // Re-runs after every restart to rebuild cached pids.
   class initialize: sup :: Supervisor -> Nil =>
-    store := sup which: EventStore
-    pool := sup which: ActivityWorkerPool
-    engine := sup which: WorkflowEngine
+    store := (sup which: EventStore) unwrap
+    pool := (sup which: ActivityWorkerPool) unwrap
+    engine := (sup which: WorkflowEngine) unwrap
     engine initWithStore: store pool: pool
     nil
 ```
@@ -3082,9 +3104,9 @@ An `Interval` represents an arithmetic sequence of integers without materialisin
 (1 to: 5) collect: [:x | x * x]                 // => #(1, 4, 9, 16, 25)
 ```
 
-### Bag — Multisets
+### Bag(E) — Multisets
 
-A `Bag` is an unordered collection that allows duplicate elements. It is backed by a `Dictionary` mapping elements to occurrence counts. Like other collections, Bag is immutable — mutating operations return a new Bag.
+`Bag(E)` is an unordered collection that allows duplicate elements. It is backed by a `Dictionary(E, Integer)` mapping elements to occurrence counts. Like other collections, Bag is immutable — mutating operations return a new Bag.
 
 ```beamtalk
 Bag new class                           // => Bag

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -861,7 +861,7 @@ class -> Self class => @primitive "class"
 // Tells the type checker the value is a class object in the named class
 // hierarchy, so class-side methods on that class resolve without false DNU
 // warnings. Resolves to Dynamic at runtime (type-erased).
-field: actorClass :: Actor class | Nil = nil
+field: actorClass :: Actor class | nil = nil
 // After `actorClass isNil ifTrue: [^nil]`, actorClass is narrowed to
 // `Actor class` — class-side methods like `isSupervisor` type-check.
 ```


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 24 commits merged to main since the last refresh (2026-04-22).

### Docs updated

- **`docs/beamtalk-language-features.md`**
  - `Supervisor>>which:` now returns `Result(Object, Error)` — updated examples at 5 locations (inline usage, nested supervisor, lifecycle table, "unchanged" list, worked migration example) (BT-2041)
  - Added `<ClassName> class` metatype annotation to the type annotations section with example (BT-2034)
  - Added "Conditional Return Type Inference" subsection documenting `ifTrue:ifFalse:` typed `Block(R), Block(R) -> R` signature (BT-2020)
  - Updated class hierarchy diagram: `Collection (abstract)` → `Collection(E) (abstract)`, `Set, Bag` → `Set(E), Bag(E)` (BT-2036)
  - Updated `collect:` signature example from `Block -> Self` to `Block(E, R) -> Self` (BT-2036)
  - Renamed Bag section to `Bag(E)` with updated description (BT-2036)

- **`CHANGELOG.md`**
  - **Language:** `<ClassName> class` metatype (BT-2034), conditional return type inference (BT-2020), `-> Never` body warning (BT-2033), generic return type inner arg validation (BT-2022)
  - **Standard Library:** `which:` → Result (BT-2041), `Collection(E)` parametrized (BT-2036), `min:/max:` return type fix (BT-2020)
  - **Tooling:** diagnostic summary accounting fixes (BT-2031), lint cross-directory + LSP parity fixes (BT-2027)
  - **Internal:** 12 entries for type checker fixes and refactoring (BT-2016..BT-2039, #2076)

### Commits reviewed (24)

| SHA | Title | Doc change |
|-----|-------|------------|
| af4b656 | Remove stale @expect type directives | CHANGELOG Internal |
| af31f9c | Migrate Supervisor which: to Result (BT-2041) | language-features + CHANGELOG |
| 0272eed | Fix spurious untyped-FFI warning (BT-2039) | CHANGELOG Internal |
| 3f0ebab | Parametrize Collection(E) (BT-2036) | language-features + CHANGELOG |
| 13c0811 | Propagate Never through class-side dispatch (BT-2037) | CHANGELOG Internal |
| 404f108 | Accept class literals for Behaviour/Class params (BT-2038) | CHANGELOG Internal |
| aa6898c | Dedup cascade receiver DNU warnings (BT-2035) | CHANGELOG Internal |
| cfada01 | ifTrue:ifFalse: typed return (BT-2020) | language-features + CHANGELOG |
| 9ec570d | Warn when -> Never body returns Known (BT-2033) | CHANGELOG Language |
| 5ea630c | LSP diagnostic parity regressions (BT-2027) | CHANGELOG Tooling |
| b4301c9 | Preserve type_args on parametric returns (BT-2019) | CHANGELOG Internal |
| 4ef50b7 | Add ClassName class metatype (BT-2034) | language-features + CHANGELOG |
| 2ce575f | Generic return type args lost (BT-2018) | CHANGELOG Internal |
| 9dc670a | Thread type_args through super sends (BT-2021) | CHANGELOG Internal |
| a90d09a | Test: classifier-vs-exports assertion (BT-2029) | Skipped (test-only) |
| be64600 | Generic return type inner arg validation (BT-2022) | CHANGELOG Language |
| 543016a | Union return type narrowing fix (BT-2017) | CHANGELOG Internal |
| 018ddbf | Generic unification edge cases (BT-2023) | CHANGELOG Internal |
| 9a24866 | DiagnosticSummary accounting fixes (BT-2031) | CHANGELOG Tooling |
| 7fddb57 | Docs: supervision chapter + ADR closer (BT-2001) | Already complete |
| 721df12 | E2E + examples: otp-tree migration (BT-2000) | Skipped (example docs only) |
| 754dda3 | Centralised parametric type resolution (BT-2025) | CHANGELOG Internal |
| 0c746d0 | Stdlib: Supervisor/DynamicSupervisor → Result (BT-1999) | Covered by 7fddb57 |
| 7bb73a3 | Resolve Nil to UndefinedObject (BT-2016) | CHANGELOG Internal |

### Skipped (no doc impact)

- a90d09a — test-only (classifier-vs-exports assertion)
- 721df12 — example project docs only (otp-tree README/AGENTS.md)
- 0c746d0 — doc changes covered by later commit 7fddb57
- 7fddb57 — already landed with complete doc updates

https://claude.ai/code/session_01T9nMY9gjFbeEAu6WPQbVP7

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9nMY9gjFbeEAu6WPQbVP7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Class metatype annotations for more precise types
  * Conditional return type inference for safer control flow
  * Supervisor API now returns explicit Result(ok/error) cases

* **Bug Fixes**
  * Lint and language-server false positives and summary reporting corrected
  * Collection APIs return-type behavior tightened (min/max -> Number)

* **Documentation**
  * Expanded language docs and changelog with collection and supervision examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->