### PR TITLE
Add EUnit tests for bindings and class event pub-sub servers (BT-2108)

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_bindings_events_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_bindings_events_tests.erl
@@ -3,6 +3,8 @@
 
 -module(beamtalk_bindings_events_tests).
 
+%%% **DDD Context:** REPL Session Context
+
 -moduledoc "Tests for beamtalk_bindings_events pub/sub gen_server.".
 -include_lib("eunit/include/eunit.hrl").
 
@@ -240,14 +242,14 @@ unknown_call_returns_error_test() ->
 unknown_cast_is_ignored_test() ->
     {ok, Pid} = gen_server:start_link(beamtalk_bindings_events, [], []),
     gen_server:cast(Pid, some_unknown_cast),
-    timer:sleep(10),
+    sys:get_state(Pid),
     ?assert(is_process_alive(Pid)),
     gen_server:stop(Pid).
 
 unknown_info_is_ignored_test() ->
     {ok, Pid} = gen_server:start_link(beamtalk_bindings_events, [], []),
     Pid ! {some_unknown, message},
-    timer:sleep(10),
+    sys:get_state(Pid),
     ?assert(is_process_alive(Pid)),
     gen_server:stop(Pid).
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_bindings_events_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_bindings_events_tests.erl
@@ -106,7 +106,8 @@ unsubscribe_when_not_subscribed_is_safe_test() ->
         sys:get_state(Pid),
         ?assert(is_process_alive(Pid))
     after
-        gen_server:stop(Pid)
+        gen_server:stop(Pid),
+        flush_messages()
     end.
 
 %%% ===========================================================================
@@ -121,6 +122,8 @@ multiple_subscribers_all_notified_test() ->
     try
         Sub1 = spawn(fun() ->
             beamtalk_bindings_events:subscribe(),
+            %% Same-sender sync: subscribe cast is processed before this returns
+            sys:get_state(beamtalk_bindings_events),
             Self ! sub1_subscribed,
             receive
                 {bindings_changed, _} = Msg -> Self ! {sub1, Msg}
@@ -129,6 +132,7 @@ multiple_subscribers_all_notified_test() ->
         end),
         Sub2 = spawn(fun() ->
             beamtalk_bindings_events:subscribe(),
+            sys:get_state(beamtalk_bindings_events),
             Self ! sub2_subscribed,
             receive
                 {bindings_changed, _} = Msg -> Self ! {sub2, Msg}
@@ -137,14 +141,12 @@ multiple_subscribers_all_notified_test() ->
         end),
         receive
             sub1_subscribed -> ok
-        after 500 -> ok
+        after 500 -> ?assert(false)
         end,
         receive
             sub2_subscribed -> ok
-        after 500 -> ok
+        after 500 -> ?assert(false)
         end,
-        %% Sync: both subscribe casts processed
-        sys:get_state(Pid),
 
         beamtalk_bindings_events:on_bindings_changed(<<"sess-broadcast">>),
         sys:get_state(Pid),
@@ -178,6 +180,8 @@ dead_subscriber_auto_removed_test() ->
     try
         SubPid = spawn(fun() ->
             beamtalk_bindings_events:subscribe(),
+            %% Same-sender sync: subscribe cast is processed before notifying parent
+            sys:get_state(beamtalk_bindings_events),
             Self ! subscribed,
             receive
                 stop -> ok
@@ -185,14 +189,21 @@ dead_subscriber_auto_removed_test() ->
         end),
         receive
             subscribed -> ok
-        after 500 -> ok
+        after 500 -> ?assert(false)
         end,
-        sys:get_state(Pid),
+
+        %% Subscriber should be present in the map before kill
+        {state, SubsBefore} = sys:get_state(Pid),
+        ?assert(maps:is_key(SubPid, SubsBefore)),
 
         exit(SubPid, kill),
-        timer:sleep(50),
-        %% Sync: DOWN message processed
-        sys:get_state(Pid),
+        %% Wait for DOWN to be processed; sys:get_state alone races with the
+        %% DOWN message because they originate from different senders.
+        wait_until_removed(Pid, SubPid, 20),
+
+        %% Subscriber should be gone from the map
+        {state, SubsAfter} = sys:get_state(Pid),
+        ?assertNot(maps:is_key(SubPid, SubsAfter)),
 
         %% Server should still be alive and handle events without crashing
         beamtalk_bindings_events:on_bindings_changed(<<"sess-after-dead">>),
@@ -248,4 +259,19 @@ flush_messages() ->
     receive
         _ -> flush_messages()
     after 0 -> ok
+    end.
+
+%% Poll the server state until Pid is no longer in the subscribers map.
+%% Needed because the DOWN message and our sys:get_state come from different
+%% senders, so ordering between them is not guaranteed.
+wait_until_removed(_Server, _Pid, 0) ->
+    ?assert(false);
+wait_until_removed(Server, Pid, N) ->
+    {state, Subs} = sys:get_state(Server),
+    case maps:is_key(Pid, Subs) of
+        false ->
+            ok;
+        true ->
+            timer:sleep(10),
+            wait_until_removed(Server, Pid, N - 1)
     end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_bindings_events_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_bindings_events_tests.erl
@@ -1,0 +1,251 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_bindings_events_tests).
+
+-moduledoc "Tests for beamtalk_bindings_events pub/sub gen_server.".
+-include_lib("eunit/include/eunit.hrl").
+
+%%% ===========================================================================
+%%% Lifecycle Tests
+%%% ===========================================================================
+
+server_starts_and_stops_test() ->
+    {ok, Pid} = gen_server:start_link(beamtalk_bindings_events, [], []),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid),
+    ?assertNot(is_process_alive(Pid)).
+
+%%% ===========================================================================
+%%% Subscribe / Unsubscribe Tests
+%%% ===========================================================================
+
+subscribe_receives_bindings_changed_notification_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_bindings_events}, beamtalk_bindings_events, [], []
+    ),
+    try
+        beamtalk_bindings_events:subscribe(),
+        %% Sync: ensure cast is processed before we fire the event
+        sys:get_state(Pid),
+
+        beamtalk_bindings_events:on_bindings_changed(<<"sess-1">>),
+        sys:get_state(Pid),
+
+        receive
+            {bindings_changed, <<"sess-1">>} -> ok
+        after 500 ->
+            ?assert(false)
+        end
+    after
+        gen_server:stop(Pid),
+        flush_messages()
+    end.
+
+duplicate_subscribe_is_idempotent_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_bindings_events}, beamtalk_bindings_events, [], []
+    ),
+    try
+        beamtalk_bindings_events:subscribe(),
+        beamtalk_bindings_events:subscribe(),
+        sys:get_state(Pid),
+
+        beamtalk_bindings_events:on_bindings_changed(<<"sess-dup">>),
+        sys:get_state(Pid),
+
+        %% Should receive exactly one notification, not two
+        receive
+            {bindings_changed, <<"sess-dup">>} -> ok
+        after 500 ->
+            ?assert(false)
+        end,
+        receive
+            {bindings_changed, <<"sess-dup">>} ->
+                ?assert(false)
+        after 50 ->
+            ok
+        end
+    after
+        gen_server:stop(Pid),
+        flush_messages()
+    end.
+
+unsubscribe_stops_notifications_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_bindings_events}, beamtalk_bindings_events, [], []
+    ),
+    try
+        beamtalk_bindings_events:subscribe(),
+        sys:get_state(Pid),
+
+        beamtalk_bindings_events:unsubscribe(),
+        sys:get_state(Pid),
+
+        beamtalk_bindings_events:on_bindings_changed(<<"sess-2">>),
+        sys:get_state(Pid),
+
+        receive
+            {bindings_changed, <<"sess-2">>} ->
+                ?assert(false)
+        after 100 ->
+            ok
+        end
+    after
+        gen_server:stop(Pid),
+        flush_messages()
+    end.
+
+unsubscribe_when_not_subscribed_is_safe_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_bindings_events}, beamtalk_bindings_events, [], []
+    ),
+    try
+        %% Should not crash — hits the `error` branch in maps:find
+        beamtalk_bindings_events:unsubscribe(),
+        sys:get_state(Pid),
+        ?assert(is_process_alive(Pid))
+    after
+        gen_server:stop(Pid)
+    end.
+
+%%% ===========================================================================
+%%% Multi-subscriber broadcast
+%%% ===========================================================================
+
+multiple_subscribers_all_notified_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_bindings_events}, beamtalk_bindings_events, [], []
+    ),
+    Self = self(),
+    try
+        Sub1 = spawn(fun() ->
+            beamtalk_bindings_events:subscribe(),
+            Self ! sub1_subscribed,
+            receive
+                {bindings_changed, _} = Msg -> Self ! {sub1, Msg}
+            after 1000 -> Self ! sub1_timeout
+            end
+        end),
+        Sub2 = spawn(fun() ->
+            beamtalk_bindings_events:subscribe(),
+            Self ! sub2_subscribed,
+            receive
+                {bindings_changed, _} = Msg -> Self ! {sub2, Msg}
+            after 1000 -> Self ! sub2_timeout
+            end
+        end),
+        receive
+            sub1_subscribed -> ok
+        after 500 -> ok
+        end,
+        receive
+            sub2_subscribed -> ok
+        after 500 -> ok
+        end,
+        %% Sync: both subscribe casts processed
+        sys:get_state(Pid),
+
+        beamtalk_bindings_events:on_bindings_changed(<<"sess-broadcast">>),
+        sys:get_state(Pid),
+
+        receive
+            {sub1, {bindings_changed, <<"sess-broadcast">>}} -> ok
+        after 500 ->
+            ?assert(false)
+        end,
+        receive
+            {sub2, {bindings_changed, <<"sess-broadcast">>}} -> ok
+        after 500 ->
+            ?assert(false)
+        end,
+        exit(Sub1, kill),
+        exit(Sub2, kill)
+    after
+        gen_server:stop(Pid),
+        flush_messages()
+    end.
+
+%%% ===========================================================================
+%%% Dead Subscriber Auto-removal
+%%% ===========================================================================
+
+dead_subscriber_auto_removed_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_bindings_events}, beamtalk_bindings_events, [], []
+    ),
+    Self = self(),
+    try
+        SubPid = spawn(fun() ->
+            beamtalk_bindings_events:subscribe(),
+            Self ! subscribed,
+            receive
+                stop -> ok
+            end
+        end),
+        receive
+            subscribed -> ok
+        after 500 -> ok
+        end,
+        sys:get_state(Pid),
+
+        exit(SubPid, kill),
+        timer:sleep(50),
+        %% Sync: DOWN message processed
+        sys:get_state(Pid),
+
+        %% Server should still be alive and handle events without crashing
+        beamtalk_bindings_events:on_bindings_changed(<<"sess-after-dead">>),
+        sys:get_state(Pid),
+        ?assert(is_process_alive(Pid))
+    after
+        gen_server:stop(Pid),
+        flush_messages()
+    end.
+
+%%% ===========================================================================
+%%% on_bindings_changed when server not running
+%%% ===========================================================================
+
+on_bindings_changed_when_server_down_is_safe_test() ->
+    %% Ensure no registered server
+    case whereis(beamtalk_bindings_events) of
+        undefined -> ok;
+        ExistingPid -> gen_server:stop(ExistingPid)
+    end,
+    %% Should return ok without crashing — hits the `undefined` branch
+    Result = beamtalk_bindings_events:on_bindings_changed(<<"sess-no-server">>),
+    ?assertEqual(ok, Result).
+
+%%% ===========================================================================
+%%% Gen_server Callback Edge Cases
+%%% ===========================================================================
+
+unknown_call_returns_error_test() ->
+    {ok, Pid} = gen_server:start_link(beamtalk_bindings_events, [], []),
+    ?assertEqual({error, unknown_request}, gen_server:call(Pid, some_unknown_request)),
+    gen_server:stop(Pid).
+
+unknown_cast_is_ignored_test() ->
+    {ok, Pid} = gen_server:start_link(beamtalk_bindings_events, [], []),
+    gen_server:cast(Pid, some_unknown_cast),
+    timer:sleep(10),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+unknown_info_is_ignored_test() ->
+    {ok, Pid} = gen_server:start_link(beamtalk_bindings_events, [], []),
+    Pid ! {some_unknown, message},
+    timer:sleep(10),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+%%% ===========================================================================
+%%% Internal helpers
+%%% ===========================================================================
+
+flush_messages() ->
+    receive
+        _ -> flush_messages()
+    after 0 -> ok
+    end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_class_events_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_class_events_tests.erl
@@ -3,6 +3,8 @@
 
 -module(beamtalk_class_events_tests).
 
+%%% **DDD Context:** REPL Session Context
+
 -moduledoc "Tests for beamtalk_class_events pub/sub gen_server.".
 -include_lib("eunit/include/eunit.hrl").
 
@@ -240,14 +242,14 @@ unknown_call_returns_error_test() ->
 unknown_cast_is_ignored_test() ->
     {ok, Pid} = gen_server:start_link(beamtalk_class_events, [], []),
     gen_server:cast(Pid, some_unknown_cast),
-    timer:sleep(10),
+    sys:get_state(Pid),
     ?assert(is_process_alive(Pid)),
     gen_server:stop(Pid).
 
 unknown_info_is_ignored_test() ->
     {ok, Pid} = gen_server:start_link(beamtalk_class_events, [], []),
     Pid ! {some_unknown, message},
-    timer:sleep(10),
+    sys:get_state(Pid),
     ?assert(is_process_alive(Pid)),
     gen_server:stop(Pid).
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_class_events_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_class_events_tests.erl
@@ -106,7 +106,8 @@ unsubscribe_when_not_subscribed_is_safe_test() ->
         sys:get_state(Pid),
         ?assert(is_process_alive(Pid))
     after
-        gen_server:stop(Pid)
+        gen_server:stop(Pid),
+        flush_messages()
     end.
 
 %%% ===========================================================================
@@ -121,6 +122,8 @@ multiple_subscribers_all_notified_test() ->
     try
         Sub1 = spawn(fun() ->
             beamtalk_class_events:subscribe(),
+            %% Same-sender sync: subscribe cast is processed before this returns
+            sys:get_state(beamtalk_class_events),
             Self ! sub1_subscribed,
             receive
                 {class_loaded, _} = Msg -> Self ! {sub1, Msg}
@@ -129,6 +132,7 @@ multiple_subscribers_all_notified_test() ->
         end),
         Sub2 = spawn(fun() ->
             beamtalk_class_events:subscribe(),
+            sys:get_state(beamtalk_class_events),
             Self ! sub2_subscribed,
             receive
                 {class_loaded, _} = Msg -> Self ! {sub2, Msg}
@@ -137,14 +141,12 @@ multiple_subscribers_all_notified_test() ->
         end),
         receive
             sub1_subscribed -> ok
-        after 500 -> ok
+        after 500 -> ?assert(false)
         end,
         receive
             sub2_subscribed -> ok
-        after 500 -> ok
+        after 500 -> ?assert(false)
         end,
-        %% Sync: both subscribe casts processed
-        sys:get_state(Pid),
 
         beamtalk_class_events:on_class_loaded('BroadcastClass'),
         sys:get_state(Pid),
@@ -178,6 +180,8 @@ dead_subscriber_auto_removed_test() ->
     try
         SubPid = spawn(fun() ->
             beamtalk_class_events:subscribe(),
+            %% Same-sender sync: subscribe cast is processed before notifying parent
+            sys:get_state(beamtalk_class_events),
             Self ! subscribed,
             receive
                 stop -> ok
@@ -185,14 +189,21 @@ dead_subscriber_auto_removed_test() ->
         end),
         receive
             subscribed -> ok
-        after 500 -> ok
+        after 500 -> ?assert(false)
         end,
-        sys:get_state(Pid),
+
+        %% Subscriber should be present in the map before kill
+        {state, SubsBefore} = sys:get_state(Pid),
+        ?assert(maps:is_key(SubPid, SubsBefore)),
 
         exit(SubPid, kill),
-        timer:sleep(50),
-        %% Sync: DOWN message processed
-        sys:get_state(Pid),
+        %% Wait for DOWN to be processed; sys:get_state alone races with the
+        %% DOWN message because they originate from different senders.
+        wait_until_removed(Pid, SubPid, 20),
+
+        %% Subscriber should be gone from the map
+        {state, SubsAfter} = sys:get_state(Pid),
+        ?assertNot(maps:is_key(SubPid, SubsAfter)),
 
         %% Server should still be alive and handle events without crashing
         beamtalk_class_events:on_class_loaded('PostDeadClass'),
@@ -248,4 +259,19 @@ flush_messages() ->
     receive
         _ -> flush_messages()
     after 0 -> ok
+    end.
+
+%% Poll the server state until Pid is no longer in the subscribers map.
+%% Needed because the DOWN message and our sys:get_state come from different
+%% senders, so ordering between them is not guaranteed.
+wait_until_removed(_Server, _Pid, 0) ->
+    ?assert(false);
+wait_until_removed(Server, Pid, N) ->
+    {state, Subs} = sys:get_state(Server),
+    case maps:is_key(Pid, Subs) of
+        false ->
+            ok;
+        true ->
+            timer:sleep(10),
+            wait_until_removed(Server, Pid, N - 1)
     end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_class_events_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_class_events_tests.erl
@@ -1,0 +1,251 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_class_events_tests).
+
+-moduledoc "Tests for beamtalk_class_events pub/sub gen_server.".
+-include_lib("eunit/include/eunit.hrl").
+
+%%% ===========================================================================
+%%% Lifecycle Tests
+%%% ===========================================================================
+
+server_starts_and_stops_test() ->
+    {ok, Pid} = gen_server:start_link(beamtalk_class_events, [], []),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid),
+    ?assertNot(is_process_alive(Pid)).
+
+%%% ===========================================================================
+%%% Subscribe / Unsubscribe Tests
+%%% ===========================================================================
+
+subscribe_receives_class_loaded_notification_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_class_events}, beamtalk_class_events, [], []
+    ),
+    try
+        beamtalk_class_events:subscribe(),
+        %% Sync: ensure cast is processed before we fire the event
+        sys:get_state(Pid),
+
+        beamtalk_class_events:on_class_loaded('MyClass'),
+        sys:get_state(Pid),
+
+        receive
+            {class_loaded, 'MyClass'} -> ok
+        after 500 ->
+            ?assert(false)
+        end
+    after
+        gen_server:stop(Pid),
+        flush_messages()
+    end.
+
+duplicate_subscribe_is_idempotent_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_class_events}, beamtalk_class_events, [], []
+    ),
+    try
+        beamtalk_class_events:subscribe(),
+        beamtalk_class_events:subscribe(),
+        sys:get_state(Pid),
+
+        beamtalk_class_events:on_class_loaded('DupClass'),
+        sys:get_state(Pid),
+
+        %% Should receive exactly one notification, not two
+        receive
+            {class_loaded, 'DupClass'} -> ok
+        after 500 ->
+            ?assert(false)
+        end,
+        receive
+            {class_loaded, 'DupClass'} ->
+                ?assert(false)
+        after 50 ->
+            ok
+        end
+    after
+        gen_server:stop(Pid),
+        flush_messages()
+    end.
+
+unsubscribe_stops_notifications_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_class_events}, beamtalk_class_events, [], []
+    ),
+    try
+        beamtalk_class_events:subscribe(),
+        sys:get_state(Pid),
+
+        beamtalk_class_events:unsubscribe(),
+        sys:get_state(Pid),
+
+        beamtalk_class_events:on_class_loaded('UnsubClass'),
+        sys:get_state(Pid),
+
+        receive
+            {class_loaded, 'UnsubClass'} ->
+                ?assert(false)
+        after 100 ->
+            ok
+        end
+    after
+        gen_server:stop(Pid),
+        flush_messages()
+    end.
+
+unsubscribe_when_not_subscribed_is_safe_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_class_events}, beamtalk_class_events, [], []
+    ),
+    try
+        %% Should not crash — hits the `error` branch in maps:find
+        beamtalk_class_events:unsubscribe(),
+        sys:get_state(Pid),
+        ?assert(is_process_alive(Pid))
+    after
+        gen_server:stop(Pid)
+    end.
+
+%%% ===========================================================================
+%%% Multi-subscriber broadcast
+%%% ===========================================================================
+
+multiple_subscribers_all_notified_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_class_events}, beamtalk_class_events, [], []
+    ),
+    Self = self(),
+    try
+        Sub1 = spawn(fun() ->
+            beamtalk_class_events:subscribe(),
+            Self ! sub1_subscribed,
+            receive
+                {class_loaded, _} = Msg -> Self ! {sub1, Msg}
+            after 1000 -> Self ! sub1_timeout
+            end
+        end),
+        Sub2 = spawn(fun() ->
+            beamtalk_class_events:subscribe(),
+            Self ! sub2_subscribed,
+            receive
+                {class_loaded, _} = Msg -> Self ! {sub2, Msg}
+            after 1000 -> Self ! sub2_timeout
+            end
+        end),
+        receive
+            sub1_subscribed -> ok
+        after 500 -> ok
+        end,
+        receive
+            sub2_subscribed -> ok
+        after 500 -> ok
+        end,
+        %% Sync: both subscribe casts processed
+        sys:get_state(Pid),
+
+        beamtalk_class_events:on_class_loaded('BroadcastClass'),
+        sys:get_state(Pid),
+
+        receive
+            {sub1, {class_loaded, 'BroadcastClass'}} -> ok
+        after 500 ->
+            ?assert(false)
+        end,
+        receive
+            {sub2, {class_loaded, 'BroadcastClass'}} -> ok
+        after 500 ->
+            ?assert(false)
+        end,
+        exit(Sub1, kill),
+        exit(Sub2, kill)
+    after
+        gen_server:stop(Pid),
+        flush_messages()
+    end.
+
+%%% ===========================================================================
+%%% Dead Subscriber Auto-removal
+%%% ===========================================================================
+
+dead_subscriber_auto_removed_test() ->
+    {ok, Pid} = gen_server:start_link(
+        {local, beamtalk_class_events}, beamtalk_class_events, [], []
+    ),
+    Self = self(),
+    try
+        SubPid = spawn(fun() ->
+            beamtalk_class_events:subscribe(),
+            Self ! subscribed,
+            receive
+                stop -> ok
+            end
+        end),
+        receive
+            subscribed -> ok
+        after 500 -> ok
+        end,
+        sys:get_state(Pid),
+
+        exit(SubPid, kill),
+        timer:sleep(50),
+        %% Sync: DOWN message processed
+        sys:get_state(Pid),
+
+        %% Server should still be alive and handle events without crashing
+        beamtalk_class_events:on_class_loaded('PostDeadClass'),
+        sys:get_state(Pid),
+        ?assert(is_process_alive(Pid))
+    after
+        gen_server:stop(Pid),
+        flush_messages()
+    end.
+
+%%% ===========================================================================
+%%% on_class_loaded when server not running
+%%% ===========================================================================
+
+on_class_loaded_when_server_down_is_safe_test() ->
+    %% Ensure no registered server
+    case whereis(beamtalk_class_events) of
+        undefined -> ok;
+        ExistingPid -> gen_server:stop(ExistingPid)
+    end,
+    %% Should return ok without crashing — hits the `undefined` branch
+    Result = beamtalk_class_events:on_class_loaded('SomeClass'),
+    ?assertEqual(ok, Result).
+
+%%% ===========================================================================
+%%% Gen_server Callback Edge Cases
+%%% ===========================================================================
+
+unknown_call_returns_error_test() ->
+    {ok, Pid} = gen_server:start_link(beamtalk_class_events, [], []),
+    ?assertEqual({error, unknown_request}, gen_server:call(Pid, some_unknown_request)),
+    gen_server:stop(Pid).
+
+unknown_cast_is_ignored_test() ->
+    {ok, Pid} = gen_server:start_link(beamtalk_class_events, [], []),
+    gen_server:cast(Pid, some_unknown_cast),
+    timer:sleep(10),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+unknown_info_is_ignored_test() ->
+    {ok, Pid} = gen_server:start_link(beamtalk_class_events, [], []),
+    Pid ! {some_unknown, message},
+    timer:sleep(10),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+%%% ===========================================================================
+%%% Internal helpers
+%%% ===========================================================================
+
+flush_messages() ->
+    receive
+        _ -> flush_messages()
+    after 0 -> ok
+    end.


### PR DESCRIPTION
## Summary

Adds comprehensive EUnit test coverage for two previously untested pub/sub gen_servers in `beamtalk_workspace`:

- **`beamtalk_bindings_events_tests.erl`** — 11 tests covering all code paths in `beamtalk_bindings_events`
- **`beamtalk_class_events_tests.erl`** — 11 tests covering all code paths in `beamtalk_class_events`

Both modules had 0% test coverage. Tests exercise: subscribe/unsubscribe lifecycle, duplicate subscribe idempotency, multi-subscriber broadcast fan-out, dead-subscriber auto-removal via `erlang:monitor` DOWN messages, safe-drop when server is not running, and unknown call/cast/info catch-all handlers.

No source files were modified.

## Key changes

- New file: `runtime/apps/beamtalk_workspace/test/beamtalk_bindings_events_tests.erl` (251 lines, 11 tests)
- New file: `runtime/apps/beamtalk_workspace/test/beamtalk_class_events_tests.erl` (251 lines, 11 tests)
- Test pattern follows existing `beamtalk_repl_actors_tests.erl` conventions (`sys:get_state` sync, `try...after` cleanup, `flush_messages/0` helper)

## Test plan

- [x] `rebar3 eunit --module=beamtalk_bindings_events_tests,beamtalk_class_events_tests` — 22 tests, 0 failures
- [x] `rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace` — 3564 tests, 0 failures
- [x] `rebar3 fmt --check` — passes
- [x] Pre-push hook (lint, dialyzer, fmt-check) — passes

Closes BT-2108
https://linear.app/beamtalk/issue/BT-2108

https://claude.ai/code/session_01V6TgG6JE6So2kf5cS5G22i

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6TgG6JE6So2kf5cS5G22i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for bindings events: verifies server lifecycle, subscribe/unsubscribe semantics, idempotent subscriptions, event notifications to multiple subscribers, dead-subscriber cleanup, and robust handling of unknown calls/casts/infos.
  * Added comprehensive test suite for class events: validates server lifecycle, subscription behavior, broadcast delivery to concurrent subscribers, cleanup of terminated subscribers, and graceful handling of edge-case requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->