### PR TITLE
Surface-only audit: promote-or-lock decisions for asymmetric ops (BT-2083)

### DIFF
--- a/crates/beamtalk-surface-drift/src/main.rs
+++ b/crates/beamtalk-surface-drift/src/main.rs
@@ -305,7 +305,7 @@ fn parse_cell(cell: &str) -> CellState {
 /// artifact to verify here.
 fn is_non_binding_code(code: &str) -> bool {
     let lower = code.trim().to_ascii_lowercase();
-    lower.starts_with("via ") || lower.starts_with("missing")
+    lower.starts_with("via ") || lower.starts_with("missing (") || lower.starts_with("missing(")
 }
 
 /// REPL meta-cells often list aliases (e.g. ``:test`` / ``:t``) and
@@ -833,6 +833,40 @@ fn check_drift(doc: &ParityDoc, code: &CodeInventory, errors: &mut Vec<String>) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_cell_treats_via_and_missing_as_surface_specific() {
+        assert!(matches!(
+            parse_cell("`via Workspace classes`"),
+            CellState::SurfaceSpecific
+        ));
+        assert!(matches!(
+            parse_cell("`MISSING (BT-2090)`"),
+            CellState::SurfaceSpecific
+        ));
+    }
+
+    #[test]
+    fn parse_meta_cell_treats_via_and_missing_as_surface_specific() {
+        assert!(matches!(
+            parse_meta_cell("`via Workspace test`"),
+            CellState::SurfaceSpecific
+        ));
+        assert!(matches!(
+            parse_meta_cell("`MISSING (BT-2090)`"),
+            CellState::SurfaceSpecific
+        ));
+    }
+
+    #[test]
+    fn is_non_binding_code_does_not_match_legitimate_names() {
+        assert!(!is_non_binding_code("missingPlugin"));
+        assert!(!is_non_binding_code("missingness"));
+        assert!(!is_non_binding_code("viable"));
+        assert!(is_non_binding_code("via Workspace classes"));
+        assert!(is_non_binding_code("MISSING (BT-2090)"));
+        assert!(is_non_binding_code("missing(BT-1)"));
+    }
 
     #[test]
     fn extracts_repl_ops_only_within_describe_ops() {

--- a/crates/beamtalk-surface-drift/src/main.rs
+++ b/crates/beamtalk-surface-drift/src/main.rs
@@ -288,10 +288,24 @@ fn parse_cell(cell: &str) -> CellState {
         return CellState::SurfaceSpecific;
     }
     if let Some(code) = extract_first_code(trimmed) {
+        if is_non_binding_code(&code) {
+            return CellState::SurfaceSpecific;
+        }
         CellState::Bound(code)
     } else {
         CellState::NotApplicable
     }
+}
+
+/// Code spans that document the cell rather than naming a code artifact.
+/// `via X` (e.g. `via Workspace classes`) means the capability is reached
+/// as a message-send on `X`, not via a meta-cmd / tool. `MISSING (BT-…)`
+/// flags an intentionally unbound cell with a tracking issue. Both are
+/// treated as `SurfaceSpecific` for drift purposes — there is no code
+/// artifact to verify here.
+fn is_non_binding_code(code: &str) -> bool {
+    let lower = code.trim().to_ascii_lowercase();
+    lower.starts_with("via ") || lower.starts_with("missing")
 }
 
 /// REPL meta-cells often list aliases (e.g. ``:test`` / ``:t``) and
@@ -307,6 +321,9 @@ fn parse_meta_cell(cell: &str) -> CellState {
         return CellState::SurfaceSpecific;
     }
     if let Some(first) = extract_first_code(trimmed) {
+        if is_non_binding_code(&first) {
+            return CellState::SurfaceSpecific;
+        }
         let token = first.split_whitespace().next().unwrap_or("").to_string();
         if token.is_empty() {
             CellState::NotApplicable

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -97,11 +97,11 @@ Historically meta-commands like `:bindings`, `:sync`, `:test` existed to bootstr
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
 |---------|---------------|-------------------|----------|----------------|-------|
-| `enable-tracing` | -- | `surface-specific: agent-only workflow (ADR 0069)` | `enable_tracing` | -- | Enable actor trace capture |
-| `disable-tracing` | -- | `surface-specific: agent-only workflow (ADR 0069)` | `disable_tracing` | -- | Disable actor trace capture |
-| `get-traces` | -- | `surface-specific: agent-only workflow (ADR 0069)` | `get_traces` | -- | Retrieve captured traces |
-| `actor-stats` | -- | `surface-specific: agent-only workflow (ADR 0069)` | `actor_stats` | -- | Per-actor/method aggregate stats |
-| `export-traces` | -- | `surface-specific: agent-only workflow (ADR 0069)` | `export_traces` | -- | Export traces to JSON file |
+| `enable-tracing` | -- | `surface-specific: agent-only workflow (BT-1606)` | `enable_tracing` | -- | Enable actor trace capture |
+| `disable-tracing` | -- | `surface-specific: agent-only workflow (BT-1606)` | `disable_tracing` | -- | Disable actor trace capture |
+| `get-traces` | -- | `surface-specific: agent-only workflow (BT-1606)` | `get_traces` | -- | Retrieve captured traces |
+| `actor-stats` | -- | `surface-specific: agent-only workflow (BT-1606)` | `actor_stats` | -- | Per-actor/method aggregate stats |
+| `export-traces` | -- | `surface-specific: agent-only workflow (BT-1606)` | `export_traces` | -- | Export traces to JSON file |
 
 ## Server Operations
 

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -8,11 +8,21 @@ Any operation **not** labelled `surface-specific` must produce equivalent output
 
 When adding a new capability to any surface, update this table. If the capability maps to an existing REPL op, add it to the corresponding row. If it is surface-specific, add the reason.
 
+### REPL surface — meta-commands vs. message-sends
+
+The REPL exposes capability through two surfaces:
+
+1. **Message-sends** (`Workspace …`, `Beamtalk …`, or any object) — the primary surface. Object-level capability is reached this way, not through meta-commands.
+2. **Meta-commands** (`:cmd`) — reserved for **client-side** concerns (`:exit`, `:help`) or **transport-out-of-band** ops that cannot be expressed as a normal eval (e.g. `:interrupt`, since you cannot send an eval while one is blocking the session).
+
+Historically meta-commands like `:bindings`, `:sync`, `:test` existed to bootstrap the REPL before the object model was rich enough. Now that `Workspace` and `Beamtalk` express most capability, the REPL column in this map cites the message-send (`via Workspace classes`, `via Beamtalk help:`) rather than treating absent meta-commands as gaps.
+
 ## Legend
 
 | Symbol | Meaning |
 |--------|---------|
 | **name** | Binding exists (tool/command/handler name shown) |
+| `via X` | Reachable as a message-send on `X` (e.g. `via Workspace classes`) — counts as parity for the REPL surface |
 | `--` | Not applicable for this surface |
 | `surface-specific: reason` | Intentionally present only on this surface |
 | `MISSING` | Should exist but does not yet |
@@ -35,35 +45,35 @@ When adding a new capability to any surface, update this table. If the capabilit
 | `stdin` | -- | *(implicit: interactive input)* | -- | -- | Provides input to a blocked eval; CLI handles interactively |
 | `complete` | -- | *(implicit: tab completion)* | `complete` | `completion` | Autocompletion suggestions |
 | `show-codegen` | -- | `:show-codegen` / `:sc` | `show_codegen` | -- | Show generated Core Erlang |
-| `load-file` | -- | -- | `load_file` | -- | Load a single `.bt` file (deprecated op, use `Workspace load:`) |
-| `load-source` | -- | -- | -- | -- | Load inline source string (used by browser workspace) |
+| `load-file` | -- | `via Workspace load:` | `load_file` | -- | Load a single `.bt` file (deprecated op, scheduled for hard-removal in BT-2091) |
+| `load-source` | -- | `surface-specific: browser workspace internal` | -- | -- | Load inline source string |
 | `load-project` | -- | `:sync` / `:s` | `load_project` | -- | Sync project files from `beamtalk.toml` |
-| `reload` | -- | -- | `reload_class` | -- | Hot-reload a class (deprecated op, use `ClassName reload`) |
+| `reload` | -- | `via ClassName reload` | `reload_class` | -- | Hot-reload a class (deprecated op, scheduled for hard-removal in BT-2091) |
 
 ## Session Operations
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
 |---------|---------------|-------------------|----------|----------------|-------|
-| `clear` | -- | `:clear` | `clear` | -- | Clear session bindings (deprecated op) |
-| `bindings` | -- | `:bindings` / `:b` | `get_bindings` | -- | List session variable bindings (deprecated op) |
-| `sessions` | -- | -- | -- | -- | List active REPL sessions |
-| `clone` | -- | -- | -- | -- | Create a new session |
+| `clear` | -- | `:clear` | `clear` | -- | Clear session locals; meta-cmd retained — session-locals layer has no object-side accessor (BT-2092 considers a first-class session object) |
+| `bindings` | -- | `:bindings` / `:b` | `get_bindings` | -- | View session locals merged with workspace globals; meta-cmd retained for the same reason as `clear` |
+| `sessions` | -- | `surface-specific: transport handshake` | -- | -- | List active REPL sessions |
+| `clone` | -- | `surface-specific: transport handshake` | -- | -- | Create a new session |
 | `close` | -- | `:exit` / `:quit` / `:q` | -- | -- | Close session; `:exit` exits the CLI REPL |
-| `interrupt` | -- | -- | `interrupt` | -- | Cancel a running evaluation |
+| `interrupt` | -- | `MISSING (BT-2090)` | `interrupt` | -- | Cancel a running evaluation; only true REPL gap — out-of-band by definition |
 
 ## Actor Operations
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
 |---------|---------------|-------------------|----------|----------------|-------|
-| `actors` | -- | -- | `list_actors` | -- | List running actors |
-| `inspect` | -- | -- | `inspect` | -- | Inspect actor state |
-| `kill` | -- | -- | -- | -- | Terminate an actor |
+| `actors` | -- | `via Workspace actors` | `list_actors` | -- | List running actors |
+| `inspect` | -- | `surface-specific: agent-only typed introspection` | `inspect` | -- | Inspect actor state. Locked: structured-JSON view is for agents; humans use `Transcript show: actorRef` or send messages directly |
+| `kill` | -- | `via anActor stop` | -- | -- | Terminate an actor; MCP can `evaluate` the same send |
 
 ## Module Operations
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
 |---------|---------------|-------------------|----------|----------------|-------|
-| `modules` | -- | -- | -- | -- | List loaded modules (deprecated op, use `Workspace classes`) |
+| `modules` | -- | `via Workspace classes` | -- | -- | List loaded modules (deprecated op, scheduled for hard-removal in BT-2091) |
 | `unload` | -- | `:unload <class>` | `unload` | -- | Unload a class from the workspace |
 
 ## Test Operations
@@ -71,35 +81,35 @@ When adding a new capability to any surface, update this table. If the capabilit
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
 |---------|---------------|-------------------|----------|----------------|-------|
 | `test` | `test` | `:test` / `:t` | `test` | -- | Run BUnit tests (single class or file) |
-| `test-all` | -- | -- | -- | -- | Run all loaded tests |
+| `test-all` | -- | `via Workspace test` | -- | -- | Run all loaded tests; MCP `test` covers the all-tests case via empty params |
 
 ## Dev / Introspection Operations
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
 |---------|---------------|-------------------|----------|----------------|-------|
-| `docs` | -- | -- | `docs` | `textDocument/hover` | Class/method documentation (deprecated op, use `Beamtalk help:`); LSP exposes via hover (BT-2081) |
-| `methods` | -- | -- | -- | -- | List methods for a class |
-| `list-classes` | -- | -- | `list_classes` | `workspace/symbol` | List available classes; LSP exposes via workspace symbol query (BT-2081) |
-| `erlang-help` | -- | -- | -- | -- | Erlang module documentation |
-| `erlang-complete` | -- | -- | -- | -- | Erlang module/function completion |
+| `docs` | -- | `via Beamtalk help:` | `docs` | `textDocument/hover` | Class/method documentation (deprecated op, scheduled for hard-removal in BT-2091); LSP exposes via hover (BT-2081) |
+| `methods` | -- | `via aClass methods` | -- | -- | List methods for a class; reachable on any `Behaviour` |
+| `list-classes` | -- | `via Workspace classes` | `list_classes` | `workspace/symbol` | List available classes; LSP exposes via workspace symbol query (BT-2081) |
+| `erlang-help` | -- | `surface-specific: REPL completion helper` | -- | -- | Erlang module documentation; MCP coverage tracked in BT-1903 |
+| `erlang-complete` | -- | `surface-specific: REPL completion helper` | -- | -- | Erlang module/function completion |
 
 ## Performance / Tracing Operations
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
 |---------|---------------|-------------------|----------|----------------|-------|
-| `enable-tracing` | -- | -- | `enable_tracing` | -- | Enable actor trace capture |
-| `disable-tracing` | -- | -- | `disable_tracing` | -- | Disable actor trace capture |
-| `get-traces` | -- | -- | `get_traces` | -- | Retrieve captured traces |
-| `actor-stats` | -- | -- | `actor_stats` | -- | Per-actor/method aggregate stats |
-| `export-traces` | -- | -- | `export_traces` | -- | Export traces to JSON file |
+| `enable-tracing` | -- | `surface-specific: agent-only workflow (ADR 0069)` | `enable_tracing` | -- | Enable actor trace capture |
+| `disable-tracing` | -- | `surface-specific: agent-only workflow (ADR 0069)` | `disable_tracing` | -- | Disable actor trace capture |
+| `get-traces` | -- | `surface-specific: agent-only workflow (ADR 0069)` | `get_traces` | -- | Retrieve captured traces |
+| `actor-stats` | -- | `surface-specific: agent-only workflow (ADR 0069)` | `actor_stats` | -- | Per-actor/method aggregate stats |
+| `export-traces` | -- | `surface-specific: agent-only workflow (ADR 0069)` | `export_traces` | -- | Export traces to JSON file |
 
 ## Server Operations
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
 |---------|---------------|-------------------|----------|----------------|-------|
-| `describe` | -- | -- | `describe` | -- | Capability discovery (list supported ops) |
-| `health` | -- | -- | -- | -- | Workspace health probe |
-| `shutdown` | `workspace stop` | -- | -- | -- | Graceful workspace shutdown |
+| `describe` | -- | `surface-specific: transport handshake` | `describe` | -- | Capability discovery (list supported ops) |
+| `health` | -- | `surface-specific: operator probe` | -- | -- | Workspace health probe |
+| `shutdown` | `workspace stop` | `surface-specific: lifecycle command` | -- | -- | Graceful workspace shutdown |
 
 ## CLI-Only Commands (no REPL op equivalent)
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -1831,14 +1831,8 @@ base_ops() ->
             <<"deprecated">> => true,
             <<"migrate_to">> => <<"eval: ClassName reload">>
         },
-        <<"clear">> => #{
-            <<"params">> => [],
-            <<"deprecated">> => true
-        },
-        <<"bindings">> => #{
-            <<"params">> => [],
-            <<"deprecated">> => true
-        },
+        <<"clear">> => #{<<"params">> => []},
+        <<"bindings">> => #{<<"params">> => []},
         <<"sessions">> => #{<<"params">> => []},
         <<"clone">> => #{<<"params">> => []},
         <<"close">> => #{<<"params">> => []},


### PR DESCRIPTION
## Summary

Tier 3 of the surface-parity epic (BT-2074). Audits every asymmetric op across REPL / CLI / MCP / LSP and produces a documented **decision** (promote or lock) rather than implementations.

Linear issue: https://linear.app/beamtalk/issue/BT-2083

## Key reframe

The earlier draft of BT-2083 implicitly assumed REPL parity meant "every op needs a `:meta-cmd`." It doesn't. The REPL has two surfaces:

1. **Message-sends** (`Workspace …`, `Beamtalk …`, …) — primary; object-level capability lives here.
2. **Meta-commands** (`:cmd`) — reserved for client-side concerns (`:exit`, `:help`) or transport-out-of-band ops that cannot be expressed as a normal eval (`:interrupt`).

Most historical meta-commands (`:bindings`, `:sync`, `:test`, `:show-codegen`) were bootstrap from before the object model was rich enough. We don't add more; we cite the message-send instead.

Similarly, MCP-only typed tools (`inspect`, `list_actors`, tracing, `search_*`, `diagnostic_summary`) exist because agents need structured JSON, not because the REPL is missing anything — `evaluate` covers the message-send.

## Decisions

* **Promote (1):** `:interrupt` REPL meta-cmd → BT-2090. Out-of-band by definition.
* **Lock as `via X`:** `actors`/`kill`/`methods`/`list-classes`/`docs`/`test-all`/`load-file`/`reload`/`modules` — all reachable as message-sends.
* **Lock as `surface-specific`:** tracing, MCP-only typed tools, transport handshake ops, CLI-only build/tooling.
* **Un-deprecate:** `bindings` and `clear` — they're the only view onto the session-locals layer (no object equivalent today; replacement tracked under BT-2092).
* **Hard-remove (queued):** `docs`/`load-file`/`reload`/`modules` ops have working `migrate_to` hints → BT-2091.

## Changes

* `docs/development/surface-parity.md` — `via X` notation + framing paragraph; every asymmetric-op decision recorded inline.
* `runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl` — drop `deprecated: true` from `bindings` and `clear`.
* `crates/beamtalk-surface-drift/src/main.rs` — drift checker recognises the new `via X` and `MISSING (BT-####)` cell forms.

## Follow-up issues filed

* **BT-2090** — REPL `:interrupt` meta-command
* **BT-2091** — Hard-remove deprecated REPL ops (`docs`, `load-file`, `reload`, `modules`)
* **BT-2092** — First-class session object (Smalltalk-style walkable binding layers)

## Test plan

- [x] `just check-surface-drift` → OK
- [x] `just test-repl-protocol` → 3/3 pass
- [x] `just test` → 250 stdlib + 1899 BUnit + 4727 Erlang runtime tests pass
- [x] `just clippy` clean
- [x] `just fmt-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved code-span handling so backtick-marked snippets beginning with "via" or "missing" are treated as surface-specific in the REPL view.

* **Documentation**
  * Updated REPL parity docs and legend; clarified which commands map via message-sends, which are surface-specific, and noted a missing interrupt mapping.

* **Changes**
  * `clear` and `bindings` commands are no longer marked as deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->