### PR TITLE
Deduplicate mtime_of helper in beamtalk-cli commands (BT-2110)

### DIFF
--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -14,12 +14,12 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::fs;
 use std::path::PathBuf;
-use std::time::SystemTime;
 use tracing::{debug, error, info, instrument, warn};
 
 use super::app_file;
 use super::manifest;
 use super::manifest::NativeDependencyMap;
+use super::util::mtime_of;
 
 /// Result of per-file change detection.
 ///
@@ -126,11 +126,6 @@ pub(crate) fn detect_changes(
         unchanged_files,
         orphaned_beam_files,
     }
-}
-
-/// Read the modification time of a file, returning `None` on any error.
-fn mtime_of(path: &Utf8Path) -> Option<SystemTime> {
-    fs::metadata(path).ok()?.modified().ok()
 }
 
 /// Find `bt@*` `.beam` files in the build directory that are not in the expected set.

--- a/crates/beamtalk-cli/src/commands/build_cache.rs
+++ b/crates/beamtalk-cli/src/commands/build_cache.rs
@@ -20,6 +20,8 @@ use std::fs;
 use std::time::SystemTime;
 use tracing::{debug, info, warn};
 
+use super::util::mtime_of;
+
 /// Name of the cache file stored inside the build directory.
 const CACHE_FILENAME: &str = ".beamtalk-pass1-cache.json";
 
@@ -403,11 +405,6 @@ fn build_cache_entries(
     }
 
     entries
-}
-
-/// Read the modification time of a file, returning `None` on any error.
-fn mtime_of(path: &Utf8Path) -> Option<SystemTime> {
-    fs::metadata(path).ok()?.modified().ok()
 }
 
 /// Serde support for `SystemTime` (required field) via duration-since-epoch.

--- a/crates/beamtalk-cli/src/commands/util.rs
+++ b/crates/beamtalk-cli/src/commands/util.rs
@@ -8,6 +8,8 @@
 use beamtalk_core::file_walker::FileWalker;
 use camino::{Utf8Path, Utf8PathBuf};
 use miette::Result;
+use std::fs;
+use std::time::SystemTime;
 
 /// What a test assertion expects: a value or an error.
 ///
@@ -18,6 +20,11 @@ pub(crate) enum Expected {
     Value(String),
     /// Match `#beamtalk_error{kind = Kind}` on error.
     Error { kind: String },
+}
+
+/// Read the modification time of a file, returning `None` on any error.
+pub(super) fn mtime_of(path: &Utf8Path) -> Option<SystemTime> {
+    fs::metadata(path).ok()?.modified().ok()
 }
 
 /// Find files matching the given extensions in a path.


### PR DESCRIPTION
## Summary

Moves the identical `fn mtime_of(path: &Utf8Path) -> Option<SystemTime>` helper from `build.rs` and `build_cache.rs` into the shared `commands/util.rs` module, which already exists as the canonical home for shared CLI command helpers.

## Changes

- **`crates/beamtalk-cli/src/commands/util.rs`** — add `pub(super) fn mtime_of`, add `use std::fs` and `use std::time::SystemTime`
- **`crates/beamtalk-cli/src/commands/build.rs`** — remove local `mtime_of` definition, remove now-unused `use std::time::SystemTime`, import from `super::util`
- **`crates/beamtalk-cli/src/commands/build_cache.rs`** — remove local `mtime_of` definition, import from `super::util`

Net: 3 files, −1 lines (10 added, 11 removed). Zero behavior change.

## Verification

- `cargo build -p beamtalk-cli` ✅
- `just clippy` ✅  
- `cargo fmt --check -p beamtalk-cli` ✅
- `cargo test -p beamtalk-cli --lib` ✅ (22 passed)

Linear: https://linear.app/beamtalk/issue/BT-2110/deduplicate-mtime-of-helper-in-beamtalk-cli-commands

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKjvhXS9c1BjqPbQhysFA7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated file modification time utilities into a shared module, eliminating code duplication across components and improving long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->