### PR TITLE
conforms_to/2 returns false for unknown protocols (BT-2136)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
@@ -134,17 +134,17 @@ selectors of the protocol (including inherited requirements from
 Returns `true` if:
 - The class responds to all required instance selectors
 - The class responds to all required class method selectors
-- The protocol is not registered (unknown protocols — conservative)
 
 Returns `false` if:
+- The protocol is not registered (unknown or non-protocol names)
 - The class is missing one or more required selectors (instance or class)
 """.
 -spec conforms_to(atom(), atom()) -> boolean().
 conforms_to(ClassName, ProtocolName) ->
     case protocol_info(ProtocolName) of
         undefined ->
-            %% Unknown protocol — conservative, assume true
-            true;
+            %% Unknown protocol — cannot conform to something that isn't a protocol
+            false;
         Info ->
             AllMethods = all_required_methods(Info),
             AllClassMethods = all_required_class_methods(Info),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
@@ -1321,8 +1321,8 @@ class_conforms_to_unknown_protocol_test_() ->
             ?_test(begin
                 {ClassObj, Pid} = register_class('BT1792BiConformsTo', #{}, #{}),
                 try
-                    %% Unknown protocol returns true (conservative)
-                    ?assert(
+                    %% Unknown protocol returns false (BT-2136)
+                    ?assertNot(
                         beamtalk_behaviour_intrinsics:classConformsTo(
                             ClassObj, 'NoSuchProtocol'
                         )

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_protocol_registry_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_protocol_registry_tests.erl
@@ -196,8 +196,19 @@ required_methods_unknown_protocol_test() ->
 
 conforms_to_unknown_protocol_test() ->
     setup(),
-    %% Unknown protocol — conservative, returns true
-    ?assert(beamtalk_protocol_registry:conforms_to('Integer', 'Unknown')).
+    %% Unknown protocol — cannot conform to something that isn't a protocol
+    ?assertNot(beamtalk_protocol_registry:conforms_to('Integer', 'Unknown')).
+
+conforms_to_nonexistent_protocol_test() ->
+    setup(),
+    %% A completely made-up protocol name (typo scenario)
+    ?assertNot(beamtalk_protocol_registry:conforms_to('Dictionary', 'Printable2')).
+
+conforms_to_class_name_as_protocol_test() ->
+    setup(),
+    %% A class name passed where a protocol name is expected (e.g. #Integer)
+    %% Integer is a class, not a protocol — should return false
+    ?assertNot(beamtalk_protocol_registry:conforms_to('Dictionary', 'Integer')).
 
 %%% ============================================================================
 %%% Empty Registry Edge Cases


### PR DESCRIPTION
## Summary

- Fix `conforms_to/2` in `beamtalk_protocol_registry` to return `false` when the protocol name is not registered, instead of incorrectly returning `true`
- Previously, `Dictionary conformsTo: #Integer` returned `true` even though `Integer` is a class, not a protocol
- Add EUnit coverage for unknown protocol name and class-name-as-protocol scenarios

## Linear Issue

https://linear.app/beamtalk/issue/BT-2136/conforms-to2-returns-true-for-unknown-protocols

## Changes

- `runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl`: Change `undefined` arm from `true` to `false`, update doc comment
- `runtime/apps/beamtalk_runtime/test/beamtalk_protocol_registry_tests.erl`: Update existing test assertion, add 2 new test cases

## Test plan

- [x] `conforms_to_unknown_protocol_test` — verifies `false` for unknown protocol name
- [x] `conforms_to_nonexistent_protocol_test` — verifies `false` for typo/nonexistent protocol
- [x] `conforms_to_class_name_as_protocol_test` — verifies `false` when class name used as protocol
- [x] All existing protocol registry tests still pass (27 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Protocol validation now correctly rejects unknown/unregistered protocols instead of accepting them by default.

* **Tests**
  * Updated test suite to expect non-conformance for unknown protocol names and when a class name is passed where a protocol name is expected.

* **Documentation**
  * Clarified conformance documentation to list unknown protocols as non-conforming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->