### PR TITLE
Tighten block printString assertion in ObjectProtocolTest (BT-2104)

### DIFF
--- a/stdlib/test/object_protocol_test.bt
+++ b/stdlib/test/object_protocol_test.bt
@@ -24,8 +24,10 @@ TestCase subclass: ObjectProtocolTest
     self assert: #(1, 2, 3) printString equals: "#(1, 2, 3)"
     self assert: #() printString equals: "#()"
     // --- Blocks ---
-    self assert: ([42] printString) notNil
+    self assert: ([42] printString) equals: "a Block"
     // --- Dictionaries ---
+    // "#{}" is 3 chars; exact equality can't be asserted (#{} in a string
+    // triggers empty interpolation — language limitation)
     self assert: #{} printString size equals: 3
     // --- Class objects (BT-477: class_send printString) ---
     self assert: 42 class printString equals: "Integer"


### PR DESCRIPTION
## Summary

Tightens one weak assertion in `stdlib/test/object_protocol_test.bt` and adds a comment explaining a language limitation that prevents tightening a second one.

**Change:** Replace `([42] printString) notNil` with `([42] printString) equals: "a Block"`

The expected value is proven correct from stdlib source:
- `Object.bt:92`: `printString -> String => "a " ++ self class printString`
- `Block.bt`: class name is `Block` → printString is `"a Block"`

Previously, a garbage string (e.g., `"oops"`) would satisfy `notNil`. The new assertion catches format regressions.

**No change to dict assertion:** `#{} printString size equals: 3` stays as-is because `"#{}"` cannot be expressed as a Beamtalk string literal — `{}` inside a string triggers empty-interpolation syntax, making exact equality impossible with current language. A comment explains this.

## Test plan
- [x] `ObjectProtocolTest` 4/4 tests pass
- [x] No Erlang files changed (Dialyzer skipped by stamp — pre-existing env can't fetch cowboy from hexpm)
- [x] Rust clippy + fmt-check pass
- [x] Beamtalk fmt-check passes
- [x] Pre-existing `TracingTest` failures (4) confirmed on `main` — unrelated

## References
- Linear: https://linear.app/beamtalk/issue/BT-2104
- `stdlib/src/Object.bt:92` — default printString implementation
- `stdlib/src/Dictionary.bt:146` — dict printString docstring (confirms `"#{}"` format)

https://claude.ai/code/session_018eu8PxLZChQgCAaGhcKZdB

---
_Generated by [Claude Code](https://claude.ai/code/session_018eu8PxLZChQgCAaGhcKZdB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test assertions for improved validation of string representations.

* **Documentation**
  * Documented string interpolation limitation affecting string output comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->