### PR TITLE
Extract beamtalk-repl-protocol crate (BT-2076)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ repository = "https://github.com/jamesc/beamtalk"
 beamtalk-core = { path = "crates/beamtalk-core" }
 beamtalk-etf = { path = "crates/beamtalk-etf" }
 beamtalk-examples = { path = "crates/beamtalk-examples" }
+beamtalk-repl-protocol = { path = "crates/beamtalk-repl-protocol" }
 beamtalk-workspace = { path = "crates/beamtalk-workspace" }
 
 # CLI

--- a/crates/beamtalk-cli/Cargo.toml
+++ b/crates/beamtalk-cli/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 beamtalk-core = { workspace = true, features = ["serde"] }
+beamtalk-repl-protocol.workspace = true
 beamtalk-workspace.workspace = true
 clap.workspace = true
 camino.workspace = true

--- a/crates/beamtalk-cli/src/commands/repl/client.rs
+++ b/crates/beamtalk-cli/src/commands/repl/client.rs
@@ -11,8 +11,10 @@ use std::time::Duration;
 
 use miette::{Result, miette};
 
+use beamtalk_repl_protocol::RequestBuilder;
+
 use super::ReplResponse;
-use crate::commands::protocol::{self, ProtocolClient};
+use crate::commands::protocol::ProtocolClient;
 
 /// REPL client that wraps [`ProtocolClient`] with REPL-specific operations.
 pub(crate) struct ReplClient {
@@ -103,11 +105,7 @@ impl ReplClient {
     /// Send an eval request and receive the response.
     #[allow(dead_code)] // Used in non-interruptible mode or tests
     pub(crate) fn eval(&mut self, expression: &str) -> Result<ReplResponse> {
-        self.send_request(&serde_json::json!({
-            "op": "eval",
-            "id": protocol::next_msg_id(),
-            "code": expression
-        }))
+        self.send_request(&RequestBuilder::eval(expression))
     }
 
     /// Send an eval request that can be interrupted by Ctrl-C (BT-666).
@@ -125,11 +123,7 @@ impl ReplClient {
         interrupted: &Arc<AtomicBool>,
     ) -> Result<ReplResponse> {
         // Send the eval request
-        let request = serde_json::json!({
-            "op": "eval",
-            "id": protocol::next_msg_id(),
-            "code": expression
-        });
+        let request = RequestBuilder::eval(expression);
         self.inner.send_only(&request)?;
 
         // Set a short read timeout for polling
@@ -207,7 +201,7 @@ impl ReplClient {
         let req_id = parsed
             .get("id")
             .and_then(|v| v.as_str())
-            .map_or_else(protocol::next_msg_id, str::to_string);
+            .map_or_else(beamtalk_repl_protocol::next_msg_id, str::to_string);
 
         // Print the prompt
         print!("{prompt}");
@@ -219,26 +213,17 @@ impl ReplClient {
         match stdin.lock().read_line(&mut input) {
             Ok(0) => {
                 // EOF
-                self.inner.send_only(&serde_json::json!({
-                    "op": "stdin",
-                    "id": req_id,
-                    "value": "eof"
-                }))?;
+                self.inner
+                    .send_only(&RequestBuilder::stdin(&req_id, "eof"))?;
             }
             Ok(_) => {
-                self.inner.send_only(&serde_json::json!({
-                    "op": "stdin",
-                    "id": req_id,
-                    "value": input
-                }))?;
+                self.inner
+                    .send_only(&RequestBuilder::stdin(&req_id, &input))?;
             }
             Err(e) => {
                 eprintln!("Error reading stdin: {e}");
-                self.inner.send_only(&serde_json::json!({
-                    "op": "stdin",
-                    "id": req_id,
-                    "value": "eof"
-                }))?;
+                self.inner
+                    .send_only(&RequestBuilder::stdin(&req_id, "eof"))?;
             }
         }
         Ok(())
@@ -246,13 +231,10 @@ impl ReplClient {
 
     /// Send an interrupt request on a separate WebSocket connection (BT-666).
     fn send_interrupt(&self) {
-        let mut interrupt_req = serde_json::json!({
-            "op": "interrupt",
-            "id": protocol::next_msg_id()
-        });
-        if let Some(ref session) = self.session_id {
-            interrupt_req["session"] = serde_json::Value::String(session.clone());
-        }
+        let interrupt_req = match self.session_id {
+            Some(ref session) => RequestBuilder::interrupt_with_session(session),
+            None => RequestBuilder::interrupt(),
+        };
         // Open a new connection and send interrupt — best effort
         if let Ok(mut interrupt_client) = ProtocolClient::connect_with_resume(
             &self.host,
@@ -267,54 +249,34 @@ impl ReplClient {
 
     /// Send a clear bindings request.
     pub(crate) fn clear_bindings(&mut self) -> Result<ReplResponse> {
-        self.send_request(&serde_json::json!({
-            "op": "clear",
-            "id": protocol::next_msg_id()
-        }))
+        self.send_request(&RequestBuilder::clear())
     }
 
     /// Get current bindings.
     pub(crate) fn get_bindings(&mut self) -> Result<ReplResponse> {
-        self.send_request(&serde_json::json!({
-            "op": "bindings",
-            "id": protocol::next_msg_id()
-        }))
+        self.send_request(&RequestBuilder::bindings())
     }
 
     /// List running actors.
     pub(crate) fn list_actors(&mut self) -> Result<ReplResponse> {
-        self.send_request(&serde_json::json!({
-            "op": "actors",
-            "id": protocol::next_msg_id()
-        }))
+        self.send_request(&RequestBuilder::actors())
     }
 
     /// List active sessions.
     pub(crate) fn list_sessions(&mut self) -> Result<ReplResponse> {
-        self.send_request(&serde_json::json!({
-            "op": "sessions",
-            "id": protocol::next_msg_id()
-        }))
+        self.send_request(&RequestBuilder::sessions())
     }
 
     /// Inspect an actor's state.
     pub(crate) fn inspect_actor(&mut self, pid_str: &str) -> Result<ReplResponse> {
-        self.send_request(&serde_json::json!({
-            "op": "inspect",
-            "id": protocol::next_msg_id(),
-            "actor": pid_str
-        }))
+        self.send_request(&RequestBuilder::inspect(pid_str))
     }
 
     /// Get completions for a prefix.
     ///
     #[allow(dead_code)] // API completeness — completions use separate ProtocolClient with short timeout
     pub(crate) fn complete(&mut self, prefix: &str) -> Result<ReplResponse> {
-        self.send_request(&serde_json::json!({
-            "op": "complete",
-            "id": protocol::next_msg_id(),
-            "code": prefix
-        }))
+        self.send_request(&RequestBuilder::complete(prefix))
     }
 
     /// Get documentation for a class or method.
@@ -324,18 +286,7 @@ impl ReplClient {
         class_side: bool,
         selector: Option<&str>,
     ) -> Result<ReplResponse> {
-        let mut req = serde_json::json!({
-            "op": "docs",
-            "id": protocol::next_msg_id(),
-            "class": class
-        });
-        if class_side {
-            req["class_side"] = serde_json::Value::Bool(true);
-        }
-        if let Some(sel) = selector {
-            req["selector"] = serde_json::Value::String(sel.to_string());
-        }
-        self.send_request(&req)
+        self.send_request(&RequestBuilder::docs(class, class_side, selector))
     }
 
     /// Get help for an Erlang module or function (BT-1852).
@@ -347,24 +298,12 @@ impl ReplClient {
         module: &str,
         function: Option<&str>,
     ) -> Result<ReplResponse> {
-        let mut req = serde_json::json!({
-            "op": "erlang-help",
-            "id": protocol::next_msg_id(),
-            "module": module
-        });
-        if let Some(func) = function {
-            req["function"] = serde_json::Value::String(func.to_string());
-        }
-        self.send_request(&req)
+        self.send_request(&RequestBuilder::erlang_help(module, function))
     }
 
     /// Show generated Core Erlang for an expression (BT-724).
     pub(crate) fn show_codegen(&mut self, code: &str) -> Result<ReplResponse> {
-        self.send_request(&serde_json::json!({
-            "op": "show-codegen",
-            "id": protocol::next_msg_id(),
-            "code": code
-        }))
+        self.send_request(&RequestBuilder::show_codegen(code))
     }
 
     /// Load/sync a project from its `beamtalk.toml` (BT-1707).
@@ -383,22 +322,15 @@ impl ReplClient {
         path: &str,
         include_tests: bool,
     ) -> Result<ReplResponse> {
-        let raw = self.inner.send_raw(&serde_json::json!({
-            "op": "load-project",
-            "id": protocol::next_msg_id(),
-            "path": path,
-            "include_tests": include_tests
-        }))?;
+        let raw = self
+            .inner
+            .send_raw(&RequestBuilder::load_project(path, include_tests))?;
         serde_json::from_value(raw)
             .map_err(|e| miette::miette!("Failed to parse load-project response: {e}"))
     }
 
     /// Unload a class from the workspace by name (BT-1243).
     pub(crate) fn unload(&mut self, class_name: &str) -> Result<ReplResponse> {
-        self.send_request(&serde_json::json!({
-            "op": "unload",
-            "id": protocol::next_msg_id(),
-            "module": class_name
-        }))
+        self.send_request(&RequestBuilder::unload(class_name))
     }
 }

--- a/crates/beamtalk-cli/src/commands/repl/helper.rs
+++ b/crates/beamtalk-cli/src/commands/repl/helper.rs
@@ -23,7 +23,7 @@ use rustyline::{Context, Helper};
 
 use beamtalk_core::source_analysis::{TokenKind, Trivia, lex_with_eof};
 
-use beamtalk_repl_protocol::next_msg_id;
+use beamtalk_repl_protocol::RequestBuilder;
 
 use crate::commands::protocol::ProtocolClient;
 
@@ -148,14 +148,7 @@ impl ReplHelper {
     ///
     /// Used when completing `:h Erlang <TAB>` or `:h Erlang mod <TAB>`.
     fn backend_erlang_complete(&self, prefix: &str, module: Option<&str>) -> Vec<String> {
-        let mut request = serde_json::json!({
-            "op": "erlang-complete",
-            "id": next_msg_id(),
-            "prefix": prefix
-        });
-        if let Some(m) = module {
-            request["module"] = serde_json::Value::String(m.to_string());
-        }
+        let request = RequestBuilder::erlang_complete(prefix, module);
         self.send_completion_request(&request)
     }
 
@@ -169,15 +162,8 @@ impl ReplHelper {
         }
 
         let session_id = self.main_session_id.borrow();
-        let mut request = serde_json::json!({
-            "op": "complete",
-            "id": next_msg_id(),
-            "code": line_to_pos,
-            "cursor": cursor
-        });
-        if let Some(ref sid) = *session_id {
-            request["session"] = serde_json::Value::String(sid.clone());
-        }
+        let request =
+            RequestBuilder::complete_with_session(line_to_pos, cursor, session_id.as_deref());
         self.send_completion_request(&request)
     }
 }

--- a/crates/beamtalk-cli/src/commands/repl/helper.rs
+++ b/crates/beamtalk-cli/src/commands/repl/helper.rs
@@ -23,7 +23,9 @@ use rustyline::{Context, Helper};
 
 use beamtalk_core::source_analysis::{TokenKind, Trivia, lex_with_eof};
 
-use crate::commands::protocol::{self, ProtocolClient};
+use beamtalk_repl_protocol::next_msg_id;
+
+use crate::commands::protocol::ProtocolClient;
 
 use super::ReplResponse;
 use super::color;
@@ -148,7 +150,7 @@ impl ReplHelper {
     fn backend_erlang_complete(&self, prefix: &str, module: Option<&str>) -> Vec<String> {
         let mut request = serde_json::json!({
             "op": "erlang-complete",
-            "id": protocol::next_msg_id(),
+            "id": next_msg_id(),
             "prefix": prefix
         });
         if let Some(m) = module {
@@ -169,7 +171,7 @@ impl ReplHelper {
         let session_id = self.main_session_id.borrow();
         let mut request = serde_json::json!({
             "op": "complete",
-            "id": protocol::next_msg_id(),
+            "id": next_msg_id(),
             "code": line_to_pos,
             "cursor": cursor
         });

--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -54,8 +54,13 @@ use miette::{IntoDiagnostic, Result, miette};
 use rustyline::error::ReadlineError;
 use rustyline::history::FileHistory;
 use rustyline::{CompletionType, Config, Editor};
-use serde::Deserialize;
 use tracing::warn;
+
+pub(crate) use beamtalk_repl_protocol::ReplResponse;
+
+// Re-export response payload types used in tests.
+#[cfg(test)]
+use beamtalk_repl_protocol::ActorInfo;
 
 use crate::commands::workspace;
 
@@ -84,138 +89,7 @@ use process::{
     resolve_node_name, resolve_port, start_beam_node,
 };
 
-/// Deserialize a JSON `null` or missing field as an empty `Vec`.
-fn deserialize_null_as_empty_vec<'de, D, T>(
-    deserializer: D,
-) -> std::result::Result<Vec<T>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-    T: serde::Deserialize<'de>,
-{
-    Option::<Vec<T>>::deserialize(deserializer).map(Option::unwrap_or_default)
-}
-
-/// JSON response from the REPL backend.
-/// Supports both legacy format (type field) and new protocol format (status field).
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)] // fields populated by serde deserialization from REPL JSON protocol
-pub(crate) struct ReplResponse {
-    /// Legacy response type (result, error, bindings, loaded, actors)
-    #[serde(rename = "type")]
-    pub(crate) response_type: Option<String>,
-    /// New protocol: message correlation ID
-    pub(crate) id: Option<String>,
-    /// New protocol: session ID
-    pub(crate) session: Option<String>,
-    /// New protocol: status flags
-    pub(crate) status: Option<Vec<String>>,
-    /// Result value (both formats)
-    pub(crate) value: Option<serde_json::Value>,
-    /// Captured stdout from evaluation (BT-355)
-    pub(crate) output: Option<String>,
-    /// Legacy: error message
-    pub(crate) message: Option<String>,
-    /// New protocol: error message
-    pub(crate) error: Option<String>,
-    /// Bindings map (both formats)
-    pub(crate) bindings: Option<serde_json::Value>,
-    /// Loaded classes (both formats)
-    pub(crate) classes: Option<Vec<String>>,
-    /// Actor list (both formats)
-    pub(crate) actors: Option<Vec<ActorInfo>>,
-    /// Module list (legacy protocol — retained for backward-compatible deserialization)
-    pub(crate) modules: Option<Vec<ModuleInfo>>,
-    /// Session list (new protocol)
-    pub(crate) sessions: Option<Vec<SessionInfo>>,
-    /// Completion suggestions (new protocol)
-    pub(crate) completions: Option<Vec<String>>,
-    /// Symbol info (new protocol)
-    pub(crate) info: Option<serde_json::Value>,
-    /// Actor state (new protocol: inspect op)
-    pub(crate) state: Option<serde_json::Value>,
-    /// Compilation warnings (BT-407)
-    pub(crate) warnings: Option<Vec<String>>,
-    /// Documentation text (BT-500: :help command)
-    pub(crate) docs: Option<String>,
-    /// Generated Core Erlang source (BT-724: :show-codegen command)
-    pub(crate) core_erlang: Option<String>,
-    /// Number of actors affected by reload (BT-266)
-    pub(crate) affected_actors: Option<u32>,
-    /// Number of actors that failed code migration (BT-266)
-    pub(crate) migration_failures: Option<u32>,
-    /// Incremental load summary (BT-1707: :sync command)
-    pub(crate) summary: Option<String>,
-    /// Per-file load errors (BT-1707: :sync command)
-    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
-    pub(crate) errors: Vec<serde_json::Value>,
-}
-
-impl ReplResponse {
-    /// Check if this is an error response (either format).
-    pub(crate) fn is_error(&self) -> bool {
-        if let Some(ref t) = self.response_type {
-            return t == "error";
-        }
-        if let Some(ref status) = self.status {
-            return status.iter().any(|s| s == "error");
-        }
-        false
-    }
-
-    /// Get the error message (either format).
-    pub(crate) fn error_message(&self) -> Option<&str> {
-        if let Some(ref msg) = self.message {
-            return Some(msg.as_str());
-        }
-        if let Some(ref err) = self.error {
-            return Some(err.as_str());
-        }
-        None
-    }
-}
-
-/// Information about a running actor, deserialized from REPL JSON.
-#[derive(Debug, Deserialize)]
-pub(crate) struct ActorInfo {
-    /// Erlang process identifier string (e.g., `<0.123.0>`).
-    pub(crate) pid: String,
-    /// Beamtalk class name of the actor (e.g., `Counter`).
-    pub(crate) class: String,
-    /// BEAM module backing the actor.
-    #[allow(dead_code)] // deserialized from JSON, used in tests
-    pub(crate) module: String,
-    /// Unix timestamp when the actor was spawned.
-    #[allow(dead_code)] // deserialized from JSON, available for future use
-    spawned_at: i64,
-}
-
-/// Information about a loaded module, deserialized from REPL JSON.
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)] // deserialized from JSON; fields retained for backward-compatible protocol handling
-pub(crate) struct ModuleInfo {
-    /// Module name as registered in the BEAM node.
-    pub(crate) name: String,
-    /// Path to the source `.bt` file that defined this module.
-    pub(crate) source_file: String,
-    /// Number of actors currently running from this module.
-    pub(crate) actor_count: u32,
-    /// Unix timestamp when the module was loaded.
-    #[allow(dead_code)] // deserialized from JSON, available for future use
-    load_time: i64,
-    /// Human-readable relative time since load (e.g., `2 minutes ago`).
-    pub(crate) time_ago: String,
-}
-
-/// Information about an active REPL session, deserialized from REPL JSON.
-#[derive(Debug, Deserialize)]
-pub(crate) struct SessionInfo {
-    /// Unique session identifier.
-    #[allow(dead_code)] // deserialized from JSON, available for future use
-    pub(crate) id: String,
-    /// Unix timestamp when the session was created.
-    #[allow(dead_code)] // deserialized from JSON, available for future use
-    created_at: Option<i64>,
-}
+// Response types re-exported from beamtalk-repl-protocol above.
 
 /// Auto-compile a package if `beamtalk.toml` is present in the project root.
 ///

--- a/crates/beamtalk-cli/tests/e2e.rs
+++ b/crates/beamtalk-cli/tests/e2e.rs
@@ -36,6 +36,7 @@
 
 use beamtalk_cli::repl_startup;
 use beamtalk_core::source_analysis::is_input_complete;
+use beamtalk_repl_protocol::{ReplResponse, RequestBuilder};
 use serial_test::serial;
 use std::env;
 use std::fs;
@@ -650,6 +651,13 @@ impl ReplClient {
         }
     }
 
+    /// Read and parse the next response into a typed `ReplResponse`.
+    fn read_repl_response(&mut self) -> Result<ReplResponse, String> {
+        let response_line = self.read_text()?;
+        serde_json::from_str(&response_line)
+            .map_err(|e| format!("Failed to parse response: {e}\nRaw: {response_line}"))
+    }
+
     /// Send a JSON message over WebSocket.
     fn write_json(&mut self, value: &serde_json::Value) -> Result<(), String> {
         self.ws
@@ -659,83 +667,29 @@ impl ReplClient {
 
     /// Evaluate an expression and return the result.
     fn eval(&mut self, expression: &str) -> Result<String, String> {
-        // Send JSON request using new protocol format
-        let request = serde_json::json!({
-            "op": "eval",
-            "id": format!("e2e-{}", std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_micros()),
-            "code": expression
-        });
-
+        let request = RequestBuilder::eval(expression);
         self.write_json(&request)?;
 
-        // Read response
-        let response_line = self.read_text()?;
-
-        // Parse JSON response (handles both legacy and new protocol)
-        let response: serde_json::Value = serde_json::from_str(&response_line)
-            .map_err(|e| format!("Failed to parse response: {e}"))?;
+        // Read and parse response using shared protocol types
+        let response = self.read_repl_response()?;
 
         // Extract warnings if present (BT-407)
         self.last_warnings.clear();
-        if let Some(warnings) = response.get("warnings").and_then(|w| w.as_array()) {
-            for warning in warnings {
-                if let Some(warn_str) = warning.as_str() {
-                    self.last_warnings.push(warn_str.to_string());
-                }
-            }
+        if let Some(ref warnings) = response.warnings {
+            self.last_warnings.clone_from(warnings);
         }
 
-        // New protocol: check status for errors
-        if let Some(status) = response.get("status").and_then(|s| s.as_array()) {
-            let is_error = status.iter().any(|s| s.as_str() == Some("error"));
-            if is_error {
-                let message = response
-                    .get("error")
-                    .and_then(|m| m.as_str())
-                    .unwrap_or("Unknown error");
-                return Err(message.to_string());
-            }
-            // Success - extract value
-            let value = response.get("value").map_or_else(
-                || "null".to_string(),
-                |v| {
-                    if v.is_string() {
-                        v.as_str().unwrap().to_string()
-                    } else {
-                        v.to_string()
-                    }
-                },
-            );
-            return Ok(value);
+        if response.is_error() {
+            let message = response.error_message().unwrap_or("Unknown error");
+            return Err(message.to_string());
         }
 
-        // Legacy protocol fallback
-        match response.get("type").and_then(|t| t.as_str()) {
-            Some("result") => {
-                let value = response.get("value").map_or_else(
-                    || "null".to_string(),
-                    |v| {
-                        if v.is_string() {
-                            v.as_str().unwrap().to_string()
-                        } else {
-                            v.to_string()
-                        }
-                    },
-                );
-                Ok(value)
-            }
-            Some("error") => {
-                let message = response
-                    .get("message")
-                    .and_then(|m| m.as_str())
-                    .unwrap_or("Unknown error");
-                Err(message.to_string())
-            }
-            _ => Err(format!("Unexpected response: {response_line}")),
-        }
+        let value = response.value_string();
+        Ok(if value.is_empty() {
+            "null".to_string()
+        } else {
+            value
+        })
     }
 
     /// Clear REPL bindings between tests.
@@ -748,163 +702,59 @@ impl ReplClient {
     /// This compiles the file and loads its classes into the REPL session,
     /// making them available for spawning and messaging.
     fn load_file(&mut self, path: &str) -> Result<Vec<String>, String> {
-        let request = serde_json::json!({
-            "op": "load-file",
-            "id": "e2e-load",
-            "path": path
-        });
+        self.write_json(&RequestBuilder::load_file(path))?;
 
-        self.write_json(&request)?;
-
-        // Read response
-        let response_line = self.read_text()?;
-
-        // Parse JSON response (handles both legacy and new protocol)
-        let response: serde_json::Value = serde_json::from_str(&response_line)
-            .map_err(|e| format!("Failed to parse load response: {e}"))?;
+        let response = self.read_repl_response()?;
 
         // Extract warnings from load response (BT-737: class collision warnings)
         self.last_warnings.clear();
-        if let Some(warnings) = response.get("warnings").and_then(|w| w.as_array()) {
-            for warning in warnings {
-                if let Some(warn_str) = warning.as_str() {
-                    self.last_warnings.push(warn_str.to_string());
-                }
-            }
+        if let Some(ref warnings) = response.warnings {
+            self.last_warnings.clone_from(warnings);
         }
 
-        // New protocol: check status for errors
-        if let Some(status) = response.get("status").and_then(|s| s.as_array()) {
-            let is_error = status.iter().any(|s| s.as_str() == Some("error"));
-            if is_error {
-                let message = response
-                    .get("error")
-                    .and_then(|m| m.as_str())
-                    .unwrap_or("Unknown error");
-                return Err(message.to_string());
-            }
-            // Success - extract classes
-            let classes = response
-                .get("classes")
-                .and_then(|c| c.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect()
-                })
-                .unwrap_or_default();
-            return Ok(classes);
+        if response.is_error() {
+            let message = response.error_message().unwrap_or("Unknown error");
+            return Err(message.to_string());
         }
 
-        // Legacy protocol fallback
-        match response.get("type").and_then(|t| t.as_str()) {
-            Some("loaded") => {
-                let classes = response
-                    .get("classes")
-                    .and_then(|c| c.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                Ok(classes)
-            }
-            Some("error") => {
-                let message = response
-                    .get("message")
-                    .and_then(|m| m.as_str())
-                    .unwrap_or("Unknown error");
-                Err(message.to_string())
-            }
-            _ => Err(format!("Unexpected load response: {response_line}")),
-        }
+        Ok(response.classes.unwrap_or_default())
     }
 
     /// Get documentation for a class or method via the docs op.
     fn get_docs(&mut self, class: &str, selector: Option<&str>) -> Result<String, String> {
-        let mut request = serde_json::json!({
-            "op": "docs",
-            "id": "e2e-docs",
-            "class": class
-        });
-        if let Some(sel) = selector {
-            request["selector"] = serde_json::Value::String(sel.to_string());
-        }
-
-        self.send_docs_request(&request)
+        self.send_docs_request(&RequestBuilder::docs(class, false, selector))
     }
 
     /// Get help for an Erlang module or function via the erlang-help op (BT-1852).
     fn get_erlang_help(&mut self, module: &str, function: Option<&str>) -> Result<String, String> {
-        let mut request = serde_json::json!({
-            "op": "erlang-help",
-            "id": "e2e-erlang-help",
-            "module": module
-        });
-        if let Some(func) = function {
-            request["function"] = serde_json::Value::String(func.to_string());
-        }
-
-        self.send_docs_request(&request)
+        self.send_docs_request(&RequestBuilder::erlang_help(module, function))
     }
 
     /// Send a docs/erlang-help request and parse the response.
     fn send_docs_request(&mut self, request: &serde_json::Value) -> Result<String, String> {
         self.write_json(request)?;
 
-        let response_line = self.read_text()?;
+        let response = self.read_repl_response()?;
 
-        let response: serde_json::Value = serde_json::from_str(&response_line)
-            .map_err(|e| format!("Failed to parse docs response: {e}"))?;
-
-        // Check for errors (new protocol)
-        if let Some(status) = response.get("status").and_then(|s| s.as_array()) {
-            let is_error = status.iter().any(|s| s.as_str() == Some("error"));
-            if is_error {
-                let message = response
-                    .get("error")
-                    .and_then(|m| m.as_str())
-                    .unwrap_or("Unknown error");
-                return Err(message.to_string());
-            }
-        }
-
-        // Check for errors (legacy protocol)
-        if response.get("type").and_then(|t| t.as_str()) == Some("error") {
-            let message = response
-                .get("message")
-                .and_then(|m| m.as_str())
-                .unwrap_or("Unknown error");
+        if response.is_error() {
+            let message = response.error_message().unwrap_or("Unknown error");
             return Err(message.to_string());
         }
 
-        // Extract docs text
         response
-            .get("docs")
-            .and_then(|d| d.as_str())
-            .map(String::from)
-            .ok_or_else(|| format!("No docs field in response: {response_line}"))
+            .docs
+            .ok_or_else(|| "No docs field in response".to_string())
     }
 
-    /// Send a generic op request and return the raw JSON response.
-    fn send_op(&mut self, request: &serde_json::Value) -> Result<serde_json::Value, String> {
+    /// Send a generic op request and return the typed response.
+    fn send_op(&mut self, request: &serde_json::Value) -> Result<ReplResponse, String> {
         self.write_json(request)?;
 
-        let response_line = self.read_text()?;
+        let response = self.read_repl_response()?;
 
-        let response: serde_json::Value = serde_json::from_str(&response_line)
-            .map_err(|e| format!("Failed to parse response: {e}"))?;
-
-        // Check for errors
-        if let Some(status) = response.get("status").and_then(|s| s.as_array()) {
-            if status.iter().any(|s| s.as_str() == Some("error")) {
-                let message = response
-                    .get("error")
-                    .and_then(|m| m.as_str())
-                    .unwrap_or("Unknown error");
-                return Err(message.to_string());
-            }
+        if response.is_error() {
+            let message = response.error_message().unwrap_or("Unknown error");
+            return Err(message.to_string());
         }
 
         Ok(response)
@@ -912,27 +762,21 @@ impl ReplClient {
 
     /// Clear bindings and return "ok" (for use as a testable expression).
     fn clear_and_report(&mut self) -> Result<String, String> {
-        let response = self.send_op(&serde_json::json!({
-            "op": "clear",
-            "id": "e2e-clear"
-        }))?;
-        Ok(response
-            .get("value")
-            .and_then(|v| v.as_str())
-            .unwrap_or("ok")
-            .to_string())
+        let response = self.send_op(&RequestBuilder::clear())?;
+        let value = response.value_string();
+        Ok(if value.is_empty() {
+            "ok".to_string()
+        } else {
+            value
+        })
     }
 
     /// Get current bindings formatted as a readable string.
     fn get_bindings(&mut self) -> Result<String, String> {
-        let response = self.send_op(&serde_json::json!({
-            "op": "bindings",
-            "id": "e2e-bindings"
-        }))?;
+        let response = self.send_op(&RequestBuilder::bindings())?;
         let bindings = response
-            .get("bindings")
-            .and_then(|b| b.as_object())
-            .cloned()
+            .bindings
+            .and_then(|b| b.as_object().cloned())
             .unwrap_or_default();
         if bindings.is_empty() {
             return Ok("No bindings".to_string());
@@ -954,25 +798,14 @@ impl ReplClient {
 
     /// Get list of running actors formatted as a readable string.
     fn get_actors(&mut self) -> Result<String, String> {
-        let response = self.send_op(&serde_json::json!({
-            "op": "actors",
-            "id": "e2e-actors"
-        }))?;
-        let actors = response
-            .get("actors")
-            .and_then(|a| a.as_array())
-            .cloned()
-            .unwrap_or_default();
+        let response = self.send_op(&RequestBuilder::actors())?;
+        let actors = response.actors.unwrap_or_default();
         if actors.is_empty() {
             return Ok("No actors".to_string());
         }
         let entries: Vec<String> = actors
             .iter()
-            .map(|a| {
-                let class = a.get("class").and_then(|c| c.as_str()).unwrap_or("?");
-                let pid = a.get("pid").and_then(|p| p.as_str()).unwrap_or("?");
-                format!("{class} ({pid})")
-            })
+            .map(|a| format!("{} ({})", a.class, a.pid))
             .collect();
         Ok(entries.join("\n"))
     }
@@ -987,21 +820,11 @@ impl ReplClient {
     fn get_completions(&mut self, code: &str) -> Result<String, String> {
         let code_with_space = format!("{code} ");
         let cursor = code_with_space.len();
-        let response = self.send_op(&serde_json::json!({
-            "op": "complete",
-            "id": format!("e2e-complete-{cursor}"),
-            "code": code_with_space,
-            "cursor": cursor
-        }))?;
-        let mut completions: Vec<String> = response
-            .get("completions")
-            .and_then(|c| c.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(str::to_string))
-                    .collect()
-            })
-            .unwrap_or_default();
+        let response = self.send_op(&RequestBuilder::complete_with_cursor(
+            &code_with_space,
+            cursor,
+        ))?;
+        let mut completions = response.completions.unwrap_or_default();
         completions.sort();
         Ok(completions.join(","))
     }
@@ -1013,16 +836,11 @@ impl ReplClient {
     fn sync_project(&mut self) -> Result<String, String> {
         let root = workspace_root();
         let project_path = root.join("tests/e2e/fixtures/incremental_project");
-        let response = self.send_op(&serde_json::json!({
-            "op": "load-project",
-            "id": "e2e-sync",
-            "path": project_path.to_string_lossy()
-        }))?;
-        let summary = response
-            .get("summary")
-            .and_then(|s| s.as_str())
-            .unwrap_or("Synced");
-        Ok(summary.to_string())
+        let response = self.send_op(&RequestBuilder::load_project(
+            &project_path.to_string_lossy(),
+            false,
+        ))?;
+        Ok(response.summary.unwrap_or_else(|| "Synced".to_string()))
     }
 
     /// Load a file or directory and return a formatted string for test assertions.
@@ -1129,15 +947,8 @@ impl ReplClient {
 
     /// Inspect an actor's state by PID string.
     fn inspect_actor(&mut self, pid_str: &str) -> Result<String, String> {
-        let response = self.send_op(&serde_json::json!({
-            "op": "inspect",
-            "id": "e2e-inspect",
-            "actor": pid_str
-        }))?;
-        let state = response
-            .get("state")
-            .cloned()
-            .unwrap_or(serde_json::Value::Null);
+        let response = self.send_op(&RequestBuilder::inspect(pid_str))?;
+        let state = response.state.unwrap_or(serde_json::Value::Null);
         match state {
             serde_json::Value::String(s) => Ok(s),
             other => Ok(other.to_string()),
@@ -1146,21 +957,13 @@ impl ReplClient {
 
     /// Kill an actor by PID string.
     fn kill_actor(&mut self, pid_str: &str) -> Result<String, String> {
-        self.send_op(&serde_json::json!({
-            "op": "kill",
-            "id": "e2e-kill",
-            "actor": pid_str
-        }))?;
+        self.send_op(&RequestBuilder::kill(pid_str))?;
         Ok("ok".to_string())
     }
 
     /// Unload a module by name.
     fn unload_module(&mut self, module: &str) -> Result<String, String> {
-        self.send_op(&serde_json::json!({
-            "op": "unload",
-            "id": "e2e-unload",
-            "module": module
-        }))?;
+        self.send_op(&RequestBuilder::unload(module))?;
         Ok("ok".to_string())
     }
 
@@ -1168,21 +971,11 @@ impl ReplClient {
     /// Note: actor ordering from the server is non-deterministic (map-based).
     /// This is acceptable for E2E tests where we need any valid actor of a class.
     fn get_first_actor_pid(&mut self, class_name: &str) -> Result<String, String> {
-        let response = self.send_op(&serde_json::json!({
-            "op": "actors",
-            "id": "e2e-actors-pid"
-        }))?;
-        let actors = response
-            .get("actors")
-            .and_then(|a| a.as_array())
-            .cloned()
-            .unwrap_or_default();
+        let response = self.send_op(&RequestBuilder::actors())?;
+        let actors = response.actors.unwrap_or_default();
         for actor in &actors {
-            let class = actor.get("class").and_then(|c| c.as_str()).unwrap_or("");
-            if class == class_name {
-                if let Some(pid) = actor.get("pid").and_then(|p| p.as_str()) {
-                    return Ok(pid.to_string());
-                }
+            if actor.class == class_name {
+                return Ok(actor.pid.clone());
             }
         }
         Err(format!("No actor of class {class_name} found"))

--- a/crates/beamtalk-cli/tests/e2e.rs
+++ b/crates/beamtalk-cli/tests/e2e.rs
@@ -684,11 +684,10 @@ impl ReplClient {
             return Err(message.to_string());
         }
 
-        let value = response.value_string();
-        Ok(if value.is_empty() {
-            "null".to_string()
-        } else {
-            value
+        Ok(match &response.value {
+            None => "null".to_string(),
+            Some(serde_json::Value::String(s)) => s.clone(),
+            Some(v) => v.to_string(),
         })
     }
 

--- a/crates/beamtalk-mcp/Cargo.toml
+++ b/crates/beamtalk-mcp/Cargo.toml
@@ -35,6 +35,9 @@ clap.workspace = true
 # Core compiler for lint passes in the lint MCP tool
 beamtalk-core.workspace = true
 
+# Shared REPL protocol types (request/response)
+beamtalk-repl-protocol.workspace = true
+
 # UTF-8 path handling for lint file collection
 camino.workspace = true
 

--- a/crates/beamtalk-mcp/src/client.rs
+++ b/crates/beamtalk-mcp/src/client.rs
@@ -9,11 +9,12 @@
 //! JSON messages over WebSocket with cookie authentication.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 
+pub use beamtalk_repl_protocol::ReplResponse;
+use beamtalk_repl_protocol::RequestBuilder;
 use futures_util::{SinkExt, StreamExt};
-use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::{
     Error as WsError, Message, error::ProtocolError as WsProtocolError,
@@ -468,12 +469,7 @@ impl ReplClient {
     // Used in integration tests (#[cfg(test)]) — suppress dead_code lint for binary crate.
     #[allow(dead_code)]
     pub async fn eval(&self, code: &str) -> Result<ReplResponse, String> {
-        let request = serde_json::json!({
-            "op": "eval",
-            "id": next_msg_id(),
-            "code": code
-        });
-        self.send_once(&request).await
+        self.send_once(&RequestBuilder::eval(code)).await
     }
 
     /// Evaluate an expression with optional trace mode (BT-1238).
@@ -489,14 +485,7 @@ impl ReplClient {
         trace: bool,
     ) -> Result<ReplResponse, String> {
         tracing::debug!(op = "eval", code_len = code.len(), trace, "REPL request");
-        let mut request = serde_json::json!({
-            "op": "eval",
-            "id": next_msg_id(),
-            "code": code
-        });
-        if trace {
-            request["trace"] = serde_json::Value::Bool(true);
-        }
+        let request = RequestBuilder::eval_with_trace(code, trace);
         let result = self.send_once(&request).await;
         tracing::debug!(op = "eval", ok = result.is_ok(), "REPL response");
         result
@@ -511,13 +500,8 @@ impl ReplClient {
     /// rather than the legacy bare-prefix path. The cursor value itself is not
     /// used by the current REPL handler — only its presence matters.
     pub async fn complete(&self, code: &str, cursor: usize) -> Result<ReplResponse, String> {
-        let request = serde_json::json!({
-            "op": "complete",
-            "id": next_msg_id(),
-            "code": code,
-            "cursor": cursor
-        });
-        self.send(&request).await
+        self.send(&RequestBuilder::complete_with_cursor(code, cursor))
+            .await
     }
 
     /// Send a load-source operation to compile inline Beamtalk source.
@@ -527,24 +511,22 @@ impl ReplClient {
     // Used in integration tests (#[cfg(test)]) — suppress dead_code lint for binary crate.
     #[allow(dead_code)]
     pub async fn load_source(&self, source: &str) -> Result<ReplResponse, String> {
-        self.send_once(&Self::request_with_param("load-source", "source", source))
-            .await
+        self.send_once(&RequestBuilder::load_source(source)).await
     }
 
     /// Send an inspect operation.
     pub async fn inspect(&self, actor: &str) -> Result<ReplResponse, String> {
-        self.send(&Self::request_with_param("inspect", "actor", actor))
-            .await
+        self.send(&RequestBuilder::inspect(actor)).await
     }
 
     /// Send an actors operation.
     pub async fn actors(&self) -> Result<ReplResponse, String> {
-        self.send(&Self::request("actors")).await
+        self.send(&RequestBuilder::actors()).await
     }
 
     /// Send a bindings operation.
     pub async fn bindings(&self) -> Result<ReplResponse, String> {
-        self.send(&Self::request("bindings")).await
+        self.send(&RequestBuilder::bindings()).await
     }
 
     /// Send a clear operation to reset REPL bindings.
@@ -552,7 +534,7 @@ impl ReplClient {
     /// Uses [`send_once`] (no retry) — clearing bindings is a mutating operation
     /// that could interleave badly with other operations on reconnect.
     pub async fn clear(&self) -> Result<ReplResponse, String> {
-        self.send_once(&Self::request("clear")).await
+        self.send_once(&RequestBuilder::clear()).await
     }
 
     /// Send an unload operation to remove a class from the workspace.
@@ -560,8 +542,7 @@ impl ReplClient {
     /// Uses [`send_once`] (no retry) — a retry after the class was already
     /// unloaded would produce a not-found error.
     pub async fn unload(&self, module: &str) -> Result<ReplResponse, String> {
-        self.send_once(&Self::request_with_param("unload", "module", module))
-            .await
+        self.send_once(&RequestBuilder::unload(module)).await
     }
 
     /// Send an interrupt operation to cancel a running evaluation.
@@ -574,13 +555,12 @@ impl ReplClient {
     /// Uses [`send_once`] (no retry) — a retry after reconnect could cancel
     /// a different evaluation that started after the session was resumed.
     pub async fn interrupt(&self) -> Result<ReplResponse, String> {
-        self.send_once(&Self::request("interrupt")).await
+        self.send_once(&RequestBuilder::interrupt()).await
     }
 
     /// Send a show-codegen operation to inspect generated Core Erlang.
     pub async fn show_codegen(&self, code: &str) -> Result<ReplResponse, String> {
-        self.send(&Self::request_with_param("show-codegen", "code", code))
-            .await
+        self.send(&RequestBuilder::show_codegen(code)).await
     }
 
     /// Send a show-codegen operation for a loaded class (BT-1236).
@@ -589,15 +569,8 @@ impl ReplClient {
         class: &str,
         selector: Option<&str>,
     ) -> Result<ReplResponse, String> {
-        let mut request = serde_json::json!({
-            "op": "show-codegen",
-            "id": next_msg_id(),
-            "class": class
-        });
-        if let Some(sel) = selector {
-            request["selector"] = serde_json::Value::String(sel.to_owned());
-        }
-        self.send(&request).await
+        self.send(&RequestBuilder::show_codegen_class(class, selector))
+            .await
     }
 
     /// Send a test operation to run `BUnit` tests for a specific class.
@@ -608,45 +581,39 @@ impl ReplClient {
     /// `BEAMTALK_MCP_TEST_TIMEOUT`) since test suites can take much longer than
     /// the default 30 s I/O timeout.
     pub async fn test_class(&self, class: &str) -> Result<ReplResponse, String> {
-        self.send_once_with_timeout(
-            &Self::request_with_param("test", "class", class),
-            test_io_timeout(),
-        )
-        .await
+        self.send_once_with_timeout(&RequestBuilder::test_class(class), test_io_timeout())
+            .await
     }
 
     /// Send a test operation scoped to a specific source file path.
     ///
     /// Uses [`send_once_with_timeout`] (no retry) — see [`test_class`] for rationale.
     pub async fn test_file(&self, file: &str) -> Result<ReplResponse, String> {
-        self.send_once_with_timeout(
-            &Self::request_with_param("test", "file", file),
-            test_io_timeout(),
-        )
-        .await
+        self.send_once_with_timeout(&RequestBuilder::test_file(file), test_io_timeout())
+            .await
     }
 
     /// Send a test-all operation to run all `BUnit` tests.
     ///
     /// Uses [`send_once_with_timeout`] (no retry) — see [`test_class`] for rationale.
     pub async fn test_all(&self) -> Result<ReplResponse, String> {
-        self.send_once_with_timeout(&Self::request("test-all"), test_io_timeout())
+        self.send_once_with_timeout(&RequestBuilder::test_all(), test_io_timeout())
             .await
     }
 
     /// Send a describe operation for capability discovery.
     pub async fn describe(&self) -> Result<ReplResponse, String> {
-        self.send(&Self::request("describe")).await
+        self.send(&RequestBuilder::describe()).await
     }
 
     /// Send an enable-tracing operation (ADR 0069).
     pub async fn enable_tracing(&self) -> Result<ReplResponse, String> {
-        self.send(&Self::request("enable-tracing")).await
+        self.send(&RequestBuilder::enable_tracing()).await
     }
 
     /// Send a disable-tracing operation (ADR 0069).
     pub async fn disable_tracing(&self) -> Result<ReplResponse, String> {
-        self.send(&Self::request("disable-tracing")).await
+        self.send(&RequestBuilder::disable_tracing()).await
     }
 
     /// Send a get-traces operation with optional filtering (ADR 0069).
@@ -659,41 +626,20 @@ impl ReplClient {
         min_duration_ns: Option<u64>,
         limit: Option<u32>,
     ) -> Result<ReplResponse, String> {
-        let mut request = serde_json::json!({
-            "op": "get-traces",
-            "id": next_msg_id()
-        });
-        if let Some(a) = actor {
-            request["actor"] = serde_json::Value::String(a.to_owned());
-        }
-        if let Some(s) = selector {
-            request["selector"] = serde_json::Value::String(s.to_owned());
-        }
-        if let Some(c) = class {
-            request["class"] = serde_json::Value::String(c.to_owned());
-        }
-        if let Some(o) = outcome {
-            request["outcome"] = serde_json::Value::String(o.to_owned());
-        }
-        if let Some(d) = min_duration_ns {
-            request["min_duration_ns"] = serde_json::json!(d);
-        }
-        if let Some(l) = limit {
-            request["limit"] = serde_json::json!(l);
-        }
-        self.send(&request).await
+        self.send(&RequestBuilder::get_traces(
+            actor,
+            selector,
+            class,
+            outcome,
+            min_duration_ns,
+            limit,
+        ))
+        .await
     }
 
     /// Send an actor-stats operation with optional actor filter (ADR 0069).
     pub async fn actor_stats(&self, actor: Option<&str>) -> Result<ReplResponse, String> {
-        let mut request = serde_json::json!({
-            "op": "actor-stats",
-            "id": next_msg_id()
-        });
-        if let Some(a) = actor {
-            request["actor"] = serde_json::Value::String(a.to_owned());
-        }
-        self.send(&request).await
+        self.send(&RequestBuilder::actor_stats(actor)).await
     }
 
     /// Send an export-traces operation with optional filters and path (ADR 0069).
@@ -708,32 +654,16 @@ impl ReplClient {
         min_duration_ns: Option<u64>,
         limit: Option<u32>,
     ) -> Result<ReplResponse, String> {
-        let mut request = serde_json::json!({
-            "op": "export-traces",
-            "id": next_msg_id()
-        });
-        if let Some(p) = path {
-            request["path"] = serde_json::Value::String(p.to_owned());
-        }
-        if let Some(a) = actor {
-            request["actor"] = serde_json::Value::String(a.to_owned());
-        }
-        if let Some(s) = selector {
-            request["selector"] = serde_json::Value::String(s.to_owned());
-        }
-        if let Some(c) = class {
-            request["class"] = serde_json::Value::String(c.to_owned());
-        }
-        if let Some(o) = outcome {
-            request["outcome"] = serde_json::Value::String(o.to_owned());
-        }
-        if let Some(d) = min_duration_ns {
-            request["min_duration_ns"] = serde_json::json!(d);
-        }
-        if let Some(l) = limit {
-            request["limit"] = serde_json::json!(l);
-        }
-        self.send(&request).await
+        self.send(&RequestBuilder::export_traces(
+            path,
+            actor,
+            selector,
+            class,
+            outcome,
+            min_duration_ns,
+            limit,
+        ))
+        .await
     }
 
     /// Send a load-project operation.
@@ -748,14 +678,12 @@ impl ReplClient {
         include_tests: bool,
         force: bool,
     ) -> Result<ReplResponse, String> {
-        let request = serde_json::json!({
-            "op": "load-project",
-            "id": next_msg_id(),
-            "path": path,
-            "include_tests": include_tests,
-            "force": force
-        });
-        self.send_once(&request).await
+        self.send_once(&RequestBuilder::load_project_with_force(
+            path,
+            include_tests,
+            force,
+        ))
+        .await
     }
 
     /// Send a JSON request and receive a JSON response for non-idempotent operations.
@@ -894,141 +822,18 @@ impl ReplClient {
         unreachable!("send_once loop always returns on attempt 1")
     }
 
-    // --- Request builder helpers ---
-
-    /// Build a no-param request for the given operation.
-    fn request(op: &str) -> serde_json::Value {
-        serde_json::json!({"op": op, "id": next_msg_id()})
-    }
-
-    /// Build a single-param request for the given operation.
-    fn request_with_param(op: &str, key: &str, value: &str) -> serde_json::Value {
-        let mut req = serde_json::json!({"op": op, "id": next_msg_id()});
-        req[key] = serde_json::Value::String(value.to_string());
-        req
-    }
-
     /// Send a list-classes operation (BT-1404).
     ///
     /// Returns all available classes with one-line descriptions. The optional
     /// `filter` narrows results: `"stdlib"` for built-in classes, `"user"` for
     /// user-defined, or a superclass name like `"Value"` or `"Actor"`.
     pub async fn list_classes(&self, filter: Option<&str>) -> Result<ReplResponse, String> {
-        let mut request = serde_json::json!({
-            "op": "list-classes",
-            "id": next_msg_id()
-        });
-        if let Some(f) = filter {
-            request["filter"] = serde_json::Value::String(f.to_string());
-        }
-        self.send(&request).await
+        self.send(&RequestBuilder::list_classes(filter)).await
     }
 }
 
-/// JSON response from the REPL backend.
-#[derive(Debug, Deserialize, Serialize)]
-pub struct ReplResponse {
-    /// Message correlation ID.
-    pub id: Option<String>,
-    /// Session ID.
-    pub session: Option<String>,
-    /// Status flags: `["done"]`, `["done", "error"]`, or `["done", "test-error"]`.
-    pub status: Option<Vec<String>>,
-    /// Result value.
-    pub value: Option<serde_json::Value>,
-    /// Captured stdout from evaluation.
-    pub output: Option<String>,
-    /// Error message.
-    pub error: Option<String>,
-    /// Bindings map.
-    pub bindings: Option<serde_json::Value>,
-    /// Loaded classes (string names, from eval/load responses).
-    pub classes: Option<Vec<String>>,
-    /// Class info list with metadata (list-classes op, BT-1404).
-    pub class_list: Option<Vec<ClassInfo>>,
-    /// Actor list.
-    pub actors: Option<Vec<ActorInfo>>,
-    /// Completion suggestions.
-    pub completions: Option<Vec<String>>,
-    /// Symbol info.
-    pub info: Option<serde_json::Value>,
-    /// Actor state (inspect op).
-    pub state: Option<serde_json::Value>,
-    /// Compilation warnings.
-    pub warnings: Option<Vec<String>>,
-    /// Line number (1-based) of a compile error in the submitted snippet (BT-1235).
-    pub line: Option<u32>,
-    /// Hint text for a compile error, where available (BT-1235).
-    pub hint: Option<String>,
-    /// Documentation text.
-    pub docs: Option<String>,
-    /// Number of actors affected by reload.
-    pub affected_actors: Option<u32>,
-    /// Number of actors that failed code migration.
-    pub migration_failures: Option<u32>,
-    /// Generated Core Erlang source (show-codegen op).
-    pub core_erlang: Option<String>,
-    /// Per-file load errors (load-project op). Each entry is a structured map
-    /// with at least `path`, `kind`, and `message` fields.
-    pub errors: Option<Vec<serde_json::Value>>,
-    /// Test results (test / test-all ops).
-    pub results: Option<serde_json::Value>,
-    /// Per-statement trace steps (eval with trace=true, BT-1238).
-    /// Each entry is `{"src": "...", "value": ...}`.
-    pub steps: Option<Vec<serde_json::Value>>,
-    /// Supported operations and protocol info (describe op).
-    pub ops: Option<serde_json::Value>,
-    /// Protocol and language versions (describe op).
-    pub versions: Option<serde_json::Value>,
-    /// Incremental load summary (load-project op, BT-1685).
-    /// E.g. "Reloaded 2 of 7 files (5 unchanged)"
-    pub summary: Option<String>,
-}
-
-impl ReplResponse {
-    /// Check if this is an error response.
-    pub fn is_error(&self) -> bool {
-        if let Some(ref status) = self.status {
-            return status.iter().any(|s| s == "error");
-        }
-        false
-    }
-
-    /// Check if the response contains a test failure (`"test-error"` status).
-    pub fn has_test_error(&self) -> bool {
-        if let Some(ref status) = self.status {
-            return status.iter().any(|s| s == "test-error");
-        }
-        false
-    }
-
-    /// Get the error message if present.
-    pub fn error_message(&self) -> Option<&str> {
-        self.error.as_deref()
-    }
-
-    /// Get the result value as a formatted string.
-    pub fn value_string(&self) -> String {
-        match &self.value {
-            Some(serde_json::Value::String(s)) => s.clone(),
-            Some(v) => v.to_string(),
-            None => String::new(),
-        }
-    }
-}
-
-/// Actor information from the REPL.
-#[derive(Debug, Deserialize, Serialize)]
-pub struct ActorInfo {
-    /// Erlang process identifier as a string (e.g., `"<0.173.0>"`).
-    pub pid: String,
-    /// Beamtalk class name of the actor (e.g., `"Counter"`).
-    pub class: String,
-    /// Source module the actor was compiled from.
-    pub module: String,
-    /// Unix timestamp (seconds) when the actor was spawned.
-    pub spawned_at: i64,
-}
+// Response types (`ReplResponse`, `ActorInfo`, `ClassInfo`) are imported from
+// `beamtalk_repl_protocol` and re-exported at the top of this module.
 
 /// Spawn a background task that sends WebSocket Ping frames at [`KEEPALIVE_INTERVAL`].
 ///
@@ -1076,22 +881,6 @@ fn spawn_keepalive(inner: Arc<Mutex<ReplClientInner>>) -> tokio::task::JoinHandl
             }
         }
     })
-}
-
-/// Class information from the list-classes op (BT-1404).
-#[derive(Debug, Deserialize, Serialize)]
-pub struct ClassInfo {
-    /// Class name (e.g., `"String"`).
-    pub name: String,
-    /// Superclass name (e.g., `"Value"`) or `null` for root classes.
-    pub superclass: Option<String>,
-    /// One-line class description, or `null` if undocumented.
-    pub doc: Option<String>,
-    /// Whether the class is sealed (cannot be subclassed).
-    pub sealed: bool,
-    /// Whether the class is abstract (cannot be instantiated directly).
-    #[serde(rename = "abstract")]
-    pub is_abstract: bool,
 }
 
 /// Perform the ADR 0020 authentication handshake on a WebSocket connection.
@@ -1189,13 +978,6 @@ where
     tokio::time::timeout(timeout, read_text_message(ws))
         .await
         .map_err(|_| format!("WebSocket read timed out after {}s", timeout.as_secs()))?
-}
-
-/// Generate a unique message ID.
-fn next_msg_id() -> String {
-    static MSG_COUNTER: AtomicU64 = AtomicU64::new(1);
-    let n = MSG_COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("msg-{n:03}")
 }
 
 #[cfg(test)]

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -668,7 +668,7 @@ impl BeamtalkMcp {
         check_response!(response, "Failed to load project");
 
         let classes = response.classes.unwrap_or_default();
-        let errors = response.errors.unwrap_or_default();
+        let errors = response.errors;
 
         let mut parts = Vec::new();
 

--- a/crates/beamtalk-repl-protocol/Cargo.toml
+++ b/crates/beamtalk-repl-protocol/Cargo.toml
@@ -1,0 +1,22 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "beamtalk-repl-protocol"
+description = "Shared REPL protocol types (request/response) for beamtalk clients"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords = ["repl", "protocol", "beam", "smalltalk"]
+categories = ["development-tools"]
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/beamtalk-repl-protocol/src/lib.rs
+++ b/crates/beamtalk-repl-protocol/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared REPL protocol types for the Beamtalk workspace JSON-over-WebSocket
+//! protocol (ADR 0020).
+//!
+//! **DDD Context:** REPL — Protocol Contract
+//!
+//! This crate provides the canonical request builder and response types used by
+//! both `beamtalk-cli` and `beamtalk-mcp` when communicating with the workspace
+//! backend. Having a single source of truth prevents the two clients from
+//! diverging when the protocol evolves.
+
+mod request;
+mod response;
+
+pub use request::{RequestBuilder, next_msg_id};
+pub use response::{ActorInfo, ClassInfo, ModuleInfo, ReplResponse, SessionInfo};

--- a/crates/beamtalk-repl-protocol/src/request.rs
+++ b/crates/beamtalk-repl-protocol/src/request.rs
@@ -73,6 +73,34 @@ impl RequestBuilder {
         })
     }
 
+    /// Build a `complete` request with cursor position and an optional session ID.
+    #[must_use]
+    pub fn complete_with_session(
+        code: &str,
+        cursor: usize,
+        session: Option<&str>,
+    ) -> serde_json::Value {
+        let mut req = Self::complete_with_cursor(code, cursor);
+        if let Some(sid) = session {
+            req["session"] = serde_json::Value::String(sid.to_owned());
+        }
+        req
+    }
+
+    /// Build an `erlang-complete` request with optional module filter.
+    #[must_use]
+    pub fn erlang_complete(prefix: &str, module: Option<&str>) -> serde_json::Value {
+        let mut req = serde_json::json!({
+            "op": "erlang-complete",
+            "id": next_msg_id(),
+            "prefix": prefix,
+        });
+        if let Some(m) = module {
+            req["module"] = serde_json::Value::String(m.to_owned());
+        }
+        req
+    }
+
     /// Build an `info` request.
     #[must_use]
     pub fn info(symbol: &str) -> serde_json::Value {

--- a/crates/beamtalk-repl-protocol/src/request.rs
+++ b/crates/beamtalk-repl-protocol/src/request.rs
@@ -1,0 +1,545 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Request builders for the REPL JSON protocol.
+//!
+//! Each method returns a `serde_json::Value` ready to be serialized and sent
+//! over the WebSocket transport. The transport layer is intentionally not
+//! included here — callers provide their own sync or async WebSocket client.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Counter for generating unique message IDs.
+static MSG_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Generate a unique, monotonically increasing message ID.
+///
+/// IDs are formatted as `msg-001`, `msg-002`, etc. The counter is global
+/// and atomic, so IDs are unique across threads and client instances within
+/// a single process.
+pub fn next_msg_id() -> String {
+    let n = MSG_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("msg-{n:03}")
+}
+
+/// Builder for REPL protocol JSON requests.
+///
+/// Provides typed constructors for every REPL operation. All methods return
+/// a `serde_json::Value` with the correct `op`, `id`, and parameters.
+#[derive(Debug)]
+pub struct RequestBuilder;
+
+impl RequestBuilder {
+    // --- Core operations ---
+
+    /// Build an `eval` request.
+    #[must_use]
+    pub fn eval(code: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "eval",
+            "id": next_msg_id(),
+            "code": code
+        })
+    }
+
+    /// Build an `eval` request with optional trace mode (BT-1238).
+    #[must_use]
+    pub fn eval_with_trace(code: &str, trace: bool) -> serde_json::Value {
+        let mut req = Self::eval(code);
+        if trace {
+            req["trace"] = serde_json::Value::Bool(true);
+        }
+        req
+    }
+
+    /// Build a `complete` request.
+    #[must_use]
+    pub fn complete(code: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "complete",
+            "id": next_msg_id(),
+            "code": code
+        })
+    }
+
+    /// Build a `complete` request with cursor position.
+    #[must_use]
+    pub fn complete_with_cursor(code: &str, cursor: usize) -> serde_json::Value {
+        serde_json::json!({
+            "op": "complete",
+            "id": next_msg_id(),
+            "code": code,
+            "cursor": cursor
+        })
+    }
+
+    /// Build an `info` request.
+    #[must_use]
+    pub fn info(symbol: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "info",
+            "id": next_msg_id(),
+            "symbol": symbol
+        })
+    }
+
+    /// Build a `show-codegen` request for an expression.
+    #[must_use]
+    pub fn show_codegen(code: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "show-codegen",
+            "id": next_msg_id(),
+            "code": code
+        })
+    }
+
+    /// Build a `show-codegen` request for a loaded class (BT-1236).
+    #[must_use]
+    pub fn show_codegen_class(class: &str, selector: Option<&str>) -> serde_json::Value {
+        let mut req = serde_json::json!({
+            "op": "show-codegen",
+            "id": next_msg_id(),
+            "class": class
+        });
+        if let Some(sel) = selector {
+            req["selector"] = serde_json::Value::String(sel.to_owned());
+        }
+        req
+    }
+
+    /// Build a `load-file` request.
+    #[must_use]
+    pub fn load_file(path: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "load-file",
+            "id": next_msg_id(),
+            "path": path
+        })
+    }
+
+    /// Build a `load-source` request.
+    #[must_use]
+    pub fn load_source(source: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "load-source",
+            "id": next_msg_id(),
+            "source": source
+        })
+    }
+
+    /// Build a `load-project` request.
+    #[must_use]
+    pub fn load_project(path: &str, include_tests: bool) -> serde_json::Value {
+        serde_json::json!({
+            "op": "load-project",
+            "id": next_msg_id(),
+            "path": path,
+            "include_tests": include_tests
+        })
+    }
+
+    /// Build a `load-project` request with force flag.
+    #[must_use]
+    pub fn load_project_with_force(
+        path: &str,
+        include_tests: bool,
+        force: bool,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "op": "load-project",
+            "id": next_msg_id(),
+            "path": path,
+            "include_tests": include_tests,
+            "force": force
+        })
+    }
+
+    /// Build a `reload` request.
+    #[must_use]
+    pub fn reload(module: &str, path: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "reload",
+            "id": next_msg_id(),
+            "module": module,
+            "path": path
+        })
+    }
+
+    // --- Session operations ---
+
+    /// Build a `clear` request.
+    #[must_use]
+    pub fn clear() -> serde_json::Value {
+        Self::no_param("clear")
+    }
+
+    /// Build a `bindings` request.
+    #[must_use]
+    pub fn bindings() -> serde_json::Value {
+        Self::no_param("bindings")
+    }
+
+    /// Build a `sessions` request.
+    #[must_use]
+    pub fn sessions() -> serde_json::Value {
+        Self::no_param("sessions")
+    }
+
+    /// Build a `clone` request.
+    #[must_use]
+    pub fn clone_session() -> serde_json::Value {
+        Self::no_param("clone")
+    }
+
+    /// Build a `close` request.
+    #[must_use]
+    pub fn close() -> serde_json::Value {
+        Self::no_param("close")
+    }
+
+    // --- Actor operations ---
+
+    /// Build an `actors` request.
+    #[must_use]
+    pub fn actors() -> serde_json::Value {
+        Self::no_param("actors")
+    }
+
+    /// Build an `inspect` request.
+    #[must_use]
+    pub fn inspect(actor: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "inspect",
+            "id": next_msg_id(),
+            "actor": actor
+        })
+    }
+
+    /// Build a `kill` request.
+    #[must_use]
+    pub fn kill(actor: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "kill",
+            "id": next_msg_id(),
+            "actor": actor
+        })
+    }
+
+    /// Build an `interrupt` request.
+    #[must_use]
+    pub fn interrupt() -> serde_json::Value {
+        Self::no_param("interrupt")
+    }
+
+    /// Build an `interrupt` request with a session ID.
+    #[must_use]
+    pub fn interrupt_with_session(session: &str) -> serde_json::Value {
+        let mut req = Self::interrupt();
+        req["session"] = serde_json::Value::String(session.to_owned());
+        req
+    }
+
+    // --- Module operations ---
+
+    /// Build a `modules` request.
+    #[must_use]
+    pub fn modules() -> serde_json::Value {
+        Self::no_param("modules")
+    }
+
+    /// Build an `unload` request.
+    #[must_use]
+    pub fn unload(module: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "unload",
+            "id": next_msg_id(),
+            "module": module
+        })
+    }
+
+    // --- Test operations ---
+
+    /// Build a `test` request for a class.
+    #[must_use]
+    pub fn test_class(class: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "test",
+            "id": next_msg_id(),
+            "class": class
+        })
+    }
+
+    /// Build a `test` request for a file.
+    #[must_use]
+    pub fn test_file(file: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "test",
+            "id": next_msg_id(),
+            "file": file
+        })
+    }
+
+    /// Build a `test` request for a class with an optional method filter.
+    #[must_use]
+    pub fn test_method(class: &str, method: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "test",
+            "id": next_msg_id(),
+            "class": class,
+            "method": method
+        })
+    }
+
+    /// Build a `test-all` request.
+    #[must_use]
+    pub fn test_all() -> serde_json::Value {
+        Self::no_param("test-all")
+    }
+
+    // --- Documentation operations ---
+
+    /// Build a `docs` request.
+    #[must_use]
+    pub fn docs(class: &str, class_side: bool, selector: Option<&str>) -> serde_json::Value {
+        let mut req = serde_json::json!({
+            "op": "docs",
+            "id": next_msg_id(),
+            "class": class
+        });
+        if class_side {
+            req["class_side"] = serde_json::Value::Bool(true);
+        }
+        if let Some(sel) = selector {
+            req["selector"] = serde_json::Value::String(sel.to_owned());
+        }
+        req
+    }
+
+    /// Build an `erlang-help` request (BT-1852).
+    #[must_use]
+    pub fn erlang_help(module: &str, function: Option<&str>) -> serde_json::Value {
+        let mut req = serde_json::json!({
+            "op": "erlang-help",
+            "id": next_msg_id(),
+            "module": module
+        });
+        if let Some(func) = function {
+            req["function"] = serde_json::Value::String(func.to_owned());
+        }
+        req
+    }
+
+    // --- Server / discovery operations ---
+
+    /// Build a `describe` request.
+    #[must_use]
+    pub fn describe() -> serde_json::Value {
+        Self::no_param("describe")
+    }
+
+    /// Build a `health` request.
+    #[must_use]
+    pub fn health() -> serde_json::Value {
+        Self::no_param("health")
+    }
+
+    /// Build a `shutdown` request.
+    #[must_use]
+    pub fn shutdown(cookie: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "shutdown",
+            "id": next_msg_id(),
+            "cookie": cookie
+        })
+    }
+
+    /// Build a `list-classes` request (BT-1404).
+    #[must_use]
+    pub fn list_classes(filter: Option<&str>) -> serde_json::Value {
+        let mut req = serde_json::json!({
+            "op": "list-classes",
+            "id": next_msg_id()
+        });
+        if let Some(f) = filter {
+            req["filter"] = serde_json::Value::String(f.to_owned());
+        }
+        req
+    }
+
+    // --- Tracing operations (ADR 0069) ---
+
+    /// Build an `enable-tracing` request.
+    #[must_use]
+    pub fn enable_tracing() -> serde_json::Value {
+        Self::no_param("enable-tracing")
+    }
+
+    /// Build a `disable-tracing` request.
+    #[must_use]
+    pub fn disable_tracing() -> serde_json::Value {
+        Self::no_param("disable-tracing")
+    }
+
+    /// Build a `get-traces` request with optional filters (ADR 0069).
+    #[must_use]
+    pub fn get_traces(
+        actor: Option<&str>,
+        selector: Option<&str>,
+        class: Option<&str>,
+        outcome: Option<&str>,
+        min_duration_ns: Option<u64>,
+        limit: Option<u32>,
+    ) -> serde_json::Value {
+        let mut req = serde_json::json!({
+            "op": "get-traces",
+            "id": next_msg_id()
+        });
+        if let Some(a) = actor {
+            req["actor"] = serde_json::Value::String(a.to_owned());
+        }
+        if let Some(s) = selector {
+            req["selector"] = serde_json::Value::String(s.to_owned());
+        }
+        if let Some(c) = class {
+            req["class"] = serde_json::Value::String(c.to_owned());
+        }
+        if let Some(o) = outcome {
+            req["outcome"] = serde_json::Value::String(o.to_owned());
+        }
+        if let Some(d) = min_duration_ns {
+            req["min_duration_ns"] = serde_json::json!(d);
+        }
+        if let Some(l) = limit {
+            req["limit"] = serde_json::json!(l);
+        }
+        req
+    }
+
+    /// Build an `actor-stats` request with optional actor filter (ADR 0069).
+    #[must_use]
+    pub fn actor_stats(actor: Option<&str>) -> serde_json::Value {
+        let mut req = serde_json::json!({
+            "op": "actor-stats",
+            "id": next_msg_id()
+        });
+        if let Some(a) = actor {
+            req["actor"] = serde_json::Value::String(a.to_owned());
+        }
+        req
+    }
+
+    /// Build an `export-traces` request with optional filters (ADR 0069).
+    #[must_use]
+    pub fn export_traces(
+        path: Option<&str>,
+        actor: Option<&str>,
+        selector: Option<&str>,
+        class: Option<&str>,
+        outcome: Option<&str>,
+        min_duration_ns: Option<u64>,
+        limit: Option<u32>,
+    ) -> serde_json::Value {
+        let mut req = serde_json::json!({
+            "op": "export-traces",
+            "id": next_msg_id()
+        });
+        if let Some(p) = path {
+            req["path"] = serde_json::Value::String(p.to_owned());
+        }
+        if let Some(a) = actor {
+            req["actor"] = serde_json::Value::String(a.to_owned());
+        }
+        if let Some(s) = selector {
+            req["selector"] = serde_json::Value::String(s.to_owned());
+        }
+        if let Some(c) = class {
+            req["class"] = serde_json::Value::String(c.to_owned());
+        }
+        if let Some(o) = outcome {
+            req["outcome"] = serde_json::Value::String(o.to_owned());
+        }
+        if let Some(d) = min_duration_ns {
+            req["min_duration_ns"] = serde_json::json!(d);
+        }
+        if let Some(l) = limit {
+            req["limit"] = serde_json::json!(l);
+        }
+        req
+    }
+
+    // --- Stdin (BT-698) ---
+
+    /// Build a `stdin` request to provide input to a running eval.
+    #[must_use]
+    pub fn stdin(id: &str, value: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "stdin",
+            "id": id,
+            "value": value
+        })
+    }
+
+    // --- Internal helpers ---
+
+    /// Build a no-parameter request for the given op.
+    fn no_param(op: &str) -> serde_json::Value {
+        serde_json::json!({"op": op, "id": next_msg_id()})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eval_request_has_correct_shape() {
+        let req = RequestBuilder::eval("1 + 2");
+        assert_eq!(req["op"], "eval");
+        assert_eq!(req["code"], "1 + 2");
+        assert!(req["id"].as_str().unwrap().starts_with("msg-"));
+    }
+
+    #[test]
+    fn msg_ids_are_monotonic() {
+        let id1 = next_msg_id();
+        let id2 = next_msg_id();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn complete_with_cursor_includes_cursor() {
+        let req = RequestBuilder::complete_with_cursor("foo ", 4);
+        assert_eq!(req["op"], "complete");
+        assert_eq!(req["code"], "foo ");
+        assert_eq!(req["cursor"], 4);
+    }
+
+    #[test]
+    fn load_project_with_force() {
+        let req = RequestBuilder::load_project_with_force(".", true, true);
+        assert_eq!(req["op"], "load-project");
+        assert_eq!(req["path"], ".");
+        assert_eq!(req["include_tests"], true);
+        assert_eq!(req["force"], true);
+    }
+
+    #[test]
+    fn docs_request_optional_params() {
+        let req = RequestBuilder::docs("Integer", false, None);
+        assert_eq!(req["op"], "docs");
+        assert_eq!(req["class"], "Integer");
+        assert!(req.get("class_side").is_none());
+        assert!(req.get("selector").is_none());
+
+        let req2 = RequestBuilder::docs("Integer", true, Some("+"));
+        assert_eq!(req2["class_side"], true);
+        assert_eq!(req2["selector"], "+");
+    }
+
+    #[test]
+    fn interrupt_with_session() {
+        let req = RequestBuilder::interrupt_with_session("sess-42");
+        assert_eq!(req["op"], "interrupt");
+        assert_eq!(req["session"], "sess-42");
+    }
+}

--- a/crates/beamtalk-repl-protocol/src/response.rs
+++ b/crates/beamtalk-repl-protocol/src/response.rs
@@ -195,6 +195,10 @@ impl ReplResponse {
     }
 
     /// Get the error message (either legacy `message` or current `error` field).
+    ///
+    /// Falls back to the first `errors[].message` entry when neither top-level
+    /// field is set — this matches load-project responses which surface
+    /// per-file failures only via the `errors` list.
     pub fn error_message(&self) -> Option<&str> {
         if let Some(ref msg) = self.message {
             return Some(msg.as_str());
@@ -202,7 +206,9 @@ impl ReplResponse {
         if let Some(ref err) = self.error {
             return Some(err.as_str());
         }
-        None
+        self.errors
+            .iter()
+            .find_map(|e| e.get("message").and_then(serde_json::Value::as_str))
     }
 
     /// Get the result value as a formatted string.

--- a/crates/beamtalk-repl-protocol/src/response.rs
+++ b/crates/beamtalk-repl-protocol/src/response.rs
@@ -177,8 +177,8 @@ pub struct ReplResponse {
 impl ReplResponse {
     /// Check if this is an error response (either legacy or current format).
     pub fn is_error(&self) -> bool {
-        if let Some(ref t) = self.response_type {
-            return t == "error";
+        if self.response_type.as_deref() == Some("error") {
+            return true;
         }
         if let Some(ref status) = self.status {
             return status.iter().any(|s| s == "error");

--- a/crates/beamtalk-repl-protocol/src/response.rs
+++ b/crates/beamtalk-repl-protocol/src/response.rs
@@ -1,0 +1,371 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Response types for the REPL JSON protocol.
+//!
+//! The canonical `ReplResponse` is a flat "super-struct" with `Option` fields
+//! for every possible response payload. Only the fields relevant to a given
+//! operation will be populated; the rest will be `None`. This matches the
+//! wire format — a single JSON object whose shape varies by op.
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Deserialize a `null` JSON value as an empty `Vec`.
+///
+/// The REPL backend sometimes sends `"errors": null` instead of `"errors": []`.
+/// This custom deserializer normalises both to an empty `Vec<T>`.
+fn deserialize_null_as_empty_vec<'de, T, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::<Vec<T>>::deserialize(deserializer).map(Option::unwrap_or_default)
+}
+
+/// JSON response from the REPL backend.
+///
+/// Supports both the legacy format (`type` field) and the current protocol
+/// format (`status` field). Fields are a union of every possible response
+/// payload across all operations.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ReplResponse {
+    // --- Protocol envelope ---
+    /// Legacy response type (`result`, `error`, `bindings`, `loaded`, `actors`).
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub response_type: Option<String>,
+
+    /// Message correlation ID (echoed from request).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// Session ID (echoed from request).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
+
+    /// Status flags: `["done"]`, `["done", "error"]`, `["done", "test-error"]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<Vec<String>>,
+
+    // --- Common payload ---
+    /// Result value (eval, clear, kill, clone, etc.).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
+
+    /// Captured stdout from evaluation (BT-355).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+
+    /// Legacy error message field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    /// Error message (current protocol).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+
+    // --- Session / bindings ---
+    /// Variable bindings map (bindings op).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bindings: Option<serde_json::Value>,
+
+    // --- Load operations ---
+    /// Loaded class names (eval/load-file/load-source/load-project).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub classes: Option<Vec<String>>,
+
+    /// Class info list with metadata (list-classes op, BT-1404).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub class_list: Option<Vec<ClassInfo>>,
+
+    // --- Actor operations ---
+    /// Actor list (actors op).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actors: Option<Vec<ActorInfo>>,
+
+    // --- Module operations ---
+    /// Module list (modules op — legacy protocol, retained for backward compat).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modules: Option<Vec<ModuleInfo>>,
+
+    // --- Session operations ---
+    /// Session list (sessions op).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sessions: Option<Vec<SessionInfo>>,
+
+    // --- Completion ---
+    /// Completion suggestions (complete op).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completions: Option<Vec<String>>,
+
+    // --- Symbol info ---
+    /// Symbol information (info op).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub info: Option<serde_json::Value>,
+
+    /// Actor state (inspect op).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<serde_json::Value>,
+
+    // --- Diagnostics ---
+    /// Compilation warnings (BT-407).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
+
+    /// Line number (1-based) of a compile error in the submitted snippet (BT-1235).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+
+    /// Hint text for a compile error, where available (BT-1235).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+
+    // --- Documentation ---
+    /// Documentation text (docs op, BT-500).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docs: Option<String>,
+
+    // --- Codegen ---
+    /// Generated Core Erlang source (show-codegen op, BT-724).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub core_erlang: Option<String>,
+
+    // --- Reload ---
+    /// Number of actors affected by reload (BT-266).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub affected_actors: Option<u32>,
+
+    /// Number of actors that failed code migration (BT-266).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migration_failures: Option<u32>,
+
+    // --- Load-project ---
+    /// Per-file load errors (load-project op). Each entry is a structured map
+    /// with at least `path`, `kind`, and `message` fields.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_as_empty_vec",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub errors: Vec<serde_json::Value>,
+
+    /// Incremental load summary (load-project op, BT-1685).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    // --- Test operations ---
+    /// Test results (test / test-all ops).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub results: Option<serde_json::Value>,
+
+    // --- Tracing (ADR 0069) ---
+    /// Per-statement trace steps (eval with trace=true, BT-1238).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub steps: Option<Vec<serde_json::Value>>,
+
+    // --- Server / discovery ---
+    /// Supported operations and protocol info (describe op).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ops: Option<serde_json::Value>,
+
+    /// Protocol and language versions (describe op).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub versions: Option<serde_json::Value>,
+}
+
+impl ReplResponse {
+    /// Check if this is an error response (either legacy or current format).
+    pub fn is_error(&self) -> bool {
+        if let Some(ref t) = self.response_type {
+            return t == "error";
+        }
+        if let Some(ref status) = self.status {
+            return status.iter().any(|s| s == "error");
+        }
+        false
+    }
+
+    /// Check if the response contains a test failure (`"test-error"` status).
+    pub fn has_test_error(&self) -> bool {
+        if let Some(ref status) = self.status {
+            return status.iter().any(|s| s == "test-error");
+        }
+        false
+    }
+
+    /// Get the error message (either legacy `message` or current `error` field).
+    pub fn error_message(&self) -> Option<&str> {
+        if let Some(ref msg) = self.message {
+            return Some(msg.as_str());
+        }
+        if let Some(ref err) = self.error {
+            return Some(err.as_str());
+        }
+        None
+    }
+
+    /// Get the result value as a formatted string.
+    ///
+    /// For JSON string values, returns the string content without quotes.
+    /// For other JSON values, returns the JSON serialization.
+    /// For `None`, returns an empty string.
+    pub fn value_string(&self) -> String {
+        match &self.value {
+            Some(serde_json::Value::String(s)) => s.clone(),
+            Some(v) => v.to_string(),
+            None => String::new(),
+        }
+    }
+}
+
+/// Information about a running actor, deserialized from REPL JSON.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ActorInfo {
+    /// Erlang process identifier string (e.g., `"<0.123.0>"`).
+    pub pid: String,
+    /// Beamtalk class name of the actor (e.g., `"Counter"`).
+    pub class: String,
+    /// Source module the actor was compiled from.
+    pub module: String,
+    /// Unix timestamp (seconds) when the actor was spawned.
+    pub spawned_at: i64,
+}
+
+/// Class information from the list-classes op (BT-1404).
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ClassInfo {
+    /// Class name (e.g., `"String"`).
+    pub name: String,
+    /// Superclass name (e.g., `"Value"`) or `null` for root classes.
+    pub superclass: Option<String>,
+    /// One-line class description, or `null` if undocumented.
+    pub doc: Option<String>,
+    /// Whether the class is sealed (cannot be subclassed).
+    pub sealed: bool,
+    /// Whether the class is abstract (cannot be instantiated directly).
+    #[serde(rename = "abstract")]
+    pub is_abstract: bool,
+}
+
+/// Information about a loaded module, deserialized from REPL JSON.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ModuleInfo {
+    /// Module name as registered in the BEAM node.
+    pub name: String,
+    /// Path to the source `.bt` file that defined this module.
+    pub source_file: String,
+    /// Number of actors currently running from this module.
+    pub actor_count: u32,
+    /// Unix timestamp when the module was loaded.
+    pub load_time: i64,
+    /// Human-readable relative time since load (e.g., `"2 minutes ago"`).
+    pub time_ago: String,
+}
+
+/// Information about an active REPL session, deserialized from REPL JSON.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SessionInfo {
+    /// Unique session identifier.
+    pub id: String,
+    /// Unix timestamp when the session was created.
+    #[serde(default)]
+    pub created_at: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_success_response() {
+        let json = r#"{"id":"msg-001","value":42,"status":["done"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        assert!(!resp.is_error());
+        assert_eq!(resp.value_string(), "42");
+        assert_eq!(resp.id.as_deref(), Some("msg-001"));
+    }
+
+    #[test]
+    fn deserialize_error_response() {
+        let json =
+            r#"{"id":"msg-001","error":"Undefined variable: foo","status":["done","error"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.is_error());
+        assert_eq!(resp.error_message(), Some("Undefined variable: foo"));
+    }
+
+    #[test]
+    fn deserialize_legacy_error() {
+        let json = r#"{"type":"error","message":"Something went wrong"}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.is_error());
+        assert_eq!(resp.error_message(), Some("Something went wrong"));
+    }
+
+    #[test]
+    fn deserialize_bindings() {
+        let json = r#"{"id":"msg-002","bindings":{"x":42},"status":["done"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        assert!(!resp.is_error());
+        let bindings = resp.bindings.unwrap();
+        assert_eq!(bindings["x"], 42);
+    }
+
+    #[test]
+    fn deserialize_actors() {
+        let json = r#"{"id":"msg-003","actors":[{"pid":"<0.123.0>","class":"Counter","module":"counter","spawned_at":1234567890}],"status":["done"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        let actors = resp.actors.unwrap();
+        assert_eq!(actors.len(), 1);
+        assert_eq!(actors[0].class, "Counter");
+        assert_eq!(actors[0].pid, "<0.123.0>");
+    }
+
+    #[test]
+    fn deserialize_null_errors_as_empty() {
+        let json = r#"{"id":"msg-004","errors":null,"status":["done"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.errors.is_empty());
+    }
+
+    #[test]
+    fn test_error_status() {
+        let json = r#"{"id":"msg-005","results":{},"status":["done","test-error"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        assert!(!resp.is_error());
+        assert!(resp.has_test_error());
+    }
+
+    #[test]
+    fn value_string_for_string_value() {
+        let json = r#"{"id":"msg-006","value":"hello","status":["done"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.value_string(), "hello");
+    }
+
+    #[test]
+    fn value_string_for_null_value() {
+        let json = r#"{"id":"msg-007","status":["done"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.value_string(), "");
+    }
+
+    #[test]
+    fn deserialize_class_info() {
+        let json = r#"{"name":"String","superclass":"Value","doc":"A string","sealed":true,"abstract":false}"#;
+        let info: ClassInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.name, "String");
+        assert_eq!(info.superclass.as_deref(), Some("Value"));
+        assert!(info.sealed);
+        assert!(!info.is_abstract);
+    }
+
+    #[test]
+    fn deserialize_module_info() {
+        let json = r#"{"name":"Counter","source_file":"counter.bt","actor_count":1,"load_time":0,"time_ago":"2m ago"}"#;
+        let info: ModuleInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.name, "Counter");
+        assert_eq!(info.actor_count, 1);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts shared REPL protocol types into a new `beamtalk-repl-protocol` crate, eliminating duplicated `ReplResponse`, `ActorInfo`, `ClassInfo`, and request-building logic between `beamtalk-cli` and `beamtalk-mcp`.

- New `crates/beamtalk-repl-protocol/` with canonical response types and `RequestBuilder` covering all REPL ops
- `beamtalk-cli` migrated: removed 130 lines of duplicate structs, replaced inline JSON request construction with `RequestBuilder`
- `beamtalk-mcp` migrated: removed 160+ lines of duplicate structs and request helpers
- E2E test harness migrated to typed `ReplResponse` parsing and `RequestBuilder`
- 17 unit tests for request/response serialization

Net: -787 lines removed, +1131 added (the new crate accounts for the growth; existing crates shrink significantly).

**Linear:** https://linear.app/beamtalk/issue/BT-2076

## Test plan

- [x] `cargo test -p beamtalk-repl-protocol` — 17 tests pass
- [x] `cargo test -p beamtalk-cli -p beamtalk-mcp` — all existing tests pass
- [x] `just clippy` — no warnings
- [x] `just test` — all stdlib, BUnit, and runtime tests pass
- [x] E2E tests compile and are structurally unchanged (they run via `just test-e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared REPL protocol library with typed request builders and structured response types for consistent REPL operations.
* **Bug Fixes**
  * More consistent error detection, warning handling, and message-ID behavior across REPL flows; improves interrupts, stdin and completions handling.
* **Chores**
  * Updated CLI, server, MCP and end-to-end REPL client to use the shared protocol for clearer, more reliable interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->