### PR TITLE
CLI subprocess test crate (BT-2084)

### DIFF
--- a/crates/beamtalk-cli/Cargo.toml
+++ b/crates/beamtalk-cli/Cargo.toml
@@ -60,6 +60,9 @@ windows-sys.workspace = true
 [dev-dependencies]
 serial_test = "3"
 criterion.workspace = true
+# why: subprocess testing for the `beamtalk` CLI binary (BT-2084)
+assert_cmd = "2"
+predicates = "3"
 
 [[bench]]
 name = "build_bench"

--- a/crates/beamtalk-cli/tests/cli_build.rs
+++ b/crates/beamtalk-cli/tests/cli_build.rs
@@ -1,0 +1,120 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Subprocess tests for `beamtalk build` (BT-2084).
+//!
+//! Verifies exit code, the `_build/` artefact set produced by a successful
+//! build, and error output when sources fail to parse.
+
+mod cli_common;
+
+use predicates::prelude::*;
+use predicates::str::contains;
+
+#[test]
+fn build_clean_project_produces_beam_artefacts() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("build")
+        .assert()
+        .success();
+
+    // Successful builds emit at least one .beam under _build/.
+    let build_dir = project.path().join("_build");
+    let beam = find_first_beam(&build_dir);
+    assert!(
+        beam.is_some(),
+        "expected a .beam under _build/; tree:\n{:#?}",
+        list_tree(&build_dir, 4)
+    );
+}
+
+#[test]
+fn build_emits_error_for_unparseable_source() {
+    let project = cli_common::fixture_project();
+    std::fs::write(
+        project.path().join("src/Bad.bt"),
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         this is not valid beamtalk syntax\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("build")
+        .assert()
+        .failure()
+        .stderr(contains("Failed to compile").or(contains("error")));
+}
+
+#[test]
+fn build_force_recompiles_unchanged_sources() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("build")
+        .assert()
+        .success();
+
+    // Second pass without --force is a no-op…
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("build")
+        .assert()
+        .success()
+        // Incremental builds report "unchanged — nothing to compile" on stderr.
+        .stderr(contains("unchanged").or(contains("nothing to compile")));
+
+    // …but --force re-runs the full pipeline.
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["build", "--force"])
+        .assert()
+        .success();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn find_first_beam(root: &std::path::Path) -> Option<std::path::PathBuf> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "beam") {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+fn list_tree(root: &std::path::Path, depth: usize) -> Vec<std::path::PathBuf> {
+    fn walk(dir: &std::path::Path, depth: usize, out: &mut Vec<std::path::PathBuf>) {
+        if depth == 0 {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            out.push(path.clone());
+            if path.is_dir() {
+                walk(&path, depth - 1, out);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, depth, &mut out);
+    out
+}

--- a/crates/beamtalk-cli/tests/cli_common/mod.rs
+++ b/crates/beamtalk-cli/tests/cli_common/mod.rs
@@ -1,0 +1,103 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helpers for CLI subprocess tests (BT-2084).
+//!
+//! These tests use `assert_cmd` to invoke the built `beamtalk` binary
+//! against synthesized fixture projects in temporary directories.
+//! Every helper is hermetic: nothing is written outside the `TempDir`
+//! it returns, so tests are safe to run in parallel.
+
+use assert_cmd::Command;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use tempfile::TempDir;
+
+/// Path to the `beamtalk` binary built by `cargo`.
+///
+/// `assert_cmd::Command::cargo_bin` works because `beamtalk-cli` declares
+/// `beamtalk` as a `[[bin]]` and the test binary lives in the same crate.
+#[allow(dead_code)] // some test binaries don't call every helper
+pub fn beamtalk() -> Command {
+    let mut cmd = Command::cargo_bin("beamtalk").expect("beamtalk binary built by cargo");
+    // Pin the runtime/sysroot to this workspace so tests do not depend on a
+    // system-installed beamtalk. `repl_startup::find_runtime_dir_with_layout`
+    // honours `BEAMTALK_RUNTIME_DIR` first, which keeps `doctor`/`build`/`test`
+    // pointing at the in-repo `runtime/` directory.
+    cmd.env("BEAMTALK_RUNTIME_DIR", runtime_dir())
+        // Disable colored output so assertions on text content are stable.
+        .env("NO_COLOR", "1")
+        // Quiet tracing — some tests assert on stderr content.
+        .env_remove("RUST_LOG");
+    cmd
+}
+
+/// Locate the workspace `runtime/` directory.
+fn runtime_dir() -> &'static Path {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        // crates/beamtalk-cli -> crates -> repo root -> runtime
+        manifest
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|root| root.join("runtime"))
+            .expect("workspace root has runtime/ directory")
+    })
+}
+
+/// Create a fresh temp directory holding a minimal Beamtalk library project.
+///
+/// The project has:
+/// * `beamtalk.toml` — package manifest
+/// * `src/Greeter.bt` — a trivial Value class
+/// * `test/GreeterTest.bt` — one passing `BUnit` test
+///
+/// All paths are derived from the returned `TempDir`; nothing is written
+/// elsewhere, so tests are hermetic and parallel-safe.
+#[allow(dead_code)] // some test binaries don't call every helper
+pub fn fixture_project() -> TempDir {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let root = dir.path();
+
+    std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+    std::fs::create_dir_all(root.join("test")).expect("mkdir test");
+
+    std::fs::write(
+        root.join("beamtalk.toml"),
+        "# Copyright 2026 James Casey\n\
+         # SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         [package]\n\
+         name = \"cli_subprocess_fixture\"\n\
+         version = \"0.1.0\"\n\
+         \n\
+         [dependencies]\n",
+    )
+    .expect("write beamtalk.toml");
+
+    std::fs::write(
+        root.join("src/Greeter.bt"),
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         /// Trivial greeter used by CLI subprocess tests.\n\
+         Value subclass: Greeter\n\
+         \n\
+         \x20\x20hello => \"hello\"\n",
+    )
+    .expect("write src/Greeter.bt");
+
+    std::fs::write(
+        root.join("test/GreeterTest.bt"),
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         TestCase subclass: GreeterTest\n\
+         \n\
+         \x20\x20testHello => self assert: Greeter new hello equals: \"hello\"\n",
+    )
+    .expect("write test/GreeterTest.bt");
+
+    dir
+}

--- a/crates/beamtalk-cli/tests/cli_doc.rs
+++ b/crates/beamtalk-cli/tests/cli_doc.rs
@@ -1,0 +1,86 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Subprocess tests for `beamtalk doc` and `beamtalk test-docs` (BT-2084).
+
+mod cli_common;
+
+use predicates::str::contains;
+
+#[test]
+fn doc_generates_html_output() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["doc", "src/", "--output", "docs_out"])
+        .assert()
+        .success()
+        .stdout(contains("Generated documentation"));
+
+    let index = project.path().join("docs_out/index.html");
+    assert!(
+        index.exists(),
+        "expected generated index.html at {}",
+        index.display()
+    );
+}
+
+#[test]
+fn doc_errors_when_no_sources_found() {
+    let project = cli_common::fixture_project();
+    let empty = project.path().join("empty_src");
+    std::fs::create_dir(&empty).unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["doc", "empty_src", "--output", "docs_out"])
+        .assert()
+        .failure()
+        .stderr(contains("No .bt source files"));
+}
+
+#[test]
+fn test_docs_runs_on_passing_doctest() {
+    let project = cli_common::fixture_project();
+    let docs_dir = project.path().join("docs_in");
+    std::fs::create_dir(&docs_dir).unwrap();
+    std::fs::write(
+        docs_dir.join("guide.md"),
+        "# Sample\n\
+         \n\
+         ```beamtalk\n\
+         3 + 4\n\
+         // => 7\n\
+         ```\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["test-docs", "--quiet", "docs_in"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_docs_fails_on_assertion_mismatch() {
+    let project = cli_common::fixture_project();
+    let docs_dir = project.path().join("docs_in");
+    std::fs::create_dir(&docs_dir).unwrap();
+    std::fs::write(
+        docs_dir.join("guide.md"),
+        "# Sample\n\
+         \n\
+         ```beamtalk\n\
+         3 + 4\n\
+         // => 99\n\
+         ```\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["test-docs", "--quiet", "docs_in"])
+        .assert()
+        .failure();
+}

--- a/crates/beamtalk-cli/tests/cli_doctor.rs
+++ b/crates/beamtalk-cli/tests/cli_doctor.rs
@@ -1,0 +1,63 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Subprocess tests for `beamtalk doctor` (BT-2084).
+//!
+//! Drives the doctor against:
+//! * the real workspace runtime (happy path) — every required check passes,
+//! * a synthesized broken runtime directory (error path) — stdlib/runtime
+//!   checks fail and the command exits non-zero with actionable output.
+
+mod cli_common;
+
+use predicates::prelude::*;
+use predicates::str::contains;
+
+#[test]
+fn doctor_passes_against_real_workspace_runtime() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(contains("Erlang/OTP"))
+        .stdout(contains("All checks passed").or(contains("required checks passed")));
+}
+
+#[test]
+fn doctor_reports_failure_for_broken_runtime() {
+    let project = cli_common::fixture_project();
+
+    // Point BEAMTALK_RUNTIME_DIR at an empty dir — the runtime layout check
+    // will fail because no apps/ or _build/ tree exists.
+    let broken = tempfile::tempdir().expect("broken-runtime tempdir");
+
+    cli_common::beamtalk()
+        // Override the env var the harness pre-sets to point at a broken dir.
+        .env("BEAMTALK_RUNTIME_DIR", broken.path())
+        .current_dir(project.path())
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stderr(contains("doctor found problems"));
+}
+
+#[test]
+fn doctor_dev_flag_includes_developer_checks() {
+    let project = cli_common::fixture_project();
+    // The `--dev` flag adds rebar3/just/rustc checks. We don't assert success
+    // for these since the test environment may lack `just`. We *do* assert
+    // that the developer-tool labels appear in stdout.
+    let output = cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["doctor", "--dev"])
+        .output()
+        .expect("run doctor --dev");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("rustc") || stdout.contains("rebar3") || stdout.contains("just"),
+        "doctor --dev should mention at least one developer tool; got:\n{stdout}"
+    );
+}

--- a/crates/beamtalk-cli/tests/cli_fmt.rs
+++ b/crates/beamtalk-cli/tests/cli_fmt.rs
@@ -1,0 +1,94 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Subprocess tests for `beamtalk fmt` and `beamtalk fmt-check` (BT-2084).
+//!
+//! Verifies in-place rewriting, unified diff output, and exit codes.
+
+mod cli_common;
+
+use predicates::prelude::*;
+use predicates::str::contains;
+
+const UNFORMATTED: &str = "// Copyright 2026 James Casey\n\
+                          // SPDX-License-Identifier: Apache-2.0\n\
+                          \n\
+                          Object subclass:    Bad\n\
+                          \x20\x20hello   =>   \"hi\"\n";
+
+const FORMATTED_PREFIX: &str = "// Copyright 2026 James Casey\n\
+                                // SPDX-License-Identifier: Apache-2.0\n\
+                                \n\
+                                Object subclass: Bad\n";
+
+#[test]
+fn fmt_check_clean_project_succeeds() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("fmt-check")
+        .assert()
+        .success();
+}
+
+#[test]
+fn fmt_check_dirty_file_emits_diff_and_fails() {
+    let project = cli_common::fixture_project();
+    let bad = project.path().join("src/Bad.bt");
+    std::fs::write(&bad, UNFORMATTED).unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("fmt-check")
+        .assert()
+        .failure()
+        // Unified diff markers — `similar` emits `+++` / `---` headers.
+        .stdout(contains("+++").or(contains("---")))
+        .stderr(contains("would be reformatted"));
+
+    // fmt-check must not modify files.
+    let still_dirty = std::fs::read_to_string(&bad).unwrap();
+    assert_eq!(still_dirty, UNFORMATTED);
+}
+
+#[test]
+fn fmt_rewrites_files_in_place() {
+    let project = cli_common::fixture_project();
+    let bad = project.path().join("src/Bad.bt");
+    std::fs::write(&bad, UNFORMATTED).unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("fmt")
+        .assert()
+        .success();
+
+    let after = std::fs::read_to_string(&bad).unwrap();
+    assert!(
+        after.starts_with(FORMATTED_PREFIX),
+        "fmt should have rewritten file in place; got:\n{after}"
+    );
+    assert_ne!(after, UNFORMATTED, "fmt should have changed the file");
+}
+
+#[test]
+fn fmt_check_rejects_legacy_check_flag() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["fmt", "--check"])
+        .assert()
+        .failure()
+        .stderr(contains("fmt-check"));
+}
+
+#[test]
+fn fmt_missing_path_fails() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["fmt", "does/not/exist.bt"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::is_match("does not exist|not found").unwrap());
+}

--- a/crates/beamtalk-cli/tests/cli_lint.rs
+++ b/crates/beamtalk-cli/tests/cli_lint.rs
@@ -1,0 +1,92 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Subprocess tests for `beamtalk lint` (BT-2084).
+//!
+//! Verifies exit codes, stdout JSON shape, and stderr text output for both
+//! happy- and error-path cases. Uses `assert_cmd` against the built
+//! `beamtalk` binary and a hermetic fixture project per test.
+
+mod cli_common;
+
+use predicates::str::contains;
+
+#[test]
+fn lint_clean_project_text_format_exits_zero() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("lint")
+        .assert()
+        .success();
+}
+
+#[test]
+fn lint_clean_project_json_format_emits_summary() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["lint", "--format=json"])
+        .assert()
+        .success()
+        // JSON line summary is on stdout; text summary goes to stderr.
+        // For a clean project we get the summary object only.
+        .stdout(contains("\"type\":\"summary\""))
+        .stdout(contains("\"total\":0"));
+}
+
+#[test]
+fn lint_dirty_file_text_format_fails() {
+    let project = cli_common::fixture_project();
+    // Trigger a real lint (BT-948 unnecessary trailing `.` is Severity::Lint).
+    std::fs::write(
+        project.path().join("src/Bad.bt"),
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         Object subclass: Bad\n\
+         \x20\x20greet => \"hi\".\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("lint")
+        .assert()
+        .failure()
+        .stderr(contains("lint diagnostic"));
+}
+
+#[test]
+fn lint_dirty_file_json_format_emits_per_diag_lines() {
+    let project = cli_common::fixture_project();
+    std::fs::write(
+        project.path().join("src/Bad.bt"),
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         Object subclass: Bad\n\
+         \x20\x20greet => \"hi\".\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["lint", "--format=json"])
+        .assert()
+        .failure()
+        // Per-diagnostic JSON lines are emitted to stdout (BT-2031).
+        .stdout(contains("\"severity\":\"lint\""))
+        .stdout(contains("\"type\":\"summary\""));
+}
+
+#[test]
+fn lint_missing_path_exits_nonzero() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["lint", "does/not/exist.bt"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::is_match("does not exist|not found").unwrap());
+}

--- a/crates/beamtalk-cli/tests/cli_new.rs
+++ b/crates/beamtalk-cli/tests/cli_new.rs
@@ -1,0 +1,77 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Subprocess tests for `beamtalk new` (BT-2084).
+
+mod cli_common;
+
+use predicates::str::contains;
+
+#[test]
+fn new_library_generates_project_structure() {
+    let dir = tempfile::tempdir().unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(dir.path())
+        .args(["new", "my_lib"])
+        .assert()
+        .success()
+        .stdout(contains("Created library package"));
+
+    let proj = dir.path().join("my_lib");
+    assert!(proj.join("beamtalk.toml").exists(), "beamtalk.toml missing");
+    assert!(proj.join("src").is_dir(), "src/ missing");
+    assert!(proj.join("test").is_dir(), "test/ missing");
+    assert!(proj.join(".gitignore").exists(), ".gitignore missing");
+    assert!(proj.join("Justfile").exists(), "Justfile missing");
+    assert!(proj.join("README.md").exists(), "README.md missing");
+
+    let toml = std::fs::read_to_string(proj.join("beamtalk.toml")).unwrap();
+    assert!(
+        toml.contains("name = \"my_lib\""),
+        "beamtalk.toml should contain the project name; got:\n{toml}"
+    );
+}
+
+#[test]
+fn new_app_emits_application_supervisor() {
+    let dir = tempfile::tempdir().unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(dir.path())
+        .args(["new", "my_app", "--app"])
+        .assert()
+        .success()
+        .stdout(contains("Created application package"));
+
+    let proj = dir.path().join("my_app");
+    let toml = std::fs::read_to_string(proj.join("beamtalk.toml")).unwrap();
+    assert!(
+        toml.contains("[application]"),
+        "application package should have [application] section; got:\n{toml}"
+    );
+    assert!(proj.join("src/Main.bt").exists(), "src/Main.bt missing");
+}
+
+#[test]
+fn new_into_existing_directory_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("existing")).unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(dir.path())
+        .args(["new", "existing"])
+        .assert()
+        .failure()
+        .stderr(contains("already exists"));
+}
+
+#[test]
+fn new_rejects_invalid_package_name() {
+    let dir = tempfile::tempdir().unwrap();
+    cli_common::beamtalk()
+        .current_dir(dir.path())
+        .args(["new", "1bad-name"])
+        .assert()
+        .failure();
+}

--- a/crates/beamtalk-cli/tests/cli_run.rs
+++ b/crates/beamtalk-cli/tests/cli_run.rs
@@ -1,0 +1,71 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Subprocess tests for `beamtalk run` (BT-2084).
+//!
+//! Covers the script-mode entry-point invocation. Service mode (`run .`)
+//! requires a running BEAM workspace and is exercised by the e2e tests.
+
+mod cli_common;
+
+use predicates::prelude::*;
+use predicates::str::contains;
+
+#[test]
+fn run_script_mode_invokes_class_method() {
+    let project = cli_common::fixture_project();
+    // Add a class with a class method that returns a value `run` can invoke.
+    std::fs::write(
+        project.path().join("src/Smoke.bt"),
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         Object subclass: Smoke\n\
+         \n\
+         \x20\x20class run => 21 + 21\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["run", "Smoke", "run"])
+        .assert()
+        .success()
+        .stdout(contains("Running Smoke>>run").or(contains("Smoke")));
+}
+
+#[test]
+fn run_without_manifest_errors() {
+    // `run` requires a beamtalk.toml in the cwd.
+    let empty = tempfile::tempdir().unwrap();
+    cli_common::beamtalk()
+        .current_dir(empty.path())
+        .args(["run", "Smoke", "run"])
+        .assert()
+        .failure()
+        .stderr(contains("beamtalk.toml"));
+}
+
+#[test]
+fn run_class_without_selector_errors() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["run", "Greeter"])
+        .assert()
+        .failure()
+        .stderr(contains("selector").or(contains("Missing")));
+}
+
+#[test]
+fn run_dot_without_application_section_errors() {
+    // The fixture is a library, not an [application]; `run .` should bail
+    // with an actionable error pointing the user at `[application]`.
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["run", "."])
+        .assert()
+        .failure()
+        .stderr(contains("entry point").or(contains("[application]")));
+}

--- a/crates/beamtalk-cli/tests/cli_test.rs
+++ b/crates/beamtalk-cli/tests/cli_test.rs
@@ -79,7 +79,7 @@ fn test_script_runs_btscript_files() {
     cli_common::beamtalk()
         .current_dir(project.path())
         .args(["test-script", "--quiet"])
-        .arg(script.to_str().unwrap())
+        .arg(&script)
         .assert()
         .success()
         .stdout(contains("1 passed").or(contains("0 failed")));
@@ -104,7 +104,7 @@ fn test_script_fails_on_assertion_mismatch() {
     cli_common::beamtalk()
         .current_dir(project.path())
         .args(["test-script", "--quiet"])
-        .arg(script.to_str().unwrap())
+        .arg(&script)
         .assert()
         .failure();
 }

--- a/crates/beamtalk-cli/tests/cli_test.rs
+++ b/crates/beamtalk-cli/tests/cli_test.rs
@@ -1,0 +1,110 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Subprocess tests for `beamtalk test` (BT-2084).
+//!
+//! Verifies exit code mapping (pass = 0, fail = nonzero) and the text
+//! summary format. Uses a hermetic fixture project per test.
+
+mod cli_common;
+
+use predicates::prelude::*;
+use predicates::str::contains;
+
+#[test]
+fn test_passes_for_passing_suite() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["test", "--quiet"])
+        .assert()
+        .success()
+        .stdout(contains("1 passed"))
+        .stdout(contains("0 failed"));
+}
+
+#[test]
+fn test_fails_for_failing_suite() {
+    let project = cli_common::fixture_project();
+    std::fs::write(
+        project.path().join("test/FailTest.bt"),
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         TestCase subclass: FailTest\n\
+         \n\
+         \x20\x20testFails => self assert: 1 equals: 2\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["test", "--quiet"])
+        .assert()
+        .failure()
+        .stdout(contains("1 failed").or(contains("FAIL")));
+}
+
+#[test]
+fn test_no_tests_found_succeeds() {
+    let project = cli_common::fixture_project();
+    // Remove the only test file to exercise the "no tests" path.
+    std::fs::remove_file(project.path().join("test/GreeterTest.bt")).unwrap();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["test", "--quiet"])
+        .assert()
+        .success()
+        .stdout(contains("No tests found"));
+}
+
+#[test]
+fn test_script_runs_btscript_files() {
+    // test-script reads `.btscript` files and asserts on `// =>` annotations.
+    // Synthesize a tiny one in the fixture project to keep the test hermetic.
+    let project = cli_common::fixture_project();
+    let script_dir = project.path().join("scripts");
+    std::fs::create_dir_all(&script_dir).unwrap();
+    let script = script_dir.join("smoke.btscript");
+    std::fs::write(
+        &script,
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         3 + 4\n\
+         // => 7\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["test-script", "--quiet"])
+        .arg(script.to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(contains("1 passed").or(contains("0 failed")));
+}
+
+#[test]
+fn test_script_fails_on_assertion_mismatch() {
+    let project = cli_common::fixture_project();
+    let script_dir = project.path().join("scripts");
+    std::fs::create_dir_all(&script_dir).unwrap();
+    let script = script_dir.join("bad.btscript");
+    std::fs::write(
+        &script,
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         3 + 4\n\
+         // => 99\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["test-script", "--quiet"])
+        .arg(script.to_str().unwrap())
+        .assert()
+        .failure();
+}

--- a/crates/beamtalk-cli/tests/cli_transcript.rs
+++ b/crates/beamtalk-cli/tests/cli_transcript.rs
@@ -1,0 +1,37 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Subprocess tests for `beamtalk workspace transcript` (BT-2084).
+//!
+//! `transcript` requires a running workspace to actually stream entries.
+//! These tests cover the input-validation surface — error paths the user
+//! sees when they invoke transcript without a workspace, or against a
+//! workspace name that doesn't exist. Streaming behaviour is covered by
+//! e2e tests against a live workspace.
+
+mod cli_common;
+
+use predicates::prelude::*;
+use predicates::str::contains;
+
+#[test]
+fn transcript_without_workspace_in_cwd_errors() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["workspace", "transcript"])
+        .assert()
+        .failure()
+        .stderr(contains("workspace").and(contains("beamtalk repl")));
+}
+
+#[test]
+fn transcript_with_unknown_workspace_name_errors() {
+    let project = cli_common::fixture_project();
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .args(["workspace", "transcript", "no-such-workspace-12345"])
+        .assert()
+        .failure()
+        .stderr(contains("does not exist").or(contains("workspace")));
+}


### PR DESCRIPTION
## Summary

Adds `crates/beamtalk-cli/tests/cli_*.rs` subprocess tests using `assert_cmd` against the built `beamtalk` binary, covering: `lint`, `test`, `fmt` / `fmt-check`, `doctor`, `build`, `run`, `doc`, `new`, `transcript`. Each module includes happy-path and error-path tests.

This closes the BT-2084 gap identified in the BT-2074 epic — `tests/e2e/` is REPL-protocol-only; the user-facing CLI surface had little subprocess coverage. New tests are not gated behind `--ignored` so they run in `just test`.

Closes BT-2084.

## Test plan
- [ ] `just ci` passes (cli_doctor depends on stdlib being built; CI runs `just build` first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive CLI tests covering build (including incremental/force), doc/doctest, doctor, fmt/fmt-check, lint (text/JSON), new project, run, test/test-script, and workspace transcript behaviors to improve reliability and user-facing correctness.

* **Chores**
  * Added development test dependencies to enable subprocess-driven CLI testing and predicate-based output assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->