### PR TITLE
Replace fake // => _ comments with real printString assertions in stream_test (BT-2098)

### DIFF
--- a/stdlib/test/stream_test.bt
+++ b/stdlib/test/stream_test.bt
@@ -100,15 +100,12 @@ TestCase subclass: StreamTest
     self assert: ((Stream on: #(1, 2, 3, 4, 5)) inject: 0 into: [:sum :n |
       sum + n
     ]) equals: 15
-    (Stream from: 1) printString
-    // => _
-    (Stream on: #(1, 2, 3)) printString
-    // => _
+    self assert: (Stream from: 1) printString equals: "Stream(from: 1)"
+    self assert: (Stream on: #(1, 2, 3)) printString equals: "Stream(on: [...])"
     // Pipeline description
-    ((Stream from: 1) select: [:n | n isEven]) printString
-    // => _
-    (Stream from: 1) printString
-    // => _
+    self assert: ((Stream from: 1) select: [:n |
+      n isEven
+    ]) printString equals: "Stream(from: 1) | select: [...]"
     self assert: (Stream from: 1) class equals: Stream
     self assert: ((Stream on: #()) take: 5) equals: #()
     self assert: (Stream on: #()) asList equals: #()


### PR DESCRIPTION
## Summary

- Removes 4 inert `// => _` comment annotations from `testStreamConstructorsAndPipelines` in `stream_test.bt`, including one exact duplicate bare expression
- Replaces them with 3 real `self assert:equals:` assertions verifying the exact `printString` output
- Expected strings taken directly from `beamtalk_stream.erl` lines 97, 122, 158

## Changes

- `(Stream from: 1) printString // => _` → `self assert: ... equals: "Stream(from: 1)"`
- `(Stream on: #(1, 2, 3)) printString // => _` → `self assert: ... equals: "Stream(on: [...])"`
- `((Stream from: 1) select: [...]) printString // => _` → `self assert: ... equals: "Stream(from: 1) | select: [...]"`
- Removed duplicate `(Stream from: 1) printString // => _` expression

The `// => _` annotations inside a BUnit test method body are comments — they are never enforced. The actual assertion infrastructure only processes `// =>` in bootstrap and REPL-protocol test files.

## Test plan

- [x] `just test-bunit` — 1901 tests, 1899 passed, 0 failed
- [x] `just fmt-check-beamtalk` — no violations
- [x] Pre-existing 5 MCP test failures confirmed unrelated (present on base branch)

Closes https://linear.app/beamtalk/issue/BT-2098

https://claude.ai/code/session_01YCa2d5oVAZDDo7gRLtP7CN

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCa2d5oVAZDDo7gRLtP7CN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation for stream constructor formatting and lazy pipeline descriptions by replacing output documentation with explicit assertion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->