### PR TITLE
docs: daily refresh 2026-05-04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,22 @@
 ### Runtime
 
 - Fix namespace collision diagnostic when hot-reloading a `Protocol define:` file on a second surface (e.g., MCP after REPL) — the compiler's class cache now filters pre-loaded protocol entries before hierarchy injection, and `register_module` accepts protocol re-registration when the existing class has superclass `Protocol` (BT-2088).
+- Fix `conformsTo:` returning `true` for unknown or non-protocol names — now correctly returns `false` when the protocol name is not registered (BT-2136).
+- Fix telemetry handler attachment race in `beamtalk_trace_store` — declare `telemetry` and `telemetry_poller` as OTP application dependencies so handler attachment is deterministic (BT-2116).
 
 ### Tooling
 
 - **REPL `:interrupt` / `:int` meta-command** — sends an out-of-band interrupt over a separate connection to cancel a running evaluation. This is the one REPL operation that cannot be expressed as a normal message-send (the session is blocked while an eval is in-flight) (BT-2090).
+- `beamtalk lint` now loads the FFI type cache from `_build/type_cache/`, so lint and build agree on FFI return types — previously lint always inferred untyped-FFI for Erlang calls (BT-2134).
+- `beamtalk lint` validates cache entries against live `.beam` file mtimes, skipping stale entries when the underlying module has been recompiled (BT-2139).
+- Fix false-positive `Unresolved class` warnings in the LSP for classes defined in fetched dependencies — the LSP now preloads `.bt` files from `_build/deps/*/src/` (BT-2137).
+- Fix LSP `is_protocol_type` always returning `false` for registered protocols, causing false-positive type warnings on protocol-typed parameters (BT-2135).
 
 ### Internal
 
 - Fix `build --stdlib-mode` to resolve FFI types via `NativeTypeRegistry` — eliminates 202 spurious untyped-FFI warnings from `just dialyzer-specs` (#2138).
 - Replace 16 `format!()` calls with `Document` API in `counted_loops.rs` codegen — continues the BT-875 cleanup (BT-2102).
+- Deduplicate atom-char escape helper into `beamtalk-core::util` (BT-2113).
 
 ## 0.4.0 — 2026-04-27
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -1231,20 +1231,20 @@ Actor subclass: Logger(T :: Printable)
 ### Runtime Protocol Queries
 
 ```beamtalk
-> Integer conformsTo: Printable
+> Integer conformsTo: #Printable
 => true
 
 > Integer conformsTo: #NonExistentProtocol
 => false
 
 > Integer protocols
-=> #(Printable, Comparable)
+=> [#Printable, #Comparable]
 
-> Printable requiredMethods
-=> #(#asString, #printString)
+> Protocol requiredMethods: #Printable
+=> [#asString, #printString]
 
-> Printable conformingClasses
-=> #(Integer, Float, String, Boolean, Symbol, Array, ...)
+> Protocol conformingClasses: #Printable
+=> [Integer, Float, String, Boolean, Symbol, Array, ...]
 ```
 
 `conformsTo:` returns `false` for unknown or non-protocol names — a class cannot conform to something that is not a registered protocol.

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -1234,6 +1234,9 @@ Actor subclass: Logger(T :: Printable)
 > Integer conformsTo: Printable
 => true
 
+> Integer conformsTo: #NonExistentProtocol
+=> false
+
 > Integer protocols
 => #(Printable, Comparable)
 
@@ -1243,6 +1246,8 @@ Actor subclass: Logger(T :: Printable)
 > Printable conformingClasses
 => #(Integer, Float, String, Boolean, Symbol, Array, ...)
 ```
+
+`conformsTo:` returns `false` for unknown or non-protocol names — a class cannot conform to something that is not a registered protocol.
 
 ### Diagnostic Philosophy
 

--- a/docs/beamtalk-tooling.md
+++ b/docs/beamtalk-tooling.md
@@ -768,7 +768,7 @@ All MCP tools map to the same `Workspace` and `Beamtalk` APIs available in the R
 The [Beamtalk VS Code extension](https://github.com/jamesc/beamtalk/tree/main/editors/vscode) connects to the live workspace and provides:
 
 - **Syntax highlighting** for `.bt` files
-- **LSP integration** — diagnostics, completions, go-to-definition, workspace symbol search. The LSP preloads classes from `_build/deps/*/src/` so dependency classes resolve without false-positive `Unresolved class` warnings.
+- **LSP integration** — diagnostics, completions, go-to-definition, workspace symbol search. The LSP preloads classes from `_build/deps/*/src/` on a best-effort basis (bounded by the preload budget), reducing most false-positive `Unresolved class` warnings for dependency types.
 - **Workspace tree view** — live actors, loaded classes, and session bindings in the sidebar
 - **Transcript view** — real-time output from the workspace
 - **Inspector panels** — inspect live actor state

--- a/docs/beamtalk-tooling.md
+++ b/docs/beamtalk-tooling.md
@@ -99,6 +99,8 @@ The summary is suppressed when `--no-warnings` is passed.
 
 `beamtalk lint` prints the same summary at end of run. In `--format json` mode, a `summary` JSON object is emitted as the last line with `totals_by_severity`, `totals_by_category`, `files_checked`, and `total` fields for CI diffing.
 
+`beamtalk lint` also loads FFI type signatures from the build cache (`_build/type_cache/`) so that lint and build agree on Erlang FFI return types. Cache entries are validated against live `.beam` file mtimes — if the underlying module has been recompiled since the cache was written, the stale entry is skipped and lint falls back to untyped-FFI inference. If the project has never been built, lint proceeds without a cache (matching its pre-cache behaviour).
+
 ### Build Artifact Layout (`BuildLayout`)
 
 All build output goes under `_build/` in the project root. The `BuildLayout` struct centralises path construction so all commands (build, test, run, repl, deps) use consistent locations.
@@ -766,7 +768,7 @@ All MCP tools map to the same `Workspace` and `Beamtalk` APIs available in the R
 The [Beamtalk VS Code extension](https://github.com/jamesc/beamtalk/tree/main/editors/vscode) connects to the live workspace and provides:
 
 - **Syntax highlighting** for `.bt` files
-- **LSP integration** — diagnostics, completions, go-to-definition, workspace symbol search
+- **LSP integration** — diagnostics, completions, go-to-definition, workspace symbol search. The LSP preloads classes from `_build/deps/*/src/` so dependency classes resolve without false-positive `Unresolved class` warnings.
 - **Workspace tree view** — live actors, loaded classes, and session bindings in the sidebar
 - **Transcript view** — real-time output from the workspace
 - **Inspector panels** — inspect live actor state


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 12 commits merged to main on 2026-05-03.

### Commits reviewed — doc changes produced

| Commit | Issue | Description | Doc change |
|--------|-------|-------------|------------|
| `0b1225c` | BT-2134 | `beamtalk lint` loads FFI type cache | CHANGELOG (Tooling) + `beamtalk-tooling.md` lint section |
| `0aa6aa6` | BT-2139 | Validate beam mtime in lint type cache | CHANGELOG (Tooling) + `beamtalk-tooling.md` lint section |
| `f0c0669` | BT-2137 | Preload dependency classes in LSP | CHANGELOG (Tooling) + `beamtalk-tooling.md` LSP bullet |
| `b0eedef` | BT-2135 | Fix `is_protocol_type` false for registered protocols | CHANGELOG (Tooling) |
| `ff017dc` | BT-2136 | `conforms_to/2` returns false for unknown protocols | CHANGELOG (Runtime) + `beamtalk-language-features.md` protocol queries |
| `837747c` | BT-2116 | Fix TracingTest telemetry startup race | CHANGELOG (Runtime) |
| `c667fc7` | BT-2113 | Deduplicate atom-char escape helper | CHANGELOG (Internal) |

### Commits skipped (test-only or excluded scope) — 5

| Commit | Issue | Reason |
|--------|-------|--------|
| `65a9953` | BT-2115 | Test-only (`stdlib/test/`) |
| `a9b788f` | BT-2111 | Test-only (codegen tests) |
| `48b8556` | BT-2109 | Test-only (runtime test refactor) |
| `9dde3d7` | BT-2107 | Test-only (test helper extraction) |
| `f9f5157` | BT-2114 | Test-only (codegen tests) |

### Files updated

- **`CHANGELOG.md`** — 7 new entries under Unreleased (2 Runtime, 4 Tooling, 1 Internal)
- **`docs/beamtalk-language-features.md`** — Added `conformsTo:` unknown-protocol example and clarification in Runtime Protocol Queries
- **`docs/beamtalk-tooling.md`** — Added lint type-cache paragraph; updated LSP bullet with dependency preloading

### Needs human judgment

None — all changes are clearly documented in diffs and tests.

https://claude.ai/code/session_016K1re3BVDH2Xs6hJ5MtZA6

---
_Generated by [Claude Code](https://claude.ai/code/session_016K1re3BVDH2Xs6hJ5MtZA6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Protocol conformance now returns false for unknown/non-protocol names
  * Telemetry handler attachment is now deterministic
  * Fixed LSP false-positive warnings for dependency code
  * Improved LSP protocol-type validation to avoid protocol-typed parameter warnings

* **New Features**
  * Lint now uses cached FFI type signatures to align with build output
  * Cache entries are validated and skipped if modules were recompiled

* **Documentation**
  * Updated language features and tooling docs with examples and clarifications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->