### PR TITLE
Add unit tests for actor_types.rs primitive BIF generators (BT-2153)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/actor_types.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/actor_types.rs
@@ -106,3 +106,125 @@ pub(crate) fn generate_file_handle_bif(
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::doc_to_string;
+    use super::*;
+
+    // pid_extra tests
+
+    #[test]
+    fn test_pid_extra_unknown_returns_none() {
+        assert_eq!(doc_to_string(pid_extra("unknown", &[])), None);
+    }
+
+    // reference_extra tests
+
+    #[test]
+    fn test_reference_demonitor() {
+        let result = doc_to_string(reference_extra("demonitor", &[]));
+        assert_eq!(result, Some("call 'erlang':'demonitor'(Self)".to_string()));
+    }
+
+    #[test]
+    fn test_reference_extra_unknown_returns_none() {
+        assert_eq!(doc_to_string(reference_extra("unknown", &[])), None);
+    }
+
+    // no_extra tests
+
+    #[test]
+    fn test_no_extra_returns_none() {
+        assert_eq!(doc_to_string(no_extra("anything", &[])), None);
+    }
+
+    // generate_future_bif tests
+
+    #[test]
+    fn test_future_await() {
+        let result = doc_to_string(generate_future_bif("await", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_future':'await'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_future_await_forever() {
+        let result = doc_to_string(generate_future_bif("awaitForever", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_future':'await_forever'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_future_await_with_timeout() {
+        let result = doc_to_string(generate_future_bif("await:", &["Timeout".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_future':'await'(Self, Timeout)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_future_when_resolved() {
+        let result = doc_to_string(generate_future_bif("whenResolved:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_future':'when_resolved'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_future_when_rejected() {
+        let result = doc_to_string(generate_future_bif("whenRejected:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_future':'when_rejected'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_future_print_string() {
+        let result = doc_to_string(generate_future_bif("printString", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_primitive':'print_string'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_future_unknown_returns_none() {
+        assert_eq!(doc_to_string(generate_future_bif("unknown", &[])), None);
+    }
+
+    // generate_file_handle_bif tests
+
+    #[test]
+    fn test_file_handle_lines() {
+        let result = doc_to_string(generate_file_handle_bif("lines", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_file':'handle_lines'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_file_handle_print_string() {
+        let result = doc_to_string(generate_file_handle_bif("printString", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_primitive':'print_string'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_file_handle_unknown_returns_none() {
+        assert_eq!(
+            doc_to_string(generate_file_handle_bif("unknown", &[])),
+            None
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 14 unit tests for `actor_types.rs` primitive BIF generators, covering 4 previously-untested functions: `reference_extra`, `no_extra`, `generate_future_bif`, `generate_file_handle_bif`, plus `pid_extra`'s fallback arm
- Uses the established `doc_to_string` pattern from sibling modules (`binary.rs`, `error_handling.rs`)
- Closes a measured coverage gap: file was at **38.2% line coverage** (CI artifact from run 25481488322), with lines 45–108 all at 0 hits

## Test plan

- [x] `cargo test -p beamtalk-core -- codegen::core_erlang::primitives::actor_types` — 14/14 pass
- [x] `cargo clippy -p beamtalk-core -- -D warnings` — clean
- [x] `cargo fmt --package beamtalk-core -- --check` — clean

https://linear.app/beamtalk/issue/BT-2153

https://claude.ai/code/session_01Du94UjEjUzQfNe2eiWYpNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Du94UjEjUzQfNe2eiWYpNS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented comprehensive unit tests to validate code generation helpers, covering multiple operation scenarios and edge cases to ensure reliability and correctness of generated code output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->