### PR TITLE
Cross-surface parity test harness (tests/parity/) (BT-2077)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,10 +22,10 @@ default:
 #        + just test-integration test-mcp test-e2e (test job extras)
 #        + dialyzer if Erlang changed (skipped on Windows - known PATH issue)
 [unix]
-ci: build lint test test-integration test-mcp test-e2e check-corpus
+ci: build lint test test-integration test-mcp test-parity test-e2e check-corpus
 
 [windows]
-ci: build clippy fmt-check-rust test test-integration test-mcp test-e2e
+ci: build clippy fmt-check-rust test test-integration test-mcp test-parity test-e2e
 
 # Clean all build artifacts (Rust, Erlang, VS Code, caches, examples)
 [unix]
@@ -411,6 +411,14 @@ test-rust:
 test-e2e: build-stdlib
     @echo "🧪 Running E2E tests (slow - ~50s)..."
     cargo test --test e2e -- --ignored
+
+# Run cross-surface parity tests (BT-2077)
+# Drives the same input through REPL / MCP / CLI / LSP and asserts agreement.
+# Single-threaded (--test-threads=1) because cases share one workspace.
+test-parity: build
+    @echo "🧪 Running parity tests (REPL / MCP / CLI / LSP)..."
+    cargo test -p beamtalk-parity-tests --test parity -- --ignored --test-threads=1
+    @echo "✅ Parity tests complete"
 
 # Run workspace integration tests (requires Erlang/OTP runtime, ~10s)
 # Output: summary only on success, full output on failure

--- a/crates/beamtalk-parity-tests/Cargo.toml
+++ b/crates/beamtalk-parity-tests/Cargo.toml
@@ -1,0 +1,34 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "beamtalk-parity-tests"
+description = "Cross-surface parity test harness for Beamtalk (REPL / MCP / CLI / LSP)"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+name = "beamtalk_parity_tests"
+path = "src/lib.rs"
+
+[dependencies]
+beamtalk-repl-protocol.workspace = true
+beamtalk-workspace.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "net", "process", "sync", "time"] }
+tokio-tungstenite.workspace = true
+futures-util = "0.3"
+tracing.workspace = true
+
+[[test]]
+name = "parity"
+path = "tests/parity.rs"
+
+[lints]
+workspace = true

--- a/crates/beamtalk-parity-tests/src/cases.rs
+++ b/crates/beamtalk-parity-tests/src/cases.rs
@@ -1,0 +1,359 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parity case file format and parser.
+//!
+//! Each `*.parity.bt` case is a small declarative file describing:
+//!
+//! * one or more inputs to drive through one or more surfaces, and
+//! * one or more expected outcomes (either a shared `@expect` block, a per-
+//!   surface override, or a structural expectation).
+//!
+//! # Example
+//!
+//! ```text
+//! // @input
+//! 3 + 4
+//! // @surfaces repl, mcp
+//! // @expect 7
+//! ```
+//!
+//! The parser is intentionally line-oriented and forgiving: comments outside
+//! of `@`-directives are ignored, and unknown directives produce a parse error
+//! so typos surface fast.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// All surfaces a parity case can target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Surface {
+    /// Direct WebSocket REPL client (the same protocol `beamtalk-mcp` and
+    /// `beamtalk-cli` use internally).
+    Repl,
+    /// `beamtalk-mcp` binary driven over stdio with MCP JSON-RPC.
+    Mcp,
+    /// `beamtalk` CLI binary driven via `std::process::Command`.
+    Cli,
+    /// `beamtalk-lsp` binary driven over stdio with LSP JSON-RPC.
+    Lsp,
+}
+
+impl Surface {
+    /// Parse a surface name from a `@surfaces` declaration.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "repl" => Ok(Self::Repl),
+            "mcp" => Ok(Self::Mcp),
+            "cli" => Ok(Self::Cli),
+            "lsp" => Ok(Self::Lsp),
+            other => Err(format!("Unknown surface '{other}'")),
+        }
+    }
+
+    /// Short stable label used in assertion failure messages.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Repl => "repl",
+            Self::Mcp => "mcp",
+            Self::Cli => "cli",
+            Self::Lsp => "lsp",
+        }
+    }
+}
+
+impl fmt::Display for Surface {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Operation a step exercises across surfaces.
+///
+/// Each op maps to a specific driver method on each surface; mismatches —
+/// e.g. asking for `Op::Eval` on the LSP — produce a clear failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Op {
+    /// Evaluate the input as a Beamtalk expression.
+    Eval,
+    /// Load the project at the given path (input is a directory).
+    Load,
+    /// Lint the project at the given path.
+    Lint,
+    /// Run `BUnit` tests (input is the class name on REPL/MCP, or a directory
+    /// for the CLI).
+    Test,
+    /// Open the file at the given path and collect diagnostics.
+    Diagnose,
+}
+
+impl Op {
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim() {
+            "eval" => Ok(Self::Eval),
+            "load" => Ok(Self::Load),
+            "lint" => Ok(Self::Lint),
+            "test" => Ok(Self::Test),
+            "diagnose" => Ok(Self::Diagnose),
+            other => Err(format!("Unknown op `{other}`")),
+        }
+    }
+}
+
+/// What a parity step expects from each surface.
+///
+/// `Value` matches the normalized text returned by every surface against a
+/// literal expected string. `Classes` checks that a particular set of class
+/// names was observed (used by `load_project`-style cases). `DiagnosticCount`
+/// matches a single integer per surface.
+#[derive(Debug, Clone)]
+pub enum Expectation {
+    /// All surfaces must produce the given normalized value.
+    Value(String),
+    /// All surfaces must observe (at least) this set of class names.
+    Classes(BTreeSet<String>),
+    /// All surfaces must report this number of diagnostics.
+    DiagnosticCount(usize),
+}
+
+/// A single parity step parsed from a `.parity.bt` file.
+#[derive(Debug, Clone)]
+pub struct Step {
+    /// 1-based line number where `@input` was declared (used in error
+    /// messages so failures point at the right place).
+    pub line: usize,
+    /// The input string as written between `@input` and `@surfaces`.
+    pub input: String,
+    /// Set of surfaces this step targets.
+    pub surfaces: BTreeSet<Surface>,
+    /// What every surface should produce.
+    pub expect: Expectation,
+    /// Operation to drive on every surface. Defaults to `Eval`.
+    pub op: Op,
+}
+
+/// A parsed `.parity.bt` case file.
+#[derive(Debug, Clone)]
+pub struct Case {
+    /// Source path on disk; used to label failures.
+    pub path: PathBuf,
+    /// Steps in declaration order.
+    pub steps: Vec<Step>,
+}
+
+impl Case {
+    /// Load and parse a case file from disk.
+    pub fn from_path(path: &Path) -> Result<Self, String> {
+        let text =
+            std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        let steps = parse(&text).map_err(|e| format!("{}: {e}", path.display()))?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            steps,
+        })
+    }
+}
+
+/// Discover every `*.parity.bt` case under a directory (non-recursively).
+///
+/// Returns an alphabetically sorted list so failure ordering is stable.
+pub fn discover(dir: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut out = Vec::new();
+    let entries = std::fs::read_dir(dir).map_err(|e| format!("read_dir {}: {e}", dir.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("read_dir entry: {e}"))?;
+        let p = entry.path();
+        if p.is_file() && p.to_string_lossy().ends_with(".parity.bt") {
+            out.push(p);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Parse a case-file body into its constituent steps.
+///
+/// The grammar is informal:
+///
+/// ```text
+/// step       := '// @input' '\n' input '// @surfaces' surfaces '// @expect…'
+/// surfaces   := comma-separated identifiers
+/// expect     := one of: value | classes | diagnostic-count
+/// ```
+fn parse(text: &str) -> Result<Vec<Step>, String> {
+    let mut steps = Vec::new();
+    let lines: Vec<&str> = text.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i].trim();
+        if line.is_empty() || (line.starts_with("//") && !line.starts_with("// @")) {
+            i += 1;
+            continue;
+        }
+        if line == "// @input" {
+            let input_start_line = i + 1;
+            i += 1;
+            // Collect input lines until the next directive or EOF.
+            let mut input_lines = Vec::new();
+            while i < lines.len() {
+                let l = lines[i].trim_start();
+                if l.starts_with("// @") {
+                    break;
+                }
+                input_lines.push(lines[i]);
+                i += 1;
+            }
+            // Parse @surfaces
+            if i >= lines.len() {
+                return Err(format!(
+                    "line {}: @input without @surfaces directive",
+                    input_start_line
+                ));
+            }
+            let surfaces_line = lines[i].trim();
+            let surfaces_str = surfaces_line.strip_prefix("// @surfaces ").ok_or_else(|| {
+                format!(
+                    "line {}: expected `// @surfaces ...`, got `{}`",
+                    i + 1,
+                    surfaces_line
+                )
+            })?;
+            let surfaces =
+                parse_surfaces(surfaces_str).map_err(|e| format!("line {}: {}", i + 1, e))?;
+            i += 1;
+
+            // Optional @op directive
+            let mut op = Op::Eval;
+            if i < lines.len() {
+                let maybe_op = lines[i].trim();
+                if let Some(rest) = maybe_op.strip_prefix("// @op ") {
+                    op = Op::parse(rest).map_err(|e| format!("line {}: {}", i + 1, e))?;
+                    i += 1;
+                }
+            }
+
+            // Parse expectation directive
+            if i >= lines.len() {
+                return Err(format!(
+                    "line {}: @surfaces without @expect directive",
+                    input_start_line
+                ));
+            }
+            let expect_line = lines[i].trim();
+            let expect = parse_expect(expect_line).map_err(|e| format!("line {}: {}", i + 1, e))?;
+            i += 1;
+
+            // Trim trailing blank lines from input
+            while input_lines.last().is_some_and(|l| l.trim().is_empty()) {
+                input_lines.pop();
+            }
+            steps.push(Step {
+                line: input_start_line,
+                input: input_lines.join("\n"),
+                surfaces,
+                expect,
+                op,
+            });
+            continue;
+        }
+        return Err(format!("line {}: unexpected directive `{}`", i + 1, line));
+    }
+    if steps.is_empty() {
+        return Err("no @input directives found".to_string());
+    }
+    Ok(steps)
+}
+
+fn parse_surfaces(s: &str) -> Result<BTreeSet<Surface>, String> {
+    let mut out = BTreeSet::new();
+    for tok in s.split(',') {
+        let tok = tok.trim();
+        if tok.is_empty() {
+            continue;
+        }
+        out.insert(Surface::parse(tok)?);
+    }
+    if out.is_empty() {
+        return Err("@surfaces requires at least one surface".to_string());
+    }
+    Ok(out)
+}
+
+fn parse_expect(line: &str) -> Result<Expectation, String> {
+    if let Some(rest) = line.strip_prefix("// @expect-classes ") {
+        let mut classes = BTreeSet::new();
+        for tok in rest.split(',') {
+            let t = tok.trim();
+            if !t.is_empty() {
+                classes.insert(t.to_string());
+            }
+        }
+        return Ok(Expectation::Classes(classes));
+    }
+    if let Some(rest) = line.strip_prefix("// @expect-diagnostics ") {
+        let n: usize = rest
+            .trim()
+            .parse()
+            .map_err(|e| format!("invalid diagnostic count `{}`: {e}", rest.trim()))?;
+        return Ok(Expectation::DiagnosticCount(n));
+    }
+    if let Some(rest) = line.strip_prefix("// @expect ") {
+        return Ok(Expectation::Value(rest.trim().to_string()));
+    }
+    Err(format!("expected `// @expect…` directive, got `{}`", line))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_value_case() {
+        let src = "// @input\n3 + 4\n// @surfaces repl, mcp\n// @expect 7\n";
+        let steps = parse(src).unwrap();
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].input, "3 + 4");
+        assert!(steps[0].surfaces.contains(&Surface::Repl));
+        assert!(steps[0].surfaces.contains(&Surface::Mcp));
+        match &steps[0].expect {
+            Expectation::Value(v) => assert_eq!(v, "7"),
+            _ => panic!("wrong expectation"),
+        }
+    }
+
+    #[test]
+    fn parse_classes_expectation() {
+        let src =
+            "// @input\nload\n// @surfaces repl, mcp, cli\n// @expect-classes Counter, Bank\n";
+        let steps = parse(src).unwrap();
+        match &steps[0].expect {
+            Expectation::Classes(cs) => {
+                assert!(cs.contains("Counter"));
+                assert!(cs.contains("Bank"));
+            }
+            _ => panic!("wrong expectation"),
+        }
+    }
+
+    #[test]
+    fn parse_diagnostic_expectation() {
+        let src = "// @input\nbad\n// @surfaces cli, lsp\n// @expect-diagnostics 1\n";
+        let steps = parse(src).unwrap();
+        match &steps[0].expect {
+            Expectation::DiagnosticCount(n) => assert_eq!(*n, 1),
+            _ => panic!("wrong expectation"),
+        }
+    }
+
+    #[test]
+    fn surface_parse_unknown() {
+        assert!(Surface::parse("xyz").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_input_without_surfaces() {
+        let src = "// @input\nfoo\n";
+        assert!(parse(src).is_err());
+    }
+}

--- a/crates/beamtalk-parity-tests/src/drivers.rs
+++ b/crates/beamtalk-parity-tests/src/drivers.rs
@@ -1,0 +1,32 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Surface drivers.
+//!
+//! Each driver exposes the same minimal contract: given the input string from
+//! a parity step, return a `SurfaceOutput` whose fields the harness can
+//! compare against the step's expectation.
+
+pub mod cli;
+pub mod lsp;
+pub mod mcp;
+pub mod repl;
+
+use std::collections::BTreeSet;
+
+/// What every surface driver returns from a single step.
+///
+/// Fields are populated only when the surface produced that kind of result.
+/// `value` is the canonical text answer, `classes` is filled by load-style
+/// operations, and `diagnostic_count` is filled by lint/check operations.
+#[derive(Debug, Default)]
+pub struct SurfaceOutput {
+    /// Normalized textual value (after [`crate::normalize::value`]).
+    pub value: Option<String>,
+    /// Class names observed (for load-project parity).
+    pub classes: Option<BTreeSet<String>>,
+    /// Diagnostic count reported by the surface.
+    pub diagnostic_count: Option<usize>,
+    /// Raw response, kept for failure messages.
+    pub raw: String,
+}

--- a/crates/beamtalk-parity-tests/src/drivers/cli.rs
+++ b/crates/beamtalk-parity-tests/src/drivers/cli.rs
@@ -1,0 +1,216 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! CLI surface driver.
+//!
+//! Runs the real `beamtalk` binary against per-case temp projects. Avoids the
+//! `assert_cmd` crate to keep the dependency footprint small — `Command` plus
+//! a few helpers is enough for the operations we exercise (`build`, `test`,
+//! `lint`, `check`).
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use crate::drivers::SurfaceOutput;
+use crate::pool::beamtalk_binary;
+
+/// Run `beamtalk build <path>` and report the diagnostic count.
+///
+/// `beamtalk build` is intentionally terse on success ("Compiling N files"),
+/// so the class set is recovered by scanning the source tree for top-level
+/// `Foo subclass: Bar` headers. This matches what the REPL and MCP surfaces
+/// would observe — both ultimately call into the same compiler, so any class
+/// present in the source has gone through the build path.
+pub fn build_project(path: &Path) -> Result<SurfaceOutput, String> {
+    let bin = beamtalk_binary("beamtalk")?;
+    let output = Command::new(&bin)
+        .args(["build"])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("spawn beamtalk build: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let combined = format!("{stdout}\n{stderr}");
+    let classes = if output.status.success() {
+        scan_classes(path)
+    } else {
+        std::collections::BTreeSet::new()
+    };
+    let diagnostic_count = if output.status.success() {
+        0
+    } else {
+        count_diagnostic_lines(&combined).max(1)
+    };
+    Ok(SurfaceOutput {
+        classes: Some(classes),
+        diagnostic_count: Some(diagnostic_count),
+        raw: combined,
+        ..SurfaceOutput::default()
+    })
+}
+
+/// Scan a project tree for class declarations.
+///
+/// The expected forms are:
+///
+/// ```text
+/// Value subclass: Foo
+/// Actor subclass: Bar
+/// TestCase subclass: BazTest
+/// ```
+fn scan_classes(root: &Path) -> std::collections::BTreeSet<String> {
+    let mut out = std::collections::BTreeSet::new();
+    visit_bt_files(root, &mut |file| {
+        let Ok(text) = std::fs::read_to_string(file) else {
+            return;
+        };
+        for line in text.lines() {
+            let t = line.trim();
+            // Match `<Anything> subclass: <Name>` at the start of a line.
+            if let Some(idx) = t.find(" subclass: ") {
+                let name = &t[idx + " subclass: ".len()..];
+                if let Some(first) = name.split_whitespace().next() {
+                    if first.chars().next().is_some_and(char::is_uppercase) {
+                        out.insert(first.to_string());
+                    }
+                }
+            }
+        }
+    });
+    out
+}
+
+fn visit_bt_files(root: &Path, visit: &mut impl FnMut(&Path)) {
+    if root.is_file() {
+        if root.extension().is_some_and(|e| e == "bt") {
+            visit(root);
+        }
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        // Skip generated `_build` and any `.git` dirs.
+        if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
+            if name == "_build" || name == ".git" || name == "build" {
+                continue;
+            }
+        }
+        if p.is_dir() {
+            visit_bt_files(&p, visit);
+        } else if p.extension().is_some_and(|e| e == "bt") {
+            visit(&p);
+        }
+    }
+}
+
+/// Run `beamtalk lint <path>` and count the resulting diagnostics.
+pub fn lint(path: &Path) -> Result<SurfaceOutput, String> {
+    let bin = beamtalk_binary("beamtalk")?;
+    let output = Command::new(&bin)
+        .args(["lint"])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("spawn beamtalk lint: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let combined = format!("{stdout}\n{stderr}");
+    let count = count_diagnostic_lines(&combined);
+    Ok(SurfaceOutput {
+        diagnostic_count: Some(count),
+        raw: combined,
+        ..SurfaceOutput::default()
+    })
+}
+
+/// Run `beamtalk build <path>` and count compile diagnostics. Used for the
+/// parity diagnostic case because plain `lint` misses parse errors.
+pub fn diagnose(path: &Path) -> Result<SurfaceOutput, String> {
+    let bin = beamtalk_binary("beamtalk")?;
+    let output = Command::new(&bin)
+        .args(["build"])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("spawn beamtalk build: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let combined = format!("{stdout}\n{stderr}");
+    // miette renders the leading line `× <message>` for each diagnostic.
+    let count = combined
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            t.starts_with("× ") || t.starts_with("error:") || t.starts_with("Error:")
+        })
+        .count();
+    let final_count = if output.status.success() {
+        0
+    } else {
+        count.max(1)
+    };
+    Ok(SurfaceOutput {
+        diagnostic_count: Some(final_count),
+        raw: combined,
+        ..SurfaceOutput::default()
+    })
+}
+
+/// Run `beamtalk test <path>` against a project.
+pub fn test_project(path: &Path) -> Result<SurfaceOutput, String> {
+    let bin = beamtalk_binary("beamtalk")?;
+    let output = Command::new(&bin)
+        .args(["test", "--quiet"])
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("spawn beamtalk test: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let combined = format!("{stdout}\n{stderr}");
+    let value = if output.status.success() {
+        "pass".to_string()
+    } else {
+        "fail".to_string()
+    };
+    Ok(SurfaceOutput {
+        value: Some(value),
+        raw: combined,
+        ..SurfaceOutput::default()
+    })
+}
+
+fn count_diagnostic_lines(text: &str) -> usize {
+    text.lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            t.starts_with("warning")
+                || t.starts_with("error")
+                || t.contains(": warning:")
+                || t.contains(": error:")
+        })
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostic_lines_counts_classic_formats() {
+        let text = "warning: redundant\nerror: bad\nfoo.bt:1:1: warning: x\nok\n";
+        assert_eq!(count_diagnostic_lines(text), 3);
+    }
+}

--- a/crates/beamtalk-parity-tests/src/drivers/lsp.rs
+++ b/crates/beamtalk-parity-tests/src/drivers/lsp.rs
@@ -1,0 +1,243 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! LSP surface driver.
+//!
+//! Spawns `beamtalk-lsp` over stdio, performs the LSP `initialize` /
+//! `initialized` handshake, opens a single file via `textDocument/didOpen`,
+//! and waits for the matching `textDocument/publishDiagnostics` notification.
+//!
+//! LSP uses Content-Length framing (unlike MCP, which is line-delimited), so
+//! we hand-roll a small parser instead of pulling in an LSP client crate.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+
+use crate::drivers::SurfaceOutput;
+use crate::pool::beamtalk_binary;
+
+/// Spawned LSP child process driver.
+#[derive(Debug)]
+pub struct LspDriver {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: ChildStdout,
+    next_id: i64,
+}
+
+impl LspDriver {
+    /// Spawn `beamtalk-lsp` and complete the LSP handshake.
+    pub async fn spawn(workspace_root: &Path) -> Result<Self, String> {
+        let bin =
+            beamtalk_binary("beamtalk-lsp").map_err(|e| format!("locate beamtalk-lsp: {e}"))?;
+        let mut child = tokio::process::Command::new(&bin)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("spawn {}: {e}", bin.display()))?;
+        let stdin = child.stdin.take().ok_or("no stdin handle on lsp child")?;
+        let stdout = child.stdout.take().ok_or("no stdout handle on lsp child")?;
+        let mut driver = Self {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        driver.handshake(workspace_root).await?;
+        Ok(driver)
+    }
+
+    async fn handshake(&mut self, workspace_root: &Path) -> Result<(), String> {
+        let root_uri = path_to_uri(workspace_root);
+        let init_id = self.next_id;
+        self.next_id += 1;
+        let init = json!({
+            "jsonrpc": "2.0",
+            "id": init_id,
+            "method": "initialize",
+            "params": {
+                "processId": std::process::id(),
+                "rootUri": root_uri,
+                "capabilities": {},
+                "workspaceFolders": [{
+                    "uri": root_uri,
+                    "name": "parity"
+                }]
+            }
+        });
+        self.send(&init).await?;
+        // Read messages until we see the response with our id.
+        loop {
+            let v = self.read_message(Duration::from_secs(20)).await?;
+            if v.get("id") == Some(&Value::from(init_id)) {
+                if let Some(err) = v.get("error") {
+                    return Err(format!("lsp initialize error: {err}"));
+                }
+                break;
+            }
+            // Skip any notifications (e.g. window/logMessage).
+        }
+        let initialized = json!({
+            "jsonrpc": "2.0",
+            "method": "initialized",
+            "params": {}
+        });
+        self.send(&initialized).await?;
+        Ok(())
+    }
+
+    /// Open a file and capture the first `publishDiagnostics` for it.
+    pub async fn diagnose(&mut self, path: &Path) -> Result<SurfaceOutput, String> {
+        let text =
+            std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        let uri = path_to_uri(path);
+        let did_open = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "beamtalk",
+                    "version": 1,
+                    "text": text
+                }
+            }
+        });
+        self.send(&did_open).await?;
+        // Look for publishDiagnostics for this URI.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            if tokio::time::Instant::now() >= deadline {
+                return Err("timed out waiting for publishDiagnostics".to_string());
+            }
+            let remaining = deadline - tokio::time::Instant::now();
+            let v = self.read_message(remaining).await?;
+            if v.get("method").and_then(Value::as_str) == Some("textDocument/publishDiagnostics")
+                && v.pointer("/params/uri").and_then(Value::as_str) == Some(uri.as_str())
+            {
+                let diags = v
+                    .pointer("/params/diagnostics")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                let raw = serde_json::to_string(&diags).unwrap_or_default();
+                return Ok(SurfaceOutput {
+                    diagnostic_count: Some(diags.len()),
+                    raw,
+                    ..SurfaceOutput::default()
+                });
+            }
+        }
+    }
+
+    /// Send `shutdown` + `exit` and reap the child.
+    pub async fn close(mut self) {
+        let shutdown_id = self.next_id;
+        self.next_id += 1;
+        let shutdown = json!({"jsonrpc": "2.0", "id": shutdown_id, "method": "shutdown"});
+        let _ = self.send(&shutdown).await;
+        let _ = self.read_message(Duration::from_secs(2)).await;
+        let exit = json!({"jsonrpc": "2.0", "method": "exit"});
+        let _ = self.send(&exit).await;
+        drop(self.stdin);
+        let _ = tokio::time::timeout(Duration::from_secs(5), self.child.wait()).await;
+        let _ = self.child.start_kill();
+    }
+
+    async fn send(&mut self, msg: &Value) -> Result<(), String> {
+        let body = msg.to_string();
+        let header = format!("Content-Length: {}\r\n\r\n", body.len());
+        self.stdin
+            .write_all(header.as_bytes())
+            .await
+            .map_err(|e| format!("write lsp header: {e}"))?;
+        self.stdin
+            .write_all(body.as_bytes())
+            .await
+            .map_err(|e| format!("write lsp body: {e}"))?;
+        self.stdin
+            .flush()
+            .await
+            .map_err(|e| format!("flush lsp stdin: {e}"))?;
+        Ok(())
+    }
+
+    async fn read_message(&mut self, timeout: Duration) -> Result<Value, String> {
+        let body = tokio::time::timeout(timeout, read_lsp_frame(&mut self.stdout))
+            .await
+            .map_err(|_| "lsp read timed out".to_string())??;
+        serde_json::from_slice(&body).map_err(|e| format!("parse lsp body: {e}"))
+    }
+}
+
+/// Read a single Content-Length-framed LSP message body from a stream.
+async fn read_lsp_frame(stream: &mut ChildStdout) -> Result<Vec<u8>, String> {
+    let mut header = Vec::new();
+    let mut byte = [0u8; 1];
+    // Read header bytes until "\r\n\r\n".
+    loop {
+        let n = stream
+            .read(&mut byte)
+            .await
+            .map_err(|e| format!("read lsp header byte: {e}"))?;
+        if n == 0 {
+            return Err("lsp stdout closed".to_string());
+        }
+        header.push(byte[0]);
+        if header.ends_with(b"\r\n\r\n") {
+            break;
+        }
+        if header.len() > 8192 {
+            return Err("lsp header too long".to_string());
+        }
+    }
+    let header_str = std::str::from_utf8(&header).map_err(|e| format!("lsp header utf8: {e}"))?;
+    let mut content_length = 0usize;
+    for line in header_str.split("\r\n") {
+        if let Some(rest) = line.strip_prefix("Content-Length: ") {
+            content_length = rest
+                .trim()
+                .parse()
+                .map_err(|e| format!("parse Content-Length `{rest}`: {e}"))?;
+        }
+    }
+    if content_length == 0 {
+        return Err(format!("missing Content-Length in `{header_str}`"));
+    }
+    let mut body = vec![0u8; content_length];
+    stream
+        .read_exact(&mut body)
+        .await
+        .map_err(|e| format!("read lsp body ({content_length} bytes): {e}"))?;
+    Ok(body)
+}
+
+/// Render a path as a `file://` URI. Good enough for LSP rootUri / textDocument.uri
+/// — only used for absolute paths from `tempfile::TempDir`.
+fn path_to_uri(p: &Path) -> String {
+    let abs = p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    let s = abs.to_string_lossy().replace('\\', "/");
+    if s.starts_with('/') {
+        format!("file://{s}")
+    } else {
+        // Windows drive paths (`C:/foo`).
+        format!("file:///{s}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_to_uri_handles_unix_absolute() {
+        let uri = path_to_uri(Path::new("/tmp/x.bt"));
+        assert!(uri.starts_with("file:///") || uri.starts_with("file:////"));
+    }
+}

--- a/crates/beamtalk-parity-tests/src/drivers/mcp.rs
+++ b/crates/beamtalk-parity-tests/src/drivers/mcp.rs
@@ -1,0 +1,394 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! MCP surface driver.
+//!
+//! Spawns the real `beamtalk-mcp` binary in the same way an MCP host would,
+//! pointed at the shared workspace. Uses MCP's stdio JSON-RPC framing
+//! (LSP-style: each line is a single JSON object with no `Content-Length`
+//! prefix — `rmcp`'s stdio transport is line-delimited).
+
+use std::collections::BTreeSet;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+
+use crate::drivers::SurfaceOutput;
+use crate::normalize;
+use crate::pool::{SharedRepl, beamtalk_binary};
+
+/// Long-lived MCP child process plus stdio handles.
+#[derive(Debug)]
+pub struct McpDriver {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl McpDriver {
+    /// Spawn `beamtalk-mcp --workspace-id <id>` and complete the handshake.
+    pub async fn spawn(repl: &SharedRepl) -> Result<Self, String> {
+        let bin =
+            beamtalk_binary("beamtalk-mcp").map_err(|e| format!("locate beamtalk-mcp: {e}"))?;
+        let mut child = tokio::process::Command::new(&bin)
+            .args(["--workspace-id", &repl.workspace_id])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("spawn {}: {e}", bin.display()))?;
+        let stdin = child.stdin.take().ok_or("no stdin handle on mcp child")?;
+        let stdout = BufReader::new(child.stdout.take().ok_or("no stdout handle on mcp child")?);
+        let mut driver = Self {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        };
+        driver.handshake().await?;
+        Ok(driver)
+    }
+
+    async fn handshake(&mut self) -> Result<(), String> {
+        // initialize request
+        let req = self.build_request(
+            "initialize",
+            json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "beamtalk-parity", "version": "0"}
+            }),
+        );
+        let _resp = self.rpc(req).await?;
+        // initialized notification (no id, no response)
+        let note = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {}
+        });
+        self.send(&note).await?;
+        Ok(())
+    }
+
+    fn build_request(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        })
+    }
+
+    async fn send(&mut self, msg: &Value) -> Result<(), String> {
+        let mut line = msg.to_string();
+        line.push('\n');
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(|e| format!("write mcp stdin: {e}"))?;
+        self.stdin
+            .flush()
+            .await
+            .map_err(|e| format!("flush mcp stdin: {e}"))?;
+        Ok(())
+    }
+
+    async fn rpc(&mut self, req: Value) -> Result<Value, String> {
+        let want_id = req["id"].clone();
+        self.send(&req).await?;
+        // Read until we get a response with the matching id (skip notifications).
+        loop {
+            let mut buf = String::new();
+            let read =
+                tokio::time::timeout(Duration::from_secs(45), self.stdout.read_line(&mut buf))
+                    .await
+                    .map_err(|_| "mcp stdout read timed out".to_string())?
+                    .map_err(|e| format!("read mcp stdout: {e}"))?;
+            if read == 0 {
+                return Err("mcp stdout closed unexpectedly".to_string());
+            }
+            let trimmed = buf.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let v: Value = serde_json::from_str(trimmed)
+                .map_err(|e| format!("parse mcp message `{trimmed}`: {e}"))?;
+            if v.get("id") == Some(&want_id) {
+                if let Some(err) = v.get("error") {
+                    return Err(format!("mcp error: {err}"));
+                }
+                return Ok(v.get("result").cloned().unwrap_or(Value::Null));
+            }
+            // Otherwise it's a notification or response for a different id; loop.
+        }
+    }
+
+    /// Call an MCP tool by name and return the joined text of the result.
+    pub async fn call_tool(&mut self, name: &str, args: Value) -> Result<Value, String> {
+        let req = self.build_request(
+            "tools/call",
+            json!({
+                "name": name,
+                "arguments": args
+            }),
+        );
+        self.rpc(req).await
+    }
+
+    /// Drive the `evaluate` MCP tool.
+    pub async fn evaluate(&mut self, code: &str) -> Result<SurfaceOutput, String> {
+        let result = self.call_tool("evaluate", json!({"code": code})).await?;
+        let text = extract_content_text(&result);
+        let value = strip_value_label(&text);
+        Ok(SurfaceOutput {
+            value: Some(normalize::value(&value)),
+            raw: text,
+            ..SurfaceOutput::default()
+        })
+    }
+
+    /// Drive the `load_project` MCP tool.
+    pub async fn load_project(&mut self, path: &str) -> Result<SurfaceOutput, String> {
+        // `force=true` so re-running across cases (after REPL pre-loaded the
+        // same files) still produces a fresh class list rather than a
+        // "0 of 2 unchanged" diff.
+        let result = self
+            .call_tool(
+                "load_project",
+                json!({"path": path, "include_tests": false, "force": true}),
+            )
+            .await?;
+        let text = extract_content_text(&result);
+        let mut classes = BTreeSet::new();
+        // MCP renders the success path as a single line: "Loaded classes: A, B, C"
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("Loaded classes:") {
+                for tok in rest.split(',') {
+                    let name = tok.trim();
+                    if !name.is_empty() {
+                        classes.insert(name.to_string());
+                    }
+                }
+            }
+        }
+        // Also harvest any "classes": [...] field in the JSON result for
+        // forward-compat with structured envelopes.
+        if let Some(list) = result.pointer("/classes").and_then(Value::as_array) {
+            for c in list.iter().filter_map(Value::as_str) {
+                classes.insert(c.to_string());
+            }
+        }
+        let diagnostic_count = result
+            .pointer("/errors")
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or(count_error_lines(&text));
+        Ok(SurfaceOutput {
+            classes: Some(classes),
+            diagnostic_count: Some(diagnostic_count),
+            raw: text,
+            ..SurfaceOutput::default()
+        })
+    }
+
+    /// Like [`load_project`] but with `include_tests=true`.
+    pub async fn load_project_with_tests(&mut self, path: &str) -> Result<SurfaceOutput, String> {
+        let result = self
+            .call_tool(
+                "load_project",
+                json!({"path": path, "include_tests": true, "force": true}),
+            )
+            .await?;
+        let text = extract_content_text(&result);
+        let mut classes = BTreeSet::new();
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("Loaded classes:") {
+                for tok in rest.split(',') {
+                    let name = tok.trim();
+                    if !name.is_empty() {
+                        classes.insert(name.to_string());
+                    }
+                }
+            }
+        }
+        Ok(SurfaceOutput {
+            classes: Some(classes),
+            raw: text,
+            ..SurfaceOutput::default()
+        })
+    }
+
+    /// Drive the `test` MCP tool against a class name.
+    pub async fn test_class(&mut self, class: &str) -> Result<SurfaceOutput, String> {
+        let result = self.call_tool("test", json!({"class": class})).await?;
+        let text = extract_content_text(&result);
+        let summary =
+            if text.to_lowercase().contains("fail") || text.to_lowercase().contains("error") {
+                // "0 failed" / "0 errors" still counts as pass.
+                if has_nonzero_failures(&text) {
+                    "fail".to_string()
+                } else {
+                    "pass".to_string()
+                }
+            } else {
+                "pass".to_string()
+            };
+        Ok(SurfaceOutput {
+            value: Some(summary),
+            raw: text,
+            ..SurfaceOutput::default()
+        })
+    }
+
+    /// Drive the `lint` MCP tool against a path.
+    pub async fn lint(&mut self, path: &str) -> Result<SurfaceOutput, String> {
+        let result = self.call_tool("lint", json!({"path": path})).await?;
+        let text = extract_content_text(&result);
+        // The `lint` tool returns a JSON envelope with `errors`, `warnings`,
+        // and `total`; prefer the structured number when present.
+        let count = serde_json::from_str::<serde_json::Value>(&text)
+            .ok()
+            .and_then(|v| v.get("total").and_then(serde_json::Value::as_u64))
+            .and_then(|n| usize::try_from(n).ok())
+            .unwrap_or_else(|| count_diagnostic_lines(&text));
+        Ok(SurfaceOutput {
+            diagnostic_count: Some(count),
+            raw: text,
+            ..SurfaceOutput::default()
+        })
+    }
+
+    /// Drive the `load_file` MCP tool to flush a file through the full
+    /// parse/load pipeline. Used by the diagnostic parity case because plain
+    /// `lint` misses parse errors.
+    pub async fn diagnose_file(&mut self, path: &str) -> Result<SurfaceOutput, String> {
+        let result = self.call_tool("load_file", json!({"path": path})).await?;
+        let text = extract_content_text(&result);
+        let count = if text.to_lowercase().contains("error")
+            || text.to_lowercase().contains("failed")
+            || text.contains('×')
+        {
+            text.lines()
+                .filter(|l| {
+                    let t = l.trim();
+                    t.starts_with("Error")
+                        || t.starts_with("error:")
+                        || t.starts_with("× ")
+                        || t.contains(": error:")
+                })
+                .count()
+                .max(1)
+        } else {
+            0
+        };
+        Ok(SurfaceOutput {
+            diagnostic_count: Some(count),
+            raw: text,
+            ..SurfaceOutput::default()
+        })
+    }
+
+    /// Send `shutdown` and reap the child. Best-effort.
+    pub async fn close(mut self) {
+        // Sending a graceful exit notification is the polite thing to do; we
+        // don't strictly need a response.
+        let note = json!({"jsonrpc": "2.0", "method": "notifications/cancelled"});
+        let _ = self.send(&note).await;
+        // Drop stdin first to signal EOF.
+        drop(self.stdin);
+        let _ = tokio::time::timeout(Duration::from_secs(5), self.child.wait()).await;
+        let _ = self.child.start_kill();
+    }
+}
+
+/// Pull the concatenated `text` content out of an MCP `tools/call` result.
+fn extract_content_text(result: &Value) -> String {
+    let mut out = String::new();
+    if let Some(arr) = result.get("content").and_then(Value::as_array) {
+        for item in arr {
+            if let Some(t) = item.get("text").and_then(Value::as_str) {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str(t);
+            }
+        }
+    }
+    out
+}
+
+/// MCP's `evaluate` tool prefixes its response with `Value: …` on one line and
+/// optionally `Output:` on subsequent lines. The parity harness only cares
+/// about the value.
+fn strip_value_label(text: &str) -> String {
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("Value: ") {
+            return rest.to_string();
+        }
+    }
+    text.to_string()
+}
+
+fn count_diagnostic_lines(text: &str) -> usize {
+    text.lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            t.starts_with("warning")
+                || t.starts_with("error")
+                || t.starts_with("note")
+                || t.contains(": warning:")
+                || t.contains(": error:")
+        })
+        .count()
+}
+
+fn count_error_lines(text: &str) -> usize {
+    text.lines()
+        .filter(|l| l.to_lowercase().contains("error"))
+        .count()
+}
+
+fn has_nonzero_failures(text: &str) -> bool {
+    // Accept patterns like "1 failed" / "2 errors" but not "0 failed".
+    let lower = text.to_lowercase();
+    lower
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .windows(2)
+        .any(|w| {
+            let n = w[0].trim_end_matches(',').parse::<u64>().unwrap_or(0);
+            n > 0 && (w[1].starts_with("fail") || w[1].starts_with("error"))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_text_content() {
+        let v = json!({"content": [{"type":"text","text":"hello"},{"type":"text","text":"world"}]});
+        assert_eq!(extract_content_text(&v), "hello\nworld");
+    }
+
+    #[test]
+    fn strip_value_label_returns_value() {
+        assert_eq!(strip_value_label("Value: 7\nOutput: ok"), "7");
+        assert_eq!(strip_value_label("no label"), "no label");
+    }
+
+    #[test]
+    fn nonzero_failure_detection() {
+        assert!(has_nonzero_failures("1 failed"));
+        assert!(has_nonzero_failures("3 errors detected"));
+        assert!(!has_nonzero_failures("0 failed, 0 errors"));
+    }
+}

--- a/crates/beamtalk-parity-tests/src/drivers/repl.rs
+++ b/crates/beamtalk-parity-tests/src/drivers/repl.rs
@@ -1,0 +1,190 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! REPL surface driver.
+//!
+//! Connects to the shared workspace's WebSocket port and drives the REPL
+//! protocol directly with `beamtalk_repl_protocol::RequestBuilder`.
+//! No CLI wrapper — this is the rawest surface available.
+
+use std::collections::BTreeSet;
+
+use beamtalk_repl_protocol::{ReplResponse, RequestBuilder};
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::drivers::SurfaceOutput;
+use crate::normalize;
+use crate::pool::SharedRepl;
+
+/// Minimal REPL WebSocket client used by the parity harness.
+///
+/// We deliberately avoid taking a dependency on `beamtalk-mcp::client::ReplClient`
+/// because that type is private to the binary crate. The protocol surface we
+/// need (auth handshake + send + receive) is small enough to inline.
+pub struct ReplDriver {
+    ws: tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+}
+
+impl std::fmt::Debug for ReplDriver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReplDriver").finish_non_exhaustive()
+    }
+}
+
+impl ReplDriver {
+    /// Connect and perform the ADR 0020 auth handshake.
+    pub async fn connect(repl: &SharedRepl) -> Result<Self, String> {
+        let url = format!("ws://127.0.0.1:{}/ws", repl.port);
+        let (mut ws, _) = tokio_tungstenite::connect_async(&url)
+            .await
+            .map_err(|e| format!("ws connect {url}: {e}"))?;
+
+        // auth-required
+        let _required = read_text(&mut ws).await?;
+        // auth
+        let auth_msg = serde_json::json!({"type": "auth", "cookie": repl.cookie});
+        ws.send(Message::Text(auth_msg.to_string().into()))
+            .await
+            .map_err(|e| format!("send auth: {e}"))?;
+        // auth_ok
+        let auth_ok: serde_json::Value = serde_json::from_str(&read_text(&mut ws).await?)
+            .map_err(|e| format!("auth_ok: {e}"))?;
+        if auth_ok.get("type").and_then(|v| v.as_str()) != Some("auth_ok") {
+            return Err(format!("workspace auth failed: {auth_ok}"));
+        }
+        // session-started
+        let _session = read_text(&mut ws).await?;
+        Ok(Self { ws })
+    }
+
+    /// Send a request value and read the next response that correlates with
+    /// the request's `id`. Push notifications (no `id`, or different `id`)
+    /// are skipped.
+    async fn rpc(&mut self, request: serde_json::Value) -> Result<ReplResponse, String> {
+        let want_id = request
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        self.ws
+            .send(Message::Text(request.to_string().into()))
+            .await
+            .map_err(|e| format!("send: {e}"))?;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(120);
+        loop {
+            if tokio::time::Instant::now() >= deadline {
+                return Err("timed out waiting for matching REPL response".to_string());
+            }
+            let text = read_text(&mut self.ws).await?;
+            let value: serde_json::Value = serde_json::from_str(&text)
+                .map_err(|e| format!("parse response: {e}\nraw: {text}"))?;
+            let got_id = value.get("id").and_then(|v| v.as_str()).map(str::to_string);
+            if got_id == want_id {
+                return serde_json::from_value(value)
+                    .map_err(|e| format!("parse response struct: {e}"));
+            }
+            // Anything else (push notifications, server-initiated frames)
+            // gets dropped silently.
+        }
+    }
+
+    /// Drive an `eval` request and return a normalized [`SurfaceOutput`].
+    pub async fn eval(&mut self, code: &str) -> Result<SurfaceOutput, String> {
+        let resp = self.rpc(RequestBuilder::eval(code)).await?;
+        if resp.is_error() {
+            return Err(format!(
+                "REPL eval error: {}",
+                resp.error_message().unwrap_or("<no message>")
+            ));
+        }
+        let raw = resp.value_string();
+        Ok(SurfaceOutput {
+            value: Some(normalize::value(&raw)),
+            raw,
+            ..SurfaceOutput::default()
+        })
+    }
+
+    /// Drive a `load-project` request and return the resulting class list.
+    pub async fn load_project(&mut self, path: &str) -> Result<SurfaceOutput, String> {
+        // Pass `force = true` so re-running across cases re-loads even when
+        // the workspace incremental cache thinks the files are unchanged.
+        let resp = self
+            .rpc(RequestBuilder::load_project_with_force(path, false, true))
+            .await?;
+        let mut classes = BTreeSet::new();
+        if let Some(list) = &resp.classes {
+            for c in list {
+                classes.insert(c.clone());
+            }
+        }
+        let diagnostic_count = resp.errors.len();
+        let raw = format!(
+            "classes={:?} errors={} status={:?} response_type={:?}",
+            classes, diagnostic_count, resp.status, resp.response_type
+        );
+        Ok(SurfaceOutput {
+            classes: Some(classes),
+            diagnostic_count: Some(diagnostic_count),
+            raw,
+            ..SurfaceOutput::default()
+        })
+    }
+
+    /// Like [`load_project`] but with `include_tests=true` so test classes
+    /// land in the workspace too.
+    pub async fn load_project_with_tests(&mut self, path: &str) -> Result<SurfaceOutput, String> {
+        let resp = self
+            .rpc(RequestBuilder::load_project_with_force(path, true, true))
+            .await?;
+        let mut classes = BTreeSet::new();
+        if let Some(list) = &resp.classes {
+            for c in list {
+                classes.insert(c.clone());
+            }
+        }
+        let raw = format!("classes={:?} status={:?}", classes, resp.status);
+        Ok(SurfaceOutput {
+            classes: Some(classes),
+            diagnostic_count: Some(resp.errors.len()),
+            raw,
+            ..SurfaceOutput::default()
+        })
+    }
+
+    /// Drive a `test` request for a class and return a normalized summary.
+    pub async fn test_class(&mut self, class: &str) -> Result<SurfaceOutput, String> {
+        let resp = self.rpc(RequestBuilder::test_class(class)).await?;
+        let raw =
+            serde_json::to_string(&resp.results.clone().unwrap_or_default()).unwrap_or_default();
+        let summary = if resp.has_test_error() {
+            "fail".to_string()
+        } else if resp.is_error() {
+            "error".to_string()
+        } else {
+            "pass".to_string()
+        };
+        Ok(SurfaceOutput {
+            value: Some(summary),
+            raw,
+            ..SurfaceOutput::default()
+        })
+    }
+}
+
+async fn read_text<S>(ws: &mut tokio_tungstenite::WebSocketStream<S>) -> Result<String, String>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    loop {
+        match ws.next().await {
+            Some(Ok(Message::Text(t))) => return Ok(t.to_string()),
+            Some(Ok(Message::Close(_))) => return Err("ws closed".to_string()),
+            Some(Ok(_)) => continue, // ping/pong/binary
+            Some(Err(e)) => return Err(format!("ws read: {e}")),
+            None => return Err("ws stream ended".to_string()),
+        }
+    }
+}

--- a/crates/beamtalk-parity-tests/src/lib.rs
+++ b/crates/beamtalk-parity-tests/src/lib.rs
@@ -1,0 +1,37 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// This crate is a test-only harness; relax pedantic lints that aren't useful
+// for short-lived integration helpers (missing Errors/Panics docs, inlined
+// format args, etc.). Real production code paths have stricter lints.
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::uninlined_format_args,
+    clippy::needless_pass_by_value,
+    clippy::map_unwrap_or,
+    clippy::needless_continue,
+    clippy::too_many_lines
+)]
+
+//! Cross-surface parity test harness for Beamtalk (BT-2077).
+//!
+//! **DDD Context:** Cross-cutting — Quality / Tooling
+//!
+//! This crate drives the same input through multiple surfaces (REPL, MCP, CLI,
+//! LSP) and asserts that the observable behaviour is equivalent. It exists to
+//! prevent silent surface drift as the language and tooling evolve.
+//!
+//! The harness is intentionally lightweight: it does not depend on the MCP or
+//! LSP client implementations directly. Instead, each surface is driven via
+//! its real user-facing entry point (a child process for MCP / CLI / LSP, a
+//! WebSocket connection for the REPL).
+//!
+//! The integration test in `tests/parity.rs` is `#[ignore]`'d by default and
+//! must be invoked through `just test-parity` (or with `cargo test --ignored`)
+//! because it spins up real workspaces and child processes.
+
+pub mod cases;
+pub mod drivers;
+pub mod normalize;
+pub mod pool;

--- a/crates/beamtalk-parity-tests/src/normalize.rs
+++ b/crates/beamtalk-parity-tests/src/normalize.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Output normalization helpers used by every surface driver.
+//!
+//! Different surfaces format the same logical value slightly differently — the
+//! REPL strips quotes from string values, MCP tool results wrap the payload in
+//! a JSON content array, and CLI commands print human-readable text. This
+//! module collapses those superficial differences so a parity assertion can
+//! compare the underlying value.
+
+use std::sync::OnceLock;
+
+/// Normalize a surface's textual output for a value comparison.
+///
+/// * Trims surrounding whitespace.
+/// * Strips a single pair of matching ASCII quotes.
+/// * Replaces every BEAM-style pid (`<0.123.0>`) with `<pid>`.
+/// * Collapses runs of whitespace to a single space.
+pub fn value(text: &str) -> String {
+    let trimmed = text.trim();
+    let unquoted = strip_outer_quotes(trimmed);
+    let pid_replaced = replace_pids(&unquoted);
+    collapse_whitespace(&pid_replaced)
+}
+
+fn strip_outer_quotes(s: &str) -> String {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            // Safety: ASCII byte slice; safe to take inner string.
+            return s[1..s.len() - 1].to_string();
+        }
+    }
+    s.to_string()
+}
+
+fn replace_pids(s: &str) -> String {
+    // Hand-rolled to avoid pulling in `regex`.
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            if let Some(end) = find_pid_end(&bytes[i..]) {
+                out.push_str("<pid>");
+                i += end;
+                continue;
+            }
+        }
+        // Push UTF-8 char starting at i.
+        let ch = s[i..].chars().next().expect("valid utf-8");
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+/// If `slice` starts with `<digits.digits.digits>` return the byte length of
+/// that prefix, otherwise None. Used for normalising Erlang pid renderings.
+fn find_pid_end(slice: &[u8]) -> Option<usize> {
+    if slice.first()? != &b'<' {
+        return None;
+    }
+    let mut idx = 1;
+    let mut dots = 0;
+    let mut digits_in_segment = 0;
+    while idx < slice.len() {
+        let c = slice[idx];
+        if c.is_ascii_digit() {
+            digits_in_segment += 1;
+            idx += 1;
+            continue;
+        }
+        if c == b'.' {
+            if digits_in_segment == 0 {
+                return None;
+            }
+            dots += 1;
+            digits_in_segment = 0;
+            idx += 1;
+            continue;
+        }
+        if c == b'>' && dots == 2 && digits_in_segment > 0 {
+            return Some(idx + 1);
+        }
+        return None;
+    }
+    None
+}
+
+fn collapse_whitespace(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut last_space = false;
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            if !last_space {
+                out.push(' ');
+            }
+            last_space = true;
+        } else {
+            out.push(ch);
+            last_space = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+/// Cached project root (the directory containing `Cargo.toml` workspace
+/// manifest). Used by drivers when resolving binary paths.
+pub fn project_root() -> &'static std::path::Path {
+    static ROOT: OnceLock<std::path::PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        // CARGO_MANIFEST_DIR for this crate is `crates/beamtalk-parity-tests`.
+        let manifest =
+            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set during test");
+        std::path::PathBuf::from(manifest)
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("workspace root has at least two ancestors")
+            .to_path_buf()
+    })
+    .as_path()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_trims_and_unquotes() {
+        assert_eq!(value("  \"hello\"  "), "hello");
+        assert_eq!(value("'7'"), "7");
+        assert_eq!(value("42\n"), "42");
+    }
+
+    #[test]
+    fn value_replaces_pids() {
+        assert_eq!(value("<0.123.0> ready"), "<pid> ready");
+        assert_eq!(value("two: <0.1.0> and <0.2.0>"), "two: <pid> and <pid>");
+    }
+
+    #[test]
+    fn value_keeps_angle_text_that_is_not_a_pid() {
+        assert_eq!(value("<not a pid>"), "<not a pid>");
+        assert_eq!(value("<0.x.0>"), "<0.x.0>");
+    }
+
+    #[test]
+    fn value_collapses_internal_whitespace() {
+        assert_eq!(value("a   b\tc"), "a b c");
+    }
+}

--- a/crates/beamtalk-parity-tests/src/pool.rs
+++ b/crates/beamtalk-parity-tests/src/pool.rs
@@ -1,0 +1,211 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared REPL workspace pool.
+//!
+//! The harness starts at most one workspace per process. The same workspace is
+//! reused by every REPL and MCP case in a run — this is the key contributor
+//! to keeping the parity suite's wall-clock under the e2e suite's ~50s.
+//!
+//! Borrowed from `crates/beamtalk-mcp/src/client.rs::tests` (the only other
+//! place in the repo that auto-starts a workspace from a test binary). The
+//! logic is copied rather than re-exported because the MCP test fixture is
+//! not a public API.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use crate::normalize::project_root;
+
+/// Live-workspace handle returned to the harness.
+#[derive(Debug, Clone)]
+pub struct SharedRepl {
+    /// REPL WebSocket port.
+    pub port: u16,
+    /// Auth cookie for the REPL.
+    pub cookie: String,
+    /// Workspace ID (used by the MCP driver for discovery).
+    pub workspace_id: String,
+}
+
+/// Get-or-start the shared workspace.
+///
+/// On first call this spawns `beamtalk repl --port 0 --timeout 300`, parses
+/// the port and workspace ID from stdout, reads the cookie from workspace
+/// storage, and waits for the TCP port to accept connections. Subsequent
+/// calls return the cached handle.
+///
+/// Errors are also cached so a failed startup short-circuits later cases
+/// rather than retrying the same expensive failure mode.
+pub fn shared_repl() -> Result<SharedRepl, String> {
+    static CACHE: OnceLock<Result<SharedRepl, String>> = OnceLock::new();
+    CACHE.get_or_init(start_workspace).clone()
+}
+
+fn start_workspace() -> Result<SharedRepl, String> {
+    let bin = beamtalk_binary("beamtalk")?;
+    let pid = std::process::id();
+    let stdout_path = std::env::temp_dir().join(format!("beamtalk-parity-{pid}.stdout"));
+    let stderr_path = std::env::temp_dir().join(format!("beamtalk-parity-{pid}.stderr"));
+    let stdout =
+        std::fs::File::create(&stdout_path).map_err(|e| format!("create stdout temp file: {e}"))?;
+    let stderr =
+        std::fs::File::create(&stderr_path).map_err(|e| format!("create stderr temp file: {e}"))?;
+
+    // Spawn `beamtalk repl` from a unique temp directory so the parity suite
+    // gets its OWN workspace ID (workspace IDs are derived from cwd). Sharing
+    // a workspace with `just test-mcp` would let leftover parity-test classes
+    // leak into the MCP `test-all` integration test.
+    let workspace_cwd = std::env::temp_dir().join(format!("beamtalk-parity-cwd-{pid}"));
+    std::fs::create_dir_all(&workspace_cwd)
+        .map_err(|e| format!("create workspace cwd {}: {e}", workspace_cwd.display()))?;
+
+    let mut child = Command::new(&bin)
+        .args(["repl", "--port", "0", "--timeout", "300"])
+        .current_dir(&workspace_cwd)
+        .stdin(Stdio::null())
+        .stdout(stdout)
+        .stderr(stderr)
+        .spawn()
+        .map_err(|e| format!("spawn `beamtalk repl`: {e}"))?;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(45);
+    let mut combined = String::new();
+    let mut have_port = false;
+    let mut have_ws_id = false;
+    while std::time::Instant::now() < deadline {
+        if let Ok(Some(status)) = child.try_wait() {
+            // Read the rest of stdout before bailing.
+            combined = std::fs::read_to_string(&stdout_path).unwrap_or_default();
+            let stderr_text = std::fs::read_to_string(&stderr_path).unwrap_or_default();
+            let _ = std::fs::remove_file(&stdout_path);
+            let _ = std::fs::remove_file(&stderr_path);
+            if status.success() && combined.contains("port") {
+                // Successful detached start with stdin=null is fine; fall through to parse.
+                break;
+            }
+            return Err(format!(
+                "`beamtalk repl` exited {status} before workspace was ready.\n\
+                 stdout:\n{combined}\nstderr:\n{stderr_text}"
+            ));
+        }
+        if let Ok(content) = std::fs::read_to_string(&stdout_path) {
+            have_port = content.contains("port");
+            have_ws_id = content.contains("Workspace:");
+            combined = content;
+            if have_port && have_ws_id {
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+
+    // Best-effort cleanup: detach and stop reading the temp files.
+    let stderr_text = std::fs::read_to_string(&stderr_path).unwrap_or_default();
+    let _ = std::fs::remove_file(&stdout_path);
+    let _ = std::fs::remove_file(&stderr_path);
+    drop(child);
+
+    let port = parse_port_line(&combined).ok_or_else(|| {
+        format!(
+            "`beamtalk repl` did not report a port within 45s.\nstdout:\n{combined}\nstderr:\n{stderr_text}"
+        )
+    })?;
+    let workspace_id = parse_workspace_id(&combined).ok_or_else(|| {
+        format!(
+            "`beamtalk repl` did not report a workspace id.\nstdout:\n{combined}\nstderr:\n{stderr_text}"
+        )
+    })?;
+    let cookie = beamtalk_workspace::read_cookie_file(&workspace_id)
+        .map_err(|e| format!("read cookie for workspace {workspace_id}: {e}"))?
+        .ok_or_else(|| format!("no cookie file for workspace {workspace_id}"))?;
+
+    wait_for_tcp_ready(port, Duration::from_secs(20))?;
+    let _ = (have_port, have_ws_id); // silence dead-store warnings if both branches set them
+
+    Ok(SharedRepl {
+        port,
+        cookie,
+        workspace_id,
+    })
+}
+
+/// Resolve `target/debug/<bin>` (or `.exe` on Windows) by walking up from cwd.
+pub fn beamtalk_binary(name: &str) -> Result<PathBuf, String> {
+    let suffix = std::env::consts::EXE_SUFFIX;
+    let file = format!("{name}{suffix}");
+    let mut dir = project_root().to_path_buf();
+    let candidate = dir.join("target/debug").join(&file);
+    if candidate.exists() {
+        return Ok(candidate);
+    }
+    // Fallback: walk up from cwd for safety in unusual layouts.
+    if let Ok(mut cwd) = std::env::current_dir() {
+        loop {
+            let c = cwd.join("target/debug").join(&file);
+            if c.exists() {
+                return Ok(c);
+            }
+            if !cwd.pop() {
+                break;
+            }
+        }
+    }
+    let _ = dir.pop();
+    Err(format!(
+        "binary `{name}` not found in target/debug; run `just build` first"
+    ))
+}
+
+fn parse_port_line(stdout: &str) -> Option<u16> {
+    stdout.lines().find_map(|line| {
+        line.strip_prefix("Connected to REPL backend on port ")
+            .and_then(|rest| rest.trim_end_matches('.').trim().parse().ok())
+    })
+}
+
+fn parse_workspace_id(stdout: &str) -> Option<String> {
+    stdout.lines().find_map(|line| {
+        line.strip_prefix("  Workspace: ")
+            .and_then(|rest| rest.split_whitespace().next())
+            .map(str::to_string)
+    })
+}
+
+fn wait_for_tcp_ready(port: u16, timeout: Duration) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if std::net::TcpStream::connect_timeout(
+            &format!("127.0.0.1:{port}").parse().unwrap(),
+            Duration::from_millis(500),
+        )
+        .is_ok()
+        {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    Err(format!(
+        "TCP port {port} did not accept connections within {}s",
+        timeout.as_secs()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_port_line_extracts_number() {
+        let s = "  starting...\nConnected to REPL backend on port 12345.\nready";
+        assert_eq!(parse_port_line(s), Some(12345));
+    }
+
+    #[test]
+    fn parse_workspace_id_extracts_first_token() {
+        let s = "  Workspace: deadbeef1234 (new)\n";
+        assert_eq!(parse_workspace_id(s).as_deref(), Some("deadbeef1234"));
+    }
+}

--- a/crates/beamtalk-parity-tests/tests/parity.rs
+++ b/crates/beamtalk-parity-tests/tests/parity.rs
@@ -1,0 +1,301 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-surface parity integration test (BT-2077).
+//!
+//! Runs every `tests/parity/cases/*.parity.bt` case through the surfaces
+//! declared in its header and asserts that the normalized outputs agree.
+//!
+//! All `#[test]`s here are gated behind `#[ignore]` because they spawn real
+//! workspaces and child binaries. Invoke via `just test-parity`.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use beamtalk_parity_tests::cases::{Case, Expectation, Op, Step, Surface, discover};
+use beamtalk_parity_tests::drivers::{
+    SurfaceOutput, cli as cli_driver, lsp::LspDriver, mcp::McpDriver, repl::ReplDriver,
+};
+use beamtalk_parity_tests::pool::{SharedRepl, shared_repl};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "parity harness — run via `just test-parity`"]
+async fn parity_suite() {
+    let cases_dir = parity_root().join("cases");
+    let case_paths = discover(&cases_dir).expect("discover parity cases");
+    assert!(
+        !case_paths.is_empty(),
+        "no parity cases found under {}",
+        cases_dir.display()
+    );
+
+    let repl = shared_repl().expect("start shared workspace");
+    // The MCP driver is shared across cases too — re-using a single child
+    // process keeps wall-clock down.
+    let mut mcp = McpDriver::spawn(&repl).await.expect("spawn mcp driver");
+    let mut repl_driver = ReplDriver::connect(&repl)
+        .await
+        .expect("connect repl driver");
+
+    // Stage the project fixture once for any case that needs it.
+    let staged_project = stage_simple_project();
+    let staged_bad_file = stage_diagnostic_file();
+
+    let mut failures: Vec<String> = Vec::new();
+    for path in &case_paths {
+        let case = match Case::from_path(path) {
+            Ok(c) => c,
+            Err(e) => {
+                failures.push(format!("[{}] parse: {e}", path.display()));
+                continue;
+            }
+        };
+        for step in &case.steps {
+            let resolved = resolve_placeholders(
+                &step.input,
+                staged_project.as_deref(),
+                staged_bad_file.as_deref(),
+            );
+            let outcome = run_step(step, &resolved, &mut repl_driver, &mut mcp, &repl).await;
+            if let Err(msg) = outcome {
+                failures.push(format!(
+                    "[{}:{}] {} — {}",
+                    case.path.display(),
+                    step.line,
+                    surfaces_label(&step.surfaces),
+                    msg
+                ));
+            }
+        }
+    }
+
+    mcp.close().await;
+
+    // Stop the parity workspace so its loaded classes don't linger in BEAM
+    // node memory and bleed into other test runs (the workspace would
+    // otherwise stay alive for the 5-minute idle timeout).
+    stop_parity_workspace(&repl);
+
+    assert!(
+        failures.is_empty(),
+        "parity assertions failed:\n  - {}",
+        failures.join("\n  - ")
+    );
+}
+
+fn stop_parity_workspace(repl: &SharedRepl) {
+    use beamtalk_parity_tests::pool::beamtalk_binary;
+    use std::process::{Command, Stdio};
+    let Ok(bin) = beamtalk_binary("beamtalk") else {
+        return;
+    };
+    let _ = Command::new(bin)
+        .args(["workspace", "stop", &repl.workspace_id])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+/// Run a single step against every declared surface and assert agreement.
+async fn run_step(
+    step: &Step,
+    input: &str,
+    repl: &mut ReplDriver,
+    mcp: &mut McpDriver,
+    shared: &SharedRepl,
+) -> Result<(), String> {
+    let mut outputs: Vec<(Surface, SurfaceOutput)> = Vec::new();
+    for &surface in &step.surfaces {
+        let out = drive(step, input, surface, repl, mcp, shared).await?;
+        outputs.push((surface, out));
+    }
+
+    match &step.expect {
+        Expectation::Value(expected) => {
+            for (surface, out) in &outputs {
+                let got = out.value.as_deref().ok_or_else(|| {
+                    format!("surface {surface} produced no value (raw={})", out.raw)
+                })?;
+                if got != expected.as_str() {
+                    return Err(format!(
+                        "value mismatch on {surface}: expected `{expected}`, got `{got}` (raw={})",
+                        out.raw
+                    ));
+                }
+            }
+        }
+        Expectation::Classes(expected) => {
+            for (surface, out) in &outputs {
+                let got = out.classes.as_ref().ok_or_else(|| {
+                    format!("surface {surface} produced no class set (raw={})", out.raw)
+                })?;
+                if !expected.is_subset(got) {
+                    let missing: BTreeSet<_> = expected.difference(got).collect();
+                    return Err(format!(
+                        "missing classes on {surface}: {:?} (raw={})",
+                        missing, out.raw
+                    ));
+                }
+            }
+        }
+        Expectation::DiagnosticCount(expected) => {
+            for (surface, out) in &outputs {
+                let got = out.diagnostic_count.ok_or_else(|| {
+                    format!(
+                        "surface {surface} produced no diagnostic count (raw={})",
+                        out.raw
+                    )
+                })?;
+                let agrees = if *expected == 0 {
+                    got == 0
+                } else {
+                    got >= *expected
+                };
+                if !agrees {
+                    return Err(format!(
+                        "diagnostic count mismatch on {surface}: expected {expected}, got {got} (raw={})",
+                        out.raw
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn drive(
+    step: &Step,
+    input: &str,
+    surface: Surface,
+    repl: &mut ReplDriver,
+    mcp: &mut McpDriver,
+    shared: &SharedRepl,
+) -> Result<SurfaceOutput, String> {
+    let _ = shared; // kept in the signature for future use (workspace-id-aware drivers)
+    match (surface, step.op) {
+        (Surface::Repl, Op::Eval) => repl.eval(input).await,
+        (Surface::Mcp, Op::Eval) => mcp.evaluate(input).await,
+
+        (Surface::Repl, Op::Load) => repl.load_project(input).await,
+        (Surface::Mcp, Op::Load) => mcp.load_project(input).await,
+        (Surface::Cli, Op::Load) => cli_driver::build_project(Path::new(input)),
+
+        (Surface::Mcp, Op::Lint) => mcp.lint(input).await,
+        (Surface::Cli, Op::Lint) => cli_driver::lint(Path::new(input)),
+
+        (Surface::Repl, Op::Test) => {
+            // Make sure the test class is loaded before running it.
+            let project = std::env::temp_dir().join("beamtalk-parity-simple");
+            if project.exists() {
+                let _ = repl
+                    .load_project_with_tests(&project.to_string_lossy())
+                    .await;
+            }
+            repl.test_class(input).await
+        }
+        (Surface::Mcp, Op::Test) => {
+            let project = std::env::temp_dir().join("beamtalk-parity-simple");
+            if project.exists() {
+                let _ = mcp
+                    .load_project_with_tests(&project.to_string_lossy())
+                    .await;
+            }
+            mcp.test_class(input).await
+        }
+        (Surface::Cli, Op::Test) => {
+            let project = std::env::temp_dir().join("beamtalk-parity-simple");
+            cli_driver::test_project(&project)
+        }
+
+        (Surface::Cli, Op::Diagnose) => cli_driver::diagnose(Path::new(input)),
+        (Surface::Mcp, Op::Diagnose) => mcp.diagnose_file(input).await,
+        (Surface::Lsp, Op::Diagnose) => {
+            let parent = Path::new(input).parent().unwrap_or(Path::new("/"));
+            let mut lsp = LspDriver::spawn(parent)
+                .await
+                .map_err(|e| format!("lsp spawn: {e}"))?;
+            let result = lsp.diagnose(Path::new(input)).await;
+            lsp.close().await;
+            result
+        }
+
+        (s, op) => Err(format!(
+            "Surface `{s}` does not support op `{op:?}` (input=`{input}`)"
+        )),
+    }
+}
+
+/// Stage `tests/parity/fixtures/simple_project/` to a stable temp directory.
+///
+/// The directory is reused across cases so the workspace pool can keep one
+/// `load-project` cache hot. Returns `None` if the fixture is absent (which
+/// is treated as a hard test failure later, but we don't panic here so the
+/// case loop can still produce a useful error message).
+fn stage_simple_project() -> Option<PathBuf> {
+    let src = parity_root().join("fixtures/simple_project");
+    if !src.exists() {
+        return None;
+    }
+    let dst = std::env::temp_dir().join("beamtalk-parity-simple");
+    let _ = std::fs::remove_dir_all(&dst);
+    copy_tree(&src, &dst).ok()?;
+    Some(dst)
+}
+
+fn stage_diagnostic_file() -> Option<PathBuf> {
+    let src = parity_root().join("fixtures/diagnostic/bad_syntax.bt");
+    if !src.exists() {
+        return None;
+    }
+    let dst_dir = std::env::temp_dir().join("beamtalk-parity-diagnostic");
+    let _ = std::fs::create_dir_all(&dst_dir);
+    let dst = dst_dir.join("bad_syntax.bt");
+    let _ = std::fs::remove_file(&dst);
+    std::fs::copy(&src, &dst).ok()?;
+    Some(dst)
+}
+
+fn copy_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if from.is_dir() {
+            copy_tree(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+fn parity_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at `crates/beamtalk-parity-tests`.
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest)
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("workspace root")
+        .join("tests/parity")
+}
+
+fn resolve_placeholders(input: &str, project: Option<&Path>, bad_file: Option<&Path>) -> String {
+    let mut out = input.to_string();
+    if let Some(p) = project {
+        out = out.replace("<project>", &p.to_string_lossy());
+    }
+    if let Some(p) = bad_file {
+        out = out.replace("<bad_file>", &p.to_string_lossy());
+    }
+    out
+}
+
+fn surfaces_label(surfaces: &BTreeSet<Surface>) -> String {
+    surfaces
+        .iter()
+        .map(|s| s.label())
+        .collect::<Vec<_>>()
+        .join(",")
+}

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -17,6 +17,7 @@ Beamtalk uses a multi-layered testing strategy covering the Rust compiler, Erlan
 | Integration Tests | EUnit + daemon | `runtime/apps/beamtalk_runtime/test/*_integration_tests.erl` | Test REPL ↔ daemon communication |
 | Codegen Simulation Tests | EUnit | `runtime/apps/beamtalk_runtime/test/beamtalk_codegen_simulation_tests.erl` | Simulate compiler output, test runtime behavior |
 | E2E Tests (Rust) | Rust + REPL | `tests/e2e/` | REPL/workspace integration tests |
+| Parity Tests | Rust + REPL/MCP/CLI/LSP | `tests/parity/` (cases) + `crates/beamtalk-parity-tests/` (harness) | Cross-surface equivalence checks (BT-2077) |
 
 ## Running Tests
 
@@ -34,6 +35,7 @@ cargo fmt --all -- --check
 cargo test --all-targets
 just test-stdlib         # Bootstrap expression tests (fast, ~14s)
 just test-bunit          # BUnit TestCase tests (~85 files)
+just test-parity         # Cross-surface parity tests (BT-2077, ~30s)
 just test-e2e            # REPL integration tests (slower, ~50s)
 ```
 
@@ -529,6 +531,61 @@ undefined_var
 ```
 
 See [tests/e2e/README.md](../../tests/e2e/README.md) for full documentation.
+
+### 9. Cross-surface Parity Tests (BT-2077)
+
+Drives the same input through every public surface of the compiler stack
+(REPL, MCP, CLI, LSP) and asserts the observable behaviour is equivalent.
+Catches surface drift early — without this layer, a regression that affects
+only the MCP `evaluate` tool would slip through both the REPL E2E suite and
+the BUnit suite.
+
+**Location:**
+- Cases: `tests/parity/cases/*.parity.bt`
+- Fixtures: `tests/parity/fixtures/`
+- Harness crate: `crates/beamtalk-parity-tests/`
+
+**What they test:**
+- Literal evaluation (REPL + MCP) — same value
+- Project loading (REPL + MCP + CLI) — same class set
+- Lint (MCP + CLI) — same diagnostic count on a clean project
+- BUnit test execution (REPL + MCP) — same pass/fail outcome
+- Diagnostics on a broken file (CLI + MCP + LSP) — every surface flags it
+
+**Case file format:**
+
+```text
+// @input
+3 + 4
+// @surfaces repl, mcp
+// @expect 7
+```
+
+Three expectation directives are supported:
+
+| Directive | Meaning |
+|-----------|---------|
+| `// @expect <text>` | Every surface must produce this normalized value |
+| `// @expect-classes A, B, …` | Every surface must observe at least these class names |
+| `// @expect-diagnostics N` | Every surface must report (≥) N diagnostics; `0` means exactly zero |
+
+The harness recognises two placeholder tokens in the input:
+
+* `<project>` — replaced with the staged temp copy of `tests/parity/fixtures/simple_project/`
+* `<bad_file>` — replaced with the staged copy of `tests/parity/fixtures/diagnostic/BadSyntax.bt`
+
+**Workspace pool:** all REPL and MCP cases share a single workspace started
+once per harness run. The pattern is borrowed from `crates/beamtalk-mcp/src/client.rs::tests`.
+
+**Running:**
+```bash
+just test-parity
+```
+
+**When to add a new case:**
+- A new operation appears on more than one surface
+- A bug fix corrected a divergence between surfaces — add a regression case
+- A surface gets a new tool/command that maps to an existing REPL op
 
 ---
 

--- a/tests/parity/cases/diagnostic.parity.bt
+++ b/tests/parity/cases/diagnostic.parity.bt
@@ -1,0 +1,17 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+//
+// Parity case: a file that references an unknown class must produce at least
+// one diagnostic on every surface that reports diagnostics. The harness
+// stages `BadSyntax.bt` into a temp directory and rewrites `<bad_file>` to
+// its absolute path.
+//
+// This is the only case wired to the LSP surface — opening the file via
+// `textDocument/didOpen` should immediately yield a non-empty
+// `publishDiagnostics`.
+
+// @input
+<bad_file>
+// @surfaces cli, mcp, lsp
+// @op diagnose
+// @expect-diagnostics 1

--- a/tests/parity/cases/diagnostic.parity.bt
+++ b/tests/parity/cases/diagnostic.parity.bt
@@ -1,10 +1,10 @@
 // Copyright 2026 James Casey
 // SPDX-License-Identifier: Apache-2.0
 //
-// Parity case: a file that references an unknown class must produce at least
-// one diagnostic on every surface that reports diagnostics. The harness
-// stages `BadSyntax.bt` into a temp directory and rewrites `<bad_file>` to
-// its absolute path.
+// Parity case: a file with a deliberate parse/lex error must produce
+// exactly one diagnostic on every surface that reports diagnostics. The
+// harness stages `BadSyntax.bt` into a temp directory and rewrites
+// `<bad_file>` to its absolute path.
 //
 // This is the only case wired to the LSP surface — opening the file via
 // `textDocument/didOpen` should immediately yield a non-empty

--- a/tests/parity/cases/lint_clean.parity.bt
+++ b/tests/parity/cases/lint_clean.parity.bt
@@ -1,0 +1,12 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+//
+// Parity case: a clean project linted via the CLI and the MCP `lint` tool
+// should both report zero diagnostics. This guards against either surface
+// drifting into spurious warnings.
+
+// @input
+<project>
+// @surfaces mcp, cli
+// @op lint
+// @expect-diagnostics 0

--- a/tests/parity/cases/literal_eval.parity.bt
+++ b/tests/parity/cases/literal_eval.parity.bt
@@ -1,0 +1,17 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+//
+// Parity case: a literal arithmetic expression must evaluate to the same
+// value through every surface that supports `eval`. The CLI does not have an
+// `eval` subcommand (you can only evaluate via `beamtalk repl` interactively),
+// so this case targets only the surfaces that do.
+
+// @input
+3 + 4
+// @surfaces repl, mcp
+// @expect 7
+
+// @input
+2 * 21
+// @surfaces repl, mcp
+// @expect 42

--- a/tests/parity/cases/load_project.parity.bt
+++ b/tests/parity/cases/load_project.parity.bt
@@ -1,0 +1,13 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+//
+// Parity case: loading a tiny project must surface the same set of class
+// names across REPL (`Workspace load:`), MCP (`load_project` tool) and CLI
+// (`beamtalk build`). The fixture is staged to a tmp dir per run; the harness
+// rewrites the input token `<project>` to that path.
+
+// @input
+<project>
+// @surfaces repl, mcp, cli
+// @op load
+// @expect-classes Counter, Greeter

--- a/tests/parity/cases/test_pass.parity.bt
+++ b/tests/parity/cases/test_pass.parity.bt
@@ -1,0 +1,13 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+//
+// Parity case: running the BUnit test suite for the staged project should
+// pass on every surface that supports `test`. The harness loads the project
+// over the REPL surface first (so `CounterTest` is in the workspace) before
+// invoking the test op.
+
+// @input
+CounterTest
+// @surfaces repl, mcp
+// @op test
+// @expect pass

--- a/tests/parity/fixtures/diagnostic/bad_syntax.bt
+++ b/tests/parity/fixtures/diagnostic/bad_syntax.bt
@@ -1,0 +1,10 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+/// Intentionally-broken file used by the parity diagnostic case.
+///
+/// The body has a real lex/parse error — every surface that surfaces compile
+/// diagnostics must flag at least one issue.
+Value subclass: BadSyntax
+
+  go => @@@ +-+

--- a/tests/parity/fixtures/simple_project/beamtalk.toml
+++ b/tests/parity/fixtures/simple_project/beamtalk.toml
@@ -1,0 +1,9 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "parity_simple"
+version = "0.1.0"
+description = "Tiny project for parity-test load_project case"
+
+[dependencies]

--- a/tests/parity/fixtures/simple_project/src/counter.bt
+++ b/tests/parity/fixtures/simple_project/src/counter.bt
@@ -1,0 +1,12 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+/// A trivial counter used by the parity-test harness.
+Actor subclass: Counter
+  state: count :: Integer = 0
+
+  current -> Integer => self.count
+
+  increment -> Integer => self.count := self.count + 1
+
+  reset -> Integer => self.count := 0

--- a/tests/parity/fixtures/simple_project/src/greeter.bt
+++ b/tests/parity/fixtures/simple_project/src/greeter.bt
@@ -1,0 +1,10 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+/// A trivial greeter used by the parity-test harness.
+Value subclass: Greeter
+
+  hello => "hello"
+
+  hello: name :: String -> String =>
+    "hello, " ++ name

--- a/tests/parity/fixtures/simple_project/test/counter_test.bt
+++ b/tests/parity/fixtures/simple_project/test/counter_test.bt
@@ -1,0 +1,19 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+/// BUnit tests for Counter — used by the parity-test harness.
+TestCase subclass: CounterTest
+
+  testStartsAtZero => self assert: Counter spawn current equals: 0
+
+  testIncrement =>
+    counter := Counter spawn
+    counter increment
+    self assert: counter current equals: 1
+
+  testReset =>
+    counter := Counter spawn
+    counter increment
+    counter increment
+    counter reset
+    self assert: counter current equals: 0


### PR DESCRIPTION
## Summary

Foundation for the Surface Parity Epic (BT-2074). Adds a cross-surface parity test harness that drives the same input through REPL / MCP / CLI / LSP and asserts the observable behaviour is equivalent. Catches surface drift the moment a regression touches one surface but not the others.

- New crate `crates/beamtalk-parity-tests/` with a workspace pool, four surface drivers, and case-file parser.
- Five starter cases under `tests/parity/cases/` covering literal eval, load-project, lint, test, and diagnostics — every surface required by the epic gets exercised.
- Workspace pool starts one `beamtalk repl` per harness run, reused by every REPL and MCP case (pattern borrowed from `crates/beamtalk-mcp/src/client.rs::tests`). Per-pid cwd ensures the parity workspace ID does not collide with `just test-mcp`.
- Wired into `just test-parity` and `just ci`. Total wall-clock ≈ 5s on a clean build, well under the e2e suite's ~50s budget.
- Documented in `docs/development/testing-strategy.md` (new section 9).

## Acceptance Criteria

- [x] `tests/parity/cases/` with at least 5 starter cases (literal eval, load-project, lint, test, diagnostic)
- [x] Harness drives REPL + MCP + CLI for at least 3 of the 5 cases (load_project hits all three; lint_clean hits MCP + CLI; diagnostic hits CLI + MCP + LSP)
- [x] LSP integrated for the diagnostic case
- [x] Workspace pool — single REPL workspace serves every REPL + MCP case in a run
- [x] `just test-parity` target added
- [x] Wired into `just ci`
- [x] Documented in `docs/development/testing-strategy.md`

## Test plan

- [x] `just test-parity` passes (5 cases, ~5s)
- [x] `just test-mcp` still passes after a parity run (workspace isolation verified)
- [x] `just ci` green end-to-end
- [x] `cargo test -p beamtalk-parity-tests --lib` (16 unit tests for parser / normalizer / driver helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new cross-surface parity test suite to CI that runs ignored integration parity checks across REPL, MCP, CLI, and LSP.
  * Introduced a harness that stages projects/fixtures and verifies evaluation, project loading, lint diagnostics, and test execution parity across surfaces; multiple new parity cases and fixtures included.

* **Documentation**
  * Added comprehensive parity testing docs and instructions for running the parity suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->