### PR TITLE
docs: daily refresh 2026-04-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Fix `undef` crash for `self spawnAs:` / `self spawnWith:as:` in class methods — new runtime helpers read class metadata from the process dictionary to avoid the gen_server deadlock (BT-2004).
 - Fix `undef` crash for inherited class-method self-sends — a new `class_self_dispatch/4` runtime helper walks the superclass chain and threads class-var state correctly (BT-2007).
 - **Workspace project loads accumulate** — loading project A then project B on the same REPL/MCP workspace no longer evicts project A's classes. Previous-mtime tracking is now scoped per-project root, so each `:sync` / `load_project` only treats files under its own tree as candidates for "deleted" classification. Cross-project class collisions surface as `warnings` in the load-project response instead of silently overwriting earlier classes (BT-2089).
+- Fix spurious namespace collision error when hot-reloading a `Protocol define:` file across surfaces (e.g., MCP after REPL) — the compiler now filters pre-loaded protocol class entries before hierarchy injection, and protocol re-registration is allowed when the existing class has superclass `Protocol` (BT-2088).
 
 ### Tooling
 
@@ -71,6 +72,8 @@
 - `just test-repl-protocol` replaces `just test-e2e`; deprecated alias kept for one release cycle (BT-2085).
 - `just check-surface-drift` CI gate ensures documented surface parity stays in sync with code (BT-2082).
 - **BREAKING: REPL protocol 2.0 — deprecated ops `docs`, `load-file`, `reload`, and `modules` removed.** WebSocket clients sending these ops now receive an `unknown_op` error. Migrate to the equivalent eval'd message-sends: `Beamtalk help: ClassName` (optionally `selector: #sel`), `Workspace load: "path"`, `ClassName reload`, `Workspace classes`. The `versions.protocol` field returned by `describe` is bumped from `1.0` to `2.0` to mark the break. The MCP tools `docs`, `load_file`, and `reload_class` continue to work — they were already routed through `evaluate` of the migration target. The CLI's `:help`, `:load`, and `:reload` REPL meta-commands are unaffected (they desugar to the new message-sends locally) (BT-2091).
+- `:interrupt` / `:int` REPL meta-command — sends an out-of-band interrupt to cancel a running evaluation. Because the main connection is blocked during eval, the interrupt is sent on a separate connection. Also fires automatically on Ctrl-C during eval (BT-2090).
+- Sealed-class and sealed-method constraint diagnostics now reach CLI and MCP lint surfaces — new `inheritance` diagnostic category ensures these are no longer silently dropped (BT-2087).
 
 ### Documentation
 

--- a/docs/beamtalk-tooling.md
+++ b/docs/beamtalk-tooling.md
@@ -407,6 +407,7 @@ Running 1 test class...
 | Command | Description |
 |---------|-------------|
 | `:clear` | Clear all variable bindings |
+| `:interrupt` / `:int` | Cancel a running evaluation (out-of-band) |
 | `:exit` / `:quit` / `:q` | Exit the REPL (Ctrl+D also works) |
 
 **`:clear`** removes all session-local variable bindings:
@@ -420,6 +421,13 @@ ok
 
 > x
 ERROR: Undefined variable
+```
+
+**`:interrupt`** cancels a running evaluation. Because the main connection is blocked while an eval is in progress, the interrupt is sent out-of-band on a separate connection. Ctrl-C during an eval sends an interrupt automatically.
+
+```beamtalk
+> :interrupt
+ok
 ```
 
 ### Multi-line Input


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 8 commits merged to `main` in the last 24 hours.

### Commits reviewed

| SHA | Title | Classification | Doc change |
|-----|-------|---------------|------------|
| `d5b688b` | Hard-remove deprecated REPL ops (BT-2091) | Tooling / Breaking | Already covered by PR #2131 — CHANGELOG, repl-protocol.md, surface-parity.md all updated inline |
| `2cddd2b` | Fix wrong asString assertion (BT-2094) | Test-only | **Skipped** — only touches `stdlib/test/character_test.bt` |
| `5b242b9` | Workspace project loads accumulate (BT-2089) | Runtime bug fix | Already covered by PR #2128 — CHANGELOG, repl-protocol.md updated inline |
| `f3ce6c0` | Extract escape_core_erlang_string helper (BT-2093) | Internal refactor | **Skipped** — pure mechanical refactor, no behavior change |
| `d64816d` | Protocol define: hot-reload without namespace collision (BT-2088) | Runtime bug fix | **Added** CHANGELOG entry under Runtime |
| `9d06e99` | REPL :interrupt meta-command (BT-2090) | Tooling — new feature | **Added** CHANGELOG entry under Tooling; **added** `:interrupt` / `:int` to `docs/beamtalk-tooling.md` Session Control table with usage example |
| `27fc7d9` | Categorize sealed-subclass diagnostics (BT-2087) | Tooling — diagnostic category | **Added** CHANGELOG entry under Tooling |
| `bd6a644` | Surface-only audit: promote-or-lock decisions (BT-2083) | Documentation / audit | **Skipped** — no user-facing code change; surface-parity.md already updated inline |

### Skipped (no doc impact)

- `2cddd2b` (BT-2094) — test-only change
- `f3ce6c0` (BT-2093) — internal codegen refactor
- `bd6a644` (BT-2083) — documentation audit, already updated inline

### Files updated

- **CHANGELOG.md** — 3 new entries: BT-2088 (protocol hot-reload fix, Runtime), BT-2090 (`:interrupt` meta-command, Tooling), BT-2087 (`inheritance` diagnostic category, Tooling)
- **docs/beamtalk-tooling.md** — `:interrupt` / `:int` added to Session Control table and documented with usage example

### Needs human judgment

None — all commits had clear user-visible semantics from diffs and tests.

https://claude.ai/code/session_01NfeWNZoLVEHyVAqVwriBkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfeWNZoLVEHyVAqVwriBkg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hot-reload behavior for Protocol definitions across multiple surfaces

* **New Features**
  * Added `:interrupt` (`:int`) command to cancel in-progress REPL evaluations
  * Enabled Ctrl-C keyboard shortcut for interrupting evaluations
  * Extended sealed-class and sealed-method constraint diagnostics coverage to CLI and MCP lint tools

* **Documentation**
  * Added documentation for the new REPL interrupt command

<!-- end of auto-generated comment: release notes by coderabbit.ai -->