### PR TITLE
Add EUnit tests for beamtalk_session_table (BT-2103)

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_session_table_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_session_table_tests.erl
@@ -1,0 +1,77 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_session_table_tests).
+
+-moduledoc """
+Unit tests for beamtalk_session_table.
+
+Covers new/0 (including idempotency), insert/2, lookup/1 (found and
+missing branches), and delete/1. The resolve_pid/2 branches are already
+exercised in beamtalk_repl_server_tests (BT-1045).
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Test fixture
+%%====================================================================
+
+session_table_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun new_creates_table/1,
+        fun new_is_idempotent/1,
+        fun insert_and_lookup/1,
+        fun lookup_missing_returns_error/1,
+        fun delete_removes_entry/1,
+        fun delete_missing_is_safe/1
+    ]}.
+
+setup() ->
+    case ets:whereis(beamtalk_sessions) of
+        undefined -> ok;
+        _Tid -> ets:delete(beamtalk_sessions)
+    end,
+    beamtalk_session_table:new(),
+    ok.
+
+cleanup(_) ->
+    case ets:whereis(beamtalk_sessions) of
+        undefined -> ok;
+        _Tid -> ets:delete(beamtalk_sessions)
+    end.
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+%%% new/0 tests
+
+new_creates_table(_) ->
+    [?_assertNotEqual(undefined, ets:whereis(beamtalk_sessions))].
+
+new_is_idempotent(_) ->
+    %% A second call on an already-existing table must still return ok.
+    [?_assertEqual(ok, beamtalk_session_table:new())].
+
+%%% insert/2 + lookup/1 tests
+
+insert_and_lookup(_) ->
+    Pid = self(),
+    beamtalk_session_table:insert(<<"s1">>, Pid),
+    [?_assertEqual({ok, Pid}, beamtalk_session_table:lookup(<<"s1">>))].
+
+lookup_missing_returns_error(_) ->
+    [?_assertEqual(error, beamtalk_session_table:lookup(<<"no_such_session">>))].
+
+%%% delete/1 tests
+
+delete_removes_entry(_) ->
+    Pid = self(),
+    beamtalk_session_table:insert(<<"s2">>, Pid),
+    beamtalk_session_table:delete(<<"s2">>),
+    [?_assertEqual(error, beamtalk_session_table:lookup(<<"s2">>))].
+
+delete_missing_is_safe(_) ->
+    %% ets:delete/2 on a missing key returns true — must not raise.
+    [?_assertEqual(true, beamtalk_session_table:delete(<<"ghost">>))].


### PR DESCRIPTION
## Summary

Adds a dedicated EUnit test module for `beamtalk_session_table`, which had zero tests despite being a non-trivial module used throughout the workspace.

**Linear:** https://linear.app/beamtalk/issue/BT-2103/add-eunit-tests-for-beamtalk-session-table-0percent-coverage

## What's covered

- `new/0` — table creation and idempotency (the `_ -> ok` branch when the table already exists was previously uncovered)
- `insert/2` + `lookup/1` — both the found branch (`{ok, Pid}`) and missing-key branch (`error`) tested directly; `lookup/1` was previously only reached indirectly through `resolve_pid/2`'s internal `ets:lookup` call
- `delete/1` — removal and no-op on a missing key

`resolve_pid/2` is fully exercised by `beamtalk_repl_server_tests` (BT-1045) and is not duplicated here.

## Key changes

- **New:** `runtime/apps/beamtalk_workspace/test/beamtalk_session_table_tests.erl` (+77 lines)
- No source changes

Uses `foreach` setup/cleanup to isolate the `beamtalk_sessions` named ETS table between tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KijqdABBPYSAgGRMTu9C5J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suite for session table functionality, covering initialization, idempotency checks, insert/lookup operations, and deletion handling to ensure robust session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->