### PR TITLE
ci: build erlang+stdlib before cargo llvm-cov (coverage hotfix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,16 +357,20 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Generate Rust coverage (Cobertura format for action)
-        run: |
-          # Generate Cobertura format (for CodeCoverageSummary action)
-          cargo llvm-cov --all-targets --workspace --cobertura --output-path coverage.cobertura.xml
-
+      # The Erlang runtime + stdlib must be built before `cargo llvm-cov`
+      # because some Rust integration tests (e.g. cli_doctor from BT-2084)
+      # exec the real `beamtalk` binary against the workspace runtime,
+      # which fails fast if stdlib .beam files are missing.
       - name: Build Erlang runtime
         run: just build-erlang
 
       - name: Build standard library
         run: just build-stdlib
+
+      - name: Generate Rust coverage (Cobertura format for action)
+        run: |
+          # Generate Cobertura format (for CodeCoverageSummary action)
+          cargo llvm-cov --all-targets --workspace --cobertura --output-path coverage.cobertura.xml
 
       - name: Generate Erlang coverage (unit + E2E + stdlib)
         run: just coverage-all


### PR DESCRIPTION
## Summary

Coverage job started failing on main after BT-2084 (CLI subprocess tests) merged. The job runs `cargo llvm-cov` *before* `just build-erlang` / `just build-stdlib`, but some new integration tests exec the real `beamtalk` binary, and `beamtalk doctor` aborts when stdlib `.beam` files are missing.

Move the runtime+stdlib build ahead of the coverage run so coverage sees the same workspace state as the main `check` jobs.

## Test plan
- [ ] CI passes on this PR's coverage job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered CI workflow steps to ensure Rust coverage generation executes after Erlang runtime and standard library build, allowing integration tests to access required artifacts during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->