### PR TITLE
Replace hardcoded /tmp/ paths in beamtalk_repl_json_tests (BT-2148)

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_json_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_json_tests.erl
@@ -1223,8 +1223,10 @@ format_modules_multiple_test() ->
     ?assertEqual(2, length(ModList)),
     [First, Second] = ModList,
     ?assertEqual(<<"Counter">>, maps:get(<<"name">>, First)),
+    ?assertEqual(<<"counter.bt">>, maps:get(<<"source_file">>, First)),
     ?assertEqual(2, maps:get(<<"actor_count">>, First)),
     ?assertEqual(<<"Point">>, maps:get(<<"name">>, Second)),
+    ?assertEqual(<<"point.bt">>, maps:get(<<"source_file">>, Second)),
     ?assertEqual(0, maps:get(<<"actor_count">>, Second)).
 
 %%% format_error_message additional coverage

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_json_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_json_tests.erl
@@ -241,7 +241,7 @@ format_modules_test() ->
     Modules = [
         {counter, #{
             name => <<"Counter">>,
-            source_file => "/tmp/counter.bt",
+            source_file => "counter.bt",
             actor_count => 2,
             load_time => 1000,
             time_ago => "5 seconds ago"
@@ -252,7 +252,7 @@ format_modules_test() ->
     ?assertEqual(<<"modules">>, maps:get(<<"type">>, Decoded)),
     [Mod] = maps:get(<<"modules">>, Decoded),
     ?assertEqual(<<"Counter">>, maps:get(<<"name">>, Mod)),
-    ?assertEqual(<<"/tmp/counter.bt">>, maps:get(<<"source_file">>, Mod)),
+    ?assertEqual(<<"counter.bt">>, maps:get(<<"source_file">>, Mod)),
     ?assertEqual(2, maps:get(<<"actor_count">>, Mod)).
 
 %%% ============================================================================
@@ -994,7 +994,7 @@ format_modules_single_test() ->
     Info =
         {counter, #{
             name => <<"Counter">>,
-            source_file => "/tmp/counter.bt",
+            source_file => "counter.bt",
             actor_count => 3,
             load_time => 1234567890,
             time_ago => "2 minutes ago"
@@ -1005,7 +1005,7 @@ format_modules_single_test() ->
     ?assertEqual(1, length(Modules)),
     [Mod] = Modules,
     ?assertEqual(<<"Counter">>, maps:get(<<"name">>, Mod)),
-    ?assertEqual(<<"/tmp/counter.bt">>, maps:get(<<"source_file">>, Mod)),
+    ?assertEqual(<<"counter.bt">>, maps:get(<<"source_file">>, Mod)),
     ?assertEqual(3, maps:get(<<"actor_count">>, Mod)).
 
 %%% format_response edge cases
@@ -1203,14 +1203,14 @@ format_modules_multiple_test() ->
     Modules = [
         {counter, #{
             name => <<"Counter">>,
-            source_file => "/tmp/counter.bt",
+            source_file => "counter.bt",
             actor_count => 2,
             load_time => 100,
             time_ago => "5 seconds ago"
         }},
         {point, #{
             name => <<"Point">>,
-            source_file => "/tmp/point.bt",
+            source_file => "point.bt",
             actor_count => 0,
             load_time => 200,
             time_ago => "10 seconds ago"


### PR DESCRIPTION
## Summary

Fixes CLAUDE.md cross-platform violation: six hardcoded `/tmp/` path strings in `beamtalk_repl_json_tests.erl` replaced with clearly synthetic relative paths.

- `format_modules_test`: `"/tmp/counter.bt"` → `"counter.bt"` (input + assertion)
- `format_modules_single_test`: `"/tmp/counter.bt"` → `"counter.bt"` (input + assertion)
- `format_modules_multiple_test`: `"/tmp/counter.bt"` → `"counter.bt"`, `"/tmp/point.bt"` → `"point.bt"` (inputs only; this test doesn't assert on `source_file`)

All paths were purely synthetic test data fed to `beamtalk_repl_json:format_modules/1` for JSON serialization testing — no filesystem access occurred. Tests are round-trip checks so input and assertion are updated consistently.

## Test plan

- [x] Zero `/tmp/` occurrences remain in `beamtalk_repl_json_tests.erl`
- [x] File compiles cleanly with `erlc`
- [x] All pre-push lint checks pass (clippy, fmt, biome, bt fmt)
- [x] CI (GitHub Actions) will run the full Erlang EUnit + dialyzer suite

https://linear.app/beamtalk/issue/BT-2148

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYhLAmsDui66Sm8CYJFAie)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test data to expect module source filenames as relative names rather than absolute paths.
  * Adjusted test expectations for module actor counts in formatting tests to match updated behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->