### PR TITLE
Lint rule: flag redundant type annotation on local variables (BT-2140)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -523,6 +523,10 @@ fn analyse_full_with_natives(
     result.diagnostics.extend(type_checker.take_diagnostics());
     let type_map = type_checker.take_type_map();
 
+    // BT-2140: Lint redundant local-variable type annotations using the
+    // populated TypeMap. Must run before the Analyser consumes `type_map`.
+    validators::check_redundant_local_type_annotation(module, &type_map, &mut result.diagnostics);
+
     // Phase 3: Block Context Analysis (captures, mutations, context determination)
     // Receive scope from NameResolver and TypeMap from TypeChecker
     let mut analyser = Analyser::with_scope(scope, type_map);

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/mod.rs
@@ -43,6 +43,7 @@ pub use native_type_registry::{FunctionSignature, NativeTypeRegistry, ParamType}
 pub use native_types::{
     is_specs_line, is_specs_result_error, is_specs_result_ok, map_type_name, parse_specs_line,
 };
+pub(in crate::semantic_analysis) use type_resolver::resolve_type_annotation;
 pub(in crate::semantic_analysis) use types::is_generic_type_param;
 pub use types::{DynamicReason, InferredType, TypeProvenance};
 

--- a/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
@@ -11,10 +11,14 @@
 //! - Empty method bodies (BT-859)
 //! - Effect-free statements (BT-951)
 
-use crate::ast::{Expression, Identifier, MessageSelector, Module, WellKnownSelector};
+use crate::ast::{
+    Expression, Identifier, MessageSelector, Module, TypeAnnotation, WellKnownSelector,
+};
 use crate::ast_walker::{walk_expression, walk_module};
 use crate::semantic_analysis::ClassHierarchy;
+use crate::semantic_analysis::type_checker::{InferredType, TypeMap};
 use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
+use std::collections::HashMap;
 
 // ── BT-950: Redundant assignment ─────────────────────────────────────────────
 
@@ -516,6 +520,127 @@ fn redundant_super_initialize_diagnostic(span: Span) -> Diagnostic {
     )
     .with_hint("Remove this line — Beamtalk auto-chains initialize up the hierarchy")
     .with_category(DiagnosticCategory::Lint)
+}
+
+// ── BT-2140: Redundant local-variable type annotation ────────────────────────
+
+/// BT-2140: Lint when a local-variable assignment carries a `:: T` annotation
+/// whose resolved type exactly matches the inferred type of the right-hand
+/// side.
+///
+/// Triggers on `name :: T := <expr>` when the static type of `<expr>` is
+/// exactly `T` (not a subtype, not narrowed via union). Skips:
+///
+/// - Union and false-or annotations (`T | nil`, `T?`) — load-bearing for widening.
+/// - RHS whose inferred type is `Dynamic`, `Never`, or `Union` — the annotation
+///   is supplying real information the inferer could not derive.
+/// - Field assignments (`self.x := ...`), destructuring assignments, and any
+///   non-`Identifier` target — those don't carry user-written type annotations
+///   in this lint's scope.
+/// - Block parameters / state declarations / method params — those use their
+///   own AST nodes, not [`Expression::Assignment`].
+///
+/// Suppressed by `@expect type_annotation` on the enclosing statement.
+pub(crate) fn check_redundant_local_type_annotation(
+    module: &Module,
+    type_map: &TypeMap,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    walk_module(module, &mut |expr| {
+        let Expression::Assignment {
+            target,
+            value,
+            type_annotation: Some(annotation),
+            span,
+        } = expr
+        else {
+            return;
+        };
+        // Only flag plain local-variable targets. `self.x :: T := ...` is not
+        // valid Beamtalk syntax for fields, but guard defensively.
+        if !matches!(target.as_ref(), Expression::Identifier(_)) {
+            return;
+        }
+        // Widening annotations are load-bearing: keep them.
+        if matches!(
+            annotation,
+            TypeAnnotation::Union { .. } | TypeAnnotation::FalseOr { .. }
+        ) {
+            return;
+        }
+
+        let Some(rhs_ty) = type_map.get(value.span()) else {
+            return;
+        };
+
+        // Only flag when the RHS resolves to a single Known type. Dynamic,
+        // Never, and Union RHS types mean the annotation is doing real work.
+        let InferredType::Known {
+            class_name: rhs_class,
+            type_args: rhs_args,
+            ..
+        } = rhs_ty
+        else {
+            return;
+        };
+
+        // Resolve the annotation against an empty substitution map. A future
+        // refinement could thread the surrounding method's type-param subst,
+        // but for the common cases (`Counter`, `List(Foo)`) the resolved form
+        // matches the inferer's symbolic placeholders without a subst.
+        let empty_subst: HashMap<ecow::EcoString, InferredType> = HashMap::new();
+        let resolved = crate::semantic_analysis::type_checker::resolve_type_annotation(
+            annotation,
+            &empty_subst,
+        );
+        let InferredType::Known {
+            class_name: ann_class,
+            type_args: ann_args,
+            ..
+        } = resolved
+        else {
+            return;
+        };
+
+        // Exact match — annotation adds no information.
+        if ann_class != *rhs_class || ann_args != *rhs_args {
+            return;
+        }
+
+        // Reject when any RHS type-arg is Dynamic but the annotation pins a
+        // concrete type at the same position — `List(Foo) := List new` style,
+        // where the annotation legitimately narrows. Equality above already
+        // rejects this case (Dynamic ≠ Foo), but keep the explicit guard
+        // defensive in case the equality semantics ever change.
+        if rhs_args
+            .iter()
+            .any(|t| matches!(t, InferredType::Dynamic(_)))
+        {
+            return;
+        }
+
+        let ann_str = InferredType::Known {
+            class_name: ann_class.clone(),
+            type_args: ann_args.clone(),
+            provenance: crate::semantic_analysis::type_checker::TypeProvenance::Declared(*span),
+        }
+        .display_for_diagnostic()
+        .unwrap_or_else(|| ann_class.clone());
+
+        diagnostics.push(
+            Diagnostic::lint(
+                format!(
+                    "Redundant type annotation: `:: {ann_str}` matches the inferred type of the right-hand side",
+                ),
+                annotation.span(),
+            )
+            .with_hint(format!(
+                "Drop the `:: {ann_str}` annotation — the right-hand side already has this type. \
+                 Suppress with `@expect type_annotation` if the explicit annotation is intentional.",
+            ))
+            .with_category(DiagnosticCategory::TypeAnnotation),
+        );
+    });
 }
 
 #[cfg(test)]
@@ -1201,6 +1326,170 @@ mod tests {
         assert!(
             diagnostics.is_empty(),
             "Expected no warnings for class-side keyword initialize, got: {diagnostics:?}"
+        );
+    }
+
+    // ── BT-2140: Redundant local-variable type annotation tests ───────────────
+
+    /// Helper: parse, type-check, and run the redundant-annotation lint.
+    fn redundant_local_type_lints(src: &str) -> Vec<Diagnostic> {
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        let hard_errs: Vec<_> = parse_diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .collect();
+        assert!(hard_errs.is_empty(), "Parse failed: {hard_errs:?}");
+        let (hierarchy, _) = ClassHierarchy::build(&module);
+        let hierarchy = hierarchy.expect("hierarchy build failed");
+        let type_map = crate::semantic_analysis::infer_types(&module, &hierarchy);
+        let mut diagnostics = Vec::new();
+        check_redundant_local_type_annotation(&module, &type_map, &mut diagnostics);
+        diagnostics
+    }
+
+    /// Top-level: `x :: Counter := Counter new` — annotation is redundant.
+    #[test]
+    fn redundant_simple_annotation_with_new_flagged() {
+        let src = "Object subclass: Counter\n  count => 0\n\nx :: Counter := Counter new";
+        let diags = redundant_local_type_lints(src);
+        assert_eq!(
+            diags.len(),
+            1,
+            "Expected 1 redundant-annotation lint, got: {diags:?}"
+        );
+        assert_eq!(diags[0].severity, Severity::Lint);
+        assert_eq!(diags[0].category, Some(DiagnosticCategory::TypeAnnotation));
+        assert!(
+            diags[0].message.contains("Redundant type annotation"),
+            "Expected 'Redundant type annotation' in message, got: {}",
+            diags[0].message
+        );
+        assert!(
+            diags[0].message.contains("Counter"),
+            "Expected 'Counter' in message, got: {}",
+            diags[0].message
+        );
+    }
+
+    /// Inside a method: `c :: Counter := Counter new` — flagged.
+    #[test]
+    fn redundant_annotation_inside_method_flagged() {
+        let src = "Object subclass: Counter\n  count => 0\n\nObject subclass: Foo\n  build =>\n    c :: Counter := Counter new.\n    c";
+        let diags = redundant_local_type_lints(src);
+        assert_eq!(
+            diags.len(),
+            1,
+            "Expected 1 redundant-annotation lint inside method, got: {diags:?}"
+        );
+    }
+
+    /// `x :: Counter | Nil := nil` — Union annotation is load-bearing, NOT flagged.
+    #[test]
+    fn union_annotation_with_nil_rhs_not_flagged() {
+        let src = "Object subclass: Counter\n  count => 0\n\nx :: Counter | Nil := nil";
+        let diags = redundant_local_type_lints(src);
+        assert!(
+            diags.is_empty(),
+            "Union annotation (T | Nil) must never be flagged, got: {diags:?}"
+        );
+    }
+
+    /// `x :: SuperType := SubType new` — annotation widens, NOT flagged.
+    #[test]
+    fn widening_annotation_not_flagged() {
+        let src = "Object subclass: Animal\n  name => \"animal\"\n\nAnimal subclass: Dog\n  bark => \"woof\"\n\nx :: Animal := Dog new";
+        let diags = redundant_local_type_lints(src);
+        assert!(
+            diags.is_empty(),
+            "Widening annotation (Super := Sub) must not be flagged, got: {diags:?}"
+        );
+    }
+
+    /// `self.x := Counter new` — field assignment has no user-facing annotation
+    /// in this lint's scope and must not be flagged.
+    #[test]
+    fn field_assignment_not_flagged() {
+        let src = "Object subclass: Counter\n  count => 0\n\nObject subclass: Foo\n  state: c = nil\n  build =>\n    self.c := Counter new.\n    self";
+        let diags = redundant_local_type_lints(src);
+        assert!(
+            diags.is_empty(),
+            "Field assignment must not be flagged, got: {diags:?}"
+        );
+    }
+
+    /// `x := Counter new` (no annotation) — nothing to flag.
+    #[test]
+    fn no_annotation_not_flagged() {
+        let src = "Object subclass: Counter\n  count => 0\n\nx := Counter new";
+        let diags = redundant_local_type_lints(src);
+        assert!(
+            diags.is_empty(),
+            "Bare `x := ...` (no annotation) must never be flagged, got: {diags:?}"
+        );
+    }
+
+    /// State declarations carry their own annotation form (`state: x :: T = ...`)
+    /// and are not flagged by this local-variable lint.
+    #[test]
+    fn state_declaration_not_flagged() {
+        let src = "Object subclass: Counter\n  count => 0\n\nObject subclass: Foo\n  state: c :: Counter = nil\n  build => self";
+        let diags = redundant_local_type_lints(src);
+        assert!(
+            diags.is_empty(),
+            "State declarations are not local-variable assignments, got: {diags:?}"
+        );
+    }
+
+    /// Method/block parameters with annotations are not local-variable
+    /// assignments — never flagged.
+    #[test]
+    fn method_parameter_annotation_not_flagged() {
+        let src = "Object subclass: Counter\n  count => 0\n\nObject subclass: Foo\n  with: c :: Counter => c";
+        let diags = redundant_local_type_lints(src);
+        assert!(
+            diags.is_empty(),
+            "Method parameter annotation must not be flagged, got: {diags:?}"
+        );
+    }
+
+    /// Hint should be present and mention `@expect type_annotation` for suppression.
+    #[test]
+    fn redundant_annotation_has_suppressible_hint() {
+        let src = "Object subclass: Counter\n  count => 0\n\nx :: Counter := Counter new";
+        let diags = redundant_local_type_lints(src);
+        assert_eq!(diags.len(), 1);
+        let hint = diags[0]
+            .hint
+            .as_ref()
+            .expect("expected hint on redundant-annotation lint");
+        assert!(
+            hint.contains("@expect type_annotation"),
+            "hint should mention @expect type_annotation, got: {hint}"
+        );
+    }
+
+    /// `x :: Integer := 42` — literal RHS already has the matching type, flagged.
+    #[test]
+    fn redundant_annotation_with_literal_rhs_flagged() {
+        let src = "x :: Integer := 42";
+        let diags = redundant_local_type_lints(src);
+        assert_eq!(
+            diags.len(),
+            1,
+            "Expected 1 lint for `x :: Integer := 42`, got: {diags:?}"
+        );
+    }
+
+    /// Multiple redundant assignments in the same method each trigger their own lint.
+    #[test]
+    fn multiple_redundant_annotations_each_flagged() {
+        let src = "Object subclass: Counter\n  count => 0\n\nObject subclass: Foo\n  build =>\n    a :: Counter := Counter new.\n    b :: Counter := Counter new.\n    a";
+        let diags = redundant_local_type_lints(src);
+        assert_eq!(
+            diags.len(),
+            2,
+            "Expected one lint per redundant annotation, got: {diags:?}"
         );
     }
 }

--- a/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
@@ -546,6 +546,11 @@ pub(crate) fn check_redundant_local_type_annotation(
     type_map: &TypeMap,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    // A future refinement could thread the surrounding method's type-param
+    // subst, but for the common cases (`Counter`, `List(Foo)`) the resolved
+    // form matches the inferer's symbolic placeholders without a subst.
+    // Hoisted out of the walker so we don't re-allocate per assignment.
+    let empty_subst: HashMap<ecow::EcoString, InferredType> = HashMap::new();
     walk_module(module, &mut |expr| {
         let Expression::Assignment {
             target,
@@ -584,11 +589,6 @@ pub(crate) fn check_redundant_local_type_annotation(
             return;
         };
 
-        // Resolve the annotation against an empty substitution map. A future
-        // refinement could thread the surrounding method's type-param subst,
-        // but for the common cases (`Counter`, `List(Foo)`) the resolved form
-        // matches the inferer's symbolic placeholders without a subst.
-        let empty_subst: HashMap<ecow::EcoString, InferredType> = HashMap::new();
         let resolved = crate::semantic_analysis::type_checker::resolve_type_annotation(
             annotation,
             &empty_subst,

--- a/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
@@ -603,19 +603,10 @@ pub(crate) fn check_redundant_local_type_annotation(
         };
 
         // Exact match — annotation adds no information.
+        // Type-arg equality also catches narrowing cases like
+        // `List(Foo) := List new`, where the RHS's `Dynamic` element type
+        // doesn't equal the annotation's concrete `Foo`.
         if ann_class != *rhs_class || ann_args != *rhs_args {
-            return;
-        }
-
-        // Reject when any RHS type-arg is Dynamic but the annotation pins a
-        // concrete type at the same position — `List(Foo) := List new` style,
-        // where the annotation legitimately narrows. Equality above already
-        // rejects this case (Dynamic ≠ Foo), but keep the explicit guard
-        // defensive in case the equality semantics ever change.
-        if rhs_args
-            .iter()
-            .any(|t| matches!(t, InferredType::Dynamic(_)))
-        {
             return;
         }
 

--- a/crates/beamtalk-core/src/semantic_analysis/validators/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/mod.rs
@@ -32,7 +32,8 @@ pub(crate) use class_validators::{
 };
 pub(crate) use lint_validators::{
     check_effect_free_statements, check_empty_method_bodies, check_literal_boolean_condition,
-    check_redundant_assignment, check_redundant_super_initialize,
+    check_redundant_assignment, check_redundant_local_type_annotation,
+    check_redundant_super_initialize,
 };
 pub(crate) use match_validators::{check_match_exhaustiveness, warn_assignment_in_match_arms};
 pub(crate) use native_validators::{check_native_delegate_return_type, check_native_state_fields};

--- a/stdlib/test/local_type_annotation_test.bt
+++ b/stdlib/test/local_type_annotation_test.bt
@@ -9,17 +9,20 @@ TestCase subclass: LocalTypeAnnotationTest
 
   testSimpleAnnotation =>
     // Type annotation on a simple local variable
+    @expect type_annotation
     x :: Integer := 42
     self assert: x equals: 42
 
   testAnnotationDoesNotChangeRuntime =>
     // The annotation is erased at runtime — value is whatever the RHS produces
+    @expect type_annotation
     x :: Integer := 10 + 5
     self assert: x equals: 15
 
   testAnnotationInBlock =>
     // Type annotation inside a block body
     result := [
+      @expect type_annotation
       name :: String := "hello"
       name ++ " world"
     ] value


### PR DESCRIPTION
## Summary

Adds a new lint rule that flags `name :: T := <expr>` when the inferred type
of `<expr>` exactly matches `T` — the annotation adds no information the
type-checker doesn't already have. Catches the over-annotation pattern that
appeared in the BT-2117 watcher epic.

Linear: https://linear.app/beamtalk/issue/BT-2140

## Key changes

- New validator `check_redundant_local_type_annotation` in
  `semantic_analysis/validators/lint_validators.rs`, wired into the analysis
  pipeline so all CLI surfaces (lint/build/test) pick it up automatically.
- Categorised under `DiagnosticCategory::TypeAnnotation`, suppressible by
  `@expect type_annotation` (same suppression key as BT-1918's
  missing-annotation warnings).
- Skips Union/FalseOr annotations (`T | nil`, `T?`) since they widen, and
  Dynamic/Never/Union RHS types where the annotation does real work.
- 10 unit tests covering flagged cases (literal/method/multiple) and
  counter-cases (Union widening, Super := Sub widening, field assignment,
  no-annotation, state declaration, method param, suppression hint).
- `stdlib/test/local_type_annotation_test.bt` — added `@expect type_annotation`
  to the cases that exist specifically to test the annotation syntax.

## Test plan

- [x] `cargo test -p beamtalk-core` (3495 passed)
- [x] `just test-stdlib` (250 passed)
- [x] `just ci` (clippy/fmt/parity/REPL protocol all green)
- [x] Manual end-to-end via `beamtalk lint` confirming flagged + suppressed cases
- [x] Repo sweep: only the dedicated annotation-syntax test file had hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BT-2140 lint that detects redundant local variable type annotations and provides an `@expect type_annotation` suppression hint.

* **Tests**
  * Expanded test coverage to assert the presence of local type annotations and to validate lint behavior across top-level, method, literal, and negative cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2187)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->