### PR TITLE
Categorize sealed-subclass diagnostics so they reach lint surfaces (BT-2087)

### DIFF
--- a/crates/beamtalk-core/src/ast/expression.rs
+++ b/crates/beamtalk-core/src/ast/expression.rs
@@ -39,6 +39,8 @@ pub enum ExpectCategory {
     ShadowedClass,
     /// Suppress missing type annotation warnings in typed classes (BT-1918).
     TypeAnnotation,
+    /// Suppress inheritance constraint errors — sealed subclass/method (BT-2087).
+    Inheritance,
     /// Suppress any diagnostic on the following expression.
     All,
 }
@@ -60,6 +62,7 @@ impl ExpectCategory {
             "arity_mismatch" => Some(Self::ArityMismatch),
             "shadowed_class" => Some(Self::ShadowedClass),
             "type_annotation" => Some(Self::TypeAnnotation),
+            "inheritance" => Some(Self::Inheritance),
             "all" => Some(Self::All),
             _ => None,
         }
@@ -81,6 +84,7 @@ impl ExpectCategory {
             Self::ArityMismatch => "arity_mismatch",
             Self::ShadowedClass => "shadowed_class",
             Self::TypeAnnotation => "type_annotation",
+            Self::Inheritance => "inheritance",
             Self::All => "all",
         }
     }
@@ -101,6 +105,7 @@ impl ExpectCategory {
             "arity_mismatch",
             "shadowed_class",
             "type_annotation",
+            "inheritance",
             "all",
         ]
     }

--- a/crates/beamtalk-core/src/queries/diagnostic_provider.rs
+++ b/crates/beamtalk-core/src/queries/diagnostic_provider.rs
@@ -390,6 +390,10 @@ fn category_matches(expect_cat: ExpectCategory, diag_cat: Option<DiagnosticCateg
                     ExpectCategory::ShadowedClass,
                     Some(DiagnosticCategory::ShadowedClass)
                 )
+                | (
+                    ExpectCategory::Inheritance,
+                    Some(DiagnosticCategory::Inheritance)
+                )
         )
 }
 

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
@@ -588,7 +588,8 @@ impl ClassHierarchy {
             .with_hint(format!(
                 "Class `{}` is sealed and cannot be extended — use composition instead",
                 superclass.name
-            )),
+            ))
+            .with_category(DiagnosticCategory::Inheritance),
         )
     }
     /// Add classes from a parsed module. Returns diagnostics for errors.
@@ -661,7 +662,8 @@ impl ClassHierarchy {
                                     "Cannot override sealed method `{selector}` from class `{sealed_class}`"
                                 ),
                                 method.span,
-                            ).with_hint(format!("Method `{selector}` is sealed in `{sealed_class}` — use a different method name")));
+                            ).with_hint(format!("Method `{selector}` is sealed in `{sealed_class}` — use a different method name"))
+                            .with_category(DiagnosticCategory::Inheritance));
                         }
                     }
                 }
@@ -683,7 +685,8 @@ impl ClassHierarchy {
                                     "Cannot override sealed method `{selector}` from class `{sealed_class}`"
                                 ),
                                 method.span,
-                            ).with_hint(format!("Method `{selector}` is sealed in `{sealed_class}` — use a different method name")));
+                            ).with_hint(format!("Method `{selector}` is sealed in `{sealed_class}` — use a different method name"))
+                            .with_category(DiagnosticCategory::Inheritance));
                         }
                     }
                 }

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -533,6 +533,9 @@ pub enum DiagnosticCategory {
     /// Separate from `Type` so that `@expect type_annotation` suppresses
     /// only missing-annotation warnings without hiding real type mismatches.
     TypeAnnotation,
+    /// Inheritance constraint violation (BT-2087) — subclassing a sealed class
+    /// or overriding a sealed method.
+    Inheritance,
 }
 
 /// A secondary note attached to a diagnostic (BT-1588).

--- a/crates/beamtalk-core/src/source_analysis/summary.rs
+++ b/crates/beamtalk-core/src/source_analysis/summary.rs
@@ -152,6 +152,7 @@ fn category_label(cat: DiagnosticCategory) -> &'static str {
         DiagnosticCategory::ArityMismatch => "ArityMismatch",
         DiagnosticCategory::ShadowedClass => "ShadowedClass",
         DiagnosticCategory::TypeAnnotation => "TypeAnnotation",
+        DiagnosticCategory::Inheritance => "Inheritance",
     }
 }
 

--- a/crates/beamtalk-parity-tests/tests/diagnostic_parity.rs
+++ b/crates/beamtalk-parity-tests/tests/diagnostic_parity.rs
@@ -152,19 +152,17 @@ fn corpus_cases() -> Vec<CorpusCase> {
             name: "sealed_subclass",
             lsp_target: "src/bad_integer.bt",
             lint_target: "",
-            // Sealed-subclass diagnostics are uncategorised in the analyser,
-            // so they only surface on LSP (which publishes every diagnostic)
-            // — CLI / MCP lint and diagnostic_summary filter to categorised
-            // diagnostics. This expected shape is locked in deliberately so
-            // any drift (in either direction) is caught.
+            // BT-2087: Sealed-subclass diagnostics now carry the `Inheritance`
+            // category, so they pass through the `category.is_some()` filter
+            // on every lint surface.
             expected: ExpectedCounts {
-                cli_lint: 0,
-                mcp_lint: 0,
-                mcp_summary: 0,
+                cli_lint: 1,
+                mcp_lint: 1,
+                mcp_summary: 1,
                 lsp: 1,
             },
             unreadable_files: &[],
-            why: "Sealed-subclass errors surface on LSP but are filtered out of lint surfaces",
+            why: "Sealed-subclass errors must surface on every diagnostic surface",
         },
         CorpusCase {
             name: "stdlib_mode",

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -3349,6 +3349,7 @@ anything                    // any diagnostic suppressed (discouraged — use a 
 | `dnu` | Does-not-understand hints |
 | `type` | Type mismatch warnings *and* method-not-found (DNU) hints |
 | `unused` | Unused variable warnings |
+| `inheritance` | Sealed-class/sealed-method constraint errors |
 | `all` | Any diagnostic on the following expression *(discouraged — use a specific category)* |
 
 **`@expect type` for method-not-found diagnostics:**


### PR DESCRIPTION
## Summary

- Add `Inheritance` diagnostic category for sealed-class and sealed-method constraint violations
- Apply the category to all three sealed-related diagnostics in the class hierarchy analyser
- Previously these diagnostics were uncategorized, so CLI/MCP lint surfaces (which filter to `category.is_some()`) silently dropped them -- only LSP showed them
- Update parity test expectations to assert 1 diagnostic on every surface

## Changes

- `DiagnosticCategory::Inheritance` variant added to `parser/mod.rs`
- `ExpectCategory::Inheritance` added with `from_name`, `as_str`, `valid_names`
- `category_matches` updated in `diagnostic_provider.rs`
- `category_label` updated in `summary.rs`
- Three diagnostics in `class_hierarchy/mod.rs` now carry `.with_category(DiagnosticCategory::Inheritance)`
- Parity test `sealed_subclass` expected counts updated from `0` to `1` on CLI, MCP lint, and MCP summary
- Language features doc updated with `@expect inheritance` category

Closes BT-2087
https://linear.app/beamtalk/issue/BT-2087

## Test plan

- [x] All 108 class hierarchy unit tests pass (including sealed subclass tests)
- [x] CLI lint tests pass
- [x] Full `just test` passes (0 failures)
- [x] Clippy and fmt-check pass
- [ ] `just test-parity` verifies sealed_subclass fixture now reports 1 diagnostic on all surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `inheritance` as a new diagnostic suppression category for the `@expect` directive, enabling selective suppression of inheritance-related diagnostics across all diagnostic surfaces.

* **Tests**
  * Updated diagnostic parity tests to validate the new category behavior.

* **Documentation**
  * Updated language feature documentation to describe the new `inheritance` suppression category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->