### PR TITLE
Migrate narrowing rules + state_threading_selectors to WellKnownSelector enum (BT-2070)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/class_eq.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/class_eq.rs
@@ -5,7 +5,7 @@
 //!
 //! Also handles `(x class) = ClassName` via a parenthesized-unwrap.
 
-use crate::ast::{Expression, MessageSelector};
+use crate::ast::{Expression, MessageSelector, WellKnownSelector};
 use crate::semantic_analysis::type_checker::InferredType;
 
 use super::super::extract::extract_variable_name;
@@ -34,13 +34,13 @@ fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
     };
     let Expression::MessageSend {
         receiver: var_expr,
-        selector: MessageSelector::Unary(sel),
+        selector,
         ..
     } = class_send
     else {
         return None;
     };
-    if sel.as_str() != "class" {
+    if selector.well_known() != Some(WellKnownSelector::Class) {
         return None;
     }
     let var_name = extract_variable_name(var_expr)?;

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_kind_of.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_kind_of.rs
@@ -3,7 +3,7 @@
 
 //! `x isKindOf: ClassName` narrowing (BT-1573 Phase 1g).
 
-use crate::ast::{Expression, MessageSelector};
+use crate::ast::{Expression, WellKnownSelector};
 use crate::semantic_analysis::type_checker::InferredType;
 
 use super::super::extract::extract_variable_name;
@@ -15,14 +15,14 @@ pub(super) const RULE: NarrowingRule = NarrowingRule { detect };
 fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
     let Expression::MessageSend {
         receiver: inner_recv,
-        selector: MessageSelector::Keyword(parts),
+        selector,
         arguments,
         ..
     } = receiver
     else {
         return None;
     };
-    if !(parts.len() == 1 && parts[0].keyword == "isKindOf:") {
+    if selector.well_known() != Some(WellKnownSelector::IsKindOf) {
         return None;
     }
     let var_name = extract_variable_name(inner_recv)?;

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_nil.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_nil.rs
@@ -10,7 +10,7 @@
 //! Supports `x isNil` and `self.field isNil` (BT-2048 synthetic key path via
 //! [`extract_variable_name`]).
 
-use crate::ast::{Expression, MessageSelector};
+use crate::ast::{Expression, WellKnownSelector};
 use crate::semantic_analysis::type_checker::InferredType;
 use crate::semantic_analysis::type_checker::well_known::WellKnownClass;
 
@@ -23,13 +23,13 @@ pub(super) const RULE: NarrowingRule = NarrowingRule { detect };
 fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
     let Expression::MessageSend {
         receiver: inner_recv,
-        selector: MessageSelector::Unary(sel),
+        selector,
         ..
     } = receiver
     else {
         return None;
     };
-    if sel.as_str() != "isNil" {
+    if selector.well_known() != Some(WellKnownSelector::IsNil) {
         return None;
     }
     let var_name = extract_variable_name(inner_recv)?;

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_result.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_result.rs
@@ -7,7 +7,7 @@
 //! are filled in by `refine_result_narrowing` in `inference.rs` once the
 //! variable's current type is resolved from the environment.
 
-use crate::ast::{Expression, MessageSelector};
+use crate::ast::{Expression, MessageSelector, WellKnownSelector};
 use crate::semantic_analysis::type_checker::{DynamicReason, InferredType};
 
 use super::super::extract::extract_variable_name;
@@ -25,29 +25,48 @@ pub(super) const IS_ERROR_RULE: NarrowingRule = NarrowingRule {
 };
 
 fn detect_is_ok_or_ok(receiver: &Expression) -> Option<NarrowingInfo> {
-    detect_unary(receiver, &["isOk", "ok"], /* is_error */ false)
-}
-
-fn detect_is_error(receiver: &Expression) -> Option<NarrowingInfo> {
-    detect_unary(receiver, &["isError"], /* is_error */ true)
-}
-
-fn detect_unary(
-    receiver: &Expression,
-    selectors: &[&str],
-    is_error: bool,
-) -> Option<NarrowingInfo> {
     let Expression::MessageSend {
         receiver: inner_recv,
-        selector: MessageSelector::Unary(sel),
+        selector,
         ..
     } = receiver
     else {
         return None;
     };
-    if !selectors.iter().any(|s| *s == sel.as_str()) {
+    // `isOk` is a well-known selector; `ok` is a bare unary selector that is
+    // not (and deliberately is not) part of `WellKnownSelector` because it is
+    // also a legitimate user-defined selector on many receivers. We only
+    // narrow when shape is unambiguous (unary send with receiver being a
+    // variable-shaped expression) — `refine_result_narrowing` later checks
+    // the receiver's declared type and drops the narrowing if it isn't a
+    // Result.
+    let is_ok = match selector.well_known() {
+        Some(WellKnownSelector::IsOk) => true,
+        None => matches!(selector, MessageSelector::Unary(sel) if sel.as_str() == "ok"),
+        _ => false,
+    };
+    if !is_ok {
         return None;
     }
+    build_info(inner_recv, /* is_error */ false)
+}
+
+fn detect_is_error(receiver: &Expression) -> Option<NarrowingInfo> {
+    let Expression::MessageSend {
+        receiver: inner_recv,
+        selector,
+        ..
+    } = receiver
+    else {
+        return None;
+    };
+    if selector.well_known() != Some(WellKnownSelector::IsError) {
+        return None;
+    }
+    build_info(inner_recv, /* is_error */ true)
+}
+
+fn build_info(inner_recv: &Expression, is_error: bool) -> Option<NarrowingInfo> {
     let var_name = extract_variable_name(inner_recv)?;
     Some(NarrowingInfo {
         variable: var_name,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/responds_to.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/responds_to.rs
@@ -7,7 +7,7 @@
 //! `inference.rs` consults the protocol registry and upgrades to a concrete
 //! protocol type when exactly one protocol requires the tested selector.
 
-use crate::ast::{Expression, Literal, MessageSelector};
+use crate::ast::{Expression, Literal, WellKnownSelector};
 use crate::semantic_analysis::type_checker::{DynamicReason, InferredType};
 
 use super::super::extract::extract_variable_name;
@@ -19,14 +19,14 @@ pub(super) const RULE: NarrowingRule = NarrowingRule { detect };
 fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
     let Expression::MessageSend {
         receiver: inner_recv,
-        selector: MessageSelector::Keyword(parts),
+        selector,
         arguments,
         ..
     } = receiver
     else {
         return None;
     };
-    if !(parts.len() == 1 && parts[0].keyword == "respondsTo:") {
+    if selector.well_known() != Some(WellKnownSelector::RespondsTo) {
         return None;
     }
     let var_name = extract_variable_name(inner_recv)?;

--- a/crates/beamtalk-core/src/state_threading_selectors.rs
+++ b/crates/beamtalk-core/src/state_threading_selectors.rs
@@ -5,6 +5,18 @@
 //!
 //! Used by both `semantic_analysis` (for `DispatchKind::ControlFlow` classification)
 //! and `codegen` (for block-mutation analysis and state-threading code generation).
+//!
+//! Predicates in this module classify selectors for block-mutation analysis.
+//! Where a selector is also part of [`WellKnownSelector`](crate::ast::WellKnownSelector)
+//! — conditionals, `on:do:` — the predicate matches on the enum via
+//! [`WellKnownSelector::from_name`] so a typo in either place is a compile
+//! error at the call site. Loop and iteration selectors (`whileTrue:`, `do:`,
+//! `collect:`, etc.) are not classified as well-known and so remain matched
+//! by string; the split is deliberate — `WellKnownSelector` is reserved for
+//! selectors the type-checker/codegen *intrinsify*, not every selector the
+//! compiler happens to recognise.
+
+use crate::ast::WellKnownSelector;
 
 /// Returns `true` if `sel` is a state-threading keyword selector.
 ///
@@ -12,6 +24,18 @@
 /// as part of state-threading control flow.
 #[must_use]
 pub(crate) fn is_state_threading_keyword_selector(sel: &str) -> bool {
+    if matches!(
+        WellKnownSelector::from_name(sel),
+        Some(
+            WellKnownSelector::OnDo
+                | WellKnownSelector::IfTrue
+                | WellKnownSelector::IfFalse
+                | WellKnownSelector::IfTrueIfFalse
+                | WellKnownSelector::IfNotNil,
+        )
+    ) {
+        return true;
+    }
     matches!(
         sel,
         "whileTrue:"
@@ -37,12 +61,7 @@ pub(crate) fn is_state_threading_keyword_selector(sel: &str) -> bool {
             | "inject:into:"
             | "doWithKey:"
             | "keysAndValuesDo:"
-            | "on:do:"
             | "ensure:"
-            | "ifTrue:"
-            | "ifFalse:"
-            | "ifTrue:ifFalse:"
-            | "ifNotNil:"
     )
 }
 
@@ -58,7 +77,12 @@ pub(crate) fn is_state_threading_unary_selector(sel: &str) -> bool {
 /// analysed for field mutations, in addition to the argument blocks.
 #[must_use]
 pub(crate) fn is_exception_selector(sel: &str) -> bool {
-    matches!(sel, "on:do:" | "ensure:")
+    // `on:do:` is a well-known selector; `ensure:` is not (it's not
+    // intrinsified by the type-checker, only by codegen's state-threading).
+    matches!(
+        WellKnownSelector::from_name(sel),
+        Some(WellKnownSelector::OnDo)
+    ) || sel == "ensure:"
 }
 
 /// Returns `true` if `sel` is a Boolean/optional conditional selector.
@@ -68,8 +92,13 @@ pub(crate) fn is_exception_selector(sel: &str) -> bool {
 #[must_use]
 pub(crate) fn is_conditional_selector(sel: &str) -> bool {
     matches!(
-        sel,
-        "ifTrue:" | "ifFalse:" | "ifTrue:ifFalse:" | "ifNotNil:"
+        WellKnownSelector::from_name(sel),
+        Some(
+            WellKnownSelector::IfTrue
+                | WellKnownSelector::IfFalse
+                | WellKnownSelector::IfTrueIfFalse
+                | WellKnownSelector::IfNotNil,
+        )
     )
 }
 


### PR DESCRIPTION
## Summary

- Type-checker narrowing rules (`is_nil`, `is_kind_of`, `is_result`, `responds_to`, `class_eq`) now match on `selector.well_known()` instead of string literals. Typos become compile errors at every rule site.
- `state_threading_selectors` predicates (`is_state_threading_keyword_selector`, `is_exception_selector`, `is_conditional_selector`) are re-expressed in terms of `WellKnownSelector` for the overlapping set (conditionals, `on:do:`); loop/iteration selectors not modelled by `WellKnownSelector` remain a string match with a comment explaining the split.
- Pure refactor — narrowing and state-threading semantics are unchanged.

Linear: https://linear.app/beamtalk/issue/BT-2070

## Acceptance criteria

- [x] Each rule under `crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/*` matches on `selector.well_known()`.
- [x] `state_threading_selectors.rs` predicates routed through `WellKnownSelector::from_name` for the variants the enum models.
- [x] Narrowing string-literal grep returns 0: `rg '"isNil"|"isKindOf:"|"respondsTo:"|"isOk"|"isError"' crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/`
- [x] Existing test suites pass unchanged (337 unit + 250 stdlib + 1899 BUnit + 3485/1242 runtime).
- [x] No behaviour changes.

Note on `"ok"`: the bare `ok` selector in `is_result.rs` is kept as a string fallback — it's not a well-known selector (and shouldn't be; it also names legitimate user selectors).

## Test plan

- [x] `just build` passes
- [x] `just test` passes
- [x] `just clippy` passes
- [x] `just fmt-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to selector matching logic for more consistent and maintainable type checking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->