### PR TITLE
Validate beam mtime when loading lint type cache (BT-2139)

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -996,6 +996,13 @@ struct TypeCacheEntry {
     /// Combined with `beam_mtime_secs` to avoid cache collisions on rapid rewrites.
     #[serde(default)]
     beam_mtime_nanos: u32,
+    /// Absolute path to the `.beam` file at the time specs were extracted.
+    /// Used by [`load_type_cache_registry`] to re-stat the file and skip the
+    /// entry if the live mtime no longer matches what was cached. Empty for
+    /// legacy entries written before BT-2139 — those are tolerated as fresh
+    /// until the next build rewrites them.
+    #[serde(default)]
+    beam_path: String,
     /// The raw `beamtalk-specs-module:...` protocol line (without newline).
     /// Empty string if the module had no specs or an error occurred.
     specs_line: String,
@@ -1071,6 +1078,7 @@ impl TypeCache {
         let entry = TypeCacheEntry {
             beam_mtime_secs,
             beam_mtime_nanos,
+            beam_path: beam_path.as_str().to_string(),
             specs_line: specs_line.to_string(),
         };
         let path = self.cache_path(module_name, beam_path);
@@ -1218,11 +1226,13 @@ pub fn extract_beam_specs(
 /// mtime — that's the one the most recent build wrote, and it matches what
 /// build's `extract_beam_specs` resolved for the current BEAM set.
 ///
-/// Cache freshness against the `.beam` itself is not checked here — build is
-/// responsible for updating cache entries against `.beam` mtimes. Lint reads
-/// whatever the most recent build produced; if the user has not run build
-/// (or has deleted the cache), the registry is empty and lint behaves as it
-/// did before.
+/// Each entry's `beam_path` is re-stat'd against the live filesystem (BT-2139).
+/// If the underlying `.beam` has changed since the build wrote the cache —
+/// e.g. `cargo build` rebuilt a NIF module, or an OTP upgrade replaced
+/// `gen_tcp.beam` — the entry is skipped so lint does not warn off stale FFI
+/// signatures. Entries written before BT-2139 carry an empty `beam_path`;
+/// those are pessimistically accepted as fresh until the next build rewrites
+/// them with a path.
 ///
 /// Returns `None` if `cache_dir` is not a directory or contains no entries.
 pub fn load_type_cache_registry(cache_dir: &Utf8Path) -> Option<NativeTypeRegistry> {
@@ -1276,6 +1286,9 @@ pub fn load_type_cache_registry(cache_dir: &Utf8Path) -> Option<NativeTypeRegist
         let Ok(entry) = serde_json::from_str::<TypeCacheEntry>(&content) else {
             continue;
         };
+        if !is_cache_entry_fresh(&entry) {
+            continue;
+        }
         if !entry.specs_line.is_empty() {
             parse_specs_line(&entry.specs_line, &mut registry);
         }
@@ -1297,6 +1310,25 @@ fn sanitize_module_name(name: &str) -> &str {
     after_slash
         .rfind('\\')
         .map_or(after_slash, |i| &after_slash[i + 1..])
+}
+
+/// Returns `true` if the cache entry still describes the live `.beam` file —
+/// i.e. the file at `beam_path` exists and its mtime matches what was cached.
+///
+/// Legacy entries written before BT-2139 carry an empty `beam_path`; we have
+/// no way to validate them, so they are pessimistically accepted as fresh.
+/// The next `beamtalk build` rewrites them with a path, which then enables
+/// validation on subsequent lint runs.
+fn is_cache_entry_fresh(entry: &TypeCacheEntry) -> bool {
+    if entry.beam_path.is_empty() {
+        return true;
+    }
+    let path = Utf8Path::new(&entry.beam_path);
+    if !path.exists() {
+        return false;
+    }
+    let (secs, nanos) = beam_mtime(path);
+    secs == entry.beam_mtime_secs && nanos == entry.beam_mtime_nanos
 }
 
 /// Returns the modification time of a `.beam` file as `(seconds, nanoseconds)`

--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -996,14 +996,14 @@ struct TypeCacheEntry {
     /// Combined with `beam_mtime_secs` to avoid cache collisions on rapid rewrites.
     #[serde(default)]
     beam_mtime_nanos: u32,
-    /// Absolute (canonicalised) path to the `.beam` file at the time specs
-    /// were extracted. Used by [`load_type_cache_registry`] to re-stat the
-    /// file and skip the entry if the live mtime no longer matches what was
-    /// cached. Canonicalising at write time means `beamtalk lint` can
-    /// validate the cache regardless of which cwd it is invoked from. Empty
-    /// for legacy entries written before BT-2139, and for the fallback case
-    /// where canonicalisation failed at write time — those are tolerated as
-    /// fresh until the next build rewrites them with a canonical path.
+    /// Absolute path to the `.beam` file at the time specs were extracted —
+    /// canonicalised when possible, otherwise resolved against the build's
+    /// cwd. Used by [`load_type_cache_registry`] to re-stat the file and
+    /// skip the entry if the live mtime no longer matches what was cached.
+    /// Persisting an absolute path means `beamtalk lint` can validate the
+    /// cache regardless of which cwd it is invoked from. Empty only for
+    /// legacy entries written before BT-2139 — those are tolerated as fresh
+    /// until the next build rewrites them with a path.
     #[serde(default)]
     beam_path: String,
     /// The raw `beamtalk-specs-module:...` protocol line (without newline).
@@ -1081,13 +1081,28 @@ impl TypeCache {
         // BT-2139: persist an absolute (canonicalised) path so freshness
         // validation in `load_type_cache_registry` works when `beamtalk lint`
         // runs from a different working directory than the build that wrote
-        // the cache. If canonicalisation fails (e.g. the file vanished
-        // mid-build), fall back to an empty string so the entry takes the
-        // legacy/permissive path on next lint — better than persisting a
-        // possibly-relative path that would resolve against the wrong cwd.
-        let canonical_beam_path = beam_path
-            .canonicalize_utf8()
-            .map_or_else(|_| String::new(), Utf8PathBuf::into_string);
+        // the cache. If `canonicalize_utf8` fails (typically because the
+        // `.beam` vanished or moved mid-build), fall back to a manually-built
+        // absolute path: if `beam_path` is already absolute, use it as-is;
+        // otherwise resolve it against the current working directory. We
+        // intentionally do *not* leave `beam_path` empty here — that would
+        // make `is_cache_entry_fresh` treat the entry as legacy/fresh, so
+        // lint would keep replaying stale specs instead of detecting that
+        // the underlying `.beam` is gone.
+        let canonical_beam_path = beam_path.canonicalize_utf8().map_or_else(
+            |_| {
+                if beam_path.is_absolute() {
+                    beam_path.as_str().to_string()
+                } else {
+                    std::env::current_dir()
+                        .ok()
+                        .and_then(|cwd| Utf8PathBuf::from_path_buf(cwd).ok())
+                        .map(|cwd| cwd.join(beam_path).into_string())
+                        .unwrap_or_default()
+                }
+            },
+            Utf8PathBuf::into_string,
+        );
         let entry = TypeCacheEntry {
             beam_mtime_secs,
             beam_mtime_nanos,

--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -996,11 +996,14 @@ struct TypeCacheEntry {
     /// Combined with `beam_mtime_secs` to avoid cache collisions on rapid rewrites.
     #[serde(default)]
     beam_mtime_nanos: u32,
-    /// Absolute path to the `.beam` file at the time specs were extracted.
-    /// Used by [`load_type_cache_registry`] to re-stat the file and skip the
-    /// entry if the live mtime no longer matches what was cached. Empty for
-    /// legacy entries written before BT-2139 — those are tolerated as fresh
-    /// until the next build rewrites them.
+    /// Absolute (canonicalised) path to the `.beam` file at the time specs
+    /// were extracted. Used by [`load_type_cache_registry`] to re-stat the
+    /// file and skip the entry if the live mtime no longer matches what was
+    /// cached. Canonicalising at write time means `beamtalk lint` can
+    /// validate the cache regardless of which cwd it is invoked from. Empty
+    /// for legacy entries written before BT-2139, and for the fallback case
+    /// where canonicalisation failed at write time — those are tolerated as
+    /// fresh until the next build rewrites them with a canonical path.
     #[serde(default)]
     beam_path: String,
     /// The raw `beamtalk-specs-module:...` protocol line (without newline).
@@ -1075,10 +1078,20 @@ impl TypeCache {
             debug!("Failed to create type cache dir: {e}");
             return;
         }
+        // BT-2139: persist an absolute (canonicalised) path so freshness
+        // validation in `load_type_cache_registry` works when `beamtalk lint`
+        // runs from a different working directory than the build that wrote
+        // the cache. If canonicalisation fails (e.g. the file vanished
+        // mid-build), fall back to an empty string so the entry takes the
+        // legacy/permissive path on next lint — better than persisting a
+        // possibly-relative path that would resolve against the wrong cwd.
+        let canonical_beam_path = beam_path
+            .canonicalize_utf8()
+            .map_or_else(|_| String::new(), Utf8PathBuf::into_string);
         let entry = TypeCacheEntry {
             beam_mtime_secs,
             beam_mtime_nanos,
-            beam_path: beam_path.as_str().to_string(),
+            beam_path: canonical_beam_path,
             specs_line: specs_line.to_string(),
         };
         let path = self.cache_path(module_name, beam_path);

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -1102,11 +1102,16 @@ mod tests {
             .unwrap();
 
         // Cache an mtime far in the past so the live file looks newer.
+        // Use serde_json to avoid Windows backslash-escaping pitfalls when
+        // interpolating a temp path into a JSON string literal.
         let stale_secs = live.as_secs().saturating_sub(3600);
-        let beam_path_str = beam_path.to_str().unwrap();
-        let entry_json = format!(
-            r#"{{"beam_mtime_secs":{stale_secs},"beam_mtime_nanos":0,"beam_path":"{beam_path_str}","specs_line":"beamtalk-specs-module:gen_tcp:[#{{arity => 2,line => 1,name => <<\"connect\">>,params => [#{{name => <<\"sockaddr\">>,type => <<\"Symbol\">>}},#{{name => <<\"port\">>,type => <<\"Integer\">>}}],return_type => <<\"Symbol\">>}}]"}}"#
-        );
+        let entry_json = serde_json::json!({
+            "beam_mtime_secs": stale_secs,
+            "beam_mtime_nanos": 0,
+            "beam_path": beam_path.to_str().unwrap(),
+            "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<"connect">>,params => [#{name => <<"sockaddr">>,type => <<"Symbol">>},#{name => <<"port">>,type => <<"Integer">>}],return_type => <<"Symbol">>}]"#,
+        })
+        .to_string();
         std::fs::write(
             cache_dir
                 .join("gen_tcp_0123456789abcdef.json")
@@ -1135,10 +1140,13 @@ mod tests {
         std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
 
         let missing_beam = temp.path().join("never_existed.beam");
-        let beam_path_str = missing_beam.to_str().unwrap();
-        let entry_json = format!(
-            r#"{{"beam_mtime_secs":1,"beam_mtime_nanos":0,"beam_path":"{beam_path_str}","specs_line":"beamtalk-specs-module:gen_tcp:[#{{arity => 1,line => 1,name => <<\"close\">>,params => [#{{name => <<\"sock\">>,type => <<\"Object\">>}}],return_type => <<\"Symbol\">>}}]"}}"#
-        );
+        let entry_json = serde_json::json!({
+            "beam_mtime_secs": 1,
+            "beam_mtime_nanos": 0,
+            "beam_path": missing_beam.to_str().unwrap(),
+            "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 1,line => 1,name => <<"close">>,params => [#{name => <<"sock">>,type => <<"Object">>}],return_type => <<"Symbol">>}]"#,
+        })
+        .to_string();
         std::fs::write(
             cache_dir
                 .join("gen_tcp_0123456789abcdef.json")
@@ -1194,12 +1202,13 @@ mod tests {
         std::fs::write(&beam_path, b"placeholder").unwrap();
         let modified = std::fs::metadata(&beam_path).unwrap().modified().unwrap();
         let dur = modified.duration_since(std::time::UNIX_EPOCH).unwrap();
-        let beam_path_str = beam_path.to_str().unwrap();
-        let entry_json = format!(
-            r#"{{"beam_mtime_secs":{secs},"beam_mtime_nanos":{nanos},"beam_path":"{beam_path_str}","specs_line":"beamtalk-specs-module:gen_tcp:[#{{arity => 2,line => 1,name => <<\"connect\">>,params => [#{{name => <<\"sockaddr\">>,type => <<\"Symbol\">>}},#{{name => <<\"port\">>,type => <<\"Integer\">>}}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}}]"}}"#,
-            secs = dur.as_secs(),
-            nanos = dur.subsec_nanos(),
-        );
+        let entry_json = serde_json::json!({
+            "beam_mtime_secs": dur.as_secs(),
+            "beam_mtime_nanos": dur.subsec_nanos(),
+            "beam_path": beam_path.to_str().unwrap(),
+            "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<"connect">>,params => [#{name => <<"sockaddr">>,type => <<"Symbol">>},#{name => <<"port">>,type => <<"Integer">>}],return_type => <<"Result(Dynamic | Tuple, Symbol)">>}]"#,
+        })
+        .to_string();
         std::fs::write(
             cache_dir
                 .join("gen_tcp_0123456789abcdef.json")

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -1078,6 +1078,143 @@ mod tests {
         );
     }
 
+    /// BT-2139: When a cache entry records a `beam_path` and the live `.beam`
+    /// at that path has a newer mtime than the cached one — e.g. `cargo build`
+    /// rebuilt a NIF module between `beamtalk build` and `beamtalk lint` — the
+    /// loader must drop the entry so lint does not warn off stale signatures.
+    #[test]
+    fn load_type_cache_registry_skips_entry_when_beam_mtime_changed() {
+        use crate::beam_compiler::load_type_cache_registry;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache_dir = camino::Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
+        std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
+
+        // Stand-in `.beam` file. We don't need real BEAM bytes here — the
+        // loader only stats mtime, not contents.
+        let beam_path = temp.path().join("gen_tcp.beam");
+        std::fs::write(&beam_path, b"placeholder").unwrap();
+        let live = std::fs::metadata(&beam_path)
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+
+        // Cache an mtime far in the past so the live file looks newer.
+        let stale_secs = live.as_secs().saturating_sub(3600);
+        let beam_path_str = beam_path.to_str().unwrap();
+        let entry_json = format!(
+            r#"{{"beam_mtime_secs":{stale_secs},"beam_mtime_nanos":0,"beam_path":"{beam_path_str}","specs_line":"beamtalk-specs-module:gen_tcp:[#{{arity => 2,line => 1,name => <<\"connect\">>,params => [#{{name => <<\"sockaddr\">>,type => <<\"Symbol\">>}},#{{name => <<\"port\">>,type => <<\"Integer\">>}}],return_type => <<\"Symbol\">>}}]"}}"#
+        );
+        std::fs::write(
+            cache_dir
+                .join("gen_tcp_0123456789abcdef.json")
+                .as_std_path(),
+            entry_json,
+        )
+        .unwrap();
+
+        // Stale entry is skipped — no other entries, so the loader returns None.
+        assert!(
+            load_type_cache_registry(&cache_dir).is_none(),
+            "stale-mtime entry must be skipped, leaving registry empty"
+        );
+    }
+
+    /// BT-2139: When a cache entry's `beam_path` no longer exists — the BEAM
+    /// file was deleted, the project moved, an OTP version was uninstalled —
+    /// the entry must be skipped rather than replayed against a registry
+    /// that may now be wrong.
+    #[test]
+    fn load_type_cache_registry_skips_entry_when_beam_missing() {
+        use crate::beam_compiler::load_type_cache_registry;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache_dir = camino::Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
+        std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
+
+        let missing_beam = temp.path().join("never_existed.beam");
+        let beam_path_str = missing_beam.to_str().unwrap();
+        let entry_json = format!(
+            r#"{{"beam_mtime_secs":1,"beam_mtime_nanos":0,"beam_path":"{beam_path_str}","specs_line":"beamtalk-specs-module:gen_tcp:[#{{arity => 1,line => 1,name => <<\"close\">>,params => [#{{name => <<\"sock\">>,type => <<\"Object\">>}}],return_type => <<\"Symbol\">>}}]"}}"#
+        );
+        std::fs::write(
+            cache_dir
+                .join("gen_tcp_0123456789abcdef.json")
+                .as_std_path(),
+            entry_json,
+        )
+        .unwrap();
+
+        assert!(
+            load_type_cache_registry(&cache_dir).is_none(),
+            "entry pointing at a missing .beam must be skipped"
+        );
+    }
+
+    /// BT-2139: Legacy entries written before BT-2139 do not carry a
+    /// `beam_path`. Those must continue to load — pessimistically treated as
+    /// fresh — so a `lint` immediately after upgrading does not blank out
+    /// every FFI signature until the user re-runs `build`.
+    #[test]
+    fn load_type_cache_registry_loads_legacy_entry_without_beam_path() {
+        use crate::beam_compiler::load_type_cache_registry;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache_dir = camino::Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
+        std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
+
+        // No `beam_path` field at all — what BT-2134 wrote.
+        std::fs::write(
+            cache_dir.join("gen_tcp_0123456789abcdef.json").as_std_path(),
+            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}]"}"#,
+        )
+        .unwrap();
+
+        let registry = load_type_cache_registry(&cache_dir).expect("legacy entry must load");
+        assert!(
+            registry.lookup("gen_tcp", "connect", 2).is_some(),
+            "legacy entry without beam_path must be tolerated as fresh"
+        );
+    }
+
+    /// BT-2139: When a cache entry records a `beam_path` *and* the live file
+    /// at that path matches the cached mtime, the entry must be loaded — this
+    /// is the steady-state case after a fresh `beamtalk build`.
+    #[test]
+    fn load_type_cache_registry_loads_entry_when_beam_mtime_matches() {
+        use crate::beam_compiler::load_type_cache_registry;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache_dir = camino::Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
+        std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
+
+        let beam_path = temp.path().join("gen_tcp.beam");
+        std::fs::write(&beam_path, b"placeholder").unwrap();
+        let modified = std::fs::metadata(&beam_path).unwrap().modified().unwrap();
+        let dur = modified.duration_since(std::time::UNIX_EPOCH).unwrap();
+        let beam_path_str = beam_path.to_str().unwrap();
+        let entry_json = format!(
+            r#"{{"beam_mtime_secs":{secs},"beam_mtime_nanos":{nanos},"beam_path":"{beam_path_str}","specs_line":"beamtalk-specs-module:gen_tcp:[#{{arity => 2,line => 1,name => <<\"connect\">>,params => [#{{name => <<\"sockaddr\">>,type => <<\"Symbol\">>}},#{{name => <<\"port\">>,type => <<\"Integer\">>}}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}}]"}}"#,
+            secs = dur.as_secs(),
+            nanos = dur.subsec_nanos(),
+        );
+        std::fs::write(
+            cache_dir
+                .join("gen_tcp_0123456789abcdef.json")
+                .as_std_path(),
+            entry_json,
+        )
+        .unwrap();
+
+        let registry = load_type_cache_registry(&cache_dir).expect("registry must load");
+        assert!(
+            registry.lookup("gen_tcp", "connect", 2).is_some(),
+            "fresh entry with matching mtime must be loaded"
+        );
+    }
+
     /// BT-2134 (`CodeRabbit` follow-up): Module names that themselves contain
     /// underscores (e.g. `gen_tcp_socket`) must not be confused with a
     /// hash-suffixed entry for `gen_tcp`. The filename parser splits on the


### PR DESCRIPTION
## Summary

`beamtalk lint` populated its `NativeTypeRegistry` from the type cache written by `beamtalk build` (BT-2134), but replayed every entry blindly. If a `.beam` changed between builds — `cargo build` rebuilt a NIF, an OTP upgrade replaced `gen_tcp.beam`, etc. — lint would warn off the old FFI signatures until the next `beamtalk build` invalidated the cache.

This PR teaches the lint loader to revalidate cache entries against the live `.beam` file:

- Add `beam_path: String` (`#[serde(default)]`) to `TypeCacheEntry` so `TypeCache::store` records where the BEAM came from.
- `load_type_cache_registry` now calls `is_cache_entry_fresh`, which re-stats the file at `beam_path` and skips entries whose mtime no longer matches or whose file is gone.
- Legacy entries written before this PR carry no `beam_path` and are pessimistically accepted as fresh — the next `beamtalk build` rewrites them with a path so subsequent lints can validate.

Failure mode is self-healing: a path mismatch just degrades lint to "no FFI types known", which matches pre-BT-2134 behaviour.

Linear: https://linear.app/beamtalk/issue/BT-2139

## Test plan

- [x] `cargo test -p beamtalk-cli --bins commands::lint` — 22/22 pass, including 4 new BT-2139 regression tests:
  - `load_type_cache_registry_skips_entry_when_beam_mtime_changed`
  - `load_type_cache_registry_skips_entry_when_beam_missing`
  - `load_type_cache_registry_loads_legacy_entry_without_beam_path`
  - `load_type_cache_registry_loads_entry_when_beam_mtime_matches`
- [x] `just ci` clean
- [x] `cargo clippy -p beamtalk-cli --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Type-spec cache now stores canonical absolute BEAM file paths and validates cached entries by comparing live file mtimes (seconds + nanoseconds); stale or missing files are skipped while legacy entries without recorded paths remain accepted.

* **Tests**
  * Added regression tests covering cache loading, freshness checks, missing-path handling, and legacy-entry compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->