### PR TITLE
Deduplicate atom-char escape helper across crates (BT-2113)

### DIFF
--- a/crates/beamtalk-cli/src/repl_startup.rs
+++ b/crates/beamtalk-cli/src/repl_startup.rs
@@ -16,6 +16,7 @@ use std::ffi::OsString;
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 
+use beamtalk_core::codegen::core_erlang::escape_atom_chars;
 use miette::{Result, miette};
 
 /// OTP kernel logger configuration that redirects the default handler to stderr.
@@ -160,7 +161,7 @@ pub fn build_eval_cmd_with_node(
     otp_app_name: Option<&str>,
     hex_dep_names: &[String],
 ) -> String {
-    let safe_name = escape_erlang_atom(node_name);
+    let safe_name = escape_atom_chars(node_name);
     let hex_deps_start = hex_deps_start_fragment(hex_dep_names);
     let otp_app_start = otp_app_start_fragment(otp_app_name);
     format!(
@@ -276,11 +277,6 @@ pub fn startup_prelude(
              auto_cleanup => false, \
              max_idle_seconds => 14400}})"
     )
-}
-
-/// Escape characters that are special inside Erlang single-quoted atoms.
-fn escape_erlang_atom(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('\'', "\\'")
 }
 
 /// Collect `-pa` paths as `OsString` arguments for passing to `Command::args`.

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -20,7 +20,7 @@
 use std::collections::HashSet;
 
 use super::document::Document;
-use super::selector_mangler::escape_atom_chars;
+use super::escape_atom_chars;
 use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result};
 use crate::ast::{
     BinaryEndianness, BinarySegment, BinarySegmentType, BinarySignedness, Block, CascadeMessage,

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -107,6 +107,7 @@ mod value_type_codegen;
 mod variable_context;
 
 // Re-export utility functions for IDE queries
+pub use util::escape_atom_chars;
 pub use util::to_module_name;
 
 use crate::ast::{Block, Expression, MessageSelector, Module, WellKnownSelector};

--- a/crates/beamtalk-core/src/codegen/core_erlang/selector_mangler.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/selector_mangler.rs
@@ -154,24 +154,6 @@ pub fn requires_quoting(name: &str) -> bool {
     false
 }
 
-/// Escapes special characters in an atom name for Core Erlang.
-///
-/// This handles characters that have special meaning in Erlang strings/atoms:
-/// - Single quotes → `\'`
-/// - Backslashes → `\\`
-#[must_use]
-pub fn escape_atom_chars(name: &str) -> String {
-    let mut result = String::with_capacity(name.len());
-    for c in name.chars() {
-        match c {
-            '\'' => result.push_str("\\'"),
-            '\\' => result.push_str("\\\\"),
-            _ => result.push(c),
-        }
-    }
-    result
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,13 +196,6 @@ mod tests {
         assert!(requires_quoting(""));
         assert!(requires_quoting("123"));
         assert!(requires_quoting("Uppercase"));
-    }
-
-    #[test]
-    fn escape_special_chars() {
-        assert_eq!(escape_atom_chars("normal"), "normal");
-        assert_eq!(escape_atom_chars("it's"), "it\\'s");
-        assert_eq!(escape_atom_chars("back\\slash"), "back\\\\slash");
     }
 
     #[test]

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -23,6 +23,23 @@ pub(super) fn escape_core_erlang_string(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+/// Escapes special characters in an atom name for Core Erlang.
+///
+/// Replaces `\` with `\\` and `'` with `\'` so the result is safe to embed
+/// between `'...'` in generated `.core` source.
+#[must_use]
+pub fn escape_atom_chars(name: &str) -> String {
+    let mut result = String::with_capacity(name.len());
+    for c in name.chars() {
+        match c {
+            '\'' => result.push_str("\\'"),
+            '\\' => result.push_str("\\\\"),
+            _ => result.push(c),
+        }
+    }
+    result
+}
+
 /// BT-745: Generate a `'beamtalk_class' = [{...}]` attribute fragment for the
 /// module attributes section. Returns `Document::Nil` when classes is empty.
 pub(super) fn beamtalk_class_attribute(classes: &[ClassDefinition]) -> Document<'static> {
@@ -390,6 +407,21 @@ mod tests {
     #[test]
     fn test_user_package_prefix_bt_only() {
         assert_eq!(user_package_prefix("bt@counter"), None);
+    }
+
+    #[test]
+    fn test_escape_atom_chars_normal() {
+        assert_eq!(escape_atom_chars("normal"), "normal");
+    }
+
+    #[test]
+    fn test_escape_atom_chars_quote() {
+        assert_eq!(escape_atom_chars("it's"), "it\\'s");
+    }
+
+    #[test]
+    fn test_escape_atom_chars_backslash() {
+        assert_eq!(escape_atom_chars("back\\slash"), "back\\\\slash");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two identical implementations of Erlang single-quoted atom escaping existed across crate boundaries:

- `beamtalk-core/src/codegen/core_erlang/selector_mangler.rs` — `pub fn escape_atom_chars`
- `beamtalk-cli/src/repl_startup.rs` — `fn escape_erlang_atom` (private)

This PR consolidates them into the shared `util.rs` module in `beamtalk-core`, where it sits alongside the existing `escape_core_erlang_string` helper. The `beamtalk-cli` crate already depends on `beamtalk-core`, so the duplicate is simply replaced with an import.

## Changes

- **Moved** `escape_atom_chars` from `selector_mangler.rs` to `util.rs` (pub visibility)
- **Re-exported** via `pub use util::escape_atom_chars` in `core_erlang/mod.rs`
- **Updated** `expressions.rs` import to use the re-export path
- **Removed** duplicate `escape_erlang_atom` from `repl_startup.rs`, replaced with import
- **Moved** tests to `util.rs` (split into 3 individual tests for better isolation)

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 3297 tests pass
- [x] `cargo test -p beamtalk-cli --lib` — 22 tests pass (including `repl_startup` tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Linear: https://linear.app/beamtalk/issue/BT-2113/deduplicate-atom-char-escape-helper-across-crates

---
_Generated by [Claude Code](https://claude.ai/code/session_018DJUEfJJnq9vnyAAEiwWGm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated atom character escaping utilities across code generation modules for consistency.

* **Tests**
  * Extended test suite with new test cases for atom character escaping, including edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->