### PR TITLE
Make beamtalk lint load FFI type cache so it agrees with build (BT-2134)

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -1201,8 +1201,8 @@ pub fn extract_beam_specs(
     Ok(registry)
 }
 
-/// Reads every `<module>_<hash>.json` file in `cache_dir` and replays the
-/// cached `specs_line` into a new [`NativeTypeRegistry`].
+/// Reads `<module>_<hash>.json` files from `cache_dir` and replays the
+/// freshest cached `specs_line` per module into a new [`NativeTypeRegistry`].
 ///
 /// Used by `beamtalk lint` (BT-2134) to populate the same FFI type registry
 /// `beamtalk build` uses, so the type checker's "Dynamic in typed class"
@@ -1210,10 +1210,19 @@ pub fn extract_beam_specs(
 /// lint sees every `(Erlang m) f:` call as `Dynamic(UntypedFfi)` even when
 /// the build cache has typed signatures.
 ///
-/// Cache freshness is not checked here — build is responsible for updating
-/// stale cache entries against `.beam` mtimes. Lint reads whatever build
-/// produced; if the user has not run build (or has deleted the cache), the
-/// registry is empty and lint behaves as it did before.
+/// `TypeCache::cache_path` keys filenames by the BEAM path hash, so multiple
+/// `<module>_<hash>.json` entries can accumulate after dependency upgrades or
+/// BEAM path changes. Replaying every file would let `read_dir` order pick a
+/// stale signature, reintroducing the lint/build disagreement BT-2134 fixed.
+/// Instead, group by module name and pick the entry with the latest file
+/// mtime — that's the one the most recent build wrote, and it matches what
+/// build's `extract_beam_specs` resolved for the current BEAM set.
+///
+/// Cache freshness against the `.beam` itself is not checked here — build is
+/// responsible for updating cache entries against `.beam` mtimes. Lint reads
+/// whatever the most recent build produced; if the user has not run build
+/// (or has deleted the cache), the registry is empty and lint behaves as it
+/// did before.
 ///
 /// Returns `None` if `cache_dir` is not a directory or contains no entries.
 pub fn load_type_cache_registry(cache_dir: &Utf8Path) -> Option<NativeTypeRegistry> {
@@ -1221,14 +1230,47 @@ pub fn load_type_cache_registry(cache_dir: &Utf8Path) -> Option<NativeTypeRegist
         return None;
     }
 
+    // Group cache files by module name, keeping the latest-mtime entry per
+    // module so a stale `<module>_<old_hash>.json` doesn't shadow the fresh
+    // one when `read_dir` happens to yield it second.
     let entries = std::fs::read_dir(cache_dir.as_std_path()).ok()?;
-    let mut registry = NativeTypeRegistry::new();
+    let mut latest_by_module: std::collections::HashMap<String, (SystemTime, std::path::PathBuf)> =
+        std::collections::HashMap::new();
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+        let Some(filename) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Some(stem) = filename.strip_suffix(".json") else {
+            continue;
+        };
+        // Cache filenames are exactly `<module>_<16-hex>`. Anything else is
+        // foreign and must be ignored, including `<module>_socket_<hash>`
+        // (where the module name itself ends in an underscore segment).
+        let Some((module, hash)) = stem.rsplit_once('_') else {
+            continue;
+        };
+        if hash.len() != 16 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
             continue;
         }
-        let Ok(content) = std::fs::read_to_string(&path) else {
+        let mtime = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        latest_by_module
+            .entry(module.to_string())
+            .and_modify(|(prev_mtime, prev_path)| {
+                if mtime > *prev_mtime {
+                    *prev_mtime = mtime;
+                    prev_path.clone_from(&path);
+                }
+            })
+            .or_insert((mtime, path));
+    }
+
+    let mut registry = NativeTypeRegistry::new();
+    for (_, path) in latest_by_module.values() {
+        let Ok(content) = std::fs::read_to_string(path) else {
             continue;
         };
         let Ok(entry) = serde_json::from_str::<TypeCacheEntry>(&content) else {

--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -1201,6 +1201,51 @@ pub fn extract_beam_specs(
     Ok(registry)
 }
 
+/// Reads every `<module>_<hash>.json` file in `cache_dir` and replays the
+/// cached `specs_line` into a new [`NativeTypeRegistry`].
+///
+/// Used by `beamtalk lint` (BT-2134) to populate the same FFI type registry
+/// `beamtalk build` uses, so the type checker's "Dynamic in typed class"
+/// warning agrees with build on whether an FFI call is typed. Without this,
+/// lint sees every `(Erlang m) f:` call as `Dynamic(UntypedFfi)` even when
+/// the build cache has typed signatures.
+///
+/// Cache freshness is not checked here — build is responsible for updating
+/// stale cache entries against `.beam` mtimes. Lint reads whatever build
+/// produced; if the user has not run build (or has deleted the cache), the
+/// registry is empty and lint behaves as it did before.
+///
+/// Returns `None` if `cache_dir` is not a directory or contains no entries.
+pub fn load_type_cache_registry(cache_dir: &Utf8Path) -> Option<NativeTypeRegistry> {
+    if !cache_dir.is_dir() {
+        return None;
+    }
+
+    let entries = std::fs::read_dir(cache_dir.as_std_path()).ok()?;
+    let mut registry = NativeTypeRegistry::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(entry) = serde_json::from_str::<TypeCacheEntry>(&content) else {
+            continue;
+        };
+        if !entry.specs_line.is_empty() {
+            parse_specs_line(&entry.specs_line, &mut registry);
+        }
+    }
+
+    if registry.module_count() == 0 {
+        None
+    } else {
+        Some(registry)
+    }
+}
+
 /// Sanitizes a module name derived from a beam file path by stripping any
 /// directory components (path separators). This prevents path traversal when
 /// the module name is used in cache filenames.

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -966,9 +966,11 @@ mod tests {
         );
     }
 
-    /// BT-2134: `load_type_cache_registry` reads every `<module>_<hash>.json`
-    /// in the cache directory and replays its `specs_line` into a registry,
-    /// matching the format `beamtalk build` writes via `TypeCache::store`.
+    /// BT-2134: `load_type_cache_registry` reads `<module>_<16-hex>.json`
+    /// files in the cache directory and replays their `specs_line` into a
+    /// registry, matching the format `beamtalk build` writes via
+    /// `TypeCache::store`. Foreign files (no hash, wrong extension, non-hex
+    /// suffix) must be ignored.
     #[test]
     fn load_type_cache_registry_populates_from_cached_json() {
         use crate::beam_compiler::load_type_cache_registry;
@@ -977,14 +979,25 @@ mod tests {
         let cache_dir = camino::Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
         std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
 
-        // Two fixture entries: one with a typed spec, one with a non-spec
-        // file that must be ignored.
+        // Real cache entry — 16-hex hash matches `TypeCache::cache_path`.
         std::fs::write(
-            cache_dir.join("gen_tcp_aaaa.json").as_std_path(),
+            cache_dir.join("gen_tcp_0123456789abcdef.json").as_std_path(),
             r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}]"}"#,
         )
         .unwrap();
+        // Foreign files that must be ignored: wrong extension, missing hash,
+        // non-hex hash, short hash.
         std::fs::write(cache_dir.join("notes.txt").as_std_path(), "ignored").unwrap();
+        std::fs::write(
+            cache_dir.join("gen_tcp.json").as_std_path(),
+            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":""}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            cache_dir.join("gen_tcp_xyz.json").as_std_path(),
+            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":""}"#,
+        )
+        .unwrap();
 
         let registry = load_type_cache_registry(&cache_dir).expect("registry must load");
         assert!(
@@ -1007,5 +1020,98 @@ mod tests {
         let empty = camino::Utf8PathBuf::from_path_buf(temp.path().join("empty")).unwrap();
         std::fs::create_dir_all(empty.as_std_path()).unwrap();
         assert!(load_type_cache_registry(&empty).is_none());
+    }
+
+    /// BT-2134 (`CodeRabbit` follow-up): When the cache has accumulated
+    /// multiple `<module>_<hash>.json` entries for the same module — e.g.
+    /// after a dependency upgrade or BEAM path change moved the spec to a
+    /// new hash — the loader must replay only the most-recently-modified
+    /// entry. Replaying both could let `read_dir` order pick the stale
+    /// signature, reintroducing the lint/build disagreement BT-2134 fixed.
+    #[test]
+    fn load_type_cache_registry_picks_latest_when_module_has_multiple_hashes() {
+        use crate::beam_compiler::load_type_cache_registry;
+        use beamtalk_core::semantic_analysis::type_checker::FunctionSignature;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache_dir = camino::Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
+        std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
+
+        // Stale entry — written first, given an older mtime explicitly.
+        // The stale spec describes `connect/2` returning `Symbol` (wrong).
+        let stale_path = cache_dir.join("gen_tcp_aaaaaaaaaaaaaaaa.json");
+        std::fs::write(
+            stale_path.as_std_path(),
+            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Symbol\">>}]"}"#,
+        )
+        .unwrap();
+        // Force the stale entry's mtime backwards so the latest-mtime test
+        // is unambiguous regardless of filesystem timestamp granularity.
+        let old = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        std::fs::File::options()
+            .write(true)
+            .open(stale_path.as_std_path())
+            .expect("reopen stale fixture")
+            .set_modified(old)
+            .expect("set stale mtime");
+
+        // Fresh entry — the spec describes the real `Result(...)` return.
+        std::fs::write(
+            cache_dir
+                .join("gen_tcp_bbbbbbbbbbbbbbbb.json")
+                .as_std_path(),
+            r#"{"beam_mtime_secs":1,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}]"}"#,
+        )
+        .unwrap();
+
+        let registry = load_type_cache_registry(&cache_dir).expect("registry must load");
+        let sig: &FunctionSignature = registry
+            .lookup("gen_tcp", "connect", 2)
+            .expect("connect/2 should resolve");
+        // The fresh `Result(...)` return must win. If the stale `Symbol`
+        // return overwrote it (last-write-loses on hash-set replay), the
+        // displayed signature would end with `-> Symbol`.
+        let display = sig.display_signature();
+        assert!(
+            display.contains("Result"),
+            "loader must pick the latest-mtime cache entry; got: {display}"
+        );
+    }
+
+    /// BT-2134 (`CodeRabbit` follow-up): Module names that themselves contain
+    /// underscores (e.g. `gen_tcp_socket`) must not be confused with a
+    /// hash-suffixed entry for `gen_tcp`. The filename parser splits on the
+    /// final underscore and requires the trailing segment to be exactly 16
+    /// hex chars — the hash format `TypeCache::cache_path` writes.
+    #[test]
+    fn load_type_cache_registry_disambiguates_underscored_module_names() {
+        use crate::beam_compiler::load_type_cache_registry;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache_dir = camino::Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
+        std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
+
+        std::fs::write(
+            cache_dir
+                .join("gen_tcp_socket_1111111111111111.json")
+                .as_std_path(),
+            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp_socket:[#{arity => 1,line => 1,name => <<\"close\">>,params => [#{name => <<\"sock\">>,type => <<\"Object\">>}],return_type => <<\"Symbol\">>}]"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            cache_dir.join("gen_tcp_2222222222222222.json").as_std_path(),
+            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 1,line => 1,name => <<\"close\">>,params => [#{name => <<\"sock\">>,type => <<\"Object\">>}],return_type => <<\"Symbol\">>}]"}"#,
+        )
+        .unwrap();
+
+        let registry = load_type_cache_registry(&cache_dir).expect("registry must load");
+        assert!(
+            registry.lookup("gen_tcp_socket", "close", 1).is_some(),
+            "gen_tcp_socket module should be loaded under its full name"
+        );
+        assert!(
+            registry.lookup("gen_tcp", "close", 1).is_some(),
+            "gen_tcp module should be loaded independently"
+        );
     }
 }

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -40,6 +40,9 @@ fn collect_diagnostics(
     module: &beamtalk_core::ast::Module,
     parse_diags: Vec<beamtalk_core::source_analysis::Diagnostic>,
     cross_file_classes: Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
+    native_type_registry: Option<
+        std::sync::Arc<beamtalk_core::semantic_analysis::type_checker::NativeTypeRegistry>,
+    >,
 ) -> Vec<beamtalk_core::source_analysis::Diagnostic> {
     // Collect parser-level lint diagnostics (e.g. unnecessary `.` — BT-948)
     // plus AST-level lint passes.
@@ -58,10 +61,17 @@ fn collect_diagnostics(
     //
     // Pass cross-file class info so lint sees the same class hierarchy as build,
     // matching diagnostics for actor instantiation, type errors, etc.
-    let analysis_result = beamtalk_core::semantic_analysis::analyse_with_options_and_classes(
+    //
+    // BT-2134: Pass the FFI type registry (loaded from the build cache) so lint
+    // sees `(Erlang m) f:` calls as typed when build does. Without it, every
+    // FFI call falls back to `Dynamic(UntypedFfi)` and lint emits a
+    // "Dynamic in typed class" warning that build does not — leaving the user
+    // with no `@expect` configuration that satisfies both passes.
+    let analysis_result = beamtalk_core::semantic_analysis::analyse_with_natives(
         module,
         &beamtalk_core::CompilerOptions::default(),
         cross_file_classes,
+        native_type_registry,
     );
     lint_diags.extend(
         analysis_result
@@ -106,6 +116,16 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
         resolve_dep_class_infos(project_root, &mut all_class_infos);
     }
 
+    // BT-2134: Load the FFI type registry from `_build/type_cache/` so lint
+    // sees Erlang FFI return types the same way build does. The cache is
+    // populated by `beamtalk build`; if it's missing, lint falls back to no
+    // registry (matching the previous behaviour for projects that have never
+    // been built).
+    let native_type_registry = package_root.as_deref().and_then(|root| {
+        let cache_dir = root.join("_build").join("type_cache");
+        crate::beam_compiler::load_type_cache_registry(&cache_dir).map(std::sync::Arc::new)
+    });
+
     // Pass 2: Analyse each file with cross-file class context.
     let mut total_lint_count = 0usize;
     let mut all_diags: Vec<beamtalk_core::source_analysis::Diagnostic> = Vec::new();
@@ -117,7 +137,12 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
                 &module,
             );
 
-        let lint_diags = collect_diagnostics(&module, parse_diags, cross_file_classes);
+        let lint_diags = collect_diagnostics(
+            &module,
+            parse_diags,
+            cross_file_classes,
+            native_type_registry.clone(),
+        );
 
         for diag in &lint_diags {
             match format {
@@ -511,7 +536,7 @@ pub(crate) fn diagnostic_summary_to_json(
 fn collect_lint_diagnostics(source: &str) -> Vec<beamtalk_core::source_analysis::Diagnostic> {
     let tokens = lex_with_eof(source);
     let (module, parse_diags) = parse(tokens);
-    collect_diagnostics(&module, parse_diags, vec![])
+    collect_diagnostics(&module, parse_diags, vec![], None)
 }
 
 #[cfg(test)]
@@ -596,7 +621,7 @@ mod tests {
 ";
         let tokens = lex_with_eof(test_source);
         let (module, parse_diags) = parse(tokens);
-        let diags = collect_diagnostics(&module, parse_diags, cross_file_classes);
+        let diags = collect_diagnostics(&module, parse_diags, cross_file_classes, None);
         let stale = diags.iter().any(|d| d.message.contains("stale @expect"));
         assert!(
             !stale,
@@ -787,7 +812,7 @@ mod tests {
                 &all_class_infos,
                 &module,
             );
-        let diags = collect_diagnostics(&module, parse_diags, cross_file_classes);
+        let diags = collect_diagnostics(&module, parse_diags, cross_file_classes, None);
 
         let unresolved: Vec<_> = diags
             .iter()
@@ -866,5 +891,121 @@ mod tests {
 
         let expected = camino::Utf8PathBuf::from_path_buf(root.canonicalize().unwrap()).unwrap();
         assert_eq!(found, Some(expected));
+    }
+
+    /// BT-2134: With no FFI registry, an `(Erlang m) f:` call in a typed class
+    /// infers as `Dynamic(UntypedFfi)` and lint emits the BT-1914
+    /// "Dynamic in typed class (untyped FFI)" warning.
+    ///
+    /// This is the pre-fix lint behaviour, captured to make the next test's
+    /// improvement clear: with the registry loaded, no warning fires.
+    #[test]
+    fn ffi_call_without_registry_warns_dynamic_in_typed_class() {
+        let source = r#"sealed typed Value subclass: TcpCheck
+  field: host :: String = "localhost"
+
+  check -> String =>
+    result := (Erlang gen_tcp) connect: self.host asAtom port: 80
+    result printString
+"#;
+        let tokens = lex_with_eof(source);
+        let (module, parse_diags) = parse(tokens);
+        let diags = collect_diagnostics(&module, parse_diags, vec![], None);
+
+        let has_untyped_ffi = diags.iter().any(|d| d.message.contains("untyped FFI"));
+        assert!(
+            has_untyped_ffi,
+            "without registry, lint should warn untyped FFI; got: {diags:?}"
+        );
+    }
+
+    /// BT-2134: With the FFI registry loaded (build cache present), an
+    /// `(Erlang m) f:` call resolves to a typed return — `Result(...)` for
+    /// `gen_tcp:connect/2`. The receiver is no longer `Dynamic` at the top
+    /// level, so the BT-1914 "Dynamic in typed class (untyped FFI)" warning
+    /// must NOT fire. This is the build behaviour; without this fix lint
+    /// disagreed.
+    #[test]
+    fn ffi_call_with_registry_does_not_warn_dynamic_in_typed_class() {
+        use beamtalk_core::semantic_analysis::type_checker::{
+            NativeTypeRegistry, parse_specs_line,
+        };
+
+        let mut registry = NativeTypeRegistry::new();
+        // Same shape as the cached spec line for gen_tcp:connect/2.
+        let line = "beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}]";
+        parse_specs_line(line, &mut registry);
+        assert!(
+            registry.lookup("gen_tcp", "connect", 2).is_some(),
+            "fixture must register gen_tcp:connect/2"
+        );
+
+        let source = r#"sealed typed Value subclass: TcpCheck
+  field: host :: String = "localhost"
+
+  check -> String =>
+    result := (Erlang gen_tcp) connect: self.host asAtom port: 80
+    result printString
+"#;
+        let tokens = lex_with_eof(source);
+        let (module, parse_diags) = parse(tokens);
+        let diags = collect_diagnostics(
+            &module,
+            parse_diags,
+            vec![],
+            Some(std::sync::Arc::new(registry)),
+        );
+
+        let untyped_ffi: Vec<_> = diags
+            .iter()
+            .filter(|d| d.message.contains("untyped FFI"))
+            .collect();
+        assert!(
+            untyped_ffi.is_empty(),
+            "with registry, lint must not warn untyped FFI; got: {untyped_ffi:?}"
+        );
+    }
+
+    /// BT-2134: `load_type_cache_registry` reads every `<module>_<hash>.json`
+    /// in the cache directory and replays its `specs_line` into a registry,
+    /// matching the format `beamtalk build` writes via `TypeCache::store`.
+    #[test]
+    fn load_type_cache_registry_populates_from_cached_json() {
+        use crate::beam_compiler::load_type_cache_registry;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache_dir = camino::Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
+        std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
+
+        // Two fixture entries: one with a typed spec, one with a non-spec
+        // file that must be ignored.
+        std::fs::write(
+            cache_dir.join("gen_tcp_aaaa.json").as_std_path(),
+            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}]"}"#,
+        )
+        .unwrap();
+        std::fs::write(cache_dir.join("notes.txt").as_std_path(), "ignored").unwrap();
+
+        let registry = load_type_cache_registry(&cache_dir).expect("registry must load");
+        assert!(
+            registry.lookup("gen_tcp", "connect", 2).is_some(),
+            "loaded registry should contain gen_tcp:connect/2"
+        );
+    }
+
+    /// BT-2134: An empty or missing `_build/type_cache/` directory must yield
+    /// `None`, not an error — projects that have never been built should still
+    /// lint without crashing.
+    #[test]
+    fn load_type_cache_registry_returns_none_when_missing() {
+        use crate::beam_compiler::load_type_cache_registry;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let missing = camino::Utf8PathBuf::from_path_buf(temp.path().join("nonexistent")).unwrap();
+        assert!(load_type_cache_registry(&missing).is_none());
+
+        let empty = camino::Utf8PathBuf::from_path_buf(temp.path().join("empty")).unwrap();
+        std::fs::create_dir_all(empty.as_std_path()).unwrap();
+        assert!(load_type_cache_registry(&empty).is_none());
     }
 }


### PR DESCRIPTION
## Summary

`beamtalk lint` ran the type checker without populating the `NativeTypeRegistry`, so every `(Erlang m) f:` call inferred as `Dynamic(UntypedFfi)` and produced a "Dynamic in typed class (untyped FFI)" warning even when the build cache held a typed signature. `beamtalk build`, which loads the registry, saw the typed return and emitted no warning — leaving users with no source state that satisfied both passes:

- With `@expect type` on the FFI call → lint clean, build warns "stale @expect type".
- Without `@expect type` → build clean, lint warns "Dynamic in typed class (untyped FFI)".

## Fix

Lint now reads `_build/type_cache/<module>_<hash>.json` from the package root and feeds the resulting registry into `analyse_with_natives`, matching what build sees. A new `load_type_cache_registry` helper in `beam_compiler.rs` reads every JSON entry the build cache wrote via `TypeCache::store`. If the cache is missing (project never built), lint falls back to no registry, preserving prior behaviour.

After the fix, build and lint agree on the BT-2134 repro: with `@expect type` both warn stale; without it, both are clean.

## Key changes

- `crates/beamtalk-cli/src/beam_compiler.rs`: new `load_type_cache_registry` helper that loads cached `specs_line` entries into a `NativeTypeRegistry`.
- `crates/beamtalk-cli/src/commands/lint.rs`: thread an optional `NativeTypeRegistry` through `collect_diagnostics`; load it from `_build/type_cache/` in `run_lint`; switch from `analyse_with_options_and_classes` to `analyse_with_natives`.
- Four new tests cover both directions (with/without registry) plus cache loading (populated and missing/empty cases).

Linear: https://linear.app/beamtalk/issue/BT-2134

## Test plan

- [x] `cargo test -p beamtalk-cli` — all unit tests pass, including the four new BT-2134 tests
- [x] `just build && just clippy && just fmt-check` — clean
- [x] Manual repro of the issue's `gen_tcp:connect/4` case: build and lint now agree
- [ ] CI on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `beamtalk lint` can now consume cached FFI type information from the build output to provide richer, typed diagnostics for Erlang foreign calls.
* **Bug Fixes**
  * Chooses the most recent cache per module to avoid stale data and ignores empty cache entries.
* **Tests**
  * Added tests validating cache loading behavior and lint diagnostics both with and without cached type information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->