### PR TITLE
Extract shared erlc-compile helper from 4 duplicated codegen test blocks (BT-2107)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -152,9 +152,6 @@ fn test_block_repeat_infinite_loop() {
 
 #[test]
 fn test_while_true_compiles_through_erlc() {
-    use std::io::Write;
-    use std::process::Command;
-
     // Generate a complete module with a whileTrue: expression
     let mut generator = CoreErlangGenerator::new("test_while_loop");
 
@@ -192,40 +189,7 @@ fn test_while_true_compiles_through_erlc() {
 
     full_output.push_str("\n\nend\n");
 
-    // Write to temp file
-    let temp_dir = std::env::temp_dir();
-    let core_file = temp_dir.join("test_while_loop.core");
-    let mut file = std::fs::File::create(&core_file).expect("Failed to create temp file");
-    file.write_all(full_output.as_bytes())
-        .expect("Failed to write Core Erlang");
-
-    // Try to compile with erlc
-    let output = Command::new("erlc")
-        .arg("+from_core")
-        .arg("-o")
-        .arg(&temp_dir)
-        .arg(&core_file)
-        .output();
-
-    // Clean up temp files regardless of result
-    let _ = std::fs::remove_file(&core_file);
-    let beam_file = temp_dir.join("test_while_loop.beam");
-    let _ = std::fs::remove_file(&beam_file);
-
-    match output {
-        Ok(result) => {
-            if !result.status.success() {
-                let stderr = String::from_utf8_lossy(&result.stderr);
-                panic!(
-                    "erlc compilation failed.\n\nGenerated Core Erlang:\n{full_output}\n\nerlc error:\n{stderr}",
-                );
-            }
-        }
-        Err(e) => {
-            // erlc not available, skip this test with a message
-            eprintln!("Skipping erlc compilation test: {e}");
-        }
-    }
+    crate::test_helpers::assert_compiles_through_erlc("test_while_loop", &full_output);
 }
 
 #[test]

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/expressions.rs
@@ -288,9 +288,6 @@ fn test_class_name_to_module_name() {
 
 #[test]
 fn test_generated_core_erlang_compiles() {
-    use std::fs;
-    use std::process::Command;
-
     // Test a self-contained Core Erlang module to verify syntax is valid
     // This specifically tests that:
     // 1. Empty map syntax ~{}~ compiles correctly
@@ -308,46 +305,11 @@ fn test_generated_core_erlang_compiles() {
 end
 ";
 
-    // Write to temporary file
-    let temp_dir = std::env::temp_dir();
-    let core_file = temp_dir.join("test_module.core");
-    fs::write(&core_file, core_erlang).expect("should write core erlang file");
-
-    // Try to compile with erlc
-    let output = Command::new("erlc")
-        .arg("+from_core")
-        .arg(&core_file)
-        .current_dir(&temp_dir)
-        .output();
-
-    // Clean up
-    let _ = fs::remove_file(&core_file);
-    let beam_file = temp_dir.join("test_module.beam");
-    let _ = fs::remove_file(&beam_file);
-
-    // Check compilation result
-    match output {
-        Ok(output) => {
-            assert!(
-                output.status.success(),
-                "erlc compilation failed:\nstdout: {}\nstderr: {}\nGenerated code:\n{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr),
-                core_erlang
-            );
-        }
-        Err(_) => {
-            // erlc not available, skip test
-            println!("Skipping test - erlc not installed in CI environment");
-        }
-    }
+    crate::test_helpers::assert_compiles_through_erlc("test_module", core_erlang);
 }
 
 #[test]
 fn test_string_literal_core_erlang_compiles() {
-    use std::fs;
-    use std::process::Command;
-
     // Test that string literals compile correctly through the full pipeline
     // This tests the new binary syntax: #{#<value>(8,1,'integer',['unsigned'|['big']]),...}#
     let core_erlang = r"module 'test_string' ['get_greeting'/0]
@@ -359,39 +321,7 @@ fn test_string_literal_core_erlang_compiles() {
 end
 ";
 
-    // Write to temporary file
-    let temp_dir = std::env::temp_dir();
-    let core_file = temp_dir.join("test_string.core");
-    fs::write(&core_file, core_erlang).expect("should write core erlang file");
-
-    // Try to compile with erlc
-    let output = Command::new("erlc")
-        .arg("+from_core")
-        .arg(&core_file)
-        .current_dir(&temp_dir)
-        .output();
-
-    // Clean up
-    let _ = fs::remove_file(&core_file);
-    let beam_file = temp_dir.join("test_string.beam");
-    let _ = fs::remove_file(&beam_file);
-
-    // Check compilation result
-    match output {
-        Ok(output) => {
-            assert!(
-                output.status.success(),
-                "erlc compilation of string literal failed:\nstdout: {}\nstderr: {}\nGenerated code:\n{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr),
-                core_erlang
-            );
-        }
-        Err(_) => {
-            // erlc not available, skip test
-            println!("Skipping test - erlc not installed in CI environment");
-        }
-    }
+    crate::test_helpers::assert_compiles_through_erlc("test_string", core_erlang);
 }
 
 #[test]
@@ -484,9 +414,6 @@ fn test_generate_map_literal_with_atoms() {
 
 #[test]
 fn test_generate_map_literal_compiles() {
-    use std::fs;
-    use std::process::Command;
-
     let pairs = vec![MapPair::new(
         Expression::Literal(Literal::Symbol("key".into()), Span::new(2, 6)),
         Expression::Literal(Literal::String("value".into()), Span::new(10, 17)),
@@ -513,32 +440,8 @@ fn test_generate_map_literal_compiles() {
         "String should be represented as binary"
     );
 
-    // Try to compile with erlc if available
-    let temp_dir = std::env::temp_dir();
-    let core_file = temp_dir.join("test_map_lit.core");
-    if let Ok(()) = fs::write(&core_file, &code) {
-        let output = Command::new("erlc")
-            .arg("+from_core")
-            .arg(&core_file)
-            .current_dir(&temp_dir)
-            .output();
-
-        // Clean up
-        let _ = fs::remove_file(&core_file);
-        let beam_file = temp_dir.join("test_map_lit.beam");
-        let _ = fs::remove_file(&beam_file);
-
-        // Check compilation result if erlc is available
-        if let Ok(output) = output {
-            assert!(
-                output.status.success(),
-                "erlc compilation of map literal failed:\nstdout: {}\nstderr: {}\nGenerated code:\n{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr),
-                code
-            );
-        }
-    }
+    // Verify the generated code compiles through erlc
+    crate::test_helpers::assert_compiles_through_erlc("test_map_lit", &code);
 }
 
 #[test]

--- a/crates/beamtalk-core/src/test_helpers.rs
+++ b/crates/beamtalk-core/src/test_helpers.rs
@@ -20,6 +20,51 @@ pub fn unique_temp_dir(prefix: &str) -> PathBuf {
     std::env::temp_dir().join(format!("{prefix}_{}_{}", std::process::id(), nanos))
 }
 
+/// Asserts that the given Core Erlang source compiles successfully through `erlc`.
+///
+/// Uses `tempfile::tempdir()` for an isolated temp directory per invocation,
+/// avoiding filename collisions when tests run in parallel. The temp dir and
+/// all its contents are automatically cleaned up on drop.
+///
+/// If `erlc` is not found in PATH, prints a skip notice and returns without
+/// failing.
+///
+/// # Panics
+///
+/// Panics if `erlc` exits with a non-zero status, including the full Core
+/// Erlang source in the panic message to aid debugging.
+#[cfg(test)]
+pub fn assert_compiles_through_erlc(module_name: &str, core_erlang: &str) {
+    use std::fs;
+    use std::process::Command;
+
+    let tmp_dir = tempfile::tempdir().expect("failed to create temp dir for erlc test");
+    let core_file = tmp_dir.path().join(format!("{module_name}.core"));
+    fs::write(&core_file, core_erlang).expect("should write core erlang file");
+
+    let output = Command::new("erlc")
+        .arg("+from_core")
+        .arg("-o")
+        .arg(tmp_dir.path())
+        .arg(&core_file)
+        .output();
+
+    match output {
+        Ok(output) => {
+            assert!(
+                output.status.success(),
+                "erlc compilation failed for module '{module_name}':\nstdout: {}\nstderr: {}\n\nGenerated Core Erlang:\n{core_erlang}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+        }
+        Err(_) => {
+            println!("Skipping erlc compilation test for '{module_name}' - erlc not in PATH");
+        }
+    }
+    // tmp_dir is dropped here, auto-cleaning .core and .beam files
+}
+
 /// Test-only helpers: parsing, codegen assertions, and AST builders.
 ///
 /// Gated on `#[cfg(any(test, feature = "test"))]` to avoid prod binary

--- a/crates/beamtalk-core/src/test_helpers.rs
+++ b/crates/beamtalk-core/src/test_helpers.rs
@@ -58,8 +58,11 @@ pub fn assert_compiles_through_erlc(module_name: &str, core_erlang: &str) {
                 String::from_utf8_lossy(&output.stderr),
             );
         }
-        Err(_) => {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             println!("Skipping erlc compilation test for '{module_name}' - erlc not in PATH");
+        }
+        Err(e) => {
+            panic!("failed to invoke erlc for module '{module_name}': {e}");
         }
     }
     // tmp_dir is dropped here, auto-cleaning .core and .beam files


### PR DESCRIPTION
## Summary

Extracts a shared `assert_compiles_through_erlc(module_name, core_erlang)` helper from 4 duplicated ~25-30 line blocks in codegen tests.

- Adds `assert_compiles_through_erlc()` to `crates/beamtalk-core/src/test_helpers.rs`
- Uses `tempfile::tempdir()` for unique temp dirs per invocation (eliminates parallel-test filename collision hazard)
- Passes `-o <dir>` to erlc so .beam lands in the temp dir
- TempDir auto-cleans on drop (no manual file removal)
- Panics with clear message including Core Erlang source on failure
- Prints skip notice if erlc not in PATH
- Replaces all 4 duplicated blocks (3 in expressions.rs, 1 in control_flow.rs)

## Linear Issue

https://linear.app/beamtalk/issue/BT-2107

## Test Plan

- [x] All 4 modified tests pass (`cargo test -p beamtalk-core --lib`)
- [x] Full beamtalk-core test suite passes (3307 tests)
- [x] Clippy clean with `-D warnings`
- [x] Formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated compilation-verification logic into a reusable test utility to improve test maintainability and consistency.

* **Tests**
  * Updated test cases to use the new helper, removing duplicated temp-file and manual compilation steps and cleaning up unused test imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->