### PR TITLE
docs: daily refresh 2026-05-07

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Replace 16 `format!()` calls with `Document` API in `counted_loops.rs` codegen — continues the BT-875 cleanup (BT-2102).
 - Deduplicate atom-char escape helper into `beamtalk-core::util` (BT-2113).
 - Replace 3 `format!()` calls with `docvec!` in `generate_start_link_doc`, `generate_class_reference`, and `class_not_found_error_doc` — continues the BT-875 cleanup (BT-2143).
+- Extract `call_self_p0`/`call_p0_self` helpers in primitives codegen — deduplicates ~56 matching arms across `string.rs`, `list.rs`, and `dictionary.rs` (BT-2146).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 4 commits since the last refresh (2026-05-06).

### Commits reviewed — doc changes produced

| Commit | Issue | Description | Doc change |
|--------|-------|-------------|------------|
| `80cef8d` | BT-2146 | Extract `call_self_p0`/`call_p0_self` helpers in primitives codegen | CHANGELOG "Internal" entry |

### Commits skipped — 3

| Commit | Issue | Reason |
|--------|-------|--------|
| `f68ffff` | BT-2148 | Test-only (replace hardcoded `/tmp/` paths in `beamtalk_repl_json_tests`) |
| `fe54d4c` | BT-2147 | Test-only (add `#[cfg(test)]` unit tests for Array/Dictionary codegen) |
| `fbdec4c` | — | Previous docs refresh (`docs: daily refresh 2026-05-06`) |

### Files updated

- **`CHANGELOG.md`** — 1 new entry under Unreleased > Internal (BT-2146 `call_self_p0`/`call_p0_self` helper extraction)

### Needs human judgment

None.

https://claude.ai/code/session_01RXkNkSwN2P57rAFLyfoYKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXkNkSwN2P57rAFLyfoYKQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release notes to track ongoing development improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->