### PR TITLE
Surface parity map: docs/development/surface-parity.md (BT-2075)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Beamtalk is a Smalltalk/Newspeak-inspired language compiling to BEAM via Rust. T
 - **REPL output:** Before changing any REPL display value, prompt format, or output behaviour, confirm with the user — existing output is usually intentional and covered by e2e tests. Do not "fix" output that looks wrong without checking first.
 - **Test assertions:** Every expression in test files MUST have a `// =>` assertion (even `// => _`). No assertion = no execution.
 - **Cross-platform temp paths:** Never hardcode `/tmp/` in tests. Use `File tempDirectory` (BT) or `beamtalk_file:'tempDirectory'()` (Erlang) when an absolute temp path is required, then concatenate: `tmp ++ "/my_file.txt"`. For runtime EUnit tests, prefer relative temp filenames in the rebar3 test working directory when possible. See `docs/development/testing-strategy.md` for details.
+- **Surface parity:** When adding or modifying operations on any surface (CLI, REPL, MCP, LSP), update `docs/development/surface-parity.md`. Any operation not labelled `surface-specific` must produce equivalent output across all surfaces where it appears.
 
 ## CI Commands
 
@@ -95,4 +96,5 @@ Fix inline: formatting/typos in files you're modifying, test failures from your 
 | Erlang guidelines | `docs/development/erlang-guidelines.md` |
 | Common tasks | `docs/development/common-tasks.md` |
 | Debugging | `docs/development/debugging.md` |
+| Surface parity | `docs/development/surface-parity.md` |
 | ADRs | `docs/ADR/` |

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -1,0 +1,181 @@
+# Surface Parity Map
+
+This document tracks which REPL operations are exposed across each Beamtalk surface (CLI, REPL meta-commands, MCP tools, LSP capabilities). It is the single source of truth for identifying gaps and preventing surface drift.
+
+## Parity Contract
+
+Any operation **not** labelled `surface-specific` must produce equivalent output across all surfaces where it appears. "Equivalent" means the same structured data (modulo transport encoding); display formatting may vary per surface.
+
+When adding a new capability to any surface, update this table. If the capability maps to an existing REPL op, add it to the corresponding row. If it is surface-specific, add the reason.
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| **name** | Binding exists (tool/command/handler name shown) |
+| `--` | Not applicable for this surface |
+| `surface-specific: reason` | Intentionally present only on this surface |
+| `MISSING` | Should exist but does not yet |
+
+## Inventory Sources
+
+| Surface | Source of truth |
+|---------|---------------|
+| REPL ops | `describe_ops()` in `beamtalk_repl_ops_dev.erl` + `beamtalk_repl_ops_perf.erl` |
+| CLI subcommands | `Command` enum in `crates/beamtalk-cli/src/main.rs` |
+| REPL meta-commands | `handle_repl_command()` in `crates/beamtalk-cli/src/commands/repl/mod.rs` |
+| MCP tools | `#[tool(...)]` in `crates/beamtalk-mcp/src/server.rs` |
+| LSP capabilities | `ServerCapabilities` in `crates/beamtalk-lsp/src/server.rs` |
+
+## Core Operations
+
+| REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
+|---------|---------------|-------------------|----------|----------------|-------|
+| `eval` | -- | *(implicit: any expression)* | `evaluate` | -- | Core evaluation; CLI uses REPL client, LSP has no eval |
+| `stdin` | -- | *(implicit: interactive input)* | -- | -- | Provides input to a blocked eval; CLI handles interactively |
+| `complete` | -- | *(implicit: tab completion)* | `complete` | `completion` | Autocompletion suggestions |
+| `show-codegen` | -- | `:show-codegen` / `:sc` | `show_codegen` | -- | Show generated Core Erlang |
+| `load-file` | -- | -- | `load_file` | -- | Load a single `.bt` file (deprecated op, use `Workspace load:`) |
+| `load-source` | -- | -- | -- | -- | Load inline source string (used by browser workspace) |
+| `load-project` | -- | `:sync` / `:s` | `load_project` | -- | Sync project files from `beamtalk.toml` |
+| `reload` | -- | -- | `reload_class` | -- | Hot-reload a class (deprecated op, use `ClassName reload`) |
+
+## Session Operations
+
+| REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
+|---------|---------------|-------------------|----------|----------------|-------|
+| `clear` | -- | `:clear` | `clear` | -- | Clear session bindings (deprecated op) |
+| `bindings` | -- | `:bindings` / `:b` | `get_bindings` | -- | List session variable bindings (deprecated op) |
+| `sessions` | -- | -- | -- | -- | List active REPL sessions |
+| `clone` | -- | -- | -- | -- | Create a new session |
+| `close` | -- | `:exit` / `:quit` / `:q` | -- | -- | Close session; `:exit` exits the CLI REPL |
+| `interrupt` | -- | -- | `interrupt` | -- | Cancel a running evaluation |
+
+## Actor Operations
+
+| REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
+|---------|---------------|-------------------|----------|----------------|-------|
+| `actors` | -- | -- | `list_actors` | -- | List running actors |
+| `inspect` | -- | -- | `inspect` | -- | Inspect actor state |
+| `kill` | -- | -- | -- | -- | Terminate an actor |
+
+## Module Operations
+
+| REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
+|---------|---------------|-------------------|----------|----------------|-------|
+| `modules` | -- | -- | -- | -- | List loaded modules (deprecated op, use `Workspace classes`) |
+| `unload` | -- | `:unload <class>` | `unload` | -- | Unload a class from the workspace |
+
+## Test Operations
+
+| REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
+|---------|---------------|-------------------|----------|----------------|-------|
+| `test` | `test` | `:test` / `:t` | `test` | -- | Run BUnit tests (single class or file) |
+| `test-all` | -- | -- | -- | -- | Run all loaded tests |
+
+## Dev / Introspection Operations
+
+| REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
+|---------|---------------|-------------------|----------|----------------|-------|
+| `docs` | -- | -- | `docs` | -- | Class/method documentation (deprecated op, use `Beamtalk help:`) |
+| `methods` | -- | -- | -- | -- | List methods for a class |
+| `list-classes` | -- | -- | `list_classes` | -- | List available classes |
+| `erlang-help` | -- | -- | -- | -- | Erlang module documentation |
+| `erlang-complete` | -- | -- | -- | -- | Erlang module/function completion |
+
+## Performance / Tracing Operations
+
+| REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
+|---------|---------------|-------------------|----------|----------------|-------|
+| `enable-tracing` | -- | -- | `enable_tracing` | -- | Enable actor trace capture |
+| `disable-tracing` | -- | -- | `disable_tracing` | -- | Disable actor trace capture |
+| `get-traces` | -- | -- | `get_traces` | -- | Retrieve captured traces |
+| `actor-stats` | -- | -- | `actor_stats` | -- | Per-actor/method aggregate stats |
+| `export-traces` | -- | -- | `export_traces` | -- | Export traces to JSON file |
+
+## Server Operations
+
+| REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
+|---------|---------------|-------------------|----------|----------------|-------|
+| `describe` | -- | -- | `describe` | -- | Capability discovery (list supported ops) |
+| `health` | -- | -- | -- | -- | Workspace health probe |
+| `shutdown` | `workspace stop` | -- | -- | -- | Graceful workspace shutdown |
+
+## CLI-Only Commands (no REPL op equivalent)
+
+These CLI subcommands are build/tooling commands that operate offline (no workspace needed) and have no corresponding REPL op.
+
+| CLI subcommand | MCP tool | LSP capability | Notes |
+|---------------|----------|----------------|-------|
+| `build` | -- | -- | `surface-specific: offline compiler, no workspace` |
+| `build-stdlib` | -- | -- | `surface-specific: internal stdlib build step` |
+| `run` | -- | -- | `surface-specific: script/service runner` |
+| `new` | -- | -- | `surface-specific: project scaffolding` |
+| `repl` | -- | -- | `surface-specific: starts the REPL client` |
+| `check` | -- | `textDocument/publishDiagnostics` | Offline syntax/type check; LSP provides diagnostics on save |
+| `fmt` | -- | `textDocument/formatting` | Format source files; LSP provides document formatting |
+| `fmt-check` | -- | -- | `surface-specific: CI formatting check` |
+| `lint` | `lint` | -- | Lint checks; MCP exposes for AI-assisted workflows |
+| `test-script` | -- | -- | `surface-specific: btscript expression tests (CI)` |
+| `test-docs` | -- | -- | `surface-specific: doctest runner (CI)` |
+| `doctor` | -- | -- | `surface-specific: environment health check` |
+| `deps add` | -- | -- | `surface-specific: package management` |
+| `deps list` | -- | -- | `surface-specific: package management` |
+| `deps update` | -- | -- | `surface-specific: package management` |
+| `generate native` | -- | -- | `surface-specific: code generation` |
+| `generate stubs` | -- | -- | `surface-specific: code generation` |
+| `doc` | -- | -- | `surface-specific: HTML documentation generator` |
+| `type-coverage` | -- | -- | `surface-specific: type inference coverage stats` |
+| `workspace list` | -- | -- | `surface-specific: workspace management` |
+| `workspace stop` | -- | -- | Maps to `shutdown` REPL op (see Server Operations) |
+| `workspace status` | -- | -- | `surface-specific: workspace management` |
+| `workspace attach` | -- | -- | `surface-specific: attaches REPL to existing workspace` |
+| `workspace transcript` | -- | -- | `surface-specific: streams Transcript output` |
+| `workspace logs` | -- | -- | `surface-specific: workspace log viewer` |
+| `workspace create` | -- | -- | `surface-specific: workspace management` |
+
+## MCP-Only Tools (no REPL op equivalent)
+
+These MCP tools provide AI-assistant-specific capabilities that have no direct REPL op.
+
+| MCP tool | Notes |
+|----------|-------|
+| `diagnostic_summary` | `surface-specific: AI-facing diagnostic overview for a file/package` |
+| `search_examples` | `surface-specific: offline corpus search for code examples` |
+| `search_classes` | `surface-specific: offline class discovery by keyword` |
+| `list_packages` | `surface-specific: list loaded Beamtalk packages` |
+| `package_classes` | `surface-specific: list classes in a named package` |
+
+## LSP-Only Capabilities (no REPL op equivalent)
+
+These LSP capabilities are editor-specific and have no direct REPL op.
+
+| LSP capability | Notes |
+|----------------|-------|
+| `textDocument/hover` | `surface-specific: editor hover information` |
+| `textDocument/signatureHelp` | `surface-specific: editor parameter hints` |
+| `textDocument/definition` | `surface-specific: editor go-to-definition` |
+| `textDocument/references` | `surface-specific: editor find-all-references` |
+| `textDocument/documentSymbol` | `surface-specific: editor outline/breadcrumbs` |
+| `textDocument/rangeFormatting` | `surface-specific: editor format-selection` |
+| `textDocument/codeAction` | `surface-specific: editor quick-fixes and refactorings` |
+| `textDocument/publishDiagnostics` | `surface-specific: editor inline error/warning display` |
+| `textDocument/didOpen` | `surface-specific: editor document lifecycle` |
+| `textDocument/didChange` | `surface-specific: editor document lifecycle` |
+| `textDocument/didClose` | `surface-specific: editor document lifecycle` |
+| `textDocument/didSave` | `surface-specific: editor document lifecycle` |
+
+## REPL Meta-Command Reference
+
+For completeness, the full list of REPL meta-commands and their corresponding REPL ops:
+
+| Meta-command | Aliases | REPL op |
+|-------------|---------|---------|
+| `:exit` | `:quit`, `:q` | `close` |
+| `:help` | `:h`, `:?` | -- (client-side) |
+| `:clear` | -- | `clear` |
+| `:bindings` | `:b` | `bindings` |
+| `:sync` | `:s` | `load-project` |
+| `:unload <class>` | -- | `unload` |
+| `:test` | `:t` | `test` / `test-all` |
+| `:show-codegen` | `:sc` | `show-codegen` |

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -1054,8 +1054,15 @@ Performance regression tests are planned but not yet implemented.
 
 ---
 
+## Surface Parity
+
+When adding or modifying operations across surfaces (CLI, REPL, MCP, LSP), consult the [Surface Parity Map](surface-parity.md) to ensure consistent coverage. Any operation not labelled `surface-specific` must produce equivalent output across all surfaces where it appears.
+
+---
+
 ## References
 
+- [Surface Parity Map](surface-parity.md) - Cross-surface operation coverage matrix
 - [ADR 0014: Beamtalk Test Framework](../ADR/0014-beamtalk-test-framework.md) - Architecture decision for the three-layer test strategy
 - [test-package-compiler/README.md](../../test-package-compiler/README.md) - Snapshot test details
 - [tests/e2e/README.md](../../tests/e2e/README.md) - E2E test framework details


### PR DESCRIPTION
## Summary

Create `docs/development/surface-parity.md` — a single-source-of-truth matrix showing which REPL operations are exposed across each Beamtalk surface (CLI, REPL meta-commands, MCP tools, LSP capabilities).

- Covers all 34 REPL ops, 27 MCP tools, CLI subcommands (including nested workspace/deps/generate), 8 REPL meta-commands, and 12 LSP capabilities
- Each cell is filled with the binding name, `--` (not applicable), or `surface-specific: <reason>`
- Parity contract documented: any op not labelled `surface-specific` must produce equivalent output across surfaces
- Referenced from `CLAUDE.md` Essential Rules and Key References, and `docs/development/testing-strategy.md`

## Linear Issue

https://linear.app/beamtalk/issue/BT-2075

## Test Plan

- [x] All 34 REPL ops verified present in document (automated grep check)
- [x] All 27 MCP tools verified present (automated grep check)
- [x] All CLI subcommands verified present (automated grep check)
- [x] CLAUDE.md and testing-strategy.md references verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established cross-surface parity guidelines to ensure consistent operation behavior and output across CLI, REPL, MCP, and LSP interfaces.
  * Added comprehensive surface parity map documenting operation equivalency across surfaces with exception mechanisms for surface-specific implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->