### PR TITLE
docs: daily refresh 2026-05-08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Deduplicate atom-char escape helper into `beamtalk-core::util` (BT-2113).
 - Replace 3 `format!()` calls with `docvec!` in `generate_start_link_doc`, `generate_class_reference`, and `class_not_found_error_doc` — continues the BT-875 cleanup (BT-2143).
 - Extract `call_self_p0`/`call_p0_self` helpers in primitives codegen — deduplicates ~56 matching arms across `string.rs`, `list.rs`, and `dictionary.rs` (BT-2146).
+- Extract `try_canonicalize` helper in `package.rs` — deduplicates 5 identical inline `canonicalize`-with-fallback patterns (BT-2149).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 3 commits since the last refresh (2026-05-07).

### Commits reviewed — doc changes produced

| Commit | Issue | Description | Doc change |
|--------|-------|-------------|------------|
| `822d31a` | BT-2149 | Extract `try_canonicalize` helper in `package.rs` | CHANGELOG "Internal" entry |

### Commits skipped — 2

| Commit | Issue | Reason |
|--------|-------|--------|
| `5b69068` | BT-2150 | Test-only (add `#[cfg(test)]` unit tests for String/CompiledMethod codegen primitives) |
| `a2dbf4f` | BT-2151 | Test-only (replace hardcoded `/tmp/` in `beamtalk_idle_monitor_tests`; excluded: `runtime/apps/*/test/`) |

### Files updated

- **`CHANGELOG.md`** — 1 new entry under Unreleased > Internal (BT-2149 `try_canonicalize` helper extraction)

### Needs human judgment

None.

https://claude.ai/code/session_011Dmd1KZi3rdhrpqHscbm2K

---
_Generated by [Claude Code](https://claude.ai/code/session_011Dmd1KZi3rdhrpqHscbm2K)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to document internal code cleanup and optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->