### PR TITLE
Add codegen tests for anySatisfy:/allSatisfy:/detect: (search_ops.rs 0% → covered) (BT-2111)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
@@ -177,9 +177,9 @@ fn test_list_do_multi_stmt_first_is_pure_generates_let_underscore() {
     let code = codegen(src);
     // The first expression (item + 1) is non-last; it must be bound as `let _ = ... in`
     // not emitted bare as `<expr> in` which is invalid Core Erlang.
-    let has_bare_expr_in = code.contains("call 'erlang':'+'") && {
+    let has_bare_expr_in = code.contains("call 'erlang':'%2B'") && {
         // Find the position of the '+' call and check what precedes it
-        if let Some(pos) = code.find("call 'erlang':'+'") {
+        if let Some(pos) = code.find("call 'erlang':'%2B'") {
             // Look for "let _ = " immediately before the + call (within 20 chars)
             let before = &code[pos.saturating_sub(20)..pos];
             !before.contains("let _ = ") && !before.contains("let _")
@@ -199,8 +199,8 @@ fn test_list_collect_multi_stmt_first_is_pure_generates_let_underscore() {
     let src = "Actor subclass: Ctr\n  state: n = 0\n\n  run: items =>\n    items collect: [:item | item + 1. self.n := self.n + 1. item * 2]\n";
     let code = codegen(src);
     // item + 1 is first and non-last — must be wrapped with let _ = ... in
-    let has_bare_expr_in = code.contains("call 'erlang':'+'") && {
-        if let Some(pos) = code.find("call 'erlang':'+'") {
+    let has_bare_expr_in = code.contains("call 'erlang':'%2B'") && {
+        if let Some(pos) = code.find("call 'erlang':'%2B'") {
             let before = &code[pos.saturating_sub(20)..pos];
             !before.contains("let _ = ") && !before.contains("let _")
         } else {
@@ -562,6 +562,10 @@ fn test_detect_if_none_pure_dispatches_to_runtime() {
     assert!(
         code.contains("'beamtalk_primitive':'send'"),
         "Pure detect:ifNone: should use beamtalk_primitive:send. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("'lists':'foldl'"),
+        "Pure detect:ifNone: should NOT use lists:foldl. Got:\n{code}"
     );
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
@@ -513,6 +513,14 @@ fn test_any_satisfy_pure_generates_lists_any() {
         "Pure anySatisfy: should generate lists:any. Got:\n{code}"
     );
     assert!(
+        code.contains("'erlang':'is_list'("),
+        "Pure anySatisfy: should guard with erlang:is_list. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'beamtalk_primitive':'send'("),
+        "Pure anySatisfy: should fall back to beamtalk_primitive:send for non-lists. Got:\n{code}"
+    );
+    assert!(
         !code.contains("'lists':'foldl'"),
         "Pure anySatisfy: should NOT use lists:foldl. Got:\n{code}"
     );
@@ -653,7 +661,8 @@ fn test_detect_if_none_with_field_mutation_threads_state() {
 #[test]
 fn test_any_satisfy_with_local_mutation_uses_tuple_acc() {
     // BT-1481 + BT-1276: anySatisfy: with only a local variable mutation uses the
-    // tuple-accumulator path (element/N reads threaded locals) instead of maps:get.
+    // tuple-accumulator path: {BoolAcc, Var1, ...}. Locals are unpacked via
+    // element(N, AccSt) inside the lambda — not via maps:get.
     let src = concat!(
         "Actor subclass: Ctr\n",
         "  state: x = 0\n\n",
@@ -663,20 +672,23 @@ fn test_any_satisfy_with_local_mutation_uses_tuple_acc() {
         "    count\n",
     );
     let code = codegen(src);
+    // BoolAcc is at position 1; 'count' is the first threaded local so it lives at
+    // position 2 inside the lambda accumulator tuple.
     assert!(
-        code.contains("'erlang':'element'("),
-        "anySatisfy: with local mutation should use element/N for tuple-acc. Got:\n{code}"
+        code.contains("let Count = call 'erlang':'element'(2, "),
+        "anySatisfy: with local mutation should extract 'count' via element(2, AccSt) in tuple-acc lambda. Got:\n{code}"
     );
     assert!(
         !code.contains("maps':'get'('__local__count'"),
-        "anySatisfy: with local mutation should NOT use maps:get inside lambda. Got:\n{code}"
+        "anySatisfy: with local mutation should NOT use maps:get for '__local__count'. Got:\n{code}"
     );
 }
 
 #[test]
 fn test_detect_with_local_mutation_uses_tuple_acc() {
     // BT-1486 + BT-1276: detect: with only a local variable mutation uses the
-    // tuple-accumulator path and still tracks FoundFlag for the found-item result.
+    // tuple-accumulator path: {FoundItem, FoundFlag, Var1, ...}. Locals are
+    // unpacked via element(N, AccSt) inside the lambda — not via maps:get.
     let src = concat!(
         "Actor subclass: Ctr\n",
         "  state: x = 0\n\n",
@@ -686,9 +698,10 @@ fn test_detect_with_local_mutation_uses_tuple_acc() {
         "    count\n",
     );
     let code = codegen(src);
+    // FoundItem=1, FoundFlag=2; 'count' is the first threaded local at position 3.
     assert!(
-        code.contains("'erlang':'element'("),
-        "detect: with local mutation should use element/N for tuple-acc. Got:\n{code}"
+        code.contains("let Count = call 'erlang':'element'(3, "),
+        "detect: with local mutation should extract 'count' via element(3, AccSt) in tuple-acc lambda. Got:\n{code}"
     );
     assert!(
         code.contains("FoundFlag"),
@@ -696,6 +709,6 @@ fn test_detect_with_local_mutation_uses_tuple_acc() {
     );
     assert!(
         !code.contains("maps':'get'('__local__count'"),
-        "detect: with local mutation should NOT use maps:get inside lambda. Got:\n{code}"
+        "detect: with local mutation should NOT use maps:get for '__local__count'. Got:\n{code}"
     );
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
@@ -499,3 +499,199 @@ fn test_drop_while_pure_generates_dropwhile() {
         "Pure dropWhile: should use lists:dropwhile. Got:\n{code}"
     );
 }
+
+// ── Search ops: anySatisfy:, allSatisfy:, detect:, detect:ifNone: ──────
+
+#[test]
+fn test_any_satisfy_pure_generates_lists_any() {
+    // BT-1481: Pure anySatisfy: (no mutations) delegates to lists:any/2 with an
+    // is_list guard so non-list receivers fall back to beamtalk_primitive:send.
+    let src = "Actor subclass: Srv\n  state: x = 0\n\n  run: items =>\n    items anySatisfy: [:item | item > 0]\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'lists':'any'"),
+        "Pure anySatisfy: should generate lists:any. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("'lists':'foldl'"),
+        "Pure anySatisfy: should NOT use lists:foldl. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_all_satisfy_pure_generates_lists_all() {
+    // BT-1481: Pure allSatisfy: (no mutations) delegates to lists:all/2.
+    let src = "Actor subclass: Srv\n  state: x = 0\n\n  run: items =>\n    items allSatisfy: [:item | item > 0]\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'lists':'all'"),
+        "Pure allSatisfy: should generate lists:all. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("'lists':'foldl'"),
+        "Pure allSatisfy: should NOT use lists:foldl. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_detect_pure_generates_beamtalk_list_detect() {
+    // BT-1486: Pure detect: (no mutations) delegates to beamtalk_list:detect/2
+    // with an is_list guard for non-list fallback via beamtalk_primitive:send.
+    let src = "Actor subclass: Srv\n  state: x = 0\n\n  run: items =>\n    items detect: [:item | item > 0]\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'beamtalk_list':'detect'"),
+        "Pure detect: should generate beamtalk_list:detect. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("'lists':'foldl'"),
+        "Pure detect: should NOT use lists:foldl. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_detect_if_none_pure_dispatches_to_runtime() {
+    // BT-1486: Pure detect:ifNone: (no mutations) dispatches to runtime via
+    // beamtalk_primitive:send with the predicate and ifNone block as arguments.
+    let src = "Actor subclass: Srv\n  state: x = 0\n\n  run: items =>\n    items detect: [:item | item > 0] ifNone: [42]\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'detect:ifNone:'"),
+        "Pure detect:ifNone: should dispatch with selector 'detect:ifNone:'. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'beamtalk_primitive':'send'"),
+        "Pure detect:ifNone: should use beamtalk_primitive:send. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_any_satisfy_with_field_mutation_threads_state() {
+    // BT-1481: anySatisfy: with a field mutation in its body cannot short-circuit
+    // (mutations must run for every element), so it uses lists:foldl with a bool
+    // accumulator starting false.
+    let src = "Actor subclass: Ctr\n  state: count = 0\n\n  run: items =>\n    items anySatisfy: [:item | self.count := self.count + 1. item > 0]\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'lists':'foldl'"),
+        "anySatisfy: with field mutation should use lists:foldl. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("'lists':'any'"),
+        "anySatisfy: with field mutation must NOT use short-circuiting lists:any. Got:\n{code}"
+    );
+    assert!(
+        code.contains("maps':'put'('count'"),
+        "anySatisfy: body should update 'count' field via maps:put. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_all_satisfy_with_field_mutation_threads_state() {
+    // BT-1481: allSatisfy: with field mutation uses foldl with bool accumulator
+    // starting true (all-satisfy assumption, set to false on first failure).
+    let src = "Actor subclass: Ctr\n  state: count = 0\n\n  run: items =>\n    items allSatisfy: [:item | self.count := self.count + 1. item > 0]\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'lists':'foldl'"),
+        "allSatisfy: with field mutation should use lists:foldl. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("'lists':'all'"),
+        "allSatisfy: with field mutation must NOT use short-circuiting lists:all. Got:\n{code}"
+    );
+    assert!(
+        code.contains("maps':'put'('count'"),
+        "allSatisfy: body should update 'count' field via maps:put. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_detect_with_field_mutation_threads_state() {
+    // BT-1486: detect: with field mutation uses foldl with a {FoundItem, FoundFlag, State...}
+    // accumulator so that mutations execute for every element (no short-circuit).
+    let src = "Actor subclass: Ctr\n  state: count = 0\n\n  run: items =>\n    items detect: [:item | self.count := self.count + 1. item > 0]\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'lists':'foldl'"),
+        "detect: with field mutation should use lists:foldl. Got:\n{code}"
+    );
+    assert!(
+        code.contains("FoundFlag"),
+        "detect: with field mutation should use FoundFlag accumulator. Got:\n{code}"
+    );
+    assert!(
+        code.contains("maps':'put'('count'"),
+        "detect: body should update 'count' field via maps:put. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_detect_if_none_with_field_mutation_threads_state() {
+    // BT-1486: detect:ifNone: with field mutation uses foldl + FoundFlag to distinguish
+    // "found nil" from "nothing matched", then evaluates the ifNone block when unmatched.
+    let src = "Actor subclass: Ctr\n  state: count = 0\n\n  run: items =>\n    items detect: [:item | self.count := self.count + 1. item > 0] ifNone: [42]\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'lists':'foldl'"),
+        "detect:ifNone: with field mutation should use lists:foldl. Got:\n{code}"
+    );
+    assert!(
+        code.contains("FoundFlag"),
+        "detect:ifNone: with mutation should use FoundFlag to distinguish no-match. Got:\n{code}"
+    );
+    assert!(
+        code.contains("maps':'put'('count'"),
+        "detect:ifNone: body should update 'count' field via maps:put. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_any_satisfy_with_local_mutation_uses_tuple_acc() {
+    // BT-1481 + BT-1276: anySatisfy: with only a local variable mutation uses the
+    // tuple-accumulator path (element/N reads threaded locals) instead of maps:get.
+    let src = concat!(
+        "Actor subclass: Ctr\n",
+        "  state: x = 0\n\n",
+        "  run: items =>\n",
+        "    count := 0\n",
+        "    items anySatisfy: [:item | count := count + 1. item > 0]\n",
+        "    count\n",
+    );
+    let code = codegen(src);
+    assert!(
+        code.contains("'erlang':'element'("),
+        "anySatisfy: with local mutation should use element/N for tuple-acc. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("maps':'get'('__local__count'"),
+        "anySatisfy: with local mutation should NOT use maps:get inside lambda. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_detect_with_local_mutation_uses_tuple_acc() {
+    // BT-1486 + BT-1276: detect: with only a local variable mutation uses the
+    // tuple-accumulator path and still tracks FoundFlag for the found-item result.
+    let src = concat!(
+        "Actor subclass: Ctr\n",
+        "  state: x = 0\n\n",
+        "  run: items =>\n",
+        "    count := 0\n",
+        "    items detect: [:item | count := count + 1. item > 0]\n",
+        "    count\n",
+    );
+    let code = codegen(src);
+    assert!(
+        code.contains("'erlang':'element'("),
+        "detect: with local mutation should use element/N for tuple-acc. Got:\n{code}"
+    );
+    assert!(
+        code.contains("FoundFlag"),
+        "detect: with local mutation should still use FoundFlag accumulator. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("maps':'get'('__local__count'"),
+        "detect: with local mutation should NOT use maps:get inside lambda. Got:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes coverage gap in `search_ops.rs`, which was at **0% line coverage** (466 executable lines) despite full implementations for all four list search operations.

Linear: https://linear.app/beamtalk/issue/BT-2111

## What Changed

Added 10 Rust unit tests to `crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs` covering `anySatisfy:`, `allSatisfy:`, `detect:`, and `detect:ifNone:` — the only list ops in `list_ops/` with zero test coverage.

**Pure (no-mutation) paths:**
- `test_any_satisfy_pure_generates_lists_any` — delegates to `lists:any/2`
- `test_all_satisfy_pure_generates_lists_all` — delegates to `lists:all/2`
- `test_detect_pure_generates_beamtalk_list_detect` — delegates to `beamtalk_list:detect/2`
- `test_detect_if_none_pure_dispatches_to_runtime` — dispatches via `beamtalk_primitive:send`

**Field-mutation paths (state-threading foldl, no short-circuit):**
- `test_any_satisfy_with_field_mutation_threads_state` — foldl + maps:put, no `lists:any`
- `test_all_satisfy_with_field_mutation_threads_state` — foldl + maps:put, no `lists:all`
- `test_detect_with_field_mutation_threads_state` — foldl + FoundFlag accumulator
- `test_detect_if_none_with_field_mutation_threads_state` — foldl + FoundFlag + ifNone block

**Local-mutation paths (tuple-accumulator optimisation, BT-1276):**
- `test_any_satisfy_with_local_mutation_uses_tuple_acc` — `element/N`, no `maps:get` inside lambda
- `test_detect_with_local_mutation_uses_tuple_acc` — `element/N` + FoundFlag, no `maps:get`

## Test Plan

- [x] `cargo test -p beamtalk-core` — 3305 tests pass, 0 failures
- [x] `cargo clippy -p beamtalk-core -- -D warnings` — clean
- [x] `cargo fmt -p beamtalk-core --check` — clean
- [x] Zero production code changes — test-only diff

https://claude.ai/code/session_011pyBinmhQyGjbiTFHRn8bz

---
_Generated by [Claude Code](https://claude.ai/code/session_011pyBinmhQyGjbiTFHRn8bz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for anySatisfy/allSatisfy/detect variants, including a new "Search ops" suite.
  * Updated multi-statement assertions to correctly recognize encoded operator usage and verify binding presence.
  * Verifies pure cases use short-circuit list paths, field-mutation cases use fold-style processing with map updates, and local-mutation cases use tuple-accumulator behavior.
  * Asserts special dispatch behavior for the detect-if-none variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->