### PR TITLE
Promote and:/or: note to its own heading (BT-2068)

### DIFF
--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -765,7 +765,7 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-15",
-      "title": "Equality (lowest precedence) (beamtalk-language-features)",
+      "title": "Short-circuit boolean operators (and:/or:) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
         "assign",

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -461,7 +461,9 @@ Binary operators follow standard math precedence (highest to lowest):
 - `=/=` - Strict inequality (Erlang `=/=`): `5 =/= 6` → `true`
 - `=` - Legacy alias for `=:=` (strict equality). Prefer `=:=` instead. `beamtalk lint` warns on `x = true` / `x = false`.
 
-**Note on `and`/`or`:** These are **not** binary operators. They are keyword messages that take blocks for short-circuit evaluation:
+#### Short-circuit boolean operators (`and:`/`or:`)
+
+`and` and `or` are **not** binary operators. They are keyword messages that take blocks for short-circuit evaluation:
 ```beamtalk
 // Short-circuit AND - second block only evaluated if first is true
 result := condition and: [self expensiveCheck]


### PR DESCRIPTION
## Summary

The corpus extractor groups beamtalk code blocks under the nearest `####` heading. The short-circuit `and:`/`or:` example in `docs/beamtalk-language-features.md` sat under `#### Equality (lowest precedence)`, so corpus entry `docs-beamtalk-language-features-block-15` was titled "Equality" while its source was the boolean-operator example (flagged by CodeRabbit on #2102).

Fix per issue Option 1: promote the note to its own `####` heading — smallest docs change, correct categorisation, idempotent under `just build-corpus`.

## Changes

- `docs/beamtalk-language-features.md`: promote `**Note on and/or:**` paragraph to `#### Short-circuit boolean operators (and:/or:)`.
- `crates/beamtalk-examples/corpus.json`: regenerated — single-line title change.

## Acceptance criteria

- [x] Source restructured so the `and:/or:` snippet has a title that reflects its content, not "Equality".
- [x] `just build-corpus && just check-corpus` clean.
- [x] Spot-checked other generated entries — no similar heading/snippet drift.

## Linear

https://linear.app/beamtalk/issue/BT-2068

## Test plan

- [x] `just ci` — all stages green except check-corpus (expected: dirty tree pre-commit); clean after commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added explicit section on short-circuit boolean operators (`and:`/`or:`) with clarified explanations of operator semantics and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->