### PR TITLE
docs: daily refresh 2026-04-26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@
 - MCP `lint` tool now surfaces warning diagnostics when package files are unreadable during cross-file class extraction (BT-2056).
 - Preserve `startup.log` on final workspace retry failure so error diagnostics referencing the file remain valid (BT-2057).
 - MCP `lint` tool now surfaces error diagnostics when direct target files are unreadable, instead of returning a deceptively clean zero-files-checked result (BT-2067).
+- LSP `workspace/symbol` search — find class definitions across the workspace from the editor's symbol picker (BT-2081).
+- `just test-repl-protocol` replaces `just test-e2e`; deprecated alias kept for one release cycle (BT-2085).
+- `just check-surface-drift` CI gate ensures documented surface parity stays in sync with code (BT-2082).
 
 ### Documentation
 
@@ -77,6 +80,10 @@
 
 ### Internal
 
+- Extract `beamtalk-repl-protocol` crate — shared REPL response types and `RequestBuilder` replacing duplicated structs in CLI and MCP (BT-2076).
+- Cross-surface parity test harness (`tests/parity/`) — drives identical input through REPL, MCP, CLI, and LSP and asserts equivalent output (BT-2077).
+- Shared output formatters for diagnostics, values, and trace steps — eliminates ~130 lines of duplicated rendering between CLI and MCP (BT-2086).
+- Extend `WellKnownSelector` to cover remaining selector-universal intrinsics: block loops, ensure, hash, error, field reflection, perform family (BT-2073).
 - ADR 0080: Migrate Supervisor Lifecycle to Result — proposed, accepted, and implemented across Phase 0 probes, Phase 1 runtime, Phase 2 stdlib, Phase 3 e2e + examples + docs (BT-1977, BT-1993..BT-2001).
 - Typechecker probe confirms class-level type parameter substitution through `Result(C, Error)` works without extension (BT-1995).
 - Unified LSP and CLI diagnostic pipelines into shared `compute_project_diagnostics` function (BT-2009).

--- a/docs/beamtalk-tooling.md
+++ b/docs/beamtalk-tooling.md
@@ -758,7 +758,7 @@ All MCP tools map to the same `Workspace` and `Beamtalk` APIs available in the R
 The [Beamtalk VS Code extension](https://github.com/jamesc/beamtalk/tree/main/editors/vscode) connects to the live workspace and provides:
 
 - **Syntax highlighting** for `.bt` files
-- **LSP integration** — diagnostics, completions, go-to-definition
+- **LSP integration** — diagnostics, completions, go-to-definition, workspace symbol search
 - **Workspace tree view** — live actors, loaded classes, and session bindings in the sidebar
 - **Transcript view** — real-time output from the workspace
 - **Inspector panels** — inspect live actor state


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 15 commits merged to main in the last 24 hours.

**Docs updated:**
- `CHANGELOG.md` — 3 Tooling entries, 4 Internal entries
- `docs/beamtalk-tooling.md` — Added `workspace/symbol` to LSP feature list

## Commits reviewed

### Tooling (CHANGELOG + docs)
- `376d2d4` BT-2081 — LSP `workspace/symbol` search (new LSP capability; updated tooling doc)
- `9bde31e` BT-2085 — `just test-repl-protocol` replaces `just test-e2e` (commit already updated all docs; CHANGELOG entry added)
- `01cf8ef` BT-2082 — Surface drift CI check (`just check-surface-drift`)

### Internal (CHANGELOG)
- `9e1afc5` BT-2076 — Extract `beamtalk-repl-protocol` shared crate
- `9108972` BT-2077 — Cross-surface parity test harness (`tests/parity/`)
- `395e017` BT-2086 — Shared output formatters (diagnostic, value, trace)
- `8507364` BT-2073 — Extend WellKnownSelector to cover remaining intrinsics

### Skipped (test-only / CI / deps / prior refresh)
- `e401cb3` — Dependabot postcss bump (editors/vscode dependency only)
- `e7e910d` — CI coverage hotfix (`.github/` only)
- `5d8f3b3` BT-2080 — Test-runner parity (test files only)
- `8198c78` BT-2078 — Diagnostic parity corpus (test files only)
- `c65ecb2` BT-2079 — Load-project parity (test files only)
- `67a332b` BT-2084 — CLI subprocess test crate (test files only)
- `402d874` BT-2075 — Surface parity map (doc already committed in that PR)
- `3588022` — Previous daily refresh (2026-04-25)

## Needs human judgment

None — all user-visible changes were clear from diffs.

https://claude.ai/code/session_01Mg12ZSfhBxmkk4MqmxYWo7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mg12ZSfhBxmkk4MqmxYWo7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace symbol search to the VS Code extension for cross-workspace class lookup.

* **Documentation**
  * Updated VS Code extension documentation to reflect new workspace symbol search capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->