### PR TITLE
Generic Visitor trait replacing hand-rolled AST walkers (BT-2063)

### DIFF
--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -85,6 +85,7 @@ mod class;
 mod expression;
 mod method;
 mod pattern;
+pub(crate) mod visitor;
 
 // Re-export all public types so `use crate::ast::Foo` continues to work.
 pub use class::*;

--- a/crates/beamtalk-core/src/ast/visitor.rs
+++ b/crates/beamtalk-core/src/ast/visitor.rs
@@ -1,0 +1,182 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generic AST visitor with **opaque-block** default recursion (BT-2063).
+//!
+//! This visitor exists for the type-checker's narrowing machinery, where an
+//! inert [`Block`] literal is a *value*, not a point of control flow.
+//! `[self error: "…"]` constructs a block but does not execute it, so walkers
+//! that answer "does this statement diverge?" or "does this branch contain
+//! `^`?" must not descend into nested blocks by default — doing so would
+//! unsoundly treat a captured-but-never-invoked block as if its body ran.
+//!
+//! # Relationship to [`crate::ast_walker`]
+//!
+//! [`crate::ast_walker::walk_expression`] also walks every variant of
+//! [`Expression`], but serves a different audience: lint and validator
+//! passes that *do* want to see every expression, including nested block
+//! bodies. Both walkers are exhaustive over variants (so adding a new
+//! [`Expression`] variant is a compile error at the match, preventing the
+//! "silent-miss" bug that motivated this trait), but they differ in whether
+//! they descend into [`Block`]:
+//!
+//! | Walker | Block default | Audience |
+//! | -- | -- | -- |
+//! | [`crate::ast_walker::walk_expression`] | descend | lint / validators / codegen |
+//! | [`Visitor`] (this module) | **opaque** | narrowing / divergence / `^` detection |
+//!
+//! # Usage
+//!
+//! Implement [`Visitor::visit_expr`] to do the per-node work. Call
+//! [`walk_expr`] to recurse into sub-expressions. Override
+//! [`Visitor::visit_block`] to opt into descending into block literals.
+//!
+//! ```ignore
+//! struct ContainsReturn(bool);
+//! impl<'ast> Visitor<'ast> for ContainsReturn {
+//!     fn visit_expr(&mut self, e: &'ast Expression) {
+//!         if self.0 { return }
+//!         if matches!(e, Expression::Return { .. }) { self.0 = true; return }
+//!         walk_expr(self, e);
+//!     }
+//!     // visit_block default (opaque) is correct here.
+//! }
+//! ```
+
+use super::{Block, Expression, StringSegment};
+
+/// Pre-order visitor over [`Expression`] trees with opaque nested-block
+/// default. See the module-level documentation for the design rationale.
+pub(crate) trait Visitor<'ast>: Sized {
+    /// Called on every expression node encountered during the walk.
+    ///
+    /// The default implementation simply recurses into sub-expressions via
+    /// [`walk_expr`]. Override to inspect the node before/after recursion or
+    /// to short-circuit traversal.
+    fn visit_expr(&mut self, expr: &'ast Expression) {
+        walk_expr(self, expr);
+    }
+
+    /// Called when a nested [`Expression::Block`] literal is encountered.
+    ///
+    /// **Default: opaque** — the block's body is not visited. This matches
+    /// the narrowing semantics (BT-2050 / BT-2051): an inert block literal
+    /// is a value construction, not a point of control flow, so walkers
+    /// answering "does this diverge?" / "does this return?" must not descend.
+    ///
+    /// Visitors that need to see inside blocks override this method to call
+    /// [`walk_block`], which iterates the block body.
+    fn visit_block(&mut self, _block: &'ast Block) {}
+}
+
+/// Exhaustively recurse into every sub-expression of `expr`.
+///
+/// Leaf variants (literals, identifiers, class references, `super`,
+/// primitives, expect directives, spread, error nodes) have no children, so
+/// this is a no-op for them. [`Expression::Block`] is delegated to
+/// [`Visitor::visit_block`] — **not** recursed into here — preserving the
+/// opaque-block default.
+///
+/// This match is deliberately **not** a catch-all: every variant must appear
+/// explicitly, so that adding a new [`Expression`] variant in the future is
+/// a compile error at this site (see BT-2063 acceptance criteria).
+pub(crate) fn walk_expr<'ast, V: Visitor<'ast>>(v: &mut V, expr: &'ast Expression) {
+    match expr {
+        Expression::FieldAccess { receiver, .. } => {
+            v.visit_expr(receiver);
+        }
+        Expression::MessageSend {
+            receiver,
+            arguments,
+            ..
+        } => {
+            v.visit_expr(receiver);
+            for arg in arguments {
+                v.visit_expr(arg);
+            }
+        }
+        Expression::Block(block) => {
+            v.visit_block(block);
+        }
+        Expression::Assignment { target, value, .. } => {
+            v.visit_expr(target);
+            v.visit_expr(value);
+        }
+        Expression::DestructureAssignment { value, .. } | Expression::Return { value, .. } => {
+            v.visit_expr(value);
+        }
+        Expression::Cascade {
+            receiver, messages, ..
+        } => {
+            v.visit_expr(receiver);
+            for msg in messages {
+                for arg in &msg.arguments {
+                    v.visit_expr(arg);
+                }
+            }
+        }
+        Expression::Parenthesized { expression, .. } => {
+            v.visit_expr(expression);
+        }
+        Expression::Match { value, arms, .. } => {
+            v.visit_expr(value);
+            for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    v.visit_expr(guard);
+                }
+                v.visit_expr(&arm.body);
+            }
+        }
+        Expression::MapLiteral { pairs, .. } => {
+            for pair in pairs {
+                v.visit_expr(&pair.key);
+                v.visit_expr(&pair.value);
+            }
+        }
+        Expression::ListLiteral { elements, tail, .. } => {
+            for elem in elements {
+                v.visit_expr(elem);
+            }
+            if let Some(t) = tail {
+                v.visit_expr(t);
+            }
+        }
+        Expression::ArrayLiteral { elements, .. } => {
+            for elem in elements {
+                v.visit_expr(elem);
+            }
+        }
+        Expression::StringInterpolation { segments, .. } => {
+            for seg in segments {
+                if let StringSegment::Interpolation(e) = seg {
+                    v.visit_expr(e);
+                }
+            }
+        }
+        // Leaf nodes — nothing to recurse into. Listed explicitly (no `_`
+        // arm) so that adding a new variant is a compile error here.
+        Expression::Literal(..)
+        | Expression::Identifier(..)
+        | Expression::ClassReference { .. }
+        | Expression::Super(..)
+        | Expression::Primitive { .. }
+        | Expression::ExpectDirective { .. }
+        | Expression::Spread { .. }
+        | Expression::Error { .. } => {}
+    }
+}
+
+/// Visit every top-level statement in `block`.
+///
+/// Call this from an overridden [`Visitor::visit_block`] to opt into
+/// descending through a nested block literal.
+///
+/// Currently only used by test helpers (e.g. `find_send_inferred_ty`), so
+/// permitted to be dead code in non-test builds. This is part of the
+/// trait's documented API — don't gate it behind `#[cfg(test)]`.
+#[allow(dead_code)]
+pub(crate) fn walk_block<'ast, V: Visitor<'ast>>(v: &mut V, block: &'ast Block) {
+    for stmt in &block.body {
+        v.visit_expr(&stmt.expression);
+    }
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2640,54 +2640,51 @@ impl TypeChecker {
             .any(|stmt| self.expr_contains_never(&stmt.expression))
     }
 
-    /// Recursively check whether `expr` — or any sub-expression in the same
-    /// statement-position slots walked by [`Self::expr_contains_return`] —
-    /// has inferred type [`InferredType::Never`] in the type map (BT-2051).
+    /// Recursively check whether `expr` — or any sub-expression — has
+    /// inferred type [`InferredType::Never`] in the type map (BT-2051).
     ///
-    /// This is the `Never`-typed companion to [`Self::expr_contains_return`]:
-    /// both walk the same `Expression` variants (`Return`, `Parenthesized`,
-    /// `Assignment`, `MessageSend`, `Cascade`, `Block`, `FieldAccess`) so a
-    /// diverging call such as `self error: "…"` is detected whether it
-    /// appears as the whole statement (`[self error: "…"]`), as a receiver,
-    /// or buried in a method-send argument
-    /// (`[logger info: (self error: "…")]`).
+    /// This is the `Never`-typed companion to
+    /// [`super::narrowing::visitors::expr_contains_return`]: both share the
+    /// exhaustive [`crate::ast::visitor`] walker so every sub-expression
+    /// variant gets covered (BT-2063). A diverging call such as
+    /// `self error: "…"` is detected whether it appears as the whole
+    /// statement (`[self error: "…"]`), as a receiver, buried in a message
+    /// send argument (`[logger info: (self error: "…")]`), inside a
+    /// `DestructureAssignment`, `Match`, `MapLiteral`, `ListLiteral`, etc.
+    ///
+    /// **Nested block literals are opaque**: a block value is *constructed*,
+    /// not *executed*, at this position. Guards like
+    /// `[callbacks add: [self error: "later"]]` would otherwise be
+    /// mis-classified as diverging even though the outer block still falls
+    /// through. This is the [`crate::ast::visitor::Visitor`] default.
     fn expr_contains_never(&self, expr: &Expression) -> bool {
-        if matches!(self.type_map.get(expr.span()), Some(InferredType::Never)) {
-            return true;
+        use crate::ast::visitor::{Visitor, walk_expr};
+
+        struct Finder<'a> {
+            type_map: &'a crate::semantic_analysis::type_checker::TypeMap,
+            found: bool,
         }
-        match expr {
-            Expression::Return { value, .. } => self.expr_contains_never(value),
-            Expression::Parenthesized { expression, .. } => self.expr_contains_never(expression),
-            Expression::Assignment { target, value, .. } => {
-                self.expr_contains_never(target) || self.expr_contains_never(value)
+        impl<'ast> Visitor<'ast> for Finder<'_> {
+            fn visit_expr(&mut self, e: &'ast Expression) {
+                if self.found {
+                    return;
+                }
+                if matches!(self.type_map.get(e.span()), Some(InferredType::Never)) {
+                    self.found = true;
+                    return;
+                }
+                walk_expr(self, e);
             }
-            Expression::MessageSend {
-                receiver,
-                arguments,
-                ..
-            } => {
-                self.expr_contains_never(receiver)
-                    || arguments.iter().any(|a| self.expr_contains_never(a))
-            }
-            Expression::Cascade {
-                receiver, messages, ..
-            } => {
-                self.expr_contains_never(receiver)
-                    || messages
-                        .iter()
-                        .any(|m| m.arguments.iter().any(|a| self.expr_contains_never(a)))
-            }
-            Expression::FieldAccess { receiver, .. } => self.expr_contains_never(receiver),
-            // - Nested `Block` literals are opaque: a block value is
-            //   *constructed*, not *executed*, at this position. Guards like
-            //   `[callbacks add: [self error: "later"]]` would otherwise be
-            //   mis-classified as diverging even though the outer block can
-            //   still fall through.
-            // - Literals, identifiers, class references, super, etc. have
-            //   no sub-expressions the top-level check above didn't already
-            //   cover.
-            _ => false,
+            // `visit_block` default (opaque) preserves the BT-2051 rule:
+            // inert block literals must NOT count toward divergence.
         }
+
+        let mut finder = Finder {
+            type_map: &self.type_map,
+            found: false,
+        };
+        finder.visit_expr(expr);
+        finder.found
     }
 
     /// Remove `UndefinedObject` (nil) from a union type or convert a known type

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/extract.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/extract.rs
@@ -10,6 +10,14 @@
 //! system rather than buried in a prefix.
 //!
 //! Extracted from `inference.rs` under BT-2050; re-typed under BT-2062.
+//!
+//! BT-2063 note: these helpers deliberately do **not** use
+//! [`crate::ast::visitor`]. They are shape destructors — "peel parens, then
+//! match one specific shape and return" — not structural walkers; feeding
+//! them through a recursive visitor would obscure their intent and change
+//! their soundness story (both callers want to reject anything that isn't
+//! exactly `Identifier` or `self.<field>`, not "contains an identifier
+//! somewhere").
 
 use crate::ast::Expression;
 use crate::semantic_analysis::type_checker::EnvKey;

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/visitors.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/visitors.rs
@@ -11,9 +11,8 @@
 //! * [`block_has_any_return`] — `^` anywhere, including nested sub-expressions
 //!   but **not** inside nested `Block` literals. A nested `[^1]` that is not
 //!   `value`-sent is just a block object that never runs, so it should stay
-//!   opaque (BT-2051). The `Block` arm of [`expr_contains_return`] preserves
-//!   this by recursing into `block_has_any_return`, which in turn only inspects
-//!   its own statements.
+//!   opaque (BT-2051). Implemented on top of the shared [`crate::ast::visitor`]
+//!   trait, whose default `visit_block` is opaque.
 //! * [`block_may_reassign`] — top-level assignments to `var_name`. Used by
 //!   BT-2049's soundness guard for `ifTrue:ifFalse:` so that reassigning the
 //!   tested variable in the false branch cancels post-guard narrowing.
@@ -24,8 +23,18 @@
 //! different — collapsing them would make it too easy to reintroduce
 //! BT-2049/BT-2051 regressions.
 //!
-//! Extracted from `inference.rs` under BT-2050.
+//! Extracted from `inference.rs` under BT-2050. Re-expressed as
+//! [`crate::ast::visitor::Visitor`] impls under BT-2063 so that the
+//! previously-hand-rolled structural match is exhaustive over
+//! [`Expression`] variants (the same bug — "your walker doesn't cover variant
+//! X" — surfaced multiple times during the BT-2044 epic).
+//!
+//! `block_has_return` and `block_may_reassign` are left as simple top-level
+//! iterations: they intentionally only inspect direct block children (not
+//! nested expressions) so the [`Visitor`] trait's structural recursion
+//! wouldn't be in scope anyway.
 
+use crate::ast::visitor::{Visitor, walk_expr};
 use crate::ast::{Block, Expression};
 use crate::semantic_analysis::type_checker::EnvKey;
 
@@ -59,49 +68,53 @@ pub(crate) fn block_has_any_return(block: &Block) -> bool {
 
 /// Does `expr` contain a `^` anywhere?
 ///
-/// Recurses through parenthesization, assignments, message sends, and cascades.
-/// **Nested block literals are opaque**: `[[^1] value]` — or any branch body
-/// that constructs a block containing `^` without invoking it — does NOT
-/// count as diverging. The inner block is a value, not control flow, so
-/// treating it as a method-exit would make `apply_early_return_narrowing`
-/// (and BT-2047's `if_nil_branch_union_ret_ty`) unsoundly narrow after
-/// branches that can still fall through. Mirrors the same opacity rule in
-/// [`expr_contains_never`] (BT-2051).
+/// Recurses through every [`Expression`] variant with sub-expressions via the
+/// shared [`crate::ast::visitor`] trait. **Nested block literals are opaque**:
+/// `[[^1] value]` — or any branch body that constructs a block containing `^`
+/// without invoking it — does NOT count as diverging. The inner block is a
+/// value, not control flow, so treating it as a method-exit would make
+/// `apply_early_return_narrowing` (and BT-2047's `if_nil_branch_union_ret_ty`)
+/// unsoundly narrow after branches that can still fall through. Mirrors the
+/// same opacity rule in [`crate::semantic_analysis::type_checker::TypeChecker`]'s
+/// `expr_contains_never` (BT-2051).
 pub(crate) fn expr_contains_return(expr: &Expression) -> bool {
-    match expr {
-        Expression::Return { .. } => true,
-        Expression::Parenthesized { expression, .. } => expr_contains_return(expression),
-        Expression::Assignment { target, value, .. } => {
-            expr_contains_return(target) || expr_contains_return(value)
+    struct Finder(bool);
+    impl<'ast> Visitor<'ast> for Finder {
+        fn visit_expr(&mut self, e: &'ast Expression) {
+            if self.0 {
+                return;
+            }
+            if matches!(e, Expression::Return { .. }) {
+                self.0 = true;
+                return;
+            }
+            walk_expr(self, e);
         }
-        Expression::MessageSend {
-            receiver,
-            arguments,
-            ..
-        } => expr_contains_return(receiver) || arguments.iter().any(expr_contains_return),
-        Expression::Cascade {
-            receiver, messages, ..
-        } => {
-            expr_contains_return(receiver)
-                || messages
-                    .iter()
-                    .any(|m| m.arguments.iter().any(expr_contains_return))
-        }
-        // - `Block` literal: opaque — an inert block value never runs here.
-        // - Literals, identifiers, class references, field access, etc.
-        //   have no sub-expressions that could contain `^`.
-        _ => false,
+        // `visit_block` default is opaque, which is what we want here:
+        // a nested `[...^...]` literal that is never invoked does not
+        // cause the enclosing expression to diverge.
     }
+    let mut finder = Finder(false);
+    finder.visit_expr(expr);
+    finder.0
 }
 
 /// Conservative scan: does `block` contain an assignment whose target is the
 /// same binding as `key`?
 ///
 /// `key` may be a lexical local or a synthetic `self.<field>` key
-/// (BT-2048 / BT-2062). Only inspects top-level statements in the block,
+/// (BT-2048 / BT-2062). Only inspects **top-level** statements in the block,
 /// which matches the shapes post-guard narrowing currently reasons about.
 /// False positives are safe (we skip narrowing); false negatives would be
 /// unsound, so anything non-trivial defaults to "assume reassignment".
+///
+/// BT-2063 note: this intentionally does NOT use [`crate::ast::visitor`].
+/// The structural recursion is a non-goal here: we only want to see
+/// reassignments at the statement level of the block body (mirrored in how
+/// the narrowing machinery observes linear statement-order effects).
+/// Recursing into sub-expressions would flip this from a "top-level scan"
+/// into a "deep search", changing the soundness story for post-guard
+/// narrowing. If a deeper scan is ever wanted, it should be a new function.
 pub(crate) fn block_may_reassign(block: &Block, key: &EnvKey) -> bool {
     block.body.iter().any(|stmt| {
         if let Expression::Assignment { target, .. } = &stmt.expression {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_if_nil_if_not_nil.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_if_nil_if_not_nil.rs
@@ -39,66 +39,71 @@ fn find_union_in_type_map<'a>(
 /// Used by BT-2047 tests to assert the exact type of the `ifNil:ifNotNil:`
 /// expression — checking diagnostics alone isn't enough because
 /// `check_return_type` bails on `Union` / `Dynamic` inferred bodies.
+///
+/// Re-expressed under BT-2063 on top of the shared
+/// [`crate::ast::visitor::Visitor`] trait so that variant coverage is
+/// exhaustive (`ArrayLiteral`, `ListLiteral`, `Match`, etc. are all
+/// searched). Unlike the default opaque-block visitor, this walker
+/// overrides `visit_block` to descend: the test needs to find sends
+/// anywhere in the AST, including inside nested block bodies.
 fn find_send_inferred_ty<'a>(
-    module: &crate::ast::Module,
+    module: &'a crate::ast::Module,
     type_map: &'a crate::semantic_analysis::type_checker::TypeMap,
-    selector_name: &str,
+    selector_name: &'a str,
 ) -> Option<&'a InferredType> {
-    fn walk_expr<'a>(
-        expr: &crate::ast::Expression,
+    use crate::ast::visitor::{Visitor, walk_block, walk_expr};
+    use crate::ast::{Expression, MessageSelector};
+
+    struct Finder<'a> {
         type_map: &'a crate::semantic_analysis::type_checker::TypeMap,
-        selector_name: &str,
-    ) -> Option<&'a InferredType> {
-        use crate::ast::{Expression, MessageSelector};
-        match expr {
-            Expression::MessageSend {
-                selector,
-                span,
-                receiver,
-                arguments,
-                ..
-            } => {
+        selector_name: &'a str,
+        found: Option<&'a InferredType>,
+    }
+    impl<'a> Visitor<'a> for Finder<'a> {
+        fn visit_expr(&mut self, e: &'a Expression) {
+            if self.found.is_some() {
+                return;
+            }
+            if let Expression::MessageSend { selector, span, .. } = e {
                 let this_sel = match selector {
                     MessageSelector::Unary(s) | MessageSelector::Binary(s) => s.to_string(),
                     MessageSelector::Keyword(parts) => {
                         parts.iter().map(|p| p.keyword.as_str()).collect::<String>()
                     }
                 };
-                if this_sel == selector_name {
-                    return type_map.get(*span);
+                if this_sel == self.selector_name {
+                    // Match: capture the outermost send's type. Intentionally
+                    // do NOT descend into receiver/arguments — tests want the
+                    // outermost `ifNil:ifNotNil:` send, not a matching send
+                    // buried inside its arguments.
+                    self.found = self.type_map.get(*span);
+                    return;
                 }
-                if let Some(t) = walk_expr(receiver, type_map, selector_name) {
-                    return Some(t);
-                }
-                for a in arguments {
-                    if let Some(t) = walk_expr(a, type_map, selector_name) {
-                        return Some(t);
-                    }
-                }
-                None
             }
-            Expression::Return { value, .. }
-            | Expression::Parenthesized {
-                expression: value, ..
-            }
-            | Expression::Assignment { value, .. } => walk_expr(value, type_map, selector_name),
-            Expression::Block(block) => block
-                .body
-                .iter()
-                .find_map(|s| walk_expr(&s.expression, type_map, selector_name)),
-            _ => None,
+            walk_expr(self, e);
+        }
+        fn visit_block(&mut self, block: &'a crate::ast::Block) {
+            // Opt-in descent: tests want to see into nested blocks.
+            walk_block(self, block);
         }
     }
+
+    let mut finder = Finder {
+        type_map,
+        selector_name,
+        found: None,
+    };
     for class in &module.classes {
         for method in &class.methods {
             for stmt in &method.body {
-                if let Some(t) = walk_expr(&stmt.expression, type_map, selector_name) {
-                    return Some(t);
+                finder.visit_expr(&stmt.expression);
+                if finder.found.is_some() {
+                    return finder.found;
                 }
             }
         }
     }
-    None
+    finder.found
 }
 
 /// Minimal repro from the BT-2047 issue: `self.snapshot ifNil: [42] ifNotNil:

--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -61,11 +61,24 @@
         "raise",
         "throw"
       ],
-      "source": "// Compile error: missing error: arm\nr match: [Result ok: v -> v + 1]\n\n// Fine: all variants covered\nr match: [Result ok: v -> v + 1; Result error: _ -> 0]\n\n// Fine: wildcard suppresses the check\nr match: [Result ok: v -> v + 1; _ -> 0]",
+      "source": "// Basic match with literals\nx match: [1 -> \"one\"; 2 -> \"two\"; _ -> \"other\"]\n\n// Variable binding in patterns\n42 match: [n -> n + 1]\n// => 43\n\n// Symbol matching\nstatus match: [#ok -> \"success\"; #error -> \"failure\"; _ -> \"unknown\"]\n\n// String matching\ngreeting match: [\"hello\" -> \"hi\"; _ -> \"huh?\"]\n\n// Guard clauses with when:\nx match: [\n  n when: [n > 100] -> \"big\";\n  n when: [n > 10] -> \"medium\";\n  _ -> \"small\"\n]\n\n// Negative number patterns\ntemp match: [-1 -> \"minus one\"; 0 -> \"zero\"; _ -> \"other\"]\n\n// Match on computed expression\n(3 + 4) match: [7 -> \"correct\"; _ -> \"wrong\"]\n\n// Array destructuring in match arms (BT-1296)\n#[10, 20] match: [\n  #[h, t] -> h + t;\n  _ -> 0\n]\n// => 30\n\n// Dict/map destructuring in match arms (BT-1296)\n#{#event => \"click\", #x => 5} match: [\n  #{#event => evName} -> evName;\n  _ -> \"unknown\"\n]\n// => \"click\"\n\n// Nested array patterns\n#[#[1, 2], 3] match: [\n  #[#[a, b], c] -> a + b + c;\n  _ -> 0\n]\n// => 6\n\n// Constructor patterns (Result ok:/error: only in this release)\n(Result ok: 42) match: [\n  Result ok: v    -> v;\n  Result error: _ -> 0\n]\n// => 42",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
       "id": "docs-beamtalk-language-features-block-101",
+      "title": "Match Expression (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features",
+        "exception",
+        "raise",
+        "throw"
+      ],
+      "source": "// Compile error: missing error: arm\nr match: [Result ok: v -> v + 1]\n\n// Fine: all variants covered\nr match: [Result ok: v -> v + 1; Result error: _ -> 0]\n\n// Fine: wildcard suppresses the check\nr match: [Result ok: v -> v + 1; _ -> 0]",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-102",
       "title": "Destructuring in Match Arms (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -80,7 +93,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-102",
+      "id": "docs-beamtalk-language-features-block-103",
       "title": "Rest Patterns in Destructuring (BT-1251) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -95,7 +108,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-103",
+      "id": "docs-beamtalk-language-features-block-104",
       "title": "Live Patching (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -131,7 +144,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-104",
+      "id": "docs-beamtalk-language-features-block-105",
       "title": "Extension Methods (Open Classes) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -145,7 +158,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-105",
+      "id": "docs-beamtalk-language-features-block-106",
       "title": "Type annotations on extensions (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -166,7 +179,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-106",
+      "id": "docs-beamtalk-language-features-block-107",
       "title": "Beamtalk — System reflection (BeamtalkInterface) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -176,7 +189,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-107",
+      "id": "docs-beamtalk-language-features-block-108",
       "title": "Workspace — Project operations (WorkspaceInterface) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -191,7 +204,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-108",
+      "id": "docs-beamtalk-language-features-block-109",
       "title": "Class-based reload via Behaviour >> reload (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -201,16 +214,6 @@
         "throw"
       ],
       "source": "Counter sourceFile\n// => \"examples/counter.bt\"\n\nCounter reload\n// => Counter  (recompiled and hot-swapped)\n\nInteger sourceFile\n// => nil  (stdlib built-in, no source file)\n\nInteger reload\n// => Error: Integer has no source file — stdlib classes cannot be reloaded",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-109",
-      "title": "Tracing Lifecycle (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features"
-      ],
-      "source": "// Enable detailed trace capture\nTracing enable\n// => nil\n\n// Check if tracing is active\nTracing isEnabled\n// => true\n\n// Disable trace capture (aggregates continue)\nTracing disable\n// => nil\n\n// Clear all trace events and aggregate stats\nTracing clear\n// => nil",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -230,6 +233,16 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-110",
+      "title": "Tracing Lifecycle (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features"
+      ],
+      "source": "// Enable detailed trace capture\nTracing enable\n// => nil\n\n// Check if tracing is active\nTracing isEnabled\n// => true\n\n// Disable trace capture (aggregates continue)\nTracing disable\n// => nil\n\n// Clear all trace events and aggregate stats\nTracing clear\n// => nil",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-111",
       "title": "Aggregate Stats (Always-On) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -244,7 +257,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-111",
+      "id": "docs-beamtalk-language-features-block-112",
       "title": "Trace Event Queries (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -262,7 +275,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-112",
+      "id": "docs-beamtalk-language-features-block-113",
       "title": "Analysis Methods (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -277,7 +290,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-113",
+      "id": "docs-beamtalk-language-features-block-114",
       "title": "Live Health (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -292,7 +305,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-114",
+      "id": "docs-beamtalk-language-features-block-115",
       "title": "Configuration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -302,7 +315,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-115",
+      "id": "docs-beamtalk-language-features-block-116",
       "title": "Typical Workflow (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -322,7 +335,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-118",
+      "id": "docs-beamtalk-language-features-block-119",
       "title": "Protected stdlib class names (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -340,27 +353,6 @@
         "value"
       ],
       "source": "// ❌ Compile-time warning: Class name `Integer` conflicts with a stdlib class.\n//    Loading will fail because stdlib class names are protected.\nValue subclass: Integer\n  field: x = 0",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-119",
-      "title": "Protected stdlib class names (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "Integer",
-        "SafeInteger",
-        "beamtalk-language-features",
-        "branch",
-        "conditional",
-        "divSafe:",
-        "extends",
-        "if",
-        "inherit",
-        "inheritance",
-        "object",
-        "subclassing"
-      ],
-      "source": "// ✓ Subclass is fine\nInteger subclass: SafeInteger\n  divSafe: divisor =>\n    divisor == 0 ifTrue: [^0]\n    self / divisor",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -389,7 +381,28 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-124",
+      "id": "docs-beamtalk-language-features-block-120",
+      "title": "Protected stdlib class names (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "Integer",
+        "SafeInteger",
+        "beamtalk-language-features",
+        "branch",
+        "conditional",
+        "divSafe:",
+        "extends",
+        "if",
+        "inherit",
+        "inheritance",
+        "object",
+        "subclassing"
+      ],
+      "source": "// ✓ Subclass is fine\nInteger subclass: SafeInteger\n  divSafe: divisor =>\n    divisor == 0 ifTrue: [^0]\n    self / divisor",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-125",
       "title": "Binary — Byte-Level Data (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -410,7 +423,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-125",
+      "id": "docs-beamtalk-language-features-block-126",
       "title": "Interval — Arithmetic Sequences (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -426,7 +439,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-126",
+      "id": "docs-beamtalk-language-features-block-127",
       "title": "Bag(E) — Multisets (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -450,7 +463,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-127",
+      "id": "docs-beamtalk-language-features-block-128",
       "title": "Constructors (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -469,7 +482,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-128",
+      "id": "docs-beamtalk-language-features-block-129",
       "title": "Lazy Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -490,19 +503,6 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-129",
-      "title": "Terminal Operations (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features",
-        "filter",
-        "filtering",
-        "where"
-      ],
-      "source": "// Terminal forces computation through the pipeline\n((Stream from: 1) select: [:n | n isEven]) take: 5\n// => [2,4,6,8,10]\n\n(Stream on: #(1, 2, 3, 4)) inject: 0 into: [:sum :n | sum + n]\n// => 10",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
       "id": "docs-beamtalk-language-features-block-13",
       "title": "Reflection (beamtalk-language-features)",
       "category": "language-reference",
@@ -519,6 +519,19 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-130",
+      "title": "Terminal Operations (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features",
+        "filter",
+        "filtering",
+        "where"
+      ],
+      "source": "// Terminal forces computation through the pipeline\n((Stream from: 1) select: [:n | n isEven]) take: 5\n// => [2,4,6,8,10]\n\n(Stream on: #(1, 2, 3, 4)) inject: 0 into: [:sum :n | sum + n]\n// => 10",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-131",
       "title": "printString — Pipeline Inspection (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -534,7 +547,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-131",
+      "id": "docs-beamtalk-language-features-block-132",
       "title": "Eager vs Lazy — The Boundary (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -547,7 +560,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-132",
+      "id": "docs-beamtalk-language-features-block-133",
       "title": "File Streaming (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -566,7 +579,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-133",
+      "id": "docs-beamtalk-language-features-block-134",
       "title": "File I/O and Directory Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -576,7 +589,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-134",
+      "id": "docs-beamtalk-language-features-block-135",
       "title": "Side-Effect Timing ⚠️ (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -594,7 +607,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-135",
+      "id": "docs-beamtalk-language-features-block-136",
       "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -609,7 +622,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-136",
+      "id": "docs-beamtalk-language-features-block-137",
       "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -619,7 +632,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-137",
+      "id": "docs-beamtalk-language-features-block-138",
       "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -647,7 +660,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-140",
+      "id": "docs-beamtalk-language-features-block-141",
       "title": "Creating a Table (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -670,7 +683,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-141",
+      "id": "docs-beamtalk-language-features-block-142",
       "title": "Reading and Writing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -680,7 +693,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-142",
+      "id": "docs-beamtalk-language-features-block-143",
       "title": "Other Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -690,7 +703,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-143",
+      "id": "docs-beamtalk-language-features-block-144",
       "title": "Cross-Actor Sharing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -713,7 +726,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-145",
+      "id": "docs-beamtalk-language-features-block-146",
       "title": "Enqueueing and Dequeueing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -728,7 +741,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-146",
+      "id": "docs-beamtalk-language-features-block-147",
       "title": "Other Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -738,7 +751,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-148",
+      "id": "docs-beamtalk-language-features-block-149",
       "title": "Atomic Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -751,7 +764,22 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-149",
+      "id": "docs-beamtalk-language-features-block-15",
+      "title": "Equality (lowest precedence) (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "assign",
+        "assignment",
+        "beamtalk-language-features",
+        "mutate",
+        "mutation",
+        "set"
+      ],
+      "source": "// Short-circuit AND - second block only evaluated if first is true\nresult := condition and: [self expensiveCheck]\n\n// Short-circuit OR - second block only evaluated if first is false  \nresult := condition or: [self fallbackValue]",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-150",
       "title": "Cross-Actor Sharing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -774,22 +802,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-15",
-      "title": "Equality (lowest precedence) (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "assign",
-        "assignment",
-        "beamtalk-language-features",
-        "mutate",
-        "mutation",
-        "set"
-      ],
-      "source": "// Short-circuit AND - second block only evaluated if first is true\nresult := condition and: [self expensiveCheck]\n\n// Short-circuit OR - second block only evaluated if first is false  \nresult := condition or: [self fallbackValue]",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-150",
+      "id": "docs-beamtalk-language-features-block-151",
       "title": "TestCase — BUnit Testing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -812,7 +825,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-151",
+      "id": "docs-beamtalk-language-features-block-152",
       "title": "TestCase — BUnit Testing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -835,7 +848,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-152",
+      "id": "docs-beamtalk-language-features-block-153",
       "title": "Suite-Level Setup — setUpOnce / tearDownOnce (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -866,7 +879,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-153",
+      "id": "docs-beamtalk-language-features-block-154",
       "title": "Parallel Test Execution (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1238,6 +1251,25 @@
         "unless"
       ],
       "source": "// Before (Tuple-based, pre-ADR-0076 — FFI returned raw Tuples):\nresult := Erlang file read_file: path\nresult isOk ifTrue: [result unwrap] ifFalse: [\"error\"]  // Tuple methods\n\n// After (Result-based):\nresult := Erlang file read_file: path\nresult ifOk: [:content | content] ifError: [:e | \"error\"]\n// Or simply:\nresult value  // raises on error",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-31",
+      "title": "Erlang FFI (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features",
+        "exception",
+        "for each",
+        "for-each",
+        "forEach",
+        "iterate",
+        "iteration",
+        "loop",
+        "raise",
+        "throw"
+      ],
+      "source": "[Erlang erlang error: #badarg] on: BEAMError do: [:e | e message]\n// => \"badarg\"\n// e is typed as BEAMError — `e message` type-checks without warnings",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -1656,6 +1688,21 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-62",
+      "title": "Conditional Return Type Inference (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "assign",
+        "assignment",
+        "beamtalk-language-features",
+        "mutate",
+        "mutation",
+        "set"
+      ],
+      "source": "name :: String | nil := dictionary at: \"name\"\nresult := name ifNil: [\"unknown\"] ifNotNil: [:n | n size]\n// result is inferred as String | Integer\n\nvalue := name ifNil: [^nil] ifNotNil: [:n | n]\n// value is inferred as String (nil branch contributes Never, skipped)",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-63",
       "title": "Union + Narrowing Compose (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1673,7 +1720,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-63",
+      "id": "docs-beamtalk-language-features-block-64",
       "title": "Local Variable Mutations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1694,7 +1741,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-64",
+      "id": "docs-beamtalk-language-features-block-65",
       "title": "Field Mutations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1727,7 +1774,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-66",
+      "id": "docs-beamtalk-language-features-block-67",
       "title": "What Works and What Doesn't (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1742,7 +1789,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-68",
+      "id": "docs-beamtalk-language-features-block-69",
       "title": "Error Messages (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1798,7 +1845,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-72",
+      "id": "docs-beamtalk-language-features-block-73",
       "title": "Custom Timeouts (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1822,7 +1869,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-73",
+      "id": "docs-beamtalk-language-features-block-74",
       "title": "Caller-Process Class Method Dispatch (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1832,7 +1879,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-74",
+      "id": "docs-beamtalk-language-features-block-75",
       "title": "Actor-to-Actor Coordination (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1842,7 +1889,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-75",
+      "id": "docs-beamtalk-language-features-block-76",
       "title": "Actor-to-Actor Coordination (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1852,7 +1899,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-76",
+      "id": "docs-beamtalk-language-features-block-77",
       "title": "Defining a Server (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1881,7 +1928,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-78",
+      "id": "docs-beamtalk-language-features-block-79",
       "title": "Timer Lifecycle (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1939,7 +1986,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-80",
+      "id": "docs-beamtalk-language-features-block-81",
       "title": "Static Supervisor (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1960,7 +2007,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-81",
+      "id": "docs-beamtalk-language-features-block-82",
       "title": "Static Supervisor (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1978,7 +2025,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-82",
+      "id": "docs-beamtalk-language-features-block-83",
       "title": "Class-Side Configuration Defaults (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2001,7 +2048,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-83",
+      "id": "docs-beamtalk-language-features-block-84",
       "title": "Actor Supervision Policy (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2026,7 +2073,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-86",
+      "id": "docs-beamtalk-language-features-block-87",
       "title": "SupervisionSpec — Per-Child Overrides (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2047,7 +2094,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-88",
+      "id": "docs-beamtalk-language-features-block-89",
       "title": "Dynamic Supervisor (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2091,7 +2138,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-90",
+      "id": "docs-beamtalk-language-features-block-91",
       "title": "Nested Supervisors (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2109,7 +2156,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-91",
+      "id": "docs-beamtalk-language-features-block-92",
       "title": "Call-site patterns (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2124,7 +2171,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-93",
+      "id": "docs-beamtalk-language-features-block-94",
       "title": "Call-site patterns (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2143,7 +2190,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-94",
+      "id": "docs-beamtalk-language-features-block-95",
       "title": "Actor Named Registration (ADR 0079) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2166,7 +2213,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-96",
+      "id": "docs-beamtalk-language-features-block-97",
       "title": "Before named registration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2194,7 +2241,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-97",
+      "id": "docs-beamtalk-language-features-block-98",
       "title": "After named registration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2216,7 +2263,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-98",
+      "id": "docs-beamtalk-language-features-block-99",
       "title": "Proxy Semantics (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2234,19 +2281,6 @@
         "supervision"
       ],
       "source": "engine := (WorkflowEngine named: #workflowEngine) unwrap\nengine runWorkflow: w1    // resolves #workflowEngine, sends to that pid\n// (#workflowEngine crashes; the supervisor restarts it under the same name)\nengine runWorkflow: w2    // re-resolves #workflowEngine, sends to the NEW pid",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-99",
-      "title": "Match Expression (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features",
-        "exception",
-        "raise",
-        "throw"
-      ],
-      "source": "// Basic match with literals\nx match: [1 -> \"one\"; 2 -> \"two\"; _ -> \"other\"]\n\n// Variable binding in patterns\n42 match: [n -> n + 1]\n// => 43\n\n// Symbol matching\nstatus match: [#ok -> \"success\"; #error -> \"failure\"; _ -> \"unknown\"]\n\n// String matching\ngreeting match: [\"hello\" -> \"hi\"; _ -> \"huh?\"]\n\n// Guard clauses with when:\nx match: [\n  n when: [n > 100] -> \"big\";\n  n when: [n > 10] -> \"medium\";\n  _ -> \"small\"\n]\n\n// Negative number patterns\ntemp match: [-1 -> \"minus one\"; 0 -> \"zero\"; _ -> \"other\"]\n\n// Match on computed expression\n(3 + 4) match: [7 -> \"correct\"; _ -> \"wrong\"]\n\n// Array destructuring in match arms (BT-1296)\n#[10, 20] match: [\n  #[h, t] -> h + t;\n  _ -> 0\n]\n// => 30\n\n// Dict/map destructuring in match arms (BT-1296)\n#{#event => \"click\", #x => 5} match: [\n  #{#event => evName} -> evName;\n  _ -> \"unknown\"\n]\n// => \"click\"\n\n// Nested array patterns\n#[#[1, 2], 3] match: [\n  #[#[a, b], c] -> a + b + c;\n  _ -> 0\n]\n// => 6\n\n// Constructor patterns (Result ok:/error: only in this release)\n(Result ok: 42) match: [\n  Result ok: v    -> v;\n  Result error: _ -> 0\n]\n// => 42",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {


### PR DESCRIPTION
## Summary

- Introduces `ast::visitor::Visitor` trait + exhaustive `walk_expr` / `walk_block` helpers in `beamtalk-core` with **opaque-block default recursion**, matching BT-2050/BT-2051 narrowing semantics (inert block literals are values, not control flow).
- Re-expresses the three structurally-recursive walkers in `type_checker/narrowing/` + the BT-2047 test helper as `Visitor` impls, deleting the hand-rolled match arms that repeatedly under-covered variants (`DestructureAssignment`, `Match`, `MapLiteral`, `ListLiteral`, `ArrayLiteral`, …).
- Second commit regenerates `crates/beamtalk-examples/corpus.json` — pre-existing drift from #2100 (daily refresh didn't rebuild the corpus), unrelated to BT-2063 but needed for `just check-corpus` to pass.

## Design

- `Visitor::visit_block` default is a no-op — the opacity rule from BT-2050/BT-2051 is preserved automatically. Opt-in descent via override (used by `find_send_inferred_ty`, which needs to find sends buried anywhere in the AST).
- `walk_expr` covers every `Expression` variant explicitly with no `_` catch-all; adding a new variant is a compile error at one site. Verified by temporarily adding a `Bt2063Probe` variant — got 18 compile errors across all call sites — and reverting.
- `block_has_return`, `block_may_reassign`, and `extract_variable_name` deliberately stay outside the visitor framework: they are top-level scans / shape destructors, not structural walkers, and changing them to recurse would alter the soundness story for post-guard narrowing. Decisions documented inline per the issue's AC.
- Sits side-by-side with the existing `ast_walker::walk_expression` (lint/validator passes, descend-by-default) — each walker serves its audience.

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 3233 passing, 0 failures
- [x] `just clippy` clean
- [x] `just fmt` no changes
- [x] `just ci` — all test suites green (Rust, stdlib, BUnit, runtime, workspace, MCP, e2e); `check-corpus` green after commit 2
- [x] New-variant compile-error check: temporarily added a bogus `Expression::Bt2063Probe` variant — `walk_expr` correctly refused to compile — reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Match Expression documentation with comprehensive pattern examples covering literals, bindings, guards, destructuring, and nested patterns.
  * Added documentation for Erlang FFI integration.
  * Added documentation for Conditional Return Type Inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->