### PR TITLE
docs: daily refresh 2026-05-06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix `build --stdlib-mode` to resolve FFI types via `NativeTypeRegistry` — eliminates 202 spurious untyped-FFI warnings from `just dialyzer-specs` (#2138).
 - Replace 16 `format!()` calls with `Document` API in `counted_loops.rs` codegen — continues the BT-875 cleanup (BT-2102).
 - Deduplicate atom-char escape helper into `beamtalk-core::util` (BT-2113).
+- Replace 3 `format!()` calls with `docvec!` in `generate_start_link_doc`, `generate_class_reference`, and `class_not_found_error_doc` — continues the BT-875 cleanup (BT-2143).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 3 commits since the last refresh (2026-05-04).

### Commits reviewed — doc changes produced

| Commit | Issue | Description | Doc change |
|--------|-------|-------------|------------|
| `b9eb3b2` | BT-2143 | Replace `format!()` with `docvec!` in 3 codegen functions | CHANGELOG "Internal" entry |

### Commits skipped — 2

| Commit | Issue | Reason |
|--------|-------|--------|
| `d5ff61e` | — | Dependabot dep bump (eetf 0.11→0.12), no user-visible change |
| `b0364e6` | — | Test-only (adds `#[cfg(test)]` unit tests to dict_ops.rs) |

### Files updated

- **`CHANGELOG.md`** — 1 new entry under Unreleased > Internal (BT-2143 format!→docvec! cleanup)

### Needs human judgment

None.

https://claude.ai/code/session_01Hn9EBycBEYYPxFdKYuTGXu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hn9EBycBEYYPxFdKYuTGXu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to code generation helpers for better maintainability.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->