### PR TITLE
Extend WellKnownSelector to cover remaining selector-universal intrinsics (BT-2073)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"305effe4-cd73-4103-a443-5f0879b8977d","pid":2863488,"procStart":"20095756","acquiredAt":1777105359922}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"305effe4-cd73-4103-a443-5f0879b8977d","pid":2863488,"procStart":"20095756","acquiredAt":1777105359922}

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ _site/
 .claude/bin/
 # Generated hex-bridge rebar config (created by worktree-init.sh)
 runtime/hex_bridge_rebar.config
+.claude/scheduled_tasks.lock

--- a/crates/beamtalk-core/src/ast/well_known.rs
+++ b/crates/beamtalk-core/src/ast/well_known.rs
@@ -87,6 +87,46 @@ pub enum WellKnownSelector {
     IsOkColon,
     /// `isError:` — keyword form for result error testing (reserved for future use).
     IsErrorColon,
+
+    // --- Block loops (Block >> @intrinsic) ---
+    /// `whileTrue:` — evaluate the block argument while the receiver block returns `true`.
+    WhileTrue,
+    /// `whileFalse:` — evaluate the block argument while the receiver block returns `false`.
+    WhileFalse,
+    /// `repeat` — evaluate the receiver block in an infinite loop.
+    Repeat,
+
+    // --- Block cleanup (Block >> @intrinsic) ---
+    /// `ensure:` — evaluate the receiver block, then unconditionally run the cleanup block.
+    Ensure,
+
+    // --- Object universal ---
+    /// `hash` — return an integer hash of the receiver via `erlang:phash2/1`.
+    Hash,
+    /// `error:` — Smalltalk-style error signaling on the receiver.
+    ///
+    /// **Dual-use caveat:** `error:` is also a `Logger` class-side log-level method
+    /// (`Logger error: "boom"`). The well-known interpretation only applies when the
+    /// receiver is *not* a class literal that defines its own class-side `error:`.
+    /// `try_generate_error_signaling` already short-circuits on
+    /// `Expression::ClassReference { .. }`, leaving the `Logger` codegen path intact.
+    Error,
+
+    // --- Object reflection ---
+    /// `fieldAt:` — read an actor instance variable by name.
+    FieldAt,
+    /// `fieldAt:put:` — write an actor instance variable by name.
+    FieldAtPut,
+    /// `fieldNames` — return the list of instance variable names of the receiver.
+    FieldNames,
+
+    // --- ProtoObject dynamic dispatch ---
+    /// `perform:` — send the named selector to the receiver with no arguments.
+    Perform,
+    /// `perform:withArguments:` — send the named selector with an argument list.
+    PerformWithArgs,
+    /// `performLocally:withArguments:` — execute a class method in the caller's process.
+    PerformLocallyWithArgs,
 }
 
 impl WellKnownSelector {
@@ -115,6 +155,18 @@ impl WellKnownSelector {
             Self::IsError => "isError",
             Self::IsOkColon => "isOk:",
             Self::IsErrorColon => "isError:",
+            Self::WhileTrue => "whileTrue:",
+            Self::WhileFalse => "whileFalse:",
+            Self::Repeat => "repeat",
+            Self::Ensure => "ensure:",
+            Self::Hash => "hash",
+            Self::Error => "error:",
+            Self::FieldAt => "fieldAt:",
+            Self::FieldAtPut => "fieldAt:put:",
+            Self::FieldNames => "fieldNames",
+            Self::Perform => "perform:",
+            Self::PerformWithArgs => "perform:withArguments:",
+            Self::PerformLocallyWithArgs => "performLocally:withArguments:",
         }
     }
 
@@ -145,6 +197,18 @@ impl WellKnownSelector {
             "isError" => Some(Self::IsError),
             "isOk:" => Some(Self::IsOkColon),
             "isError:" => Some(Self::IsErrorColon),
+            "whileTrue:" => Some(Self::WhileTrue),
+            "whileFalse:" => Some(Self::WhileFalse),
+            "repeat" => Some(Self::Repeat),
+            "ensure:" => Some(Self::Ensure),
+            "hash" => Some(Self::Hash),
+            "error:" => Some(Self::Error),
+            "fieldAt:" => Some(Self::FieldAt),
+            "fieldAt:put:" => Some(Self::FieldAtPut),
+            "fieldNames" => Some(Self::FieldNames),
+            "perform:" => Some(Self::Perform),
+            "perform:withArguments:" => Some(Self::PerformWithArgs),
+            "performLocally:withArguments:" => Some(Self::PerformLocallyWithArgs),
             _ => None,
         }
     }
@@ -156,9 +220,15 @@ impl WellKnownSelector {
     #[must_use]
     pub fn arity(self) -> usize {
         match self {
-            Self::IsNil | Self::NotNil | Self::Class | Self::IsOk | Self::IsError | Self::Value => {
-                0
-            }
+            Self::IsNil
+            | Self::NotNil
+            | Self::Class
+            | Self::IsOk
+            | Self::IsError
+            | Self::Value
+            | Self::Repeat
+            | Self::Hash
+            | Self::FieldNames => 0,
             Self::IfNil
             | Self::IfNotNil
             | Self::IsKindOf
@@ -167,12 +237,21 @@ impl WellKnownSelector {
             | Self::IfFalse
             | Self::ValueColon
             | Self::IsOkColon
-            | Self::IsErrorColon => 1,
+            | Self::IsErrorColon
+            | Self::WhileTrue
+            | Self::WhileFalse
+            | Self::Ensure
+            | Self::Error
+            | Self::FieldAt
+            | Self::Perform => 1,
             Self::IfNilIfNotNil
             | Self::IfNotNilIfNil
             | Self::IfTrueIfFalse
             | Self::OnDo
-            | Self::ValueValue => 2,
+            | Self::ValueValue
+            | Self::FieldAtPut
+            | Self::PerformWithArgs
+            | Self::PerformLocallyWithArgs => 2,
             Self::ValueValueValue => 3,
         }
     }
@@ -233,6 +312,18 @@ mod tests {
         WellKnownSelector::IsError,
         WellKnownSelector::IsOkColon,
         WellKnownSelector::IsErrorColon,
+        WellKnownSelector::WhileTrue,
+        WellKnownSelector::WhileFalse,
+        WellKnownSelector::Repeat,
+        WellKnownSelector::Ensure,
+        WellKnownSelector::Hash,
+        WellKnownSelector::Error,
+        WellKnownSelector::FieldAt,
+        WellKnownSelector::FieldAtPut,
+        WellKnownSelector::FieldNames,
+        WellKnownSelector::Perform,
+        WellKnownSelector::PerformWithArgs,
+        WellKnownSelector::PerformLocallyWithArgs,
     ];
 
     #[test]
@@ -503,6 +594,109 @@ mod tests {
             KeywordPart::new("value:", Span::new(0, 1)),
         ]);
         assert_eq!(WellKnownSelector::from_selector(&keyword_4), None);
+    }
+
+    #[test]
+    fn from_selector_block_loops_and_cleanup() {
+        let span = Span::new(0, 1);
+
+        let sel = MessageSelector::Unary("repeat".into());
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::Repeat)
+        );
+
+        let sel = MessageSelector::Keyword(vec![KeywordPart::new("whileTrue:", span)]);
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::WhileTrue)
+        );
+
+        let sel = MessageSelector::Keyword(vec![KeywordPart::new("whileFalse:", span)]);
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::WhileFalse)
+        );
+
+        let sel = MessageSelector::Keyword(vec![KeywordPart::new("ensure:", span)]);
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::Ensure)
+        );
+    }
+
+    #[test]
+    fn from_selector_object_universal_and_reflection() {
+        let span = Span::new(0, 1);
+
+        let sel = MessageSelector::Unary("hash".into());
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::Hash)
+        );
+
+        let sel = MessageSelector::Keyword(vec![KeywordPart::new("error:", span)]);
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::Error)
+        );
+
+        let sel = MessageSelector::Keyword(vec![KeywordPart::new("fieldAt:", span)]);
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::FieldAt)
+        );
+
+        let sel = MessageSelector::Keyword(vec![
+            KeywordPart::new("fieldAt:", span),
+            KeywordPart::new("put:", span),
+        ]);
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::FieldAtPut)
+        );
+
+        let sel = MessageSelector::Unary("fieldNames".into());
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::FieldNames)
+        );
+    }
+
+    #[test]
+    fn from_selector_perform_variants() {
+        let span = Span::new(0, 1);
+
+        let sel = MessageSelector::Keyword(vec![KeywordPart::new("perform:", span)]);
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::Perform)
+        );
+
+        let sel = MessageSelector::Keyword(vec![
+            KeywordPart::new("perform:", span),
+            KeywordPart::new("withArguments:", span),
+        ]);
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::PerformWithArgs)
+        );
+
+        let sel = MessageSelector::Keyword(vec![
+            KeywordPart::new("performLocally:", span),
+            KeywordPart::new("withArguments:", span),
+        ]);
+        assert_eq!(
+            WellKnownSelector::from_selector(&sel),
+            Some(WellKnownSelector::PerformLocallyWithArgs)
+        );
+
+        // Flattened single-part forms must NOT classify (parser would not produce these).
+        let sel = MessageSelector::Keyword(vec![KeywordPart::new("perform:withArguments:", span)]);
+        assert_eq!(WellKnownSelector::from_selector(&sel), None);
+
+        let sel = MessageSelector::Keyword(vec![KeywordPart::new("fieldAt:put:", span)]);
+        assert_eq!(WellKnownSelector::from_selector(&sel), None);
     }
 
     #[test]

--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -1675,14 +1675,20 @@ impl CoreErlangGenerator {
     /// Since `erlang:error/1` never returns (always throws an exception),
     /// expressions ending with `error:` should not be wrapped in reply tuples.
     pub(super) fn is_error_message_send(expr: &Expression) -> bool {
-        matches!(
-            expr,
-            Expression::MessageSend {
-                selector: MessageSelector::Keyword(parts),
-                arguments,
-                ..
-            } if parts.len() == 1 && parts[0].keyword == "error:" && arguments.len() == 1
-        )
+        // BT-2073: classify via the well-known enum so a future rename of the
+        // `Error` variant forces this site to update too. The classifier
+        // guarantees keyword/arity = 1, but we still gate on arguments.len()
+        // for the same defensive reason the original predicate did.
+        if let Expression::MessageSend {
+            selector,
+            arguments,
+            ..
+        } = expr
+        {
+            return matches!(selector.well_known(), Some(WellKnownSelector::Error))
+                && arguments.len() == 1;
+        }
+        false
     }
 
     /// Generates the opening part of a field assignment with state threading.
@@ -1767,17 +1773,18 @@ impl CoreErlangGenerator {
         }
         if let Expression::MessageSend {
             receiver,
-            selector: MessageSelector::Keyword(parts),
+            selector,
             arguments,
             ..
         } = expr
         {
             if let Expression::Identifier(id) = receiver.as_ref() {
+                // BT-2073: classify via the well-known enum. The classifier
+                // already guarantees the two-part keyword shape; arguments.len()
+                // is checked defensively for parser-shape consistency.
                 if id.name == "self"
                     && self.lookup_var("self").is_none()
-                    && parts.len() == 2
-                    && parts[0].keyword == "fieldAt:"
-                    && parts[1].keyword == "put:"
+                    && matches!(selector.well_known(), Some(WellKnownSelector::FieldAtPut))
                     && arguments.len() == 2
                 {
                     return true;

--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -1605,13 +1605,17 @@ impl CoreErlangGenerator {
             if matches!(selector, MessageSelector::Binary(_)) {
                 return false;
             }
-            // BT-2065/BT-2071: Well-known selectors that the intrinsics layer
-            // **unconditionally** handles before `try_handle_self_dispatch`.
-            // Covers ProtoObject (`class`), Object reflection (`respondsTo:`),
-            // Nil protocol (`isNil`/`notNil`/`ifNil:`/`ifNotNil:`/
-            // `ifNil:ifNotNil:`/`ifNotNil:ifNil:`), exception handling (`on:do:`)
-            // and block application (`value`/`value:`/`value:value:`/
-            // `value:value:value:`).
+            // BT-2065/BT-2071/BT-2073: Well-known selectors that the intrinsics
+            // layer **unconditionally** handles before `try_handle_self_dispatch`.
+            // Covers ProtoObject (`class`, `perform:`/`perform:withArguments:`/
+            // `performLocally:withArguments:`), Object reflection (`respondsTo:`,
+            // `fieldAt:`, `fieldAt:put:`, `fieldNames`), Nil protocol
+            // (`isNil`/`notNil`/`ifNil:`/`ifNotNil:`/`ifNil:ifNotNil:`/
+            // `ifNotNil:ifNil:`), exception handling (`on:do:`, `ensure:`),
+            // block application (`value`/`value:`/`value:value:`/
+            // `value:value:value:`), block loops (`repeat`/`whileTrue:`/
+            // `whileFalse:`), object identity (`hash`) and error signaling
+            // (`error:`).
             //
             // NOTE: Boolean conditionals (`ifTrue:`/`ifFalse:`/`ifTrue:ifFalse:`)
             // are NOT included here — `try_generate_boolean_protocol` returns
@@ -1633,30 +1637,32 @@ impl CoreErlangGenerator {
                         | WellKnownSelector::ValueColon
                         | WellKnownSelector::ValueValue
                         | WellKnownSelector::ValueValueValue
+                        | WellKnownSelector::WhileTrue
+                        | WellKnownSelector::WhileFalse
+                        | WellKnownSelector::Repeat
+                        | WellKnownSelector::Ensure
+                        | WellKnownSelector::Hash
+                        | WellKnownSelector::Error
+                        | WellKnownSelector::FieldAt
+                        | WellKnownSelector::FieldAtPut
+                        | WellKnownSelector::FieldNames
+                        | WellKnownSelector::Perform
+                        | WellKnownSelector::PerformWithArgs
+                        | WellKnownSelector::PerformLocallyWithArgs
                 ) {
                     return false;
                 }
             }
-            // Remaining intrinsics not yet modelled as `WellKnownSelector`
-            // variants — these still need string matching for now.
+            // Remaining intrinsics not modelled as `WellKnownSelector` variants
+            // — these are class-specific or compile-time-only constructs that
+            // do not warrant universal selector classification.
             let name = selector.name();
             if matches!(
                 name.as_str(),
                 // asType: (compile-time erasure)
                 "asType:"
-                // ProtoObject — dynamic dispatch
-                | "perform:" | "perform:withArguments:" | "performLocally:withArguments:"
-                // Object reflection — slot access
-                | "fieldAt:" | "fieldAt:put:" | "fieldNames"
                 // Identity
-                | "yourself" | "hash"
-                // Error signaling
-                | "error:"
-                // Block loops (non-well-known)
-                | "repeat" | "whileTrue:" | "whileFalse:"
-                // Exception cleanup — intercepted by intrinsics.rs as a plain
-                // intrinsic expression, so it is not a dispatching self-send.
-                | "ensure:"
+                | "yourself"
             ) {
                 return false;
             }

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -12,7 +12,7 @@ use super::super::document::{Document, INDENT, line, nest};
 use super::super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result, block_analysis};
 use crate::ast::{
     Block, ClassDefinition, ClassKind, Expression, Literal, MessageSelector, MethodDefinition,
-    MethodKind, Module, StateDeclaration, TypeParamDecl,
+    MethodKind, Module, StateDeclaration, TypeParamDecl, WellKnownSelector,
 };
 use crate::docvec;
 use crate::unparse::unparse_method_display_signature;
@@ -1185,16 +1185,17 @@ impl CoreErlangGenerator {
         if body.len() != 1 {
             return false;
         }
+        // BT-2073: classify `error:` via the well-known enum so a future rename
+        // forces this site to update too.
         matches!(
             &body[0].expression,
             Expression::MessageSend {
                 receiver,
-                selector: MessageSelector::Keyword(parts),
+                selector,
                 arguments,
                 ..
             } if matches!(receiver.as_ref(), Expression::Identifier(id) if id.name == "self")
-                && parts.len() == 1
-                && parts[0].keyword == "error:"
+                && matches!(selector.well_known(), Some(WellKnownSelector::Error))
                 && arguments.len() == 1
                 && matches!(&arguments[0], Expression::Literal(Literal::String(_), _))
         )

--- a/crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs
@@ -171,14 +171,13 @@ impl CoreErlangGenerator {
             return self.try_generate_block_value_unary(receiver, arguments);
         }
 
-        match selector {
-            // `repeat` is not a well-known selector (not intrinsified outside block
-            // evaluation semantics), so it stays as a string match.
-            MessageSelector::Unary(name) if name == "repeat" => {
-                let doc = self.generate_repeat(receiver)?;
-                Ok(Some(doc))
-            }
+        // BT-2073: `repeat` is well-known; dispatch via the enum.
+        if matches!(selector.well_known(), Some(WellKnownSelector::Repeat)) {
+            let doc = self.generate_repeat(receiver)?;
+            return Ok(Some(doc));
+        }
 
+        match selector {
             MessageSelector::Keyword(parts) => {
                 let selector_name: String = parts.iter().map(|p| p.keyword.as_str()).collect();
                 self.try_generate_block_keyword_message(
@@ -253,10 +252,11 @@ impl CoreErlangGenerator {
     /// Generates code for keyword block messages (`value:`, `whileTrue:`, `timesRepeat:`, etc.).
     ///
     /// Well-known keyword selectors (`value:`/`value:value:`/`value:value:value:`,
-    /// `on:do:`) route through the `WellKnownSelector` enum so arity is checked
-    /// structurally by the classifier (see BT-1260 / BT-2065 epic). The remaining
-    /// keyword selectors (`whileTrue:`, `whileFalse:`, `timesRepeat:`, `to:do:`,
-    /// `to:by:do:`, `ensure:`) are not in the enum and stay as string matches.
+    /// `on:do:`, `whileTrue:`/`whileFalse:`, `ensure:`) route through the
+    /// `WellKnownSelector` enum so arity is checked structurally by the
+    /// classifier (see BT-1260 / BT-2065 epic / BT-2073). The remaining keyword
+    /// selectors (`timesRepeat:`, `to:do:`, `to:by:do:`) are class-specific
+    /// loop helpers and stay as string matches.
     fn try_generate_block_keyword_message(
         &mut self,
         receiver: &Expression,
@@ -264,7 +264,7 @@ impl CoreErlangGenerator {
         arguments: &[Expression],
         selector_name: &str,
     ) -> Result<Option<Document<'static>>> {
-        // Well-known block-application / exception-handling selectors.
+        // Well-known block-application / loop / exception selectors.
         // The classifier handles arity matching — intercept before the FFI path.
         match selector.well_known() {
             Some(
@@ -279,30 +279,30 @@ impl CoreErlangGenerator {
                 let doc = self.generate_on_do(receiver, &arguments[0], &arguments[1])?;
                 return Ok(Some(doc));
             }
+            Some(WellKnownSelector::WhileTrue) => {
+                debug_assert_eq!(arguments.len(), 1);
+                let doc = self.generate_while_true(receiver, &arguments[0])?;
+                return Ok(Some(doc));
+            }
+            Some(WellKnownSelector::WhileFalse) => {
+                debug_assert_eq!(arguments.len(), 1);
+                let doc = self.generate_while_false(receiver, &arguments[0])?;
+                return Ok(Some(doc));
+            }
+            Some(WellKnownSelector::Ensure) => {
+                debug_assert_eq!(arguments.len(), 1);
+                let doc = self.generate_ensure(receiver, &arguments[0])?;
+                return Ok(Some(doc));
+            }
             _ => {}
         }
 
         match selector_name {
-            "whileTrue:" => {
-                let doc = self.generate_while_true(receiver, &arguments[0])?;
-                Ok(Some(doc))
-            }
-
-            "whileFalse:" => {
-                let doc = self.generate_while_false(receiver, &arguments[0])?;
-                Ok(Some(doc))
-            }
-
             "timesRepeat:" => self.try_generate_times_repeat(receiver, arguments),
 
             "to:do:" if arguments.len() == 2 => self.try_generate_to_do(receiver, arguments),
 
             "to:by:do:" if arguments.len() == 3 => self.try_generate_to_by_do(receiver, arguments),
-
-            "ensure:" => {
-                let doc = self.generate_ensure(receiver, &arguments[0])?;
-                Ok(Some(doc))
-            }
 
             _ => Ok(None),
         }
@@ -1064,80 +1064,77 @@ impl CoreErlangGenerator {
             ));
         }
 
-        match selector {
-            MessageSelector::Keyword(parts) => {
-                let selector_name: String = parts.iter().map(|p| p.keyword.as_str()).collect();
-
-                match selector_name.as_str() {
-                    "perform:withArguments:" if arguments.len() == 2 => {
-                        // BT-1942: Hoist open-scope receiver + args (e.g. class method self-sends).
-                        let (preamble, mut docs) = self.capture_subexpr_sequence(
-                            &[receiver, &arguments[0], &arguments[1]],
-                            "Perf",
-                        )?;
-                        let recv_doc = docs.remove(0);
-                        let sel_doc = docs.remove(0);
-                        let args_doc = docs.remove(0);
-                        let call_doc = docvec![
-                            "call 'beamtalk_message_dispatch':'send'(",
-                            recv_doc,
-                            ", ",
-                            sel_doc,
-                            ", ",
-                            args_doc,
-                            ")",
-                        ];
-                        Ok(Some(self.finalize_dispatch_with_preamble(
-                            preamble, call_doc, "PerfRes",
-                        )))
-                    }
-                    // BT-1664: Execute a class method in the caller's process,
-                    // bypassing the class object's gen_server.
-                    "performLocally:withArguments:" if arguments.len() == 2 => {
-                        // BT-1942: Hoist open-scope receiver + args (e.g. class method self-sends).
-                        let (preamble, mut docs) = self.capture_subexpr_sequence(
-                            &[receiver, &arguments[0], &arguments[1]],
-                            "PerfLoc",
-                        )?;
-                        let recv_doc = docs.remove(0);
-                        let sel_doc = docs.remove(0);
-                        let args_doc = docs.remove(0);
-                        let call_doc = docvec![
-                            "call 'beamtalk_object_class':'local_call'(",
-                            recv_doc,
-                            ", ",
-                            sel_doc,
-                            ", ",
-                            args_doc,
-                            ")",
-                        ];
-                        Ok(Some(self.finalize_dispatch_with_preamble(
-                            preamble,
-                            call_doc,
-                            "PerfLocRes",
-                        )))
-                    }
-                    "perform:" if arguments.len() == 1 => {
-                        // BT-1942: Hoist open-scope receiver + selector arg.
-                        let (preamble, mut docs) =
-                            self.capture_subexpr_sequence(&[receiver, &arguments[0]], "Perf")?;
-                        let recv_doc = docs.remove(0);
-                        let sel_doc = docs.remove(0);
-                        let call_doc = docvec![
-                            "call 'beamtalk_message_dispatch':'send'(",
-                            recv_doc,
-                            ", ",
-                            sel_doc,
-                            ", [])",
-                        ];
-                        Ok(Some(self.finalize_dispatch_with_preamble(
-                            preamble, call_doc, "PerfRes",
-                        )))
-                    }
-                    _ => Ok(None),
-                }
+        // BT-2073: `perform:` family routes through the `WellKnownSelector` enum;
+        // the classifier guarantees arity, so explicit `arguments.len()` guards
+        // become `debug_assert_eq!` for parser-shape invariants.
+        match selector.well_known() {
+            Some(WellKnownSelector::PerformWithArgs) => {
+                debug_assert_eq!(arguments.len(), 2);
+                // BT-1942: Hoist open-scope receiver + args (e.g. class method self-sends).
+                let (preamble, mut docs) = self
+                    .capture_subexpr_sequence(&[receiver, &arguments[0], &arguments[1]], "Perf")?;
+                let recv_doc = docs.remove(0);
+                let sel_doc = docs.remove(0);
+                let args_doc = docs.remove(0);
+                let call_doc = docvec![
+                    "call 'beamtalk_message_dispatch':'send'(",
+                    recv_doc,
+                    ", ",
+                    sel_doc,
+                    ", ",
+                    args_doc,
+                    ")",
+                ];
+                Ok(Some(self.finalize_dispatch_with_preamble(
+                    preamble, call_doc, "PerfRes",
+                )))
             }
-            MessageSelector::Unary(_) | MessageSelector::Binary(_) => Ok(None),
+            // BT-1664: Execute a class method in the caller's process,
+            // bypassing the class object's gen_server.
+            Some(WellKnownSelector::PerformLocallyWithArgs) => {
+                debug_assert_eq!(arguments.len(), 2);
+                // BT-1942: Hoist open-scope receiver + args (e.g. class method self-sends).
+                let (preamble, mut docs) = self.capture_subexpr_sequence(
+                    &[receiver, &arguments[0], &arguments[1]],
+                    "PerfLoc",
+                )?;
+                let recv_doc = docs.remove(0);
+                let sel_doc = docs.remove(0);
+                let args_doc = docs.remove(0);
+                let call_doc = docvec![
+                    "call 'beamtalk_object_class':'local_call'(",
+                    recv_doc,
+                    ", ",
+                    sel_doc,
+                    ", ",
+                    args_doc,
+                    ")",
+                ];
+                Ok(Some(self.finalize_dispatch_with_preamble(
+                    preamble,
+                    call_doc,
+                    "PerfLocRes",
+                )))
+            }
+            Some(WellKnownSelector::Perform) => {
+                debug_assert_eq!(arguments.len(), 1);
+                // BT-1942: Hoist open-scope receiver + selector arg.
+                let (preamble, mut docs) =
+                    self.capture_subexpr_sequence(&[receiver, &arguments[0]], "Perf")?;
+                let recv_doc = docs.remove(0);
+                let sel_doc = docs.remove(0);
+                let call_doc = docvec![
+                    "call 'beamtalk_message_dispatch':'send'(",
+                    recv_doc,
+                    ", ",
+                    sel_doc,
+                    ", [])",
+                ];
+                Ok(Some(self.finalize_dispatch_with_preamble(
+                    preamble, call_doc, "PerfRes",
+                )))
+            }
+            _ => Ok(None),
         }
     }
 
@@ -1427,62 +1424,57 @@ impl CoreErlangGenerator {
     ) -> Result<Option<Document<'static>>> {
         // BT-1254: `error:` on a ClassReference is a class method call (e.g. `Result error: reason`),
         // not the Object#error: error-signaling intrinsic. Skip so class method dispatch handles it.
+        // Also covers `Logger error: "msg"` — see `WellKnownSelector::Error` rustdoc
+        // for the dual-use caveat (Object >> error: vs Logger class >> error:).
         if matches!(receiver, Expression::ClassReference { .. }) {
             return Ok(None);
         }
-        match selector {
-            MessageSelector::Keyword(parts) => {
-                let selector_name: String = parts.iter().map(|p| p.keyword.as_str()).collect();
-
-                match selector_name.as_str() {
-                    "error:" if arguments.len() == 1 => {
-                        // BT-1942: Hoist open-scope receiver + message (e.g. class method self-sends).
-                        let (preamble, mut docs) =
-                            self.capture_subexpr_sequence(&[receiver, &arguments[0]], "Err")?;
-                        let recv_doc = docs.remove(0);
-                        let msg_doc = docs.remove(0);
-                        let recv_var = self.fresh_temp_var("Obj");
-                        let msg_var = self.fresh_temp_var("Msg");
-                        let class_var = self.fresh_temp_var("Class");
-                        let err0 = self.fresh_temp_var("Err");
-                        let err1 = self.fresh_temp_var("Err");
-
-                        let call_doc = docvec![
-                            "let ",
-                            Document::String(recv_var.clone()),
-                            " = ",
-                            recv_doc,
-                            " in let ",
-                            Document::String(msg_var.clone()),
-                            " = ",
-                            msg_doc,
-                            " in let ",
-                            Document::String(class_var.clone()),
-                            " = call 'beamtalk_primitive':'class_of'(",
-                            Document::String(recv_var),
-                            ") in let ",
-                            Document::String(err0.clone()),
-                            " = call 'beamtalk_error':'new'('user_error', ",
-                            Document::String(class_var),
-                            ") in let ",
-                            Document::String(err1.clone()),
-                            " = call 'beamtalk_error':'with_message'(",
-                            Document::String(err0),
-                            ", ",
-                            Document::String(msg_var),
-                            ") in call 'beamtalk_error':'raise'(",
-                            Document::String(err1),
-                            ")",
-                        ];
-                        Ok(Some(self.finalize_dispatch_with_preamble(
-                            preamble, call_doc, "ErrRes",
-                        )))
-                    }
-                    _ => Ok(None),
-                }
-            }
-            _ => Ok(None),
+        // BT-2073: `error:` is well-known; dispatch via the enum.
+        if !matches!(selector.well_known(), Some(WellKnownSelector::Error)) {
+            return Ok(None);
         }
+        debug_assert_eq!(arguments.len(), 1);
+        // BT-1942: Hoist open-scope receiver + message (e.g. class method self-sends).
+        let (preamble, mut docs) =
+            self.capture_subexpr_sequence(&[receiver, &arguments[0]], "Err")?;
+        let recv_doc = docs.remove(0);
+        let msg_doc = docs.remove(0);
+        let recv_var = self.fresh_temp_var("Obj");
+        let msg_var = self.fresh_temp_var("Msg");
+        let class_var = self.fresh_temp_var("Class");
+        let err0 = self.fresh_temp_var("Err");
+        let err1 = self.fresh_temp_var("Err");
+
+        let call_doc = docvec![
+            "let ",
+            Document::String(recv_var.clone()),
+            " = ",
+            recv_doc,
+            " in let ",
+            Document::String(msg_var.clone()),
+            " = ",
+            msg_doc,
+            " in let ",
+            Document::String(class_var.clone()),
+            " = call 'beamtalk_primitive':'class_of'(",
+            Document::String(recv_var),
+            ") in let ",
+            Document::String(err0.clone()),
+            " = call 'beamtalk_error':'new'('user_error', ",
+            Document::String(class_var),
+            ") in let ",
+            Document::String(err1.clone()),
+            " = call 'beamtalk_error':'with_message'(",
+            Document::String(err0),
+            ", ",
+            Document::String(msg_var),
+            ") in call 'beamtalk_error':'raise'(",
+            Document::String(err1),
+            ")",
+        ];
+        Ok(Some(self.finalize_dispatch_with_preamble(
+            preamble, call_doc, "ErrRes",
+        )))
     }
 
     /// Generates code for object identity and representation methods.
@@ -1497,6 +1489,27 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arguments: &[Expression],
     ) -> Result<Option<Document<'static>>> {
+        // BT-2073: `hash` (well-known) — dispatch via the enum so the
+        // classifier validates kind/arity.
+        if matches!(selector.well_known(), Some(WellKnownSelector::Hash)) {
+            debug_assert!(arguments.is_empty());
+            // BT-1942: Hoist open-scope receiver (e.g. class method self-send).
+            let (preamble, mut docs) = self.capture_subexpr_sequence(&[receiver], "Obj")?;
+            let recv_doc = docs.remove(0);
+            let recv_var = self.fresh_temp_var("Obj");
+            let call_doc = docvec![
+                "let ",
+                Document::String(recv_var.clone()),
+                " = ",
+                recv_doc,
+                " in call 'erlang':'phash2'(",
+                Document::String(recv_var),
+                ")",
+            ];
+            return Ok(Some(
+                self.finalize_dispatch_with_preamble(preamble, call_doc, "HashRes"),
+            ));
+        }
         match selector {
             MessageSelector::Unary(name) => match name.as_str() {
                 "yourself" if arguments.is_empty() => {
@@ -1511,24 +1524,6 @@ impl CoreErlangGenerator {
                         preamble,
                         recv_doc,
                         "YourselfRes",
-                    )))
-                }
-                "hash" if arguments.is_empty() => {
-                    // BT-1942: Hoist open-scope receiver (e.g. class method self-send).
-                    let (preamble, mut docs) = self.capture_subexpr_sequence(&[receiver], "Obj")?;
-                    let recv_doc = docs.remove(0);
-                    let recv_var = self.fresh_temp_var("Obj");
-                    let call_doc = docvec![
-                        "let ",
-                        Document::String(recv_var.clone()),
-                        " = ",
-                        recv_doc,
-                        " in call 'erlang':'phash2'(",
-                        Document::String(recv_var),
-                        ")",
-                    ];
-                    Ok(Some(self.finalize_dispatch_with_preamble(
-                        preamble, call_doc, "HashRes",
                     )))
                 }
                 // BT-477: printString removed as intrinsic — now uses polymorphic
@@ -1557,65 +1552,64 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arguments: &[Expression],
     ) -> Result<Option<Document<'static>>> {
-        match selector {
-            MessageSelector::Unary(name) => match name.as_str() {
-                "fieldNames" if arguments.is_empty() => {
-                    // BT-1321: Fast-path for `self` receiver in actor context.
-                    // `Self` is a `#beamtalk_object{..., pid: self()}` tuple, so the
-                    // normal is_tuple branch would call sync_send(self()) which is
-                    // gen_server:call(self(), ...) → deadlock.
-                    // Use beamtalk_primitive:send(State, ...) directly instead.
-                    if let Expression::Identifier(id) = receiver {
-                        if id.name == "self"
-                            && self.context == super::CodeGenContext::Actor
-                            && self.lookup_var("self").is_none()
-                        {
-                            let doc = docvec![
-                                "call 'beamtalk_primitive':'send'(",
-                                Document::String(self.current_state_var()),
-                                ", 'fieldNames', [])",
-                            ];
-                            return Ok(Some(doc));
-                        }
-                    }
-
-                    // BT-1942: Hoist open-scope receiver (e.g. class method self-send).
-                    let (preamble, mut docs) =
-                        self.capture_subexpr_sequence(&[receiver], "FNames")?;
-                    let recv_doc = docs.remove(0);
-                    let receiver_var = self.fresh_var("Receiver");
-                    let pid_var = self.fresh_var("Pid");
-
-                    // BT-924: If receiver is a map (value object or stdlib tagged map),
-                    // delegate to beamtalk_primitive:send which routes through the
-                    // correct dispatch/3 for the receiver's class kind.
-                    // Actor (tuple) receivers use sync_send (ADR-0043).
-                    let call_doc = docvec![
-                        "let ",
-                        Document::String(receiver_var.clone()),
-                        " = ",
-                        recv_doc,
-                        " in case call 'erlang':'is_map'(",
-                        Document::String(receiver_var.clone()),
-                        ") of <'true'> when 'true' -> call 'beamtalk_primitive':'send'(",
-                        Document::String(receiver_var.clone()),
-                        ", 'fieldNames', []) <_> when 'true' -> let ",
-                        Document::String(pid_var.clone()),
-                        " = call 'erlang':'element'(4, ",
-                        Document::String(receiver_var),
-                        ") in call 'beamtalk_actor':'sync_send'(",
-                        Document::String(pid_var),
-                        ", 'fieldNames', []) end",
+        // BT-2073: `fieldNames` (well-known unary). The classifier validates
+        // kind/arity, so explicit `arguments.is_empty()` becomes a `debug_assert!`.
+        if matches!(selector.well_known(), Some(WellKnownSelector::FieldNames)) {
+            debug_assert!(arguments.is_empty());
+            // BT-1321: Fast-path for `self` receiver in actor context.
+            // `Self` is a `#beamtalk_object{..., pid: self()}` tuple, so the
+            // normal is_tuple branch would call sync_send(self()) which is
+            // gen_server:call(self(), ...) → deadlock.
+            // Use beamtalk_primitive:send(State, ...) directly instead.
+            if let Expression::Identifier(id) = receiver {
+                if id.name == "self"
+                    && self.context == super::CodeGenContext::Actor
+                    && self.lookup_var("self").is_none()
+                {
+                    let doc = docvec![
+                        "call 'beamtalk_primitive':'send'(",
+                        Document::String(self.current_state_var()),
+                        ", 'fieldNames', [])",
                     ];
-                    Ok(Some(self.finalize_dispatch_with_preamble(
-                        preamble,
-                        call_doc,
-                        "FNamesRes",
-                    )))
+                    return Ok(Some(doc));
                 }
-                _ => Ok(None),
-            },
-            MessageSelector::Keyword(parts) => {
+            }
+
+            // BT-1942: Hoist open-scope receiver (e.g. class method self-send).
+            let (preamble, mut docs) = self.capture_subexpr_sequence(&[receiver], "FNames")?;
+            let recv_doc = docs.remove(0);
+            let receiver_var = self.fresh_var("Receiver");
+            let pid_var = self.fresh_var("Pid");
+
+            // BT-924: If receiver is a map (value object or stdlib tagged map),
+            // delegate to beamtalk_primitive:send which routes through the
+            // correct dispatch/3 for the receiver's class kind.
+            // Actor (tuple) receivers use sync_send (ADR-0043).
+            let call_doc = docvec![
+                "let ",
+                Document::String(receiver_var.clone()),
+                " = ",
+                recv_doc,
+                " in case call 'erlang':'is_map'(",
+                Document::String(receiver_var.clone()),
+                ") of <'true'> when 'true' -> call 'beamtalk_primitive':'send'(",
+                Document::String(receiver_var.clone()),
+                ", 'fieldNames', []) <_> when 'true' -> let ",
+                Document::String(pid_var.clone()),
+                " = call 'erlang':'element'(4, ",
+                Document::String(receiver_var),
+                ") in call 'beamtalk_actor':'sync_send'(",
+                Document::String(pid_var),
+                ", 'fieldNames', []) end",
+            ];
+            return Ok(Some(self.finalize_dispatch_with_preamble(
+                preamble,
+                call_doc,
+                "FNamesRes",
+            )));
+        }
+        match selector {
+            MessageSelector::Keyword(_) => {
                 // `respondsTo:` is well-known; dispatch via the enum first so arity
                 // correctness is guaranteed by the classifier.
                 if matches!(selector.well_known(), Some(WellKnownSelector::RespondsTo)) {
@@ -1650,10 +1644,12 @@ impl CoreErlangGenerator {
                     )));
                 }
 
-                let selector_name: String = parts.iter().map(|p| p.keyword.as_str()).collect();
-
-                match selector_name.as_str() {
-                    "fieldAt:" if arguments.len() == 1 => {
+                // BT-2073: `fieldAt:` and `fieldAt:put:` route via the enum so
+                // the classifier validates kind/arity (`fieldAt:put:` requires
+                // exactly two keyword parts, not a flattened single part).
+                match selector.well_known() {
+                    Some(WellKnownSelector::FieldAt) => {
+                        debug_assert_eq!(arguments.len(), 1);
                         // BT-1321: Fast-path for `self` receiver in actor context.
                         // Avoids sync_send(self()) → gen_server:call(self(), ...) → deadlock.
                         if let Expression::Identifier(id) = receiver {
@@ -1758,7 +1754,8 @@ impl CoreErlangGenerator {
                             preamble, call_doc, "FAtRes",
                         )))
                     }
-                    "fieldAt:put:" if arguments.len() == 2 => {
+                    Some(WellKnownSelector::FieldAtPut) => {
+                        debug_assert_eq!(arguments.len(), 2);
                         // BT-1321: Fast-path for `self` receiver in actor context.
                         // Avoids sync_send(self()) → gen_server:call(self(), ...) → deadlock.
                         //
@@ -1883,7 +1880,7 @@ impl CoreErlangGenerator {
                     _ => Ok(None),
                 }
             }
-            MessageSelector::Binary(_) => Ok(None),
+            MessageSelector::Unary(_) | MessageSelector::Binary(_) => Ok(None),
         }
     }
     /// BT-915: Tries to generate inline code for Boolean conditionals with field mutation

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -109,7 +109,7 @@ mod variable_context;
 // Re-export utility functions for IDE queries
 pub use util::to_module_name;
 
-use crate::ast::{Block, Expression, MessageSelector, Module};
+use crate::ast::{Block, Expression, MessageSelector, Module, WellKnownSelector};
 use crate::docvec;
 use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
 use document::{Document, INDENT, line, nest};
@@ -2506,7 +2506,7 @@ impl CoreErlangGenerator {
     fn get_control_flow_threaded_vars(&self, expr: &Expression) -> Option<Vec<String>> {
         let Expression::MessageSend {
             receiver,
-            selector: MessageSelector::Keyword(parts),
+            selector,
             arguments,
             ..
         } = expr
@@ -2514,10 +2514,20 @@ impl CoreErlangGenerator {
             return None;
         };
 
+        // BT-2073: `whileTrue:` / `whileFalse:` are well-known; dispatch via the enum.
+        if matches!(
+            selector.well_known(),
+            Some(WellKnownSelector::WhileTrue | WellKnownSelector::WhileFalse)
+        ) {
+            return self.threaded_vars_while(receiver, arguments);
+        }
+
+        let MessageSelector::Keyword(parts) = selector else {
+            return None;
+        };
         let selector_name: String = parts.iter().map(|kw| kw.keyword.as_str()).collect();
 
         match selector_name.as_str() {
-            "whileTrue:" | "whileFalse:" => self.threaded_vars_while(receiver, arguments),
             "timesRepeat:" => self.threaded_vars_times_repeat(arguments),
             "to:do:" if arguments.len() == 2 => self.threaded_vars_to_do(&arguments[1]),
             "to:by:do:" if arguments.len() == 3 => self.threaded_vars_to_do(&arguments[2]),

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -18,6 +18,7 @@ use super::util::ClassIdentity;
 use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result};
 use crate::ast::{
     ClassDefinition, ClassKind, Expression, MessageSelector, MethodDefinition, MethodKind, Module,
+    WellKnownSelector,
 };
 use crate::docvec;
 
@@ -1450,13 +1451,16 @@ impl CoreErlangGenerator {
         }
         if let Expression::MessageSend {
             receiver,
-            selector: MessageSelector::Keyword(parts),
+            selector,
             arguments,
             ..
         } = expr
         {
-            let sel: String = parts.iter().map(|p| p.keyword.as_str()).collect();
-            if sel == "whileTrue:" || sel == "whileFalse:" {
+            // BT-2073: Match `whileTrue:` / `whileFalse:` via the `WellKnownSelector` enum.
+            if matches!(
+                selector.well_known(),
+                Some(WellKnownSelector::WhileTrue | WellKnownSelector::WhileFalse)
+            ) {
                 if let Some(Expression::Block(body)) = arguments.first() {
                     // Must match the same check used by generate_while_true/generate_while_false
                     let analysis = super::block_analysis::analyze_block(body);


### PR DESCRIPTION
## Summary

Adds 11 new variants to `WellKnownSelector` for the second wave of `@intrinsic` stdlib methods that the compiler intercepts regardless of receiver class:

- **Block loops:** `WhileTrue`, `WhileFalse`, `Repeat`
- **Block cleanup:** `Ensure`
- **Object universal:** `Hash`, `Error`
- **Object reflection:** `FieldAt`, `FieldAtPut`, `FieldNames`
- **ProtoObject dynamic dispatch:** `Perform`, `PerformWithArgs`, `PerformLocallyWithArgs`

Migrates string-match dispatch sites in:
- `dispatch_codegen::is_dispatching_actor_self_send` — fallback list reduced to class-specific exclusions only (`asType:`, `yourself`)
- `dispatch_codegen::is_error_message_send`, `is_self_field_at_put` — AST shape predicates classify via the enum so a future rename forces these sites to update
- `intrinsics.rs` — block loops, ensure:, hash, error:, fieldNames/fieldAt:/fieldAt:put:, perform: family route via the enum
- `mod.rs::get_control_flow_threaded_vars` and `value_type_codegen::is_while_with_vt_local_threading` — `whileTrue:`/`whileFalse:` via the enum
- `gen_server/methods.rs::is_self_error_body` — `error:` classification via the enum

The `error:` variant rustdoc documents the dual-use clash with `Logger class >> error:` — the existing `Expression::ClassReference` short-circuit in `try_generate_error_signaling` preserves the Logger codegen path.

Behavior is byte-identical: pure refactor, all existing tests pass.

Closes BT-2073 — https://linear.app/beamtalk/issue/BT-2073

## Test plan

- [x] All `cargo test -p beamtalk-core --lib` (3248 unit tests) pass
- [x] `just test` (Rust + stdlib + BUnit + runtime tests) passes
- [x] `just ci` (full pipeline incl. e2e + clippy + fmt) passes
- [x] Grep-check confirms only acceptable hits remain (test fixtures, generated Erlang strings, rustdoc examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored compiler selector-matching logic to use structured enum-based classification instead of string comparisons.
  * Added support for additional compiler-recognized selectors including block operations, object utilities, reflection, and dynamic dispatch.
  * Expanded test coverage for selector handling and validation.
  * Updated repository ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->