### PR TITLE
Narrow ifNotNil: block param to non-Nil branch (BT-2046)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2113,13 +2113,30 @@ impl TypeChecker {
                 if Some(i) == not_nil_index {
                     self.infer_if_not_nil_block(
                         arg,
+                        receiver_ty,
                         &non_nil_ty,
                         hierarchy,
                         env,
                         in_abstract_method,
                     )
                 } else {
-                    self.infer_expr(arg, hierarchy, env, in_abstract_method)
+                    // Preserve block-context inference for the `ifNil:` arm in
+                    // `ifNil:ifNotNil:` / `ifNotNil:ifNil:` — a bare
+                    // `infer_expr` would drop the `Block(..., R)` return type,
+                    // degrading the whole send on statically-known receivers.
+                    let inner = Self::unwrap_parens(arg);
+                    if let Expression::Block(block) = inner {
+                        self.infer_block_with_typed_params(
+                            block,
+                            arg.span(),
+                            &[],
+                            hierarchy,
+                            env,
+                            in_abstract_method,
+                        )
+                    } else {
+                        self.infer_expr(arg, hierarchy, env, in_abstract_method)
+                    }
                 }
             })
             .collect()
@@ -2134,6 +2151,7 @@ impl TypeChecker {
     fn infer_if_not_nil_block(
         &mut self,
         arg: &Expression,
+        receiver_ty: &InferredType,
         non_nil_ty: &InferredType,
         hierarchy: &ClassHierarchy,
         env: &mut TypeEnv,
@@ -2153,13 +2171,13 @@ impl TypeChecker {
         let param_types: Vec<InferredType> = if block.parameters.is_empty() {
             vec![]
         } else {
-            // If the non-nil branch is itself `UndefinedObject`/`Nil` (e.g.
-            // receiver is a literal `nil`), the block is dead code. Don't
-            // narrow the param to `UndefinedObject` — that would break
-            // otherwise-legal body code (like `s ++ "!"`) by producing DNU
-            // errors. Leave the param as Dynamic so unreachable bodies still
-            // compile.
-            let first_param_ty = if Self::is_nil_only(non_nil_ty) {
+            // If the RECEIVER is nil-only (e.g. receiver is a literal `nil`,
+            // `UndefinedObject | Nil`), the block is dead code. Check against
+            // the original receiver — `non_nil_type` collapses a nil-only
+            // union to `Dynamic(Unknown)`, so checking `non_nil_ty` here would
+            // miss the case. Leave the param as `Dynamic(UnannotatedParam)`
+            // so unreachable bodies still compile without DNU noise.
+            let first_param_ty = if Self::is_nil_only(receiver_ty) {
                 InferredType::Dynamic(DynamicReason::UnannotatedParam)
             } else {
                 non_nil_ty.clone()

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -930,6 +930,21 @@ impl TypeChecker {
             // `[...] on: SomeException do: [:e | ...]` — infer `e` as `SomeException`
             // when the first argument is a class reference.
             self.infer_args_for_on_do(arguments, hierarchy, env, in_abstract_method)
+        } else if matches!(
+            selector_name.as_str(),
+            "ifNotNil:" | "ifNil:ifNotNil:" | "ifNotNil:ifNil:"
+        ) {
+            // BT-2046: Narrow block parameter of `ifNotNil: [:x | ...]` to the
+            // non-nil branch of the receiver's type. Dual of the receiver-side
+            // `isNil ifFalse:` narrowing (BT-2048).
+            self.infer_args_for_if_not_nil(
+                &selector_name,
+                arguments,
+                &receiver_ty,
+                hierarchy,
+                env,
+                in_abstract_method,
+            )
         } else {
             self.infer_args_with_block_context(
                 arguments,
@@ -2058,6 +2073,118 @@ impl TypeChecker {
         vec![ex_class_ty, handler_ty]
     }
 
+    /// BT-2046: Infer argument types for `ifNotNil:` / `ifNil:ifNotNil:` /
+    /// `ifNotNil:ifNil:` with non-nil narrowing of the receiver propagated to
+    /// the not-nil block's parameter.
+    ///
+    /// When the receiver is `T | Nil`, the block parameter in
+    /// `ifNotNil: [:x | ...]` should be typed `T` (the non-nil branch),
+    /// instead of `Dynamic(UnannotatedParam)`. For non-nullable receivers the
+    /// parameter is typed as the full receiver type (not a regression from
+    /// prior behaviour, which also produced `Dynamic`).
+    ///
+    /// Nil-branch blocks (`ifNil:`) and blocks with no declared parameter get
+    /// the default inference path.
+    fn infer_args_for_if_not_nil(
+        &mut self,
+        selector_name: &str,
+        arguments: &[Expression],
+        receiver_ty: &InferredType,
+        hierarchy: &ClassHierarchy,
+        env: &mut TypeEnv,
+        in_abstract_method: bool,
+    ) -> Vec<InferredType> {
+        // Compute the non-nil branch type once. `non_nil_type` strips
+        // `UndefinedObject` / `Nil` from a union and returns other types
+        // unchanged (matches the `isNil ifFalse:` narrowing — BT-2048).
+        let non_nil_ty = Self::non_nil_type(receiver_ty);
+
+        // Positions of the `ifNotNil:` block in the argument list per selector.
+        let not_nil_index: Option<usize> = match selector_name {
+            "ifNil:ifNotNil:" => Some(1),
+            "ifNotNil:" | "ifNotNil:ifNil:" => Some(0),
+            _ => None,
+        };
+
+        arguments
+            .iter()
+            .enumerate()
+            .map(|(i, arg)| {
+                if Some(i) == not_nil_index {
+                    self.infer_if_not_nil_block(
+                        arg,
+                        &non_nil_ty,
+                        hierarchy,
+                        env,
+                        in_abstract_method,
+                    )
+                } else {
+                    self.infer_expr(arg, hierarchy, env, in_abstract_method)
+                }
+            })
+            .collect()
+    }
+
+    /// Infer the `ifNotNil:` block, typing its first parameter (if any) as the
+    /// non-nil branch of the receiver's type.
+    ///
+    /// Falls back to the normal expression inference path when the argument
+    /// isn't a block literal (e.g. `receiver ifNotNil: aSymbol` is legal but
+    /// non-local-inferable here).
+    fn infer_if_not_nil_block(
+        &mut self,
+        arg: &Expression,
+        non_nil_ty: &InferredType,
+        hierarchy: &ClassHierarchy,
+        env: &mut TypeEnv,
+        in_abstract_method: bool,
+    ) -> InferredType {
+        // Unwrap parens: `ifNotNil: ([:x | ...])` should narrow the same as
+        // the unparenthesised form.
+        let inner = Self::unwrap_parens(arg);
+        let Expression::Block(block) = inner else {
+            return self.infer_expr(arg, hierarchy, env, in_abstract_method);
+        };
+
+        // Zero-arity `ifNotNil: [ ... ]` — still call the typed-param helper
+        // with an empty param list so the returned `Block(..., R)` type
+        // carries the body's return type (consistent with
+        // `infer_block_with_narrowing`; relevant for BT-2047).
+        let param_types: Vec<InferredType> = if block.parameters.is_empty() {
+            vec![]
+        } else {
+            // If the non-nil branch is itself `UndefinedObject`/`Nil` (e.g.
+            // receiver is a literal `nil`), the block is dead code. Don't
+            // narrow the param to `UndefinedObject` — that would break
+            // otherwise-legal body code (like `s ++ "!"`) by producing DNU
+            // errors. Leave the param as Dynamic so unreachable bodies still
+            // compile.
+            let first_param_ty = if Self::is_nil_only(non_nil_ty) {
+                InferredType::Dynamic(DynamicReason::UnannotatedParam)
+            } else {
+                non_nil_ty.clone()
+            };
+            let mut types = Vec::with_capacity(block.parameters.len());
+            types.push(first_param_ty);
+            // Any additional params beyond the first stay Dynamic. A
+            // well-formed `ifNotNil:` block has 0 or 1 parameter (validated by
+            // `validate_if_not_nil_block` in codegen), so this is defensive.
+            for _ in 1..block.parameters.len() {
+                types.push(InferredType::Dynamic(DynamicReason::UnannotatedParam));
+            }
+            types
+        };
+
+        self.infer_block_with_typed_params(
+            block,
+            arg.span(),
+            &param_types,
+            hierarchy,
+            env,
+            in_abstract_method,
+        )
+    }
+
     /// Infer argument types for `ifTrue:` / `ifFalse:` / `ifTrue:ifFalse:` with
     /// narrowed type environments for block arguments.
     ///
@@ -2479,6 +2606,24 @@ impl TypeChecker {
             .body
             .iter()
             .any(|stmt| matches!(stmt.expression, Expression::Return { .. }))
+    }
+
+    /// Check whether a type is *only* the nil type (`UndefinedObject` or
+    /// its legacy `Nil` alias). Returns `true` for the bare nil type itself,
+    /// or a union whose members are all nil. Used by the `ifNotNil:` block-
+    /// param narrowing (BT-2046) to avoid typing the param as `UndefinedObject`
+    /// when the non-nil branch is dead code.
+    fn is_nil_only(ty: &InferredType) -> bool {
+        match ty {
+            InferredType::Known { class_name, .. } => {
+                class_name.as_str() == "UndefinedObject" || class_name.as_str() == "Nil"
+            }
+            InferredType::Union { members, .. } => members.iter().all(|m| {
+                m.as_known()
+                    .is_some_and(|n| n.as_str() == "UndefinedObject" || n.as_str() == "Nil")
+            }),
+            _ => false,
+        }
     }
 
     /// Remove `UndefinedObject` (nil) from a union type or convert a known type

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -14869,3 +14869,273 @@ typed Object subclass: Repro
         "variable first arg should leave handler param as Dynamic(UnannotatedParam)"
     );
 }
+
+// --- BT-2046: ifNotNil: block parameter narrowing ---
+//
+// When the receiver of `ifNotNil: [:x | ...]` is typed `T | Nil`, the block
+// parameter `:x` should be typed `T` inside the block (non-nil branch). Dual
+// of the receiver-side `isNil ifFalse:` narrowing shipped in BT-2048.
+
+/// Minimal repro from the issue: `self.snapshot` typed `ReplaySnapshot | Nil`,
+/// block param `snap` should be `ReplaySnapshot`, so `snap workflowId` resolves.
+#[test]
+fn bt2046_if_not_nil_narrows_block_param_on_union_field() {
+    let source = r#"
+typed Object subclass: ReplaySnapshot
+  workflowId -> String =>
+    [^"wf-1"]
+
+typed Object subclass: Repro
+  field: snapshot :: ReplaySnapshot | Nil = nil
+
+  use -> String =>
+    ^self.snapshot
+      ifNotNil: [:snap | snap workflowId]
+      ifNil: ["none"]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dnu_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .collect();
+    assert!(
+        dnu_warnings.is_empty(),
+        "snap workflowId should resolve — snap narrowed to ReplaySnapshot; got: {:?}",
+        dnu_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+
+    // The key signal: no "unannotated parameter" Dynamic warning for snap. If
+    // the narrowing is missing, the block param `snap` stays Dynamic and emits
+    // a "unannotated parameter" warning; if the block param is narrowed,
+    // `snap workflowId` resolves to String and no such warning fires.
+    let unannotated_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("unannotated parameter"))
+        .collect();
+    assert!(
+        unannotated_warnings.is_empty(),
+        "ifNotNil: block param `snap` should narrow to ReplaySnapshot, not stay Dynamic; got: {:?}",
+        unannotated_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Non-nullable receiver: `ifNotNil: [:x | ...]` over plain `T` should still
+/// type `x` as `T` (no regression — previously it was `Dynamic`).
+#[test]
+fn bt2046_if_not_nil_passes_through_non_nullable_receiver() {
+    let source = r#"
+typed Object subclass: Widget
+  name -> String =>
+    [^"widget"]
+
+typed Object subclass: Repro
+  field: widget :: Widget = nil
+
+  use -> String =>
+    self.widget ifNotNil: [:w |
+      ^w name
+    ]
+    ^"none"
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dnu_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .collect();
+    assert!(
+        dnu_warnings.is_empty(),
+        "w name should resolve — w typed as Widget; got: {:?}",
+        dnu_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// `ifNil: [..] ifNotNil: [:x | ..]` — the `ifNotNil:` block param (second
+/// argument) should get the non-nil narrowing.
+#[test]
+fn bt2046_if_nil_if_not_nil_narrows_second_block_param() {
+    let source = r#"
+typed Object subclass: ReplaySnapshot
+  workflowId -> String =>
+    [^"wf-1"]
+
+typed Object subclass: Repro
+  field: snapshot :: ReplaySnapshot | Nil = nil
+
+  use -> String =>
+    ^self.snapshot
+      ifNil: ["none"]
+      ifNotNil: [:snap | snap workflowId]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dnu_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .collect();
+    assert!(
+        dnu_warnings.is_empty(),
+        "snap workflowId should resolve — snap narrowed to ReplaySnapshot; got: {:?}",
+        dnu_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// `ifNotNil: [:x | ..] ifNil: [..]` — the `ifNotNil:` block param (first
+/// argument) should get the non-nil narrowing.
+#[test]
+fn bt2046_if_not_nil_if_nil_narrows_first_block_param() {
+    let source = r#"
+typed Object subclass: ReplaySnapshot
+  workflowId -> String =>
+    [^"wf-1"]
+
+typed Object subclass: Repro
+  field: snapshot :: ReplaySnapshot | Nil = nil
+
+  use -> String =>
+    ^self.snapshot
+      ifNotNil: [:snap | snap workflowId]
+      ifNil: ["none"]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dnu_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .collect();
+    assert!(
+        dnu_warnings.is_empty(),
+        "snap workflowId should resolve — snap narrowed to ReplaySnapshot; got: {:?}",
+        dnu_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Zero-arity `ifNotNil: [ ... ]` (no block param) should not crash and should
+/// still type-check normally.
+#[test]
+fn bt2046_if_not_nil_zero_arity_block_does_not_crash() {
+    let source = r#"
+typed Object subclass: ReplaySnapshot
+  workflowId -> String =>
+    [^"wf-1"]
+
+typed Object subclass: Repro
+  field: snapshot :: ReplaySnapshot | Nil = nil
+
+  use -> String =>
+    self.snapshot ifNotNil: ["present"]
+    ^"done"
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let errors: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.severity == crate::source_analysis::Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "zero-arity ifNotNil: block should type-check cleanly; got errors: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Local variable with union annotation: `x :: Widget | Nil` should narrow
+/// the block param to `Widget` inside `ifNotNil: [:w | ...]`.
+#[test]
+fn bt2046_if_not_nil_narrows_local_variable_union() {
+    let source = r#"
+typed Object subclass: Widget
+  name -> String =>
+    [^"widget"]
+
+typed Object subclass: Repro
+  tryIt: x :: Widget | Nil -> String =>
+    ^x
+      ifNotNil: [:w | w name]
+      ifNil: ["none"]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dnu_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .collect();
+    assert!(
+        dnu_warnings.is_empty(),
+        "w name should resolve — w narrowed to Widget from Widget|Nil; got: {:?}",
+        dnu_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+
+    let unannotated_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("unannotated parameter"))
+        .collect();
+    assert!(
+        unannotated_warnings.is_empty(),
+        "block param `w` should narrow to Widget, not stay Dynamic; got: {:?}",
+        unannotated_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -14971,6 +14971,19 @@ typed Object subclass: Repro
         "w name should resolve — w typed as Widget; got: {:?}",
         dnu_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
+    let unannotated_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("unannotated parameter"))
+        .collect();
+    assert!(
+        unannotated_warnings.is_empty(),
+        "block param `w` should be typed Widget, not Dynamic; got: {:?}",
+        unannotated_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
 }
 
 /// `ifNil: [..] ifNotNil: [:x | ..]` — the `ifNotNil:` block param (second
@@ -15010,6 +15023,19 @@ typed Object subclass: Repro
         "snap workflowId should resolve — snap narrowed to ReplaySnapshot; got: {:?}",
         dnu_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
+    let unannotated_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("unannotated parameter"))
+        .collect();
+    assert!(
+        unannotated_warnings.is_empty(),
+        "block param `snap` should be narrowed to ReplaySnapshot, not Dynamic; got: {:?}",
+        unannotated_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
 }
 
 /// `ifNotNil: [:x | ..] ifNil: [..]` — the `ifNotNil:` block param (first
@@ -15048,6 +15074,19 @@ typed Object subclass: Repro
         dnu_warnings.is_empty(),
         "snap workflowId should resolve — snap narrowed to ReplaySnapshot; got: {:?}",
         dnu_warnings.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let unannotated_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("unannotated parameter"))
+        .collect();
+    assert!(
+        unannotated_warnings.is_empty(),
+        "block param `snap` should be narrowed to ReplaySnapshot, not Dynamic; got: {:?}",
+        unannotated_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
     );
 }
 


### PR DESCRIPTION
## Summary

- Narrows `(x :: T | Nil) ifNotNil: [:v | ...]` so `v` is typed `T` inside the block, instead of `Dynamic(UnannotatedParam)`. Covers the combined `ifNil:ifNotNil:` and `ifNotNil:ifNil:` selectors too.
- Reuses BT-2048's `non_nil_type` helper to strip `Nil` from the receiver union, and BT-2045's `infer_block_with_typed_params` path to apply the narrowed type to the block parameter.
- Gracefully falls back for non-nullable receivers (block param = receiver type) and Dynamic receivers (stays Dynamic). An `is_nil_only` guard short-circuits the dead-block case of a statically-nil receiver so we don't produce an empty Union.
- Unblocks the `@expect type` at `beamtalk-exdura/src/workflow_runner.bt:80`.

## Test plan

- [x] `cargo test -p beamtalk-core --lib type_checker::` — 641 pass
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI green on the PR
- [ ] Verify `beamtalk-exdura` `@expect type` at `workflow_runner.bt:80` can be removed (epic-level sweep in BT-2044)

Part of epic BT-2044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More precise type narrowing for nil-conditional message sends (`ifNotNil:`, `ifNil:ifNotNil:`, `ifNotNil:ifNil:`), so block parameters receive the non-nil type when appropriate and unreachable-nil branches avoid spurious typing.
* **Tests**
  * Added regression tests to ensure correct narrowing behavior across various nil/non-nil and composition cases, including zero-arity blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->