### PR TITLE
refactor: replace format!() with docvec! in three codegen functions (BT-2143)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -2139,10 +2139,11 @@ impl CoreErlangGenerator {
                 INDENT,
                 docvec![
                     line(),
-                    format!(
-                        "call 'gen_server':'start_link'('{}', InitArgs, [])",
-                        self.module_name
-                    ),
+                    docvec![
+                        "call 'gen_server':'start_link'('",
+                        Document::Eco(self.module_name.clone()),
+                        "', InitArgs, [])",
+                    ],
                 ]
             ),
             "\n\n",
@@ -2420,54 +2421,61 @@ impl CoreErlangGenerator {
             let error_doc = self.class_not_found_error_doc(class_name);
 
             Ok(docvec![
-                format!("case call 'maps':'find'('{class_name}', {state_var}) of "),
+                "case call 'maps':'find'('",
+                Document::String(class_name.to_string()),
+                "', ",
+                Document::String(state_var),
+                ") of ",
                 "<{'ok', _BindingVal}> when 'true' -> _BindingVal ",
                 "<'error'> when 'true' -> ",
-                format!("case call 'beamtalk_class_registry':'whereis_class'('{class_name}') of "),
+                "case call 'beamtalk_class_registry':'whereis_class'('",
+                Document::String(class_name.to_string()),
+                "') of ",
                 error_doc,
-                format!("<{class_pid_var}> when 'true' -> "),
-                format!(
-                    "let {class_mod_var} = call 'beamtalk_object_class':'module_name'({class_pid_var}) in "
-                ),
-                format!(
-                    "{{'beamtalk_object', '{display_name} class', {class_mod_var}, {class_pid_var}}} "
-                ),
+                "<",
+                Document::String(class_pid_var.clone()),
+                "> when 'true' -> ",
+                "let ",
+                Document::String(class_mod_var.clone()),
+                " = call 'beamtalk_object_class':'module_name'(",
+                Document::String(class_pid_var.clone()),
+                ") in ",
+                "{'beamtalk_object', '",
+                Document::String(display_name),
+                " class', ",
+                Document::String(class_mod_var),
+                ", ",
+                Document::String(class_pid_var),
+                "} ",
                 "end end",
             ])
-        } else if self.workspace_mode() {
-            // Actor/ValueType methods in workspace mode: try class lookup.
-            // ADR 0019 Phase 4: No persistent_term fallback — use class registry only.
-            let class_pid_var = self.fresh_var("ClassPid");
-            let class_mod_var = self.fresh_var("ClassModName");
-            let error_doc = self.class_not_found_error_doc(class_name);
-
-            Ok(docvec![
-                format!("case call 'beamtalk_class_registry':'whereis_class'('{class_name}') of "),
-                error_doc,
-                format!("<{class_pid_var}> when 'true' -> "),
-                format!(
-                    "let {class_mod_var} = call 'beamtalk_object_class':'module_name'({class_pid_var}) in "
-                ),
-                format!(
-                    "{{'beamtalk_object', '{display_name} class', {class_mod_var}, {class_pid_var}}} "
-                ),
-                "end",
-            ])
         } else {
+            // Actor/ValueType methods in workspace mode and batch mode both use
+            // registry-only lookup. ADR 0019 Phase 4: No persistent_term fallback.
             let class_pid_var = self.fresh_var("ClassPid");
             let class_mod_var = self.fresh_var("ClassModName");
             let error_doc = self.class_not_found_error_doc(class_name);
 
             Ok(docvec![
-                format!("case call 'beamtalk_class_registry':'whereis_class'('{class_name}') of "),
+                "case call 'beamtalk_class_registry':'whereis_class'('",
+                Document::String(class_name.to_string()),
+                "') of ",
                 error_doc,
-                format!("<{class_pid_var}> when 'true' -> "),
-                format!(
-                    "let {class_mod_var} = call 'beamtalk_object_class':'module_name'({class_pid_var}) in "
-                ),
-                format!(
-                    "{{'beamtalk_object', '{display_name} class', {class_mod_var}, {class_pid_var}}} "
-                ),
+                "<",
+                Document::String(class_pid_var.clone()),
+                "> when 'true' -> ",
+                "let ",
+                Document::String(class_mod_var.clone()),
+                " = call 'beamtalk_object_class':'module_name'(",
+                Document::String(class_pid_var.clone()),
+                ") in ",
+                "{'beamtalk_object', '",
+                Document::String(display_name),
+                " class', ",
+                Document::String(class_mod_var),
+                ", ",
+                Document::String(class_pid_var),
+                "} ",
                 "end",
             ])
         }
@@ -2483,13 +2491,21 @@ impl CoreErlangGenerator {
         let hint_binary = Self::binary_string_literal(&hint);
 
         docvec![
-            format!(
-                "<'undefined'> when 'true' -> let {err0_var} = call 'beamtalk_error':'new'('class_not_found', '{class_name}') in "
-            ),
-            format!(
-                "let {err1_var} = call 'beamtalk_error':'with_hint'({err0_var}, {hint_binary}) in "
-            ),
-            format!("call 'beamtalk_error':'raise'({err1_var}) "),
+            "<'undefined'> when 'true' -> let ",
+            Document::String(err0_var.clone()),
+            " = call 'beamtalk_error':'new'('class_not_found', '",
+            Document::String(class_name.to_string()),
+            "') in ",
+            "let ",
+            Document::String(err1_var.clone()),
+            " = call 'beamtalk_error':'with_hint'(",
+            Document::String(err0_var),
+            ", ",
+            Document::String(hint_binary),
+            ") in ",
+            "call 'beamtalk_error':'raise'(",
+            Document::String(err1_var),
+            ") ",
         ]
     }
 


### PR DESCRIPTION
## Summary

Removes three BT-875 recurrences in `crates/beamtalk-core/src/codegen/core_erlang/mod.rs` where `format!()` was being used to produce Core Erlang fragments, violating the CLAUDE.md rule.

- `generate_start_link_doc`: replaced `format!("call 'gen_server':'start_link'('{}', ...)", self.module_name)` with `docvec![..., Document::Eco(self.module_name.clone()), ...]`, matching the pattern already used in the neighbouring `generate_start_link_named_doc`.
- `generate_class_reference`: replaced all `format!()` calls producing Core Erlang tokens with static `&str` literals and `Document::String(var)` nodes composed via `docvec![]`. Also collapsed the identical `else if self.workspace_mode()` and `else` branches into a single `else` — both generated the same registry-only lookup code.
- `class_not_found_error_doc`: same treatment — static Core Erlang keywords as `&str`, variable parts as `Document::String`.

Generated Core Erlang output is byte-identical to before. All 760 codegen tests and 3319 total Rust tests pass.

## Linear issue

https://linear.app/beamtalk/issue/BT-2143

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 3319 tests pass
- [x] `cargo test -p beamtalk-core --lib codegen` — 760 codegen tests pass (includes dispatch tests that assert on exact generated Core Erlang strings)
- [x] `just clippy` — clean
- [x] `just fmt-check-rust` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScATGZDNTYRUyYcgb1C6hg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code generation processes for improved performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->