### PR TITLE
Add unit tests for codegen primitives at 0% coverage (BT-2100)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/binary.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/binary.rs
@@ -75,3 +75,111 @@ pub(crate) fn generate_binary_bif(selector: &str, params: &[String]) -> Option<D
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::doc_to_string;
+    use super::*;
+
+    #[test]
+    fn test_size() {
+        let result = doc_to_string(generate_binary_bif("size", &[]));
+        assert_eq!(result, Some("call 'erlang':'byte_size'(Self)".to_string()));
+    }
+
+    #[test]
+    fn test_byte_size_alias() {
+        let result = doc_to_string(generate_binary_bif("byteSize", &[]));
+        assert_eq!(result, Some("call 'erlang':'byte_size'(Self)".to_string()));
+    }
+
+    #[test]
+    fn test_do() {
+        let result = doc_to_string(generate_binary_bif("do:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_binary':'do'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_print_string() {
+        let result = doc_to_string(generate_binary_bif("printString", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_binary':'print_string'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_at() {
+        let result = doc_to_string(generate_binary_bif("at:", &["Index".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_binary':'at'(Self, Index)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_byte_at() {
+        let result = doc_to_string(generate_binary_bif("byteAt:", &["Offset".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_binary':'byte_at'(Self, Offset)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_part_size() {
+        let result = doc_to_string(generate_binary_bif(
+            "part:size:",
+            &["Offset".to_string(), "Length".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_binary':'part'(Self, Offset, Length)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_concat() {
+        let result = doc_to_string(generate_binary_bif("concat:", &["Other".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_binary':'concat'(Self, Other)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_to_bytes() {
+        let result = doc_to_string(generate_binary_bif("toBytes", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_binary':'to_bytes'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_as_string() {
+        let result = doc_to_string(generate_binary_bif("asString", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_binary':'as_string'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_as_string_unchecked() {
+        let result = doc_to_string(generate_binary_bif("asStringUnchecked", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_binary':'as_string_unchecked'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_unknown_selector_returns_none() {
+        assert!(generate_binary_bif("size:", &[]).is_none());
+        assert!(generate_binary_bif("asInteger", &[]).is_none());
+    }
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/block.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/block.rs
@@ -28,3 +28,50 @@ pub(crate) fn generate_block_bif(selector: &str, params: &[String]) -> Option<Do
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::doc_to_string;
+    use super::*;
+
+    #[test]
+    fn test_arity() {
+        let result = doc_to_string(generate_block_bif("arity", &[]));
+        assert_eq!(
+            result,
+            Some(
+                "let <ArityTuple> = call 'erlang':'fun_info'(Self, 'arity') in \
+                 call 'erlang':'element'(2, ArityTuple)"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_value_with_arguments() {
+        let result = doc_to_string(generate_block_bif(
+            "valueWithArguments:",
+            &["MyArgs".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'apply'(Self, MyArgs)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_value_with_arguments_uses_default_when_no_params() {
+        let result = doc_to_string(generate_block_bif("valueWithArguments:", &[]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'apply'(Self, _Args)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_unknown_selector_returns_none() {
+        assert!(generate_block_bif("on:do:", &[]).is_none());
+        assert!(generate_block_bif("ensure:", &[]).is_none());
+        assert!(generate_block_bif("value", &[]).is_none());
+    }
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/collection.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/collection.rs
@@ -40,3 +40,36 @@ pub(crate) fn generate_collection_bif(
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::doc_to_string;
+    use super::*;
+
+    #[test]
+    fn test_inject_into_with_params() {
+        let result = doc_to_string(generate_collection_bif(
+            "inject:into:",
+            &["Initial".to_string(), "Block".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_collection':'inject_into'(Self, Initial, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_inject_into_uses_defaults_when_no_params() {
+        let result = doc_to_string(generate_collection_bif("inject:into:", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_collection':'inject_into'(Self, _Initial, _Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_unknown_selector_returns_none() {
+        assert!(generate_collection_bif("do:", &[]).is_none());
+        assert!(generate_collection_bif("collect:", &[]).is_none());
+    }
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/error_handling.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/error_handling.rs
@@ -86,3 +86,207 @@ pub(crate) fn generate_stack_frame_bif(
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::doc_to_string;
+    use super::*;
+
+    // generate_exception_bif tests
+
+    #[test]
+    fn test_exception_message() {
+        let result = doc_to_string(generate_exception_bif("message", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_exception_handler':'dispatch'('message', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_exception_hint() {
+        let result = doc_to_string(generate_exception_bif("hint", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_exception_handler':'dispatch'('hint', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_exception_kind() {
+        let result = doc_to_string(generate_exception_bif("kind", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_exception_handler':'dispatch'('kind', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_exception_selector() {
+        let result = doc_to_string(generate_exception_bif("selector", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_exception_handler':'dispatch'('selector', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_exception_error_class() {
+        let result = doc_to_string(generate_exception_bif("errorClass", &[]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'beamtalk_exception_handler':'dispatch'('errorClass', [], Self)".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_exception_print_string() {
+        let result = doc_to_string(generate_exception_bif("printString", &[]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'beamtalk_exception_handler':'dispatch'('printString', [], Self)".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_exception_signal() {
+        let result = doc_to_string(generate_exception_bif("signal", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_exception_handler':'dispatch'('signal', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_exception_signal_with_message() {
+        let result = doc_to_string(generate_exception_bif("signal:", &["Msg".to_string()]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'beamtalk_exception_handler':'dispatch'('signal:', [Msg], Self)".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_exception_stack_trace() {
+        let result = doc_to_string(generate_exception_bif("stackTrace", &[]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'beamtalk_exception_handler':'dispatch'('stackTrace', [], Self)".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_exception_class_signal_with_message() {
+        let result = doc_to_string(generate_exception_bif("classSignal:", &["Msg".to_string()]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'beamtalk_exception_handler':'class_signal_message'(Msg, ClassSelf)"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_exception_class_signal() {
+        let result = doc_to_string(generate_exception_bif("classSignal", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_exception_handler':'class_signal'(ClassSelf)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_exception_unknown_selector_returns_none() {
+        assert!(generate_exception_bif("raise", &[]).is_none());
+        assert!(generate_exception_bif("new", &[]).is_none());
+    }
+
+    // generate_stack_frame_bif tests
+
+    #[test]
+    fn test_stack_frame_method() {
+        let result = doc_to_string(generate_stack_frame_bif("method", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_stack_frame':'dispatch'('method', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_stack_frame_receiver_class() {
+        let result = doc_to_string(generate_stack_frame_bif("receiverClass", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_stack_frame':'dispatch'('receiverClass', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_stack_frame_arguments() {
+        let result = doc_to_string(generate_stack_frame_bif("arguments", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_stack_frame':'dispatch'('arguments', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_stack_frame_source_location() {
+        let result = doc_to_string(generate_stack_frame_bif("sourceLocation", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_stack_frame':'dispatch'('sourceLocation', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_stack_frame_module_name() {
+        let result = doc_to_string(generate_stack_frame_bif("moduleName", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_stack_frame':'dispatch'('moduleName', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_stack_frame_line() {
+        let result = doc_to_string(generate_stack_frame_bif("line", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_stack_frame':'dispatch'('line', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_stack_frame_file() {
+        let result = doc_to_string(generate_stack_frame_bif("file", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_stack_frame':'dispatch'('file', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_stack_frame_print_string() {
+        let result = doc_to_string(generate_stack_frame_bif("printString", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_stack_frame':'dispatch'('printString', [], Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_stack_frame_unknown_selector_returns_none() {
+        assert!(generate_stack_frame_bif("new", &[]).is_none());
+        assert!(generate_stack_frame_bif("signal", &[]).is_none());
+    }
+}


### PR DESCRIPTION
## Summary\n\nCloses coverage gap for four BIF-generator files in `crates/beamtalk-core/src/codegen/core_erlang/primitives/` that were at **0% line coverage** per the CI coverage artifact (run 24997480347 on main, 2026-04-27).\n\n- **`block.rs`** (14 exec lines → 100%): `arity`, `valueWithArguments:`, default-param fallback, unknown→None\n- **`collection.rs`** (15 exec lines → 100%): `inject:into:` with/without params, unknown→None\n- **`binary.rs`** (35 exec lines → 100%): all 9 match arms (`size`/`byteSize`, `do:`, `printString`, `at:`, `byteAt:`, `part:size:`, `concat:`, `toBytes`, `asString`, `asStringUnchecked`) + unknown→None\n- **`error_handling.rs`** (56 exec lines → 100%): all 11 arms of `generate_exception_bif` + all 8 selectors of `generate_stack_frame_bif` + unknown→None for both\n\n**37 new tests** following the `doc_to_string` pattern established by `behaviour.rs` and `protocol.rs` in the same directory.\n\n## Test plan\n\n- [x] `cargo test -p beamtalk-core` — all 3295 tests pass (0 failures)\n- [x] `cargo clippy --all-targets -- -D warnings` — clean\n- [x] `cargo fmt --all -- --check` — clean\n- [x] No snapshot changes required (purely additive `#[cfg(test)]` modules)\n\nhttps://linear.app/beamtalk/issue/BT-2100\nhttps://claude.ai/code/session_01H7SP6KzvLkuVR8eg3PjyZ4"

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7SP6KzvLkuVR8eg3PjyZ4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit test coverage for code generation modules validating correct output of Erlang call expressions for binary operations, block management, collection handling, and error handling primitives.
  * Tests verify proper behavior for supported selectors and confirm fallback behavior for unsupported operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->