### PR TITLE
Type checker: infer block-param type from on:do: first argument (BT-2045)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1995,8 +1995,13 @@ impl TypeChecker {
         // Infer the exception class argument normally
         let ex_class_ty = self.infer_expr(ex_class_arg, hierarchy, env, in_abstract_method);
 
+        // Unwrap parentheses so `on: (Error) do: ([:e | ...])` also gets the
+        // contextual block-param typing.
+        let ex_class_inner = Self::unwrap_parens(ex_class_arg);
+        let handler_inner = Self::unwrap_parens(handler_arg);
+
         // Extract class name from ClassReference for block param typing
-        let exception_class_name = if let Expression::ClassReference { name, .. } = ex_class_arg {
+        let exception_class_name = if let Expression::ClassReference { name, .. } = ex_class_inner {
             Some(name.name.clone())
         } else {
             None
@@ -2004,7 +2009,7 @@ impl TypeChecker {
 
         // If handler is a block and we have a class name, type the block param
         let handler_ty = if let (Some(class_name), Expression::Block(block)) =
-            (&exception_class_name, handler_arg)
+            (&exception_class_name, handler_inner)
         {
             let param_types = if block.parameters.is_empty() {
                 vec![]
@@ -2420,6 +2425,15 @@ impl TypeChecker {
             Expression::Identifier(ident) => Some(ident.name.clone()),
             Expression::Parenthesized { expression, .. } => Self::extract_variable_name(expression),
             _ => None,
+        }
+    }
+
+    /// Peel `Expression::Parenthesized` wrappers so callers can pattern-match
+    /// on the inner expression directly.
+    fn unwrap_parens(expr: &Expression) -> &Expression {
+        match expr {
+            Expression::Parenthesized { expression, .. } => Self::unwrap_parens(expression),
+            other => other,
         }
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -906,6 +906,11 @@ impl TypeChecker {
                 env,
                 in_abstract_method,
             )
+        } else if selector_name == "on:do:" {
+            // BT-2045: Exception handler block parameter inference.
+            // `[...] on: SomeException do: [:e | ...]` — infer `e` as `SomeException`
+            // when the first argument is a class reference.
+            self.infer_args_for_on_do(arguments, hierarchy, env, in_abstract_method)
         } else {
             self.infer_args_with_block_context(
                 arguments,
@@ -1960,6 +1965,71 @@ impl TypeChecker {
             info.false_type = None;
         }
         info
+    }
+
+    /// BT-2045: Infer argument types for `on:do:` with exception class propagation.
+    ///
+    /// When the first argument is a class reference (e.g., `Exception`, `Error`),
+    /// the handler block's parameter is typed as that class instead of
+    /// `Dynamic(UnannotatedParam)`.
+    ///
+    /// `[...] on: Error do: [:e | e message]` → `e :: Error`
+    fn infer_args_for_on_do(
+        &mut self,
+        arguments: &[Expression],
+        hierarchy: &ClassHierarchy,
+        env: &mut TypeEnv,
+        in_abstract_method: bool,
+    ) -> Vec<InferredType> {
+        // on:do: expects exactly 2 arguments: exClass and handler
+        if arguments.len() != 2 {
+            return arguments
+                .iter()
+                .map(|arg| self.infer_expr(arg, hierarchy, env, in_abstract_method))
+                .collect();
+        }
+
+        let ex_class_arg = &arguments[0];
+        let handler_arg = &arguments[1];
+
+        // Infer the exception class argument normally
+        let ex_class_ty = self.infer_expr(ex_class_arg, hierarchy, env, in_abstract_method);
+
+        // Extract class name from ClassReference for block param typing
+        let exception_class_name = if let Expression::ClassReference { name, .. } = ex_class_arg {
+            Some(name.name.clone())
+        } else {
+            None
+        };
+
+        // If handler is a block and we have a class name, type the block param
+        let handler_ty = if let (Some(class_name), Expression::Block(block)) =
+            (&exception_class_name, handler_arg)
+        {
+            let param_types = if block.parameters.is_empty() {
+                vec![]
+            } else {
+                // Type the first (and typically only) block parameter as the exception class
+                let mut types = vec![InferredType::known(class_name.clone())];
+                // Any additional params beyond the first stay Dynamic
+                for _ in 1..block.parameters.len() {
+                    types.push(InferredType::Dynamic(DynamicReason::UnannotatedParam));
+                }
+                types
+            };
+            self.infer_block_with_typed_params(
+                block,
+                handler_arg.span(),
+                &param_types,
+                hierarchy,
+                env,
+                in_abstract_method,
+            )
+        } else {
+            self.infer_expr(handler_arg, hierarchy, env, in_abstract_method)
+        };
+
+        vec![ex_class_ty, handler_ty]
     }
 
     /// Infer argument types for `ifTrue:` / `ifFalse:` / `ifTrue:ifFalse:` with

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -14736,3 +14736,136 @@ typed Object subclass: ExduraWorker
             .collect::<Vec<_>>()
     );
 }
+
+// --- BT-2045: on:do: block parameter inference ---
+
+/// `on: Exception do: [:e | e message]` should infer `e :: Exception`,
+/// so `e message` resolves to `String` with no Dynamic or DNU warnings.
+#[test]
+fn bt2045_on_do_infers_block_param_from_exception_class() {
+    let source = "
+typed Object subclass: Repro
+  handleIt -> String =>
+    [^42]
+      on: Exception
+      do: [:e | e message]
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dynamic_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "on:do: handler param should be typed as Exception, not Dynamic; got: {:?}",
+        dynamic_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+
+    let dnu_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .collect();
+    assert!(
+        dnu_warnings.is_empty(),
+        "e message should resolve — Exception defines `message`; got: {:?}",
+        dnu_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Subclass of Exception: `on: Error do: [:e | e message]` should
+/// infer `e :: Error` and its inherited `message` method should resolve.
+#[test]
+fn bt2045_on_do_infers_block_param_from_exception_subclass() {
+    let source = "
+typed Object subclass: Repro
+  handleIt -> String =>
+    [^42]
+      on: Error
+      do: [:e | e message]
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dynamic_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "on:do: handler param should be typed as Error, not Dynamic; got: {:?}",
+        dynamic_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+
+    let dnu_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .collect();
+    assert!(
+        dnu_warnings.is_empty(),
+        "e message should resolve — Error inherits `message` from Exception; got: {:?}",
+        dnu_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Non-class-reference first argument to `on:do:` should not crash;
+/// the handler param falls back to `Dynamic(UnannotatedParam)`.
+#[test]
+fn bt2045_on_do_non_class_ref_falls_back_to_dynamic() {
+    let source = "
+typed Object subclass: Repro
+  handleIt: exClass :: Object -> Nil =>
+    [^42]
+      on: exClass
+      do: [:e | e message]
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    // With a variable (not class reference), we expect Dynamic — which is
+    // correct because we can't statically determine the exception class.
+    // The test just verifies we don't crash.
+    let dynamic_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| {
+            d.message.contains("inferred as Dynamic") && d.message.contains("unannotated parameter")
+        })
+        .collect();
+    assert!(
+        !dynamic_warnings.is_empty(),
+        "variable first arg should leave handler param as Dynamic(UnannotatedParam)"
+    );
+}


### PR DESCRIPTION
## Summary

Resolves [BT-2045](https://linear.app/beamtalk/issue/BT-2045)

When a literal block is passed to `on:do:` as the handler, the block parameter (e.g., `:e`) was previously inferred as `Dynamic(UnannotatedParam)` in typed classes. This PR adds special-case inference so the handler block's parameter is typed as the exception class from the first argument.

**Before:** `[...] on: Exception do: [:e | e message]` -- `e` inferred as `Dynamic`, triggers "expression inferred as Dynamic" warning in typed classes.

**After:** `[...] on: Exception do: [:e | e message]` -- `e` inferred as `Exception`, `message` resolves to `String`.

## Changes

- Added `infer_args_for_on_do` method to type checker inference, intercepting the `on:do:` selector similar to how `ifTrue:`/`ifFalse:` have special narrowing logic
- When the first argument is a `ClassReference`, the handler block's first parameter is typed as that class
- Works for `Exception` and any subclass (`Error`, `TypeError`, etc.)
- Falls back gracefully to `Dynamic(UnannotatedParam)` when the first argument is a variable (not a class reference)
- Added 3 tests: direct Exception class, Error subclass, and variable fallback

## Test plan

- [x] `bt2045_on_do_infers_block_param_from_exception_class` -- `on: Exception do: [:e | e message]` produces no Dynamic/DNU warnings
- [x] `bt2045_on_do_infers_block_param_from_exception_subclass` -- `on: Error do: [:e | e message]` works with inherited methods
- [x] `bt2045_on_do_non_class_ref_falls_back_to_dynamic` -- variable first arg correctly falls back to Dynamic
- [x] All 420 type checker tests pass
- [x] Full `just test` passes (Rust + stdlib + BUnit + runtime)
- [x] `just clippy` and `just fmt-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for `on:do:` exception-handler blocks so block parameters infer the referenced exception class when given, reducing false "dynamic" and "does not understand" diagnostics.
  * Retains safe fallback to dynamic inference when the exception argument isn’t a class reference.

* **Tests**
  * Added regression tests covering these inference cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->