### PR TITLE
refactor: replace format!() with Document API in counted_loops codegen (BT-2102)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/counted_loops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/counted_loops.rs
@@ -30,11 +30,19 @@ impl CoreErlangGenerator {
         let body_var = self.fresh_temp_var("BodyFun");
         let body_code = self.expression_doc(body)?;
         Ok(docvec![
-            format!("letrec '{loop_fn}'/0 = fun () -> "),
-            format!("let {body_var} = "),
+            "letrec '",
+            Document::String(loop_fn.clone()),
+            "'/0 = fun () -> let ",
+            Document::String(body_var.clone()),
+            " = ",
             body_code,
-            format!(" in let _ = apply {body_var} () in apply '{loop_fn}'/0 () "),
-            format!("in apply '{loop_fn}'/0 ()"),
+            " in let _ = apply ",
+            Document::String(body_var),
+            " () in apply '",
+            Document::String(loop_fn.clone()),
+            "'/0 () in apply '",
+            Document::String(loop_fn),
+            "'/0 ()",
         ])
     }
 
@@ -50,10 +58,18 @@ impl CoreErlangGenerator {
         let receiver_code = self.expression_doc(receiver)?;
 
         let frame = CountedLoopFrame {
-            preamble: docvec![format!("let {n_var} = "), receiver_code, " in"],
+            preamble: docvec![
+                "let ",
+                Document::String(n_var.clone()),
+                " = ",
+                receiver_code,
+                " in"
+            ],
             fn_name: "repeat".to_string(),
             continue_header: docvec![
-                format!("case call 'erlang':'=<'(I, {n_var}) of "),
+                "case call 'erlang':'=<'(I, ",
+                Document::String(n_var),
+                ") of ",
                 "<'true'> when 'true' -> ",
             ],
             next_counter: "call 'erlang':'+'(I, 1)".to_string(),
@@ -84,15 +100,21 @@ impl CoreErlangGenerator {
 
         let frame = CountedLoopFrame {
             preamble: docvec![
-                format!("let {start_var} = "),
+                "let ",
+                Document::String(start_var.clone()),
+                " = ",
                 receiver_code,
-                format!(" in let {end_var} = "),
+                " in let ",
+                Document::String(end_var.clone()),
+                " = ",
                 limit_code,
                 " in",
             ],
             fn_name: "loop".to_string(),
             continue_header: docvec![
-                format!("case call 'erlang':'=<'(I, {end_var}) of "),
+                "case call 'erlang':'=<'(I, ",
+                Document::String(end_var),
+                ") of ",
                 "<'true'> when 'true' -> ",
             ],
             next_counter: "call 'erlang':'+'(I, 1)".to_string(),
@@ -125,21 +147,35 @@ impl CoreErlangGenerator {
 
         let frame = CountedLoopFrame {
             preamble: docvec![
-                format!("let {start_var} = "),
+                "let ",
+                Document::String(start_var.clone()),
+                " = ",
                 receiver_code,
-                format!(" in let {end_var} = "),
+                " in let ",
+                Document::String(end_var.clone()),
+                " = ",
                 limit_code,
-                format!(" in let {step_var} = "),
+                " in let ",
+                Document::String(step_var.clone()),
+                " = ",
                 step_code,
                 " in",
             ],
             fn_name: "loop".to_string(),
             continue_header: docvec![
-                format!("let Continue = case call 'erlang':'>'({step_var}, 0) of "),
-                format!("<'true'> when 'true' -> call 'erlang':'=<'(I, {end_var}) "),
+                "let Continue = case call 'erlang':'>'(",
+                Document::String(step_var.clone()),
+                ", 0) of ",
+                "<'true'> when 'true' -> call 'erlang':'=<'(I, ",
+                Document::String(end_var.clone()),
+                ") ",
                 "<'false'> when 'true' -> ",
-                format!("case call 'erlang':'<'({step_var}, 0) of "),
-                format!("<'true'> when 'true' -> call 'erlang':'>='(I, {end_var}) "),
+                "case call 'erlang':'<'(",
+                Document::String(step_var.clone()),
+                ", 0) of ",
+                "<'true'> when 'true' -> call 'erlang':'>='(I, ",
+                Document::String(end_var),
+                ") ",
                 "<'false'> when 'true' -> 'false' ",
                 "end ",
                 "end in case Continue of ",


### PR DESCRIPTION
## Summary

- Replace all 16 `format!()` calls in `Document<'static>`-typed positions in `counted_loops.rs` with `docvec![]` + `Document::String(var)` fragments
- Fixes CLAUDE.md rule violation: "NEVER use `format!()` or string concatenation to produce Core Erlang fragments"
- No behavior change — codegen output is identical

## Changes

**`crates/beamtalk-core/src/codegen/core_erlang/control_flow/counted_loops.rs`**

Four functions fixed:
- `generate_repeat` — 4 `format!()` calls in the final `docvec![]` return
- `generate_times_repeat_with_mutations` — 2 `format!()` calls in `preamble` / `continue_header`
- `generate_to_do_with_mutations` — 3 `format!()` calls in `preamble` / `continue_header`
- `generate_to_by_do_with_mutations` — 7 `format!()` calls in `preamble` / `continue_header`

Intentionally left as-is (out of scope — requires `CountedLoopFrame` struct refactor):
- `next_counter: format!(...)` — this is a `String` field, not `Document`; tracked as follow-up

## Testing

- All 10 existing unit tests pass (`cargo test -p beamtalk-core counted_loops`)
- `just clippy` passes clean
- `cargo fmt` clean

## Follow-up

Remaining `format!()` violations in the codegen layer:
- `dispatch_codegen.rs` (~40 violations)
- `mod.rs` (~5 violations)
- `CountedLoopFrame.next_counter` String field (struct refactor needed)

Fixes BT-2102

https://claude.ai/code/session_01NeneKUudnGRQYNuy4ybMJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeneKUudnGRQYNuy4ybMJA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code generation architecture for counted loops in Erlang compilation through enhanced variable handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->