### PR TITLE
MCP lint: surface unreadable package files during cross-file class extraction (BT-2056)

### DIFF
--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -1834,9 +1834,18 @@ fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
     // Pass 1: Parse all files and extract class metadata.
     let mut all_class_infos = Vec::new();
     let mut parsed_files = Vec::new();
+    let mut unreadable_files: Vec<String> = Vec::new();
 
     for file in &extraction_files {
         let Ok(source) = std::fs::read_to_string(file) else {
+            // BT-2056: Track package-extraction files that couldn't be read so
+            // the caller knows cross-file class extraction may be incomplete.
+            // Only warn for files the resolver chose (not direct targets, which
+            // are already counted by `resolve_source_files`).
+            let canonical = std::fs::canonicalize(file).unwrap_or_else(|_| file.clone());
+            if !target_set.contains(&canonical) {
+                unreadable_files.push(file.to_string_lossy().into_owned());
+            }
             continue;
         };
         let file_str = file.to_string_lossy().into_owned();
@@ -1924,7 +1933,9 @@ fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
         0.0
     };
 
-    serde_json::json!({
+    // BT-2056: Include unreadable package files in the output so the caller
+    // knows cross-file class extraction may be incomplete.
+    let mut result = serde_json::json!({
         "files_checked": files_checked,
         "totals_by_severity": {
             "error": totals.error,
@@ -1939,7 +1950,11 @@ fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
             "total": coverage.total_expressions,
             "dynamic_percent": dynamic_pct,
         },
-    })
+    });
+    if !unreadable_files.is_empty() {
+        result["unreadable_package_files"] = serde_json::json!(unreadable_files);
+    }
+    result
 }
 
 /// Resolve `path` to a list of `.bt` source files, or return a `LintResult`
@@ -2136,6 +2151,21 @@ fn run_lint_structured(path: &str) -> LintResult {
                     line: None,
                     message: format!("Failed to read '{}'", file.display()),
                     severity: "error",
+                });
+            } else {
+                // BT-2056: Surface a warning when a package-extraction file
+                // (chosen by the resolver but not a direct lint target) cannot
+                // be read. Without this, cross-file class extraction silently
+                // drops the file, potentially re-introducing diagnostic
+                // divergence from CLI lint.
+                warnings.push(LintDiagnostic {
+                    file: file.to_string_lossy().into_owned(),
+                    line: None,
+                    message: format!(
+                        "Failed to read package file '{}'; cross-file class extraction may be incomplete",
+                        file.display()
+                    ),
+                    severity: "warning",
                 });
             }
             continue;
@@ -2441,6 +2471,119 @@ mod tests {
             !stale,
             "MCP lint with cross-file classes should not report @expect as stale, got: {result:?}",
         );
+    }
+
+    /// BT-2056: When a package-extraction file in src/ cannot be read, MCP lint
+    /// must surface a warning rather than silently dropping it from the
+    /// extraction set.
+    #[test]
+    fn run_lint_structured_unreadable_package_file_warns() {
+        let dir = std::env::temp_dir().join(format!(
+            "beamtalk-mcp-lint-unreadable-{}",
+            std::process::id()
+        ));
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        // Create a beamtalk.toml so find_package_root works.
+        std::fs::write(
+            dir.join("beamtalk.toml"),
+            "[package]\nname = \"unreadable-test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        // Create a readable target file.
+        let target = src_dir.join("main.bt");
+        std::fs::write(&target, "Object subclass: Main\n  class hello => 42\n").unwrap();
+
+        // Create a sibling file, then make it unreadable.
+        let sibling = src_dir.join("helper.bt");
+        std::fs::write(&sibling, "Object subclass: Helper\n  class help => 1\n").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o000);
+            std::fs::set_permissions(&sibling, perms).unwrap();
+        }
+
+        let result = run_lint_structured(target.to_str().unwrap());
+
+        // Restore permissions before cleanup so remove_dir_all succeeds.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o644);
+            let _ = std::fs::set_permissions(&sibling, perms);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+
+        #[cfg(unix)]
+        {
+            let has_unreadable_warning = result.warnings.iter().any(|d| {
+                d.message
+                    .contains("cross-file class extraction may be incomplete")
+            });
+            assert!(
+                has_unreadable_warning,
+                "MCP lint should warn about unreadable package files, got: {result:?}",
+            );
+        }
+    }
+
+    /// BT-2056: `compute_diagnostic_summary` should include unreadable package
+    /// files in its output when a sibling file cannot be read.
+    #[test]
+    fn compute_diagnostic_summary_unreadable_package_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "beamtalk-mcp-summary-unreadable-{}",
+            std::process::id()
+        ));
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        std::fs::write(
+            dir.join("beamtalk.toml"),
+            "[package]\nname = \"unreadable-test\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        let target = src_dir.join("main.bt");
+        std::fs::write(&target, "Object subclass: Main\n  class hello => 42\n").unwrap();
+
+        let sibling = src_dir.join("helper.bt");
+        std::fs::write(&sibling, "Object subclass: Helper\n  class help => 1\n").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o000);
+            std::fs::set_permissions(&sibling, perms).unwrap();
+        }
+
+        let result = compute_diagnostic_summary(target.to_str().unwrap());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o644);
+            let _ = std::fs::set_permissions(&sibling, perms);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+
+        #[cfg(unix)]
+        {
+            assert!(
+                result.get("unreadable_package_files").is_some(),
+                "diagnostic summary should include unreadable_package_files, got: {result}",
+            );
+            let unreadable = result["unreadable_package_files"].as_array().unwrap();
+            assert_eq!(unreadable.len(), 1);
+            assert!(
+                unreadable[0].as_str().unwrap().contains("helper.bt"),
+                "unreadable file should be helper.bt, got: {unreadable:?}",
+            );
+        }
     }
 
     /// BT-2052: Verify `find_package_root` walks ancestors to find `beamtalk.toml`.

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -2476,8 +2476,11 @@ mod tests {
     /// BT-2056: When a package-extraction file in src/ cannot be read, MCP lint
     /// must surface a warning rather than silently dropping it from the
     /// extraction set.
+    #[cfg(unix)]
     #[test]
     fn run_lint_structured_unreadable_package_file_warns() {
+        use std::os::unix::fs::PermissionsExt;
+
         let dir = std::env::temp_dir().join(format!(
             "beamtalk-mcp-lint-unreadable-{}",
             std::process::id()
@@ -2499,42 +2502,31 @@ mod tests {
         // Create a sibling file, then make it unreadable.
         let sibling = src_dir.join("helper.bt");
         std::fs::write(&sibling, "Object subclass: Helper\n  class help => 1\n").unwrap();
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o000);
-            std::fs::set_permissions(&sibling, perms).unwrap();
-        }
+        std::fs::set_permissions(&sibling, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         let result = run_lint_structured(target.to_str().unwrap());
 
         // Restore permissions before cleanup so remove_dir_all succeeds.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o644);
-            let _ = std::fs::set_permissions(&sibling, perms);
-        }
+        let _ = std::fs::set_permissions(&sibling, std::fs::Permissions::from_mode(0o644));
         let _ = std::fs::remove_dir_all(&dir);
 
-        #[cfg(unix)]
-        {
-            let has_unreadable_warning = result.warnings.iter().any(|d| {
-                d.message
-                    .contains("cross-file class extraction may be incomplete")
-            });
-            assert!(
-                has_unreadable_warning,
-                "MCP lint should warn about unreadable package files, got: {result:?}",
-            );
-        }
+        let has_unreadable_warning = result.warnings.iter().any(|d| {
+            d.message
+                .contains("cross-file class extraction may be incomplete")
+        });
+        assert!(
+            has_unreadable_warning,
+            "MCP lint should warn about unreadable package files, got: {result:?}",
+        );
     }
 
     /// BT-2056: `compute_diagnostic_summary` should include unreadable package
     /// files in its output when a sibling file cannot be read.
+    #[cfg(unix)]
     #[test]
     fn compute_diagnostic_summary_unreadable_package_file() {
+        use std::os::unix::fs::PermissionsExt;
+
         let dir = std::env::temp_dir().join(format!(
             "beamtalk-mcp-summary-unreadable-{}",
             std::process::id()
@@ -2553,37 +2545,23 @@ mod tests {
 
         let sibling = src_dir.join("helper.bt");
         std::fs::write(&sibling, "Object subclass: Helper\n  class help => 1\n").unwrap();
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o000);
-            std::fs::set_permissions(&sibling, perms).unwrap();
-        }
+        std::fs::set_permissions(&sibling, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         let result = compute_diagnostic_summary(target.to_str().unwrap());
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o644);
-            let _ = std::fs::set_permissions(&sibling, perms);
-        }
+        let _ = std::fs::set_permissions(&sibling, std::fs::Permissions::from_mode(0o644));
         let _ = std::fs::remove_dir_all(&dir);
 
-        #[cfg(unix)]
-        {
-            assert!(
-                result.get("unreadable_package_files").is_some(),
-                "diagnostic summary should include unreadable_package_files, got: {result}",
-            );
-            let unreadable = result["unreadable_package_files"].as_array().unwrap();
-            assert_eq!(unreadable.len(), 1);
-            assert!(
-                unreadable[0].as_str().unwrap().contains("helper.bt"),
-                "unreadable file should be helper.bt, got: {unreadable:?}",
-            );
-        }
+        assert!(
+            result.get("unreadable_package_files").is_some(),
+            "diagnostic summary should include unreadable_package_files, got: {result}",
+        );
+        let unreadable = result["unreadable_package_files"].as_array().unwrap();
+        assert_eq!(unreadable.len(), 1);
+        assert!(
+            unreadable[0].as_str().unwrap().contains("helper.bt"),
+            "unreadable file should be helper.bt, got: {unreadable:?}",
+        );
     }
 
     /// BT-2052: Verify `find_package_root` walks ancestors to find `beamtalk.toml`.


### PR DESCRIPTION
## Summary

- When a package-extraction file (chosen by the resolver for cross-file class resolution) cannot be read, `run_lint_structured` now emits a warning diagnostic and `compute_diagnostic_summary` includes the file paths in an `unreadable_package_files` JSON field
- The warning is distinguishable from "file not in package" -- only files the resolver chose to include but couldn't read trigger it
- Two unit tests covering a package layout with one unreadable sibling file in `src/`

Fixes: https://linear.app/beamtalk/issue/BT-2056

## Test plan

- [x] `cargo test -p beamtalk-mcp` -- all 85 tests pass
- [x] `just clippy` -- clean
- [x] `just fmt-check` -- clean
- [x] New test: `run_lint_structured_unreadable_package_file_warns` verifies warning diagnostic
- [x] New test: `compute_diagnostic_summary_unreadable_package_file` verifies JSON output field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unreadable package-extraction files now generate warning diagnostics (instead of being silently skipped) when they affect cross-file extraction, improving visibility.
  * Diagnostic output now includes an unreadable package files field to surface extraction issues in summaries.

* **Tests**
  * Added tests verifying the warning behavior and diagnostic summary inclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->