### PR TITLE
docs: daily refresh 2026-04-24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 - **Conditional return type inference** — `ifTrue:ifFalse:` now declares `Block(R), Block(R) -> R`, so the type checker unifies both arms to a common return type instead of collapsing to `Dynamic` (BT-2020).
 - Typechecker warns when a method declared `-> Never` has a body that returns a known type (BT-2033).
 - Fix generic return type inner arg validation — the type checker now correctly warns when inner type args of a generic return type mismatch (e.g., `-> Result(Integer, Error)` with body returning `Result(String, Error)`) (BT-2022).
+- **Nil-check narrowing extensions** — `isNil ifFalse:` narrows receiver to non-nil inside the block; diverging guards (`isNil ifTrue: [self error: "..."]`) narrow to non-nil for the rest of the method, not just `^` returns; `self.field` reads narrow after nil-check guards (BT-2048, BT-2049).
+- **`ifNotNil:` block parameter narrowing** — block parameters in `ifNotNil:`, `ifNil:ifNotNil:`, and `ifNotNil:ifNil:` are typed as the non-nil branch of the receiver's type (BT-2046).
+- **`ifNil:ifNotNil:` branch-union return type** — `receiver ifNil: [a] ifNotNil: [:x | b]` infers as `typeof(a) | typeof(b)` instead of `Dynamic`; a branch containing `^` contributes `Never` (BT-2047).
+- **`on:do:` handler block parameter inference** — block parameters in `on: SomeException do: [:e | ...]` are typed as the exception class argument instead of `Dynamic` (BT-2045).
+- Diagnostics now render `Nil` where the source uses `Nil`, instead of the internal name `UndefinedObject` (BT-2066).
+- Deep-descendant `Never` detection in diverging guard blocks — nested `Never`-typed expressions (e.g., `[Sink log: (self error: "...")]`) correctly trigger nil-check narrowing (BT-2051).
+- Fix false-positive "Unused variable" warning from typed block parameters — block parameters with `:: Type` annotations are now parsed correctly (BT-2043).
+- Fix spurious `Dynamic` inference on block parameters when iterating a `Dynamic`-typed receiver in a typed class (BT-2042).
 
 ### Standard Library
 
@@ -52,6 +60,11 @@
 - **Diagnostic summary** — `beamtalk build` and `beamtalk lint` print an aggregated diagnostic summary (category × severity) at end of run; `beamtalk lint --format json` emits a `summary` JSON object for CI diffing; new `diagnostic_summary` MCP tool for agent use (BT-2014).
 - Fix `beamtalk lint` diagnostic summary accounting — `files_checked` count, error surfacing, and `--format json` buffered output now report correctly (BT-2031).
 - Fix `beamtalk lint test/` emitting spurious `Unresolved class` diagnostics for classes defined in the package's `src/`; fix LSP falsely flagging every class as "conflicts with a stdlib class" when opening stdlib `.bt` files (BT-2027).
+- Fix `beamtalk lint` false-positive on keyword-form function calls inside Erlang function bodies being misidentified as undocumented exports (BT-2053).
+- Fix `beamtalk fmt` silently failing on `.erl` files containing non-ASCII Unicode characters (BT-2054).
+- Fix MCP `lint` tool producing different diagnostics from CLI `beamtalk lint` for cross-file type/DNU issues (BT-2052).
+- MCP `lint` tool now surfaces warning diagnostics when package files are unreadable during cross-file class extraction (BT-2056).
+- Preserve `startup.log` on final workspace retry failure so error diagnostics referencing the file remain valid (BT-2057).
 
 ### Documentation
 
@@ -79,6 +92,13 @@
 - Dedup cascade receiver inference so inner DNU warnings fire once instead of duplicating (BT-2035).
 - Fix spurious untyped-FFI warning on narrowing-path blocks in Result.bt (BT-2039).
 - Remove 11+ stale `@expect type` directives across stdlib following type checker improvements (#2076).
+- Split 16k-line `type_checker/tests.rs` into 28 per-feature test modules (BT-2061).
+- Typed `EnvKey` enum replaces string-key convention for type environment entries (BT-2062).
+- Typed `WellKnownClass` enum replaces fragile class-name string comparisons across type checker (BT-2064).
+- Refactor narrowing into `NarrowingRule` table with per-rule modules and env-level refinement (BT-2050).
+- Unify workspace retry helpers into single parameterized `retry_with_cleanup` wrapper (BT-2058).
+- Replace erlfmt inline Erlang eval strings with structured `ErlangEval` builder (BT-2059).
+- Share package-root resolution between MCP lint and CLI lint via `project::package` module (BT-2060).
 
 ## 0.3.1 — 2026-03-26
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -724,11 +724,12 @@ result ifOk: [:content | content] ifError: [:e | "error"]
 result value  // raises on error
 ```
 
-**Error handling:** Errors from Erlang calls are wrapped as `BEAMError`, `ExitError`, or `ThrowError` — catchable with `on:do:`:
+**Error handling:** Errors from Erlang calls are wrapped as `BEAMError`, `ExitError`, or `ThrowError` — catchable with `on:do:`. The handler block parameter is typed from the exception class argument, so `e` in `on: BEAMError do: [:e | ...]` is inferred as `BEAMError` (not `Dynamic`):
 
 ```beamtalk
 [Erlang erlang error: #badarg] on: BEAMError do: [:e | e message]
 // => "badarg"
+// e is typed as BEAMError — `e message` type-checks without warnings
 ```
 
 ### Type Specs for Native Modules
@@ -1301,7 +1302,7 @@ The nullable pattern (`String | nil`) is the most common union — Beamtalk's Op
 
 ```beamtalk
 name :: String | nil := dictionary at: "name"
-name size              // Warning: UndefinedObject does not respond to 'size'
+name size              // Warning: Nil does not respond to 'size'
 ```
 
 Similarly, `false` in type position resolves to `False` — used for Erlang FFI patterns:
@@ -1341,7 +1342,13 @@ validate: x :: Object =>
 | `x class = Foo ifTrue: [...]` | `x` is `Foo` in true block | True block only |
 | `x isKindOf: Foo ifTrue: [...]` | `x` is `Foo` in true block | True block only |
 | `x isNil ifTrue: [^...]` | `x` is non-nil after the statement | Rest of method |
+| `x isNil ifTrue: [self error: "..."]` | `x` is non-nil after the statement | Rest of method |
+| `x isNil ifFalse: [...]` | `x` is non-nil in false block | False block |
 | `x isNil ifTrue: [^...] ifFalse: [...]` | `x` is non-nil in false block | False block |
+| `x ifNotNil: [:v \| ...]` | `v` is non-nil in block | Block only |
+| `x ifNil: [...] ifNotNil: [:v \| ...]` | `v` is non-nil in notNil block | NotNil block |
+
+The diverging-guard pattern (`isNil ifTrue: [self error: "..."]`) recognises any block whose body infers as `Never` — including calls to `error:`, `notImplemented`, or any `-> Never` method — not just non-local returns (`^`). Narrowing also works on `self.field` reads: inside `self.field isNil ifFalse: [...]`, the field narrows to non-nil within the block.
 
 ### Conditional Return Type Inference
 
@@ -1353,6 +1360,17 @@ x := condition ifTrue: [42] ifFalse: [0]
 
 result isOk ifTrue: [result unwrap] ifFalse: [default]
 // inferred as the common type of both arms
+```
+
+`ifNil:ifNotNil:` (and `ifNotNil:ifNil:`) on nullable receivers also infers a branch-union return type — `typeof(nilBranch) | typeof(notNilBranch)`. A branch containing a non-local return (`^`) contributes `Never`, leaving only the surviving branch's type:
+
+```beamtalk
+name :: String | nil := dictionary at: "name"
+result := name ifNil: ["unknown"] ifNotNil: [:n | n size]
+// result is inferred as String | Integer
+
+value := name ifNil: [^nil] ifNotNil: [:n | n]
+// value is inferred as String (nil branch contributes Never, skipped)
 ```
 
 ### Union + Narrowing Compose


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 23 commits merged to main in the last 24 hours.

**Docs updated:**
- `docs/beamtalk-language-features.md` — expanded narrowing patterns table (4 new patterns), added diverging-guard explanation, added `ifNil:ifNotNil:` branch-union return type section, updated `on:do:` handler block param typing, fixed `UndefinedObject` → `Nil` in diagnostic example
- `CHANGELOG.md` — 8 Language entries, 5 Tooling entries, 7 Internal entries

## Commits reviewed

### Language (doc + CHANGELOG)
- `73c7de0` BT-2048 — Narrow receiver to non-Nil inside `isNil ifFalse:` block
- `d41cc27` BT-2049 — Post-guard narrowing for nullable locals/fields after `isNil ifTrue: [diverge]`
- `f366f8f` BT-2046 — Narrow `ifNotNil:` block param to non-Nil branch
- `cb23edc` BT-2047 — Type `ifNil:ifNotNil:` expression as branch-union
- `212e636` BT-2045 — Infer block-param type from `on:do:` first argument
- `b7c8df5` BT-2066 — Diagnostics render Nil where source uses Nil, not UndefinedObject

### Language (CHANGELOG only)
- `475f22d` BT-2051 — Deep-descendant Never detection in block_diverges
- `c9008c8` BT-2043 — Fix false-positive "Unused variable" from typed block params
- `2fdb616` BT-2042 — Block param inferred Dynamic in typed class

### Tooling (CHANGELOG only)
- `57aebf4` BT-2053 — Fix lint false-positive for keyword-form function calls
- `f53a446` BT-2054 — Fix erlfmt silent failure on non-ASCII characters
- `aeb8447` BT-2052 — MCP lint diagnostics diverge from CLI
- `27e3688` BT-2056 — MCP lint: surface unreadable package files
- `34aa4e5` BT-2057 — Preserve startup.log on final workspace retry failure

### Internal (CHANGELOG only)
- `ffe2af0` BT-2061 — Split type_checker/tests.rs into per-feature modules
- `16dd94e` BT-2062 — Typed EnvKey enum
- `35faf77` BT-2064 — Typed WellKnownClass enum
- `0979858` BT-2050 — Refactor narrowing into NarrowingRule table
- `0df0051` BT-2058 — Unify workspace retry helpers
- `ca1e5dc` BT-2059 — Replace erlfmt eval strings with builder
- `219759f` BT-2060 — Share package-root resolution

### Skipped
- `52d6c83` — Previous daily refresh (2026-04-23)
- `1972774` BT-2040 — Test-only (fix flaky WS health check)

## Test plan

- [ ] Verify language-features.md narrowing table renders correctly
- [ ] Verify CHANGELOG entries are under correct subsections
- [ ] Verify no broken markdown links

https://claude.ai/code/session_01DrThGxEk1YUL1CVPiNfHHZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrThGxEk1YUL1CVPiNfHHZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type-checker narrowing for nil-check patterns and condition blocks.
  * Enhanced exception type inference in block handlers.
  * Corrected spurious type inference warnings in specific code patterns.
  * Fixed diagnostic consistency and output accuracy in linting and formatting tools.

* **Documentation**
  * Updated typing behavior documentation and exception handling examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->