### PR TITLE
Type ifNil:ifNotNil: expression as branch-union (BT-2047)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -976,9 +976,12 @@ impl TypeChecker {
         // Restricted to non-class-side receivers: `ClassName ifNil: ... ifNotNil: ...`
         // and `self ifNil: ... ifNotNil: ...` inside a class method must
         // flow through `check_class_side_send` so an invalid metaclass send
-        // still emits DNU.
-        let is_class_side_receiver = matches!(receiver, Expression::ClassReference { .. })
-            || (env.in_class_method && Self::is_self_receiver(receiver));
+        // still emits DNU. Unwrap parens first so `(ClassName) ifNil: ...`
+        // and `(self) ifNil: ...` aren't accidentally treated as non-class-side.
+        let unwrapped_receiver = Self::unwrap_parens(receiver);
+        let is_class_side_receiver =
+            matches!(unwrapped_receiver, Expression::ClassReference { .. })
+                || (env.in_class_method && Self::is_self_receiver(unwrapped_receiver));
         if !is_class_side_receiver
             && matches!(
                 selector_name.as_str(),

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -965,6 +965,22 @@ impl TypeChecker {
             return receiver_ty;
         }
 
+        // BT-2047: `ifNil:ifNotNil:` / `ifNotNil:ifNil:` return the union of
+        // both branch bodies' return types. `infer_args_for_if_not_nil`
+        // (BT-2046) already inferred both branches as `Block(..., R)` with
+        // narrowed params, so we read back R from each arg and union them.
+        // Blocks with a non-local return (`^`) exit the enclosing method —
+        // their branch contributes `Never`, and `union_of` skips Never, so
+        // the expression's type comes from the surviving branch.
+        if matches!(
+            selector_name.as_str(),
+            "ifNil:ifNotNil:" | "ifNotNil:ifNil:"
+        ) {
+            if let Some(ty) = Self::if_nil_branch_union_ret_ty(arguments, &arg_types) {
+                return ty;
+            }
+        }
+
         // Validate binary operand types when both sides are known
         // Only check if the receiver type actually defines the operator (avoids
         // duplicate warnings when the selector is already unknown).
@@ -2201,6 +2217,53 @@ impl TypeChecker {
             env,
             in_abstract_method,
         )
+    }
+
+    /// BT-2047: Compute the return type of `ifNil:ifNotNil:` /
+    /// `ifNotNil:ifNil:` as the union of both branch bodies' return types.
+    ///
+    /// `arg_types` must be the pair of `Block(..., R)` types produced by
+    /// [`Self::infer_args_for_if_not_nil`]; the last type-arg of each Block is
+    /// the branch body's inferred return type. A block literal containing a
+    /// non-local return (`^`) exits the enclosing method, so its branch
+    /// contributes `Never` to the union regardless of the returned value's
+    /// type — matching the semantics noted in the issue's AC #3.
+    ///
+    /// Returns `None` if either arg isn't a well-formed `Block(...)` (e.g. the
+    /// caller passed a symbol or bare value instead of a block literal), so
+    /// the caller falls back to the generic method-lookup path for those cases.
+    fn if_nil_branch_union_ret_ty(
+        arguments: &[Expression],
+        arg_types: &[InferredType],
+    ) -> Option<InferredType> {
+        if arg_types.len() < 2 || arguments.len() < 2 {
+            return None;
+        }
+        let branch_ret = |arg: &Expression, ty: &InferredType| -> Option<InferredType> {
+            let InferredType::Known {
+                class_name,
+                type_args,
+                ..
+            } = ty
+            else {
+                return None;
+            };
+            if class_name.as_str() != "Block" {
+                return None;
+            }
+            // Non-local `^` inside the branch exits the method before the
+            // expression value is observed — treat as Never so `union_of`
+            // skips it.
+            if let Expression::Block(block) = Self::unwrap_parens(arg) {
+                if Self::block_has_return(block) {
+                    return Some(InferredType::Never);
+                }
+            }
+            type_args.last().cloned()
+        };
+        let a = branch_ret(&arguments[0], &arg_types[0])?;
+        let b = branch_ret(&arguments[1], &arg_types[1])?;
+        Some(InferredType::union_of(&[a, b]))
     }
 
     /// Infer argument types for `ifTrue:` / `ifFalse:` / `ifTrue:ifFalse:` with

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -972,10 +972,19 @@ impl TypeChecker {
         // Blocks with a non-local return (`^`) exit the enclosing method —
         // their branch contributes `Never`, and `union_of` skips Never, so
         // the expression's type comes from the surviving branch.
-        if matches!(
-            selector_name.as_str(),
-            "ifNil:ifNotNil:" | "ifNotNil:ifNil:"
-        ) {
+        //
+        // Restricted to non-class-side receivers: `ClassName ifNil: ... ifNotNil: ...`
+        // and `self ifNil: ... ifNotNil: ...` inside a class method must
+        // flow through `check_class_side_send` so an invalid metaclass send
+        // still emits DNU.
+        let is_class_side_receiver = matches!(receiver, Expression::ClassReference { .. })
+            || (env.in_class_method && Self::is_self_receiver(receiver));
+        if !is_class_side_receiver
+            && matches!(
+                selector_name.as_str(),
+                "ifNil:ifNotNil:" | "ifNotNil:ifNil:"
+            )
+        {
             if let Some(ty) = Self::if_nil_branch_union_ret_ty(arguments, &arg_types) {
                 return ty;
             }
@@ -2251,11 +2260,12 @@ impl TypeChecker {
             if class_name.as_str() != "Block" {
                 return None;
             }
-            // Non-local `^` inside the branch exits the method before the
-            // expression value is observed — treat as Never so `union_of`
-            // skips it.
+            // Non-local `^` anywhere inside the branch (including nested
+            // sub-expressions like `[[^1] value]` or `foo: (^bar)`) exits
+            // the method before the expression value is observed — treat
+            // the branch as Never so `union_of` skips it.
             if let Expression::Block(block) = Self::unwrap_parens(arg) {
-                if Self::block_has_return(block) {
+                if Self::block_has_any_return(block) {
                     return Some(InferredType::Never);
                 }
             }
@@ -2681,12 +2691,56 @@ impl TypeChecker {
         }
     }
 
-    /// Check whether a block contains a non-local return (`^`).
+    /// Check whether a block contains a non-local return (`^`) at the top
+    /// level of its body. Used where only the block's own direct return
+    /// matters (e.g. guard-block divergence checks).
     fn block_has_return(block: &crate::ast::Block) -> bool {
         block
             .body
             .iter()
             .any(|stmt| matches!(stmt.expression, Expression::Return { .. }))
+    }
+
+    /// Check whether a block contains a non-local return (`^`) anywhere
+    /// in its body, including inside nested expressions (e.g.
+    /// `[[^1] value]` or `[foo: (^bar)]`). BT-2047 uses this to detect
+    /// branches that exit the enclosing method even when the `^` is
+    /// buried in a sub-expression.
+    fn block_has_any_return(block: &crate::ast::Block) -> bool {
+        block
+            .body
+            .iter()
+            .any(|stmt| Self::expr_contains_return(&stmt.expression))
+    }
+
+    fn expr_contains_return(expr: &Expression) -> bool {
+        match expr {
+            Expression::Return { .. } => true,
+            Expression::Parenthesized { expression, .. } => Self::expr_contains_return(expression),
+            Expression::Assignment { target, value, .. } => {
+                Self::expr_contains_return(target) || Self::expr_contains_return(value)
+            }
+            Expression::MessageSend {
+                receiver,
+                arguments,
+                ..
+            } => {
+                Self::expr_contains_return(receiver)
+                    || arguments.iter().any(Self::expr_contains_return)
+            }
+            Expression::Cascade {
+                receiver, messages, ..
+            } => {
+                Self::expr_contains_return(receiver)
+                    || messages
+                        .iter()
+                        .any(|m| m.arguments.iter().any(Self::expr_contains_return))
+            }
+            Expression::Block(block) => Self::block_has_any_return(block),
+            // Literals, identifiers, class references, field access —
+            // no sub-expressions that could contain `^`.
+            _ => false,
+        }
     }
 
     /// Check whether a type is *only* the nil type (`UndefinedObject` or

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -15482,6 +15482,73 @@ fn find_union_in_type_map<'a>(
     })
 }
 
+/// Walk the module AST to find the first `MessageSend` whose selector name
+/// matches `selector_name`, then look up its inferred type in `type_map`.
+/// Used by BT-2047 tests to assert the exact type of the `ifNil:ifNotNil:`
+/// expression — checking diagnostics alone isn't enough because
+/// `check_return_type` bails on `Union` / `Dynamic` inferred bodies.
+fn find_send_inferred_ty<'a>(
+    module: &crate::ast::Module,
+    type_map: &'a crate::semantic_analysis::type_checker::TypeMap,
+    selector_name: &str,
+) -> Option<&'a InferredType> {
+    fn walk_expr<'a>(
+        expr: &crate::ast::Expression,
+        type_map: &'a crate::semantic_analysis::type_checker::TypeMap,
+        selector_name: &str,
+    ) -> Option<&'a InferredType> {
+        use crate::ast::{Expression, MessageSelector};
+        match expr {
+            Expression::MessageSend {
+                selector,
+                span,
+                receiver,
+                arguments,
+                ..
+            } => {
+                let this_sel = match selector {
+                    MessageSelector::Unary(s) | MessageSelector::Binary(s) => s.to_string(),
+                    MessageSelector::Keyword(parts) => {
+                        parts.iter().map(|p| p.keyword.as_str()).collect::<String>()
+                    }
+                };
+                if this_sel == selector_name {
+                    return type_map.get(*span);
+                }
+                if let Some(t) = walk_expr(receiver, type_map, selector_name) {
+                    return Some(t);
+                }
+                for a in arguments {
+                    if let Some(t) = walk_expr(a, type_map, selector_name) {
+                        return Some(t);
+                    }
+                }
+                None
+            }
+            Expression::Return { value, .. }
+            | Expression::Parenthesized {
+                expression: value, ..
+            }
+            | Expression::Assignment { value, .. } => walk_expr(value, type_map, selector_name),
+            Expression::Block(block) => block
+                .body
+                .iter()
+                .find_map(|s| walk_expr(&s.expression, type_map, selector_name)),
+            _ => None,
+        }
+    }
+    for class in &module.classes {
+        for method in &class.methods {
+            for stmt in &method.body {
+                if let Some(t) = walk_expr(&stmt.expression, type_map, selector_name) {
+                    return Some(t);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Minimal repro from the BT-2047 issue: `self.snapshot ifNil: [42] ifNotNil:
 /// [:snap | "got one"]` should type as `Integer | String`, not Dynamic.
 #[test]
@@ -15583,17 +15650,14 @@ typed Object subclass: Repro
     let mut checker = TypeChecker::new();
     checker.check_module(&module, &hierarchy);
 
-    // No type warnings — method declares -> String, and dedup'd branch union
-    // resolves to bare `String`, which satisfies the declared return.
-    let diags: Vec<_> = checker
-        .diagnostics()
-        .iter()
-        .filter(|d| d.category == Some(DiagnosticCategory::Type))
-        .collect();
+    // Assert the inferred type of the `ifNil:ifNotNil:` send directly —
+    // "no Type diagnostics" alone would pass even if the expression fell
+    // back to `Dynamic` (which skips return-type mismatch checks).
+    let send_ty = find_send_inferred_ty(&module, checker.type_map(), "ifNil:ifNotNil:")
+        .expect("no ifNil:ifNotNil: send found in type_map");
     assert!(
-        diags.is_empty(),
-        "both branches typed String — expression should infer String, not Dynamic; got: {:?}",
-        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        matches!(send_ty, InferredType::Known { class_name, .. } if class_name.as_str() == "String"),
+        "both branches typed String — expression should dedup to Known(\"String\"), got: {send_ty:?}",
     );
 }
 
@@ -15624,18 +15688,11 @@ typed Object subclass: Repro
     let mut checker = TypeChecker::new();
     checker.check_module(&module, &hierarchy);
 
-    // No type mismatch warnings — the diverging ifNil: branch is Never, so the
-    // expression's type comes from the ifNotNil: branch (String), which
-    // satisfies the method's declared -> String.
-    let diags: Vec<_> = checker
-        .diagnostics()
-        .iter()
-        .filter(|d| d.category == Some(DiagnosticCategory::Type))
-        .collect();
+    let send_ty = find_send_inferred_ty(&module, checker.type_map(), "ifNil:ifNotNil:")
+        .expect("no ifNil:ifNotNil: send found in type_map");
     assert!(
-        diags.is_empty(),
-        "diverging ifNil: branch should not widen the expression type; got: {:?}",
-        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        matches!(send_ty, InferredType::Known { class_name, .. } if class_name.as_str() == "String"),
+        "diverging ifNil: branch should project to Never — expression should be Known(\"String\"), got: {send_ty:?}",
     );
 }
 
@@ -15667,15 +15724,15 @@ typed Object subclass: Repro
     let mut checker = TypeChecker::new();
     checker.check_module(&module, &hierarchy);
 
-    // Must NOT surface `Integer | String` return-type mismatch against `-> String`.
-    let type_diags: Vec<_> = checker
-        .diagnostics()
-        .iter()
-        .filter(|d| d.category == Some(DiagnosticCategory::Type))
-        .collect();
+    // The key assertion: the send's inferred type is Known("String"), not
+    // `Integer | String`. Without the `Never` projection, the union would
+    // include Integer and the return type mismatch would surface; with it,
+    // the diverging branch drops out.
+    let send_ty = find_send_inferred_ty(&module, checker.type_map(), "ifNil:ifNotNil:")
+        .expect("no ifNil:ifNotNil: send found in type_map");
     assert!(
-        type_diags.is_empty(),
-        "diverging `ifNil: [^42]` should not widen expression to Integer | String; got: {:?}",
-        type_diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        matches!(send_ty, InferredType::Known { class_name, .. } if class_name.as_str() == "String"),
+        "diverging `ifNil: [^42]` with distinct `ifNotNil:` type should project to \
+         Known(\"String\"), not `Integer | String`; got: {send_ty:?}",
     );
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -15452,3 +15452,230 @@ typed Object subclass: Caller
             .collect::<Vec<_>>()
     );
 }
+
+// ── BT-2047: `ifNil:ifNotNil:` / `ifNotNil:ifNil:` return-type unification ──
+//
+// The whole `receiver ifNil: [a] ifNotNil: [:x | b]` expression should type as
+// `typeof(a) | typeof(b)` (deduplicated) instead of `Dynamic`. BT-2046 already
+// inferred both branches as `Block(..., R)` with narrowed params — this test
+// family locks in that the outer send's return type is the branch union.
+
+/// Assert the module's `type_map` contains a Union whose members' class names
+/// match `expected` (order-insensitive). Returns the matching type on success.
+fn find_union_in_type_map<'a>(
+    type_map: &'a crate::semantic_analysis::type_checker::TypeMap,
+    expected: &[&str],
+) -> Option<&'a InferredType> {
+    type_map.iter().find_map(|(_, ty)| {
+        if let InferredType::Union { members, .. } = ty {
+            let names: std::collections::BTreeSet<String> = members
+                .iter()
+                .filter_map(|m| m.as_known().map(std::string::ToString::to_string))
+                .collect();
+            let want: std::collections::BTreeSet<String> =
+                expected.iter().map(|s| (*s).to_string()).collect();
+            if names == want {
+                return Some(ty);
+            }
+        }
+        None
+    })
+}
+
+/// Minimal repro from the BT-2047 issue: `self.snapshot ifNil: [42] ifNotNil:
+/// [:snap | "got one"]` should type as `Integer | String`, not Dynamic.
+#[test]
+fn bt2047_if_nil_if_not_nil_returns_branch_union() {
+    let source = r#"
+typed Object subclass: ReplaySnapshot
+  workflowId -> String =>
+    [^"wf-1"]
+
+typed Object subclass: Repro
+  field: snapshot :: ReplaySnapshot | Nil = nil
+
+  go =>
+    self.snapshot
+      ifNil: [42]
+      ifNotNil: [:snap | "got one"]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    assert!(
+        find_union_in_type_map(checker.type_map(), &["Integer", "String"]).is_some(),
+        "expected `Integer | String` in type_map; got entries: {:?}",
+        checker
+            .type_map()
+            .iter()
+            .filter_map(|(_, ty)| ty.display_name())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Reversed keyword order: `ifNotNil: [:x | a] ifNil: [b]` yields the same
+/// union (acceptance criterion #2).
+#[test]
+fn bt2047_if_not_nil_if_nil_returns_branch_union() {
+    let source = r#"
+typed Object subclass: ReplaySnapshot
+  workflowId -> String =>
+    [^"wf-1"]
+
+typed Object subclass: Repro
+  field: snapshot :: ReplaySnapshot | Nil = nil
+
+  go =>
+    self.snapshot
+      ifNotNil: [:snap | "got one"]
+      ifNil: [42]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    assert!(
+        find_union_in_type_map(checker.type_map(), &["Integer", "String"]).is_some(),
+        "expected `Integer | String` in type_map; got entries: {:?}",
+        checker
+            .type_map()
+            .iter()
+            .filter_map(|(_, ty)| ty.display_name())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// When both branches produce the same type, `union_of` dedups to that type
+/// (no spurious `String | String`).
+#[test]
+fn bt2047_same_branch_types_deduplicate() {
+    let source = r#"
+typed Object subclass: ReplaySnapshot
+
+typed Object subclass: Repro
+  field: snapshot :: ReplaySnapshot | Nil = nil
+
+  go -> String =>
+    ^self.snapshot
+      ifNil: ["none"]
+      ifNotNil: [:snap | "some"]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    // No type warnings — method declares -> String, and dedup'd branch union
+    // resolves to bare `String`, which satisfies the declared return.
+    let diags: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
+        .collect();
+    assert!(
+        diags.is_empty(),
+        "both branches typed String — expression should infer String, not Dynamic; got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Early-returning branch: `ifNil: [^42] ifNotNil: [:x | "ok"]` should type
+/// as `String` alone (the non-diverging branch), NOT `Integer | String`. The
+/// `^` exits the method before the expression value is observed, so the
+/// diverging branch contributes `Never` to the union (AC #3).
+#[test]
+fn bt2047_diverging_if_nil_branch_contributes_only_other_arm() {
+    let source = r#"
+typed Object subclass: ReplaySnapshot
+
+typed Object subclass: Repro
+  field: snapshot :: ReplaySnapshot | Nil = nil
+
+  go -> String =>
+    ^self.snapshot
+      ifNil: [^"early"]
+      ifNotNil: [:snap | "got one"]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    // No type mismatch warnings — the diverging ifNil: branch is Never, so the
+    // expression's type comes from the ifNotNil: branch (String), which
+    // satisfies the method's declared -> String.
+    let diags: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
+        .collect();
+    assert!(
+        diags.is_empty(),
+        "diverging ifNil: branch should not widen the expression type; got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Key test: the divergent branch has a DIFFERENT type than the surviving
+/// branch. `ifNil: [^42]` (Integer) with `ifNotNil: [:x | "ok"]` (String) —
+/// without the `Never` projection, the expression would type as
+/// `Integer | String` and mismatch the method's declared `-> String`. With
+/// it, only the non-diverging branch contributes.
+#[test]
+fn bt2047_diverging_branch_with_distinct_type_projects_to_never() {
+    let source = r#"
+typed Object subclass: ReplaySnapshot
+
+typed Object subclass: Repro
+  field: snapshot :: ReplaySnapshot | Nil = nil
+
+  go -> String =>
+    ^self.snapshot
+      ifNil: [^42]
+      ifNotNil: [:snap | "got one"]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    // Must NOT surface `Integer | String` return-type mismatch against `-> String`.
+    let type_diags: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
+        .collect();
+    assert!(
+        type_diags.is_empty(),
+        "diverging `ifNil: [^42]` should not widen expression to Integer | String; got: {:?}",
+        type_diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Resolves [BT-2047](https://linear.app/beamtalk/issue/BT-2047). The overall `receiver ifNil: [a] ifNotNil: [:x | b]` expression now types as `typeof(a) | typeof(b)` (deduplicated) instead of `Dynamic`. BT-2046 already inferred both branches as `Block(..., R)` via `infer_args_for_if_not_nil` / `infer_if_not_nil_block`; this change consumes the returned type args at the send site to construct the union.

A branch whose body contains a non-local return (`^`) exits the enclosing method before its value is observed, so that branch contributes `Never` to the union — `union_of` skips `Never`, leaving the surviving branch's type. Applies to both keyword orders (`ifNil:ifNotNil:` and `ifNotNil:ifNil:`).

## Key changes

- `crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs`:
  - Short-circuit the send's return-type computation in `infer_message_send_with_receiver_ty` for `ifNil:ifNotNil:` / `ifNotNil:ifNil:` when both arg types are well-formed `Block(...)`.
  - New helper `if_nil_branch_union_ret_ty` extracts each branch's return type (last type-arg of its `Block`) and unions them; blocks containing `^` contribute `Never`.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs`: 5 new tests covering both keyword orders, dedup when both branches agree, and divergence (with matching and distinct branch types).

## Acceptance criteria

- [x] `ifNil: [a] ifNotNil: [:x | b]` has inferred return type `typeof(a) | typeof(b)` (deduplicated)
- [x] Same for `ifNotNil:ifNil:` (reversed order)
- [x] When one branch returns (`^...`), the expression's type comes from the other branch
- [x] Test added in type-checker test suite with the minimal repro from the issue
- [ ] `@expect type` at `beamtalk-exdura/src/workflow_runner.bt:71` (external repo, not in this worktree)

## Test plan

- [x] `cargo test -p beamtalk-core --lib bt2047` — 5 new tests pass
- [x] `cargo test -p beamtalk-core --lib` — all 3201 lib tests pass, no regressions
- [x] `just test` — Rust (3201) + stdlib (250) + BUnit (1899/1901) + runtime (3485 + 1242) pass
- [x] `just clippy` + `just fmt` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved return-type inference for conditional message sends (`ifNil:ifNotNil:` and `ifNotNil:ifNil:`): the result is the union of branch return types, with branches that perform non-local returns excluded from the union so diverging arms don't widen inferred types.
* **Tests**
  * New tests verifying union inference, deduplication when branches match, and correct handling of diverging (non-local-returning) branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->