### PR TITLE
fix: replace hardcoded /tmp/ path in beamtalk_idle_monitor_tests (BT-2151)

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_idle_monitor_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_idle_monitor_tests.erl
@@ -21,9 +21,10 @@ test_config() ->
     #{enabled => false, max_idle_seconds => 14400}.
 
 test_metadata() ->
+    TmpDir = beamtalk_file:'tempDirectory'(),
     #{
         workspace_id => <<"test123">>,
-        project_path => <<"/tmp/test">>,
+        project_path => <<TmpDir/binary, "/bt_idle_test">>,
         % Use seconds, not milliseconds
         created_at => erlang:system_time(second),
         last_activity => erlang:system_time(second)


### PR DESCRIPTION
## Summary

- Replace hardcoded `/tmp/test` path in `test_metadata()` with `beamtalk_file:'tempDirectory'()` per CLAUDE.md cross-platform temp path rule
- Use unique suffix `/bt_idle_test` to avoid collisions with other test modules
- None of the 5 tests using `test_metadata()` assert on `project_path`, so the fix is safe

## Test plan

- [ ] 5 integration tests that call `test_metadata()` continue to pass (`just test-runtime`)
- [ ] No test asserts the exact value of `project_path`

Fixes BT-2151

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTQgaWBxderBR8TJ46ejar)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to use dynamically generated temporary directory paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->