### PR TITLE
Replace hardcoded /tmp/ paths with tempDirectory() in activity tracking tests (BT-2101)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_activity_tracking_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_activity_tracking_tests.erl
@@ -20,6 +20,9 @@ their respective test modules.
 %% Helpers
 %%====================================================================
 
+test_project_path() ->
+    iolist_to_binary([beamtalk_file:'tempDirectory'(), "/bt-activity-test"]).
+
 %% Stop any pre-existing beamtalk_workspace_meta process to ensure
 %% a clean slate for each test.
 stop_if_running() ->
@@ -41,7 +44,7 @@ session_connect_updates_activity_test() ->
     stop_if_running(),
     {ok, MetaPid} = beamtalk_workspace_meta:start_link(#{
         workspace_id => <<"test_session">>,
-        project_path => <<"/tmp/test">>,
+        project_path => test_project_path(),
         created_at => erlang:system_time(second)
     }),
 
@@ -69,7 +72,7 @@ actor_spawn_updates_activity_test() ->
     stop_if_running(),
     {ok, MetaPid} = beamtalk_workspace_meta:start_link(#{
         workspace_id => <<"test_actor">>,
-        project_path => <<"/tmp/test">>,
+        project_path => test_project_path(),
         created_at => erlang:system_time(second)
     }),
 
@@ -97,7 +100,7 @@ code_reload_updates_activity_test() ->
     stop_if_running(),
     {ok, MetaPid} = beamtalk_workspace_meta:start_link(#{
         workspace_id => <<"test_reload">>,
-        project_path => <<"/tmp/test">>,
+        project_path => test_project_path(),
         created_at => erlang:system_time(second)
     }),
 
@@ -125,7 +128,7 @@ multiple_activity_updates_test() ->
     stop_if_running(),
     {ok, MetaPid} = beamtalk_workspace_meta:start_link(#{
         workspace_id => <<"test_multiple">>,
-        project_path => <<"/tmp/test">>,
+        project_path => test_project_path(),
         created_at => erlang:system_time(second)
     }),
 
@@ -160,7 +163,7 @@ mark_activity_delegates_to_workspace_meta_test() ->
     stop_if_running(),
     {ok, MetaPid} = beamtalk_workspace_meta:start_link(#{
         workspace_id => <<"test_mark">>,
-        project_path => <<"/tmp/test">>,
+        project_path => test_project_path(),
         created_at => erlang:system_time(second)
     }),
 


### PR DESCRIPTION
## Summary

Fixes 5 hardcoded `<<"/tmp/test">>` project_path values in `beamtalk_activity_tracking_tests.erl` that violated the CLAUDE.md cross-platform temp path rule.

**Linear issue:** https://linear.app/beamtalk/issue/BT-2101

## Changes

- Add `test_project_path/0` helper that derives the path from `beamtalk_file:'tempDirectory'()` — the CLAUDE.md-prescribed cross-platform API
- Replace all 5 hardcoded `<<"/tmp/test">>` occurrences with `test_project_path()`

## Why it's safe

The `project_path` value in these tests is passed to `beamtalk_workspace_meta:start_link/1` and stored in workspace state, but never accessed as a real filesystem path — all 5 tests exercise only `update_activity/0` and `get_last_activity/0`. No assertions check the path value directly.

## Verification

- File compiles cleanly via `erlc`
- `beamtalk_file:'tempDirectory'()` confirmed to return `<<"/tmp">>` on Linux and correctly composable via `iolist_to_binary/1`
- Rust clippy ✅, Rust fmt ✅
- Zero `/tmp/` hardcodes remain in the file

https://claude.ai/code/session_01ANQiga35uaw5P2fszuaqdw

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANQiga35uaw5P2fszuaqdw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for enhanced reliability and consistency in activity tracking tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->