### PR TITLE
Extract object_kind_new_error helper in class_validators (BT-2099)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/validators/class_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/class_validators.rs
@@ -155,9 +155,9 @@ fn actor_must_spawn_error(class_name: &str, selector: &str, span: Span) -> Diagn
 }
 
 /// Creates a diagnostic for using `new`/`new:` on an Object-kind class (BT-1540).
-fn object_kind_new_error(class_name: &str, sel: &str, span: Span) -> Diagnostic {
+fn object_kind_new_error(class_name: &str, selector: &str, span: Span) -> Diagnostic {
     Diagnostic::error(
-        format!("Object-kind class `{class_name}` cannot be instantiated with `{sel}`"),
+        format!("Object-kind class `{class_name}` cannot be instantiated with `{selector}`"),
         span,
     )
     .with_hint("Object subclasses are not instantiable. Use `Value subclass:` for data types")

--- a/crates/beamtalk-core/src/semantic_analysis/validators/class_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/class_validators.rs
@@ -154,6 +154,16 @@ fn actor_must_spawn_error(class_name: &str, selector: &str, span: Span) -> Diagn
     .with_category(DiagnosticCategory::ActorNew)
 }
 
+/// Creates a diagnostic for using `new`/`new:` on an Object-kind class (BT-1540).
+fn object_kind_new_error(class_name: &str, sel: &str, span: Span) -> Diagnostic {
+    Diagnostic::error(
+        format!("Object-kind class `{class_name}` cannot be instantiated with `{sel}`"),
+        span,
+    )
+    .with_hint("Object subclasses are not instantiable. Use `Value subclass:` for data types")
+    .with_category(DiagnosticCategory::Type)
+}
+
 fn visit_actor_new(
     expr: &Expression,
     hierarchy: &ClassHierarchy,
@@ -234,18 +244,7 @@ fn visit_object_new(
         if let Some(class_name) = receiver_class_name(receiver) {
             let sel = selector.name();
             if is_object_new_error(class_name, &sel, hierarchy) {
-                diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "Object-kind class `{class_name}` cannot be instantiated with `{sel}`"
-                        ),
-                        *span,
-                    )
-                    .with_hint(
-                        "Object subclasses are not instantiable. Use `Value subclass:` for data types",
-                    )
-                    .with_category(DiagnosticCategory::Type),
-                );
+                diagnostics.push(object_kind_new_error(class_name, &sel, *span));
             }
         }
     }
@@ -258,18 +257,7 @@ fn visit_object_new(
             for msg in messages {
                 let sel = msg.selector.name();
                 if is_object_new_error(class_name, &sel, hierarchy) {
-                    diagnostics.push(
-                        Diagnostic::error(
-                            format!(
-                                "Object-kind class `{class_name}` cannot be instantiated with `{sel}`"
-                            ),
-                            msg.span,
-                        )
-                        .with_hint(
-                            "Object subclasses are not instantiable. Use `Value subclass:` for data types",
-                        )
-                        .with_category(DiagnosticCategory::Type),
-                    );
+                    diagnostics.push(object_kind_new_error(class_name, &sel, msg.span));
                 }
             }
         }


### PR DESCRIPTION
## Summary

`check_object_new_usage` (BT-1540) had the same 12-line `Diagnostic::error(...)` construction duplicated in its `MessageSend` and `Cascade` branches. This PR extracts it into a private `object_kind_new_error` helper, mirroring the `actor_must_spawn_error` pattern already established in the same file.

## Changes

- **`crates/beamtalk-core/src/semantic_analysis/validators/class_validators.rs`**
  - Add `object_kind_new_error(class_name, sel, span) -> Diagnostic` helper (lines 157–165)
  - Replace two identical 12-line inline constructions in `visit_object_new` with single-line calls

## Why it's safe

- Zero behavioral change: the new helper produces byte-for-byte identical diagnostics
- Follows the direct precedent of `actor_must_spawn_error` (line 148) and `abstract_class_error` (line 47) in the same file
- Net: −12 lines (24 removed, 12 added)
- All beamtalk-core unit tests pass

## Linear

https://linear.app/beamtalk/issue/BT-2099/extract-object-kind-new-error-helper-in-class-validatorsrs

---
_Generated by [Claude Code](https://claude.ai/code/session_016XRLahzdnu9t5BtHpCchsD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal validation code by removing duplicated diagnostic construction. This streamlines the implementation while preserving all existing error messages, hints, and validation behavior; no public interfaces or user-facing diagnostics changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->