### PR TITLE
Add missing domain metadata to stdlib LOG calls (BT-2141)

### DIFF
--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_file.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_file.erl
@@ -952,7 +952,9 @@ make_line_gen_no_close(Fd) ->
             eof ->
                 done;
             {error, Reason} ->
-                ?LOG_WARNING("File stream read error", #{reason => Reason}),
+                ?LOG_WARNING("File stream read error", #{
+                    reason => Reason, domain => [beamtalk, stdlib]
+                }),
                 done
         end
     end.

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_logger.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_logger.erl
@@ -63,7 +63,10 @@ maybe_emit_deprecation_warning() ->
             ok;
         false ->
             persistent_term:put(Key, true),
-            ?LOG_WARNING("Logger setLevel: is deprecated. Use Beamtalk logLevel: instead.")
+            ?LOG_WARNING(
+                "Logger setLevel: is deprecated. Use Beamtalk logLevel: instead.",
+                #{domain => [beamtalk, stdlib]}
+            )
     end.
 
 -doc "Raise a type error for the Logger class.".

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_reactive_subprocess.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_reactive_subprocess.erl
@@ -191,6 +191,7 @@ start(Config) ->
 -doc "Open the exec port, spawn the child subprocess, and store self-reference.".
 -spec init(config()) -> {ok, map()} | {stop, term()}.
 init(Config) ->
+    logger:set_process_metadata(#{domain => [beamtalk, stdlib]}),
     Executable = maps:get(executable, Config),
     Args = maps:get(args, Config, []),
     Options = maps:with([env, dir], Config),

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_test_case.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_test_case.erl
@@ -1101,7 +1101,8 @@ spawn_test_execution(Selector, Args, ClassName, TestModule, FlatMethods, From) -
                         selector => Selector,
                         error_class => C,
                         error => E,
-                        stacktrace => ST
+                        stacktrace => ST,
+                        domain => [beamtalk, stdlib]
                     }
                 ),
                 gen_server:reply(From, {error, Error})

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_transcript_stream.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_transcript_stream.erl
@@ -129,6 +129,7 @@ unsubscribe(TranscriptRef) ->
 -doc "Initialize the TranscriptStream gen_server with the given buffer size.".
 -spec init([max_buffer()]) -> {ok, state()} | {stop, term()}.
 init([MaxBuffer]) when is_integer(MaxBuffer), MaxBuffer > 0 ->
+    logger:set_process_metadata(#{domain => [beamtalk, stdlib]}),
     SelfRef = {beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, self()},
     {ok, #state{
         buffer = queue:new(),

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_transcript_stream.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_transcript_stream.erl
@@ -190,7 +190,11 @@ handle_call({Selector, Args}, From, State) when is_atom(Selector), is_list(Args)
         catch
             Class:Reason:Stack ->
                 ?LOG_ERROR("TranscriptStream dispatch handler crashed", #{
-                    selector => Selector, class => Class, reason => Reason, stacktrace => Stack
+                    selector => Selector,
+                    class => Class,
+                    reason => Reason,
+                    stacktrace => Stack,
+                    domain => [beamtalk, stdlib]
                 }),
                 Err = beamtalk_error:new(runtime_error, 'TranscriptStream'),
                 gen_server:reply(
@@ -276,7 +280,11 @@ handle_cast({Selector, Args, FuturePid}, State) when
         catch
             Class:Reason:Stack ->
                 ?LOG_ERROR("TranscriptStream dispatch handler crashed", #{
-                    selector => Selector, class => Class, reason => Reason, stacktrace => Stack
+                    selector => Selector,
+                    class => Class,
+                    reason => Reason,
+                    stacktrace => Stack,
+                    domain => [beamtalk, stdlib]
                 }),
                 Err = beamtalk_error:new(runtime_error, 'TranscriptStream'),
                 beamtalk_future:reject(


### PR DESCRIPTION
## Summary

Adds `domain => [beamtalk, stdlib]` to nine `?LOG_*` macro calls across five `beamtalk_stdlib` modules that were missing it, satisfying the CLAUDE.md Erlang logging rule.

For gen_servers, applied via `logger:set_process_metadata/1` in `init/1` (preferred per CLAUDE.md). For non-gen-server modules, added inline.

Linear issue: https://linear.app/beamtalk/issue/BT-2141

## Changes

- `beamtalk_transcript_stream.erl` — `set_process_metadata` in `init/1` (covers 2 LOG calls)
- `beamtalk_reactive_subprocess.erl` — `set_process_metadata` in `init/1` (covers 4 LOG calls)
- `beamtalk_file.erl:955` — inline `domain` in metadata map
- `beamtalk_logger.erl:66` — added metadata map with `domain`
- `beamtalk_test_case.erl:1096` — added `domain` to existing metadata map

## Test plan

- [x] `just ci` passes
- [x] No behavioral change — purely metadata for the OTP logger domain filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced logging and deprecation warnings across core components: logs now include structured metadata (domain tags) and improved warning formatting to provide clearer diagnostic context for subprocesses, stream generators, transcript handlers, and test execution failures. This improves filtering, tracing, and supportability without altering runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->