### PR TITLE
Diagnostics render Nil where source uses Nil, not UndefinedObject (BT-2066)

### DIFF
--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -1183,8 +1183,9 @@ impl LanguageService for SimpleLanguageService {
                     method.selector.name(),
                     is_class_method,
                 );
-                // BT-2022: inferred map now stores InferredType; use display_name
-                // to get e.g. "List(String)" for the annotation.
+                // BT-2022: inferred map stores InferredType; use
+                // `display_for_diagnostic()` so user-facing annotations render
+                // source-friendly names (e.g., `Nil` instead of `UndefinedObject`).
                 if let Some(inferred_ty) = inferred.get(&key) {
                     let display = inferred_ty
                         .display_for_diagnostic()

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -1187,7 +1187,7 @@ impl LanguageService for SimpleLanguageService {
                 // to get e.g. "List(String)" for the annotation.
                 if let Some(inferred_ty) = inferred.get(&key) {
                     let display = inferred_ty
-                        .display_name()
+                        .display_for_diagnostic()
                         .unwrap_or_else(|| ecow::EcoString::from("Dynamic"));
                     if let Some(offset) = find_body_open_offset(source, method.span) {
                         actions.push(CodeAction::new(
@@ -1220,7 +1220,7 @@ impl LanguageService for SimpleLanguageService {
             );
             if let Some(inferred_ty) = inferred.get(&key) {
                 let display = inferred_ty
-                    .display_name()
+                    .display_for_diagnostic()
                     .unwrap_or_else(|| ecow::EcoString::from("Dynamic"));
                 if let Some(offset) = find_body_open_offset(source, method.span) {
                     actions.push(CodeAction::new(

--- a/crates/beamtalk-core/src/queries/hover_provider.rs
+++ b/crates/beamtalk-core/src/queries/hover_provider.rs
@@ -564,7 +564,7 @@ fn find_hover_in_pattern(pattern: &Pattern, offset: u32, type_map: &TypeMap) -> 
             if offset >= ident.span.start() && offset < ident.span.end() {
                 let type_info = type_map
                     .get(ident.span)
-                    .and_then(InferredType::display_name);
+                    .and_then(InferredType::display_for_diagnostic);
                 let contents = if let Some(ty) = type_info {
                     format!("Pattern variable: `{}` — Type: {ty}", ident.name)
                 } else {
@@ -640,7 +640,7 @@ fn find_hover_in_expr(
                 // Show inferred type if available
                 let type_info = type_map
                     .get(ident.span)
-                    .and_then(InferredType::display_name);
+                    .and_then(InferredType::display_for_diagnostic);
                 let contents = if let Some(ty) = type_info {
                     format!("Identifier: `{}` — Type: {ty}", ident.name)
                 } else {

--- a/crates/beamtalk-core/src/queries/signature_help_provider.rs
+++ b/crates/beamtalk-core/src/queries/signature_help_provider.rs
@@ -384,7 +384,7 @@ fn resolve_ffi_signature_help(
         let param_name = param.keyword.as_deref().unwrap_or("arg");
         let type_display = param
             .type_
-            .display_name()
+            .display_for_diagnostic()
             .unwrap_or_else(|| EcoString::from("Dynamic"));
         let param_label = format!("{keyword} {param_name} :: {type_display}");
         label_fragments.push(param_label.clone());
@@ -396,7 +396,7 @@ fn resolve_ffi_signature_help(
 
     let ret_display = sig
         .return_type
-        .display_name()
+        .display_for_diagnostic()
         .unwrap_or_else(|| EcoString::from("Dynamic"));
     let label = format!("{} -> {ret_display}", label_fragments.join(" "));
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -439,16 +439,23 @@ impl TypeChecker {
                                     hierarchy,
                                 );
                                 if !rhs_assignable_to_declared && !declared_assignable_to_rhs {
+                                    // BT-2066: Use source-sympathetic spelling (`Nil`) for user-facing messages.
+                                    let inferred_display = inferred_ty
+                                        .display_for_diagnostic()
+                                        .unwrap_or_else(|| inferred_name.clone());
+                                    let declared_display = declared
+                                        .display_for_diagnostic()
+                                        .unwrap_or_else(|| declared_name.clone());
                                     self.diagnostics.push(
                                         Diagnostic::warning(
                                             format!(
-                                                "Type mismatch: declared as {declared_name}, got {inferred_name}"
+                                                "Type mismatch: declared as {declared_display}, got {inferred_display}"
                                             ),
                                             *span,
                                         )
                                         .with_category(DiagnosticCategory::Type)
                                         .with_hint(format!(
-                                            "The right-hand side has type {inferred_name} which is not assignable to {declared_name}"
+                                            "The right-hand side has type {inferred_display} which is not assignable to {declared_display}"
                                         )),
                                     );
                                 }
@@ -1355,9 +1362,12 @@ impl TypeChecker {
                 let param_pos = i + 1;
                 let fallback_label = format!("parameter {param_pos}");
                 let param_label = param.keyword.as_deref().unwrap_or(&fallback_label);
+                // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+                let expected_display = InferredType::class_name_for_diagnostic(expected.as_str());
+                let actual_display = InferredType::class_name_for_diagnostic(actual.as_str());
                 self.diagnostics.push(Diagnostic::warning(
                     format!(
-                        "{module_name}:{function_name}/{arity} {param_label} expects {expected}, got {actual}",
+                        "{module_name}:{function_name}/{arity} {param_label} expects {expected_display}, got {actual_display}",
                         arity = sig.arity,
                     ),
                     span,
@@ -1726,12 +1736,17 @@ impl TypeChecker {
         // BT-1857: Suppress DNU warnings when Dynamic is in the union —
         // Dynamic accepts any message, so we can't know the full method set.
         if !missing_names.is_empty() && !has_dynamic {
+            // BT-2066: Render `UndefinedObject` as `Nil` for user-facing messages.
             let member_names: Vec<String> = members
                 .iter()
-                .filter_map(|m| m.display_name().map(|n| n.to_string()))
+                .filter_map(|m| m.display_for_diagnostic().map(|n| n.to_string()))
                 .collect();
             let union_display = member_names.join(" | ");
-            let missing_display: Vec<&str> = missing_names.iter().map(EcoString::as_str).collect();
+            // BT-2066: Also map missing-member names through the diagnostic rewriter.
+            let missing_display: Vec<EcoString> = missing_names
+                .iter()
+                .map(|n| InferredType::class_name_for_diagnostic(n.as_str()))
+                .collect();
 
             let message = if missing_names.len() == 1 {
                 format!(

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/native_type_registry.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/native_type_registry.rs
@@ -71,7 +71,7 @@ impl FunctionSignature {
         if self.params.is_empty() {
             let ret_display = self
                 .return_type
-                .display_name()
+                .display_for_diagnostic()
                 .unwrap_or_else(|| EcoString::from("Dynamic"));
             return format!("{} -> {ret_display}", self.name);
         }
@@ -89,14 +89,14 @@ impl FunctionSignature {
             let param_name = param.keyword.as_deref().unwrap_or("arg");
             let type_display = param
                 .type_
-                .display_name()
+                .display_for_diagnostic()
                 .unwrap_or_else(|| EcoString::from("Dynamic"));
             parts.push(format!("{keyword} {param_name} :: {type_display}"));
         }
 
         let ret_display = self
             .return_type
-            .display_name()
+            .display_for_diagnostic()
             .unwrap_or_else(|| EcoString::from("Dynamic"));
         format!("{} -> {ret_display}", parts.join(" "))
     }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
@@ -416,17 +416,20 @@ impl TypeChecker {
             hierarchy,
             protocol_registry,
         ) {
+            // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+            let declared_display = InferredType::class_name_for_diagnostic(declared_type.as_str());
+            let value_display = InferredType::class_name_for_diagnostic(value_type.as_str());
             self.diagnostics.push(
                 Diagnostic::warning(
                     format!(
-                        "Type mismatch: state `{}` declared as {declared_type}, default is {value_type}",
+                        "Type mismatch: state `{}` declared as {declared_display}, default is {value_display}",
                         state_decl.name.name
                     ),
                     state_decl.span,
                 )
                 .with_category(DiagnosticCategory::Type)
                 .with_hint(format!(
-                    "Default value type {value_type} is not compatible with {declared_type}"
+                    "Default value type {value_display} is not compatible with {declared_display}"
                 )),
             );
         }
@@ -503,16 +506,25 @@ impl TypeChecker {
                                                         protocol_registry,
                                                     ) {
                                                         let param_pos = i + 1;
+                                                        // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+                                                        let expected_display =
+                                                            InferredType::class_name_for_diagnostic(
+                                                                expected_ty.as_str(),
+                                                            );
+                                                        let arg_display =
+                                                            InferredType::class_name_for_diagnostic(
+                                                                arg_str.as_str(),
+                                                            );
                                                         self.diagnostics.push(
                                                             Diagnostic::warning(
                                                                 format!(
-                                                                    "Argument {param_pos} of '{sel_name}' on {class_name} expects {expected_ty}, got {arg_str}"
+                                                                    "Argument {param_pos} of '{sel_name}' on {class_name} expects {expected_display}, got {arg_display}"
                                                                 ),
                                                                 *span,
                                                             )
                                                             .with_category(DiagnosticCategory::Type)
                                                             .with_hint(format!(
-                                                                "Type arguments are not compatible: expected {expected_ty}, got {arg_str}"
+                                                                "Type arguments are not compatible: expected {expected_display}, got {arg_display}"
                                                             )),
                                                         );
                                                     }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -15682,6 +15682,15 @@ typed Object subclass: Caller
             .map(|d| &d.message)
             .collect::<Vec<_>>()
     );
+    // BT-2066: canonical `UndefinedObject` must NOT leak into user-facing
+    // diagnostic messages.
+    for d in &mismatch_warnings {
+        assert!(
+            !d.message.contains("UndefinedObject"),
+            "user-facing diagnostic leaked canonical `UndefinedObject`: {}",
+            d.message
+        );
+    }
 }
 
 // ── BT-2047: `ifNil:ifNotNil:` / `ifNotNil:ifNil:` return-type unification ──

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests.rs
@@ -15309,16 +15309,21 @@ typed Object subclass: Caller
     );
     // The negative case must produce the specific argument-mismatch
     // diagnostic at the `process:` call site: `ms` should still be
-    // `Integer | UndefinedObject` because the `ifTrue: [42]` block does not
+    // `Integer | Nil` because the `ifTrue: [42]` block does not
     // diverge. A bare "any Type warning" check could hide regressions where
     // narrowing silently happens but some other Type warning appears.
+    //
+    // BT-2066: user-facing messages render the source-sympathetic `Nil`
+    // spelling, not the canonical `UndefinedObject` hierarchy name. The
+    // assertion below is deliberately strict — if the renderer regresses
+    // and leaks `UndefinedObject` back into diagnostics, this test fails.
     let mismatch_warnings: Vec<_> = result
         .diagnostics
         .iter()
         .filter(|d| {
             d.category == Some(DiagnosticCategory::Type)
                 && d.message.contains("'process:'")
-                && d.message.contains("UndefinedObject")
+                && d.message.contains("Nil")
         })
         .collect();
     assert!(
@@ -15331,6 +15336,15 @@ typed Object subclass: Caller
             .map(|d| &d.message)
             .collect::<Vec<_>>()
     );
+    // BT-2066: the canonical `UndefinedObject` name must NOT leak into the
+    // user-facing message. Guard against regressions explicitly.
+    for d in &mismatch_warnings {
+        assert!(
+            !d.message.contains("UndefinedObject"),
+            "user-facing diagnostic leaked canonical `UndefinedObject`: {}",
+            d.message
+        );
+    }
 }
 
 /// BT-2049: Bare identifier `eventStore` (sugar for `self.eventStore`) should
@@ -15433,13 +15447,16 @@ typed Object subclass: Caller
     );
     // Because the ifFalse: block reassigns `ms` to nil, we must still warn
     // on the `process:` call — otherwise we'd be unsound.
+    //
+    // BT-2066: user-facing messages render the source-sympathetic `Nil`
+    // spelling, not the canonical `UndefinedObject` hierarchy name.
     let mismatch_warnings: Vec<_> = result
         .diagnostics
         .iter()
         .filter(|d| {
             d.category == Some(DiagnosticCategory::Type)
                 && d.message.contains("'process:'")
-                && d.message.contains("UndefinedObject")
+                && d.message.contains("Nil")
         })
         .collect();
     assert!(
@@ -15451,6 +15468,15 @@ typed Object subclass: Caller
             .map(|d| &d.message)
             .collect::<Vec<_>>()
     );
+    // BT-2066: the canonical `UndefinedObject` name must NOT leak into the
+    // user-facing message.
+    for d in &mismatch_warnings {
+        assert!(
+            !d.message.contains("UndefinedObject"),
+            "user-facing diagnostic leaked canonical `UndefinedObject`: {}",
+            d.message
+        );
+    }
 }
 
 // ── BT-2051: Deep-descendant `Never` detection in `block_diverges` ──
@@ -15634,13 +15660,16 @@ typed Object subclass: Caller
     // but the outer branch doesn't execute it — control falls through to
     // `Receiver process: ms` with `ms` still `Integer | Nil`, so the
     // argument-mismatch diagnostic must still fire.
+    //
+    // BT-2066: user-facing messages render the source-sympathetic `Nil`
+    // spelling, not the canonical `UndefinedObject` hierarchy name.
     let mismatch_warnings: Vec<_> = result
         .diagnostics
         .iter()
         .filter(|d| {
             d.category == Some(DiagnosticCategory::Type)
                 && d.message.contains("'process:'")
-                && d.message.contains("UndefinedObject")
+                && d.message.contains("Nil")
         })
         .collect();
     assert!(

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
@@ -72,6 +72,27 @@ pub enum TypeProvenance {
     Extracted,
 }
 
+/// Controls how [`InferredType`] renders class names when converted to a
+/// display string.
+///
+/// See [`InferredType::display_name`] and
+/// [`InferredType::display_for_diagnostic`].
+#[derive(Debug, Clone, Copy)]
+struct DisplayOptions {
+    /// When `true`, `Known("UndefinedObject")` renders as `"Nil"`. When
+    /// `false`, the canonical `UndefinedObject` name is used.
+    nil_as_source_name: bool,
+}
+
+impl DisplayOptions {
+    const CANONICAL: Self = Self {
+        nil_as_source_name: false,
+    };
+    const SOURCE_FRIENDLY: Self = Self {
+        nil_as_source_name: true,
+    };
+}
+
 /// Inferred type for an expression or variable.
 ///
 /// **Equality semantics:** Two types are equal if they represent the same type,
@@ -187,36 +208,85 @@ impl InferredType {
         }
     }
 
-    /// Returns a human-readable display name for this type.
+    /// Returns a human-readable display name for this type, using canonical
+    /// class-hierarchy names.
     ///
     /// - `Known("Integer", [])` → `"Integer"`
+    /// - `Known("UndefinedObject", [])` → `"UndefinedObject"`
     /// - `Known("Result", [Known("Integer"), Known("String")])` → `"Result(Integer, String)"`
     /// - `Union([Known("String"), Known("UndefinedObject")])` → `"String | UndefinedObject"`
     /// - `Dynamic(Unknown)` → `"Dynamic"`
     /// - `Dynamic(UnannotatedParam)` → `"Dynamic (unannotated parameter)"`
+    ///
+    /// This is the "internal" display — it surfaces the canonical
+    /// `UndefinedObject` name. For user-facing diagnostics, hover, signature
+    /// help, and code actions, prefer [`display_for_diagnostic`](Self::display_for_diagnostic),
+    /// which renders the source-sympathetic `Nil` spelling instead.
     #[must_use]
     pub fn display_name(&self) -> Option<EcoString> {
+        Some(self.display_with_options(DisplayOptions::CANONICAL))
+    }
+
+    /// Maps a raw class-name string to its user-facing diagnostic spelling.
+    ///
+    /// Today this rewrites `"UndefinedObject"` → `"Nil"` and leaves all other
+    /// names untouched. Use this when you have a bare `EcoString`/`&str`
+    /// class name (e.g., a union-member list passed to a diagnostic) rather
+    /// than a full `InferredType`.
+    ///
+    /// **References:** BT-2066
+    #[must_use]
+    pub fn class_name_for_diagnostic(name: &str) -> EcoString {
+        if WellKnownClass::from_str(name).is_some_and(WellKnownClass::is_nil_class) {
+            EcoString::from("Nil")
+        } else {
+            EcoString::from(name)
+        }
+    }
+
+    /// Returns a human-readable display name for this type, using the
+    /// source-sympathetic names users type in their code.
+    ///
+    /// Identical to [`display_name`](Self::display_name) except that
+    /// `Known("UndefinedObject")` renders as `"Nil"`. Users write `:: Foo | Nil`
+    /// in source and never see the canonical `UndefinedObject` spelling
+    /// anywhere else, so diagnostics echoing `UndefinedObject` back at them
+    /// were jarring and triggered BT-2066.
+    ///
+    /// Use this for any user-facing string: diagnostic messages, hover
+    /// contents, signature help labels, and code-action inserts. Keep
+    /// [`display_name`](Self::display_name) for internal bookkeeping where the
+    /// canonical name is required (e.g., `is_assignable_to` lookups).
+    ///
+    /// **References:** BT-2066
+    #[must_use]
+    pub fn display_for_diagnostic(&self) -> Option<EcoString> {
+        Some(self.display_with_options(DisplayOptions::SOURCE_FRIENDLY))
+    }
+
+    fn display_with_options(&self, opts: DisplayOptions) -> EcoString {
         match self {
             Self::Known {
                 class_name,
                 type_args,
                 ..
             } => {
+                let rendered_name: EcoString = if opts.nil_as_source_name
+                    && WellKnownClass::from_str(class_name.as_str())
+                        .is_some_and(WellKnownClass::is_nil_class)
+                {
+                    EcoString::from("Nil")
+                } else {
+                    class_name.clone()
+                };
                 if type_args.is_empty() {
-                    Some(class_name.clone())
+                    rendered_name
                 } else {
                     let args: Vec<String> = type_args
                         .iter()
-                        .map(|a| {
-                            a.display_name()
-                                .map_or_else(|| "Dynamic".to_string(), |n| n.to_string())
-                        })
+                        .map(|a| a.display_with_options(opts).to_string())
                         .collect();
-                    Some(EcoString::from(format!(
-                        "{}({})",
-                        class_name,
-                        args.join(", ")
-                    )))
+                    EcoString::from(format!("{}({})", rendered_name, args.join(", ")))
                 }
             }
             Self::Union { members, .. } => {
@@ -225,22 +295,18 @@ impl InferredType {
                     if i > 0 {
                         result.push_str(" | ");
                     }
-                    if let Some(name) = m.display_name() {
-                        result.push_str(&name);
-                    } else {
-                        result.push_str("Dynamic");
-                    }
+                    result.push_str(&m.display_with_options(opts));
                 }
-                Some(result)
+                result
             }
             Self::Dynamic(reason) => {
                 if let Some(desc) = reason.description() {
-                    Some(EcoString::from(format!("Dynamic ({desc})")))
+                    EcoString::from(format!("Dynamic ({desc})"))
                 } else {
-                    Some(EcoString::from("Dynamic"))
+                    EcoString::from("Dynamic")
                 }
             }
-            Self::Never => Some(EcoString::from("Never")),
+            Self::Never => EcoString::from("Never"),
         }
     }
 
@@ -333,4 +399,105 @@ impl InferredType {
 pub(in crate::semantic_analysis) fn is_generic_type_param(name: &str) -> bool {
     let bytes = name.as_bytes();
     bytes.len() == 1 && bytes[0].is_ascii_uppercase()
+}
+
+#[cfg(test)]
+mod display_tests {
+    //! BT-2066: `display_name` uses the canonical `UndefinedObject`
+    //! class-hierarchy spelling; `display_for_diagnostic` substitutes the
+    //! source-sympathetic `Nil` spelling for user-facing messages.
+
+    use super::*;
+
+    #[test]
+    fn display_name_keeps_canonical_undefined_object() {
+        let ty = InferredType::known("UndefinedObject");
+        assert_eq!(ty.display_name().unwrap(), "UndefinedObject");
+    }
+
+    #[test]
+    fn display_for_diagnostic_renders_undefined_object_as_nil() {
+        let ty = InferredType::known("UndefinedObject");
+        assert_eq!(ty.display_for_diagnostic().unwrap(), "Nil");
+    }
+
+    #[test]
+    fn display_for_diagnostic_renders_union_members_as_nil() {
+        let ty = InferredType::simple_union(&["Integer", "UndefinedObject"]);
+        let rendered = ty.display_for_diagnostic().unwrap();
+        assert!(
+            rendered.contains("Nil"),
+            "union should render `Nil` not `UndefinedObject`, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("UndefinedObject"),
+            "union must not leak canonical name, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn display_name_union_keeps_canonical_undefined_object() {
+        let ty = InferredType::simple_union(&["Integer", "UndefinedObject"]);
+        let rendered = ty.display_name().unwrap();
+        assert!(
+            rendered.contains("UndefinedObject"),
+            "display_name must keep canonical spelling for internal use, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn display_for_diagnostic_rewrites_nested_generic_nil() {
+        // `Result(Integer, UndefinedObject)` should display as
+        // `Result(Integer, Nil)` in user-facing messages.
+        let ty = InferredType::Known {
+            class_name: "Result".into(),
+            type_args: vec![
+                InferredType::known("Integer"),
+                InferredType::known("UndefinedObject"),
+            ],
+            provenance: TypeProvenance::Inferred(Span::default()),
+        };
+        let rendered = ty.display_for_diagnostic().unwrap();
+        assert_eq!(rendered, "Result(Integer, Nil)");
+    }
+
+    #[test]
+    fn display_for_diagnostic_leaves_non_nil_names_untouched() {
+        let ty = InferredType::known("Integer");
+        assert_eq!(ty.display_for_diagnostic().unwrap(), "Integer");
+
+        let ty2 = InferredType::known("MyCustomClass");
+        assert_eq!(ty2.display_for_diagnostic().unwrap(), "MyCustomClass");
+    }
+
+    #[test]
+    fn class_name_for_diagnostic_maps_undefined_object_and_nil_alias() {
+        assert_eq!(
+            InferredType::class_name_for_diagnostic("UndefinedObject"),
+            "Nil"
+        );
+        // The legacy `Nil` spelling is already source-sympathetic; round-trip.
+        assert_eq!(InferredType::class_name_for_diagnostic("Nil"), "Nil");
+        // Non-nil names pass through.
+        assert_eq!(
+            InferredType::class_name_for_diagnostic("Integer"),
+            "Integer"
+        );
+        assert_eq!(
+            InferredType::class_name_for_diagnostic("MyCustomClass"),
+            "MyCustomClass"
+        );
+    }
+
+    #[test]
+    fn debug_still_shows_canonical_undefined_object() {
+        // `Debug` derive uses the raw class_name — must stay canonical for
+        // unambiguous test-failure / log output.
+        let ty = InferredType::known("UndefinedObject");
+        let debug_out = format!("{ty:?}");
+        assert!(
+            debug_out.contains("UndefinedObject"),
+            "Debug output must keep canonical name, got: {debug_out}"
+        );
+    }
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
@@ -260,10 +260,7 @@ impl InferredType {
                 .chars()
                 .next_back()
                 .is_none_or(|c| !is_ident_char(c));
-            let after_ok = name[end..]
-                .chars()
-                .next()
-                .is_none_or(|c| !is_ident_char(c));
+            let after_ok = name[end..].chars().next().is_none_or(|c| !is_ident_char(c));
             if before_ok && after_ok {
                 out.push_str("Nil");
             } else {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
@@ -250,7 +250,10 @@ impl InferredType {
         let mut remaining = name;
         while let Some(idx) = remaining.find(TARGET) {
             out.push_str(&remaining[..idx]);
-            let before_ok = remaining[..idx].chars().next_back().is_none_or(|c| !is_ident_char(c));
+            let before_ok = remaining[..idx]
+                .chars()
+                .next_back()
+                .is_none_or(|c| !is_ident_char(c));
             let tail = &remaining[idx + TARGET.len()..];
             let after_ok = tail.chars().next().is_none_or(|c| !is_ident_char(c));
             if before_ok && after_ok {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
@@ -247,23 +247,31 @@ impl InferredType {
         }
         let is_ident_char = |c: char| c.is_ascii_alphanumeric() || c == '_';
         let mut out = String::with_capacity(name.len());
-        let mut remaining = name;
-        while let Some(idx) = remaining.find(TARGET) {
-            out.push_str(&remaining[..idx]);
-            let before_ok = remaining[..idx]
+        let mut cursor = 0;
+        while let Some(rel) = name[cursor..].find(TARGET) {
+            let start = cursor + rel;
+            let end = start + TARGET.len();
+            out.push_str(&name[cursor..start]);
+            // Use the original `name` for both boundary checks — the cursor
+            // walks forward, but the char immediately before `start` must be
+            // inspected against full context, not the (possibly empty) slice
+            // we copied over this iteration.
+            let before_ok = name[..start]
                 .chars()
                 .next_back()
                 .is_none_or(|c| !is_ident_char(c));
-            let tail = &remaining[idx + TARGET.len()..];
-            let after_ok = tail.chars().next().is_none_or(|c| !is_ident_char(c));
+            let after_ok = name[end..]
+                .chars()
+                .next()
+                .is_none_or(|c| !is_ident_char(c));
             if before_ok && after_ok {
                 out.push_str("Nil");
             } else {
                 out.push_str(TARGET);
             }
-            remaining = tail;
+            cursor = end;
         }
-        out.push_str(remaining);
+        out.push_str(&name[cursor..]);
         EcoString::from(out)
     }
 
@@ -540,6 +548,12 @@ mod display_tests {
         assert_eq!(
             InferredType::class_name_for_diagnostic("UndefinedObjectFactory"),
             "UndefinedObjectFactory"
+        );
+        // Adjacent repeats — both sides are identifier characters, neither
+        // occurrence forms a whole identifier, so both must be preserved.
+        assert_eq!(
+            InferredType::class_name_for_diagnostic("UndefinedObjectUndefinedObject"),
+            "UndefinedObjectUndefinedObject"
         );
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
@@ -291,11 +291,8 @@ impl InferredType {
                 type_args,
                 ..
             } => {
-                let rendered_name: EcoString = if opts.nil_as_source_name
-                    && WellKnownClass::from_str(class_name.as_str())
-                        .is_some_and(WellKnownClass::is_nil_class)
-                {
-                    EcoString::from("Nil")
+                let rendered_name: EcoString = if opts.nil_as_source_name {
+                    Self::class_name_for_diagnostic(class_name.as_str())
                 } else {
                     class_name.clone()
                 };

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
@@ -229,19 +229,39 @@ impl InferredType {
 
     /// Maps a raw class-name string to its user-facing diagnostic spelling.
     ///
-    /// Today this rewrites `"UndefinedObject"` → `"Nil"` and leaves all other
-    /// names untouched. Use this when you have a bare `EcoString`/`&str`
-    /// class name (e.g., a union-member list passed to a diagnostic) rather
-    /// than a full `InferredType`.
+    /// Rewrites every occurrence of `"UndefinedObject"` → `"Nil"` as a whole
+    /// identifier, so this scrubs both bare class names (`"UndefinedObject"`)
+    /// and nested annotations (`"Array(UndefinedObject)"`,
+    /// `"Foo | UndefinedObject"`). Identifiers that merely *contain*
+    /// `UndefinedObject` as a substring (e.g. `"MyUndefinedObjectWrapper"`)
+    /// are left alone. Use this when you have an `EcoString`/`&str` that may
+    /// be either a bare class name or a full annotation string rather than a
+    /// structured [`InferredType`].
     ///
     /// **References:** BT-2066
     #[must_use]
     pub fn class_name_for_diagnostic(name: &str) -> EcoString {
-        if WellKnownClass::from_str(name).is_some_and(WellKnownClass::is_nil_class) {
-            EcoString::from("Nil")
-        } else {
-            EcoString::from(name)
+        const TARGET: &str = "UndefinedObject";
+        if !name.contains(TARGET) {
+            return EcoString::from(name);
         }
+        let is_ident_char = |c: char| c.is_ascii_alphanumeric() || c == '_';
+        let mut out = String::with_capacity(name.len());
+        let mut remaining = name;
+        while let Some(idx) = remaining.find(TARGET) {
+            out.push_str(&remaining[..idx]);
+            let before_ok = remaining[..idx].chars().next_back().is_none_or(|c| !is_ident_char(c));
+            let tail = &remaining[idx + TARGET.len()..];
+            let after_ok = tail.chars().next().is_none_or(|c| !is_ident_char(c));
+            if before_ok && after_ok {
+                out.push_str("Nil");
+            } else {
+                out.push_str(TARGET);
+            }
+            remaining = tail;
+        }
+        out.push_str(remaining);
+        EcoString::from(out)
     }
 
     /// Returns a human-readable display name for this type, using the
@@ -486,6 +506,40 @@ mod display_tests {
         assert_eq!(
             InferredType::class_name_for_diagnostic("MyCustomClass"),
             "MyCustomClass"
+        );
+    }
+
+    #[test]
+    fn class_name_for_diagnostic_scrubs_nested_undefined_object() {
+        // Nested generic — annotation strings like `Array(UndefinedObject)`
+        // must also get scrubbed even though they aren't bare class names.
+        assert_eq!(
+            InferredType::class_name_for_diagnostic("Array(UndefinedObject)"),
+            "Array(Nil)"
+        );
+        // Union spelling.
+        assert_eq!(
+            InferredType::class_name_for_diagnostic("Foo | UndefinedObject"),
+            "Foo | Nil"
+        );
+        // Deeply nested.
+        assert_eq!(
+            InferredType::class_name_for_diagnostic("Result(Integer, UndefinedObject)"),
+            "Result(Integer, Nil)"
+        );
+    }
+
+    #[test]
+    fn class_name_for_diagnostic_preserves_substring_matches() {
+        // `UndefinedObject` as part of a longer identifier (user-defined
+        // wrapper class) must NOT be scrubbed — whole-identifier match only.
+        assert_eq!(
+            InferredType::class_name_for_diagnostic("MyUndefinedObjectWrapper"),
+            "MyUndefinedObjectWrapper"
+        );
+        assert_eq!(
+            InferredType::class_name_for_diagnostic("UndefinedObjectFactory"),
+            "UndefinedObjectFactory"
         );
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -702,25 +702,30 @@ impl TypeChecker {
                         let param_pos = i + 1;
                         // BT-1588: Use hint severity for generic type params (likely false positive)
                         let is_generic = super::is_generic_type_param(actual_ty);
+                        // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+                        let actual_display =
+                            InferredType::class_name_for_diagnostic(actual_ty.as_str());
+                        let expected_display =
+                            InferredType::class_name_for_diagnostic(expected_ty.as_str());
                         let mut diag = if is_generic {
                             Diagnostic::hint(
                                 format!(
-                                    "Argument {param_pos} of '{selector}' on {class_name} expects {expected_ty}, got {actual_ty}"
+                                    "Argument {param_pos} of '{selector}' on {class_name} expects {expected_display}, got {actual_display}"
                                 ),
                                 span,
                             )
                             .with_hint(format!(
-                                "This is likely a false positive — `{actual_ty}` is a generic type parameter that may be {expected_ty} at runtime. \
+                                "This is likely a false positive — `{actual_display}` is a generic type parameter that may be {expected_display} at runtime. \
                                  Use `@expect type` to suppress"
                             ))
                         } else {
                             Diagnostic::warning(
                                 format!(
-                                    "Argument {param_pos} of '{selector}' on {class_name} expects {expected_ty}, got {actual_ty}"
+                                    "Argument {param_pos} of '{selector}' on {class_name} expects {expected_display}, got {actual_display}"
                                 ),
                                 span,
                             )
-                            .with_hint(format!("Expected {expected_ty} (or a subclass), got {actual_ty}"))
+                            .with_hint(format!("Expected {expected_display} (or a subclass), got {actual_display}"))
                         };
                         // BT-1588: Attach origin note if available
                         if let (Some(exprs), Some(e)) = (arg_exprs, env) {
@@ -749,25 +754,28 @@ impl TypeChecker {
                     }
                     let param_pos = i + 1;
                     let union_display = arg_ty
-                        .display_name()
+                        .display_for_diagnostic()
                         .unwrap_or_else(|| EcoString::from("Dynamic"));
+                    // BT-2066: Render `UndefinedObject` as `Nil` for the declared type too.
+                    let expected_display =
+                        InferredType::class_name_for_diagnostic(expected_ty.as_str());
                     let mut diag = if compat == 0 {
                         Diagnostic::warning(
-                            format!("Argument {param_pos} of '{selector}' on {class_name} expects {expected_ty}, got {union_display}"),
+                            format!("Argument {param_pos} of '{selector}' on {class_name} expects {expected_display}, got {union_display}"),
                             span,
                         )
-                        .with_hint(format!("No member of {union_display} is compatible with {expected_ty}"))
+                        .with_hint(format!("No member of {union_display} is compatible with {expected_display}"))
                     } else {
                         let list = incompatible
                             .iter()
-                            .map(|m| m.as_str())
+                            .map(|m| InferredType::class_name_for_diagnostic(m.as_str()))
                             .collect::<Vec<_>>()
                             .join(", ");
                         Diagnostic::hint(
-                            format!("Argument {param_pos} of '{selector}' on {class_name} expects {expected_ty}, got {union_display}"),
+                            format!("Argument {param_pos} of '{selector}' on {class_name} expects {expected_display}, got {union_display}"),
                             span,
                         )
-                        .with_hint(format!("Some members of the union are not compatible with {expected_ty}: {list}"))
+                        .with_hint(format!("Some members of the union are not compatible with {expected_display}: {list}"))
                     };
                     if let (Some(exprs), Some(e)) = (arg_exprs, env) {
                         if let Some(Expression::Identifier(ident)) = exprs.get(i) {
@@ -859,12 +867,12 @@ impl TypeChecker {
                             !Self::type_args_compatible(exp_arg, act_arg, hierarchy)
                         });
                 if base_mismatch || args_mismatch {
-                    let expected_display = expected
-                        .display_name()
-                        .unwrap_or_else(|| expected_ty.clone());
-                    let actual_display = body_type
-                        .display_name()
-                        .unwrap_or_else(|| actual_ty.clone());
+                    let expected_display = expected.display_for_diagnostic().unwrap_or_else(|| {
+                        InferredType::class_name_for_diagnostic(expected_ty.as_str())
+                    });
+                    let actual_display = body_type.display_for_diagnostic().unwrap_or_else(|| {
+                        InferredType::class_name_for_diagnostic(actual_ty.as_str())
+                    });
                     let selector = method.selector.name();
                     self.diagnostics.push(
                         Diagnostic::warning(
@@ -888,17 +896,19 @@ impl TypeChecker {
                 if !compatible {
                     let selector = method.selector.name();
                     let union_display = expected
-                        .display_name()
+                        .display_for_diagnostic()
                         .unwrap_or_else(|| EcoString::from("Dynamic"));
+                    let actual_display =
+                        InferredType::class_name_for_diagnostic(actual_ty.as_str());
                     self.diagnostics.push(
                         Diagnostic::warning(
                             format!(
-                                "Method '{selector}' in {class_name} declares return type {union_display}, but body returns {actual_ty}"
+                                "Method '{selector}' in {class_name} declares return type {union_display}, but body returns {actual_display}"
                             ),
                             method.span,
                         )
                         .with_category(DiagnosticCategory::Type)
-                        .with_hint(format!("Declared -> {union_display}, inferred body type is {actual_ty}")),
+                        .with_hint(format!("Declared -> {union_display}, inferred body type is {actual_display}")),
                     );
                 }
             }
@@ -914,8 +924,8 @@ impl TypeChecker {
                 // `actual_ty`).
                 let selector = method.selector.name();
                 let actual_display = body_type
-                    .display_name()
-                    .unwrap_or_else(|| actual_ty.clone());
+                    .display_for_diagnostic()
+                    .unwrap_or_else(|| InferredType::class_name_for_diagnostic(actual_ty.as_str()));
                 self.diagnostics.push(
                     Diagnostic::warning(
                         format!(
@@ -1042,6 +1052,9 @@ impl TypeChecker {
         let is_arithmetic = matches!(operator, "+" | "-" | "*" | "/");
         let is_comparison = matches!(operator, "<" | ">" | "<=" | ">=");
         let is_generic = super::is_generic_type_param(arg_ty);
+        // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+        let arg_display = InferredType::class_name_for_diagnostic(arg_ty.as_str());
+        let receiver_display = InferredType::class_name_for_diagnostic(receiver_ty.as_str());
 
         // Arithmetic operators on numeric types require numeric arguments
         if is_arithmetic && is_numeric(receiver_ty) && !is_numeric(arg_ty) {
@@ -1049,14 +1062,14 @@ impl TypeChecker {
             let mut diag = if is_generic {
                 Diagnostic::hint(
                     format!(
-                        "`{operator}` on {receiver_ty} expects a numeric argument, got {arg_ty}"
+                        "`{operator}` on {receiver_display} expects a numeric argument, got {arg_display}"
                     ),
                     span,
                 )
             } else {
                 Diagnostic::warning(
                     format!(
-                        "`{operator}` on {receiver_ty} expects a numeric argument, got {arg_ty}"
+                        "`{operator}` on {receiver_display} expects a numeric argument, got {arg_display}"
                     ),
                     span,
                 )
@@ -1081,7 +1094,7 @@ impl TypeChecker {
             // BT-1588: Use hint severity for generic type params (likely false positive)
             let mut diag = if is_generic {
                 Diagnostic::hint(
-                    format!("`++` on String expects a String argument, got {arg_ty}"),
+                    format!("`++` on String expects a String argument, got {arg_display}"),
                     span,
                 )
                 .with_hint(
@@ -1090,7 +1103,7 @@ impl TypeChecker {
                 )
             } else {
                 Diagnostic::warning(
-                    format!("`++` on String expects a String argument, got {arg_ty}"),
+                    format!("`++` on String expects a String argument, got {arg_display}"),
                     span,
                 )
                 .with_hint("Convert the argument to String first")
@@ -1108,14 +1121,14 @@ impl TypeChecker {
             let mut diag = if is_generic {
                 Diagnostic::hint(
                     format!(
-                        "`{operator}` on {receiver_ty} expects a numeric argument, got {arg_ty}"
+                        "`{operator}` on {receiver_display} expects a numeric argument, got {arg_display}"
                     ),
                     span,
                 )
             } else {
                 Diagnostic::warning(
                     format!(
-                        "`{operator}` on {receiver_ty} expects a numeric argument, got {arg_ty}"
+                        "`{operator}` on {receiver_display} expects a numeric argument, got {arg_display}"
                     ),
                     span,
                 )
@@ -1154,17 +1167,22 @@ impl TypeChecker {
                 ..
             } => {
                 if !Self::is_assignable_to(value_type, &declared_type, hierarchy) {
+                    // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+                    let declared_display =
+                        InferredType::class_name_for_diagnostic(declared_type.as_str());
+                    let value_display =
+                        InferredType::class_name_for_diagnostic(value_type.as_str());
                     self.diagnostics.push(
                         Diagnostic::warning(
                             format!(
-                                "Type mismatch: field `{}` declared as {declared_type}, got {value_type}",
+                                "Type mismatch: field `{}` declared as {declared_display}, got {value_display}",
                                 field.name
                             ),
                             span,
                         )
                         .with_category(DiagnosticCategory::Type)
                         .with_hint(format!(
-                            "Expected {declared_type} but assigning {value_type}"
+                            "Expected {declared_display} but assigning {value_display}"
                         )),
                     );
                 }
@@ -1182,25 +1200,28 @@ impl TypeChecker {
                     return; // All match → pass
                 }
                 let union_display = value_ty
-                    .display_name()
+                    .display_for_diagnostic()
                     .unwrap_or_else(|| EcoString::from("Dynamic"));
+                // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+                let declared_display =
+                    InferredType::class_name_for_diagnostic(declared_type.as_str());
                 let diag = if compat == 0 {
                     Diagnostic::warning(
-                        format!("Type mismatch: field `{}` declared as {declared_type}, got {union_display}", field.name),
+                        format!("Type mismatch: field `{}` declared as {declared_display}, got {union_display}", field.name),
                         span,
                     )
-                    .with_hint(format!("No member of {union_display} is compatible with {declared_type}"))
+                    .with_hint(format!("No member of {union_display} is compatible with {declared_display}"))
                 } else {
                     let list = incompatible
                         .iter()
-                        .map(|m| m.as_str())
+                        .map(|m| InferredType::class_name_for_diagnostic(m.as_str()))
                         .collect::<Vec<_>>()
                         .join(", ");
                     Diagnostic::hint(
-                        format!("Type mismatch: field `{}` declared as {declared_type}, got {union_display}", field.name),
+                        format!("Type mismatch: field `{}` declared as {declared_display}, got {union_display}", field.name),
                         span,
                     )
-                    .with_hint(format!("Some members of the union are not compatible with {declared_type}: {list}"))
+                    .with_hint(format!("Some members of the union are not compatible with {declared_display}: {list}"))
                 };
                 self.diagnostics
                     .push(diag.with_category(DiagnosticCategory::Type));
@@ -1244,17 +1265,21 @@ impl TypeChecker {
                 continue; // Dynamic defaults are fine
             };
             if !Self::is_assignable_to(value_type, &declared_type, hierarchy) {
+                // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+                let declared_display =
+                    InferredType::class_name_for_diagnostic(declared_type.as_str());
+                let value_display = InferredType::class_name_for_diagnostic(value_type.as_str());
                 self.diagnostics.push(
                     Diagnostic::warning(
                         format!(
-                            "Type mismatch: state `{}` declared as {declared_type}, default is {value_type}",
+                            "Type mismatch: state `{}` declared as {declared_display}, default is {value_display}",
                             decl.name.name
                         ),
                         decl.span,
                     )
                     .with_category(DiagnosticCategory::Type)
                     .with_hint(format!(
-                        "Default value type {value_type} is not compatible with {declared_type}"
+                        "Default value type {value_display} is not compatible with {declared_display}"
                     )),
                 );
             }
@@ -1576,8 +1601,9 @@ impl TypeChecker {
                 if compat == total {
                     return; // All conform → pass
                 }
+                // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
                 let union_display = arg_type
-                    .display_name()
+                    .display_for_diagnostic()
                     .unwrap_or_else(|| EcoString::from("Dynamic"));
                 let diag = if compat == 0 {
                     // Collect missing methods across all members
@@ -1597,7 +1623,7 @@ impl TypeChecker {
                 } else {
                     let list = non_conforming
                         .iter()
-                        .map(|m| m.as_str())
+                        .map(|m| InferredType::class_name_for_diagnostic(m.as_str()))
                         .collect::<Vec<_>>()
                         .join(", ");
                     Diagnostic::hint(
@@ -1719,8 +1745,9 @@ impl TypeChecker {
                         continue; // All conform → pass
                     }
                     let param_name = param_names.get(i).map_or("?", |p| p.as_str());
+                    // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
                     let union_display = arg
-                        .display_name()
+                        .display_for_diagnostic()
                         .unwrap_or_else(|| EcoString::from("Dynamic"));
                     let diag = if compat == 0 {
                         let missing = Self::collect_missing_protocol_methods(
@@ -1737,7 +1764,7 @@ impl TypeChecker {
                     } else {
                         let list = non_conforming
                             .iter()
-                            .map(|m| m.as_str())
+                            .map(|m| InferredType::class_name_for_diagnostic(m.as_str()))
                             .collect::<Vec<_>>()
                             .join(", ");
                         Diagnostic::hint(

--- a/docs/development/common-tasks.md
+++ b/docs/development/common-tasks.md
@@ -217,7 +217,7 @@ Beamtalk has **one** nil class with **two** names:
 | Name              | Where it appears                                                                 |
 | ----------------- | -------------------------------------------------------------------------------- |
 | `UndefinedObject` | Canonical class-hierarchy spelling. Used internally by the type checker, BEAM FFI specs, protocol registry, `InferredType::known(...)`, `is_assignable_to` lookups, `Debug` output for `InferredType`, and the stdlib class definition (`stdlib/src/UndefinedObject.bt`). |
-| `Nil`             | Source-sympathetic surface spelling. What users type in annotations (`:: Foo \| Nil`) and read back in user-facing messages: diagnostics, hover, signature help, code-action inserts, and REPL output. |
+| `Nil`             | Source-sympathetic surface spelling. What users type in annotations (`:: Nil`, `-> Nil`) and read back in user-facing messages: diagnostics, hover, signature help, code-action inserts, and REPL output. (Beamtalk does not yet support union type annotations in `.bt` source — `Foo \| Nil` is how the compiler _renders_ a nullable inference, not something you can write as a type.) |
 
 The two are aliased: the type resolver canonicalises `Nil`/`nil` → `UndefinedObject` during annotation resolution (`type_resolver.rs`), and `WellKnownClass::is_nil_class()` treats both as the nil type.
 

--- a/docs/development/common-tasks.md
+++ b/docs/development/common-tasks.md
@@ -209,3 +209,24 @@ Example: `runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl` has compr
 - Future awaiting
 
 **Summary:** Add `// =>` assertions for every deterministic result. For actor state tests, use runtime EUnit tests where you have full control.
+
+## `Nil` vs `UndefinedObject` — the two spellings
+
+Beamtalk has **one** nil class with **two** names:
+
+| Name              | Where it appears                                                                 |
+| ----------------- | -------------------------------------------------------------------------------- |
+| `UndefinedObject` | Canonical class-hierarchy spelling. Used internally by the type checker, BEAM FFI specs, protocol registry, `InferredType::known(...)`, `is_assignable_to` lookups, `Debug` output for `InferredType`, and the stdlib class definition (`stdlib/src/UndefinedObject.bt`). |
+| `Nil`             | Source-sympathetic surface spelling. What users type in annotations (`:: Foo \| Nil`) and read back in user-facing messages: diagnostics, hover, signature help, code-action inserts, and REPL output. |
+
+The two are aliased: the type resolver canonicalises `Nil`/`nil` → `UndefinedObject` during annotation resolution (`type_resolver.rs`), and `WellKnownClass::is_nil_class()` treats both as the nil type.
+
+**When rendering an `InferredType`, pick the right method for the audience:**
+
+- `InferredType::display_name()` — canonical. Use for internal bookkeeping (method-resolution keys, hierarchy enrichment) where the string must round-trip through `is_type_compatible` / `is_assignable_to`.
+- `InferredType::display_for_diagnostic()` — source-sympathetic. Use for anything the user reads: diagnostic messages, hover contents, signature-help labels, code-action insert text, signature display in `display_signature()`.
+- `InferredType::class_name_for_diagnostic(name)` — when you have a bare `EcoString` / `&str` (e.g., union-member names in a hint), use this helper to apply the same `UndefinedObject → Nil` rewrite.
+
+The `Debug` derive on `InferredType` keeps the canonical `UndefinedObject` spelling so test failures and logs stay unambiguous.
+
+**History:** The canonical-vs-surface split is enforced at the rendering boundary because renaming the class in the hierarchy would break BEAM FFI and stdlib protocols (BT-2016 documents the alias history; BT-2066 fixed the rendering regression that leaked `UndefinedObject` into diagnostics during the BT-2044 narrowing epic).


### PR DESCRIPTION
## Summary

Fixes the rendering regression where user-facing diagnostics surfaced the canonical `UndefinedObject` class-hierarchy name instead of the source-sympathetic `Nil` spelling that users write in their annotations.

**Linear issue:** https://linear.app/beamtalk/issue/BT-2066

## Changes

- **New rendering API**: Added `InferredType::display_for_diagnostic()` and `InferredType::class_name_for_diagnostic()` that rewrite `UndefinedObject` to `Nil` for user-facing output, while preserving `display_name()` for internal canonical lookups
- **All diagnostic sites updated**: Validation (argument types, return types, field assignments, state defaults, binary operators, protocol conformance), inference (DNU union messages, type mismatch, FFI argument types), hover, signature help, code actions, native type registry signatures
- **3 regressed tests fixed**: `bt2049_non_diverging_guard_does_not_narrow`, `bt2049_if_true_if_false_reassigning_false_branch_does_not_narrow`, and `bt2051_never_inside_nested_block_literal_does_not_diverge` now assert `"Nil"` with explicit negative guards against `"UndefinedObject"` leaking
- **8 new unit tests**: Cover `display_for_diagnostic`, `class_name_for_diagnostic`, union rendering, nested generics, and `Debug` canonical preservation
- **Documentation**: Added `Nil vs UndefinedObject` section to `docs/development/common-tasks.md` explaining the two-name convention and which rendering method to use
- **Leverages BT-2064**: Uses `WellKnownClass::is_nil_class()` from the recently merged `WellKnownClass` enum to drive the rendering mapping

## Test plan

- [x] All 3225 `beamtalk-core` unit tests pass
- [x] Clippy clean with `-D warnings`
- [x] Format check passes
- [x] BT-2049/BT-2051 tests explicitly assert `"Nil"` and reject `"UndefinedObject"` in diagnostic messages
- [x] `rg "UndefinedObject"` audit: no remaining user-visible message assertions use canonical name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Type names now render consistently across diagnostics, hover tooltips, signature help, and code-action titles/edits; internal canonical names like UndefinedObject are shown as the user-facing "Nil" where appropriate.

* **Tests**
  * Updated tests to assert the user-facing "Nil" spelling and stricter diagnostic rendering to prevent leakage of canonical names.

* **Documentation**
  * Added guidance explaining canonical vs. user-facing type name rendering and when each form is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->