### PR TITLE
Block param inferred Dynamic in typed class when iterable's element type is Dynamic (BT-2042)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2646,21 +2646,27 @@ impl TypeChecker {
 
         arguments
             .iter()
-            .map(|arg| match arg {
-                Expression::Block(block) if propagate_dynamic => {
-                    let param_types: Vec<InferredType> = (0..block.parameters.len())
-                        .map(|_| InferredType::Dynamic(DynamicReason::DynamicReceiver))
-                        .collect();
-                    self.infer_block_with_typed_params(
-                        block,
-                        arg.span(),
-                        &param_types,
-                        hierarchy,
-                        env,
-                        in_abstract_method,
-                    )
+            .map(|arg| {
+                // Unwrap parens so `foo: ([:x | ...])` gets the same
+                // Dynamic(DynamicReceiver) propagation as the unparenthesised
+                // `foo: [:x | ...]` form.
+                let inner = Self::unwrap_parens(arg);
+                if let Expression::Block(block) = inner {
+                    if propagate_dynamic {
+                        let param_types: Vec<InferredType> = (0..block.parameters.len())
+                            .map(|_| InferredType::Dynamic(DynamicReason::DynamicReceiver))
+                            .collect();
+                        return self.infer_block_with_typed_params(
+                            block,
+                            arg.span(),
+                            &param_types,
+                            hierarchy,
+                            env,
+                            in_abstract_method,
+                        );
+                    }
                 }
-                _ => self.infer_expr(arg, hierarchy, env, in_abstract_method),
+                self.infer_expr(arg, hierarchy, env, in_abstract_method)
             })
             .collect()
     }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2390,6 +2390,17 @@ impl TypeChecker {
     /// For example, `List(String)>>sort:` declares `Block(E, E, Boolean)`.
     /// With E=String (from receiver type args), block params get typed as String
     /// instead of `Dynamic(UnannotatedParam)`.
+    ///
+    /// **BT-2042:** When the receiver is Dynamic (or the method can't be resolved),
+    /// block arguments still need their parameters typed — otherwise each unannotated
+    /// block param defaults to `Dynamic(UnannotatedParam)`, which fires the
+    /// "expression inferred as Dynamic in typed class" warning at every use of the
+    /// block param. In a `typed` class this forces users to annotate every block
+    /// parameter whose upstream iterable happens to be Dynamic, even though the
+    /// root cause is the Dynamic receiver, not the block itself. We propagate
+    /// `Dynamic(DynamicReceiver)` into block params in the fallback paths so
+    /// downstream uses propagate that reason (which is filtered from the warning),
+    /// matching how the send result itself is already classified.
     fn infer_args_with_block_context(
         &mut self,
         arguments: &[Expression],
@@ -2399,25 +2410,37 @@ impl TypeChecker {
         env: &mut TypeEnv,
         in_abstract_method: bool,
     ) -> Vec<InferredType> {
-        // Fast path: receiver must be Known to look up method signatures
+        // Fast path: receiver must be Known to look up method signatures.
+        // For non-Known receivers (Dynamic, Never, etc.), we can't resolve block
+        // param types from the signature — but we can still propagate a reason-
+        // preserving type into the block params so their uses don't re-fire the
+        // "Dynamic in typed class" warning (BT-2042).
         let InferredType::Known {
             class_name,
             type_args,
             ..
         } = receiver_ty
         else {
-            return arguments
-                .iter()
-                .map(|arg| self.infer_expr(arg, hierarchy, env, in_abstract_method))
-                .collect();
+            return self.infer_args_with_dynamic_block_params(
+                arguments,
+                receiver_ty,
+                hierarchy,
+                env,
+                in_abstract_method,
+            );
         };
 
-        // Look up the method to get param types
+        // Look up the method to get param types. If the selector isn't defined on
+        // the receiver's class, block params likewise have no resolvable type;
+        // use the Dynamic-block-param fallback so usages don't double-warn.
         let Some(method) = hierarchy.find_method(class_name, selector_name) else {
-            return arguments
-                .iter()
-                .map(|arg| self.infer_expr(arg, hierarchy, env, in_abstract_method))
-                .collect();
+            return self.infer_args_with_dynamic_block_params(
+                arguments,
+                receiver_ty,
+                hierarchy,
+                env,
+                in_abstract_method,
+            );
         };
 
         // Check if any param type is a Block(...) type
@@ -2514,6 +2537,56 @@ impl TypeChecker {
         }
 
         arg_types
+    }
+
+    /// Fallback variant of [`Self::infer_args_with_block_context`] used when the
+    /// receiver type isn't `Known` (Dynamic/Never/Union/…) or when the selector
+    /// can't be resolved on the receiver.
+    ///
+    /// Walks each argument via `infer_expr`, **except** for block literals: those
+    /// are walked with their parameters pre-bound to `Dynamic(DynamicReceiver)`
+    /// so that usages inside the block body inherit a "propagated Dynamic" reason
+    /// (which is filtered out of the BT-1914 "Dynamic in typed class" warning).
+    /// Without this step, each block param would default to
+    /// `Dynamic(UnannotatedParam)`, re-firing the warning at every use of the
+    /// block param inside a `typed` class — see BT-2042.
+    ///
+    /// The chosen reason follows the send's result classification at line
+    /// `infer_message_send_with_receiver_ty` fallback (see `Dynamic(DynamicReceiver)`
+    /// returns): the send's result is already classified that way for the same
+    /// root cause, so block params inherit the same provenance for consistency.
+    fn infer_args_with_dynamic_block_params(
+        &mut self,
+        arguments: &[Expression],
+        receiver_ty: &InferredType,
+        hierarchy: &ClassHierarchy,
+        env: &mut TypeEnv,
+        in_abstract_method: bool,
+    ) -> Vec<InferredType> {
+        // Only propagate DynamicReceiver when the receiver actually is Dynamic.
+        // For Never / Union / other shapes, fall back to the plain walk so we
+        // don't mask unrelated root causes.
+        let propagate_dynamic = matches!(receiver_ty, InferredType::Dynamic(_));
+
+        arguments
+            .iter()
+            .map(|arg| match arg {
+                Expression::Block(block) if propagate_dynamic => {
+                    let param_types: Vec<InferredType> = (0..block.parameters.len())
+                        .map(|_| InferredType::Dynamic(DynamicReason::DynamicReceiver))
+                        .collect();
+                    self.infer_block_with_typed_params(
+                        block,
+                        arg.span(),
+                        &param_types,
+                        hierarchy,
+                        env,
+                        in_abstract_method,
+                    )
+                }
+                _ => self.infer_expr(arg, hierarchy, env, in_abstract_method),
+            })
+            .collect()
     }
 
     /// Infer a block expression with typed parameters resolved from the callee

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -15452,3 +15452,141 @@ typed Object subclass: Caller
             .collect::<Vec<_>>()
     );
 }
+
+// =========================================================================
+// BT-2042: Block param inferred Dynamic in `typed` class when iterable's
+// element type is Dynamic.
+//
+// When a block argument is passed to a method on a Dynamic receiver (e.g.,
+// `Dictionary at:ifAbsent:` returns Dynamic, and we call `anySatisfy:` on
+// it), the block's parameters previously defaulted to
+// `Dynamic(UnannotatedParam)`. In a `typed` class, every use of the block
+// param then re-fired the "expression inferred as Dynamic in typed class"
+// warning — forcing users to annotate iterators whose upstream iterable was
+// Dynamic, even though the root cause lives at the receiver, not the block.
+//
+// The fix propagates `Dynamic(DynamicReceiver)` into block params in the
+// fallback path (non-Known receiver / unresolved selector), matching how the
+// send's result itself is classified. `DynamicReceiver` is filtered from the
+// BT-1914 warning, so usages of the block param no longer double-warn.
+// =========================================================================
+
+/// Repro from the issue: iterating the result of `Dictionary at:ifAbsent:`
+/// (Dynamic) inside a `typed` class. The block param `b` is unannotated and
+/// its usage `b at: "state" ifAbsent: [nil]` previously emitted a spurious
+/// "Dynamic in typed class (unannotated parameter)" warning.
+#[test]
+fn bt2042_dynamic_iterable_does_not_warn_on_block_param_usage() {
+    let source = r#"
+typed Value subclass: Filter
+  hasMissingState: issue :: Dictionary -> Boolean =>
+    blockers := issue at: "blocked_by" ifAbsent: [#()]
+    blockers anySatisfy: [:b |
+      bState := b at: "state" ifAbsent: [nil]
+      bState isNil
+    ]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dynamic_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("expression inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "block param use should not fire the Dynamic-in-typed-class warning when \
+         the receiver is itself Dynamic (the root cause is the iterable, not the \
+         block); got: {:?}",
+        dynamic_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Workaround: annotating the local that feeds the iterator
+/// (`blockers :: List(Dictionary) := ...`) still lints clean.
+#[test]
+fn bt2042_workaround_annotated_local_still_works() {
+    let source = r#"
+typed Value subclass: Filter
+  hasMissingState: issue :: Dictionary -> Boolean =>
+    blockers :: List(Dictionary) := issue at: "blocked_by" ifAbsent: [#()]
+    blockers anySatisfy: [:b |
+      bState := b at: "state" ifAbsent: [nil]
+      bState isNil
+    ]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dynamic_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("expression inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "annotated local should lint clean (block params resolve via List(Dictionary)); got: {:?}",
+        dynamic_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Regression guard: when the receiver's element type *is* known (e.g.,
+/// iterating a typed `List(Dictionary)` field), the existing block-param
+/// inference path continues to resolve `b` to `Dictionary` — no regression.
+#[test]
+fn bt2042_known_receiver_still_resolves_block_param_type() {
+    let source = r#"
+typed Value subclass: Filter
+  field: items :: List(Dictionary) = #()
+
+  hasMissingState -> Boolean =>
+    self.items anySatisfy: [:b |
+      bState := b at: "state" ifAbsent: [nil]
+      bState isNil
+    ]
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let hierarchy = crate::semantic_analysis::ClassHierarchy::build(&module)
+        .0
+        .unwrap();
+
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let dynamic_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("expression inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "Known List(Dictionary) receiver should resolve block param to Dictionary; got: {:?}",
+        dynamic_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the BT-2042 false-positive where iterating a Dynamic value inside a `typed` class forced users to annotate every block parameter.

When `blockers anySatisfy: [:b | ...]` ran against a Dynamic `blockers` (e.g., the result of `Dictionary at:ifAbsent:`), the block param `b` defaulted to `Dynamic(UnannotatedParam)`, and every use of `b` inside the body re-fired the "expression inferred as Dynamic in typed class" warning — pointing the user at a usage deep in the block body rather than the actual root cause (the Dynamic iterable).

The fix propagates `Dynamic(DynamicReceiver)` into block params in the fallback paths of `infer_args_with_block_context` when the receiver itself is Dynamic. `DynamicReceiver` is already filtered from the BT-1914 warning (matching how the send's own result is classified), so block-param usages no longer double-warn. Non-Dynamic fallback shapes (Union, Never, etc.) keep their existing behavior.

- Linear issue: https://linear.app/beamtalk/issue/BT-2042

## Changes

- `crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs`: added `infer_args_with_dynamic_block_params` helper and routed both early-bail paths (non-Known receiver, unresolved selector) through it.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs`: added three regression tests (repro from the issue, known-receiver regression guard, and annotated-local workaround).

## Test plan

- [x] `just clippy` clean
- [x] `just test` — all 3199 Rust lib tests pass (3 new), stdlib 250/250, BUnit 1899/1899, runtime 4727/4727
- [x] Manual repro from the issue (`/tmp/bt-2042-repro/filter.bt`) now lints clean
- [x] Workaround forms (annotated local, `@expect type`) still lint clean
- [x] Known-receiver path (`List(Dictionary)` field) still resolves block param correctly

Acceptance criteria:
- [x] Repro does not emit the Dynamic warning
- [x] Regression test in type-system suite covering `typed class + iterate over Dictionary at:ifAbsent: result`
- [x] Existing workarounds (`@expect type`, local type annotation) continue to work

Note: the issue lists block-parameter annotation `[:b :: Dictionary | ...]` as a workaround, but the current parser does not accept that syntax; only the `@expect type` and local-annotation workarounds are real today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block-parameter type inference when calls involve dynamic receivers, eliminating spurious "expression inferred as Dynamic" diagnostics in typed classes.
* **Tests**
  * Added tests validating block-parameter typing for sends with dynamic and known collection receivers to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->