### PR TITLE
Fix false-positive "Unused variable" from typed block params (BT-2043)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/tests.rs
@@ -3944,3 +3944,86 @@ fn fixture_sourced_protocol_name_is_not_unresolved() {
         "Fixture-sourced protocol name should not trigger unresolved-class warnings, got: {unresolved:?}"
     );
 }
+
+// ── BT-2043: typed block parameters should not cause false-positive
+//    "Unused variable" warnings for method-local names read on a later line.
+
+#[test]
+fn typed_block_param_in_typed_class_nested_if_false_no_unused_warning() {
+    // BT-2043: In a `typed` class, a local assigned inside a deeply nested
+    // `ifFalse:` block and read on the next line was reported as "Unused"
+    // because the typed block param `:: Dictionary` on the inner block
+    // confused the parser, corrupting the surrounding AST.
+    let source = r#"
+typed Value subclass: UnusedInTyped
+  field: states :: List(String) = #()
+
+  check: issue :: Dictionary -> Boolean =>
+    state := issue at: "state" ifAbsent: [nil]
+    state isNil ifTrue: [^false]
+
+    (state == "todo")
+      ifTrue: [
+        blockers := issue at: "blocked_by" ifAbsent: [#()]
+        blockers isEmpty
+          ifFalse: [
+            hasNonTerminal := blockers
+              anySatisfy: [:b :: Dictionary |
+                bState := b at: "state" ifAbsent: [nil]
+                bState isNil
+              ]
+            hasNonTerminal ifTrue: [^false]
+          ]
+      ]
+
+    true
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, _) = crate::source_analysis::parse(tokens);
+    let result = analyse(&module);
+
+    let unused: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.message.contains("Unused variable"))
+        .collect();
+    assert!(
+        unused.is_empty(),
+        "`hasNonTerminal` is read on the next line; no unused warning expected, got: {unused:?}"
+    );
+}
+
+#[test]
+fn typed_block_param_does_not_affect_unused_variable_pass() {
+    // BT-2043: The Unused-variable pass must behave identically with or
+    // without a `typed` class modifier. Both variants should be warning-free.
+    let typed_src = r"
+typed Value subclass: UnusedInTypedSmall
+  check: xs :: List(Dictionary) -> Boolean =>
+    hasMore := xs anySatisfy: [:b :: Dictionary | b isNil]
+    hasMore ifTrue: [^false]
+    true
+";
+    let untyped_src = r"
+Value subclass: UnusedUntypedSmall
+  check: xs =>
+    hasMore := xs anySatisfy: [:b :: Dictionary | b isNil]
+    hasMore ifTrue: [^false]
+    true
+";
+
+    for source in [typed_src, untyped_src] {
+        let tokens = crate::source_analysis::lex_with_eof(source);
+        let (module, _) = crate::source_analysis::parse(tokens);
+        let result = analyse(&module);
+        let unused: Vec<_> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Unused variable"))
+            .collect();
+        assert!(
+            unused.is_empty(),
+            "Expected no unused warnings for source:\n{source}\ngot: {unused:?}"
+        );
+    }
+}

--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -931,7 +931,7 @@ impl Parser {
     /// - Generic types: `Result(T, E)`, `Array(Integer)`, `Block(T, Result(R, E))`
     /// - Self type: `Self`
     /// - Self class metatype: `Self class`
-    fn parse_single_type_annotation(&mut self) -> TypeAnnotation {
+    pub(super) fn parse_single_type_annotation(&mut self) -> TypeAnnotation {
         if let TokenKind::Identifier(name) = self.current_kind() {
             let span = self.current_token().span();
             if name.as_str() == "Self" {

--- a/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
@@ -1035,12 +1035,31 @@ impl Parser {
 
         let mut parameters = Vec::new();
 
-        // Parse block parameters: [:x :y |
+        // Parse block parameters: [:x :y | ...] or [:x :: Type :y :: Type | ...]
+        //
+        // Optional `:: Type` annotations after each parameter are accepted and
+        // consumed so the parser stays on track. Block parameter types are
+        // currently inferred by the type checker from the message signature
+        // (BT-2036) rather than from these annotations, so the annotation is
+        // parsed and discarded. Supporting it as a workaround for BT-2042 /
+        // BT-2043 avoids cascading parse errors that previously caused false
+        // "Unused variable" warnings because the surrounding method body
+        // failed to parse cleanly.
+        //
+        // Use `parse_single_type_annotation` — not `parse_type_annotation` —
+        // because union `|` would otherwise swallow the block's `|` separator.
+        // Callers that need a union type on a block parameter can wrap the
+        // type in parentheses via a generic, e.g. `Maybe(Integer | String)`.
         while self.match_token(&TokenKind::Colon) {
             if let TokenKind::Identifier(name) = self.current_kind() {
                 let span = self.current_token().span();
                 parameters.push(BlockParameter::new(name.clone(), span));
                 self.advance();
+
+                // Optional `:: Type` annotation — parse and discard.
+                if self.match_token(&TokenKind::DoubleColon) {
+                    let _ = self.parse_single_type_annotation();
+                }
             } else {
                 self.error("Expected parameter name after ':'");
                 break;

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/class_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/class_tests.rs
@@ -139,6 +139,54 @@ fn parse_block_with_params() {
 }
 
 #[test]
+fn parse_block_with_typed_param_simple() {
+    // BT-2043: `[:b :: Dictionary | b isNil]` — the `:: Type` annotation is
+    // consumed (and currently discarded). Prior to the fix the parser left
+    // `::` in place, producing cascading errors that also corrupted the
+    // surrounding method body and caused a spurious "Unused variable"
+    // warning for the assignment receiving the block.
+    let module = parse_ok("[:b :: Dictionary | b isNil]");
+    match &module.expressions[0].expression {
+        Expression::Block(block) => {
+            assert_eq!(block.parameters.len(), 1);
+            assert_eq!(block.parameters[0].name.as_str(), "b");
+            assert_eq!(block.body.len(), 1);
+        }
+        _ => panic!("Expected block"),
+    }
+}
+
+#[test]
+fn parse_block_with_typed_params_multiple() {
+    // BT-2043: multiple typed block parameters.
+    let module = parse_ok("[:x :: Integer :y :: Integer | x + y]");
+    match &module.expressions[0].expression {
+        Expression::Block(block) => {
+            assert_eq!(block.parameters.len(), 2);
+            assert_eq!(block.parameters[0].name.as_str(), "x");
+            assert_eq!(block.parameters[1].name.as_str(), "y");
+            assert_eq!(block.body.len(), 1);
+        }
+        _ => panic!("Expected block"),
+    }
+}
+
+#[test]
+fn parse_block_with_typed_param_generic() {
+    // BT-2043: Generic types such as `List(Integer)` should not confuse the
+    // block parser, since the parens are balanced inside the type annotation.
+    let module = parse_ok("[:xs :: List(Integer) | xs size]");
+    match &module.expressions[0].expression {
+        Expression::Block(block) => {
+            assert_eq!(block.parameters.len(), 1);
+            assert_eq!(block.parameters[0].name.as_str(), "xs");
+            assert_eq!(block.body.len(), 1);
+        }
+        _ => panic!("Expected block"),
+    }
+}
+
+#[test]
 fn parse_return_statement() {
     let module = parse_ok("^42");
     assert_eq!(module.expressions.len(), 1);


### PR DESCRIPTION
## Summary

Fixes [BT-2043](https://linear.app/beamtalk/issue/BT-2043/false-positive-unused-variable-in-typed-class-for-local-read-on-the). The block parser did not consume optional `:: Type` annotations on block parameters (e.g. `[:b :: Dictionary | ...]`). The leftover `::` token triggered cascading parse errors that corrupted the surrounding method body, which in turn caused the Unused-variable lint to miss a later read of a method local and emit a spurious "Unused variable" warning.

The issue originally surfaced in a `typed` class, but the root cause was the block parameter parsing path — the same false positive fires in any class if the inner block has a typed parameter. The issue's own repro uses `[:b :: Dictionary | ...]` as a workaround for BT-2042 (Dynamic block param), which is what made the syntax necessary and exposed the parser bug.

## Key changes

- `parser/expressions.rs` — `parse_block` now consumes an optional `:: Type` after each block parameter.
- `parser/declarations.rs` — exposed `parse_single_type_annotation` to `pub(super)` so block-param annotations can be parsed without the union-type parser swallowing the block's `|` separator. Union types on block parameters are not supported (no unambiguous terminator); wrap in a generic such as `Maybe(Integer | String)` if needed.
- Regression tests at the parser level (`parse_block_with_typed_param_*`) and at the semantic level covering the exact `typed` class nested-`ifFalse:` repro plus a parity check between `typed` and untyped classes.

Block-parameter types remain inferred by the type checker from the message signature (BT-2036); the annotation is parsed and discarded. Exposing it on the AST can be a follow-up if/when the type checker wants to honour it.

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 3201 passed
- [x] `just test` — stdlib + BUnit + runtime all green
- [x] `just clippy`, `just fmt-check` — clean
- [x] Acceptance: `beamtalk lint /tmp/bt-type-repro/src/unused_in_typed.bt` no longer reports "Unused variable `hasNonTerminal`" (only the unrelated BT-2042 Dynamic warning remains, as documented in the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Block parameters now support optional type annotations using the `:: Type` syntax.

* **Bug Fixes**
  * Fixed false positives in the "Unused variable" diagnostic when variables are referenced after typed block parameters.

* **Tests**
  * Added regression test coverage for typed block parameters and unused variable diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->