### PR TITLE
docs: daily refresh 2026-04-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Fix MCP `lint` tool producing different diagnostics from CLI `beamtalk lint` for cross-file type/DNU issues (BT-2052).
 - MCP `lint` tool now surfaces warning diagnostics when package files are unreadable during cross-file class extraction (BT-2056).
 - Preserve `startup.log` on final workspace retry failure so error diagnostics referencing the file remain valid (BT-2057).
+- MCP `lint` tool now surfaces error diagnostics when direct target files are unreadable, instead of returning a deceptively clean zero-files-checked result (BT-2067).
 
 ### Documentation
 
@@ -99,6 +100,8 @@
 - Unify workspace retry helpers into single parameterized `retry_with_cleanup` wrapper (BT-2058).
 - Replace erlfmt inline Erlang eval strings with structured `ErlangEval` builder (BT-2059).
 - Share package-root resolution between MCP lint and CLI lint via `project::package` module (BT-2060).
+- `WellKnownSelector` enum replaces fragile selector-name string comparisons across narrowing rules, codegen intrinsic dispatch, lint validators, and state-threading predicates (BT-2065 epic: BT-2069, BT-2070, BT-2071, BT-2072).
+- Generic `Visitor` trait with exhaustive `walk_expr` replaces hand-rolled AST walkers in narrowing and type inference (BT-2063).
 
 ## 0.3.1 — 2026-03-26
 


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 8 commits merged to main in the last 24 hours.

**Docs updated:**
- `CHANGELOG.md` — 1 Tooling entry, 2 Internal entries

## Commits reviewed

### Tooling (CHANGELOG)
- `91f33c4` BT-2067 — MCP lint: surface unreadable target files as error diagnostics

### Internal (CHANGELOG)
- `a90a5ec` BT-2069 — Add WellKnownSelector enum + classifier
- `b426ef8` BT-2070 — Migrate narrowing rules + state_threading_selectors to WellKnownSelector
- `5c0b66a` BT-2071 — Migrate codegen intrinsic dispatch to WellKnownSelector
- `9b14cd3` BT-2072 — Migrate lint to WellKnownSelector
- `827c072` BT-2063 — Generic Visitor trait replacing hand-rolled AST walkers

### Skipped
- `d55949c` BT-2068 — Docs change itself (promoted and:/or: note to own heading); no further doc action needed
- `fd2b330` — Previous daily refresh (2026-04-24)

## Notes

Light day for user-facing changes — all commits are either pure internal refactors (WellKnownSelector epic, Visitor trait) or tooling bug fixes (MCP lint error surfacing). No language feature, stdlib, or runtime behavior changes requiring doc updates beyond CHANGELOG entries.

https://claude.ai/code/session_015k6HRSoxbxg7njCbLWs3Tp

---
_Generated by [Claude Code](https://claude.ai/code/session_015k6HRSoxbxg7njCbLWs3Tp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The MCP `lint` tool now generates error diagnostics when it encounters unreadable target files, instead of displaying a misleading "zero files checked" success message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->