### PR TITLE
Shared output formatters: diagnostic, value, trace (BT-2086)

### DIFF
--- a/crates/beamtalk-cli/src/commands/attach.rs
+++ b/crates/beamtalk-cli/src/commands/attach.rs
@@ -14,6 +14,7 @@ use miette::{Result, miette};
 
 use super::repl::client::ReplClient;
 use super::repl::color;
+use super::repl::display::output_mode;
 use super::workspace::{self, get_node_info, read_workspace_cookie};
 
 /// Run the `beamtalk workspace attach` command.
@@ -109,8 +110,14 @@ fn connect_and_run(host: &str, port: u16, cookie: &str) -> Result<()> {
             if let Some(actors) = response.actors {
                 if !actors.is_empty() {
                     println!("\nAvailable actors:");
-                    for actor in actors {
-                        println!("  - {} ({})", actor.class, actor.pid);
+                    for actor in &actors {
+                        println!(
+                            "  - {}",
+                            beamtalk_repl_protocol::format::format_actor_summary(
+                                actor,
+                                output_mode(),
+                            )
+                        );
                     }
                 }
             }

--- a/crates/beamtalk-cli/src/commands/repl/color.rs
+++ b/crates/beamtalk-cli/src/commands/repl/color.rs
@@ -42,8 +42,6 @@ pub fn is_enabled() -> bool {
 
 /// ANSI escape sequence to reset all text attributes.
 pub const RESET: &str = "\x1b[0m";
-/// ANSI escape sequence for bold text.
-pub const BOLD: &str = "\x1b[1m";
 /// ANSI escape sequence for dim (faint) text.
 pub const DIM: &str = "\x1b[2m";
 

--- a/crates/beamtalk-cli/src/commands/repl/display.rs
+++ b/crates/beamtalk-cli/src/commands/repl/display.rs
@@ -10,11 +10,21 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 
+use beamtalk_repl_protocol::format::{self as fmt, Diagnostic as FmtDiagnostic, OutputMode};
 use miette::{IntoDiagnostic, Result};
 
 use crate::paths::beamtalk_dir;
 
 use super::color;
+
+/// Selects [`OutputMode::Ansi`] when colour is enabled, otherwise plain.
+pub(crate) fn output_mode() -> OutputMode {
+    if color::is_enabled() {
+        OutputMode::Ansi
+    } else {
+        OutputMode::Plain
+    }
+}
 
 /// Return the path to the REPL history file, creating the parent directory if needed.
 pub(crate) fn history_path() -> Result<PathBuf> {
@@ -24,48 +34,20 @@ pub(crate) fn history_path() -> Result<PathBuf> {
 }
 
 /// Format a value for REPL display with optional coloring.
+///
+/// Delegates to the shared [`beamtalk_repl_protocol::format::format_value`]
+/// helper (BT-2086) so CLI / MCP / future surfaces share a single rendering
+/// for REPL eval results.
 pub(crate) fn format_value(value: &serde_json::Value) -> String {
-    match value {
-        serde_json::Value::String(s) => {
-            // Values are pre-formatted by the backend:
-            // - Actors: "#Actor<0.123.0>" or "#ClassName<0.123.0>"
-            // - Blocks: "a Block/N"
-            // - Floats: "6.0", "3.14" (BT-1336: sent as strings to preserve ".0")
-            if (s.starts_with('#') && s.contains('<')) || s.starts_with("a Block") {
-                color::paint(color::CYAN, s)
-            } else if s.contains('.') && s.parse::<f64>().is_ok() {
-                // BT-1336: Float values are serialized as strings to preserve
-                // the decimal point (e.g. "6.0" instead of JSON number 6).
-                color::paint(color::YELLOW, s)
-            } else {
-                color::paint(color::GREEN, s)
-            }
-        }
-        serde_json::Value::Number(n) => color::paint(color::YELLOW, &n.to_string()),
-        serde_json::Value::Bool(b) => color::paint(color::BOLD_BLUE, &b.to_string()),
-        serde_json::Value::Null => color::paint(color::BOLD_BLUE, "nil"),
-        serde_json::Value::Array(arr) => {
-            let items: Vec<String> = arr.iter().map(format_value).collect();
-            format!("#({})", items.join(", "))
-        }
-        serde_json::Value::Object(obj) => {
-            // Regular object
-            let pairs: Vec<String> = obj
-                .iter()
-                .map(|(k, v)| format!("{k}: {}", format_value(v)))
-                .collect();
-            format!("{{{}}}", pairs.join(", "))
-        }
-    }
+    fmt::format_value(value, output_mode())
 }
 
 /// Format an error message for REPL display.
+///
+/// Delegates to the shared [`beamtalk_repl_protocol::format::format_diagnostic`]
+/// helper (BT-2086).
 pub(crate) fn format_error(msg: &str) -> String {
-    if color::is_enabled() {
-        format!("{}{}Error:{} {msg}", color::BOLD, color::RED, color::RESET)
-    } else {
-        format!("Error: {msg}")
-    }
+    fmt::format_diagnostic(&FmtDiagnostic::new(msg), output_mode())
 }
 
 /// Print help message.

--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -82,7 +82,7 @@ pub mod bind;
 
 use bind::{resolve_bind_addr, validate_network_binding};
 use client::ReplClient;
-use display::{format_error, format_value, history_path, print_help};
+use display::{format_error, format_value, history_path, output_mode, print_help};
 use helper::ReplHelper;
 use process::{
     BeamChildGuard, connect_with_retries, drain_child_stderr, read_port_from_child,
@@ -483,8 +483,14 @@ pub fn run(
                 if let Some(actors) = response.actors {
                     if !actors.is_empty() {
                         println!("\nAvailable actors:");
-                        for actor in actors {
-                            println!("  - {} ({})", actor.class, actor.pid);
+                        for actor in &actors {
+                            println!(
+                                "  - {}",
+                                beamtalk_repl_protocol::format::format_actor_summary(
+                                    actor,
+                                    output_mode(),
+                                )
+                            );
                         }
                     }
                 }
@@ -786,33 +792,21 @@ fn handle_sync(client: &mut ReplClient) {
 /// hint (when available), followed by a summary line listing all failed file
 /// paths so the user can identify problems without manual bisection.
 fn display_sync_diagnostics(response: &ReplResponse) {
+    use beamtalk_repl_protocol::format::{WarningStyle, format_file_diagnostic, format_warning};
+
+    let mode = output_mode();
+
     // BT-1855: Collect distinct failed file paths for the summary line.
     let mut failed_paths: Vec<&str> = Vec::new();
 
     for err in &response.errors {
-        if let Some(msg) = err.get("message").and_then(|m| m.as_str()) {
+        if let Some(rendered) = format_file_diagnostic(err, mode) {
+            eprintln!("{rendered}");
+
             let path = err
                 .get("path")
                 .and_then(|p| p.as_str())
                 .unwrap_or("unknown");
-            let line = err.get("line").and_then(serde_json::Value::as_u64);
-            let hint = err.get("hint").and_then(serde_json::Value::as_str);
-            let painted = color::paint(color::RED, &format!("Error: {msg}"));
-            match (line, hint) {
-                (Some(ln), Some(h)) => {
-                    eprintln!("  {painted} in {path} at line {ln} ({h})");
-                }
-                (Some(ln), None) => {
-                    eprintln!("  {painted} in {path} at line {ln}");
-                }
-                (None, Some(h)) => {
-                    eprintln!("  {painted} in {path} ({h})");
-                }
-                (None, None) => {
-                    eprintln!("  {painted} in {path}");
-                }
-            }
-
             if !failed_paths.contains(&path) {
                 failed_paths.push(path);
             }
@@ -831,7 +825,7 @@ fn display_sync_diagnostics(response: &ReplResponse) {
 
     if let Some(ref warns) = response.warnings {
         for w in warns {
-            eprintln!("{}", color::paint(color::YELLOW, &format!("Warning: {w}")));
+            eprintln!("{}", format_warning(w, mode, WarningStyle::Prefixed));
         }
     }
 }
@@ -881,7 +875,14 @@ fn handle_show_codegen(line: &str, client: &mut ReplClient) {
             }
             if let Some(ref warns) = response.warnings {
                 for w in warns {
-                    eprintln!("{}", color::paint(color::YELLOW, &format!("Warning: {w}")));
+                    eprintln!(
+                        "{}",
+                        beamtalk_repl_protocol::format::format_warning(
+                            w,
+                            output_mode(),
+                            beamtalk_repl_protocol::format::WarningStyle::Prefixed,
+                        )
+                    );
                 }
             }
         }
@@ -984,7 +985,14 @@ fn display_eval_response(response: &ReplResponse) {
     // Display compilation warnings (BT-407)
     if let Some(ref warnings) = response.warnings {
         for warning in warnings {
-            eprintln!("⚠ {warning}");
+            eprintln!(
+                "{}",
+                beamtalk_repl_protocol::format::format_warning(
+                    warning,
+                    output_mode(),
+                    beamtalk_repl_protocol::format::WarningStyle::Bullet,
+                )
+            );
         }
     }
     if response.is_error() {

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -21,7 +21,12 @@ use rmcp::{
 };
 use sha2::{Digest, Sha256};
 
+use beamtalk_repl_protocol::format::{self as fmt, Diagnostic as FmtDiagnostic, OutputMode};
+
 use crate::client::ReplClient;
+
+/// MCP tool responses are plain text (no terminal escapes).
+const MCP_OUTPUT_MODE: OutputMode = OutputMode::Plain;
 
 /// Drop guard that logs MCP tool completion with duration and result status.
 ///
@@ -224,11 +229,16 @@ fn pretty_json(value: &serde_json::Value) -> String {
 /// Check a REPL response for errors and return early with a formatted error result.
 ///
 /// The `$fallback` string is used when the response has no error message.
+/// Uses the shared `format_diagnostic` helper (BT-2086) so MCP error rendering
+/// stays in lockstep with CLI output.
 macro_rules! check_response {
     ($response:expr, $fallback:expr) => {
         if $response.is_error() {
             let msg = $response.error_message().unwrap_or($fallback);
-            return Ok(error_result(format!("ERROR: {msg}")));
+            return Ok(error_result(fmt::format_diagnostic(
+                &FmtDiagnostic::new(msg),
+                MCP_OUTPUT_MODE,
+            )));
         }
     };
 }
@@ -560,16 +570,15 @@ impl BeamtalkMcp {
             .map_err(|e| rmcp::ErrorData::internal_error(e, None))?;
 
         if response.is_error() {
-            use std::fmt::Write as _;
             let msg = response.error_message().unwrap_or("Unknown error");
-            let mut error_text = format!("ERROR: {msg}");
+            let mut diag = FmtDiagnostic::new(msg);
             if let Some(line) = response.line {
-                let _ = write!(error_text, "\nLine: {line}");
+                diag = diag.with_line(line);
             }
             if let Some(ref hint) = response.hint {
-                let _ = write!(error_text, "\nHint: {hint}");
+                diag = diag.with_hint(hint);
             }
-            return Ok(error_result(error_text));
+            return Ok(error_result(fmt::format_diagnostic(&diag, MCP_OUTPUT_MODE)));
         }
 
         let mut parts = Vec::new();
@@ -586,16 +595,7 @@ impl BeamtalkMcp {
                 parts.push(Content::text("(no steps)"));
             } else {
                 for step in &steps {
-                    let src = step.get("src").and_then(|v| v.as_str()).unwrap_or("?");
-                    let val = step
-                        .get("value")
-                        .cloned()
-                        .unwrap_or(serde_json::Value::Null);
-                    let val_str = match &val {
-                        serde_json::Value::String(s) => s.clone(),
-                        v => v.to_string(),
-                    };
-                    parts.push(Content::text(format!("{src} => {val_str}")));
+                    parts.push(Content::text(fmt::format_trace_step(step, MCP_OUTPUT_MODE)));
                 }
             }
         } else {
@@ -855,15 +855,7 @@ impl BeamtalkMcp {
         check_response!(response, "Failed to list actors");
 
         let actors = response.actors.unwrap_or_default();
-        let text = if actors.is_empty() {
-            "No actors running".to_string()
-        } else {
-            actors
-                .iter()
-                .map(|a| format!("{} — pid: {}", a.class, a.pid))
-                .collect::<Vec<_>>()
-                .join("\n")
-        };
+        let text = fmt::format_actor_list(&actors, MCP_OUTPUT_MODE);
 
         timer.mark_ok();
         Ok(CallToolResult::success(vec![Content::text(text)]))
@@ -888,44 +880,7 @@ impl BeamtalkMcp {
         check_response!(response, "Failed to list classes");
 
         let classes = response.class_list.unwrap_or_default();
-        let text = if classes.is_empty() {
-            "No classes found".to_string()
-        } else {
-            classes
-                .iter()
-                .map(|c| {
-                    let super_str = c.superclass.as_deref().unwrap_or("(root)");
-                    let doc_str = c
-                        .doc
-                        .as_deref()
-                        .unwrap_or("")
-                        .lines()
-                        .next()
-                        .unwrap_or("")
-                        .trim();
-                    let modifiers = {
-                        let mut m = Vec::new();
-                        if c.sealed {
-                            m.push("sealed");
-                        }
-                        if c.is_abstract {
-                            m.push("abstract");
-                        }
-                        if m.is_empty() {
-                            String::new()
-                        } else {
-                            format!(" [{}]", m.join(", "))
-                        }
-                    };
-                    if doc_str.is_empty() {
-                        format!("{} < {}{}", c.name, super_str, modifiers)
-                    } else {
-                        format!("{} < {}{} — {}", c.name, super_str, modifiers, doc_str)
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-        };
+        let text = fmt::format_class_list(&classes, MCP_OUTPUT_MODE);
 
         timer.mark_ok();
         Ok(CallToolResult::success(vec![Content::text(text)]))
@@ -1210,7 +1165,7 @@ impl BeamtalkMcp {
         let has_failures = response.has_test_error();
 
         let text = match response.results {
-            Some(results) => pretty_json(&results),
+            Some(results) => fmt::format_test_result(&results, MCP_OUTPUT_MODE),
             None => "Tests completed (no structured results)".to_string(),
         };
 

--- a/crates/beamtalk-repl-protocol/Cargo.toml
+++ b/crates/beamtalk-repl-protocol/Cargo.toml
@@ -18,5 +18,8 @@ categories = ["development-tools"]
 serde.workspace = true
 serde_json.workspace = true
 
+[dev-dependencies]
+insta.workspace = true
+
 [lints]
 workspace = true

--- a/crates/beamtalk-repl-protocol/src/format.rs
+++ b/crates/beamtalk-repl-protocol/src/format.rs
@@ -206,16 +206,14 @@ pub fn format_file_diagnostic(err: &serde_json::Value, mode: OutputMode) -> Opti
     if !err.is_object() {
         let raw = err
             .as_str()
-            .map(str::to_owned)
-            .unwrap_or_else(|| err.to_string());
+            .map_or_else(|| err.to_string(), str::to_owned);
         return Some(format!("  {}", paint(mode, RED, &format!("Error: {raw}"))));
     }
 
     let msg = err
         .get("message")
         .and_then(|m| m.as_str())
-        .map(str::to_owned)
-        .unwrap_or_else(|| err.to_string());
+        .map_or_else(|| err.to_string(), str::to_owned);
     let path = err
         .get("path")
         .and_then(|p| p.as_str())

--- a/crates/beamtalk-repl-protocol/src/format.rs
+++ b/crates/beamtalk-repl-protocol/src/format.rs
@@ -204,9 +204,7 @@ pub fn format_file_diagnostic(err: &serde_json::Value, mode: OutputMode) -> Opti
     // Non-object entries (raw strings or arbitrary JSON) — surface them rather
     // than silently dropping. They have no path/line/hint to attach.
     if !err.is_object() {
-        let raw = err
-            .as_str()
-            .map_or_else(|| err.to_string(), str::to_owned);
+        let raw = err.as_str().map_or_else(|| err.to_string(), str::to_owned);
         return Some(format!("  {}", paint(mode, RED, &format!("Error: {raw}"))));
     }
 

--- a/crates/beamtalk-repl-protocol/src/format.rs
+++ b/crates/beamtalk-repl-protocol/src/format.rs
@@ -201,7 +201,21 @@ pub fn format_diagnostic(diag: &Diagnostic<'_>, mode: OutputMode) -> String {
 /// ```
 #[must_use]
 pub fn format_file_diagnostic(err: &serde_json::Value, mode: OutputMode) -> Option<String> {
-    let msg = err.get("message").and_then(|m| m.as_str())?;
+    // Non-object entries (raw strings or arbitrary JSON) — surface them rather
+    // than silently dropping. They have no path/line/hint to attach.
+    if !err.is_object() {
+        let raw = err
+            .as_str()
+            .map(str::to_owned)
+            .unwrap_or_else(|| err.to_string());
+        return Some(format!("  {}", paint(mode, RED, &format!("Error: {raw}"))));
+    }
+
+    let msg = err
+        .get("message")
+        .and_then(|m| m.as_str())
+        .map(str::to_owned)
+        .unwrap_or_else(|| err.to_string());
     let path = err
         .get("path")
         .and_then(|p| p.as_str())
@@ -227,7 +241,7 @@ pub fn format_file_diagnostic(err: &serde_json::Value, mode: OutputMode) -> Opti
 pub fn format_warning(msg: &str, mode: OutputMode, style: WarningStyle) -> String {
     match style {
         WarningStyle::Prefixed => paint(mode, YELLOW, &format!("Warning: {msg}")),
-        WarningStyle::Bullet => format!("⚠ {msg}"),
+        WarningStyle::Bullet => paint(mode, YELLOW, &format!("⚠ {msg}")),
     }
 }
 
@@ -505,9 +519,18 @@ mod tests {
     }
 
     #[test]
-    fn file_diagnostic_no_message_returns_none() {
+    fn file_diagnostic_no_message_falls_back_to_raw_json() {
         let err = serde_json::json!({"path": "x.bt"});
-        assert!(format_file_diagnostic(&err, OutputMode::Plain).is_none());
+        let out = format_file_diagnostic(&err, OutputMode::Plain).unwrap();
+        assert!(out.contains("x.bt"));
+        assert!(out.contains("Error:"));
+    }
+
+    #[test]
+    fn file_diagnostic_string_entry_surfaces_text() {
+        let err = serde_json::json!("disk full");
+        let out = format_file_diagnostic(&err, OutputMode::Plain).unwrap();
+        assert_eq!(out, "  Error: disk full");
     }
 
     #[test]

--- a/crates/beamtalk-repl-protocol/src/format.rs
+++ b/crates/beamtalk-repl-protocol/src/format.rs
@@ -1,0 +1,716 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared output formatters for REPL response payloads (BT-2086).
+//!
+//! **DDD Context:** REPL — Presentation Contract
+//!
+//! These helpers produce the canonical text rendering of REPL response data
+//! (values, diagnostics, trace steps, test results, actor/class summaries) and
+//! are consumed by every surface that displays REPL output: `beamtalk-cli`
+//! (interactive REPL + `attach`), `beamtalk-mcp` (tool responses), and any
+//! future client.
+//!
+//! # Design
+//!
+//! Each formatter accepts an [`OutputMode`] that selects the rendering style:
+//!
+//! * [`OutputMode::Plain`] — no escape sequences, suitable for MCP, logs,
+//!   and snapshot tests.
+//! * [`OutputMode::Ansi`] — ANSI colour escapes for interactive terminals.
+//!
+//! Surface-specific decoration (prompts, leading bullets, trailing newlines)
+//! stays at the call site; only the value-shape rendering is shared.
+//!
+//! # Why not LSP?
+//!
+//! The LSP server emits structured `lsp_types::Diagnostic` values, not
+//! free-form text. The diagnostic-message construction in LSP shares
+//! conceptual structure (`message + notes + hint`) with these formatters but
+//! operates on a different input type (`beamtalk_core::language_service::Diagnostic`).
+//! Including LSP would force a `beamtalk-core` dependency on this crate and
+//! is deliberately out of scope here.
+
+use crate::response::{ActorInfo, ClassInfo, ModuleInfo};
+
+// ---------------------------------------------------------------------------
+// OutputMode
+// ---------------------------------------------------------------------------
+
+/// Selects how formatters decorate their output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputMode {
+    /// No escape sequences. Suitable for MCP responses, logs, and tests.
+    #[default]
+    Plain,
+    /// ANSI colour escapes for interactive terminals.
+    Ansi,
+}
+
+impl OutputMode {
+    /// Returns true when output should include ANSI colour codes.
+    #[must_use]
+    pub fn is_ansi(self) -> bool {
+        matches!(self, Self::Ansi)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ANSI colour codes (kept private — surfaces use the formatters, not the codes)
+// ---------------------------------------------------------------------------
+
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const RED: &str = "\x1b[31m";
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const CYAN: &str = "\x1b[36m";
+const BOLD_BLUE: &str = "\x1b[1;34m";
+
+fn paint(mode: OutputMode, color: &str, text: &str) -> String {
+    if mode.is_ansi() {
+        format!("{color}{text}{RESET}")
+    } else {
+        text.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// format_value
+// ---------------------------------------------------------------------------
+
+/// Format a REPL eval result for display.
+///
+/// Mirrors the conventions established by the legacy CLI formatter:
+///
+/// * Strings beginning with `#` and containing `<` (e.g. `"#Actor<0.123.0>"`)
+///   or starting with `"a Block"` are rendered as cyan opaque values.
+/// * Strings that look like floats (contain `.` and parse as `f64`) — sent
+///   as strings to preserve trailing zeros (BT-1336) — are rendered as numbers.
+/// * Plain strings render unquoted in green.
+/// * Numbers render in yellow, booleans/`null` in bold-blue.
+/// * Arrays render as Beamtalk list literals: `#(a, b, c)`.
+/// * Objects render as `{k: v, ...}`.
+#[must_use]
+pub fn format_value(value: &serde_json::Value, mode: OutputMode) -> String {
+    match value {
+        serde_json::Value::String(s) => {
+            if (s.starts_with('#') && s.contains('<')) || s.starts_with("a Block") {
+                paint(mode, CYAN, s)
+            } else if s.contains('.') && s.parse::<f64>().is_ok() {
+                paint(mode, YELLOW, s)
+            } else {
+                paint(mode, GREEN, s)
+            }
+        }
+        serde_json::Value::Number(n) => paint(mode, YELLOW, &n.to_string()),
+        serde_json::Value::Bool(b) => paint(mode, BOLD_BLUE, &b.to_string()),
+        serde_json::Value::Null => paint(mode, BOLD_BLUE, "nil"),
+        serde_json::Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(|v| format_value(v, mode)).collect();
+            format!("#({})", items.join(", "))
+        }
+        serde_json::Value::Object(obj) => {
+            let pairs: Vec<String> = obj
+                .iter()
+                .map(|(k, v)| format!("{k}: {}", format_value(v, mode)))
+                .collect();
+            format!("{{{}}}", pairs.join(", "))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// format_diagnostic
+// ---------------------------------------------------------------------------
+
+/// A diagnostic to render. Borrowed from a [`ReplResponse`] (or constructed
+/// from a per-file error map inside `errors`).
+///
+/// [`ReplResponse`]: crate::response::ReplResponse
+#[derive(Debug, Clone, Copy)]
+pub struct Diagnostic<'a> {
+    /// Primary error message (required).
+    pub message: &'a str,
+    /// Optional 1-based line number in the submitted snippet (BT-1235).
+    pub line: Option<u32>,
+    /// Optional hint text (BT-1235).
+    pub hint: Option<&'a str>,
+}
+
+impl<'a> Diagnostic<'a> {
+    /// Create a diagnostic with just a message.
+    #[must_use]
+    pub fn new(message: &'a str) -> Self {
+        Self {
+            message,
+            line: None,
+            hint: None,
+        }
+    }
+
+    /// Attach a line number.
+    #[must_use]
+    pub fn with_line(mut self, line: u32) -> Self {
+        self.line = Some(line);
+        self
+    }
+
+    /// Attach a hint.
+    #[must_use]
+    pub fn with_hint(mut self, hint: &'a str) -> Self {
+        self.hint = Some(hint);
+        self
+    }
+}
+
+/// Format a diagnostic as `Error: <msg>` with optional `Line:` and `Hint:`
+/// continuation lines. The bold-red `Error:` prefix is only emitted in ANSI
+/// mode.
+///
+/// This shape is shared by the CLI REPL (`format_error`) and MCP tool
+/// responses (`evaluate` error path).
+#[must_use]
+pub fn format_diagnostic(diag: &Diagnostic<'_>, mode: OutputMode) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = if mode.is_ansi() {
+        format!("{BOLD}{RED}Error:{RESET} {}", diag.message)
+    } else {
+        format!("Error: {}", diag.message)
+    };
+
+    if let Some(line) = diag.line {
+        let _ = write!(out, "\nLine: {line}");
+    }
+    if let Some(hint) = diag.hint {
+        let _ = write!(out, "\nHint: {hint}");
+    }
+
+    out
+}
+
+/// Format a single per-file diagnostic from a `load-project`/`sync` response.
+///
+/// Each entry in `ReplResponse::errors` is a JSON map with at least
+/// `message`, plus optional `path`, `line`, and `hint` fields. This helper
+/// renders the legacy CLI line shape:
+///
+/// ```text
+///   Error: <msg> in <path> at line <N> (<hint>)
+/// ```
+#[must_use]
+pub fn format_file_diagnostic(err: &serde_json::Value, mode: OutputMode) -> Option<String> {
+    let msg = err.get("message").and_then(|m| m.as_str())?;
+    let path = err
+        .get("path")
+        .and_then(|p| p.as_str())
+        .unwrap_or("unknown");
+    let line = err.get("line").and_then(serde_json::Value::as_u64);
+    let hint = err.get("hint").and_then(serde_json::Value::as_str);
+
+    let painted = paint(mode, RED, &format!("Error: {msg}"));
+    let suffix = match (line, hint) {
+        (Some(ln), Some(h)) => format!(" in {path} at line {ln} ({h})"),
+        (Some(ln), None) => format!(" in {path} at line {ln}"),
+        (None, Some(h)) => format!(" in {path} ({h})"),
+        (None, None) => format!(" in {path}"),
+    };
+    Some(format!("  {painted}{suffix}"))
+}
+
+/// Format a compilation warning consistently across surfaces.
+///
+/// CLI uses `Warning: <msg>` (yellow); MCP/REPL eval uses `⚠ <msg>` for
+/// stdout-friendly output. The output style is selected via `style`.
+#[must_use]
+pub fn format_warning(msg: &str, mode: OutputMode, style: WarningStyle) -> String {
+    match style {
+        WarningStyle::Prefixed => paint(mode, YELLOW, &format!("Warning: {msg}")),
+        WarningStyle::Bullet => format!("⚠ {msg}"),
+    }
+}
+
+/// Style of warning rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WarningStyle {
+    /// `Warning: <msg>` — used by sync diagnostics, show-codegen, etc.
+    Prefixed,
+    /// `⚠ <msg>` — used inline in eval response output (BT-407).
+    Bullet,
+}
+
+// ---------------------------------------------------------------------------
+// format_trace_step
+// ---------------------------------------------------------------------------
+
+/// Format one entry from a trace-step list (BT-1238 / ADR 0069).
+///
+/// Each step is a JSON object with `src` (source text) and `value` (evaluated
+/// result, may be a JSON string or any other value). Renders as:
+///
+/// ```text
+/// <src> => <value>
+/// ```
+#[must_use]
+pub fn format_trace_step(step: &serde_json::Value, mode: OutputMode) -> String {
+    let src = step.get("src").and_then(|v| v.as_str()).unwrap_or("?");
+    let val = step
+        .get("value")
+        .map_or_else(|| "nil".to_string(), |v| format_value(v, mode));
+    format!("{src} => {val}")
+}
+
+// ---------------------------------------------------------------------------
+// format_test_result
+// ---------------------------------------------------------------------------
+
+/// Format the structured `results` payload from a `test`/`test-all` response.
+///
+/// The wire shape varies (`BUnit` results use one schema, `Workspace test`
+/// uses another), so this helper delegates to a pretty-printed JSON
+/// rendering with stable key ordering for snapshot tests. Surfaces that
+/// want a human summary line should compose it from named fields directly.
+#[must_use]
+pub fn format_test_result(results: &serde_json::Value, _mode: OutputMode) -> String {
+    serde_json::to_string_pretty(results).unwrap_or_else(|_| results.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// format_actor_summary
+// ---------------------------------------------------------------------------
+
+/// Single-line actor summary in `<Class> (<pid>)` form. Used by the CLI REPL
+/// startup banner ("Available actors:") and the MCP `list_actors` tool.
+#[must_use]
+pub fn format_actor_summary(actor: &ActorInfo, mode: OutputMode) -> String {
+    let class = paint(mode, CYAN, &actor.class);
+    format!("{class} ({})", actor.pid)
+}
+
+/// Format a list of actors as one summary per line. Returns `"No actors running"`
+/// when the list is empty.
+#[must_use]
+pub fn format_actor_list(actors: &[ActorInfo], mode: OutputMode) -> String {
+    if actors.is_empty() {
+        return "No actors running".to_string();
+    }
+    actors
+        .iter()
+        .map(|a| format_actor_summary(a, mode))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// format_class_summary
+// ---------------------------------------------------------------------------
+
+/// Single-line class summary used by `list_classes` (BT-1404).
+///
+/// Renders as `<Name> < <Super>[ [sealed, abstract]] — <doc>`, with the
+/// dash + doc suffix omitted when no documentation is present.
+#[must_use]
+pub fn format_class_summary(class: &ClassInfo, mode: OutputMode) -> String {
+    let super_str = class.superclass.as_deref().unwrap_or("(root)");
+    let doc_str = class
+        .doc
+        .as_deref()
+        .unwrap_or("")
+        .lines()
+        .next()
+        .unwrap_or("")
+        .trim();
+    let modifiers = {
+        let mut m = Vec::new();
+        if class.sealed {
+            m.push("sealed");
+        }
+        if class.is_abstract {
+            m.push("abstract");
+        }
+        if m.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", m.join(", "))
+        }
+    };
+    let name = paint(mode, BOLD, &class.name);
+    if doc_str.is_empty() {
+        format!("{name} < {super_str}{modifiers}")
+    } else {
+        format!("{name} < {super_str}{modifiers} — {doc_str}")
+    }
+}
+
+/// Format a class list, returning `"No classes found"` for an empty list.
+#[must_use]
+pub fn format_class_list(classes: &[ClassInfo], mode: OutputMode) -> String {
+    if classes.is_empty() {
+        return "No classes found".to_string();
+    }
+    classes
+        .iter()
+        .map(|c| format_class_summary(c, mode))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// format_module_summary
+// ---------------------------------------------------------------------------
+
+/// Single-line module summary: `<name> (<actor_count> actors, loaded <time_ago>)`.
+#[must_use]
+pub fn format_module_summary(module: &ModuleInfo, mode: OutputMode) -> String {
+    let name = paint(mode, BOLD, &module.name);
+    format!(
+        "{name} ({} actor{}, loaded {})",
+        module.actor_count,
+        if module.actor_count == 1 { "" } else { "s" },
+        module.time_ago,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                for ch in chars.by_ref() {
+                    if ch == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    // --- format_value ---
+
+    #[test]
+    fn value_string_plain() {
+        let v = serde_json::json!("hello");
+        assert_eq!(format_value(&v, OutputMode::Plain), "hello");
+    }
+
+    #[test]
+    fn value_pid_plain() {
+        let v = serde_json::json!("#Actor<0.123.0>");
+        assert_eq!(format_value(&v, OutputMode::Plain), "#Actor<0.123.0>");
+    }
+
+    #[test]
+    fn value_block_plain() {
+        let v = serde_json::json!("a Block/2");
+        assert_eq!(format_value(&v, OutputMode::Plain), "a Block/2");
+    }
+
+    #[test]
+    fn value_float_string_plain() {
+        // BT-1336: floats arrive as strings to preserve ".0"
+        let v = serde_json::json!("6.0");
+        assert_eq!(format_value(&v, OutputMode::Plain), "6.0");
+    }
+
+    #[test]
+    fn value_number_plain() {
+        let v = serde_json::json!(42);
+        assert_eq!(format_value(&v, OutputMode::Plain), "42");
+    }
+
+    #[test]
+    fn value_bool_plain() {
+        let v = serde_json::json!(true);
+        assert_eq!(format_value(&v, OutputMode::Plain), "true");
+    }
+
+    #[test]
+    fn value_null_plain() {
+        let v = serde_json::json!(null);
+        assert_eq!(format_value(&v, OutputMode::Plain), "nil");
+    }
+
+    #[test]
+    fn value_array_plain() {
+        let v = serde_json::json!([1, 2, 3]);
+        assert_eq!(format_value(&v, OutputMode::Plain), "#(1, 2, 3)");
+    }
+
+    #[test]
+    fn value_nested_array_plain() {
+        let v = serde_json::json!([[1, 2], [3, 4]]);
+        assert_eq!(format_value(&v, OutputMode::Plain), "#(#(1, 2), #(3, 4))");
+    }
+
+    #[test]
+    fn value_string_ansi_is_green() {
+        let v = serde_json::json!("hello");
+        let out = format_value(&v, OutputMode::Ansi);
+        assert!(out.contains(GREEN), "expected GREEN colour, got {out:?}");
+        assert_eq!(strip_ansi(&out), "hello");
+    }
+
+    // --- format_diagnostic ---
+
+    #[test]
+    fn diagnostic_plain_message_only() {
+        let d = Diagnostic::new("oops");
+        assert_eq!(format_diagnostic(&d, OutputMode::Plain), "Error: oops");
+    }
+
+    #[test]
+    fn diagnostic_plain_with_line_and_hint() {
+        let d = Diagnostic::new("undefined")
+            .with_line(3)
+            .with_hint("did you mean foo?");
+        assert_eq!(
+            format_diagnostic(&d, OutputMode::Plain),
+            "Error: undefined\nLine: 3\nHint: did you mean foo?"
+        );
+    }
+
+    #[test]
+    fn diagnostic_ansi_includes_red() {
+        let d = Diagnostic::new("oops");
+        let out = format_diagnostic(&d, OutputMode::Ansi);
+        assert!(out.contains(RED));
+        assert_eq!(strip_ansi(&out), "Error: oops");
+    }
+
+    #[test]
+    fn file_diagnostic_full() {
+        let err = serde_json::json!({
+            "message": "parse error",
+            "path": "src/foo.bt",
+            "line": 12,
+            "hint": "missing ]"
+        });
+        let out = format_file_diagnostic(&err, OutputMode::Plain).unwrap();
+        assert_eq!(
+            out,
+            "  Error: parse error in src/foo.bt at line 12 (missing ])"
+        );
+    }
+
+    #[test]
+    fn file_diagnostic_no_message_returns_none() {
+        let err = serde_json::json!({"path": "x.bt"});
+        assert!(format_file_diagnostic(&err, OutputMode::Plain).is_none());
+    }
+
+    #[test]
+    fn file_diagnostic_unknown_path() {
+        let err = serde_json::json!({"message": "boom"});
+        let out = format_file_diagnostic(&err, OutputMode::Plain).unwrap();
+        assert_eq!(out, "  Error: boom in unknown");
+    }
+
+    // --- format_warning ---
+
+    #[test]
+    fn warning_prefixed_plain() {
+        assert_eq!(
+            format_warning("deprecated", OutputMode::Plain, WarningStyle::Prefixed),
+            "Warning: deprecated"
+        );
+    }
+
+    #[test]
+    fn warning_bullet_plain() {
+        assert_eq!(
+            format_warning("deprecated", OutputMode::Plain, WarningStyle::Bullet),
+            "⚠ deprecated"
+        );
+    }
+
+    // --- format_trace_step ---
+
+    #[test]
+    fn trace_step_plain() {
+        let step = serde_json::json!({"src": "1 + 2", "value": 3});
+        assert_eq!(format_trace_step(&step, OutputMode::Plain), "1 + 2 => 3");
+    }
+
+    #[test]
+    fn trace_step_string_value() {
+        let step = serde_json::json!({"src": "Actor", "value": "#Actor<0.1.0>"});
+        assert_eq!(
+            format_trace_step(&step, OutputMode::Plain),
+            "Actor => #Actor<0.1.0>"
+        );
+    }
+
+    #[test]
+    fn trace_step_missing_value_renders_nil() {
+        let step = serde_json::json!({"src": "x"});
+        assert_eq!(format_trace_step(&step, OutputMode::Plain), "x => nil");
+    }
+
+    // --- format_test_result ---
+
+    #[test]
+    fn test_result_pretty_json() {
+        let r = serde_json::json!({"passed": 3, "failed": 0});
+        let out = format_test_result(&r, OutputMode::Plain);
+        assert!(out.contains("\"passed\": 3"));
+    }
+
+    // --- format_actor_summary ---
+
+    fn make_actor(class: &str, pid: &str) -> ActorInfo {
+        ActorInfo {
+            pid: pid.to_string(),
+            class: class.to_string(),
+            module: "m".to_string(),
+            spawned_at: 0,
+        }
+    }
+
+    #[test]
+    fn actor_summary_plain() {
+        let a = make_actor("Counter", "<0.123.0>");
+        assert_eq!(
+            format_actor_summary(&a, OutputMode::Plain),
+            "Counter (<0.123.0>)"
+        );
+    }
+
+    #[test]
+    fn actor_list_empty() {
+        assert_eq!(
+            format_actor_list(&[], OutputMode::Plain),
+            "No actors running"
+        );
+    }
+
+    #[test]
+    fn actor_list_multi() {
+        let actors = vec![
+            make_actor("Counter", "<0.1.0>"),
+            make_actor("Logger", "<0.2.0>"),
+        ];
+        assert_eq!(
+            format_actor_list(&actors, OutputMode::Plain),
+            "Counter (<0.1.0>)\nLogger (<0.2.0>)"
+        );
+    }
+
+    // --- format_class_summary ---
+
+    fn make_class(
+        name: &str,
+        superclass: Option<&str>,
+        doc: Option<&str>,
+        sealed: bool,
+        is_abstract: bool,
+    ) -> ClassInfo {
+        ClassInfo {
+            name: name.to_string(),
+            superclass: superclass.map(String::from),
+            doc: doc.map(String::from),
+            sealed,
+            is_abstract,
+        }
+    }
+
+    #[test]
+    fn class_summary_minimal() {
+        let c = make_class("Counter", Some("Actor"), None, false, false);
+        assert_eq!(
+            format_class_summary(&c, OutputMode::Plain),
+            "Counter < Actor"
+        );
+    }
+
+    #[test]
+    fn class_summary_root() {
+        let c = make_class("Object", None, None, false, false);
+        assert_eq!(
+            format_class_summary(&c, OutputMode::Plain),
+            "Object < (root)"
+        );
+    }
+
+    #[test]
+    fn class_summary_with_modifiers_and_doc() {
+        let c = make_class(
+            "String",
+            Some("Value"),
+            Some("Immutable string.\nMore details."),
+            true,
+            false,
+        );
+        assert_eq!(
+            format_class_summary(&c, OutputMode::Plain),
+            "String < Value [sealed] — Immutable string."
+        );
+    }
+
+    #[test]
+    fn class_summary_sealed_and_abstract() {
+        let c = make_class("Base", None, None, true, true);
+        assert_eq!(
+            format_class_summary(&c, OutputMode::Plain),
+            "Base < (root) [sealed, abstract]"
+        );
+    }
+
+    #[test]
+    fn class_list_empty() {
+        assert_eq!(
+            format_class_list(&[], OutputMode::Plain),
+            "No classes found"
+        );
+    }
+
+    // --- format_module_summary ---
+
+    fn make_module(name: &str, count: u32, time_ago: &str) -> ModuleInfo {
+        ModuleInfo {
+            name: name.to_string(),
+            source_file: "x.bt".to_string(),
+            actor_count: count,
+            load_time: 0,
+            time_ago: time_ago.to_string(),
+        }
+    }
+
+    #[test]
+    fn module_summary_singular() {
+        let m = make_module("Counter", 1, "2m ago");
+        assert_eq!(
+            format_module_summary(&m, OutputMode::Plain),
+            "Counter (1 actor, loaded 2m ago)"
+        );
+    }
+
+    #[test]
+    fn module_summary_plural() {
+        let m = make_module("Counter", 3, "now");
+        assert_eq!(
+            format_module_summary(&m, OutputMode::Plain),
+            "Counter (3 actors, loaded now)"
+        );
+    }
+
+    #[test]
+    fn module_summary_zero() {
+        let m = make_module("Counter", 0, "5m ago");
+        assert_eq!(
+            format_module_summary(&m, OutputMode::Plain),
+            "Counter (0 actors, loaded 5m ago)"
+        );
+    }
+}

--- a/crates/beamtalk-repl-protocol/src/lib.rs
+++ b/crates/beamtalk-repl-protocol/src/lib.rs
@@ -11,6 +11,7 @@
 //! backend. Having a single source of truth prevents the two clients from
 //! diverging when the protocol evolves.
 
+pub mod format;
 mod request;
 mod response;
 

--- a/crates/beamtalk-repl-protocol/tests/format_snapshots.rs
+++ b/crates/beamtalk-repl-protocol/tests/format_snapshots.rs
@@ -1,0 +1,348 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Snapshot tests for shared output formatters (BT-2086).
+//!
+//! These snapshots pin the canonical text rendering for every REPL surface.
+//! Both [`OutputMode::Plain`] and [`OutputMode::Ansi`] are exercised so
+//! divergence between modes (or accidental ANSI bleed into MCP responses) is
+//! caught at review time.
+//!
+//! When a snapshot needs updating, run `cargo insta review`.
+
+use beamtalk_repl_protocol::format::{self, Diagnostic, OutputMode, WarningStyle};
+use beamtalk_repl_protocol::{ActorInfo, ClassInfo, ModuleInfo};
+
+// ---------------------------------------------------------------------------
+// format_value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_value_string_plain() {
+    let v = serde_json::json!("hello world");
+    insta::assert_snapshot!(format::format_value(&v, OutputMode::Plain), @"hello world");
+}
+
+#[test]
+fn snapshot_value_array_plain() {
+    let v = serde_json::json!([1, 2, 3, [4, 5]]);
+    insta::assert_snapshot!(
+        format::format_value(&v, OutputMode::Plain),
+        @"#(1, 2, 3, #(4, 5))"
+    );
+}
+
+#[test]
+fn snapshot_value_pid_plain() {
+    let v = serde_json::json!("#Counter<0.123.0>");
+    insta::assert_snapshot!(
+        format::format_value(&v, OutputMode::Plain),
+        @"#Counter<0.123.0>"
+    );
+}
+
+#[test]
+fn snapshot_value_object_plain() {
+    let v = serde_json::json!({"x": 1, "y": "two"});
+    insta::assert_snapshot!(
+        format::format_value(&v, OutputMode::Plain),
+        @"{x: 1, y: two}"
+    );
+}
+
+/// Strip ANSI escape sequences so ANSI-mode snapshots remain readable as text.
+/// We separately assert the raw bytes contain the expected escape codes.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::new();
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            for ch in chars.by_ref() {
+                if ch == 'm' {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[test]
+fn snapshot_value_string_ansi() {
+    let v = serde_json::json!("hello");
+    let out = format::format_value(&v, OutputMode::Ansi);
+    assert!(out.contains("\x1b[32m"), "expected GREEN ANSI code");
+    insta::assert_snapshot!(strip_ansi(&out), @"hello");
+}
+
+#[test]
+fn snapshot_value_pid_ansi() {
+    let v = serde_json::json!("#Counter<0.1.0>");
+    let out = format::format_value(&v, OutputMode::Ansi);
+    assert!(out.contains("\x1b[36m"), "expected CYAN ANSI code");
+    insta::assert_snapshot!(strip_ansi(&out), @"#Counter<0.1.0>");
+}
+
+// ---------------------------------------------------------------------------
+// format_diagnostic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_diagnostic_message_only_plain() {
+    let d = Diagnostic::new("Undefined variable: foo");
+    insta::assert_snapshot!(
+        format::format_diagnostic(&d, OutputMode::Plain),
+        @"Error: Undefined variable: foo"
+    );
+}
+
+#[test]
+fn snapshot_diagnostic_full_plain() {
+    let d = Diagnostic::new("Parse error: expected ']'")
+        .with_line(7)
+        .with_hint("close the open bracket on line 5");
+    insta::assert_snapshot!(
+        format::format_diagnostic(&d, OutputMode::Plain),
+        @r#"
+    Error: Parse error: expected ']'
+    Line: 7
+    Hint: close the open bracket on line 5
+    "#
+    );
+}
+
+#[test]
+fn snapshot_diagnostic_full_ansi() {
+    let d = Diagnostic::new("oops").with_line(1).with_hint("nope");
+    let out = format::format_diagnostic(&d, OutputMode::Ansi);
+    assert!(
+        out.contains("\x1b[1m\x1b[31m"),
+        "expected BOLD+RED ANSI prefix"
+    );
+    insta::assert_snapshot!(
+        strip_ansi(&out),
+        @r"
+    Error: oops
+    Line: 1
+    Hint: nope
+    "
+    );
+}
+
+#[test]
+fn snapshot_file_diagnostic_plain() {
+    let err = serde_json::json!({
+        "message": "duplicate class definition",
+        "path": "src/Counter.bt",
+        "line": 4,
+        "hint": "remove the second class block"
+    });
+    insta::assert_snapshot!(
+        format::format_file_diagnostic(&err, OutputMode::Plain).unwrap(),
+        @"  Error: duplicate class definition in src/Counter.bt at line 4 (remove the second class block)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// format_warning
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_warning_prefixed_plain() {
+    insta::assert_snapshot!(
+        format::format_warning("deprecated method", OutputMode::Plain, WarningStyle::Prefixed),
+        @"Warning: deprecated method"
+    );
+}
+
+#[test]
+fn snapshot_warning_bullet_plain() {
+    insta::assert_snapshot!(
+        format::format_warning("partial match", OutputMode::Plain, WarningStyle::Bullet),
+        @"⚠ partial match"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// format_trace_step
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_trace_step_plain() {
+    let step = serde_json::json!({"src": "x := 42", "value": 42});
+    insta::assert_snapshot!(
+        format::format_trace_step(&step, OutputMode::Plain),
+        @"x := 42 => 42"
+    );
+}
+
+#[test]
+fn snapshot_trace_step_with_actor_value() {
+    let step = serde_json::json!({"src": "Counter spawn", "value": "#Counter<0.7.0>"});
+    insta::assert_snapshot!(
+        format::format_trace_step(&step, OutputMode::Plain),
+        @"Counter spawn => #Counter<0.7.0>"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// format_test_result
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_test_result_summary() {
+    // Parse from a string so the resulting map preserves insertion order.
+    let r: serde_json::Value = serde_json::from_str(
+        r#"{"passed":12,"failed":1,"errors":[{"name":"test_x","message":"expected 1, got 2"}]}"#,
+    )
+    .unwrap();
+    insta::assert_snapshot!(
+        format::format_test_result(&r, OutputMode::Plain),
+        @r#"
+    {
+      "errors": [
+        {
+          "message": "expected 1, got 2",
+          "name": "test_x"
+        }
+      ],
+      "failed": 1,
+      "passed": 12
+    }
+    "#
+    );
+}
+
+// ---------------------------------------------------------------------------
+// format_actor_summary / list
+// ---------------------------------------------------------------------------
+
+fn make_actor(class: &str, pid: &str) -> ActorInfo {
+    ActorInfo {
+        pid: pid.to_string(),
+        class: class.to_string(),
+        module: "m".to_string(),
+        spawned_at: 0,
+    }
+}
+
+#[test]
+fn snapshot_actor_list_empty() {
+    insta::assert_snapshot!(
+        format::format_actor_list(&[], OutputMode::Plain),
+        @"No actors running"
+    );
+}
+
+#[test]
+fn snapshot_actor_list_multi_plain() {
+    let actors = [
+        make_actor("Counter", "<0.123.0>"),
+        make_actor("Logger", "<0.124.0>"),
+    ];
+    insta::assert_snapshot!(
+        format::format_actor_list(&actors, OutputMode::Plain),
+        @r"
+    Counter (<0.123.0>)
+    Logger (<0.124.0>)
+    "
+    );
+}
+
+#[test]
+fn snapshot_actor_summary_ansi() {
+    let a = make_actor("Counter", "<0.1.0>");
+    let out = format::format_actor_summary(&a, OutputMode::Ansi);
+    assert!(
+        out.contains("\x1b[36m"),
+        "expected CYAN ANSI code on class name"
+    );
+    insta::assert_snapshot!(strip_ansi(&out), @"Counter (<0.1.0>)");
+}
+
+// ---------------------------------------------------------------------------
+// format_class_summary / list
+// ---------------------------------------------------------------------------
+
+fn make_class(
+    name: &str,
+    superclass: Option<&str>,
+    doc: Option<&str>,
+    sealed: bool,
+    is_abstract: bool,
+) -> ClassInfo {
+    ClassInfo {
+        name: name.to_string(),
+        superclass: superclass.map(String::from),
+        doc: doc.map(String::from),
+        sealed,
+        is_abstract,
+    }
+}
+
+#[test]
+fn snapshot_class_list_empty() {
+    insta::assert_snapshot!(
+        format::format_class_list(&[], OutputMode::Plain),
+        @"No classes found"
+    );
+}
+
+#[test]
+fn snapshot_class_list_plain() {
+    let classes = [
+        make_class(
+            "String",
+            Some("Value"),
+            Some("Immutable string."),
+            true,
+            false,
+        ),
+        make_class("Stream", Some("Object"), None, false, true),
+        make_class("Object", None, None, false, false),
+    ];
+    insta::assert_snapshot!(
+        format::format_class_list(&classes, OutputMode::Plain),
+        @r"
+    String < Value [sealed] — Immutable string.
+    Stream < Object [abstract]
+    Object < (root)
+    "
+    );
+}
+
+// ---------------------------------------------------------------------------
+// format_module_summary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_module_summary_singular() {
+    let m = ModuleInfo {
+        name: "Counter".into(),
+        source_file: "counter.bt".into(),
+        actor_count: 1,
+        load_time: 0,
+        time_ago: "2m ago".into(),
+    };
+    insta::assert_snapshot!(
+        format::format_module_summary(&m, OutputMode::Plain),
+        @"Counter (1 actor, loaded 2m ago)"
+    );
+}
+
+#[test]
+fn snapshot_module_summary_plural() {
+    let m = ModuleInfo {
+        name: "Counter".into(),
+        source_file: "counter.bt".into(),
+        actor_count: 7,
+        load_time: 0,
+        time_ago: "now".into(),
+    };
+    insta::assert_snapshot!(
+        format::format_module_summary(&m, OutputMode::Plain),
+        @"Counter (7 actors, loaded now)"
+    );
+}

--- a/crates/beamtalk-repl-protocol/tests/format_snapshots.rs
+++ b/crates/beamtalk-repl-protocol/tests/format_snapshots.rs
@@ -165,6 +165,14 @@ fn snapshot_warning_bullet_plain() {
     );
 }
 
+#[test]
+fn snapshot_warning_bullet_ansi() {
+    insta::assert_snapshot!(
+        format::format_warning("partial match", OutputMode::Ansi, WarningStyle::Bullet),
+        @"\u{1b}[33m⚠ partial match\u{1b}[0m"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // format_trace_step
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a `format` module to `beamtalk-repl-protocol` with shared text renderers for every REPL response payload, eliminating duplicated formatting logic between CLI and MCP.

- New `beamtalk_repl_protocol::format` module with `OutputMode` enum (Plain/Ansi) and canonical formatters for values, diagnostics, warnings, trace steps, test results, actors, classes, and modules
- CLI `format_value`/`format_error` now delegate to shared helpers; actor lists, sync diagnostics, and warning rendering migrated
- MCP `check_response!` macro, evaluate error path, trace steps, actor/class list, and test results all migrated to shared formatters
- 22 inline snapshot tests (insta) pinning both Plain and Ansi output modes
- Extracted `output_mode()` helper to eliminate 4x repeated color-mode selection pattern in CLI

Net effect: ~130 lines of duplicated formatting removed from CLI/MCP, replaced by shared formatters with snapshot test coverage. Per-surface variation (ANSI vs plain) is expressed via `OutputMode`, not reimplementation.

**Linear:** https://linear.app/beamtalk/issue/BT-2086

## Test plan

- [x] `cargo test -p beamtalk-repl-protocol` — 50 unit + 22 snapshot tests pass
- [x] `cargo test -p beamtalk-cli` — 840 tests pass
- [x] `cargo test -p beamtalk-mcp` — 86 tests pass
- [x] `just clippy` — no warnings
- [x] `just test` — stdlib (250), BUnit (1901), runtime (4727) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared, centralized formatters for consistent actor/class/module summaries, trace steps, test results, warnings, and diagnostics with plain and colored output modes.

* **Refactor**
  * REPL, CLI, and server outputs now use unified formatting for listings, errors, and warnings for consistent wording and presentation.

* **Style**
  * ANSI styling consolidated; standalone bold variant removed and color handling unified.

* **Tests**
  * Added comprehensive snapshot tests validating formatted outputs (plain and ANSI-stripped).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->