### PR TITLE
Workspace project loads accumulate, not evict (BT-2089)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Fix deadlock when calling `self class spawnAs:` / `self class spawnWith:as:` inside a class factory method — metaclass dispatch now short-circuits spawn selectors to avoid re-entering the class gen_server (BT-2005).
 - Fix `undef` crash for `self spawnAs:` / `self spawnWith:as:` in class methods — new runtime helpers read class metadata from the process dictionary to avoid the gen_server deadlock (BT-2004).
 - Fix `undef` crash for inherited class-method self-sends — a new `class_self_dispatch/4` runtime helper walks the superclass chain and threads class-var state correctly (BT-2007).
+- **Workspace project loads accumulate** — loading project A then project B on the same REPL/MCP workspace no longer evicts project A's classes. Previous-mtime tracking is now scoped per-project root, so each `:sync` / `load_project` only treats files under its own tree as candidates for "deleted" classification. Cross-project class collisions surface as `warnings` in the load-project response instead of silently overwriting earlier classes (BT-2089).
 
 ### Tooling
 

--- a/crates/beamtalk-parity-tests/tests/parity.rs
+++ b/crates/beamtalk-parity-tests/tests/parity.rs
@@ -43,6 +43,36 @@ async fn parity_suite() {
     let staged_test_runner = stage_test_runner_project();
     let staged_mixed = stage_mixed_project();
 
+    // BT-2089: pre-load every test-fixture project on the REPL and MCP
+    // workspaces so all `Op::Test` cases see every class regardless of
+    // load order. Workspace loads now accumulate across projects, so this
+    // is a one-time setup rather than the per-class workaround that BT-2080
+    // used to need.
+    if let Some(p) = staged_project.as_deref() {
+        let path = p.to_string_lossy();
+        repl_driver
+            .load_project_with_tests(&path)
+            .await
+            .map_err(|e| format!("repl preload {}: {e}", p.display()))
+            .expect("preload simple_project on repl");
+        mcp.load_project_with_tests(&path)
+            .await
+            .map_err(|e| format!("mcp preload {}: {e}", p.display()))
+            .expect("preload simple_project on mcp");
+    }
+    if let Some(p) = staged_test_runner.as_deref() {
+        let path = p.to_string_lossy();
+        repl_driver
+            .load_project_with_tests(&path)
+            .await
+            .map_err(|e| format!("repl preload {}: {e}", p.display()))
+            .expect("preload test_runner_project on repl");
+        mcp.load_project_with_tests(&path)
+            .await
+            .map_err(|e| format!("mcp preload {}: {e}", p.display()))
+            .expect("preload test_runner_project on mcp");
+    }
+
     let mut failures: Vec<String> = Vec::new();
     for path in &case_paths {
         let case = match Case::from_path(path) {
@@ -189,30 +219,15 @@ async fn drive(
         (Surface::Cli, Op::Lint) => cli_driver::lint(Path::new(input)),
 
         (Surface::Repl, Op::Test) => {
-            // Make sure the test class is loaded before running it. Each
-            // input class has exactly one fixture project; loading just
-            // that one keeps the workspace's class registry consistent
-            // (loading multiple projects back-to-back was observed to
-            // wipe earlier projects' classes on the REPL surface).
-            let project = fixture_project_for_class(input);
-            if project.exists() {
-                repl.load_project_with_tests(&project.to_string_lossy())
-                    .await
-                    .map_err(|e| {
-                        format!("repl load_project_with_tests({}): {e}", project.display())
-                    })?;
-            }
+            // BT-2089: workspace project loads now accumulate, so we no
+            // longer need the per-class pre-load workaround. Both
+            // `simple_project` and `test_runner_project` are loaded once
+            // at the start of `parity_suite`; this branch just runs the
+            // test against the already-loaded workspace.
             repl.test_class(input).await
         }
         (Surface::Mcp, Op::Test) => {
-            let project = fixture_project_for_class(input);
-            if project.exists() {
-                mcp.load_project_with_tests(&project.to_string_lossy())
-                    .await
-                    .map_err(|e| {
-                        format!("mcp load_project_with_tests({}): {e}", project.display())
-                    })?;
-            }
+            // BT-2089: see Repl branch above.
             mcp.test_class(input).await
         }
         (Surface::Cli, Op::Test) => {
@@ -295,8 +310,10 @@ fn stage_mixed_project() -> Option<PathBuf> {
 
 /// Class-name → test-runner-project test file mapping.
 ///
-/// Shared between [`cli_test_path_for_class`] and
-/// [`fixture_project_for_class`] so the two lookups cannot drift.
+/// Used by [`cli_test_path_for_class`] to map a class name to the
+/// staged test file. (BT-2089: REPL/MCP no longer need a class→project
+/// lookup because both fixture projects are pre-loaded at the start of
+/// the parity suite.)
 const TEST_RUNNER_CLASSES: &[(&str, &str)] = &[
     ("PassingRunnerTest", "passing_test.bt"),
     ("AssertFailRunnerTest", "asserting_fail_test.bt"),
@@ -317,21 +334,6 @@ fn cli_test_path_for_class(class: &str) -> PathBuf {
     let runner_root = std::env::temp_dir().join("beamtalk-parity-test-runner");
     if let Some((_, file)) = TEST_RUNNER_CLASSES.iter().find(|(c, _)| *c == class) {
         runner_root.join("test").join(file)
-    } else {
-        std::env::temp_dir().join("beamtalk-parity-simple")
-    }
-}
-
-/// Map a `TestCase` class name to the staged fixture project that defines it.
-///
-/// REPL/MCP `:test ClassName` requires the class to be loaded into the
-/// workspace; this lookup is the classifier the harness uses to load the
-/// correct project before each test op. Pre-loading both projects up
-/// front was tried and rejected — loading a second project on the same
-/// workspace evicted classes from the first.
-fn fixture_project_for_class(class: &str) -> PathBuf {
-    if TEST_RUNNER_CLASSES.iter().any(|(c, _)| *c == class) {
-        std::env::temp_dir().join("beamtalk-parity-test-runner")
     } else {
         std::env::temp_dir().join("beamtalk-parity-simple")
     }

--- a/docs/repl-protocol.md
+++ b/docs/repl-protocol.md
@@ -303,6 +303,7 @@ Incrementally compile and load all `.bt` and native `.erl` files in a Beamtalk p
 | `classes` | string[] | Names of classes that were (re)loaded |
 | `errors` | object[] | Structured per-file errors (empty on full success) |
 | `summary` | string | Human-readable one-line summary |
+| `warnings` | string[] | (Optional) Class collision warnings — emitted when `load-project` redefines a class that was already registered from a different module (e.g., when loading a second project that defines a class of the same name). Only present when there is at least one warning. |
 
 **Response (no `beamtalk.toml`):**
 ```json

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
@@ -35,7 +35,8 @@ Extracted from beamtalk_repl_server (BT-705).
     extract_package_from_module/1,
     classify_files_by_change/2,
     get_file_mtime/1,
-    extract_native_refs/1
+    extract_native_refs/1,
+    filter_mtimes_under_project/2
 ]).
 -endif.
 
@@ -130,15 +131,41 @@ do_sync_project(AbsPath, IncludeTests, Force, SessionPid) ->
             {ok, Mtimes} -> Mtimes;
             {error, _} -> #{}
         end,
+    %% BT-2089: Scope previous-mtime tracking to the project being synced.
+    %% The workspace meta table accumulates mtimes for every project ever
+    %% loaded into this workspace, so unfiltered classification would treat
+    %% every other project's files as "deleted" and unload their classes.
+    %% Only files whose path lies under AbsPath belong to this project sync.
+    ProjectMtimes = filter_mtimes_under_project(PreviousMtimes, AbsPath),
+    %% BT-2089: When include_tests=false, also drop previously-tracked test
+    %% files from the baseline. Otherwise an `Op::Load` (which defaults to
+    %% include_tests=false) classifies the test files loaded by an earlier
+    %% `:test`/include_tests=true sync as "deleted" and unregisters them.
+    TestDirPrefix = filename:join(AbsPath, "test") ++ "/",
+    BaselineMtimes =
+        case IncludeTests of
+            true ->
+                ProjectMtimes;
+            false ->
+                maps:filter(
+                    fun
+                        (P, _M) when is_list(P) ->
+                            not lists:prefix(TestDirPrefix, P);
+                        (_NonString, _M) ->
+                            false
+                    end,
+                    ProjectMtimes
+                )
+        end,
     PrevErlMtimes =
         maps:filter(
             fun(P, _Mtime) -> filename:extension(P) =:= ".erl" end,
-            PreviousMtimes
+            BaselineMtimes
         ),
     PrevBtMtimes =
         maps:filter(
             fun(P, _Mtime) -> filename:extension(P) =:= ".bt" end,
-            PreviousMtimes
+            BaselineMtimes
         ),
     {ChangedErl, UnchangedErl, DeletedErl} =
         case Force of
@@ -223,6 +250,9 @@ do_sync_project(AbsPath, IncludeTests, Force, SessionPid) ->
             end
          || C <- AllClasses
         ],
+    %% BT-2089: Drain class collision warnings so cross-project class
+    %% redefinitions produce a clear diagnostic instead of silent eviction.
+    CollisionWarnings = collect_load_warnings(AllClasses),
     TotalFiles = length(AllFiles) + DeletedCount,
     ChangedCount = length(ChangedBt) + length(ChangedErl),
     UnchangedCount = length(UnchangedBt) + length(UnchangedErl),
@@ -231,6 +261,7 @@ do_sync_project(AbsPath, IncludeTests, Force, SessionPid) ->
         classes => ClassNames,
         errors => Errors,
         dep_errors => DepErrorMsgs,
+        warnings => CollisionWarnings,
         summary => build_incremental_summary(
             ChangedCount, TotalFiles, UnchangedCount, DeletedCount
         ),
@@ -260,12 +291,21 @@ handle(<<"load-project">>, Params, Msg, SessionPid) ->
         {ok, Result} ->
             Base = beamtalk_repl_protocol:base_response(Msg),
             DepErrors = maps:get(dep_errors, Result, []),
-            Response = Base#{
+            %% BT-2089: Surface collision warnings to the load-project caller
+            %% so that cross-project class collisions produce a clear
+            %% diagnostic instead of silent eviction.
+            Warnings = maps:get(warnings, Result, []),
+            Response0 = Base#{
                 <<"status">> => [<<"done">>],
                 <<"classes">> => maps:get(classes, Result),
                 <<"errors">> => maps:get(errors, Result) ++ DepErrors,
                 <<"summary">> => maps:get(summary, Result)
             },
+            Response =
+                case Warnings of
+                    [] -> Response0;
+                    _ -> Response0#{<<"warnings">> => Warnings}
+                end,
             iolist_to_binary(json:encode(Response))
     end;
 handle(<<"load-file">>, Params, Msg, SessionPid) ->
@@ -1340,6 +1380,38 @@ classify_files_by_change(CurrentFiles, PreviousMtimes) ->
         not sets:is_element(P, CurrentSet)
     ],
     {Changed, Unchanged, Deleted}.
+
+-doc """
+Filter previously-tracked file mtimes to only those under the given project root.
+
+BT-2089: Multiple `load-project` calls against the same workspace should
+accumulate, not evict. The workspace meta table accumulates mtimes across
+every project loaded into the workspace, so unfiltered "deleted file"
+detection treats files from sibling projects as deleted and unloads
+their classes. Scoping by project root keeps each sync responsible only
+for its own files.
+
+The `ProjectRoot` is expected to be an absolute path. Files under it are
+matched by string prefix on the directory boundary; the path
+`/p/foo/src/a.bt` matches root `/p/foo` but `/p/foobar/src/a.bt` does not.
+""".
+-spec filter_mtimes_under_project(
+    #{string() => calendar:datetime()}, string()
+) -> #{string() => calendar:datetime()}.
+filter_mtimes_under_project(Mtimes, ProjectRoot) ->
+    %% Normalise the project root so the prefix check is unambiguous.
+    %% Trim any trailing separator to avoid double-slash artefacts.
+    Root = string:trim(ProjectRoot, trailing, "/"),
+    Prefix = Root ++ "/",
+    maps:filter(
+        fun
+            (Path, _Mtime) when is_list(Path) ->
+                Path =:= Root orelse lists:prefix(Prefix, Path);
+            (_NonString, _Mtime) ->
+                false
+        end,
+        Mtimes
+    ).
 
 -doc """
 Get the mtime of a file.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_load_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_load_tests.erl
@@ -309,6 +309,83 @@ classify_files_mixed_test() ->
     end.
 
 %%====================================================================
+%% filter_mtimes_under_project/2 (BT-2089)
+%%====================================================================
+
+filter_mtimes_under_project_basic_test() ->
+    %% Files under the project root are kept; files outside are dropped.
+    Mtimes = #{
+        "/projects/foo/src/a.bt" => {{2026, 4, 26}, {0, 0, 0}},
+        "/projects/foo/src/b.bt" => {{2026, 4, 26}, {0, 0, 0}},
+        "/projects/bar/src/c.bt" => {{2026, 4, 26}, {0, 0, 0}}
+    },
+    Filtered = beamtalk_repl_ops_load:filter_mtimes_under_project(
+        Mtimes, "/projects/foo"
+    ),
+    ?assertEqual(2, maps:size(Filtered)),
+    ?assert(maps:is_key("/projects/foo/src/a.bt", Filtered)),
+    ?assert(maps:is_key("/projects/foo/src/b.bt", Filtered)),
+    ?assertNot(maps:is_key("/projects/bar/src/c.bt", Filtered)).
+
+filter_mtimes_under_project_prefix_boundary_test() ->
+    %% A path that shares a string prefix with the project root but lies in
+    %% a different directory must NOT match — `/projects/foobar` is not a
+    %% child of `/projects/foo`.
+    Mtimes = #{
+        "/projects/foo/src/a.bt" => {{2026, 4, 26}, {0, 0, 0}},
+        "/projects/foobar/src/c.bt" => {{2026, 4, 26}, {0, 0, 0}}
+    },
+    Filtered = beamtalk_repl_ops_load:filter_mtimes_under_project(
+        Mtimes, "/projects/foo"
+    ),
+    ?assertEqual(1, maps:size(Filtered)),
+    ?assert(maps:is_key("/projects/foo/src/a.bt", Filtered)),
+    ?assertNot(maps:is_key("/projects/foobar/src/c.bt", Filtered)).
+
+filter_mtimes_under_project_trailing_slash_test() ->
+    %% A trailing slash on the project root must be tolerated.
+    Mtimes = #{
+        "/projects/foo/src/a.bt" => {{2026, 4, 26}, {0, 0, 0}},
+        "/projects/bar/src/b.bt" => {{2026, 4, 26}, {0, 0, 0}}
+    },
+    Filtered = beamtalk_repl_ops_load:filter_mtimes_under_project(
+        Mtimes, "/projects/foo/"
+    ),
+    ?assertEqual(1, maps:size(Filtered)),
+    ?assert(maps:is_key("/projects/foo/src/a.bt", Filtered)).
+
+filter_mtimes_under_project_empty_test() ->
+    %% Empty input map yields empty output.
+    ?assertEqual(
+        #{},
+        beamtalk_repl_ops_load:filter_mtimes_under_project(#{}, "/projects/foo")
+    ).
+
+filter_mtimes_under_project_no_matches_test() ->
+    %% No files under the root → empty result.
+    Mtimes = #{
+        "/other/a.bt" => {{2026, 4, 26}, {0, 0, 0}},
+        "/elsewhere/b.bt" => {{2026, 4, 26}, {0, 0, 0}}
+    },
+    ?assertEqual(
+        #{},
+        beamtalk_repl_ops_load:filter_mtimes_under_project(Mtimes, "/projects/foo")
+    ).
+
+filter_mtimes_under_project_keeps_test_dir_test() ->
+    %% Test files under the project root are still scoped in.
+    %% (BT-2089: scoping out test/ when include_tests=false is the
+    %% caller's responsibility — this helper only filters by project root.)
+    Mtimes = #{
+        "/projects/foo/src/a.bt" => {{2026, 4, 26}, {0, 0, 0}},
+        "/projects/foo/test/b.bt" => {{2026, 4, 26}, {0, 0, 0}}
+    },
+    Filtered = beamtalk_repl_ops_load:filter_mtimes_under_project(
+        Mtimes, "/projects/foo"
+    ),
+    ?assertEqual(2, maps:size(Filtered)).
+
+%%====================================================================
 %% get_file_mtime/1 (BT-1685)
 %%====================================================================
 


### PR DESCRIPTION
## Summary

Fixes [BT-2089](https://linear.app/beamtalk/issue/BT-2089). Loading project A then project B on the same REPL/MCP workspace no longer evicts project A's classes — workspace project loads now accumulate, matching the mental model that the workspace is a long-lived registry that projects layer onto.

The root cause was in `do_sync_project/4`: it pulled `PreviousMtimes` from `beamtalk_workspace_meta` (a workspace-global table that accumulates across every project ever loaded) and then handed those mtimes unfiltered to `classify_files_by_change/2`. That function classifies any file in `PreviousMtimes` but missing from the current project's `AllBtFiles` as "deleted" — so syncing project B classified all of project A's files as deleted and unloaded their classes.

## Key changes

- **Scope previous-mtime tracking per project.** New `filter_mtimes_under_project/2` helper limits the baseline to files under the project root being synced. Sibling projects' mtimes are left alone.
- **Drop test-dir mtimes from baseline when `include_tests=false`.** Without this, an `Op::Load` (default `include_tests=false`) classified test files loaded by an earlier `:test` / `include_tests=true` sync as deleted and unregistered them. Found by the parity-suite regression run after the per-project scope fix.
- **Surface class collision warnings** as a `warnings` field on the `load-project` response. Cross-project class redefinitions now produce a clear diagnostic instead of silent eviction.
- **Drop the BT-2080 per-class pre-load workaround** in `crates/beamtalk-parity-tests/tests/parity.rs::fixture_project_for_class`. Both `simple_project` and `test_runner_project` are now pre-loaded once at the start of the parity suite; `Op::Test` cases run against the accumulated workspace.
- **Docs:** add `warnings` field to `docs/repl-protocol.md` `load-project` response shape; CHANGELOG entry.

## Acceptance criteria

- [x] Loading project A then project B leaves both projects' classes available on the workspace.
- [x] Class collisions across projects produce a clear diagnostic (`warnings` field on `load-project` response), not silent eviction.
- [x] The BT-2080 parity harness drops the per-class pre-load workaround in `fixture_project_for_class()`.

## Test plan

- [x] New EUnit tests for `filter_mtimes_under_project/2`: basic, prefix-boundary (`/projects/foo` vs `/projects/foobar`), trailing slash, empty input, no matches, test-dir pass-through (6 cases).
- [x] `rebar3 eunit --module beamtalk_repl_ops_load_tests` — 56/56 passing.
- [x] `cargo test -p beamtalk-parity-tests --test parity -- --ignored --test-threads=1` — passes (104s) with the workaround removed.
- [x] `cargo clippy --all-targets --workspace` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `rebar3 fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Classes from previously loaded projects no longer get evicted when loading multiple projects into the same workspace.
  * File deletion detection now correctly scopes to the current project.

* **New Features**
  * Cross-project class name collisions are now reported as warnings in load-project responses.

* **Documentation**
  * Updated protocol documentation to reflect the new warnings field in load-project responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->