### PR TITLE
fix: use tempDirectory() instead of hardcoded /tmp/ in workspace tests (BT-2157)

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_tests.erl
@@ -15,9 +15,10 @@ Tests the workspace API (status/0).
 %%====================================================================
 
 test_metadata() ->
+    TmpDir = beamtalk_file:'tempDirectory'(),
     #{
         workspace_id => <<"test-ws-123">>,
-        project_path => <<"/tmp/test-project">>,
+        project_path => <<TmpDir/binary, "/test-project">>,
         created_at => erlang:system_time(second),
         last_activity => erlang:system_time(second)
     }.
@@ -38,11 +39,12 @@ status_returns_error_when_meta_not_started_test() ->
 
 status_returns_ok_map_when_meta_started_test() ->
     ensure_meta_stopped(),
-    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+    Meta = test_metadata(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(Meta),
     try
         {ok, Status} = beamtalk_workspace:status(),
         ?assertEqual(<<"test-ws-123">>, maps:get(workspace_id, Status)),
-        ?assertEqual(<<"/tmp/test-project">>, maps:get(project_path, Status)),
+        ?assertEqual(maps:get(project_path, Meta), maps:get(project_path, Status)),
         ?assert(is_integer(maps:get(created_at, Status))),
         ?assert(is_integer(maps:get(last_activity, Status))),
         ?assertEqual(0, maps:get(actor_count, Status)),


### PR DESCRIPTION
## Summary

- `test_metadata/0` hardcoded `project_path => <<"/tmp/test-project">>`, violating the CLAUDE.md cross-platform rule. `beamtalk_workspace_meta` passes this path to `detect_package_name/1`, which reads `{path}/beamtalk.toml` from disk — making this a real filesystem path, not just metadata.
- Replace with `beamtalk_file:'tempDirectory'()` concatenated with `"/test-project"` so the OS temp dir is resolved correctly on all platforms (Linux, macOS, Windows).
- Capture `Meta = test_metadata()` once at the top of the round-trip test and assert `maps:get(project_path, Meta)` against the status value, so the assertion never re-introduces a hardcoded literal.

## Test plan

- [ ] `just test-runtime` passes (Erlang EUnit, including `beamtalk_workspace_tests`)
- [ ] `erlc -Wall runtime/apps/beamtalk_workspace/test/beamtalk_workspace_tests.erl` — zero warnings (verified locally)
- [ ] Binary concat `<<TmpDir/binary, "/test-project">>` verified to produce correct path via `erl -noshell` (verified locally)

## Notes

Local `just test-runtime` and `just ci` are blocked by a pre-existing infrastructure issue: the local rebar3 binary cannot resolve hex.pm packages (no network access / no cache). This failure reproduces on unmodified `main` and is unrelated to this change. CI on GitHub should have access and will be the authoritative gate.

https://claude.ai/code/session_01Y6oiRzakhuxBbw3C97ym1V

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6oiRzakhuxBbw3C97ym1V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by using dynamically generated temporary directories instead of fixed paths, improving test isolation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->