### PR TITLE
Tighten Set printString assertions in SetTest (BT-2115)

### DIFF
--- a/stdlib/test/set_test.bt
+++ b/stdlib/test/set_test.bt
@@ -5,9 +5,7 @@
 
 TestCase subclass: SetTest
 
-  testCreationClass =>
-    Set new
-    self assert: (Set new) class equals: Set
+  testCreationClass => self assert: (Set new) class equals: Set
 
   testIsemptySize =>
     self assert: (Set new) isEmpty
@@ -86,5 +84,5 @@ TestCase subclass: SetTest
     self deny: (s4 respondsTo: #nonExistent)
 
   testPrintstring =>
-    self assert: (((Set new) fromList: #(1, 2, 3)) printString) notNil
-    self assert: ((Set new) printString) notNil
+    self assert: (((Set new) fromList: #(1, 2, 3)) printString) equals: "Set(1, 2, 3)"
+    self assert: ((Set new) printString) equals: "Set()"


### PR DESCRIPTION
## Summary

- Replace two loose `assert: ... notNil` guards in `testPrintstring` with exact `assert:equals:` assertions
- Remove a dead no-op `Set new` expression in `testCreationClass`
- Apply Beamtalk formatter (collapses single-expression `testCreationClass` to one-liner)

## Detail

`testPrintstring` previously only verified the result was non-nil. The exact format is deterministic and traceable directly from the runtime:

- `beamtalk_primitive:print_string/1` (lines 163–165): formats sets as `Set(<comma-separated elements>)`
- `beamtalk_set:from_list/1` uses `ordsets:from_list/1` → sorted order
- `#(1, 2, 3)` → `[1,2,3]` (already sorted) → `"Set(1, 2, 3)"`
- Empty set → `"Set()"` (confirmed by existing `chat_room.btscript`: `// => Set()`)

Now a regression in the Set print format will be caught with a clear failure message instead of silently passing.

## Test plan

- [x] `SetTest` passes (1904 BUnit tests, same 4 pre-existing `TracingTest` failures as on main — tracked in BT-2116)
- [x] `just fmt-check-beamtalk` passes
- [x] `just clippy` + `just fmt-check-rust` pass
- [x] Pre-push lint hook passes (Erlang skipped — no `.erl`/`.hrl` changes)

Linear: https://linear.app/beamtalk/issue/BT-2115/tighten-loose-printstring-assertions-in-stdlibtestset-testbt

https://claude.ai/code/session_016Jgz6uRyrK2TkM9XkCXhn9

---
_Generated by [Claude Code](https://claude.ai/code/session_016Jgz6uRyrK2TkM9XkCXhn9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test assertions for Set class creation and string representation. Tests now verify proper Set object initialization and ensure correct display formatting for both populated and empty Set instances, strengthening quality assurance standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->