### PR TITLE
Add codegen tests for allSatisfy:/detect:ifNone: with local mutation (BT-2114)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
@@ -712,3 +712,58 @@ fn test_detect_with_local_mutation_uses_tuple_acc() {
         "detect: with local mutation should NOT use maps:get for '__local__count'. Got:\n{code}"
     );
 }
+
+#[test]
+fn test_all_satisfy_with_local_mutation_uses_tuple_acc() {
+    // BT-1481 + BT-1276: allSatisfy: with only a local variable mutation uses the
+    // tuple-accumulator path: {BoolAcc, Var1, ...}. Locals are unpacked via
+    // element(N, AccSt) inside the lambda — not via maps:get.
+    let src = concat!(
+        "Actor subclass: Ctr\n",
+        "  state: x = 0\n\n",
+        "  run: items =>\n",
+        "    count := 0\n",
+        "    items allSatisfy: [:item | count := count + 1. item > 0]\n",
+        "    count\n",
+    );
+    let code = codegen(src);
+    // BoolAcc is at position 1; 'count' is the first threaded local so it lives at
+    // position 2 inside the lambda accumulator tuple.
+    assert!(
+        code.contains("let Count = call 'erlang':'element'(2, "),
+        "allSatisfy: with local mutation should extract 'count' via element(2, AccSt) in tuple-acc lambda. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("maps':'get'('__local__count'"),
+        "allSatisfy: with local mutation should NOT use maps:get for '__local__count'. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_detect_if_none_with_local_mutation_uses_tuple_acc() {
+    // BT-1486 + BT-1276: detect:ifNone: with only a local variable mutation uses the
+    // tuple-accumulator path: {FoundItem, FoundFlag, Var1, ...}. Locals are
+    // unpacked via element(N, AccSt) inside the lambda — not via maps:get.
+    let src = concat!(
+        "Actor subclass: Ctr\n",
+        "  state: x = 0\n\n",
+        "  run: items =>\n",
+        "    count := 0\n",
+        "    items detect: [:item | count := count + 1. item > 0] ifNone: [42]\n",
+        "    count\n",
+    );
+    let code = codegen(src);
+    // FoundItem=1, FoundFlag=2; 'count' is the first threaded local at position 3.
+    assert!(
+        code.contains("let Count = call 'erlang':'element'(3, "),
+        "detect:ifNone: with local mutation should extract 'count' via element(3, AccSt) in tuple-acc lambda. Got:\n{code}"
+    );
+    assert!(
+        code.contains("FoundFlag"),
+        "detect:ifNone: with local mutation should still use FoundFlag accumulator. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("maps':'get'('__local__count'"),
+        "detect:ifNone: with local mutation should NOT use maps:get for '__local__count'. Got:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the two acceptance criteria from BT-2114 left uncovered by BT-2111 (#2152):
- `allSatisfy:` with local mutation — tuple-accumulator path
- `detect:ifNone:` with local mutation — tuple-accumulator path

Both tests follow the existing pattern established by `test_any_satisfy_with_local_mutation_uses_tuple_acc` and `test_detect_with_local_mutation_uses_tuple_acc`, asserting that locals are extracted via `element(N, AccSt)` (not `maps:get`) inside the `lists:foldl` lambda.

Linear: https://linear.app/beamtalk/issue/BT-2114

## Key Changes

- `crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs`: +55 lines, two new tests.
  - `test_all_satisfy_with_local_mutation_uses_tuple_acc` — asserts `Count = element(2, ...)` (BoolAcc=1, locals from 2).
  - `test_detect_if_none_with_local_mutation_uses_tuple_acc` — asserts `Count = element(3, ...)` (FoundItem=1, FoundFlag=2, locals from 3) and that `FoundFlag` is still threaded.

No production code changes.

## Test Plan

- [x] `cargo test -p beamtalk-core --lib -- test_all_satisfy_with_local_mutation_uses_tuple_acc test_detect_if_none_with_local_mutation_uses_tuple_acc` passes
- [x] Full search-ops test suite (51 tests) passes
- [x] `just clippy` passes
- [x] `just fmt-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification tests for tuple-accumulator behavior in local mutation scenarios to ensure correct code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->