### PR TITLE
Fix format!() violations in spec_codegen.rs Core Erlang spec generation (BT-2096)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
@@ -68,7 +68,7 @@ fn type_annotation_to_spec(annotation: &TypeAnnotation) -> Document<'static> {
             ]
         }
         TypeAnnotation::Singleton { name, .. } => {
-            Document::String(format!("{{'atom', 0, '{name}'}}"))
+            docvec!["{'atom', 0, '", Document::String(name.to_string()), "'}"]
         }
         TypeAnnotation::Generic {
             base, parameters, ..
@@ -231,7 +231,11 @@ pub fn generate_method_spec(
     };
 
     Some(docvec![
-        Document::String(format!("{{'{erlang_name}', {arity}}}")),
+        "{'",
+        Document::String(erlang_name),
+        "', ",
+        Document::String(arity.to_string()),
+        "}",
         ", [{'type', 0, 'fun', [",
         product,
         ", ",
@@ -288,7 +292,11 @@ fn generate_class_method_spec(method: &MethodDefinition) -> Option<Document<'sta
     ];
 
     Some(docvec![
-        Document::String(format!("{{'{erlang_name}', {arity}}}")),
+        "{'",
+        Document::String(erlang_name),
+        "', ",
+        Document::String(arity.to_string()),
+        "}",
         ", [{'type', 0, 'fun', [",
         product,
         ", ",


### PR DESCRIPTION
## Summary

Three `Document::String(format!(...))` calls in `spec_codegen.rs` were building Core Erlang fragments using `format!()`, directly violating the CLAUDE.md rule:

> **NEVER use `format!()` or string concatenation to produce Core Erlang fragments — not even for "simple" atoms, arities, or map keys.**

This rule was the subject of dedicated cleanup effort BT-875; this PR removes three regressions that slipped through.

## Changes

All in `crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs`:

- **Line 71** (`TypeAnnotation::Singleton`): `Document::String(format!("{{'atom', 0, '{name}'}}"))` → `docvec!["{'atom', 0, '", Document::String(name.to_string()), "'}"]`
- **Line 234** (instance method spec): `Document::String(format!("{{'{erlang_name}', {arity}}}"))` → `docvec!["{'", Document::String(erlang_name), "', ", Document::String(arity.to_string()), "}"]`
- **Line 291** (class method spec): same fix as line 234

Output is byte-identical in all cases — purely mechanical substitution of `format!()` + `Document::String` with `docvec!` composition.

## Testing

- All 700 `beamtalk-core` codegen tests pass, including `successful_codegen_no_format_artifacts`
- `cargo clippy` clean
- `cargo fmt --check` clean
- No Erlang files modified

## Linear

https://linear.app/beamtalk/issue/BT-2096/fix-format-violations-in-spec-codegenrs-core-erlang-spec-generation

---
_Generated by [Claude Code](https://claude.ai/code/session_012mAFeHycduL7eXX3r9NZXB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to code generation structure for Erlang specifications. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->