### PR TITLE
REPL :interrupt meta-command — out-of-band eval cancellation (BT-2090)

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/client.rs
+++ b/crates/beamtalk-cli/src/commands/repl/client.rs
@@ -229,6 +229,33 @@ impl ReplClient {
         Ok(())
     }
 
+    /// Send an interrupt op, for use from the `:interrupt` meta-command (BT-2090).
+    ///
+    /// Like the internal [`send_interrupt`] (used by Ctrl-C during eval), this
+    /// opens a **separate** connection so it works even when the main connection
+    /// is blocked. Unlike `send_interrupt`, this variant reports errors to the
+    /// caller instead of swallowing them (best-effort is fine for Ctrl-C, but
+    /// the user typing `:interrupt` deserves feedback).
+    pub(crate) fn interrupt(&self) -> Result<()> {
+        let interrupt_req = match self.session_id {
+            Some(ref session) => RequestBuilder::interrupt_with_session(session),
+            None => RequestBuilder::interrupt(),
+        };
+        match ProtocolClient::connect_with_resume(
+            &self.host,
+            self.port,
+            &self.cookie,
+            Some(Duration::from_secs(5)),
+            self.session_id.as_deref(),
+        ) {
+            Ok(mut int_client) => {
+                let _ = int_client.send_request::<serde_json::Value>(&interrupt_req);
+                Ok(())
+            }
+            Err(e) => Err(miette!("Failed to send interrupt: {e}")),
+        }
+    }
+
     /// Send an interrupt request on a separate WebSocket connection (BT-666).
     fn send_interrupt(&self) {
         let interrupt_req = match self.session_id {

--- a/crates/beamtalk-cli/src/commands/repl/client.rs
+++ b/crates/beamtalk-cli/src/commands/repl/client.rs
@@ -249,7 +249,9 @@ impl ReplClient {
             self.session_id.as_deref(),
         ) {
             Ok(mut int_client) => {
-                let _ = int_client.send_request::<serde_json::Value>(&interrupt_req);
+                int_client
+                    .send_request::<serde_json::Value>(&interrupt_req)
+                    .map_err(|e| miette!("Failed to send interrupt: {e}"))?;
                 Ok(())
             }
             Err(e) => Err(miette!("Failed to send interrupt: {e}")),

--- a/crates/beamtalk-cli/src/commands/repl/display.rs
+++ b/crates/beamtalk-cli/src/commands/repl/display.rs
@@ -72,6 +72,7 @@ pub(crate) fn print_help() {
     println!("  :test <Class>   Run a test class (→ Workspace test: ClassName)");
     println!("  :show-codegen <expr>  Show generated Core Erlang for an expression");
     println!("  :sc <expr>      Short alias for :show-codegen");
+    println!("  :interrupt, :int  Cancel a running evaluation (sends out-of-band interrupt)");
     println!();
     println!("Expression examples:");
     println!("  x := 42              # Variable assignment");

--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -660,6 +660,10 @@ fn handle_repl_command(line: &str, client: &mut ReplClient) -> CommandResult {
             handle_show_codegen(line, client);
             return CommandResult::Handled;
         }
+        ":interrupt" | ":int" => {
+            handle_interrupt(client);
+            return CommandResult::Handled;
+        }
         _ => {}
     }
 
@@ -886,6 +890,19 @@ fn handle_show_codegen(line: &str, client: &mut ReplClient) {
                 }
             }
         }
+        Err(e) => eprintln!("Error: {e}"),
+    }
+}
+
+/// Handle `:interrupt` -- send an interrupt op to cancel a running evaluation.
+///
+/// The interrupt is sent on a **separate** connection (out-of-band) so it
+/// works even when the main session connection is blocked waiting for an
+/// eval response. This is the manual counterpart to the automatic Ctrl-C
+/// interrupt that fires during `eval_interruptible` (BT-2090).
+fn handle_interrupt(client: &mut ReplClient) {
+    match client.interrupt() {
+        Ok(()) => println!("Interrupt sent."),
         Err(e) => eprintln!("Error: {e}"),
     }
 }

--- a/crates/beamtalk-cli/tests/repl_protocol.rs
+++ b/crates/beamtalk-cli/tests/repl_protocol.rs
@@ -966,6 +966,12 @@ impl ReplClient {
         Ok("ok".to_string())
     }
 
+    /// Send an interrupt op to cancel a running evaluation (BT-2090).
+    fn send_interrupt(&mut self) -> Result<String, String> {
+        self.send_op(&RequestBuilder::interrupt())?;
+        Ok("Interrupt sent.".to_string())
+    }
+
     /// Get the PID of the first actor of a given class from the actors list.
     /// Note: actor ordering from the server is non-deterministic (map-based).
     /// This is acceptable for E2E tests where we need any valid actor of a class.
@@ -1247,6 +1253,8 @@ fn run_test_file(path: &PathBuf, client: &mut ReplClient) -> (usize, Vec<String>
                     Err(e) => Err(e),
                 }
             }
+        } else if case.expression == ":interrupt" || case.expression == ":int" {
+            client.send_interrupt()
         } else if case.expression.starts_with(":unload ") {
             let module = case.expression.strip_prefix(":unload ").unwrap().trim();
             client.unload_module(module)

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -59,7 +59,7 @@ Historically meta-commands like `:bindings`, `:sync`, `:test` existed to bootstr
 | `sessions` | -- | `surface-specific: transport handshake` | -- | -- | List active REPL sessions |
 | `clone` | -- | `surface-specific: transport handshake` | -- | -- | Create a new session |
 | `close` | -- | `:exit` / `:quit` / `:q` | -- | -- | Close session; `:exit` exits the CLI REPL |
-| `interrupt` | -- | `MISSING (BT-2090)` | `interrupt` | -- | Cancel a running evaluation; only true REPL gap — out-of-band by definition |
+| `interrupt` | -- | `:interrupt` / `:int` | `interrupt` | -- | Cancel a running evaluation; out-of-band by definition (BT-2090) |
 
 ## Actor Operations
 
@@ -221,3 +221,4 @@ For completeness, the full list of REPL meta-commands and their corresponding RE
 | `:unload <class>` | -- | `unload` |
 | `:test` | `:t` | `test` / `test-all` |
 | `:show-codegen` | `:sc` | `show-codegen` |
+| `:interrupt` | `:int` | `interrupt` |

--- a/docs/repl-protocol.md
+++ b/docs/repl-protocol.md
@@ -390,6 +390,29 @@ Close the current session and clean up resources.
 {"id": "msg-014", "value": "ok", "status": ["done"]}
 ```
 
+#### `interrupt` — Cancel Running Evaluation (BT-2090)
+
+Cancel a running evaluation on the session. Because the main connection is
+blocked waiting for the eval response, the interrupt **must** be sent on a
+separate connection (out-of-band). The REPL CLI exposes this as the
+`:interrupt` / `:int` meta-command and also sends it automatically on Ctrl-C
+during an eval (BT-666).
+
+**Request:**
+```json
+{"op": "interrupt", "id": "msg-015"}
+```
+
+To target a specific session, include the `session` field:
+```json
+{"op": "interrupt", "id": "msg-015", "session": "sess-42"}
+```
+
+**Response:**
+```json
+{"id": "msg-015", "value": "ok", "status": ["done"]}
+```
+
 ### Actor Operations
 
 #### `actors` — List Actors

--- a/tests/repl-protocol/cases/interrupt.btscript
+++ b/tests/repl-protocol/cases/interrupt.btscript
@@ -1,0 +1,41 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E tests for :interrupt meta-command (BT-2090).
+//
+// The :interrupt command sends an out-of-band interrupt op to cancel a
+// running evaluation. These tests verify the command is recognised,
+// the interrupt op round-trips successfully, and the session remains
+// functional afterwards.
+//
+// Note: testing a true long-running eval + interrupt race requires
+// concurrent sends which the sequential btscript harness cannot do.
+// The important thing is that the op is wired up and does not break
+// the session.
+
+// ===========================================================================
+// :interrupt — idle session (no eval running)
+// ===========================================================================
+
+// Sending :interrupt when nothing is running should succeed gracefully
+:interrupt
+// => Interrupt sent.
+
+// Session should still be functional after interrupt
+1 + 1
+// => 2
+
+// ===========================================================================
+// :int — short alias
+// ===========================================================================
+
+// The :int alias should also work
+:int
+// => Interrupt sent.
+
+// Session still functional after alias
+x := 42
+// => 42
+
+x
+// => 42


### PR DESCRIPTION
## Summary

Adds the `:interrupt` (alias `:int`) REPL meta-command, the only true REPL surface gap identified by the surface-parity audit (BT-2083). This command sends an out-of-band interrupt op to cancel a running evaluation — it cannot be expressed as a `Workspace` message-send because when an eval is blocking the session, you cannot send another eval to cancel it.

**Linear:** https://linear.app/beamtalk/issue/BT-2090

## Changes

- **`:interrupt` / `:int` dispatch** in `handle_repl_command` (`crates/beamtalk-cli/src/commands/repl/mod.rs`)
- **Public `interrupt()` method** on `ReplClient` that opens a separate connection to send the interrupt op (error-reporting variant of the existing best-effort `send_interrupt` used by Ctrl-C)
- **Help text** updated in `display.rs`
- **`docs/repl-protocol.md`** — new `interrupt` section under Session Operations with request/response examples
- **`docs/development/surface-parity.md`** — `MISSING (BT-2090)` → `:interrupt` / `:int`; added to Meta-Command Reference table
- **E2E test** in `tests/repl-protocol/cases/interrupt.btscript` — verifies both `:interrupt` and `:int` are recognized, the op succeeds (even on idle session), and the session remains functional afterwards

## Test plan

- [x] `just ci` passes (clippy, fmt-check, test, test-parity, surface-drift)
- [x] E2E test covers `:interrupt` and `:int` alias
- [x] Surface drift check confirms parity doc matches code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `:interrupt` / `:int` meta-command to send an out-of-band interrupt; REPL now reports success or failure when interrupts are issued and resumes sessions when applicable.
  * REPL help text updated to include the new command.

* **Documentation**
  * REPL protocol and surface-parity docs updated with interrupt operation details and usage.

* **Tests**
  * Added E2E tests and a test script covering `:interrupt` / `:int` behavior and session continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->