### PR TITLE
Protocol define: hot-reload without namespace collision (BT-2088)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -418,6 +418,22 @@ fn analyse_full_with_natives(
     // structural validator can decide whether unresolved-class warnings are useful.
     let has_cross_file_classes = !pre_loaded_classes.is_empty();
 
+    // BT-2088: Filter out pre-loaded class entries whose names match a protocol
+    // definition in the current module. The compiler server's class cache
+    // includes synthetic protocol class entries from prior loads; injecting
+    // them into the hierarchy would cause a spurious "namespace collision"
+    // error when `register_module` sees the protocol name as an existing class.
+    let pre_loaded_classes = if !module.protocols.is_empty() && !pre_loaded_classes.is_empty() {
+        let current_protocol_names: std::collections::HashSet<&ecow::EcoString> =
+            module.protocols.iter().map(|p| &p.name.name).collect();
+        pre_loaded_classes
+            .into_iter()
+            .filter(|ci| !current_protocol_names.contains(&ci.name))
+            .collect()
+    } else {
+        pre_loaded_classes
+    };
+
     // ADR 0050 Phase 4: inject REPL-session class metadata before TypeChecking
     if !pre_loaded_classes.is_empty() {
         result

--- a/crates/beamtalk-core/src/semantic_analysis/protocol_registry.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/protocol_registry.rs
@@ -255,22 +255,31 @@ impl ProtocolRegistry {
         let mut diagnostics = Vec::new();
         for info in protocols {
             if hierarchy.has_class(&info.name) {
-                diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "Pre-loaded protocol `{}` collides with class of the same name — \
-                             protocols and classes share a namespace",
+                // BT-2088: Skip collision when the existing "class" is a synthetic
+                // protocol class entry (superclass is Protocol) — this is just the
+                // class-side representation of the same protocol from a prior load.
+                let is_protocol_class = hierarchy
+                    .get_class(&info.name)
+                    .and_then(|ci| ci.superclass.as_deref())
+                    .is_some_and(|sc| sc == "Protocol");
+                if !is_protocol_class {
+                    diagnostics.push(
+                        Diagnostic::error(
+                            format!(
+                                "Pre-loaded protocol `{}` collides with class of the same name — \
+                                 protocols and classes share a namespace",
+                                info.name
+                            ),
+                            info.span,
+                        )
+                        .with_hint(format!(
+                            "Rename the protocol in its defining file to avoid conflicting with class `{}`",
                             info.name
-                        ),
-                        info.span,
-                    )
-                    .with_hint(format!(
-                        "Rename the protocol in its defining file to avoid conflicting with class `{}`",
-                        info.name
-                    ))
-                    .with_category(DiagnosticCategory::Type),
-                );
-                continue;
+                        ))
+                        .with_category(DiagnosticCategory::Type),
+                    );
+                    continue;
+                }
             }
             self.protocols.entry(info.name.clone()).or_insert(info);
         }
@@ -293,22 +302,34 @@ impl ProtocolRegistry {
         for protocol_def in &module.protocols {
             let name = &protocol_def.name.name;
 
-            // Namespace collision: protocol name matches a class name
+            // Namespace collision: protocol name matches a class name.
+            // BT-2088: Allow re-registration when the existing "class" is actually
+            // a synthetic protocol class entry from a previous load (superclass is
+            // `Protocol`). This happens during hot-reload when the compiler server's
+            // class cache still contains the protocol from the first surface that
+            // loaded it. Real class vs. protocol collisions (superclass != Protocol)
+            // remain errors.
             if hierarchy.has_class(name) {
-                diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "`{name}` is already defined as a class — \
-                             protocols and classes share a namespace"
-                        ),
-                        protocol_def.name.span,
-                    )
-                    .with_hint(format!(
-                        "Rename the protocol to avoid conflicting with class `{name}`"
-                    ))
-                    .with_category(DiagnosticCategory::Type),
-                );
-                continue;
+                let is_protocol_class = hierarchy
+                    .get_class(name)
+                    .and_then(|info| info.superclass.as_deref())
+                    .is_some_and(|sc| sc == "Protocol");
+                if !is_protocol_class {
+                    diagnostics.push(
+                        Diagnostic::error(
+                            format!(
+                                "`{name}` is already defined as a class — \
+                                 protocols and classes share a namespace"
+                            ),
+                            protocol_def.name.span,
+                        )
+                        .with_hint(format!(
+                            "Rename the protocol to avoid conflicting with class `{name}`"
+                        ))
+                        .with_category(DiagnosticCategory::Type),
+                    );
+                    continue;
+                }
             }
 
             // Duplicate protocol definition
@@ -1163,5 +1184,123 @@ mod tests {
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("collides with class"));
         assert!(!registry.has_protocol("Integer"));
+    }
+
+    // ---- BT-2088: Protocol hot-reload with synthetic protocol class ----
+
+    #[test]
+    fn register_module_allows_protocol_when_hierarchy_has_protocol_class() {
+        // Simulate hot-reload: the hierarchy already contains a synthetic
+        // protocol class entry (superclass = Protocol) from a previous load.
+        // Registering the same protocol name should succeed — it's not a
+        // real namespace collision.
+        let mut hierarchy = ClassHierarchy::with_builtins();
+        hierarchy.classes_mut().insert(
+            "Printable".into(),
+            crate::semantic_analysis::class_hierarchy::ClassInfo {
+                name: "Printable".into(),
+                superclass: Some("Protocol".into()),
+                is_sealed: true,
+                is_abstract: true,
+                is_typed: true,
+                is_internal: false,
+                package: None,
+                is_value: false,
+                is_native: false,
+                state: vec![],
+                state_types: HashMap::new(),
+                state_has_default: HashMap::new(),
+                methods: vec![],
+                class_methods: vec![],
+                class_variables: vec![],
+                type_params: vec![],
+                type_param_bounds: vec![],
+                superclass_type_args: vec![],
+            },
+        );
+
+        let module = Module {
+            protocols: vec![make_protocol(
+                "Printable",
+                vec![("asString", 0, Some("String"))],
+            )],
+            ..empty_module()
+        };
+        let mut registry = ProtocolRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy);
+
+        assert!(
+            diags.is_empty(),
+            "Re-registering a protocol whose class entry has superclass Protocol \
+             should not produce namespace collision diagnostics, got: {diags:?}"
+        );
+        assert!(registry.has_protocol("Printable"));
+    }
+
+    #[test]
+    fn register_module_still_rejects_real_class_collision() {
+        // A real class (not superclass Protocol) should still collide.
+        let hierarchy = ClassHierarchy::with_builtins();
+        let module = Module {
+            protocols: vec![make_protocol(
+                "Integer",
+                vec![("asString", 0, Some("String"))],
+            )],
+            ..empty_module()
+        };
+        let mut registry = ProtocolRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy);
+
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("already defined as a class"));
+        assert!(!registry.has_protocol("Integer"));
+    }
+
+    #[test]
+    fn add_pre_loaded_allows_protocol_class_entry() {
+        // BT-2088: Pre-loaded protocol should not collide with a synthetic
+        // protocol class entry in the hierarchy.
+        let mut hierarchy = ClassHierarchy::with_builtins();
+        hierarchy.classes_mut().insert(
+            "Tickable".into(),
+            crate::semantic_analysis::class_hierarchy::ClassInfo {
+                name: "Tickable".into(),
+                superclass: Some("Protocol".into()),
+                is_sealed: true,
+                is_abstract: true,
+                is_typed: true,
+                is_internal: false,
+                package: None,
+                is_value: false,
+                is_native: false,
+                state: vec![],
+                state_types: HashMap::new(),
+                state_has_default: HashMap::new(),
+                methods: vec![],
+                class_methods: vec![],
+                class_variables: vec![],
+                type_params: vec![],
+                type_param_bounds: vec![],
+                superclass_type_args: vec![],
+            },
+        );
+
+        let mut registry = ProtocolRegistry::new();
+        let protocol = ProtocolInfo {
+            name: "Tickable".into(),
+            type_params: vec![],
+            type_param_bounds: vec![],
+            extending: None,
+            methods: vec![],
+            class_methods: vec![],
+            span: span(),
+        };
+
+        let diags = registry.add_pre_loaded(vec![protocol], &hierarchy);
+        assert!(
+            diags.is_empty(),
+            "Pre-loaded protocol should not collide with synthetic protocol class, got: {diags:?}"
+        );
+        assert!(registry.has_protocol("Tickable"));
     }
 }

--- a/tests/parity/cases/load_project_mixed.parity.bt
+++ b/tests/parity/cases/load_project_mixed.parity.bt
@@ -20,19 +20,14 @@
 // edge-case files (CamelCase filename `HotSwap.bt`, deeply nested
 // `deep/nested/path/widget.bt`, sibling files in the same subdirectory).
 
-// The expected class set below covers the concrete classes defined by the
-// fixture. `MixedPrintable` (a `Protocol define:`) is intentionally OMITTED
-// from the assertion — the fixture still loads the protocol file on every
-// surface (so the BT-1950 regression scenario is reproduced), but second-
-// pass `force=true` reloads of `Protocol define:` files currently surface
-// a "namespace collision" diagnostic on whichever surface runs second
-// against the shared workspace. The fixture pins the regression scenario
-// so the parity assertion will tighten to require `MixedPrintable` once
-// the underlying hot-reload-of-protocols behaviour is stable across all
-// load paths.
+// The expected class set covers the concrete classes AND protocol classes
+// defined by the fixture. `MixedPrintable` (a `Protocol define:`) must
+// load successfully on every surface, including second-pass `force=true`
+// reloads against a workspace that already has the protocol registered
+// (BT-2088 fixed the namespace collision on hot-reload).
 
 // @input
 <mixed_project>
 // @surfaces repl, mcp, cli
 // @op load
-// @expect-classes AbstractAnimal, ActorCounter, ActorLogger, ActorTicker, AnimalDog, AnimalPuppy, ArrayExtensionsHost, Circle, ClassMethodsOnly, Cylinder, DeepWidget, FactoryWidget, HotSwap, MathHelper, ObjectWithExtensions, PlainObject, ProtoConsumer, SealedToken, Shape, StringExtensionsHost, StringUtil, TypedAccount, ValueColor, ValueMoney, ValuePair, ValuePoint, ValueTyped
+// @expect-classes AbstractAnimal, ActorCounter, ActorLogger, ActorTicker, AnimalDog, AnimalPuppy, ArrayExtensionsHost, Circle, ClassMethodsOnly, Cylinder, DeepWidget, FactoryWidget, HotSwap, MathHelper, MixedPrintable, ObjectWithExtensions, PlainObject, ProtoConsumer, SealedToken, Shape, StringExtensionsHost, StringUtil, TypedAccount, ValueColor, ValueMoney, ValuePair, ValuePoint, ValueTyped


### PR DESCRIPTION
## Summary

Fixes the namespace collision diagnostic that occurred when a `Protocol define:` file was reloaded on a second surface (e.g., MCP after REPL) against a shared workspace that already had the protocol registered.

- **Root cause**: The compiler server's class cache retained synthetic protocol class entries from prior loads. When `analyse_full_with_natives` injected these into the hierarchy, `register_module` saw the protocol name as an existing class and raised a spurious collision error.
- **Primary fix**: Filter pre-loaded class entries matching protocol names in the current module before injecting into the class hierarchy (`semantic_analysis/mod.rs`)
- **Defence-in-depth**: Allow `register_module` and `add_pre_loaded` to accept protocol re-registration when the existing class has superclass `Protocol` (`protocol_registry.rs`)
- **Parity assertion tightened**: `MixedPrintable` now included in `@expect-classes` (was omitted as a workaround)

## Linear

https://linear.app/beamtalk/issue/BT-2088

## Test plan

- [x] 3 new unit tests in `protocol_registry.rs` covering allow/reject paths
- [x] Parity test `load_project_mixed.parity.bt` now asserts `MixedPrintable` across all 3 surfaces (REPL, MCP, CLI)
- [x] Full CI green (`just ci`) including parity, REPL protocol, stdlib, BUnit, and runtime tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved namespace collision detection errors that were incorrectly blocking protocol definitions from loading during hot-reload scenarios.

* **Tests**
  * Enhanced test coverage for protocol hot-reload behavior and collision detection edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->