### PR TITLE
docs: daily refresh 2026-05-09

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Replace 3 `format!()` calls with `docvec!` in `generate_start_link_doc`, `generate_class_reference`, and `class_not_found_error_doc` — continues the BT-875 cleanup (BT-2143).
 - Extract `call_self_p0`/`call_p0_self` helpers in primitives codegen — deduplicates ~56 matching arms across `string.rs`, `list.rs`, and `dictionary.rs` (BT-2146).
 - Extract `try_canonicalize` helper in `package.rs` — deduplicates 5 identical inline `canonicalize`-with-fallback patterns (BT-2149).
+- Add missing `domain => [beamtalk, stdlib]` metadata to nine `?LOG_*` calls across five stdlib modules (BT-2141).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 2 commits since the last refresh (2026-05-08).

**Note:** 0 new commits landed on `main` in the last 24 hours (last main commit: May 4). This refresh covers 2 commits on the working branch since the previous daily refresh.

### Commits reviewed — doc changes produced

| Commit | Issue | Description | Doc change |
|--------|-------|-------------|------------|
| `860d5c1` | BT-2141 | Add missing `domain => [beamtalk, stdlib]` metadata to nine `?LOG_*` calls across five stdlib modules | CHANGELOG "Internal" entry |

### Commits skipped — 1

| Commit | Issue | Reason |
|--------|-------|--------|
| `9105d28` | BT-2144 | Test-only (add unit tests for `ast_walker.rs`; no user-visible change) |

### Files updated

- **`CHANGELOG.md`** — 1 new entry under Unreleased > Internal (BT-2141 domain metadata fix)

### Needs human judgment

None.

### Previous daily refresh commits included in this branch

This branch accumulates daily refreshes. Prior refreshes (May 4–8) already covered:
- CHANGELOG entries for BT-2136, BT-2116, BT-2134, BT-2139, BT-2137, BT-2135, BT-2113, BT-2143, BT-2146, BT-2149
- `docs/beamtalk-tooling.md` updates for lint FFI cache and LSP dependency preloading
- `docs/beamtalk-language-features.md` updates for `conformsTo:` protocol query semantics

https://claude.ai/code/session_01BrcDv7aZ34nZeRupndJwUX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrcDv7aZ34nZeRupndJwUX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog to document internal metadata fixes that supplied missing domain information to logging macro calls across multiple stdlib modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->