### PR TITLE
Draft ADR 0081 - first-class session object (BT-2092)

### DIFF
--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -42,65 +42,69 @@ The CLI REPL has one session. WebSocket and MCP clients can have many — `beamt
 
 ## Decision
 
-Introduce a new `Session` class with a **class-side API** as the primary interface. The class itself is the entry point — `Session bindings` is a class-side message send, mirroring Smalltalk patterns like `Date today`, `Time now`, and `Smalltalk current`. There is **no injected `Session` binding** at the shell level; the class is reachable because it is loaded, not because it was singled out.
+Introduce a new `Session` class used as a **factory**: two class methods return session *values*, and **all binding operations are instance methods on the returned value**.
 
-`Session` is **not** an Actor (gen_server). It is a Beamtalk class whose class-side methods delegate to `beamtalk_session_primitives`, which uses process-context resolution (process dictionary seeded during eval worker spawn) to find the calling session.
+- `Session current` returns the calling process's session (or `nil` outside a REPL eval — see below), mirroring `Date today` / `Smalltalk current`: the class method returns an instance you then message (`Date today year`, not `Date year`).
+- `Session withId: aSessionId` returns another session by its protocol id, for cross-session tooling access.
 
-`Session bindings` and `Session globals` return **live binding views** — mutating them writes through to the underlying state. `view at: #x put: 42` sets a session-local; `view removeKey: #x` removes it. Globals mutations route through the existing `bind:as:` / `unbind:` machinery and inherit those conflict checks.
+There is **no class-side operation mirror** — no `Session bindings`, no `Session clear`. You write `Session current bindings`, `(Session withId: x) bindings`. This keeps `Session` a *normal class* (factory class-methods plus instance methods, like `Array new` then instance sends), rather than a bespoke singleton-with-sugar. The system's true singletons (`Transcript`, `Beamtalk`, `Workspace`) are reached through an injected binding that *is* the instance; `Session` cannot be one of those because it is **per-process, not per-node** (each connection has its own), so it earns factory access instead — but it does not earn a duplicate class-side API. (See "Why no class-side convenience mirror" under Tension Points.)
+
+There is **no injected `Session` binding** at the shell level; the class is reachable because it is loaded, not because it was singled out.
+
+`Session` is **not** an Actor (gen_server). It is a Beamtalk class whose methods delegate to `beamtalk_session_primitives`. `Session current` uses process-context resolution (process dictionary seeded during eval worker spawn) to find the calling session; instance methods carry their session's id for cross-session dispatch.
+
+`aSession bindings` and `aSession globals` return **live binding views** — mutating them writes through to the underlying state. `view at: #x put: 42` sets a session-local; `view removeKey: #x` removes it. Globals mutations route through the existing `bind:as:` / `unbind:` machinery and inherit those conflict checks.
 
 ### API
 
 ```beamtalk
 sealed typed Object subclass: Session
 
-  /// Live view of session-local bindings. Reads return current values;
-  /// `at:put:` and `removeKey:` mutate session state directly.
-  class bindings -> BindingsView =>
-    (Erlang beamtalk_session_primitives) bindingsView
+  // ─── Class-side: factory methods only ───
+
+  /// The calling process's session as a value. Returns `nil` outside a
+  /// REPL eval context (compiled program code has no session), matching
+  /// `Workspace currentSession`.
+  class current -> Session | Nil =>
+    (Erlang beamtalk_session_primitives) current
+
+  /// Look up a session by its protocol session ID. Returns `nil` if no
+  /// such session exists or it is no longer alive. Used for cross-session
+  /// access — see "Cross-session access (LSP, VS Code)" below.
+  class withId: aSessionId :: String -> Session | Nil =>
+    (Erlang beamtalk_session_primitives) withId: aSessionId
+
+  // ─── Instance-side: all operations live here ───
+
+  /// Live view of this session's local bindings (the `x := 42` layer).
+  /// Reads return current values; `at:put:` and `removeKey:` mutate
+  /// session state (write-through, for the calling session only).
+  bindings -> BindingsView =>
+    (Erlang beamtalk_session_primitives) bindingsViewFor: self
 
   /// Live view of workspace globals (singletons + bind:as: entries).
-  /// Mutations route through `Workspace bind:as:` / `unbind:`, including
-  /// the existing protected-name conflict checks for system singletons.
-  class globals -> BindingsView =>
+  /// Shared across sessions; mutations route through `Workspace bind:as:`
+  /// / `unbind:`, including the existing protected-name conflict checks.
+  globals -> BindingsView =>
     (Erlang beamtalk_session_primitives) globalsView
 
   /// Walk binding layers, return first match or nil.
   /// Lookup order: session locals → workspace globals.
   /// Primarily a REPL debugging tool: answers "where does this name
   /// resolve from?" interactively.
-  class resolve: aName :: Symbol -> Object =>
-    (Erlang beamtalk_session_primitives) resolve: aName
-
-  /// Clear all session-local bindings. Workspace globals remain.
-  class clear -> Nil =>
-    (Erlang beamtalk_session_primitives) clear
-
-  /// Stable session identifier (matches the protocol session ID).
-  class id -> String =>
-    (Erlang beamtalk_session_primitives) id
-
-  /// Return the calling process's session as a value, for pass-by-reference.
-  /// Returns `nil` outside a REPL eval context.
-  class current -> Session | Nil =>
-    (Erlang beamtalk_session_primitives) current
-
-  /// Look up a session by its protocol session ID (returns nil if no
-  /// such session). Used for cross-session access — see "Cross-session
-  /// access (LSP, VS Code)" below.
-  class withId: aSessionId :: String -> Session | Nil =>
-    (Erlang beamtalk_session_primitives) withId: aSessionId
-
-  // Instance-side methods (used when a Session value is passed around):
-  bindings -> BindingsView =>
-    (Erlang beamtalk_session_primitives) bindingsViewFor: self
-  globals -> BindingsView =>
-    (Erlang beamtalk_session_primitives) globalsView
   resolve: aName :: Symbol -> Object =>
-    (Erlang beamtalk_session_primitives) resolve: aName for: self
+    (Erlang beamtalk_session_primitives) resolveFor: self name: aName
+
+  /// Clear this session's local bindings. Workspace globals remain.
   clear -> Nil =>
     (Erlang beamtalk_session_primitives) clearFor: self
-  id -> String => (Erlang beamtalk_session_primitives) idOf: self
+
+  /// Stable session identifier (matches the protocol session ID).
+  id -> String =>
+    (Erlang beamtalk_session_primitives) idOf: self
 ```
+
+The common idiom is `Session current bindings keys`; for another session, `(Session withId: "…") bindings keys`. Binding a session to a temp (`s := Session current`) works too, but note `s` then becomes a session-local and will appear in `s bindings keys` — so the inline form is cleaner for one-off inspection.
 
 **Session instance representation.** `Session` is declared `Object subclass` (no `field:`/`state:` declarations, which an `Object` subclass cannot have), yet a `Session` *value* returned by `current` / `withId:` must carry its session's PID and protocol ID. This follows the existing `FileHandle` / `Port` pattern: a `sealed typed Object subclass` whose per-instance identity lives in the runtime representation (a tagged map produced by the primitive), not in a declared field. Instance methods pass `self` to a `*For:` primitive, which extracts the PID/ID from that representation — exactly as `FileHandle lines` passes `self` to `(Erlang beamtalk_file) handleLines: self`.
 
@@ -131,7 +135,7 @@ userSession ifNotNil: [
 Workspace sessions collect: [:s | s id]
 ```
 
-The class-side methods (`Session bindings`) operate on the calling process's session — semantically "my session". The instance-side methods (`aSession bindings`) operate on whichever session the value represents, including ones owned by other connections. This is the load-bearing reason for instance methods on `Session`: cross-session **introspection** from tooling.
+`Session current bindings` operates on the calling process's session — semantically "my session". `(Session withId: x) bindings` operates on whichever session the id names, including ones owned by other connections. Both are the *same* instance methods on a `Session` value; only the factory call differs (`current` vs `withId:`). This is the load-bearing reason `Session` is value-shaped at all: cross-session **introspection** from tooling.
 
 Cross-session access is **read-only**. The instance-side reads (`bindings keys`, `bindings at:`, `resolve:`, `id`) work against any live session; the instance-side mutators (`at:put:`, `removeKey:`, `clear`) raise `cross_session_mutation_unsupported` (see Consequences → Negative → "Cross-session writes"). The LSP/completion use case needs only reads, and cross-session writes would race the target session's in-flight eval. `withId:` itself performs a liveness check and returns `nil` for an unknown *or* dead session id; a previously-captured `Session` whose shell later dies raises `session_not_found` on its next send.
 
@@ -142,36 +146,36 @@ The LSP and any other client that previously called the `bindings` / `clear` pro
 ```text
 beamtalk> x := 42
 42
-beamtalk> Session bindings keys
+beamtalk> Session current bindings keys
 #(#x)
-beamtalk> Session bindings at: #x
+beamtalk> Session current bindings at: #x
 42
-beamtalk> Session globals keys
+beamtalk> Session current globals keys
 #(#Transcript, #Beamtalk, #Workspace)
-beamtalk> Session resolve: #x
+beamtalk> Session current resolve: #x
 42
-beamtalk> Session resolve: #Transcript
+beamtalk> Session current resolve: #Transcript
 #<TranscriptStream>
-beamtalk> Session resolve: #notDefined
+beamtalk> Session current resolve: #notDefined
 nil
 
 // Live mutations write through:
-beamtalk> Session bindings at: #y put: 99
+beamtalk> Session current bindings at: #y put: 99
 99
 beamtalk> y
 99
-beamtalk> Session bindings removeKey: #x
+beamtalk> Session current bindings removeKey: #x
 nil
 beamtalk> x
 // => #beamtalk_error{kind: undefined_variable, name: #x}
 
 // Globals mutations route through bind:as: / unbind:
 // at:put: returns the value put (Dictionary protocol), like the session view above.
-beamtalk> Session globals at: #MyTool put: someActor
+beamtalk> Session current globals at: #MyTool put: someActor
 #<Counter @ <0.123.0>>
 beamtalk> MyTool
 #<Counter @ <0.123.0>>
-beamtalk> Session globals removeKey: #MyTool
+beamtalk> Session current globals removeKey: #MyTool
 nil
 
 // Pass-by-reference (cross-session access from LSP / tooling):
@@ -182,9 +186,9 @@ beamtalk> userSession bindings keys
 
 beamtalk> Workspace currentSession id
 "abc123-..."
-beamtalk> Session clear
+beamtalk> Session current clear
 nil
-beamtalk> Session bindings keys
+beamtalk> Session current bindings keys
 #()
 ```
 
@@ -199,14 +203,21 @@ Workspace currentSession  // => nil
 Workspace hasSession   // => false
 ```
 
-Class-side `Session bindings` outside a REPL session raises a structured error:
+Outside a REPL, `Session current` is `nil`, so messaging it DNUs on `nil`:
 
 ```beamtalk
-Session bindings
-// => #beamtalk_error{kind: no_session, message: "no session in scope"}
+Session current bindings
+// `Session current` => nil, then:
+// => #beamtalk_error{kind: does_not_understand, selector: #bindings, receiver: nil}
 ```
 
-Cross-session `withId:` for an unknown session ID returns nil:
+This is the *intended* trade for keeping `current` consistent with `Workspace currentSession` (both return `nil` with no session). It is acceptable because `Session` is an interactive/tooling surface, not something production library code depends on — and code that wants to guard checks `Workspace hasSession` first:
+
+```beamtalk
+Workspace hasSession ifTrue: [ Session current clear ]
+```
+
+Cross-session `withId:` for an unknown (or dead) session ID returns nil:
 
 ```beamtalk
 Session withId: "nonexistent"  // => nil
@@ -242,21 +253,22 @@ staleSession bindings keys
 
 | Question | Decision | Rationale |
 |----------|----------|-----------|
-| Singleton or per-PID? | **Per-PID** | CLI has one session, WebSocket/MCP clients can have many. Class-side methods use process-context resolution to find the calling session; instance methods carry their own session ID for cross-session access. |
-| What outside REPL eval? | **`Session current` returns `nil`**; class-side methods like `Session bindings` raise a structured `no_session` error. | Compiled program code has no session. Returning a stub or nil from `bindings` would mask the meaningful absence; an error is louder. |
+| Singleton or per-PID? | **Per-PID** | CLI has one session, WebSocket/MCP clients can have many. `Session current` uses process-context resolution to find the calling session; instance values carry their own session ID for cross-session access. |
+| Class-side operation mirror (`Session bindings`)? | **No.** Factory class-methods only (`current`, `withId:`); all operations are instance methods. | A class-side mirror would make `Session` a bespoke pattern unlike every other class (the true singletons use an injected binding; Session can't be one). It buys only terseness and a marginally nicer no-session error — not worth a duplicated surface. See Tension Points. |
+| What outside REPL eval? | **`Session current` returns `nil`** (matching `Workspace currentSession`); `Session current bindings` then DNUs on `nil`. | Compiled program code has no session. Returning `nil` keeps `current` consistent with `Workspace currentSession`; the DNU-on-nil is acceptable because `Session` is an interactive/tooling surface, not a production dependency. Guard with `Workspace hasSession`. |
 | Persist across `:sync` / reload? | **Yes** — unchanged from current behaviour. | Session locals are shell-process state, owned independently of class definitions. Sync rebuilds modules; the session keeps its bindings. |
 | Are bindings/globals views live or snapshots? | **Live views.** Mutations write through. | Matches Pharo semantics (`Smalltalk globals at:put:`). A snapshot would force a parallel setter API (`Session at:put:`); the live view collapses both into one Dictionary protocol. |
 | Layer-walking abstraction? | **Dropped.** No `layers` method, no recursive `parent`. | Beamtalk has settled on exactly two layers; package encapsulation (ADR 0070) is class-scoped, not a binding-resolution layer. A `layers` constant would be pure decoration. |
-| `bind:as:` interaction? | **Unchanged.** `Session globals at:put:` is equivalent to `Workspace bind:as:`, including conflict checks. | One write path through the existing primitives; the new view is sugar over the established API. |
-| Cross-session access? | **Instance methods + `Session withId:`, read-only** | LSP/VS Code completion sessions need to query the user's session. Class-side methods are "my session"; instance methods are "that session". Cross-session *writes* race the target's in-flight eval and are unneeded, so they raise `cross_session_mutation_unsupported`. |
+| `bind:as:` interaction? | **Unchanged.** `Session current globals at:put:` is equivalent to `Workspace bind:as:`, including conflict checks. | One write path through the existing primitives; the new view is sugar over the established API. |
+| Cross-session access? | **Instance methods on a value from `Session withId:`, read-only** | LSP/VS Code completion sessions need to query the user's session. `Session current` is "my session"; `Session withId:` is "that session"; both return values you message identically. Cross-session *writes* race the target's in-flight eval and are unneeded, so they raise `cross_session_mutation_unsupported`. |
 | Stale / dead session reference? | **`withId:` does a liveness check (returns `nil`); a captured value whose shell later dies raises `session_not_found`.** | Avoids a `gen_server:call` to a dead PID blocking for the full timeout. |
 
 ## Prior Art
 
 | System | Binding model | What we adopt | What we reject |
 |--------|---------------|---------------|----------------|
-| **Pharo `Smalltalk current` / `Date today` / `Time now`** | Class-side methods that return a "current" instance — the class itself is the entry point. | The class-as-entry-point pattern (`Session bindings` is a class-side message, like `Date today`). | None — this is the load-bearing prior art for Option F. |
-| **Pharo / Squeak Workspace** | `Dictionary` of bindings on the workspace, mutable via `at:put:`, with fallback to `Smalltalk globals`. Methods: `bindings`, `bindingOf:`, `removeBinding:`, `resetBindings`. | The mutable-Dictionary shape (`Session bindings at:put:` writes through, matching `Smalltalk globals at:put:`). | Pharo merges workspace and session — Beamtalk has separate workspace (shared) and session (per-PID) layers because of multi-client BEAM hosting. |
+| **Pharo `Smalltalk current` / `Date today` / `Time now`** | Class-side *factory* methods that return an instance — you then message the instance (`Date today year`, not `Date year`). | The factory-then-instance pattern exactly: `Session current` / `Session withId:` return a session value you message. We deliberately do **not** add a class-side operation mirror — `Date` itself doesn't (`Date today daysInMonth`, never `Date daysInMonth`). | A class-side operation mirror — it would be unlike `Date`/`Time` and every other class. |
+| **Pharo / Squeak Workspace** | `Dictionary` of bindings on the workspace, mutable via `at:put:`, with fallback to `Smalltalk globals`. Methods: `bindings`, `bindingOf:`, `removeBinding:`, `resetBindings`. | The mutable-Dictionary shape (`aSession bindings at:put:` writes through, matching `Smalltalk globals at:put:`). | Pharo merges workspace and session — Beamtalk has separate workspace (shared) and session (per-PID) layers because of multi-client BEAM hosting. |
 | **Pharo Environment** | Wraps a `Dictionary` of globals; multiple Environments allowed. | Layer reification via named accessors. | Beamtalk does not need user-creatable environments — workspace is bootstrapped once per BEAM node. |
 | **Newspeak** | Lexical nesting only; no global namespace; capability passing via constructor parameter. | The principle that scope is explicit, not magic. | Beamtalk has Smalltalk-style globals (`Transcript`, classes); a fully-lexical model would invalidate the existing namespace design. |
 | **Self** | Parent slot chain; scope walks via `parent*` slots. | Explicit layer separation (`bindings` vs `globals`), inspired by Self's transparent parent hierarchy. | Recursive `parent` chains overstate the complexity for two layers. |
@@ -268,7 +280,7 @@ staleSession bindings keys
 ## User Impact
 
 **Newcomer (Python/JS background).**
-`Session` is discoverable via tab-completion on the class name — type `Ses<TAB>` and the class-side methods appear. Discovering "how do I see my variables" via `Session bindings` is more direct than memorising a `:b` meta-command. The live-mutation pattern (`Session bindings at: #x put: 42`) matches how Dictionary works everywhere else in the language.
+`Session` is discoverable via tab-completion on the class name — type `Ses<TAB>` and `current` / `withId:` appear; `Session current <TAB>` then surfaces the operations. Discovering "how do I see my variables" via `Session current bindings` is more direct than memorising a `:b` meta-command. The live-mutation pattern (`Session current bindings at: #x put: 42`) matches how Dictionary works everywhere else in the language.
 
 **Smalltalk developer.**
 The session-as-object model is recognisably Smalltalk: `Session` is to a Beamtalk shell what `Smalltalk` is to a Pharo image. The two-layer split (session vs. workspace) is more honest about multi-client BEAM hosting than Pharo's single-image model.
@@ -280,7 +292,7 @@ Class-side methods that use process-context resolution match how BEAM convention
 `Workspace sessions` (a follow-up extension) can return a list of `Session` objects, each individually inspectable. Compared to opaque PIDs in `supervisor:which_children`, this gives operators a structured view of who is connected and what they have bound.
 
 **Tooling developer (LSP / VS Code).**
-The MCP server can call `Session bindings` and `Session globals` via `evaluate` to display per-session state in the inspector panel. Tooling that needs the merged binding map (e.g. completions) merges those two Dictionaries in resolution order — no separate primitive needed.
+The MCP server can call `Session current bindings` and `Session current globals` via `evaluate` to display per-session state in the inspector panel. Tooling that needs the merged binding map (e.g. completions) merges those two Dictionaries in resolution order — no separate primitive needed.
 
 ## Steelman Analysis
 
@@ -290,18 +302,18 @@ The MCP server can call `Session bindings` and `Session globals` via `evaluate` 
 
 **Smalltalk purist:** "Adding methods to `Workspace` matches how `Smalltalk` accumulates introspection in Pharo — `Smalltalk globals`, `Smalltalk allClasses`, `Smalltalk current`. Why is sessions special enough to warrant its own class?"
 
-**BEAM veteran:** "`Workspace sessionBindings` could use the same process-context resolution that `Session bindings` uses anyway. The dispatch cost is identical; you're just spelling it differently. For the 99% case — introspecting your own session — adding methods to an existing object is simpler than introducing a whole new class. No new Erlang module, no new class registry entry."
+**BEAM veteran:** "`Workspace sessionBindings` could use the same process-context resolution that `Session current bindings` uses anyway. The dispatch cost is identical; you're just spelling it differently. For the 99% case — introspecting your own session — adding methods to an existing object is simpler than introducing a whole new class. No new Erlang module, no new class registry entry."
 
 **Operator:** "Fewer object types in the system means fewer surfaces to learn for postmortem debugging. `Workspace` is already the operator's entry point — keep it that way."
 
 **Language designer:** "Adding methods is cheaper than adding classes. The composability argument for first-class Session is partly speculative — today nobody writes `Workspace sessions collect: [:s | s bindings]`. YAGNI."
 
-**Why not adopted:** Option B *works* for the common case and is genuinely simpler. Two factors push us to F (class-side Session) despite this:
+**Why not adopted:** Option B *works* for the common case and is genuinely simpler. Two factors push us to a dedicated `Session` class despite this:
 
 1. **Pass-by-reference.** `Session` as a value can be stored, passed to library code, or used for cross-session access — `Session withId:` for LSP completion against the user's session, `Workspace sessions collect: [:s | s id]` for multi-session enumeration. Option B cannot express any of these without inventing per-call session-id parameters.
-2. **Workspace's role.** `Workspace` is a navigation entry point — `Workspace actors`, `Workspace classes`, `Workspace supervisor`, `Workspace dependencies` — each method *finds you something*. Session bindings are not something you navigate to from the workspace; they belong to a session, which has its own identity. Loading four session-state methods (`sessionBindings`, `sessionGlobals`, `clearSession`, `resolveBinding:`) directly onto `Workspace` would be the same category error as putting `Counter increment` on `Workspace`. The class-side `Session` API keeps the surface focused.
+2. **Workspace's role.** `Workspace` is a navigation entry point — `Workspace actors`, `Workspace classes`, `Workspace supervisor`, `Workspace dependencies` — each method *finds you something*. Session bindings are not something you navigate to from the workspace; they belong to a session, which has its own identity. Loading four session-state methods (`sessionBindings`, `sessionGlobals`, `clearSession`, `resolveBinding:`) directly onto `Workspace` would be the same category error as putting `Counter increment` on `Workspace`. A dedicated `Session` class keeps the surface focused.
 
-Option F gives us almost all of B's simplicity (no injection, no shadowing, no `injected_ws_keys` plumbing) plus pass-by-reference for the cross-session and multi-session cases that B cannot express.
+The chosen design gives us almost all of B's simplicity (no injection, no shadowing, no `injected_ws_keys` plumbing) plus pass-by-reference for the cross-session and multi-session cases that B cannot express — while keeping the surface minimal by exposing only factory class-methods (`current`, `withId:`), not a class-side operation mirror.
 
 ### Option C: Recursive Scope Chain (rejected)
 
@@ -319,9 +331,13 @@ Option F gives us almost all of B's simplicity (no injection, no shadowing, no `
 
 ### Tension Points
 
-- **Class-side vs. injected-binding ergonomics.** Both are two words to type (`Session bindings` either way). The class-side approach wins on principled grounds — Pharo's `Date today` / `Smalltalk current` pattern is the right precedent for a per-PID "current" value. The injected-binding approach (Alternative A) was the original sketch but pretends Session is a singleton when it isn't.
-- **The LSP cross-session case is real, not speculative.** BT-1045 already established the protocol-level cross-session pattern; the LSP runs its own completion session and queries the user's session for bindings. Option B has no Beamtalk-native expression of this; Option F's `Session withId:` does.
-- **Live mutation cost.** Pharo-style `Smalltalk globals at:put:` write-through is genuinely useful, but adds a `pending_mutations` queue to `beamtalk_repl_state` to handle eval-ordering. This complexity is paid regardless of class-side vs. injected-binding — it's a property of the live-view decision, not the entry-point decision.
+- **Why no class-side convenience mirror.** It is tempting to add class-side sugar (`Session bindings` ≡ `Session current bindings`) so the common case is one word shorter. We reject it deliberately:
+  - **It makes `Session` a bespoke pattern.** No other class has it. The true singletons (`Transcript`, `Beamtalk`, `Workspace`) are an *injected binding that is the instance* — `Transcript show:` is a plain instance send, with no class-side `TranscriptStream show:` mirror. Factory classes like `Date` return an instance you message (`Date today year`, never `Date year`). A class-side operation mirror on `Session` would match neither pattern.
+  - **It buys little.** Only terseness (one word) and a slightly nicer no-session error (`Session bindings` could raise a structured `no_session`, vs `Session current bindings` DNUing on `nil`). Neither justifies a duplicated surface or the internal inconsistency it creates (`current` returns `nil` but `bindings` would raise, for the *same* condition).
+  - **`Session` genuinely can't be an injected singleton** (it's per-process, not per-node), so it earns *factory* access (`current`/`withId:`) — but that is the whole of its specialness. The operations belong on the value.
+- **Returning `nil` outside a REPL, not raising.** `Session current` returns `nil` to stay consistent with `Workspace currentSession`. The cost is that `Session current bindings` DNUs on `nil` outside a REPL rather than giving a domain-specific error — acceptable because `Session` is an interactive/tooling surface, and library code guards with `Workspace hasSession`.
+- **The LSP cross-session case is real, not speculative.** BT-1045 already established the protocol-level cross-session pattern; the LSP runs its own completion session and queries the user's session for bindings. Option B has no Beamtalk-native expression of this; `Session withId:` does.
+- **Live mutation cost.** Pharo-style `Smalltalk globals at:put:` write-through is genuinely useful, but adds a `pending_mutations` queue to `beamtalk_repl_state` to handle eval-ordering. This complexity is a property of the live-view decision, independent of the entry-point shape.
 - **Two layers is settled.** Option C's strongest argument (future layer flexibility) requires bet-against-settled-design. Beamtalk has committed to exactly two binding layers; package encapsulation (ADR 0070) is class-scoped, not a binding-resolution layer.
 
 ## Alternatives Considered
@@ -331,10 +347,10 @@ Option F gives us almost all of B's simplicity (no injection, no shadowing, no `
 The original sketch in BT-2092 — inject `Session` as a per-shell binding (alongside `Transcript`, `Beamtalk`, `Workspace`) so `Session bindings` resolves to an instance method on the injected value.
 
 Rejected because:
-- **Less Smalltalk than the class-side approach.** Pharo's pattern for "the current X" is class-side (`Date today`, `Time now`, `Smalltalk current`), not a top-level singleton binding. Sessions are per-PID, not singular — injecting them as if they were singletons is dishonest.
+- **Less Smalltalk than the factory approach.** Pharo's pattern for "the current X" is a class-side factory (`Date today`, `Time now`, `Smalltalk current`) returning an instance, not a top-level singleton binding. Sessions are per-PID, not singular — injecting them as if they were singletons is dishonest.
 - **Shadowing footgun.** `Session := MyThing new` in the shell silently overwrites the injected binding. The existing `bind:as:` conflict checks don't catch shell-level `:=`. Mitigating this requires a new compiler warning, which is cost we don't pay if there is no injected binding.
-- **Implementation complexity.** Requires extending `injected_ws_keys`, modifying `inject_workspace_bindings`, adding `Session` to `is_protected_name/1`, and a clear-and-reinject loop. The class-side approach skips all of this.
-- **Tooling parity is messier.** Cross-session access (LSP completion against the user's session) doesn't fit naturally — the LSP's session sees its own injected `Session`, not the user's. Class-side methods plus `Session withId:` separate "my session" from "that session" cleanly.
+- **Implementation complexity.** Requires extending `injected_ws_keys`, modifying `inject_workspace_bindings`, adding `Session` to `is_protected_name/1`, and a clear-and-reinject loop. The factory approach skips all of this.
+- **Tooling parity is messier.** Cross-session access (LSP completion against the user's session) doesn't fit naturally — the LSP's session sees its own injected `Session`, not the user's. Factory methods `Session current` / `Session withId:` separate "my session" from "that session" cleanly.
 
 ### Alternative B: Workspace extension methods (no new class)
 
@@ -364,8 +380,8 @@ Rejected because it locks in the violation of Principle 6 (messages all the way 
 
 ### Positive
 
-- **Layers become inspectable.** `Session bindings` and `Session globals` make the two-layer model visible; users no longer wonder why `Transcript` shows up in `:bindings` but is not something they assigned.
-- **Resolution becomes debuggable.** `Session resolve: #x` answers "where does this name come from?" interactively.
+- **Layers become inspectable.** `Session current bindings` and `Session current globals` make the two-layer model visible; users no longer wonder why `Transcript` shows up in `:bindings` but is not something they assigned.
+- **Resolution becomes debuggable.** `Session current resolve: #x` answers "where does this name come from?" interactively.
 - **`:bindings` and `:clear` get a Beamtalk-native replacement.** Surface parity restored: MCP `evaluate` and any other client can drive session inspection through the standard message-send surface.
 - **Multi-session aware.** The design works unchanged for CLI (one session), WebSocket, MCP, and any future multi-client surface.
 - **Foundation for future ops.** Per-session metadata (connect time, client kind, idle status), session-to-session messaging, and live-session listings (`Workspace sessions`) all become straightforward extensions.
@@ -373,19 +389,19 @@ Rejected because it locks in the violation of Principle 6 (messages all the way 
 ### Negative
 
 - **New `BindingsView` class.** A small Dictionary-protocol class is required to support live read/write views. Implementation cost is moderate (one class plus primitives for read/write/iterate). The class is simple — every method delegates to a primitive — but it is a new public surface that has to be documented and tested.
-- **Mutation during eval has ordering constraints.** Both `Session clear` and `Session bindings at:put:` mutate shell state. The eval worker holds a *state snapshot*; on completion its returned state is merged back, so a naive direct write would be overwritten. The implementation adds a `pending_mutations` queue to `beamtalk_repl_state`, modelled on the existing `pending_module_removals` mechanism (`beamtalk_repl_shell.erl` `apply_pending_removals/2` + `drain_pending_removals/1`). Primitives enqueue `{op, key, value}` tuples rather than writing directly; the queue is drained in the eval-result handler. The exact merge order and the behaviour on every eval exit path are specified in Phase 1 — they are correctness-critical and must not be left implicit.
+- **Mutation during eval has ordering constraints.** Both `Session current clear` and `Session current bindings at:put:` mutate shell state. The eval worker holds a *state snapshot*; on completion its returned state is merged back, so a naive direct write would be overwritten. The implementation adds a `pending_mutations` queue to `beamtalk_repl_state`, modelled on the existing `pending_module_removals` mechanism (`beamtalk_repl_shell.erl` `apply_pending_removals/2` + `drain_pending_removals/1`). Primitives enqueue `{op, key, value}` tuples rather than writing directly; the queue is drained in the eval-result handler. The exact merge order and the behaviour on every eval exit path are specified in Phase 1 — they are correctness-critical and must not be left implicit.
 - **Reads do not observe same-eval writes (read-your-own-writes lag).** Because mutations are *enqueued* and drained only at eval-result time, a mutation does not take effect until the *next* eval. This holds for both bare-variable reads and view reads:
-  - `Session bindings at: #x put: 99. x + 1` evaluates `x + 1` against the **original** `x`.
-  - `Session bindings at: #x put: 99. Session bindings at: #x` returns the **original** value of `x`, not `99`.
-  This matches the user expectation that an expression sees its own pre-state, and matches how `bind:as:` already behaves mid-eval (its effect is re-injected by `refresh_ws_bindings` only after the eval completes). It is nonetheless a surprise worth documenting: to thread a freshly-computed value into the same expression, use a local (`y := 99. Session bindings at: #x put: y. y`) instead of reading back through the view.
+  - `Session current bindings at: #x put: 99. x + 1` evaluates `x + 1` against the **original** `x`.
+  - `Session current bindings at: #x put: 99. Session current bindings at: #x` returns the **original** value of `x`, not `99`.
+  This matches the user expectation that an expression sees its own pre-state, and matches how `bind:as:` already behaves mid-eval (its effect is re-injected by `refresh_ws_bindings` only after the eval completes). It is nonetheless a surprise worth documenting: to thread a freshly-computed value into the same expression, use a local (`y := 99. Session current bindings at: #x put: y. y`) instead of reading back through the view.
 - **Cross-session writes are not supported.** Instance-side `aSession bindings at:put:` / `removeKey:` against a session owned by *another* connection (obtained via `Session withId:`) would mutate that shell's state while its own in-flight eval worker holds an older snapshot — the worker's writeback would silently clobber the cross-session mutation, and the `pending_mutations` queue (which lives in the *calling* eval's flow) does not help the target. Because the only concrete cross-session use case — LSP/VS Code completion — needs **reads only**, cross-session `at:put:` / `removeKey:` / `clear` raise `#beamtalk_error{kind: cross_session_mutation_unsupported}` rather than racing. Cross-session **reads** (`keys`, `at:`, `resolve:`, `id`) are fully supported. This also keeps the F-over-B justification honest: the load-bearing win over Option B is cross-session *introspection*, not mutation.
 - **Stored `Session` / view lifetime.** A `Session` value (or a `BindingsView`) can outlive the shell it refers to — e.g. the user closes their REPL tab after an LSP session captured `Session withId: …`. `withId:` performs a liveness check (`resolve_pid`-style `is_process_alive`, not a raw `lookup`) and returns `nil` for a session that is gone. A `Session` value captured earlier whose shell *subsequently* dies raises `#beamtalk_error{kind: session_not_found}` on the next message send rather than blocking on a `gen_server:call` to a dead PID until timeout. Views are transient handles (like `FileHandle`); they are not durable references.
-- **Outside-REPL behaviour.** `Session current` returns `nil`; class-side methods like `Session bindings` raise a structured `no_session` error. Library code that wants graceful degradation must check `Workspace hasSession` first.
-- **`Session clear` is asymmetric with the view.** `Session bindings removeKey: #x` removes one binding; `Session clear` removes all. There is no `Session bindings clear` because the view's protocol is generic Dictionary semantics — `Session bindings` returns a *view*, not a Dictionary the user owns, so a `clear` on the view would be ambiguous (clear-the-view or clear-the-state). Keeping `Session clear` as a top-level method avoids this ambiguity.
+- **Outside-REPL behaviour.** `Session current` returns `nil`, so `Session current bindings` DNUs on `nil` outside a REPL eval. There is no class-side `no_session` error because there are no class-side operation methods — `current` returning `nil` (consistent with `Workspace currentSession`) is the single source of "no session here". Library code that wants graceful degradation checks `Workspace hasSession` first.
+- **`clear` is asymmetric with the view.** `aSession bindings removeKey: #x` removes one binding; `aSession clear` removes all. There is no `bindings clear` on the view because its protocol is generic Dictionary semantics — `bindings` returns a *view*, not a Dictionary the user owns, so a `clear` on the view would be ambiguous (clear-the-view or clear-the-state). Keeping `clear` as a method on the session avoids this ambiguity.
 
 ### Neutral
 
-- **`bind:as:` semantics unchanged.** Continues to write to the workspace ETS layer. `Session bindings` will not include `bind:as:` entries (those appear in `Session globals`). This is a clarification, not a behaviour change.
+- **`bind:as:` semantics unchanged.** Continues to write to the workspace ETS layer. `Session current bindings` will not include `bind:as:` entries (those appear in `Session current globals`). This is a clarification, not a behaviour change.
 - **Session persistence across sync unchanged.** Existing behaviour preserved: session locals survive `Workspace sync`.
 - **Protocol `bindings` / `clear` ops are removed** in Phase 5, alongside the rest of the work. The Session API ships first (Phases 1–4), so when the meta-commands disappear the replacement is already in place. There is no deprecation window — single coordinated release.
 
@@ -395,7 +411,7 @@ The implementation breaks down into a Phase 0 wire-check plus five shippable pha
 
 ### Phase 0: Wire-check / napkin (XS)
 
-Before building any of the surface, prove the single load-bearing assumption end-to-end: *a primitive running inside an eval worker can recover the calling session*. Seed the worker's process dictionary with `beamtalk_session_pid` / `beamtalk_session_id` at spawn, add a throwaway `beamtalk_session_primitives:id/0` that reads it back, and confirm `(Erlang beamtalk_session_primitives) id` returns the right id from a live eval — and `nil`/`no_session` from a non-eval context. One EUnit test plus one manual REPL round-trip. If this does not work cleanly (e.g. process-dictionary seeding interacts badly with the worker spawn or the streaming path), the rest of the design is re-examined before investing in `BindingsView` and `pending_mutations`.
+Before building any of the surface, prove the single load-bearing assumption end-to-end: *a primitive running inside an eval worker can recover the calling session*. Seed the worker's process dictionary with `beamtalk_session_pid` / `beamtalk_session_id` at spawn, add a throwaway `beamtalk_session_primitives:current/0` that reads it back, and confirm `(Erlang beamtalk_session_primitives) current` returns the right session from a live eval — and `nil` from a non-eval context. One EUnit test plus one manual REPL round-trip. If this does not work cleanly (e.g. process-dictionary seeding interacts badly with the worker spawn or the streaming path), the rest of the design is re-examined before investing in `BindingsView` and `pending_mutations`.
 
 ### Phase 1: Process-context plumbing + pending-mutation merge (M)
 
@@ -403,7 +419,7 @@ Before building any of the surface, prove the single load-bearing assumption end
 - `handle_call({eval, _}, ...)` and `handle_call({eval_trace, _}, ...)` — the synchronous REPL path.
 - `handle_cast({eval_async, _, Subscriber}, ...)` — the streaming path (`do_eval/3`).
 
-A primitive that finds `get(beamtalk_session_pid) =:= undefined` reports `no_session` (class-side) or `nil` (`current`/`hasSession`); seeding only one path would make `Session` behave inconsistently between normal and streaming eval.
+A primitive that finds `get(beamtalk_session_pid) =:= undefined` returns `nil` (`current` / `Workspace currentSession` / `hasSession`); seeding only one path would make `Session` behave inconsistently between normal and streaming eval.
 
 **Add the `pending_mutations` queue.** Add `pending_mutations` to `beamtalk_repl_state` — a list of `{op, key, value}` tuples (`op ∈ {put, remove, clear}`) — with accessors mirroring the existing `pending_module_removals` field. Primitives **enqueue** rather than write directly. The queue is owned by the shell's `ShellState` (not the worker snapshot): primitives enqueue via a `gen_server:call` to the shell, which is safe from the worker because the shell is in `noreply` while the worker runs and is free to service its mailbox. Visibility is guaranteed by ordering: the worker's enqueue `gen_server:call` is synchronous and completes *before* the worker sends `{eval_result, …}`, so the shell processes every enqueue (updating its loop state) strictly before it processes the result message — the `ShellState` bound in the `eval_result` handler always reflects the enqueued mutations.
 
@@ -414,7 +430,7 @@ A primitive that finds `get(beamtalk_session_pid) =:= undefined` reports `no_ses
 | Eval exit path | Handler | Action |
 |----------------|---------|--------|
 | Success | `handle_info({eval_result, _, {ok, ...}}, ...)` | `M1 = apply_pending_removals(ShellState, WorkerState)`; `M2 = apply_pending_mutations(ShellState, M1)`; `refresh_ws_bindings(M2)`. Mutations apply **on top of** the worker's returned bindings (so the worker's own `x := …` is visible) but **after** removals, and before ws-refresh re-injects globals. |
-| Error | `handle_info({eval_result, _, {error, ...}}, ...)` | `apply_pending_removals` + `apply_pending_mutations` for `put`/`remove` ops only, **no** `refresh_ws_bindings` (unchanged from today). `put`/`remove` are explicit per-key edits the user issued, independent of the failed expression, so they take effect. A queued **`clear`** (whole-session destruction) is **dropped** on the error path: `Session clear. someTypo` should not wipe every local because the line after `clear` failed. `clear` applies only on the success path. |
+| Error | `handle_info({eval_result, _, {error, ...}}, ...)` | `apply_pending_removals` + `apply_pending_mutations` for `put`/`remove` ops only, **no** `refresh_ws_bindings` (unchanged from today). `put`/`remove` are explicit per-key edits the user issued, independent of the failed expression, so they take effect. A queued **`clear`** (whole-session destruction) is **dropped** on the error path: `Session current clear. someTypo` should not wipe every local because the line after `clear` failed. `clear` applies only on the success path. |
 | Interrupt | `handle_call(interrupt, ...)` | Drain `pending_mutations` alongside the existing `drain_pending_removals/1` so an interrupted eval's issued mutations are not lost. |
 | Worker crash | `handle_info({'DOWN', ...}, ...)` | **Discard** `pending_mutations` — a crashed worker's partial mutations are not trustworthy; drain removals as today but drop the mutation queue. |
 
@@ -424,34 +440,36 @@ EUnit tests: worker-spawn seeding on **both** paths; `apply_pending_mutations` f
 
 ### Phase 2: Runtime primitives module (M)
 
-Create `beamtalk_session_primitives.erl` in `runtime/apps/beamtalk_workspace/src/`. Each primitive resolves the session via `get(beamtalk_session_pid)` (or the explicit Session instance for the `*For:` variants):
+Create `beamtalk_session_primitives.erl` in `runtime/apps/beamtalk_workspace/src/`. Two **factory** primitives mint Session values; the rest take a Session value (`self`) and act on the session it names:
 
-- `current/0` — returns a Session value with the calling session's PID and ID, or `nil`.
+Factory (class-side):
+- `current/0` — returns a Session value carrying the calling session's PID and ID (read from the process dictionary), or `nil` outside an eval context.
 - `withId/1` — looks up a session by protocol ID and **checks liveness** (`is_process_alive`, the `resolve_pid` discipline — not a raw `beamtalk_session_table:lookup/1`, which can return a dead PID). Returns a Session value or `nil`.
-- `bindingsView/0` — returns a `BindingsView` tagged for session-local scope, bound to the calling session.
-- `globalsView/0` — returns a `BindingsView` tagged for workspace scope (shared across sessions). Note `globals` carries no per-session identity; the instance-side `globals` returns the same shared view for any receiver.
-- `bindingsViewFor/1` — instance variant; the view records the **target** session id so cross-session reads resolve against it and cross-session writes can be rejected.
-- `resolve/1`, `resolve/2` — walk session locals first, then workspace globals; return value or nil.
-- `clear/0`, `clearFor/1` — enqueue a clear mutation via the shell's pending-mutations API (Phase 1). `clearFor/1` against a non-self session raises `cross_session_mutation_unsupported`.
-- `id/0`, `idOf/1` — read `beamtalk_session_id` (process dictionary) / extract it from a Session value.
+
+Operations (instance-side, all take a Session value):
+- `bindingsViewFor/1` — returns a `BindingsView` tagged for session-local scope, recording the **target** session id (from the value) so reads resolve against the right shell and cross-session writes can be rejected.
+- `globalsView/0` — returns a `BindingsView` tagged for workspace scope. Workspace globals are shared across sessions, so this carries no per-session identity; instance `globals` returns the same shared view regardless of receiver.
+- `resolveFor/2` — walk the target session's locals first, then workspace globals; return value or nil.
+- `clearFor/1` — enqueue a clear mutation via the shell's pending-mutations API (Phase 1). Against a non-self session, raises `cross_session_mutation_unsupported`.
+- `idOf/1` — extract the protocol id from a Session value.
 
 **Session-locals vs. merged map — and why it must be computed shell-side.** Because workspace globals are *injected* into each shell's single bindings map at init (`inject_workspace_bindings/1`, BT-883) and refreshed after each eval, "session locals" is not a separate map — it is the bindings map **minus** the injected keys. The filter is `maps:without(get_injected_ws_keys(State), get_bindings(State))`.
 
-The two operands (`bindings` and `injected_ws_keys`) live *together* in a shell's `beamtalk_repl_state`, so the subtraction can only be done where both are in hand — **on the owning shell**. The existing `get_bindings` gen_server call returns only the merged map (`beamtalk_repl_shell.erl:235`), with no companion call for the injected-key set; computing locals on the *reader* side is therefore impossible for a cross-session target. Phase 1 must add a `get_session_locals` gen_server call to `beamtalk_repl_shell` that performs the subtraction and returns session-locals directly. Both `bindingsView/0` (calls its own shell) and `bindingsViewFor/1` (calls the target shell) route through it, so local and cross-session reads share one code path and one definition of "locals".
+The two operands (`bindings` and `injected_ws_keys`) live *together* in a shell's `beamtalk_repl_state`, so the subtraction can only be done where both are in hand — **on the owning shell**. The existing `get_bindings` gen_server call returns only the merged map (`beamtalk_repl_shell.erl:235`), with no companion call for the injected-key set; computing locals on the *reader* side is therefore impossible for a cross-session target. Phase 1 must add a `get_session_locals` gen_server call to `beamtalk_repl_shell` that performs the subtraction and returns session-locals directly. `bindingsViewFor/1` routes through it for both the calling session and a cross-session target (the value carries the target's PID), so local and cross-session reads share one code path and one definition of "locals".
 
-Use `get_injected_ws_keys/1` (the per-session dynamic set, which *includes* `bind:as:` names) — **not** `beamtalk_workspace_config:binding_names/0`, which lists only the static singletons and excludes `bind:as:` names. The two are not interchangeable. This is a deliberate behaviour change from today's `:bindings` op (which filters with `binding_names/0` and therefore *shows* `bind:as:` names): under this ADR `bind:as:` names move out of `Session bindings` and into `Session globals`, which is the correct home for them (see Migration Path). This is the load-bearing step that keeps `Session bindings` (locals) and `Session globals` (injected ws-keys + ETS) disjoint.
+Use `get_injected_ws_keys/1` (the per-session dynamic set, which *includes* `bind:as:` names) — **not** `beamtalk_workspace_config:binding_names/0`, which lists only the static singletons and excludes `bind:as:` names. The two are not interchangeable. This is a deliberate behaviour change from today's `:bindings` op (which filters with `binding_names/0` and therefore *shows* `bind:as:` names): under this ADR `bind:as:` names move out of `Session current bindings` and into `Session current globals`, which is the correct home for them (see Migration Path). This is the load-bearing step that keeps session-local bindings (locals) and globals (injected ws-keys + ETS) disjoint.
 
 **Liveness on every cross-session send.** A `Session` value captured earlier may outlive its shell. The `*For:` / `idOf:` primitives check `is_process_alive` on the carried PID and raise `#beamtalk_error{kind: session_not_found}` rather than issuing a `gen_server:call` that blocks to timeout against a dead PID.
 
 Plus the BindingsView read/write primitives: `view_at/2`, `view_at_put/3`, `view_remove/2`, `view_keys/1`, `view_size/1`. Session-scope writes for the **calling** session enqueue against its pending-mutations queue; session-scope writes targeting **another** session (a cross-session `BindingsView`) raise `cross_session_mutation_unsupported`. Workspace-scope writes route through `beamtalk_workspace_interface_primitives:bind/2` and `unbind/1`, inheriting protected-name conflict checks.
 
-**Two write models, by design.** Session-scope writes are *deferred* (queued, applied at eval-end — the read-your-own-writes lag in Consequences). Workspace-scope writes are *synchronous*: `bind/2` / `unbind/1` hit the shared ETS table immediately, exactly as `Workspace bind:as:` does today. The asymmetry is intrinsic — session state is per-shell and snapshot-isolated during eval, workspace state is shared ETS. One consequence: a mid-eval `Session globals at:put:` is written to ETS at once but is not re-injected into the shell's bindings map until `refresh_ws_bindings` runs, which (as today for `bind:as:`) happens only on the **success** path; on the error path the injected copy stays stale until the next successful eval. This matches existing `bind:as:` behaviour and is not a regression.
+**Two write models, by design.** Session-scope writes are *deferred* (queued, applied at eval-end — the read-your-own-writes lag in Consequences). Workspace-scope writes are *synchronous*: `bind/2` / `unbind/1` hit the shared ETS table immediately, exactly as `Workspace bind:as:` does today. The asymmetry is intrinsic — session state is per-shell and snapshot-isolated during eval, workspace state is shared ETS. One consequence: a mid-eval `Session current globals at:put:` is written to ETS at once but is not re-injected into the shell's bindings map until `refresh_ws_bindings` runs, which (as today for `bind:as:`) happens only on the **success** path; on the error path the injected copy stays stale until the next successful eval. This matches existing `bind:as:` behaviour and is not a regression.
 
 EUnit tests for each primitive, including: cross-session **read** via `withId/1`, cross-session **write** rejection, the session-locals filter, and a dead-session `session_not_found` case.
 
 ### Phase 3: Stdlib `Session` and `BindingsView` classes (M)
 
-Add `stdlib/src/Session.bt` with the class-side and instance-side methods defined in the API. Add `stdlib/src/BindingsView.bt` implementing the Dictionary protocol (`at:`, `at:put:`, `removeKey:`, `includesKey:`, `keys`, `values`, `size`, `do:`, `printOn:`).
+Add `stdlib/src/Session.bt` with the two factory class-methods (`current`, `withId:`) and the instance-side operation methods defined in the API — no class-side operation mirror. Add `stdlib/src/BindingsView.bt` implementing the Dictionary protocol (`at:`, `at:put:`, `removeKey:`, `includesKey:`, `keys`, `values`, `size`, `do:`, `printOn:`).
 
 No binding injection: `Session` is reachable as a class name through the class registry, no special-case handling. No protected-name additions, no `injected_ws_keys` changes.
 
@@ -461,9 +479,9 @@ Add `currentSession` and `hasSession` to `WorkspaceInterface` (Beamtalk class), 
 
 ### Phase 5: Remove `:bindings` and `:clear` meta-commands (M)
 
-Delete the `<<"bindings">>` and `<<"clear">>` op handlers in `beamtalk_repl_ops_eval.erl` and remove their entries from `beamtalk_repl_ops_dev.erl`'s op map. Update `surface-parity.md` rows for `bindings` and `clear` to cite `via Session bindings` / `via Session clear`.
+Delete the `<<"bindings">>` and `<<"clear">>` op handlers in `beamtalk_repl_ops_eval.erl` and remove their entries from `beamtalk_repl_ops_dev.erl`'s op map. Update `surface-parity.md` rows for `bindings` and `clear` to cite `via Session current bindings` / `via Session current clear`.
 
-**Bindings-changed push is preserved; only the fetch moves.** The `{bindings_changed, SessionId}` pub/sub (`beamtalk_bindings_events`, fired by the shell after each successful eval) is *not* removed — the VS Code sidebar still relies on it to know *when* to refresh. What changes is *how* the client fetches after the notification: it moves from the removed `bindings` op to `evaluate "Session bindings keys"` (and `Session globals keys`) carrying the user's `session` id, or to `Session withId:` + instance reads. This is a client-side change in the VS Code extension and must land with this phase, not after it — otherwise the sidebar refreshes against a dead op.
+**Bindings-changed push is preserved; only the fetch moves.** The `{bindings_changed, SessionId}` pub/sub (`beamtalk_bindings_events`, fired by the shell after each successful eval) is *not* removed — the VS Code sidebar still relies on it to know *when* to refresh. What changes is *how* the client fetches after the notification: it moves from the removed `bindings` op to `evaluate "Session current bindings keys"` (and `Session current globals keys`) carrying the user's `session` id, or to `Session withId:` + instance reads. This is a client-side change in the VS Code extension and must land with this phase, not after it — otherwise the sidebar refreshes against a dead op.
 
 **Test migration is non-trivial.** Migrating `:bindings` / `:clear` from meta-commands to evaluated expressions changes the protocol op (`bindings`/`clear` → `eval`) and therefore the response shape (a bindings map → an eval result value). Existing `tests/repl-protocol/cases/*.btscript` cases that assert on the old op responses need real rewrites, not find-replace — audit and enumerate them before locking the estimate. Add a new e2e btscript case covering the full Session API including cross-session read access (`Session withId:`) and cross-session write rejection.
 
@@ -473,11 +491,11 @@ The `:bindings` and `:clear` meta-commands are removed in Phase 5; the replaceme
 
 | Before | After |
 |--------|-------|
-| `:bindings` | `Session bindings keys` (session locals only) <br> `Session globals keys` (workspace globals) <br> ⚠️ **behaviour change:** `:bindings` today (via `binding_names/0`) *shows* `bind:as:` names mixed in; under this ADR they move to `Session globals` and no longer appear in `Session bindings`. |
-| `:clear` | `Session clear` |
-| (no equivalent) | `Session bindings at: #x put: 99` (live mutation) |
-| (no equivalent) | `Session bindings removeKey: #x` |
-| (no equivalent) | `Session resolve: #name` (REPL debugging tool) |
+| `:bindings` | `Session current bindings keys` (session locals only) <br> `Session current globals keys` (workspace globals) <br> ⚠️ **behaviour change:** `:bindings` today (via `binding_names/0`) *shows* `bind:as:` names mixed in; under this ADR they move to `Session current globals` and no longer appear in `Session current bindings`. |
+| `:clear` | `Session current clear` |
+| (no equivalent) | `Session current bindings at: #x put: 99` (live mutation) |
+| (no equivalent) | `Session current bindings removeKey: #x` |
+| (no equivalent) | `Session current resolve: #name` (REPL debugging tool) |
 | (no equivalent) | `Workspace currentSession` / `Session current` |
 | (no equivalent) | `Session withId: aSessionId` (LSP cross-session) |
 

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -558,6 +558,20 @@ The `:bindings` and `:clear` meta-commands (and the `get_bindings` MCP tool) are
 
 The meta-commands existed only on the REPL surface. Removing them is a small loss for muscle-memory CLI users (one `migrate_to` shell-side error message in the release notes is sufficient) and a strict gain for MCP and WebSocket clients, which now have a Beamtalk-native path to per-session state with both reads and write-through mutations.
 
+## Implementation Tracking
+
+**Epic:** [BT-2364](https://linear.app/beamtalk/issue/BT-2364) — First-Class Session Object (ADR 0081)
+**Status:** Planned
+
+| # | Issue | Scope | Blocked by |
+|---|-------|-------|------------|
+| 1 | BT-2365 | Binding-model foundation: locals-only storage + lazy global resolution | — |
+| 2 | BT-2366 | Session runtime primitives + pending-mutation plumbing | BT-2365 |
+| 3 | BT-2367 | Stdlib `Session` + `BindingsView`; upgrade `Workspace globals` | BT-2366 |
+| 4 | BT-2368 | `WorkspaceInterface`: `currentSession` + `sessions` | BT-2366 |
+| 5 | BT-2369 | Remove `:bindings` / `:clear` + `get_bindings` MCP tool | BT-2367, BT-2368 |
+| 6 | BT-2370 | E2E btscript + docs | BT-2369 |
+
 ## References
 
 - [BT-2092](https://linear.app/beamtalk/issue/BT-2092/first-class-session-object-walkable-binding-layers-smalltalk-style) — driving issue

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -38,26 +38,25 @@ The CLI REPL has one session. WebSocket and MCP clients can have many — `beamt
 - **Hot reload safety.** Session locals must persist across `Workspace sync` and class reloads (current behaviour).
 - **Existing infrastructure.** `beamtalk_session_table`, `beamtalk_session_sup`, and the `sessions` protocol op already exist — the design should build on them rather than replace.
 - **Surface parity.** `:bindings` / `:clear` work in the REPL surface only; the object-level replacement must be reachable from MCP `evaluate`, LSP eval, and any future client.
+- **Call safety.** Session primitives call back to the shell gen_server via `gen_server:call`. This is safe from eval worker processes (the shell is in `noreply` state, processing its mailbox). It is NOT safe from `handle_call`/`handle_cast` handlers running directly on the shell process (would deadlock). Session methods must only be called from eval context, never from shell-internal dispatch.
 
 ## Decision
 
 Introduce a new `Session` class — a lightweight `Object subclass` that wraps a session shell PID — and make it accessible via two paths:
 
 1. **Per-session binding `Session`**, injected into the shell's binding map at startup (alongside `Transcript`, `Beamtalk`, `Workspace`). Each shell sees a `Session` binding pointing to *its own* session object.
-2. **`Workspace currentSession`**, a method on the existing `WorkspaceInterface` singleton that resolves the current eval's session via process context. Returns `nil` outside a REPL eval context.
+2. **`Workspace currentSession`**, a method on the existing `WorkspaceInterface` singleton that resolves the current eval's session via process context. Returns `nil` outside a REPL eval context. A companion **`Workspace hasSession`** predicate returns `true` or `false`, allowing library code to guard session-dependent logic without nil-checking.
 
-`Session` is **not** an Actor (gen_server). It is a value-shaped handle holding the shell PID, with primitive methods that delegate to the shell process via `gen_server:call`. This mirrors the `Supervisor` pattern (a Beamtalk object wrapping an OTP supervisor PID).
+`Session` is **not** an Actor (gen_server). It is a handle object whose methods delegate to the shell process via `gen_server:call`. Similar to how `Ets` wraps a table reference without exposing it as a Beamtalk field, Session's internal shell PID is managed by the primitives module, not stored in a user-visible `field:`.
 
 ### API
 
 ```beamtalk
 sealed typed Object subclass: Session
-  field: pid :: Pid
-  field: id :: String
 
   /// Session-local bindings only (the `x := 42` layer).
   bindings -> Dictionary(Symbol, Object) =>
-    (Erlang beamtalk_session_primitives) bindings: self.pid
+    (Erlang beamtalk_session_primitives) bindings
 
   /// Workspace globals visible to this session (singletons + bind:as:).
   globals -> Dictionary(Symbol, Object) =>
@@ -66,18 +65,22 @@ sealed typed Object subclass: Session
   /// Walk binding layers, return first match or nil.
   /// Lookup order: session locals → workspace globals.
   resolve: aName :: Symbol -> Object =>
-    (Erlang beamtalk_session_primitives) resolve: aName for: self.pid
+    (Erlang beamtalk_session_primitives) resolve: aName
 
   /// Clear session-local bindings. Workspace globals remain.
   clear -> Nil =>
-    (Erlang beamtalk_session_primitives) clear: self.pid
+    (Erlang beamtalk_session_primitives) clear
 
   /// Layer name symbols, in resolution order.
-  layers -> List(Symbol) => #(#session #workspace)
+  layers -> List(Symbol) => #(#session, #workspace)
 
   /// Stable session identifier (matches the protocol session ID).
-  id -> String => self.id
+  id -> String => (Erlang beamtalk_session_primitives) id
 ```
+
+The shell PID is not stored in Beamtalk-level fields. Primitives resolve the calling session from process context (process dictionary seeded during eval worker spawn), matching the pattern used by `Ets` and other runtime-backed objects.
+
+**`Session` itself is a system-injected binding.** It does not appear in `Session bindings` (that shows user-typed locals only) and does not appear in `Session globals` (that shows workspace-level globals from ETS). It is part of the `injected_ws_keys` set — visible during normal name resolution, but excluded from the per-layer introspection views. `Session resolve: #Session` returns the Session object (it walks the merged binding map). This is consistent with how `Transcript`, `Beamtalk`, and `Workspace` are treated by the existing `:bindings` meta-command, which already strips system bindings from its output.
 
 ### REPL Examples
 
@@ -87,15 +90,15 @@ beamtalk> x := 42
 beamtalk> Session bindings
 #{#x => 42}
 beamtalk> Session globals keys
-#(#Transcript #Beamtalk #Workspace #Session)
+#(#Transcript, #Beamtalk, #Workspace)
 beamtalk> Session resolve: #x
 42
 beamtalk> Session resolve: #Transcript
-#TranscriptStream<default>
+#<TranscriptStream>
 beamtalk> Session resolve: #notDefined
 nil
 beamtalk> Session layers
-#(#session #workspace)
+#(#session, #workspace)
 beamtalk> Workspace currentSession id
 "abc123-..."
 beamtalk> Session clear
@@ -103,7 +106,7 @@ nil
 beamtalk> Session bindings
 #{}
 beamtalk> Session globals keys
-#(#Transcript #Beamtalk #Workspace #Session)
+#(#Transcript, #Beamtalk, #Workspace)
 ```
 
 ### Error Examples
@@ -144,6 +147,8 @@ Session bindings
 | **Newspeak** | Lexical nesting only; no global namespace; capability passing via constructor parameter. | The principle that scope is explicit, not magic. | Beamtalk has Smalltalk-style globals (`Transcript`, classes); a fully-lexical model would invalidate the existing namespace design. |
 | **Self** | Parent slot chain; scope walks via `parent*` slots. | Layer ordering as a first-class concept (`layers` returns the resolution order). | Recursive `parent` chains overstate the complexity for two layers. |
 | **IPython `get_ipython()`** | Shell singleton with `user_ns` dict, `who_ls()`, `reset()`. | The "current session is reachable through a global accessor" pattern (`Workspace currentSession`). | A single mutable dict obscures layer ownership; we keep layers separate. |
+| **Ruby `Binding`** | First-class scope object. `binding` returns the current scope; `Binding#local_variables` lists names. Can be passed for scoped expression execution. Closest prior art to the `Session` design. | A scope object that can be inspected and passed around. | Ruby's Binding captures lexical scope (closures); Beamtalk's Session wraps a session process, not a lexical frame. |
+| **Erlang shell `b()` / `f()`** | `b()` lists shell bindings; `f()` clears all; `f(X)` clears one. Shell-only built-in commands, not callable from program code. | Demonstrates the universal need to inspect REPL state. | Shell commands, not values — cannot be composed, stored, or called from non-shell code. Exactly the problem this ADR solves. |
 | **Elixir `binding()`** | Macro returning current bindings as a keyword list. | Treating bindings as inspectable data. | A macro/keyword-list shape is non-Smalltalk; we use Dictionary returns and explicit objects. |
 
 ## User Impact
@@ -237,8 +242,8 @@ Rejected because it locks in the violation of Principle 6 (messages all the way 
 
 ### Negative
 
-- **One more top-level binding name.** `Session` joins `Transcript`, `Beamtalk`, `Workspace` as an injected per-session global. Users could shadow it with a local; the runtime should warn when that happens (covered by existing `bind:as:` conflict checks).
-- **`Session clear` during eval has subtle semantics.** The eval worker has a state snapshot; mutations propagate via the worker's returned state. The implementation must ensure `Session clear` clears in a way that survives the worker's state writeback, either by routing through the worker's state thread or by post-eval reconciliation. This is an implementation detail, not a design flaw, but it requires care.
+- **One more top-level binding name.** `Session` joins `Transcript`, `Beamtalk`, `Workspace` as an injected per-session global. Users could shadow it via `Session := MyThing new` in the shell — the existing `bind:as:` conflict checks only protect workspace-level assignments, not shell-level `:=`. The implementation should add a guard in `beamtalk_repl_eval` that emits a compiler warning (not an error) when a user assignment shadows an injected system binding, consistent with the project's footgun-warning philosophy (emit a compiler warning whenever we detect a footgun, rather than leaving it as a known limitation).
+- **`Session clear` during eval has ordering constraints.** The eval worker has a state snapshot; when it completes, the shell merges the worker's state back. A naive `gen_server:call(ShellPid, clear_bindings)` during eval would be overwritten by the worker's stale snapshot. The implementation must add a `clear_requested` flag to `beamtalk_repl_state`: `clear` sets the flag via the shell; eval-result processing checks the flag and applies the clear after merging the worker's state. This ensures `Session clear` followed by more expressions in the same eval works correctly (the clear takes effect for the *next* eval, not mid-expression).
 - **Outside-REPL `nil`.** `Workspace currentSession` returns `nil` in compiled program code, which means `Workspace currentSession bindings` raises `does_not_understand` (correct DNU semantics, but a footgun if users assume the API is always available). Documentation must call this out.
 
 ### Neutral
@@ -251,30 +256,37 @@ Rejected because it locks in the violation of Principle 6 (messages all the way 
 
 The implementation breaks down into four phases. Each is independently shippable.
 
-### Phase 1: Runtime primitives module
+### Phase 1: Runtime primitives module (S)
 
-Create `beamtalk_session_primitives.erl` with the four primitive operations:
-- `bindings/1` — gen_server:call to the shell, returning session-locals only (with workspace-injected keys removed via `injected_ws_keys` tracking already present in `beamtalk_repl_state`).
+Create `beamtalk_session_primitives.erl` in `runtime/apps/beamtalk_workspace/src/` with the four primitive operations. Each primitive reads the calling process's session PID from process dictionary (seeded during eval worker spawn in Phase 2):
+
+- `bindings/0` — reads the process dictionary session PID, calls `beamtalk_repl_shell:get_bindings/1`, then strips workspace-injected keys using the `injected_ws_keys` tracking already present in `beamtalk_repl_state`. Returns session-locals only.
 - `globals/0` — calls `beamtalk_workspace_interface_primitives:get_session_bindings/0`, the existing workspace-globals accessor.
-- `resolve/2` — combines the two; session locals first, workspace globals second.
-- `clear/1` — gen_server:call to the shell's existing `clear_bindings` handler.
+- `resolve/1` — combines the two; session locals first, workspace globals second. Returns `nil` if name not found.
+- `clear/0` — calls `beamtalk_repl_shell:clear_bindings/1` on the session PID. Note: during eval, this clears the shell's state via gen_server:call. The eval worker's snapshot is stale after clear, but clear is typically the final expression in an eval. If the cleared state is overwritten by the worker's return, the shell must reconcile by checking a `clear_requested` flag (set by the clear handler) during eval-result processing.
+- `id/0` — reads the session ID from process dictionary.
 
-EUnit tests for each. Existing infrastructure (`beamtalk_repl_shell`, `beamtalk_session_table`) is reused.
+EUnit tests for each primitive. Existing infrastructure (`beamtalk_repl_shell`, `beamtalk_session_table`) is reused.
 
-### Phase 2: Stdlib `Session` class and binding injection
+### Phase 2: Stdlib `Session` class and binding injection (M)
 
-Add `stdlib/src/Session.bt` with the API defined above. Extend `beamtalk_workspace_config:singletons/0` and shell init (`beamtalk_repl_shell:init/1`) to inject a `Session` binding pointing to a Session object constructed with the shell's PID and session ID. Update `beamtalk_workspace_interface_primitives:handle_session_bindings/1` to include `Session` in the workspace-injected keys (so it propagates correctly through `clear` and refresh paths).
+Add `stdlib/src/Session.bt` with the API defined above. Session is NOT a workspace singleton (it varies per shell), so it cannot be added to `beamtalk_workspace_config:singletons/0`.
 
-### Phase 3: `Workspace currentSession` and process-context resolution
+Injection path: modify `beamtalk_repl_shell:init/1` to construct a Session object (via `beamtalk_object:create/2`) with the shell's PID and session ID, and inject it as a binding alongside workspace globals. Add `'Session'` to the `injected_ws_keys` set so that `clear` preserves it and `Session bindings` excludes it from user-locals.
+
+Seed process dictionary: modify the eval worker spawn (`handle_call({eval, ...})`) to set `beamtalk_session_pid` and `beamtalk_session_id` in the worker's process dictionary before calling `do_eval`. This allows Phase 1 primitives to resolve the session context.
+
+Add `'Session'` to `is_protected_name/1` in `beamtalk_workspace_interface_primitives.erl` so `bind:as:` cannot shadow it.
+
+### Phase 3: `Workspace currentSession` and process-context resolution (S)
 
 Add `currentSession` to `WorkspaceInterface` (Beamtalk class) with an Erlang primitive that:
-1. Reads the calling process's session PID from process dictionary, or
-2. Walks up to find the shell PID via `$ancestors` if direct lookup fails, or
-3. Returns `nil` if no session is in scope.
+1. Reads `beamtalk_session_pid` from the calling process's dictionary, or
+2. Returns `nil` if no session marker is set (compiled program code, non-REPL contexts).
 
-Eval worker spawn must seed the worker's process dictionary with the shell PID for the lookup to work.
+This uses the same process dictionary key seeded in Phase 2 — no additional plumbing needed.
 
-### Phase 4: Migration and meta-command deprecation
+### Phase 4: Migration and meta-command deprecation (M)
 
 Re-deprecate `:bindings` and `:clear` in `beamtalk_repl_ops_dev.erl` with `migrate_to` hints pointing at `Session bindings` and `Session clear`. Update `surface-parity.md` rows for `bindings` and `clear` to cite `via Session bindings` / `via Session clear`. Add an e2e btscript test under `tests/repl-protocol/cases/` covering the full Session API. Hard removal of the meta-commands is a separate follow-up issue once the new API has been validated in real use.
 

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -1,0 +1,305 @@
+# ADR 0081: First-Class Session Object — Walkable Binding Layers
+
+## Status
+Proposed (2026-05-09)
+
+## Context
+
+### Problem
+
+The Beamtalk REPL has two binding layers, merged into a single map at eval time:
+
+| Layer | Owner | Source |
+|-------|-------|--------|
+| **Workspace globals** | `beamtalk_workspace_interface_primitives` (ETS, shared) | Singletons (`Transcript`, `Beamtalk`, `Workspace`) + `bind:as:` entries |
+| **Session locals** | `beamtalk_repl_shell` gen_server (per session, owned by session PID) | `x := 42` typed in the shell |
+
+The session-locals layer has **no object-level accessor**. The only way to view or clear it is through two REPL meta-commands:
+
+| Meta-command | Purpose |
+|--------------|---------|
+| `:bindings` / `:b` | List all bindings (session locals + workspace globals merged) |
+| `:clear` | Clear session locals |
+
+The surface-only audit ([BT-2083](https://linear.app/beamtalk/issue/BT-2083)) un-deprecated `:bindings` and `:clear` because no object-side equivalent exists. ADR 0040 successfully moved most meta-commands onto `Workspace` and `Beamtalk` — but the session layer was left behind because *the session itself is not a first-class object*.
+
+This violates the architectural pattern established by ADR 0040 (workspace-native REPL commands) and Principle 6 (everything is a message send). Users can introspect classes, actors, the workspace, even singletons — but cannot programmatically inspect or manipulate the binding layers that resolve their own variable names.
+
+### Current State
+
+Each REPL connection gets a `beamtalk_repl_shell` gen_server, supervised under `beamtalk_session_sup` and tracked in the `beamtalk_sessions` ETS table (`beamtalk_session_table`). The shell holds session-local bindings in `beamtalk_repl_state`, refreshed with workspace globals before each eval (`refresh_ws_bindings/1` in `beamtalk_repl_shell.erl:441`). Eval workers spawn from the shell with a snapshot of state, returning updated state when they complete.
+
+The CLI REPL has one session. WebSocket and MCP clients can have many — `beamtalk_session_sup` already supports multi-session, and `beamtalk_repl_ops_session.erl` exposes a `sessions` protocol op listing live shells. But no Beamtalk class represents an individual session.
+
+### Constraints
+
+- **Per-process state.** Session locals are owned by the shell PID; any object representation must respect that ownership boundary.
+- **Eval ordering.** Eval workers run in spawned worker processes with a state snapshot. Mutations to session bindings during an eval interact with the shell's state-update flow.
+- **Hot reload safety.** Session locals must persist across `Workspace sync` and class reloads (current behaviour).
+- **Existing infrastructure.** `beamtalk_session_table`, `beamtalk_session_sup`, and the `sessions` protocol op already exist — the design should build on them rather than replace.
+- **Surface parity.** `:bindings` / `:clear` work in the REPL surface only; the object-level replacement must be reachable from MCP `evaluate`, LSP eval, and any future client.
+
+## Decision
+
+Introduce a new `Session` class — a lightweight `Object subclass` that wraps a session shell PID — and make it accessible via two paths:
+
+1. **Per-session binding `Session`**, injected into the shell's binding map at startup (alongside `Transcript`, `Beamtalk`, `Workspace`). Each shell sees a `Session` binding pointing to *its own* session object.
+2. **`Workspace currentSession`**, a method on the existing `WorkspaceInterface` singleton that resolves the current eval's session via process context. Returns `nil` outside a REPL eval context.
+
+`Session` is **not** an Actor (gen_server). It is a value-shaped handle holding the shell PID, with primitive methods that delegate to the shell process via `gen_server:call`. This mirrors the `Supervisor` pattern (a Beamtalk object wrapping an OTP supervisor PID).
+
+### API
+
+```beamtalk
+sealed typed Object subclass: Session
+  field: pid :: Pid
+  field: id :: String
+
+  /// Session-local bindings only (the `x := 42` layer).
+  bindings -> Dictionary(Symbol, Object) =>
+    (Erlang beamtalk_session_primitives) bindings: self.pid
+
+  /// Workspace globals visible to this session (singletons + bind:as:).
+  globals -> Dictionary(Symbol, Object) =>
+    (Erlang beamtalk_session_primitives) globals
+
+  /// Walk binding layers, return first match or nil.
+  /// Lookup order: session locals → workspace globals.
+  resolve: aName :: Symbol -> Object =>
+    (Erlang beamtalk_session_primitives) resolve: aName for: self.pid
+
+  /// Clear session-local bindings. Workspace globals remain.
+  clear -> Nil =>
+    (Erlang beamtalk_session_primitives) clear: self.pid
+
+  /// Layer name symbols, in resolution order.
+  layers -> List(Symbol) => #(#session #workspace)
+
+  /// Stable session identifier (matches the protocol session ID).
+  id -> String => self.id
+```
+
+### REPL Examples
+
+```
+beamtalk> x := 42
+42
+beamtalk> Session bindings
+#{#x => 42}
+beamtalk> Session globals keys
+#(#Transcript #Beamtalk #Workspace #Session)
+beamtalk> Session resolve: #x
+42
+beamtalk> Session resolve: #Transcript
+#TranscriptStream<default>
+beamtalk> Session resolve: #notDefined
+nil
+beamtalk> Session layers
+#(#session #workspace)
+beamtalk> Workspace currentSession id
+"abc123-..."
+beamtalk> Session clear
+nil
+beamtalk> Session bindings
+#{}
+beamtalk> Session globals keys
+#(#Transcript #Beamtalk #Workspace #Session)
+```
+
+### Error Examples
+
+Outside a REPL eval (compiled program code), `Workspace currentSession` returns `nil`:
+
+```beamtalk
+// In a .bt file run via `beamtalk run`:
+Workspace currentSession  // => nil
+Workspace currentSession bindings
+// => #beamtalk_error{kind: does_not_understand, selector: #bindings, receiver: nil}
+```
+
+Calling `Session` from a context where it is not bound:
+
+```beamtalk
+// In compiled program code, Session is not in scope:
+Session bindings
+// => #beamtalk_error{kind: undefined_variable, name: #Session}
+```
+
+### Open Design Questions — Resolved
+
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| Singleton or per-PID? | **Per-PID** | CLI has one session, but WebSocket/MCP clients have many. Each shell injects its own `Session` binding; `Workspace currentSession` resolves from eval context. |
+| What outside REPL eval? | **`nil`** for `Workspace currentSession`; `Session` binding not present. | Compiled program code has no session. Returning a stub object would mask the meaningful absence. |
+| Persist across `:sync` / reload? | **Yes** — unchanged from current behaviour. | Session locals are shell-process state, owned independently of class definitions. Sync rebuilds modules; the session keeps its bindings. |
+| Expose `parent` for layer walking? | **No, not initially.** | Two layers; `bindings` and `globals` cover both. Parent links can be added later if a third layer (e.g. per-module scope) appears. Keeps the initial surface small. |
+| `bind:as:` interaction? | **Unchanged.** `Workspace bind:value as:#name` continues to write to the workspace ETS layer. Visible via `Session globals`. | `bind:as:` is workspace-scoped (shared across sessions). Confirms the layer separation: session = per-PID, workspace = shared. |
+
+## Prior Art
+
+| System | Binding model | What we adopt | What we reject |
+|--------|---------------|---------------|----------------|
+| **Pharo / Squeak Workspace** | `Dictionary` of bindings on the workspace, with fallback to `Smalltalk globals`. Methods: `bindings`, `bindingOf:`, `removeBinding:`, `resetBindings`. | The flat-Dictionary shape and the `bindings` accessor name. | Pharo merges workspace and session — Beamtalk has separate workspace (shared) and session (per-PID) layers because of multi-client BEAM hosting. |
+| **Pharo Environment** | Wraps a `Dictionary` of globals; multiple Environments allowed. | Layer reification via named accessors. | Beamtalk does not need user-creatable environments — workspace is bootstrapped once per BEAM node. |
+| **Newspeak** | Lexical nesting only; no global namespace; capability passing via constructor parameter. | The principle that scope is explicit, not magic. | Beamtalk has Smalltalk-style globals (`Transcript`, classes); a fully-lexical model would invalidate the existing namespace design. |
+| **Self** | Parent slot chain; scope walks via `parent*` slots. | Layer ordering as a first-class concept (`layers` returns the resolution order). | Recursive `parent` chains overstate the complexity for two layers. |
+| **IPython `get_ipython()`** | Shell singleton with `user_ns` dict, `who_ls()`, `reset()`. | The "current session is reachable through a global accessor" pattern (`Workspace currentSession`). | A single mutable dict obscures layer ownership; we keep layers separate. |
+| **Elixir `binding()`** | Macro returning current bindings as a keyword list. | Treating bindings as inspectable data. | A macro/keyword-list shape is non-Smalltalk; we use Dictionary returns and explicit objects. |
+
+## User Impact
+
+**Newcomer (Python/JS background).**
+`Session` joins `Transcript`, `Beamtalk`, `Workspace` as a small, discoverable set of always-available objects. Tab-completion on `Session` lists every session operation. Discovering "how do I see my variables" via `Session bindings` is more direct than memorising a `:b` meta-command.
+
+**Smalltalk developer.**
+The session-as-object model is recognisably Smalltalk: `Session` is to a Beamtalk shell what `Smalltalk` is to a Pharo image. The two-layer split (session vs. workspace) is more honest about multi-client BEAM hosting than Pharo's single-image model.
+
+**Erlang/BEAM developer.**
+`Session` maps cleanly to the existing `beamtalk_repl_shell` gen_server. The PID-handle pattern is familiar from `gen_server:call/2` and matches the `Supervisor` wrapper. Multi-session debugging (MCP, WebSocket) gets a first-class object to work with.
+
+**Production operator.**
+`Workspace sessions` (a follow-up extension) can return a list of `Session` objects, each individually inspectable. Compared to opaque PIDs in `supervisor:which_children`, this gives operators a structured view of who is connected and what they have bound.
+
+**Tooling developer (LSP / VS Code).**
+LSP completions can call `Session resolve: aSymbol` to mirror the runtime resolution path exactly, instead of duplicating the merge-and-shadow logic. The MCP server can call `Session bindings` directly via `evaluate` to display per-session state in the inspector panel.
+
+## Steelman Analysis
+
+### Option B: Workspace Extension (rejected)
+
+**Newcomer:** "I already know `Workspace` from `Workspace classes` and `Workspace actors`; adding `Workspace sessionBindings` is one more method on a familiar object. No new concept to learn."
+
+**Smalltalk purist:** "`Workspace` is the natural place for workspace-state operations. Splitting Session out is a needless ontological commitment."
+
+**BEAM veteran:** "Function calls on a singleton are simpler than navigating to a per-PID object. Less indirection in the dispatch path."
+
+**Operator:** "Fewer object types to debug. `Workspace` is already the operator's entry point."
+
+**Language designer:** "Adding methods is cheaper than adding classes. YAGNI applies."
+
+**Why not adopted:** Single-session ergonomics break in multi-session deployments. `Workspace sessionBindings` cannot answer "which session?" without extra parameters or context-aware lookup. The first-class object generalises naturally to `Workspace sessions collect: [:s | s bindings]`, which Option B cannot express.
+
+### Option C: Recursive Scope Chain (rejected)
+
+**Newcomer:** "Once I learn the parent pattern, I can walk any depth — just like prototype chains in JavaScript."
+
+**Smalltalk purist:** "Self's slot-chain model is the most principled scoping mechanism in any object language. This adopts proven prior art."
+
+**BEAM veteran:** "A uniform parent walk is easier to implement recursively than a fixed two-layer structure."
+
+**Operator:** "Depth-flexible scopes future-proof the design — package-level scopes, module-level scopes, etc., all fit without redesign."
+
+**Language designer:** "Most elegant. Layers are a special case of a more general scope-chain abstraction."
+
+**Why not adopted:** Premature generalisation. We have two layers and no concrete plan for a third. The cost (a `Scope` class hierarchy, recursive resolution semantics, tooling for chain inspection) is paid up front for hypothetical future flexibility. If a third layer appears, `Session` can grow a `parent` accessor non-breakingly.
+
+### Tension Points
+
+- **Newcomers** would mildly prefer Option B (fewer concepts) but are not harmed by Option A — `Session` is itself a small, learnable concept.
+- **Operators** prefer Option A as soon as multi-session is a real concern; Option B becomes brittle.
+- **Language designers** are split between A and C; the deciding factor is current need versus speculative need.
+
+## Alternatives Considered
+
+### Alternative B: Workspace extension methods (no new class)
+
+Add `Workspace sessionBindings`, `Workspace clearSession`, `Workspace resolveBinding:` directly to `WorkspaceInterface`. No new class, no new top-level binding.
+
+Rejected because:
+- Cannot represent "the session" as a value to pass, store, or compose.
+- Cannot answer "which session?" cleanly when multiple sessions exist (`Workspace sessions` lists them, but they cannot expose their own state).
+- Method names grow long and clunky as session-related operations accumulate.
+
+### Alternative C: Recursive `Scope` chain with `parent` links
+
+Introduce a `Scope` abstraction with a `parent` accessor, walked recursively for resolution. `Workspace currentScope` returns the session scope; `currentScope parent` returns the workspace scope.
+
+Rejected because:
+- Two layers do not justify a recursive abstraction.
+- "Scope" is a compiler concept, not a Smalltalk concept; introduces foreign vocabulary.
+- Premature: `Session` can grow a `parent` accessor later non-breakingly if a third layer appears.
+
+### Alternative D: Make `:bindings` and `:clear` permanent meta-commands
+
+Accept the surface asymmetry permanently and document `bindings` / `clear` as REPL-specific.
+
+Rejected because it locks in the violation of Principle 6 (messages all the way down) and ADR 0040 (workspace-native commands), and leaves the session layer permanently invisible to MCP and other clients.
+
+## Consequences
+
+### Positive
+
+- **Layers become inspectable.** `Session bindings` and `Session globals` make the two-layer model visible; users no longer wonder why `Transcript` shows up in `:bindings` but is not something they assigned.
+- **Resolution becomes debuggable.** `Session resolve: #x` answers "where does this name come from?" interactively.
+- **`:bindings` and `:clear` get a Beamtalk-native replacement.** Surface parity restored: MCP `evaluate` and any other client can drive session inspection through the standard message-send surface.
+- **Multi-session aware.** The design works unchanged for CLI (one session), WebSocket, MCP, and any future multi-client surface.
+- **Foundation for future ops.** Per-session metadata (connect time, client kind, idle status), session-to-session messaging, and live-session listings (`Workspace sessions`) all become straightforward extensions.
+
+### Negative
+
+- **One more top-level binding name.** `Session` joins `Transcript`, `Beamtalk`, `Workspace` as an injected per-session global. Users could shadow it with a local; the runtime should warn when that happens (covered by existing `bind:as:` conflict checks).
+- **`Session clear` during eval has subtle semantics.** The eval worker has a state snapshot; mutations propagate via the worker's returned state. The implementation must ensure `Session clear` clears in a way that survives the worker's state writeback, either by routing through the worker's state thread or by post-eval reconciliation. This is an implementation detail, not a design flaw, but it requires care.
+- **Outside-REPL `nil`.** `Workspace currentSession` returns `nil` in compiled program code, which means `Workspace currentSession bindings` raises `does_not_understand` (correct DNU semantics, but a footgun if users assume the API is always available). Documentation must call this out.
+
+### Neutral
+
+- **`bind:as:` semantics unchanged.** Continues to write to the workspace ETS layer. `Session bindings` will not include `bind:as:` entries (those appear in `Session globals`). This is a clarification, not a behaviour change.
+- **Session persistence across sync unchanged.** Existing behaviour preserved: session locals survive `Workspace sync`.
+- **Protocol surface unchanged initially.** The existing `bindings` and `clear` ops continue to work, redirected to `Session bindings` / `Session clear` semantics. Hard removal is a follow-up after the new API has soaked.
+
+## Implementation
+
+The implementation breaks down into four phases. Each is independently shippable.
+
+### Phase 1: Runtime primitives module
+
+Create `beamtalk_session_primitives.erl` with the four primitive operations:
+- `bindings/1` — gen_server:call to the shell, returning session-locals only (with workspace-injected keys removed via `injected_ws_keys` tracking already present in `beamtalk_repl_state`).
+- `globals/0` — calls `beamtalk_workspace_interface_primitives:get_session_bindings/0`, the existing workspace-globals accessor.
+- `resolve/2` — combines the two; session locals first, workspace globals second.
+- `clear/1` — gen_server:call to the shell's existing `clear_bindings` handler.
+
+EUnit tests for each. Existing infrastructure (`beamtalk_repl_shell`, `beamtalk_session_table`) is reused.
+
+### Phase 2: Stdlib `Session` class and binding injection
+
+Add `stdlib/src/Session.bt` with the API defined above. Extend `beamtalk_workspace_config:singletons/0` and shell init (`beamtalk_repl_shell:init/1`) to inject a `Session` binding pointing to a Session object constructed with the shell's PID and session ID. Update `beamtalk_workspace_interface_primitives:handle_session_bindings/1` to include `Session` in the workspace-injected keys (so it propagates correctly through `clear` and refresh paths).
+
+### Phase 3: `Workspace currentSession` and process-context resolution
+
+Add `currentSession` to `WorkspaceInterface` (Beamtalk class) with an Erlang primitive that:
+1. Reads the calling process's session PID from process dictionary, or
+2. Walks up to find the shell PID via `$ancestors` if direct lookup fails, or
+3. Returns `nil` if no session is in scope.
+
+Eval worker spawn must seed the worker's process dictionary with the shell PID for the lookup to work.
+
+### Phase 4: Migration and meta-command deprecation
+
+Re-deprecate `:bindings` and `:clear` in `beamtalk_repl_ops_dev.erl` with `migrate_to` hints pointing at `Session bindings` and `Session clear`. Update `surface-parity.md` rows for `bindings` and `clear` to cite `via Session bindings` / `via Session clear`. Add an e2e btscript test under `tests/repl-protocol/cases/` covering the full Session API. Hard removal of the meta-commands is a separate follow-up issue once the new API has been validated in real use.
+
+## Migration Path
+
+For users of `:bindings` and `:clear`:
+
+| Before | After |
+|--------|-------|
+| `:bindings` | `Session bindings` (session locals only) <br> `Session globals` (workspace globals) |
+| `:clear` | `Session clear` |
+| (no equivalent) | `Session resolve: #name` |
+| (no equivalent) | `Workspace currentSession` |
+
+The meta-commands continue to work during the deprecation window. CLI users see a `migrate_to` hint in the deprecated-op response. MCP and WebSocket clients gain a new capability (the meta-commands were REPL-only; the object API works on every surface).
+
+## References
+
+- [BT-2092](https://linear.app/beamtalk/issue/BT-2092/first-class-session-object-walkable-binding-layers-smalltalk-style) — driving issue
+- [BT-2083](https://linear.app/beamtalk/issue/BT-2083/surface-only-audit-decide-promote-or-lock-for-asymmetric-ops) — surface audit that un-deprecated `:bindings` / `:clear` and filed BT-2092
+- ADR 0040 — Workspace-Native REPL Commands (the precedent for moving meta-commands onto Beamtalk objects)
+- ADR 0010 — Global Objects and Singleton Dispatch (the singleton injection mechanism `Session` reuses)
+- ADR 0004 — Persistent Workspace Management (workspace lifecycle context)
+- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl:62-77` — current `:bindings` / `:clear` handlers
+- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl:155-244` — shell init and binding lifecycle
+- `runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl:765-786` — workspace-globals injection
+- `runtime/apps/beamtalk_workspace/src/beamtalk_session_table.erl` — session registry
+- Pharo Workspace `bindings` accessor; Squeak `Environment`; IPython `get_ipython()` — prior art for first-class binding scope objects

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -27,7 +27,7 @@ This violates the architectural pattern established by ADR 0040 (workspace-nativ
 
 ### Current State
 
-Each REPL connection gets a `beamtalk_repl_shell` gen_server, supervised under `beamtalk_session_sup` and tracked in the `beamtalk_sessions` ETS table (`beamtalk_session_table`). The shell holds session-local bindings in `beamtalk_repl_state`, refreshed with workspace globals before each eval (`refresh_ws_bindings/1` in `beamtalk_repl_shell.erl:441`). Eval workers spawn from the shell with a snapshot of state, returning updated state when they complete.
+Each REPL connection gets a `beamtalk_repl_shell` gen_server, supervised under `beamtalk_session_sup` and tracked in the `beamtalk_sessions` ETS table (`beamtalk_session_table`). The shell holds session-local bindings in `beamtalk_repl_state`, reconciled with workspace globals after each eval (`refresh_ws_bindings/1` in `beamtalk_repl_shell.erl:441`, called during eval-result processing to pick up `bind:as:`/`unbind:` changes). Eval workers spawn from the shell with a snapshot of state, returning updated state when they complete.
 
 The CLI REPL has one session. WebSocket and MCP clients can have many — `beamtalk_session_sup` already supports multi-session, and `beamtalk_repl_ops_session.erl` exposes a `sessions` protocol op listing live shells. But no Beamtalk class represents an individual session.
 
@@ -84,7 +84,7 @@ The shell PID is not stored in Beamtalk-level fields. Primitives resolve the cal
 
 ### REPL Examples
 
-```
+```text
 beamtalk> x := 42
 42
 beamtalk> Session bindings

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -178,37 +178,43 @@ The MCP server can call `Session bindings` and `Session globals` via `evaluate` 
 
 ### Option B: Workspace Extension (rejected)
 
-**Newcomer:** "I already know `Workspace` from `Workspace classes` and `Workspace actors`; adding `Workspace sessionBindings` is one more method on a familiar object. No new concept to learn."
+**Newcomer:** "I already know `Workspace` from `Workspace classes` and `Workspace actors`; adding `Workspace sessionBindings` is one more method on a familiar object. No new concept to learn, no new top-level binding to discover."
 
-**Smalltalk purist:** "`Workspace` is the natural place for workspace-state operations. Splitting Session out is a needless ontological commitment."
+**Smalltalk purist:** "Adding methods to `Workspace` matches how `Smalltalk` accumulates introspection in Pharo — `Smalltalk globals`, `Smalltalk allClasses`, `Smalltalk current`. Why is sessions special enough to warrant its own class?"
 
-**BEAM veteran:** "Function calls on a singleton are simpler than navigating to a per-PID object. Less indirection in the dispatch path."
+**BEAM veteran:** "`Workspace sessionBindings` could use the same process-context resolution that `Workspace currentSession` uses anyway. The dispatch cost is identical; you're just spelling it differently. For the 99% case — introspecting your own session — Option B is shorter and avoids the shadowing-via-`:=` footgun entirely (no injected binding, nothing to shadow)."
 
-**Operator:** "Fewer object types to debug. `Workspace` is already the operator's entry point."
+**Operator:** "Fewer object types in the system means fewer surfaces to learn for postmortem debugging. `Workspace` is already the operator's entry point — keep it that way."
 
-**Language designer:** "Adding methods is cheaper than adding classes. YAGNI applies."
+**Language designer:** "Adding methods is cheaper than adding classes. The composability argument for first-class Session is partly speculative — today nobody writes `Workspace sessions collect: [:s | s bindings]`. YAGNI."
 
-**Why not adopted:** Single-session ergonomics break in multi-session deployments. `Workspace sessionBindings` cannot answer "which session?" without extra parameters or context-aware lookup. The first-class object generalises naturally to `Workspace sessions collect: [:s | s bindings]`, which Option B cannot express.
+**Why not adopted:** The BEAM-veteran argument is the strongest — Option B *works* for the common case and avoids the injected-binding shadowing problem. Two factors push us to A despite this:
+
+1. **Pass-by-reference.** `Session` as a value can be stored, passed to library code, or returned from `Workspace sessions`. Option B cannot express `analyzer analyze: aSession` — there's no first-class session value to pass.
+2. **Namespace coherence.** `Workspace` already mixes actors, classes, supervisors, packages, sync, test, bind:as:, and load. Adding `sessionBindings`, `sessionGlobals`, `clearSession`, `resolveBinding:` would push it past discoverable scale. A dedicated `Session` class keeps each surface focused.
+
+The shadowing footgun (Option B's genuine advantage) is mitigated by the proposed shadowing warning. The ergonomic loss in Option B (no first-class session value) is permanent and not mitigable.
 
 ### Option C: Recursive Scope Chain (rejected)
 
-**Newcomer:** "Once I learn the parent pattern, I can walk any depth — just like prototype chains in JavaScript."
+**Newcomer:** "Once I learn the parent pattern, I can walk any depth. It's just like prototype chains in JavaScript or `__getattr__` chains in Python — a familiar mental model from outside the Smalltalk world."
 
-**Smalltalk purist:** "Self's slot-chain model is the most principled scoping mechanism in any object language. This adopts proven prior art."
+**Smalltalk purist:** "Self's slot-chain model is the most principled scoping mechanism in any object language. Walking `parent` is more uniform than special-casing each layer with a named accessor (`bindings`, `globals`, ...). Adopt proven prior art."
 
-**BEAM veteran:** "A uniform parent walk is easier to implement recursively than a fixed two-layer structure."
+**BEAM veteran:** "Process linking already gives BEAM a parent chain (`$ancestors`). A uniform `parent` accessor on Scope objects mirrors what's already happening at the OTP level — recursive walks are idiomatic on BEAM."
 
-**Operator:** "Depth-flexible scopes future-proof the design — package-level scopes, module-level scopes, etc., all fit without redesign."
+**Operator:** "If we ever introduce per-package, per-module, or per-actor scopes, depth-flexible scopes absorb them without redesign. Today's two-layer model becomes tomorrow's five-layer model without breaking callers."
 
-**Language designer:** "Most elegant. Layers are a special case of a more general scope-chain abstraction."
+**Language designer:** "Most elegant. Two layers IS the special case; the general case is a chain. Designing for the general case prevents future entrenchment of the wrong abstraction."
 
-**Why not adopted:** Premature generalisation. We have two layers and no concrete plan for a third. The cost (a `Scope` class hierarchy, recursive resolution semantics, tooling for chain inspection) is paid up front for hypothetical future flexibility. If a third layer appears, `Session` can grow a `parent` accessor non-breakingly.
+**Why not adopted:** Beamtalk has explicitly settled on a two-layer binding model — session locals over workspace globals — with no plans for additional layers. Package encapsulation (ADR 0070) is class-scoped, not a binding-resolution layer; module scope is an Erlang concept invisible to Beamtalk users (per project memory). The general-case argument requires a third layer to ever materialise; given the design direction, that's a bet against settled decisions. The cost — a `Scope` class hierarchy, recursive resolution semantics, tooling for chain inspection, plus the foreign vocabulary of "scope" in a Smalltalk context — is paid for an extension we are choosing not to take.
 
 ### Tension Points
 
-- **Newcomers** would mildly prefer Option B (fewer concepts) but are not harmed by Option A — `Session` is itself a small, learnable concept.
-- **Operators** prefer Option A as soon as multi-session is a real concern; Option B becomes brittle.
-- **Language designers** are split between A and C; the deciding factor is current need versus speculative need.
+- **Common-case ergonomics vs. composability.** Option B genuinely wins for the introspect-your-own-session case (no injected binding to shadow, no new class to learn). Option A wins when sessions need to be passed as values or enumerated. The decision turns on whether composability matters enough to pay the shadowing-warning cost.
+- **`Session` as injected binding** is the load-bearing footgun. Without it, Option A loses much of its ergonomic advantage (you'd always type `Workspace currentSession bindings`). With it, we add a name that can be shadowed by `:=`. The shadowing warning is the bridge.
+- **Speculative future use.** `Workspace sessions collect: [:s | s bindings]` is not exercised by any current caller. We're paying class-design complexity for a use case that today only appears in the Consequences section. Honest assessment: if this stays unused for 12 months, the value of a first-class Session over Option B is substantially weaker.
+- **Two layers is settled.** Option C's strongest argument (future layer flexibility) requires bet-against-settled-design. Both A and C agree the current need is two layers; A says "two named accessors", C says "n-arity chain". Given Beamtalk's commitment to two layers, A is the right level of generality.
 
 ## Alternatives Considered
 

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -99,7 +99,7 @@ sealed typed Object subclass: Session
     (Erlang beamtalk_session_primitives) resolve: aName for: self
   clear -> Nil =>
     (Erlang beamtalk_session_primitives) clearFor: self
-  id -> String => self.id
+  id -> String => (Erlang beamtalk_session_primitives) idOf: self
 ```
 
 `BindingsView` is a small Dictionary-protocol-compatible class backed by primitives that read/write session or workspace state. It implements `at:`, `at:put:`, `removeKey:`, `includesKey:`, `keys`, `values`, `size`, and `do:`. Mutations via `at:put:` / `removeKey:` are write-through.
@@ -231,7 +231,7 @@ Session globals at: #Workspace put: nil
 | **Pharo / Squeak Workspace** | `Dictionary` of bindings on the workspace, mutable via `at:put:`, with fallback to `Smalltalk globals`. Methods: `bindings`, `bindingOf:`, `removeBinding:`, `resetBindings`. | The mutable-Dictionary shape (`Session bindings at:put:` writes through, matching `Smalltalk globals at:put:`). | Pharo merges workspace and session — Beamtalk has separate workspace (shared) and session (per-PID) layers because of multi-client BEAM hosting. |
 | **Pharo Environment** | Wraps a `Dictionary` of globals; multiple Environments allowed. | Layer reification via named accessors. | Beamtalk does not need user-creatable environments — workspace is bootstrapped once per BEAM node. |
 | **Newspeak** | Lexical nesting only; no global namespace; capability passing via constructor parameter. | The principle that scope is explicit, not magic. | Beamtalk has Smalltalk-style globals (`Transcript`, classes); a fully-lexical model would invalidate the existing namespace design. |
-| **Self** | Parent slot chain; scope walks via `parent*` slots. | Layer ordering as a first-class concept (`layers` returns the resolution order). | Recursive `parent` chains overstate the complexity for two layers. |
+| **Self** | Parent slot chain; scope walks via `parent*` slots. | Explicit layer separation (`bindings` vs `globals`), inspired by Self's transparent parent hierarchy. | Recursive `parent` chains overstate the complexity for two layers. |
 | **IPython `get_ipython()`** | Shell singleton with `user_ns` dict, `who_ls()`, `reset()`. | The "current session is reachable through a global accessor" pattern (`Workspace currentSession`). | A single mutable dict obscures layer ownership; we keep layers separate. |
 | **Ruby `Binding`** | First-class scope object. `binding` returns the current scope; `Binding#local_variables` lists names. Can be passed for scoped expression execution. Closest prior art to the `Session` design. | A scope object that can be inspected and passed around. | Ruby's Binding captures lexical scope (closures); Beamtalk's Session wraps a session process, not a lexical frame. |
 | **Erlang shell `b()` / `f()`** | `b()` lists shell bindings; `f()` clears all; `f(X)` clears one. Shell-only built-in commands, not callable from program code. | Demonstrates the universal need to inspect REPL state. | Shell commands, not values — cannot be composed, stored, or called from non-shell code. Exactly the problem this ADR solves. |
@@ -240,13 +240,13 @@ Session globals at: #Workspace put: nil
 ## User Impact
 
 **Newcomer (Python/JS background).**
-`Session` joins `Transcript`, `Beamtalk`, `Workspace` as a small, discoverable set of always-available objects. Tab-completion on `Session` lists every session operation. Discovering "how do I see my variables" via `Session bindings` is more direct than memorising a `:b` meta-command.
+`Session` is discoverable via tab-completion on the class name — type `Ses<TAB>` and the class-side methods appear. Discovering "how do I see my variables" via `Session bindings` is more direct than memorising a `:b` meta-command. The live-mutation pattern (`Session bindings at: #x put: 42`) matches how Dictionary works everywhere else in the language.
 
 **Smalltalk developer.**
 The session-as-object model is recognisably Smalltalk: `Session` is to a Beamtalk shell what `Smalltalk` is to a Pharo image. The two-layer split (session vs. workspace) is more honest about multi-client BEAM hosting than Pharo's single-image model.
 
 **Erlang/BEAM developer.**
-`Session` maps cleanly to the existing `beamtalk_repl_shell` gen_server. The PID-handle pattern is familiar from `gen_server:call/2` and matches the `Supervisor` wrapper. Multi-session debugging (MCP, WebSocket) gets a first-class object to work with.
+Class-side methods that use process-context resolution match how BEAM convention works — the "calling process determines context" pattern is idiomatic (e.g. `self()`, process dictionary, `$ancestors`). `Session withId:` for cross-session access maps directly to the existing `beamtalk_session_table:lookup/1`. Multi-session debugging (MCP, WebSocket) gets a first-class object to work with.
 
 **Production operator.**
 `Workspace sessions` (a follow-up extension) can return a list of `Session` objects, each individually inspectable. Compared to opaque PIDs in `supervisor:which_children`, this gives operators a structured view of who is connected and what they have bound.
@@ -262,7 +262,7 @@ The MCP server can call `Session bindings` and `Session globals` via `evaluate` 
 
 **Smalltalk purist:** "Adding methods to `Workspace` matches how `Smalltalk` accumulates introspection in Pharo — `Smalltalk globals`, `Smalltalk allClasses`, `Smalltalk current`. Why is sessions special enough to warrant its own class?"
 
-**BEAM veteran:** "`Workspace sessionBindings` could use the same process-context resolution that `Workspace currentSession` uses anyway. The dispatch cost is identical; you're just spelling it differently. For the 99% case — introspecting your own session — Option B is shorter and avoids the shadowing-via-`:=` footgun entirely (no injected binding, nothing to shadow)."
+**BEAM veteran:** "`Workspace sessionBindings` could use the same process-context resolution that `Session bindings` uses anyway. The dispatch cost is identical; you're just spelling it differently. For the 99% case — introspecting your own session — adding methods to an existing object is simpler than introducing a whole new class. No new Erlang module, no new class registry entry."
 
 **Operator:** "Fewer object types in the system means fewer surfaces to learn for postmortem debugging. `Workspace` is already the operator's entry point — keep it that way."
 
@@ -331,7 +331,6 @@ Rejected because:
 Accept the surface asymmetry permanently and document `bindings` / `clear` as REPL-specific.
 
 Rejected because it locks in the violation of Principle 6 (messages all the way down) and ADR 0040 (workspace-native commands), and leaves the session layer permanently invisible to MCP and other clients.
-
 
 ## Consequences
 
@@ -420,7 +419,7 @@ The meta-commands existed only on the REPL surface. Removing them is a small los
 - [BT-2092](https://linear.app/beamtalk/issue/BT-2092/first-class-session-object-walkable-binding-layers-smalltalk-style) — driving issue
 - [BT-2083](https://linear.app/beamtalk/issue/BT-2083/surface-only-audit-decide-promote-or-lock-for-asymmetric-ops) — surface audit that un-deprecated `:bindings` / `:clear` and filed BT-2092
 - ADR 0040 — Workspace-Native REPL Commands (the precedent for moving meta-commands onto Beamtalk objects)
-- ADR 0010 — Global Objects and Singleton Dispatch (the singleton injection mechanism `Session` reuses)
+- ADR 0010 — Global Objects and Singleton Dispatch (established the `Beamtalk` / `Workspace` / `Transcript` bindings that form the workspace globals layer)
 - ADR 0004 — Persistent Workspace Management (workspace lifecycle context)
 - `runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl:62-77` — current `:bindings` / `:clear` handlers
 - `runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl:155-244` — shell init and binding lifecycle

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -53,7 +53,7 @@ There is **no injected `Session` binding** at the shell level; the class is reac
 
 `Session` is **not** an Actor (gen_server). It is a Beamtalk class whose methods delegate to `beamtalk_session_primitives`. `Session current` uses process-context resolution (process dictionary seeded during eval worker spawn) to find the calling session; instance methods carry their session's id for cross-session dispatch.
 
-`aSession bindings` and `aSession globals` return **live binding views** — mutating them writes through to the underlying state. `view at: #x put: 42` sets a session-local; `view removeKey: #x` removes it. Globals mutations route through the existing `bind:as:` / `unbind:` machinery and inherit those conflict checks.
+`aSession bindings` returns a **live binding view** of the session-locals layer — mutating it writes through to session state. `view at: #x put: 42` sets a session-local; `view removeKey: #x` removes it. The *globals* layer is **not** a Session method (globals are workspace-owned, not session state); it lives on `Workspace globals`, which this ADR upgrades to the same live `BindingsView` type — see "Two layers, two owners" below.
 
 ### API
 
@@ -79,19 +79,16 @@ sealed typed Object subclass: Session
   /// Live view of this session's local bindings (the `x := 42` layer).
   /// Reads return current values; `at:put:` and `removeKey:` mutate
   /// session state (write-through, for the calling session only).
+  /// (There is no `globals` here — globals are workspace-owned;
+  /// use `Workspace globals`.)
   bindings -> BindingsView =>
     (Erlang beamtalk_session_primitives) bindingsViewFor: self
 
-  /// Live view of workspace globals (singletons + bind:as: entries).
-  /// Shared across sessions; mutations route through `Workspace bind:as:`
-  /// / `unbind:`, including the existing protected-name conflict checks.
-  globals -> BindingsView =>
-    (Erlang beamtalk_session_primitives) globalsView
-
-  /// Walk binding layers, return first match or nil.
+  /// Walk both binding layers, return first match or nil.
   /// Lookup order: session locals → workspace globals.
   /// Primarily a REPL debugging tool: answers "where does this name
-  /// resolve from?" interactively.
+  /// resolve from?" interactively. Reads workspace globals internally
+  /// (the same registries name resolution uses).
   resolve: aName :: Symbol -> Object =>
     (Erlang beamtalk_session_primitives) resolveFor: self name: aName
 
@@ -116,7 +113,41 @@ A `BindingsView` is a handle over live session/workspace state. Its **runtime re
 
 **No injected binding.** `Session` is a class name resolved through the class registry, like `Counter` or `Integer`. It cannot be shadowed by a user `:=` assignment because class names are not in the binding map; assigning `Session := foo` creates a local binding that shadows the class reference *only in that local scope*, the same way assigning `Counter := foo` works. This is normal Smalltalk behaviour and not a footgun specific to Session.
 
-`Workspace currentSession` is **also** retained on `WorkspaceInterface` as a navigation method — Workspace is a discovery entry point, and "find the current session" fits the pattern of `Workspace actors`, `Workspace supervisor`, etc. It returns the same value as `Session current`. A companion `Workspace hasSession` predicate returns true/false, useful for library code that conditionally uses session state.
+`Workspace currentSession` is **also** added to `WorkspaceInterface` (it does not exist today) as a navigation method — Workspace is a discovery entry point, and "find the current session" fits the pattern of the existing `Workspace actors`, `Workspace supervisor`, `Workspace globals`, etc. It returns the same value as `Session current` (the session value, or `nil` outside a REPL eval). Code that conditionally uses session state guards with `ifNotNil:` — `Session current ifNotNil: [:s | …]` — rather than a separate `hasSession` predicate; the nil-returning factory already carries that information.
+
+### Two layers, two owners
+
+Each layer is owned by exactly one object, and there is **one** accessor per layer — no duplicate surface:
+
+| Layer | Owner | Read | Write |
+|-------|-------|------|-------|
+| Session locals (`x := 42`) | the session | `Session current bindings` (`BindingsView`) | `… bindings at:put:` / `removeKey:` (write-through, deferred — see eval ordering) |
+| Workspace globals (singletons + `bind:as:`) | the workspace | `Workspace globals` (`BindingsView`) | `… globals at:put:` / `removeKey:`, **or** the intention-revealing `Workspace bind:as:` / `unbind:` (both route through the same conflict-checked path) |
+
+`Session` deliberately has **no `globals` method** — globals are workspace state shared across every session, not session state. Putting a `globals` accessor on the session would duplicate `Workspace globals` and falsely imply globals are session-scoped (the same category error as the rejected class-side mirror). The one cross-layer operation, `Session current resolve:`, legitimately lives on the session because *shadowing is session-relative* (locals shadow globals); it reads `Workspace globals` internally.
+
+**`Workspace globals` is upgraded from a `Dictionary` snapshot to a live `BindingsView`** (same type as `Session current bindings`), so both layers share one Dictionary protocol. This is a pre-1.0 breaking change to an interactive-only method; the audit found callers use only `at:` / `includesKey:` / `keys`, which `BindingsView` implements. `BindingsView printOn:` renders like a `Dictionary` so REPL output stays familiar. Writes route through `bind/2` / `unbind/1`, inheriting the protected-name conflict checks. (`Beamtalk globals` — the *class registry* snapshot — stays a `Dictionary`; it is not a mutable binding layer.)
+
+**One documented asymmetry under the shared type:** session-local writes are *deferred to end of eval* (the eval worker holds a state snapshot — see eval ordering), while workspace-global writes hit shared ETS *synchronously* (other sessions must see them at once; they cannot be deferred into one session's eval). So within a single expression, `Session current bindings at: #x put: 9. x` sees the **old** `x`, whereas `Workspace globals at: #G put: 9. G` sees the **new** `G`. This reflects genuinely different layer semantics — *your* locals settle at expression end; the *shared* namespace updates immediately — not a quirk of the API spelling.
+
+### Binding storage model — locals-only with lazy global resolution
+
+Today (BT-883) each shell **eagerly copies** workspace globals (the `Transcript`/`Beamtalk`/`Workspace` singletons plus every `bind:as:` entry) into its per-session binding map at init (`inject_workspace_bindings/1`), re-syncs them after every eval (`refresh_ws_bindings/1`), and tracks which keys came from the copy (`injected_ws_keys`). This ADR replaces eager injection with **lazy resolution**, because the two-layer model the `Session` object exposes is far cleaner if the layers are actually stored separately rather than merged-then-unmerged:
+
+- A session's binding map holds **only session locals** (`x := 42`).
+- A free identifier `N` not bound locally is resolved against the **live** workspace sources, in order: (1) the `bind:as:` registry (workspace bindings ETS), (2) the singleton registry (`beamtalk_workspace_config:singletons/0` + `value_singletons/0` → `Transcript`/`Beamtalk`/`Workspace`), (3) the class registry (`Counter`, `Integer`, `Session` — already the case today), else `undefined_variable`.
+- Locals are checked first, so **shadowing is preserved** (`Transcript := 5` shadows the singleton within that session).
+- **One shared resolution function** backs both bare-name resolution and `Session current resolve:`, so they cannot drift.
+
+This is behaviour-preserving: the REPL compiler runs in-workspace and reads the same registries the injected snapshot was copied from, at the same point, so a `bind:as:` from a prior eval is visible on the next expression exactly as before (next-eval visibility either way). What changes is that the copy — and its reconciliation — disappear.
+
+Why it is worth doing here (not just later):
+- **Smaller, honest session state.** Each session map is true locals; the global set is not duplicated N times across connections.
+- **Removes machinery.** `inject_workspace_bindings/1`, `refresh_ws_bindings/1`, and `injected_ws_keys` all go away, along with the post-eval reconciliation they force.
+- **Simplifies this ADR.** `Session current bindings` becomes *the whole session map* — no `map − injected_ws_keys` subtraction, no extra `get_session_locals` gen_server call. Cross-session read is just the target shell's existing `get_bindings`. `Workspace globals` reads the same registries the resolver uses. The bindings/globals split *falls out of* the storage model (locals on the session, globals in the registries) instead of being reconstructed by filtering.
+- **More correct cross-session.** A `bind:as:` in one session is visible to others on their next resolution (read live from ETS) instead of waiting for each session's own `refresh`.
+
+Sequencing: this is foundational and lands **before** the binding-view phases, so the throwaway subtraction is never built. Design parity to verify (see Phase 1): resolution order matches `resolve:`; `undefined_variable` fires at the same phase as today; ETS/registry lookups stay O(1) (interactive path, not hot).
 
 ### Cross-session access (LSP, VS Code)
 
@@ -137,7 +168,7 @@ Workspace sessions collect: [:s | s id]
 
 `Session current bindings` operates on the calling process's session — semantically "my session". `(Session withId: x) bindings` operates on whichever session the id names, including ones owned by other connections. Both are the *same* instance methods on a `Session` value; only the factory call differs (`current` vs `withId:`). This is the load-bearing reason `Session` is value-shaped at all: cross-session **introspection** from tooling.
 
-Cross-session access is **read-only**. The instance-side reads (`bindings keys`, `bindings at:`, `resolve:`, `id`) work against any live session; the instance-side mutators (`at:put:`, `removeKey:`, `clear`) raise `cross_session_mutation_unsupported` (see Consequences → Negative → "Cross-session writes"). The LSP/completion use case needs only reads, and cross-session writes would race the target session's in-flight eval. `withId:` itself performs a liveness check and returns `nil` for an unknown *or* dead session id; a previously-captured `Session` whose shell later dies raises `session_not_found` on its next send.
+Cross-session access concerns the **session-locals** layer only (globals are shared — any session reads them via `Workspace globals`). It is **read-only**: the reads (`bindings keys`, `bindings at:`, `resolve:`, `id`) work against any live session; the mutators on another session's `bindings` view (`at:put:`, `removeKey:`) and `clear` raise `cross_session_mutation_unsupported` (see Consequences → Negative → "Cross-session writes"). The LSP/completion use case needs only reads, and cross-session writes would race the target session's in-flight eval. `withId:` itself performs a liveness check and returns `nil` for an unknown *or* dead session id; a previously-captured `Session` whose shell later dies raises `session_not_found` on its next send.
 
 The LSP and any other client that previously called the `bindings` / `clear` protocol ops moves to `Session withId:` + instance methods in the same release.
 
@@ -150,7 +181,7 @@ beamtalk> Session current bindings keys
 #(#x)
 beamtalk> Session current bindings at: #x
 42
-beamtalk> Session current globals keys
+beamtalk> Workspace globals keys
 #(#Transcript, #Beamtalk, #Workspace)
 beamtalk> Session current resolve: #x
 42
@@ -169,13 +200,13 @@ nil
 beamtalk> x
 // => #beamtalk_error{kind: undefined_variable, name: #x}
 
-// Globals mutations route through bind:as: / unbind:
+// Workspace globals is the same live BindingsView; writes route through bind:as:.
 // at:put: returns the value put (Dictionary protocol), like the session view above.
-beamtalk> Session current globals at: #MyTool put: someActor
+beamtalk> Workspace globals at: #MyTool put: someActor
 #<Counter @ <0.123.0>>
 beamtalk> MyTool
 #<Counter @ <0.123.0>>
-beamtalk> Session current globals removeKey: #MyTool
+beamtalk> Workspace globals removeKey: #MyTool
 nil
 
 // Pass-by-reference (cross-session access from LSP / tooling):
@@ -200,7 +231,7 @@ Outside a REPL eval, `Session current` and `Workspace currentSession` return `ni
 // In a .bt file run via `beamtalk run`:
 Session current        // => nil
 Workspace currentSession  // => nil
-Workspace hasSession   // => false
+Session current isNil  // => true
 ```
 
 Outside a REPL, `Session current` is `nil`, so messaging it DNUs on `nil`:
@@ -211,10 +242,10 @@ Session current bindings
 // => #beamtalk_error{kind: does_not_understand, selector: #bindings, receiver: nil}
 ```
 
-This is the *intended* trade for keeping `current` consistent with `Workspace currentSession` (both return `nil` with no session). It is acceptable because `Session` is an interactive/tooling surface, not something production library code depends on — and code that wants to guard checks `Workspace hasSession` first:
+This is the *intended* trade for keeping `current` consistent with `Workspace currentSession` (both return `nil` with no session). It is acceptable because `Session` is an interactive/tooling surface, not something production library code depends on — and code that wants to guard uses `ifNotNil:` (no separate predicate):
 
 ```beamtalk
-Workspace hasSession ifTrue: [ Session current clear ]
+Session current ifNotNil: [:s | s clear]
 ```
 
 Cross-session `withId:` for an unknown (or dead) session ID returns nil:
@@ -226,7 +257,7 @@ Session withId: "nonexistent"  // => nil
 Globals mutations that violate protected-name rules raise the existing `bind:as:` error:
 
 ```beamtalk
-Session globals at: #Workspace put: nil
+Workspace globals at: #Workspace put: nil
 // => #beamtalk_error{kind: name_conflict, selector: #'bind:as:',
 //    message: "Workspace is a system name and cannot be shadowed"}
 ```
@@ -255,11 +286,13 @@ staleSession bindings keys
 |----------|----------|-----------|
 | Singleton or per-PID? | **Per-PID** | CLI has one session, WebSocket/MCP clients can have many. `Session current` uses process-context resolution to find the calling session; instance values carry their own session ID for cross-session access. |
 | Class-side operation mirror (`Session bindings`)? | **No.** Factory class-methods only (`current`, `withId:`); all operations are instance methods. | A class-side mirror would make `Session` a bespoke pattern unlike every other class (the true singletons use an injected binding; Session can't be one). It buys only terseness and a marginally nicer no-session error — not worth a duplicated surface. See Tension Points. |
-| What outside REPL eval? | **`Session current` returns `nil`** (matching `Workspace currentSession`); `Session current bindings` then DNUs on `nil`. | Compiled program code has no session. Returning `nil` keeps `current` consistent with `Workspace currentSession`; the DNU-on-nil is acceptable because `Session` is an interactive/tooling surface, not a production dependency. Guard with `Workspace hasSession`. |
+| What outside REPL eval? | **`Session current` returns `nil`** (matching `Workspace currentSession`); `Session current bindings` then DNUs on `nil`. | Compiled program code has no session. Returning `nil` keeps `current` consistent with `Workspace currentSession`; the DNU-on-nil is acceptable because `Session` is an interactive/tooling surface, not a production dependency. Guard with `Session current ifNotNil: [:s | …]` — no `hasSession` predicate. |
 | Persist across `:sync` / reload? | **Yes** — unchanged from current behaviour. | Session locals are shell-process state, owned independently of class definitions. Sync rebuilds modules; the session keeps its bindings. |
-| Are bindings/globals views live or snapshots? | **Live views.** Mutations write through. | Matches Pharo semantics (`Smalltalk globals at:put:`). A snapshot would force a parallel setter API (`Session at:put:`); the live view collapses both into one Dictionary protocol. |
+| Are the binding views live or snapshots? | **Live views.** Mutations write through. | Matches Pharo semantics (`Smalltalk globals at:put:`). A snapshot would force a parallel setter API; the live view collapses read and write into one Dictionary protocol. |
+| Where do globals live — on Session or Workspace? | **Workspace.** `Session current bindings` is locals only; globals are `Workspace globals`. `Session` has no `globals` method. | Globals are shared workspace state, not session state. A `Session globals` accessor would duplicate `Workspace globals` and imply globals are session-scoped (same category error as the class-side mirror). `resolve:` still walks both, reading `Workspace globals` internally. |
+| `Workspace globals` return type? | **Upgraded `Dictionary` → live `BindingsView`** (pre-1.0 break). | Unifies both layers under one type; makes `Workspace globals at:put:` a discoverable write path. Interactive-only; audited callers use only `at:`/`includesKey:`/`keys`. |
 | Layer-walking abstraction? | **Dropped.** No `layers` method, no recursive `parent`. | Beamtalk has settled on exactly two layers; package encapsulation (ADR 0070) is class-scoped, not a binding-resolution layer. A `layers` constant would be pure decoration. |
-| `bind:as:` interaction? | **Unchanged.** `Session current globals at:put:` is equivalent to `Workspace bind:as:`, including conflict checks. | One write path through the existing primitives; the new view is sugar over the established API. |
+| `bind:as:` interaction? | **Unchanged.** `Workspace globals at:put:` is equivalent to `Workspace bind:as:`, including conflict checks. | One write path through the existing primitives; the view is sugar over the established API. |
 | Cross-session access? | **Instance methods on a value from `Session withId:`, read-only** | LSP/VS Code completion sessions need to query the user's session. `Session current` is "my session"; `Session withId:` is "that session"; both return values you message identically. Cross-session *writes* race the target's in-flight eval and are unneeded, so they raise `cross_session_mutation_unsupported`. |
 | Stale / dead session reference? | **`withId:` does a liveness check (returns `nil`); a captured value whose shell later dies raises `session_not_found`.** | Avoids a `gen_server:call` to a dead PID blocking for the full timeout. |
 
@@ -271,7 +304,7 @@ staleSession bindings keys
 | **Pharo / Squeak Workspace** | `Dictionary` of bindings on the workspace, mutable via `at:put:`, with fallback to `Smalltalk globals`. Methods: `bindings`, `bindingOf:`, `removeBinding:`, `resetBindings`. | The mutable-Dictionary shape (`aSession bindings at:put:` writes through, matching `Smalltalk globals at:put:`). | Pharo merges workspace and session — Beamtalk has separate workspace (shared) and session (per-PID) layers because of multi-client BEAM hosting. |
 | **Pharo Environment** | Wraps a `Dictionary` of globals; multiple Environments allowed. | Layer reification via named accessors. | Beamtalk does not need user-creatable environments — workspace is bootstrapped once per BEAM node. |
 | **Newspeak** | Lexical nesting only; no global namespace; capability passing via constructor parameter. | The principle that scope is explicit, not magic. | Beamtalk has Smalltalk-style globals (`Transcript`, classes); a fully-lexical model would invalidate the existing namespace design. |
-| **Self** | Parent slot chain; scope walks via `parent*` slots. | Explicit layer separation (`bindings` vs `globals`), inspired by Self's transparent parent hierarchy. | Recursive `parent` chains overstate the complexity for two layers. |
+| **Self** | Parent slot chain; scope walks via `parent*` slots. | Explicit layer separation by owner (`Session current bindings` vs `Workspace globals`), inspired by Self's transparent parent hierarchy. | Recursive `parent` chains overstate the complexity for two layers. |
 | **IPython `get_ipython()`** | Shell singleton with `user_ns` dict, `who_ls()`, `reset()`. | The "current session is reachable through a global accessor" pattern (`Workspace currentSession`). | A single mutable dict obscures layer ownership; we keep layers separate. |
 | **Ruby `Binding`** | First-class scope object. `binding` returns the current scope; `Binding#local_variables` lists names. Can be passed for scoped expression execution. Closest prior art to the `Session` design. | A scope object that can be inspected and passed around. | Ruby's Binding captures lexical scope (closures); Beamtalk's Session wraps a session process, not a lexical frame. |
 | **Erlang shell `b()` / `f()`** | `b()` lists shell bindings; `f()` clears all; `f(X)` clears one. Shell-only built-in commands, not callable from program code. | Demonstrates the universal need to inspect REPL state. | Shell commands, not values — cannot be composed, stored, or called from non-shell code. Exactly the problem this ADR solves. |
@@ -289,10 +322,10 @@ The session-as-object model is recognisably Smalltalk: `Session` is to a Beamtal
 Class-side methods that use process-context resolution match how BEAM convention works — the "calling process determines context" pattern is idiomatic (e.g. `self()`, process dictionary, `$ancestors`). `Session withId:` for cross-session access maps directly to the existing `beamtalk_session_table:lookup/1`. Multi-session debugging (MCP, WebSocket) gets a first-class object to work with.
 
 **Production operator.**
-`Workspace sessions` (a follow-up extension) can return a list of `Session` objects, each individually inspectable. Compared to opaque PIDs in `supervisor:which_children`, this gives operators a structured view of who is connected and what they have bound.
+`Workspace sessions` (Phase 7) returns a list of `Session` objects, each individually inspectable. Compared to opaque PIDs in `supervisor:which_children`, this gives operators a structured view of who is connected and what they have bound.
 
 **Tooling developer (LSP / VS Code).**
-The MCP server can call `Session current bindings` and `Session current globals` via `evaluate` to display per-session state in the inspector panel. Tooling that needs the merged binding map (e.g. completions) merges those two Dictionaries in resolution order — no separate primitive needed.
+The MCP server can call `Session current bindings` and `Workspace globals` via `evaluate` to display per-session state in the inspector panel. Tooling that needs the merged binding map (e.g. completions) merges the two layers in resolution order — no separate primitive needed. Session ids for cross-session reads come from `Workspace sessions collect: [:s | s id]`.
 
 ## Steelman Analysis
 
@@ -335,7 +368,7 @@ The chosen design gives us almost all of B's simplicity (no injection, no shadow
   - **It makes `Session` a bespoke pattern.** No other class has it. The true singletons (`Transcript`, `Beamtalk`, `Workspace`) are an *injected binding that is the instance* — `Transcript show:` is a plain instance send, with no class-side `TranscriptStream show:` mirror. Factory classes like `Date` return an instance you message (`Date today year`, never `Date year`). A class-side operation mirror on `Session` would match neither pattern.
   - **It buys little.** Only terseness (one word) and a slightly nicer no-session error (`Session bindings` could raise a structured `no_session`, vs `Session current bindings` DNUing on `nil`). Neither justifies a duplicated surface or the internal inconsistency it creates (`current` returns `nil` but `bindings` would raise, for the *same* condition).
   - **`Session` genuinely can't be an injected singleton** (it's per-process, not per-node), so it earns *factory* access (`current`/`withId:`) — but that is the whole of its specialness. The operations belong on the value.
-- **Returning `nil` outside a REPL, not raising.** `Session current` returns `nil` to stay consistent with `Workspace currentSession`. The cost is that `Session current bindings` DNUs on `nil` outside a REPL rather than giving a domain-specific error — acceptable because `Session` is an interactive/tooling surface, and library code guards with `Workspace hasSession`.
+- **Returning `nil` outside a REPL, not raising.** `Session current` returns `nil` to stay consistent with `Workspace currentSession`. The cost is that `Session current bindings` DNUs on `nil` outside a REPL rather than giving a domain-specific error — acceptable because `Session` is an interactive/tooling surface, and library code guards with `Session current ifNotNil: [:s | …]` (no `hasSession` predicate).
 - **The LSP cross-session case is real, not speculative.** BT-1045 already established the protocol-level cross-session pattern; the LSP runs its own completion session and queries the user's session for bindings. Option B has no Beamtalk-native expression of this; `Session withId:` does.
 - **Live mutation cost.** Pharo-style `Smalltalk globals at:put:` write-through is genuinely useful, but adds a `pending_mutations` queue to `beamtalk_repl_state` to handle eval-ordering. This complexity is a property of the live-view decision, independent of the entry-point shape.
 - **Two layers is settled.** Option C's strongest argument (future layer flexibility) requires bet-against-settled-design. Beamtalk has committed to exactly two binding layers; package encapsulation (ADR 0070) is class-scoped, not a binding-resolution layer.
@@ -380,65 +413,77 @@ Rejected because it locks in the violation of Principle 6 (messages all the way 
 
 ### Positive
 
-- **Layers become inspectable.** `Session current bindings` and `Session current globals` make the two-layer model visible; users no longer wonder why `Transcript` shows up in `:bindings` but is not something they assigned.
-- **Resolution becomes debuggable.** `Session current resolve: #x` answers "where does this name come from?" interactively.
+- **Layers become inspectable, with clear ownership.** `Session current bindings` (locals) and `Workspace globals` (globals) make the two-layer model visible — and each layer has exactly one accessor on its owner; users no longer wonder why `Transcript` shows up in `:bindings` but is not something they assigned.
+- **Smaller, honest session state.** Lazy global resolution stops eagerly copying the global set into every session's binding map. Each session map is true locals; `inject_workspace_bindings/1`, `refresh_ws_bindings/1`, and `injected_ws_keys` (plus their post-eval reconciliation) are removed. Cross-session reads need no special subtraction — the target shell's binding map *is* its locals.
+- **Resolution becomes debuggable.** `Session current resolve: #x` answers "where does this name come from?" interactively, and shares one resolution function with bare-name lookup so they cannot drift.
 - **`:bindings` and `:clear` get a Beamtalk-native replacement.** Surface parity restored: MCP `evaluate` and any other client can drive session inspection through the standard message-send surface.
-- **Multi-session aware.** The design works unchanged for CLI (one session), WebSocket, MCP, and any future multi-client surface.
-- **Foundation for future ops.** Per-session metadata (connect time, client kind, idle status), session-to-session messaging, and live-session listings (`Workspace sessions`) all become straightforward extensions.
+- **Multi-session aware.** The design works unchanged for CLI (one session), WebSocket, MCP, and any future multi-client surface, and `Workspace sessions` (Phase 7) makes the live session set first-class.
+- **Foundation for future ops.** Per-session metadata (connect time, client kind, idle status) and session-to-session messaging become straightforward extensions on the `Session` value.
 
 ### Negative
 
 - **New `BindingsView` class.** A small Dictionary-protocol class is required to support live read/write views. Implementation cost is moderate (one class plus primitives for read/write/iterate). The class is simple — every method delegates to a primitive — but it is a new public surface that has to be documented and tested.
-- **Mutation during eval has ordering constraints.** Both `Session current clear` and `Session current bindings at:put:` mutate shell state. The eval worker holds a *state snapshot*; on completion its returned state is merged back, so a naive direct write would be overwritten. The implementation adds a `pending_mutations` queue to `beamtalk_repl_state`, modelled on the existing `pending_module_removals` mechanism (`beamtalk_repl_shell.erl` `apply_pending_removals/2` + `drain_pending_removals/1`). Primitives enqueue `{op, key, value}` tuples rather than writing directly; the queue is drained in the eval-result handler. The exact merge order and the behaviour on every eval exit path are specified in Phase 1 — they are correctness-critical and must not be left implicit.
-- **Reads do not observe same-eval writes (read-your-own-writes lag).** Because mutations are *enqueued* and drained only at eval-result time, a mutation does not take effect until the *next* eval. This holds for both bare-variable reads and view reads:
+- **Session-local mutation during eval has ordering constraints.** Both `Session current clear` and `Session current bindings at:put:` mutate shell state. The eval worker holds a *state snapshot*; on completion its returned state is merged back, so a naive direct write would be overwritten. The implementation adds a `pending_mutations` queue to `beamtalk_repl_state`, modelled on the existing `pending_module_removals` mechanism (`beamtalk_repl_shell.erl` `apply_pending_removals/2` + `drain_pending_removals/1`). Primitives enqueue `{op, key, value}` tuples rather than writing directly; the queue is drained in the eval-result handler. The exact merge order and the behaviour on every eval exit path are specified in Phase 2 — they are correctness-critical and must not be left implicit. (This applies to **session-local** writes only; workspace-global writes go straight to shared ETS — see next bullet.)
+- **Reads do not observe same-eval session-local writes (read-your-own-writes lag).** Because session-local mutations are *enqueued* and drained only at eval-result time, such a mutation does not take effect until the *next* eval:
   - `Session current bindings at: #x put: 99. x + 1` evaluates `x + 1` against the **original** `x`.
   - `Session current bindings at: #x put: 99. Session current bindings at: #x` returns the **original** value of `x`, not `99`.
-  This matches the user expectation that an expression sees its own pre-state, and matches how `bind:as:` already behaves mid-eval (its effect is re-injected by `refresh_ws_bindings` only after the eval completes). It is nonetheless a surprise worth documenting: to thread a freshly-computed value into the same expression, use a local (`y := 99. Session current bindings at: #x put: y. y`) instead of reading back through the view.
-- **Cross-session writes are not supported.** Instance-side `aSession bindings at:put:` / `removeKey:` against a session owned by *another* connection (obtained via `Session withId:`) would mutate that shell's state while its own in-flight eval worker holds an older snapshot — the worker's writeback would silently clobber the cross-session mutation, and the `pending_mutations` queue (which lives in the *calling* eval's flow) does not help the target. Because the only concrete cross-session use case — LSP/VS Code completion — needs **reads only**, cross-session `at:put:` / `removeKey:` / `clear` raise `#beamtalk_error{kind: cross_session_mutation_unsupported}` rather than racing. Cross-session **reads** (`keys`, `at:`, `resolve:`, `id`) are fully supported. This also keeps the F-over-B justification honest: the load-bearing win over Option B is cross-session *introspection*, not mutation.
+  This matches the expectation that an expression sees its own pre-state. **Workspace-global writes differ**: `Workspace globals at: #G put: 9. G` *does* see `9` in the same eval, because globals hit shared ETS synchronously (other sessions must see them at once). Same `BindingsView` type, different timing — documented under "Two layers, two owners". To thread a freshly-computed session-local value into the same expression, use a local (`y := 99. Session current bindings at: #x put: y. y`) instead of reading back through the view.
+- **Cross-session writes are not supported.** A cross-session `bindings at:put:` / `removeKey:` / `clear` (against a session from `Session withId:`) would mutate that shell's state while its own in-flight eval worker holds an older snapshot — the worker's writeback would silently clobber it, and the `pending_mutations` queue (which lives in the *calling* eval's flow) does not help the target. Because the only concrete cross-session use case — LSP/VS Code completion — needs **reads only**, those mutators raise `#beamtalk_error{kind: cross_session_mutation_unsupported}` rather than racing. Cross-session **reads** (`bindings keys`, `bindings at:`, `resolve:`, `id`) are fully supported. (Globals are shared, so there is no "cross-session globals" — every session sees the same `Workspace globals`.) This keeps the win over Option B honest: the load-bearing gain is cross-session *introspection*, not mutation.
 - **Stored `Session` / view lifetime.** A `Session` value (or a `BindingsView`) can outlive the shell it refers to — e.g. the user closes their REPL tab after an LSP session captured `Session withId: …`. `withId:` performs a liveness check (`resolve_pid`-style `is_process_alive`, not a raw `lookup`) and returns `nil` for a session that is gone. A `Session` value captured earlier whose shell *subsequently* dies raises `#beamtalk_error{kind: session_not_found}` on the next message send rather than blocking on a `gen_server:call` to a dead PID until timeout. Views are transient handles (like `FileHandle`); they are not durable references.
-- **Outside-REPL behaviour.** `Session current` returns `nil`, so `Session current bindings` DNUs on `nil` outside a REPL eval. There is no class-side `no_session` error because there are no class-side operation methods — `current` returning `nil` (consistent with `Workspace currentSession`) is the single source of "no session here". Library code that wants graceful degradation checks `Workspace hasSession` first.
+- **Outside-REPL behaviour.** `Session current` returns `nil`, so `Session current bindings` DNUs on `nil` outside a REPL eval. There is no class-side `no_session` error because there are no class-side operation methods — `current` returning `nil` (consistent with `Workspace currentSession`) is the single source of "no session here". Library code that wants graceful degradation uses `Session current ifNotNil: [:s | …]`.
 - **`clear` is asymmetric with the view.** `aSession bindings removeKey: #x` removes one binding; `aSession clear` removes all. There is no `bindings clear` on the view because its protocol is generic Dictionary semantics — `bindings` returns a *view*, not a Dictionary the user owns, so a `clear` on the view would be ambiguous (clear-the-view or clear-the-state). Keeping `clear` as a method on the session avoids this ambiguity.
 
 ### Neutral
 
-- **`bind:as:` semantics unchanged.** Continues to write to the workspace ETS layer. `Session current bindings` will not include `bind:as:` entries (those appear in `Session current globals`). This is a clarification, not a behaviour change.
+- **`bind:as:` write semantics unchanged.** `Workspace bind:as:` / `unbind:` continue to write the shared workspace ETS layer; `Workspace globals at:put:` / `removeKey:` are sugar over the same path. `Session current bindings` (locals) never includes `bind:as:` entries — those are globals, read via `Workspace globals`. (Under lazy resolution they are no longer copied into the session map at all.)
 - **Session persistence across sync unchanged.** Existing behaviour preserved: session locals survive `Workspace sync`.
-- **Protocol `bindings` / `clear` ops are removed** in Phase 5, alongside the rest of the work. The Session API ships first (Phases 1–4), so when the meta-commands disappear the replacement is already in place. There is no deprecation window — single coordinated release.
+- **Protocol `bindings` / `clear` ops are removed** in Phase 6, alongside the rest of the work. The Session API ships first (Phases 1–5), so when the meta-commands disappear the replacement is already in place. There is no deprecation window — single coordinated release.
 
 ## Implementation
 
-The implementation breaks down into a Phase 0 wire-check plus five shippable phases.
+The implementation breaks down into a Phase 0 wire-check plus seven shippable phases.
 
 ### Phase 0: Wire-check / napkin (XS)
 
 Before building any of the surface, prove the single load-bearing assumption end-to-end: *a primitive running inside an eval worker can recover the calling session*. Seed the worker's process dictionary with `beamtalk_session_pid` / `beamtalk_session_id` at spawn, add a throwaway `beamtalk_session_primitives:current/0` that reads it back, and confirm `(Erlang beamtalk_session_primitives) current` returns the right session from a live eval — and `nil` from a non-eval context. One EUnit test plus one manual REPL round-trip. If this does not work cleanly (e.g. process-dictionary seeding interacts badly with the worker spawn or the streaming path), the rest of the design is re-examined before investing in `BindingsView` and `pending_mutations`.
 
-### Phase 1: Process-context plumbing + pending-mutation merge (M)
+### Phase 1: Locals-only binding storage + lazy global resolution (M–L)
+
+Replace eager global injection with lazy resolution (see "Binding storage model" in the Decision). This is the foundational, **highest-risk** phase — it touches name resolution — which is why it lands first: every later phase assumes a locals-only session map, so building it first avoids a throwaway `bindings − injected` subtraction.
+
+- Stop calling `inject_workspace_bindings/1` at shell init; a new session's binding map starts **empty** and accumulates only locals as the user assigns.
+- Remove `refresh_ws_bindings/1` from the eval-result handler and delete the `injected_ws_keys` field (and `get_injected_ws_keys/1` / `set_injected_ws_keys/2`) from `beamtalk_repl_state` — there is no injected copy to reconcile.
+- Add one shared resolver, `beamtalk_workspace:resolve_name/2` (locals-map, Name), used by **both** REPL name resolution and `Session resolve:`. Order: (1) locals map, (2) `bind:as:` ETS, (3) singleton registry (`beamtalk_workspace_config:singletons/0` + `value_singletons/0`), (4) class registry, else `undefined_variable`.
+- Point the REPL compiler's free-identifier resolution at `resolve_name/2` (it already runs in-workspace and can read the registries directly) instead of consulting a pre-injected binding map.
+
+Parity tests (this phase must not regress behaviour): shadowing (`Transcript := 5` then `Transcript` returns `5`); `bind:as:` visibility on the next eval; `undefined_variable` fires at the same phase as today; and `resolve_name/2`'s order matches `Session resolve:` exactly (one function, two callers, so they cannot drift).
+
+### Phase 2: Process-context plumbing + pending-mutation merge (M)
 
 **Seed both eval spawn paths.** Modify the worker spawn in `beamtalk_repl_shell` to seed the worker's process dictionary with `beamtalk_session_pid` (the shell's `self()`) and `beamtalk_session_id` (the protocol session ID) before calling `do_eval`. There are **two** spawn paths and both must be seeded:
 - `handle_call({eval, _}, ...)` and `handle_call({eval_trace, _}, ...)` — the synchronous REPL path.
 - `handle_cast({eval_async, _, Subscriber}, ...)` — the streaming path (`do_eval/3`).
 
-A primitive that finds `get(beamtalk_session_pid) =:= undefined` returns `nil` (`current` / `Workspace currentSession` / `hasSession`); seeding only one path would make `Session` behave inconsistently between normal and streaming eval.
+A primitive that finds `get(beamtalk_session_pid) =:= undefined` returns `nil` (`current` / `Workspace currentSession`); seeding only one path would make `Session` behave inconsistently between normal and streaming eval.
 
 **Add the `pending_mutations` queue.** Add `pending_mutations` to `beamtalk_repl_state` — a list of `{op, key, value}` tuples (`op ∈ {put, remove, clear}`) — with accessors mirroring the existing `pending_module_removals` field. Primitives **enqueue** rather than write directly. The queue is owned by the shell's `ShellState` (not the worker snapshot): primitives enqueue via a `gen_server:call` to the shell, which is safe from the worker because the shell is in `noreply` while the worker runs and is free to service its mailbox. Visibility is guaranteed by ordering: the worker's enqueue `gen_server:call` is synchronous and completes *before* the worker sends `{eval_result, …}`, so the shell processes every enqueue (updating its loop state) strictly before it processes the result message — the `ShellState` bound in the `eval_result` handler always reflects the enqueued mutations.
 
-**Add a `get_session_locals` gen_server call.** Add `handle_call(get_session_locals, ...)` to `beamtalk_repl_shell` returning `maps:without(get_injected_ws_keys(State), get_bindings(State))`. This is required for cross-session reads (Phase 2): the subtraction needs both the bindings map and the injected-key set, which only co-exist inside the owning shell's state. `get_bindings` alone (which returns the merged map) is insufficient.
+(No `get_session_locals` call is needed: after Phase 1 a session's binding map *is* its locals, so a cross-session read is just the target shell's existing `get_bindings` — no subtraction, no companion call.)
 
-**Specify the merge order on every eval exit path.** The current eval-result handler does `apply_pending_removals(ShellState, WorkerState)` then (success only) `refresh_ws_bindings/1`. The drain slots in as follows:
+**Specify the merge order on every eval exit path.** After Phase 1 the eval-result handler no longer calls `refresh_ws_bindings/1` (globals are resolved live, not injected). The pending-mutation drain slots in as follows:
 
 | Eval exit path | Handler | Action |
 |----------------|---------|--------|
-| Success | `handle_info({eval_result, _, {ok, ...}}, ...)` | `M1 = apply_pending_removals(ShellState, WorkerState)`; `M2 = apply_pending_mutations(ShellState, M1)`; `refresh_ws_bindings(M2)`. Mutations apply **on top of** the worker's returned bindings (so the worker's own `x := …` is visible) but **after** removals, and before ws-refresh re-injects globals. |
-| Error | `handle_info({eval_result, _, {error, ...}}, ...)` | `apply_pending_removals` + `apply_pending_mutations` for `put`/`remove` ops only, **no** `refresh_ws_bindings` (unchanged from today). `put`/`remove` are explicit per-key edits the user issued, independent of the failed expression, so they take effect. A queued **`clear`** (whole-session destruction) is **dropped** on the error path: `Session current clear. someTypo` should not wipe every local because the line after `clear` failed. `clear` applies only on the success path. |
+| Success | `handle_info({eval_result, _, {ok, ...}}, ...)` | `M1 = apply_pending_removals(ShellState, WorkerState)`; `apply_pending_mutations(ShellState, M1)`. Mutations apply **on top of** the worker's returned bindings (so the worker's own `x := …` is visible) and **after** removals. (No `refresh_ws_bindings` — removed in Phase 1.) |
+| Error | `handle_info({eval_result, _, {error, ...}}, ...)` | `apply_pending_removals` + `apply_pending_mutations` for `put`/`remove` ops only. `put`/`remove` are explicit per-key edits the user issued, independent of the failed expression, so they take effect. A queued **`clear`** (whole-session destruction) is **dropped** on the error path: `Session current clear. someTypo` should not wipe every local because the line after `clear` failed. `clear` applies only on the success path. |
 | Interrupt | `handle_call(interrupt, ...)` | Drain `pending_mutations` alongside the existing `drain_pending_removals/1` so an interrupted eval's issued mutations are not lost. |
 | Worker crash | `handle_info({'DOWN', ...}, ...)` | **Discard** `pending_mutations` — a crashed worker's partial mutations are not trustworthy; drain removals as today but drop the mutation queue. |
 
-`apply_pending_mutations/2` reads the queue from `ShellState` and folds it over the merged bindings in enqueue order (`put`/`remove` per key, `clear` empties session-locals while preserving injected ws-keys), then resets the queue to `[]`.
+`apply_pending_mutations/2` reads the queue from `ShellState` and folds it over the locals map in enqueue order (`put`/`remove` per key, `clear` empties the locals map — no injected-key caveat now that the map is locals only), then resets the queue to `[]`.
 
 EUnit tests: worker-spawn seeding on **both** paths; `apply_pending_mutations` fold order; the four exit-path behaviours above (success/error apply, interrupt applies, crash discards); and a `clear`-then-`put` ordering case.
 
-### Phase 2: Runtime primitives module (M)
+### Phase 3: Runtime primitives module (M)
 
 Create `beamtalk_session_primitives.erl` in `runtime/apps/beamtalk_workspace/src/`. Two **factory** primitives mint Session values; the rest take a Session value (`self`) and act on the session it names:
 
@@ -447,57 +492,68 @@ Factory (class-side):
 - `withId/1` — looks up a session by protocol ID and **checks liveness** (`is_process_alive`, the `resolve_pid` discipline — not a raw `beamtalk_session_table:lookup/1`, which can return a dead PID). Returns a Session value or `nil`.
 
 Operations (instance-side, all take a Session value):
-- `bindingsViewFor/1` — returns a `BindingsView` tagged for session-local scope, recording the **target** session id (from the value) so reads resolve against the right shell and cross-session writes can be rejected.
-- `globalsView/0` — returns a `BindingsView` tagged for workspace scope. Workspace globals are shared across sessions, so this carries no per-session identity; instance `globals` returns the same shared view regardless of receiver.
-- `resolveFor/2` — walk the target session's locals first, then workspace globals; return value or nil.
-- `clearFor/1` — enqueue a clear mutation via the shell's pending-mutations API (Phase 1). Against a non-self session, raises `cross_session_mutation_unsupported`.
+- `bindingsViewFor/1` — returns a `BindingsView` over the target session's locals map. After Phase 1 that map *is* the locals (no subtraction); a cross-session read is the target shell's existing `get_bindings`. The view records the target session id so cross-session writes can be rejected.
+- `resolveFor/2` — delegates to the shared `resolve_name/2` (Phase 1): locals → `bind:as:` → singletons → classes.
+- `clearFor/1` — enqueue a clear mutation via the shell's pending-mutations API (Phase 2). Against a non-self session, raises `cross_session_mutation_unsupported`.
 - `idOf/1` — extract the protocol id from a Session value.
 
-**Session-locals vs. merged map — and why it must be computed shell-side.** Because workspace globals are *injected* into each shell's single bindings map at init (`inject_workspace_bindings/1`, BT-883) and refreshed after each eval, "session locals" is not a separate map — it is the bindings map **minus** the injected keys. The filter is `maps:without(get_injected_ws_keys(State), get_bindings(State))`.
+Plus the **workspace-globals** view primitive backing `Workspace globals` (not a Session method): `globalsView/0` returns a `BindingsView` tagged for workspace scope, reading the singleton registry + `bind:as:` ETS live.
 
-The two operands (`bindings` and `injected_ws_keys`) live *together* in a shell's `beamtalk_repl_state`, so the subtraction can only be done where both are in hand — **on the owning shell**. The existing `get_bindings` gen_server call returns only the merged map (`beamtalk_repl_shell.erl:235`), with no companion call for the injected-key set; computing locals on the *reader* side is therefore impossible for a cross-session target. Phase 1 must add a `get_session_locals` gen_server call to `beamtalk_repl_shell` that performs the subtraction and returns session-locals directly. `bindingsViewFor/1` routes through it for both the calling session and a cross-session target (the value carries the target's PID), so local and cross-session reads share one code path and one definition of "locals".
-
-Use `get_injected_ws_keys/1` (the per-session dynamic set, which *includes* `bind:as:` names) — **not** `beamtalk_workspace_config:binding_names/0`, which lists only the static singletons and excludes `bind:as:` names. The two are not interchangeable. This is a deliberate behaviour change from today's `:bindings` op (which filters with `binding_names/0` and therefore *shows* `bind:as:` names): under this ADR `bind:as:` names move out of `Session current bindings` and into `Session current globals`, which is the correct home for them (see Migration Path). This is the load-bearing step that keeps session-local bindings (locals) and globals (injected ws-keys + ETS) disjoint.
+`BindingsView` read/write primitives: `view_at/2`, `view_at_put/3`, `view_remove/2`, `view_keys/1`, `view_size/1`. Writes dispatch by the view's tagged scope:
+- **Session scope, calling session** → enqueue against `pending_mutations` (deferred; read-your-own-writes lag).
+- **Session scope, another session** → raise `cross_session_mutation_unsupported`.
+- **Workspace scope** → route through `beamtalk_workspace_interface_primitives:bind/2` / `unbind/1` (synchronous ETS, protected-name conflict checks).
 
 **Liveness on every cross-session send.** A `Session` value captured earlier may outlive its shell. The `*For:` / `idOf:` primitives check `is_process_alive` on the carried PID and raise `#beamtalk_error{kind: session_not_found}` rather than issuing a `gen_server:call` that blocks to timeout against a dead PID.
 
-Plus the BindingsView read/write primitives: `view_at/2`, `view_at_put/3`, `view_remove/2`, `view_keys/1`, `view_size/1`. Session-scope writes for the **calling** session enqueue against its pending-mutations queue; session-scope writes targeting **another** session (a cross-session `BindingsView`) raise `cross_session_mutation_unsupported`. Workspace-scope writes route through `beamtalk_workspace_interface_primitives:bind/2` and `unbind/1`, inheriting protected-name conflict checks.
+EUnit tests for each primitive, including: cross-session **read** via `withId/1`, cross-session **write** rejection, the workspace-globals view (read + write-through to `bind:as:`), and a dead-session `session_not_found` case.
 
-**Two write models, by design.** Session-scope writes are *deferred* (queued, applied at eval-end — the read-your-own-writes lag in Consequences). Workspace-scope writes are *synchronous*: `bind/2` / `unbind/1` hit the shared ETS table immediately, exactly as `Workspace bind:as:` does today. The asymmetry is intrinsic — session state is per-shell and snapshot-isolated during eval, workspace state is shared ETS. One consequence: a mid-eval `Session current globals at:put:` is written to ETS at once but is not re-injected into the shell's bindings map until `refresh_ws_bindings` runs, which (as today for `bind:as:`) happens only on the **success** path; on the error path the injected copy stays stale until the next successful eval. This matches existing `bind:as:` behaviour and is not a regression.
+### Phase 4: Stdlib `Session` and `BindingsView` classes; upgrade `Workspace globals` (M)
 
-EUnit tests for each primitive, including: cross-session **read** via `withId/1`, cross-session **write** rejection, the session-locals filter, and a dead-session `session_not_found` case.
+Add `stdlib/src/Session.bt` with the two factory class-methods (`current`, `withId:`) and the instance-side operation methods defined in the API (`bindings`, `resolve:`, `clear`, `id`) — no class-side operation mirror, **no `globals` method** (globals are workspace-owned). Add `stdlib/src/BindingsView.bt` implementing the Dictionary protocol subset (`at:`, `at:put:`, `removeKey:`, `includesKey:`, `keys`, `values`, `size`, `do:`, `printOn:`); `printOn:` renders like a `Dictionary` so REPL output stays familiar.
 
-### Phase 3: Stdlib `Session` and `BindingsView` classes (M)
+**Upgrade `Workspace globals`** in `WorkspaceInterface.bt` from `-> Dictionary` to `-> BindingsView` (the same view type), backed by `globalsView/0` (Phase 3). This is a pre-1.0 breaking change to an interactive-only method; update its doc-comment, the REPL display expectation, and the `tests/repl-protocol/cases/*.btscript` cases that read `Workspace globals` (they use `at:` / `includesKey:` / `keys`, which `BindingsView` supports). `Beamtalk globals` (class registry) stays `-> Dictionary`.
 
-Add `stdlib/src/Session.bt` with the two factory class-methods (`current`, `withId:`) and the instance-side operation methods defined in the API — no class-side operation mirror. Add `stdlib/src/BindingsView.bt` implementing the Dictionary protocol (`at:`, `at:put:`, `removeKey:`, `includesKey:`, `keys`, `values`, `size`, `do:`, `printOn:`).
+No binding injection: `Session` is reachable as a class name through the class registry, no special-case handling, no protected-name additions.
 
-No binding injection: `Session` is reachable as a class name through the class registry, no special-case handling. No protected-name additions, no `injected_ws_keys` changes.
+### Phase 5: `Workspace currentSession` (S)
 
-### Phase 4: `Workspace currentSession` / `hasSession` (S)
+Add `currentSession` to `WorkspaceInterface` (Beamtalk class), delegating to a one-line primitive that reads the same `beamtalk_session_pid` process dictionary key seeded in Phase 2. Returns the same value as `Session current` (the session value, or `nil`). No `hasSession` predicate — callers guard with `Session current ifNotNil: [:s | …]` / `Workspace currentSession isNil`.
 
-Add `currentSession` and `hasSession` to `WorkspaceInterface` (Beamtalk class), each delegating to a one-line primitive that reads the same `beamtalk_session_pid` process dictionary key seeded in Phase 1. Returns the same value as `Session current` (or its boolean).
-
-### Phase 5: Remove `:bindings` and `:clear` meta-commands (M)
+### Phase 6: Remove `:bindings` / `:clear` meta-commands and the `get_bindings` MCP tool (M)
 
 Delete the `<<"bindings">>` and `<<"clear">>` op handlers in `beamtalk_repl_ops_eval.erl` and remove their entries from `beamtalk_repl_ops_dev.erl`'s op map. Update `surface-parity.md` rows for `bindings` and `clear` to cite `via Session current bindings` / `via Session current clear`.
 
-**Bindings-changed push is preserved; only the fetch moves.** The `{bindings_changed, SessionId}` pub/sub (`beamtalk_bindings_events`, fired by the shell after each successful eval) is *not* removed — the VS Code sidebar still relies on it to know *when* to refresh. What changes is *how* the client fetches after the notification: it moves from the removed `bindings` op to `evaluate "Session current bindings keys"` (and `Session current globals keys`) carrying the user's `session` id, or to `Session withId:` + instance reads. This is a client-side change in the VS Code extension and must land with this phase, not after it — otherwise the sidebar refreshes against a dead op.
+**Resolve the `get_bindings` MCP tool.** A dedicated `get_bindings` MCP tool exists today (`crates/beamtalk-mcp/src/server.rs`), backed by the now-deleted `bindings` op. **Remove it.** MCP clients discover and read session state through the existing general surface: `search_classes` finds `Session`; `evaluate "Session current bindings keys"` (and `Workspace globals keys`) reads the layers; `evaluate "(Session withId: id) bindings keys"` reads another session. This matches the convention that per-feature MCP tools are thin front-ends over `evaluate` — and once `Workspace sessions` (Phase 7) lands, an MCP client enumerates session ids with `evaluate "Workspace sessions collect: [:s | s id]"` rather than needing them out-of-band. Update the `get_bindings` row in `surface-parity.md` accordingly.
+
+**Bindings-changed push is preserved; only the fetch moves.** The `{bindings_changed, SessionId}` pub/sub (`beamtalk_bindings_events`, fired by the shell after each successful eval) is *not* removed — the VS Code sidebar still relies on it to know *when* to refresh. What changes is *how* the client fetches after the notification: it moves from the removed `bindings` op / `get_bindings` tool to `evaluate "Session current bindings keys"` (and `Workspace globals keys`) carrying the user's `session` id, or to `Session withId:` + instance reads. This is a client-side change in the VS Code extension and must land with this phase, not after it — otherwise the sidebar refreshes against a dead op.
 
 **Test migration is non-trivial.** Migrating `:bindings` / `:clear` from meta-commands to evaluated expressions changes the protocol op (`bindings`/`clear` → `eval`) and therefore the response shape (a bindings map → an eval result value). Existing `tests/repl-protocol/cases/*.btscript` cases that assert on the old op responses need real rewrites, not find-replace — audit and enumerate them before locking the estimate. Add a new e2e btscript case covering the full Session API including cross-session read access (`Session withId:`) and cross-session write rejection.
 
+### Phase 7: `Workspace sessions -> List(Session)` (S)
+
+Add `sessions` to `WorkspaceInterface`, returning a `List` of `Session` values — one per live shell — built on the existing `sessions` protocol op (`beamtalk_repl_ops_session.erl`) + `beamtalk_session_table`, minting each `Session` value the same way `withId:` does. This serves two audiences at once:
+- **Operators:** `Workspace sessions` gives a structured, individually-inspectable view of who is connected — `Workspace sessions collect: [:s | s id]`, `Workspace sessions size` — versus opaque PIDs in `supervisor:which_children`. Per-session metadata (connect time, client kind, idle status) is a later extension on the `Session` value, explicitly out of scope here.
+- **Tooling cross-session discovery:** it closes the gap left by `withId:` (which assumes you already know the id). An LSP/MCP client finds the user's session with `Workspace sessions` instead of an out-of-band id.
+
+EUnit + e2e btscript: list shape, ids match live shells, values are usable with the instance reads (and reject cross-session writes).
+
 ## Migration Path
 
-The `:bindings` and `:clear` meta-commands are removed in Phase 5; the replacement API is shipped in Phases 1–4 first so they land in the same release.
+The `:bindings` and `:clear` meta-commands (and the `get_bindings` MCP tool) are removed in Phase 6; the replacement API is shipped in Phases 1–5 first so they land in the same release.
 
 | Before | After |
 |--------|-------|
-| `:bindings` | `Session current bindings keys` (session locals only) <br> `Session current globals keys` (workspace globals) <br> ⚠️ **behaviour change:** `:bindings` today (via `binding_names/0`) *shows* `bind:as:` names mixed in; under this ADR they move to `Session current globals` and no longer appear in `Session current bindings`. |
+| `:bindings` | `Session current bindings keys` (session locals only) <br> `Workspace globals keys` (workspace globals) <br> ⚠️ **behaviour change:** `:bindings` today (via `binding_names/0`) *shows* `bind:as:` names mixed in; under this ADR they are globals, read via `Workspace globals` — they no longer appear in `Session current bindings`. |
 | `:clear` | `Session current clear` |
+| MCP `get_bindings` tool | `evaluate "Session current bindings keys"` (and `Workspace globals keys`) |
+| `Workspace globals` returns `Dictionary` | `Workspace globals` returns a live `BindingsView` (write-through; ⚠️ pre-1.0 return-type change, interactive-only) |
 | (no equivalent) | `Session current bindings at: #x put: 99` (live mutation) |
 | (no equivalent) | `Session current bindings removeKey: #x` |
 | (no equivalent) | `Session current resolve: #name` (REPL debugging tool) |
 | (no equivalent) | `Workspace currentSession` / `Session current` |
 | (no equivalent) | `Session withId: aSessionId` (LSP cross-session) |
+| (no equivalent) | `Workspace sessions` → `List(Session)` (operators; cross-session discovery) |
 
 The meta-commands existed only on the REPL surface. Removing them is a small loss for muscle-memory CLI users (one `migrate_to` shell-side error message in the release notes is sufficient) and a strict gain for MCP and WebSocket clients, which now have a Beamtalk-native path to per-session state with both reads and write-through mutations.
 

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -191,7 +191,7 @@ The MCP server can call `Session bindings` and `Session globals` via `evaluate` 
 **Why not adopted:** The BEAM-veteran argument is the strongest — Option B *works* for the common case and avoids the injected-binding shadowing problem. Two factors push us to A despite this:
 
 1. **Pass-by-reference.** `Session` as a value can be stored, passed to library code, or returned from `Workspace sessions`. Option B cannot express `analyzer analyze: aSession` — there's no first-class session value to pass.
-2. **Namespace coherence.** `Workspace` already mixes actors, classes, supervisors, packages, sync, test, bind:as:, and load. Adding `sessionBindings`, `sessionGlobals`, `clearSession`, `resolveBinding:` would push it past discoverable scale. A dedicated `Session` class keeps each surface focused.
+2. **Workspace's role.** `Workspace` is a navigation entry point — `Workspace actors`, `Workspace classes`, `Workspace supervisor`, `Workspace dependencies` — each method *finds you something*. Session bindings are not something you navigate to from the workspace; they belong to a session, which has its own identity. Loading session-state methods directly onto `Workspace` would be the same category error as putting `Counter increment` on `Workspace`. Four new session-state methods on `Workspace` is too much.
 
 The shadowing footgun (Option B's genuine advantage) is mitigated by the proposed shadowing warning. The ergonomic loss in Option B (no first-class session value) is permanent and not mitigable.
 
@@ -241,6 +241,17 @@ Rejected because:
 Accept the surface asymmetry permanently and document `bindings` / `clear` as REPL-specific.
 
 Rejected because it locks in the violation of Principle 6 (messages all the way down) and ADR 0040 (workspace-native commands), and leaves the session layer permanently invisible to MCP and other clients.
+
+### Alternative E: Hybrid — Session class with no injected binding
+
+Define the `Session` class (as in Option A) so that `Workspace currentSession` can return one, but skip the per-shell `Session` binding injection. Users always type `Workspace currentSession bindings` — never the shorter `Session bindings`.
+
+This was considered as a way to capture A's composability (pass-by-reference, multi-session enumeration) while eliminating the shadowing footgun (no injected binding to overwrite via `:=`).
+
+Rejected because:
+- The 99% interactive case becomes verbose: `Workspace currentSession bindings` four words long for an operation users will type repeatedly.
+- It miscategorises `Workspace`'s role. `Workspace` is a navigation entry point — methods on `Workspace` *find you something*. `currentSession` fits that pattern; making it the *only* path to session ops loses the directness of `Session bindings`.
+- The shadowing footgun is mitigable via the proposed compiler warning. The verbosity cost of E is permanent and not mitigable.
 
 ## Consequences
 

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -102,7 +102,13 @@ sealed typed Object subclass: Session
   id -> String => (Erlang beamtalk_session_primitives) idOf: self
 ```
 
+**Session instance representation.** `Session` is declared `Object subclass` (no `field:`/`state:` declarations, which an `Object` subclass cannot have), yet a `Session` *value* returned by `current` / `withId:` must carry its session's PID and protocol ID. This follows the existing `FileHandle` / `Port` pattern: a `sealed typed Object subclass` whose per-instance identity lives in the runtime representation (a tagged map produced by the primitive), not in a declared field. Instance methods pass `self` to a `*For:` primitive, which extracts the PID/ID from that representation — exactly as `FileHandle lines` passes `self` to `(Erlang beamtalk_file) handleLines: self`.
+
 `BindingsView` is a small Dictionary-protocol-compatible class backed by primitives that read/write session or workspace state. It implements `at:`, `at:put:`, `removeKey:`, `includesKey:`, `keys`, `values`, `size`, and `do:`. Mutations via `at:put:` / `removeKey:` are write-through.
+
+**Return-value contract.** `at:put:` returns the value put (standard Dictionary protocol), for both session and workspace views. `removeKey:` uniformly returns `nil` rather than the removed value: session-local removals are *enqueued* (see the eval-ordering note in Consequences) so the removed value is not read back synchronously, and returning it for one view but not the other would be a worse inconsistency — `nil` for both is the honest contract. Reads (`at:`, `keys`, `values`, `size`, `do:`) reflect committed state — within a single eval they do **not** observe mutations enqueued earlier in that same eval (see Consequences → Negative → eval ordering).
+
+A `BindingsView` is a handle over live session/workspace state. Its **runtime representation** follows `FileHandle` / `Port` — a `sealed typed Object subclass` with no `field:` declarations, minted by a primitive as a tagged map carrying per-instance identity, with instance dispatch routed to a primitive module. Note the precedent is for the *representation only*, not the lifetime contract: `FileHandle` must **not** escape its `open:do:` block, whereas a `Session` value is explicitly meant to be stored and passed (pass-by-reference is the whole justification over Option B). Escape-safety for `Session` is handled not by the FileHandle "don't escape" rule but by the liveness check on every send (`session_not_found` if the backing shell has died — see "Stored Session / view lifetime" in Consequences). A view read against a dead session raises rather than returning stale data.
 
 **No injected binding.** `Session` is a class name resolved through the class registry, like `Counter` or `Integer`. It cannot be shadowed by a user `:=` assignment because class names are not in the binding map; assigning `Session := foo` creates a local binding that shadows the class reference *only in that local scope*, the same way assigning `Counter := foo` works. This is normal Smalltalk behaviour and not a footgun specific to Session.
 
@@ -125,7 +131,9 @@ userSession ifNotNil: [
 Workspace sessions collect: [:s | s id]
 ```
 
-The class-side methods (`Session bindings`) operate on the calling process's session — semantically "my session". The instance-side methods (`aSession bindings`) operate on whichever session the value represents, including ones owned by other connections. This is the load-bearing reason for instance methods on `Session`: cross-session access from tooling.
+The class-side methods (`Session bindings`) operate on the calling process's session — semantically "my session". The instance-side methods (`aSession bindings`) operate on whichever session the value represents, including ones owned by other connections. This is the load-bearing reason for instance methods on `Session`: cross-session **introspection** from tooling.
+
+Cross-session access is **read-only**. The instance-side reads (`bindings keys`, `bindings at:`, `resolve:`, `id`) work against any live session; the instance-side mutators (`at:put:`, `removeKey:`, `clear`) raise `cross_session_mutation_unsupported` (see Consequences → Negative → "Cross-session writes"). The LSP/completion use case needs only reads, and cross-session writes would race the target session's in-flight eval. `withId:` itself performs a liveness check and returns `nil` for an unknown *or* dead session id; a previously-captured `Session` whose shell later dies raises `session_not_found` on its next send.
 
 The LSP and any other client that previously called the `bindings` / `clear` protocol ops moves to `Session withId:` + instance methods in the same release.
 
@@ -158,8 +166,9 @@ beamtalk> x
 // => #beamtalk_error{kind: undefined_variable, name: #x}
 
 // Globals mutations route through bind:as: / unbind:
+// at:put: returns the value put (Dictionary protocol), like the session view above.
 beamtalk> Session globals at: #MyTool put: someActor
-nil
+#<Counter @ <0.123.0>>
 beamtalk> MyTool
 #<Counter @ <0.123.0>>
 beamtalk> Session globals removeKey: #MyTool
@@ -211,6 +220,24 @@ Session globals at: #Workspace put: nil
 //    message: "Workspace is a system name and cannot be shadowed"}
 ```
 
+Cross-session **writes** are rejected (reads are allowed — see "Cross-session access"):
+
+```beamtalk
+otherSession := Session withId: "user-repl-abc-123".
+otherSession bindings at: #x put: 99
+// => #beamtalk_error{kind: cross_session_mutation_unsupported,
+//    message: "cannot mutate bindings of another session; reads only"}
+```
+
+A `Session` value whose shell has since died raises on the next send (rather than
+blocking on a call to a dead PID):
+
+```beamtalk
+// captured earlier; the owning REPL tab has since closed
+staleSession bindings keys
+// => #beamtalk_error{kind: session_not_found, message: "session is no longer alive"}
+```
+
 ### Open Design Questions — Resolved
 
 | Question | Decision | Rationale |
@@ -221,7 +248,8 @@ Session globals at: #Workspace put: nil
 | Are bindings/globals views live or snapshots? | **Live views.** Mutations write through. | Matches Pharo semantics (`Smalltalk globals at:put:`). A snapshot would force a parallel setter API (`Session at:put:`); the live view collapses both into one Dictionary protocol. |
 | Layer-walking abstraction? | **Dropped.** No `layers` method, no recursive `parent`. | Beamtalk has settled on exactly two layers; package encapsulation (ADR 0070) is class-scoped, not a binding-resolution layer. A `layers` constant would be pure decoration. |
 | `bind:as:` interaction? | **Unchanged.** `Session globals at:put:` is equivalent to `Workspace bind:as:`, including conflict checks. | One write path through the existing primitives; the new view is sugar over the established API. |
-| Cross-session access? | **Instance methods + `Session withId:`** | LSP/VS Code completion sessions need to query the user's session. Class-side methods are "my session"; instance methods are "that session". |
+| Cross-session access? | **Instance methods + `Session withId:`, read-only** | LSP/VS Code completion sessions need to query the user's session. Class-side methods are "my session"; instance methods are "that session". Cross-session *writes* race the target's in-flight eval and are unneeded, so they raise `cross_session_mutation_unsupported`. |
+| Stale / dead session reference? | **`withId:` does a liveness check (returns `nil`); a captured value whose shell later dies raises `session_not_found`.** | Avoids a `gen_server:call` to a dead PID blocking for the full timeout. |
 
 ## Prior Art
 
@@ -345,7 +373,13 @@ Rejected because it locks in the violation of Principle 6 (messages all the way 
 ### Negative
 
 - **New `BindingsView` class.** A small Dictionary-protocol class is required to support live read/write views. Implementation cost is moderate (one class plus primitives for read/write/iterate). The class is simple — every method delegates to a primitive — but it is a new public surface that has to be documented and tested.
-- **Mutation during eval has ordering constraints.** Both `Session clear` and `Session bindings at:put:` mutate shell state via gen_server calls. The eval worker holds a state snapshot; without reconciliation the worker's writeback would overwrite the mutation. The implementation must add a `pending_mutations` queue to `beamtalk_repl_state`: mutations append to the queue (instead of being applied directly); the eval-result handler drains the queue after merging the worker's state. This ensures `Session bindings at: #x put: 99. x + 1` evaluates `x + 1` against the original `x` (the mutation takes effect for the *next* eval), which matches user expectations that an expression sees its own pre-state.
+- **Mutation during eval has ordering constraints.** Both `Session clear` and `Session bindings at:put:` mutate shell state. The eval worker holds a *state snapshot*; on completion its returned state is merged back, so a naive direct write would be overwritten. The implementation adds a `pending_mutations` queue to `beamtalk_repl_state`, modelled on the existing `pending_module_removals` mechanism (`beamtalk_repl_shell.erl` `apply_pending_removals/2` + `drain_pending_removals/1`). Primitives enqueue `{op, key, value}` tuples rather than writing directly; the queue is drained in the eval-result handler. The exact merge order and the behaviour on every eval exit path are specified in Phase 1 — they are correctness-critical and must not be left implicit.
+- **Reads do not observe same-eval writes (read-your-own-writes lag).** Because mutations are *enqueued* and drained only at eval-result time, a mutation does not take effect until the *next* eval. This holds for both bare-variable reads and view reads:
+  - `Session bindings at: #x put: 99. x + 1` evaluates `x + 1` against the **original** `x`.
+  - `Session bindings at: #x put: 99. Session bindings at: #x` returns the **original** value of `x`, not `99`.
+  This matches the user expectation that an expression sees its own pre-state, and matches how `bind:as:` already behaves mid-eval (its effect is re-injected by `refresh_ws_bindings` only after the eval completes). It is nonetheless a surprise worth documenting: to thread a freshly-computed value into the same expression, use a local (`y := 99. Session bindings at: #x put: y. y`) instead of reading back through the view.
+- **Cross-session writes are not supported.** Instance-side `aSession bindings at:put:` / `removeKey:` against a session owned by *another* connection (obtained via `Session withId:`) would mutate that shell's state while its own in-flight eval worker holds an older snapshot — the worker's writeback would silently clobber the cross-session mutation, and the `pending_mutations` queue (which lives in the *calling* eval's flow) does not help the target. Because the only concrete cross-session use case — LSP/VS Code completion — needs **reads only**, cross-session `at:put:` / `removeKey:` / `clear` raise `#beamtalk_error{kind: cross_session_mutation_unsupported}` rather than racing. Cross-session **reads** (`keys`, `at:`, `resolve:`, `id`) are fully supported. This also keeps the F-over-B justification honest: the load-bearing win over Option B is cross-session *introspection*, not mutation.
+- **Stored `Session` / view lifetime.** A `Session` value (or a `BindingsView`) can outlive the shell it refers to — e.g. the user closes their REPL tab after an LSP session captured `Session withId: …`. `withId:` performs a liveness check (`resolve_pid`-style `is_process_alive`, not a raw `lookup`) and returns `nil` for a session that is gone. A `Session` value captured earlier whose shell *subsequently* dies raises `#beamtalk_error{kind: session_not_found}` on the next message send rather than blocking on a `gen_server:call` to a dead PID until timeout. Views are transient handles (like `FileHandle`); they are not durable references.
 - **Outside-REPL behaviour.** `Session current` returns `nil`; class-side methods like `Session bindings` raise a structured `no_session` error. Library code that wants graceful degradation must check `Workspace hasSession` first.
 - **`Session clear` is asymmetric with the view.** `Session bindings removeKey: #x` removes one binding; `Session clear` removes all. There is no `Session bindings clear` because the view's protocol is generic Dictionary semantics — `Session bindings` returns a *view*, not a Dictionary the user owns, so a `clear` on the view would be ambiguous (clear-the-view or clear-the-state). Keeping `Session clear` as a top-level method avoids this ambiguity.
 
@@ -357,32 +391,63 @@ Rejected because it locks in the violation of Principle 6 (messages all the way 
 
 ## Implementation
 
-The implementation breaks down into five phases. Each is independently shippable.
+The implementation breaks down into a Phase 0 wire-check plus five shippable phases.
 
-### Phase 1: Process-context plumbing (S)
+### Phase 0: Wire-check / napkin (XS)
 
-Modify `beamtalk_repl_shell:handle_call({eval, _}, ...)` to seed the eval worker's process dictionary with `beamtalk_session_pid` (the shell's `self()`) and `beamtalk_session_id` (the protocol session ID) before calling `do_eval`. This makes the calling session reachable from any primitive without explicit threading.
+Before building any of the surface, prove the single load-bearing assumption end-to-end: *a primitive running inside an eval worker can recover the calling session*. Seed the worker's process dictionary with `beamtalk_session_pid` / `beamtalk_session_id` at spawn, add a throwaway `beamtalk_session_primitives:id/0` that reads it back, and confirm `(Erlang beamtalk_session_primitives) id` returns the right id from a live eval — and `nil`/`no_session` from a non-eval context. One EUnit test plus one manual REPL round-trip. If this does not work cleanly (e.g. process-dictionary seeding interacts badly with the worker spawn or the streaming path), the rest of the design is re-examined before investing in `BindingsView` and `pending_mutations`.
 
-Add `pending_mutations` to `beamtalk_repl_state` — a queue of `{op, key, value}` tuples. Add an applicator that drains the queue at eval-result time, after merging the worker's returned state. This is the foundation for `Session clear` and `Session bindings at:put:` correctness during eval.
+### Phase 1: Process-context plumbing + pending-mutation merge (M)
 
-EUnit tests for the worker spawn seeding and the pending-mutation drain ordering.
+**Seed both eval spawn paths.** Modify the worker spawn in `beamtalk_repl_shell` to seed the worker's process dictionary with `beamtalk_session_pid` (the shell's `self()`) and `beamtalk_session_id` (the protocol session ID) before calling `do_eval`. There are **two** spawn paths and both must be seeded:
+- `handle_call({eval, _}, ...)` and `handle_call({eval_trace, _}, ...)` — the synchronous REPL path.
+- `handle_cast({eval_async, _, Subscriber}, ...)` — the streaming path (`do_eval/3`).
+
+A primitive that finds `get(beamtalk_session_pid) =:= undefined` reports `no_session` (class-side) or `nil` (`current`/`hasSession`); seeding only one path would make `Session` behave inconsistently between normal and streaming eval.
+
+**Add the `pending_mutations` queue.** Add `pending_mutations` to `beamtalk_repl_state` — a list of `{op, key, value}` tuples (`op ∈ {put, remove, clear}`) — with accessors mirroring the existing `pending_module_removals` field. Primitives **enqueue** rather than write directly. The queue is owned by the shell's `ShellState` (not the worker snapshot): primitives enqueue via a `gen_server:call` to the shell, which is safe from the worker because the shell is in `noreply` while the worker runs and is free to service its mailbox. Visibility is guaranteed by ordering: the worker's enqueue `gen_server:call` is synchronous and completes *before* the worker sends `{eval_result, …}`, so the shell processes every enqueue (updating its loop state) strictly before it processes the result message — the `ShellState` bound in the `eval_result` handler always reflects the enqueued mutations.
+
+**Add a `get_session_locals` gen_server call.** Add `handle_call(get_session_locals, ...)` to `beamtalk_repl_shell` returning `maps:without(get_injected_ws_keys(State), get_bindings(State))`. This is required for cross-session reads (Phase 2): the subtraction needs both the bindings map and the injected-key set, which only co-exist inside the owning shell's state. `get_bindings` alone (which returns the merged map) is insufficient.
+
+**Specify the merge order on every eval exit path.** The current eval-result handler does `apply_pending_removals(ShellState, WorkerState)` then (success only) `refresh_ws_bindings/1`. The drain slots in as follows:
+
+| Eval exit path | Handler | Action |
+|----------------|---------|--------|
+| Success | `handle_info({eval_result, _, {ok, ...}}, ...)` | `M1 = apply_pending_removals(ShellState, WorkerState)`; `M2 = apply_pending_mutations(ShellState, M1)`; `refresh_ws_bindings(M2)`. Mutations apply **on top of** the worker's returned bindings (so the worker's own `x := …` is visible) but **after** removals, and before ws-refresh re-injects globals. |
+| Error | `handle_info({eval_result, _, {error, ...}}, ...)` | `apply_pending_removals` + `apply_pending_mutations` for `put`/`remove` ops only, **no** `refresh_ws_bindings` (unchanged from today). `put`/`remove` are explicit per-key edits the user issued, independent of the failed expression, so they take effect. A queued **`clear`** (whole-session destruction) is **dropped** on the error path: `Session clear. someTypo` should not wipe every local because the line after `clear` failed. `clear` applies only on the success path. |
+| Interrupt | `handle_call(interrupt, ...)` | Drain `pending_mutations` alongside the existing `drain_pending_removals/1` so an interrupted eval's issued mutations are not lost. |
+| Worker crash | `handle_info({'DOWN', ...}, ...)` | **Discard** `pending_mutations` — a crashed worker's partial mutations are not trustworthy; drain removals as today but drop the mutation queue. |
+
+`apply_pending_mutations/2` reads the queue from `ShellState` and folds it over the merged bindings in enqueue order (`put`/`remove` per key, `clear` empties session-locals while preserving injected ws-keys), then resets the queue to `[]`.
+
+EUnit tests: worker-spawn seeding on **both** paths; `apply_pending_mutations` fold order; the four exit-path behaviours above (success/error apply, interrupt applies, crash discards); and a `clear`-then-`put` ordering case.
 
 ### Phase 2: Runtime primitives module (M)
 
 Create `beamtalk_session_primitives.erl` in `runtime/apps/beamtalk_workspace/src/`. Each primitive resolves the session via `get(beamtalk_session_pid)` (or the explicit Session instance for the `*For:` variants):
 
 - `current/0` — returns a Session value with the calling session's PID and ID, or `nil`.
-- `withId/1` — looks up a session by protocol ID via `beamtalk_session_table:lookup/1`, returns Session or nil.
-- `bindingsView/0` — returns a `BindingsView` value tagged for session-local scope, bound to the calling session.
-- `globalsView/0` — returns a `BindingsView` value tagged for workspace scope (shared across sessions).
-- `bindingsViewFor/1`, `clearFor/1` — instance variants (target a specific Session value).
+- `withId/1` — looks up a session by protocol ID and **checks liveness** (`is_process_alive`, the `resolve_pid` discipline — not a raw `beamtalk_session_table:lookup/1`, which can return a dead PID). Returns a Session value or `nil`.
+- `bindingsView/0` — returns a `BindingsView` tagged for session-local scope, bound to the calling session.
+- `globalsView/0` — returns a `BindingsView` tagged for workspace scope (shared across sessions). Note `globals` carries no per-session identity; the instance-side `globals` returns the same shared view for any receiver.
+- `bindingsViewFor/1` — instance variant; the view records the **target** session id so cross-session reads resolve against it and cross-session writes can be rejected.
 - `resolve/1`, `resolve/2` — walk session locals first, then workspace globals; return value or nil.
-- `clear/0`, `clearFor/1` — enqueue a clear mutation via the shell's pending-mutations API (Phase 1).
-- `id/0` — reads `beamtalk_session_id` from process dictionary.
+- `clear/0`, `clearFor/1` — enqueue a clear mutation via the shell's pending-mutations API (Phase 1). `clearFor/1` against a non-self session raises `cross_session_mutation_unsupported`.
+- `id/0`, `idOf/1` — read `beamtalk_session_id` (process dictionary) / extract it from a Session value.
 
-Plus the BindingsView read/write primitives: `view_at/2`, `view_at_put/3`, `view_remove/2`, `view_keys/1`, `view_size/1`. Session-scope writes enqueue against the shell's pending-mutations queue; workspace-scope writes route through `beamtalk_workspace_interface_primitives:bind/2` and `unbind/1`, inheriting protected-name conflict checks.
+**Session-locals vs. merged map — and why it must be computed shell-side.** Because workspace globals are *injected* into each shell's single bindings map at init (`inject_workspace_bindings/1`, BT-883) and refreshed after each eval, "session locals" is not a separate map — it is the bindings map **minus** the injected keys. The filter is `maps:without(get_injected_ws_keys(State), get_bindings(State))`.
 
-EUnit tests for each primitive, including cross-session access via `withId/1`.
+The two operands (`bindings` and `injected_ws_keys`) live *together* in a shell's `beamtalk_repl_state`, so the subtraction can only be done where both are in hand — **on the owning shell**. The existing `get_bindings` gen_server call returns only the merged map (`beamtalk_repl_shell.erl:235`), with no companion call for the injected-key set; computing locals on the *reader* side is therefore impossible for a cross-session target. Phase 1 must add a `get_session_locals` gen_server call to `beamtalk_repl_shell` that performs the subtraction and returns session-locals directly. Both `bindingsView/0` (calls its own shell) and `bindingsViewFor/1` (calls the target shell) route through it, so local and cross-session reads share one code path and one definition of "locals".
+
+Use `get_injected_ws_keys/1` (the per-session dynamic set, which *includes* `bind:as:` names) — **not** `beamtalk_workspace_config:binding_names/0`, which lists only the static singletons and excludes `bind:as:` names. The two are not interchangeable. This is a deliberate behaviour change from today's `:bindings` op (which filters with `binding_names/0` and therefore *shows* `bind:as:` names): under this ADR `bind:as:` names move out of `Session bindings` and into `Session globals`, which is the correct home for them (see Migration Path). This is the load-bearing step that keeps `Session bindings` (locals) and `Session globals` (injected ws-keys + ETS) disjoint.
+
+**Liveness on every cross-session send.** A `Session` value captured earlier may outlive its shell. The `*For:` / `idOf:` primitives check `is_process_alive` on the carried PID and raise `#beamtalk_error{kind: session_not_found}` rather than issuing a `gen_server:call` that blocks to timeout against a dead PID.
+
+Plus the BindingsView read/write primitives: `view_at/2`, `view_at_put/3`, `view_remove/2`, `view_keys/1`, `view_size/1`. Session-scope writes for the **calling** session enqueue against its pending-mutations queue; session-scope writes targeting **another** session (a cross-session `BindingsView`) raise `cross_session_mutation_unsupported`. Workspace-scope writes route through `beamtalk_workspace_interface_primitives:bind/2` and `unbind/1`, inheriting protected-name conflict checks.
+
+**Two write models, by design.** Session-scope writes are *deferred* (queued, applied at eval-end — the read-your-own-writes lag in Consequences). Workspace-scope writes are *synchronous*: `bind/2` / `unbind/1` hit the shared ETS table immediately, exactly as `Workspace bind:as:` does today. The asymmetry is intrinsic — session state is per-shell and snapshot-isolated during eval, workspace state is shared ETS. One consequence: a mid-eval `Session globals at:put:` is written to ETS at once but is not re-injected into the shell's bindings map until `refresh_ws_bindings` runs, which (as today for `bind:as:`) happens only on the **success** path; on the error path the injected copy stays stale until the next successful eval. This matches existing `bind:as:` behaviour and is not a regression.
+
+EUnit tests for each primitive, including: cross-session **read** via `withId/1`, cross-session **write** rejection, the session-locals filter, and a dead-session `session_not_found` case.
 
 ### Phase 3: Stdlib `Session` and `BindingsView` classes (M)
 
@@ -394,9 +459,13 @@ No binding injection: `Session` is reachable as a class name through the class r
 
 Add `currentSession` and `hasSession` to `WorkspaceInterface` (Beamtalk class), each delegating to a one-line primitive that reads the same `beamtalk_session_pid` process dictionary key seeded in Phase 1. Returns the same value as `Session current` (or its boolean).
 
-### Phase 5: Remove `:bindings` and `:clear` meta-commands (S)
+### Phase 5: Remove `:bindings` and `:clear` meta-commands (M)
 
-Delete the `<<"bindings">>` and `<<"clear">>` op handlers in `beamtalk_repl_ops_eval.erl` and remove their entries from `beamtalk_repl_ops_dev.erl`'s op map. Update `surface-parity.md` rows for `bindings` and `clear` to cite `via Session bindings` / `via Session clear`. Update any existing e2e tests that exercised the meta-commands to use the new Session API. Add an e2e btscript test under `tests/repl-protocol/cases/` covering the full Session API including cross-session access (`Session withId:`).
+Delete the `<<"bindings">>` and `<<"clear">>` op handlers in `beamtalk_repl_ops_eval.erl` and remove their entries from `beamtalk_repl_ops_dev.erl`'s op map. Update `surface-parity.md` rows for `bindings` and `clear` to cite `via Session bindings` / `via Session clear`.
+
+**Bindings-changed push is preserved; only the fetch moves.** The `{bindings_changed, SessionId}` pub/sub (`beamtalk_bindings_events`, fired by the shell after each successful eval) is *not* removed — the VS Code sidebar still relies on it to know *when* to refresh. What changes is *how* the client fetches after the notification: it moves from the removed `bindings` op to `evaluate "Session bindings keys"` (and `Session globals keys`) carrying the user's `session` id, or to `Session withId:` + instance reads. This is a client-side change in the VS Code extension and must land with this phase, not after it — otherwise the sidebar refreshes against a dead op.
+
+**Test migration is non-trivial.** Migrating `:bindings` / `:clear` from meta-commands to evaluated expressions changes the protocol op (`bindings`/`clear` → `eval`) and therefore the response shape (a bindings map → an eval result value). Existing `tests/repl-protocol/cases/*.btscript` cases that assert on the old op responses need real rewrites, not find-replace — audit and enumerate them before locking the estimate. Add a new e2e btscript case covering the full Session API including cross-session read access (`Session withId:`) and cross-session write rejection.
 
 ## Migration Path
 
@@ -404,7 +473,7 @@ The `:bindings` and `:clear` meta-commands are removed in Phase 5; the replaceme
 
 | Before | After |
 |--------|-------|
-| `:bindings` | `Session bindings keys` (session locals only) <br> `Session globals keys` (workspace globals) |
+| `:bindings` | `Session bindings keys` (session locals only) <br> `Session globals keys` (workspace globals) <br> ⚠️ **behaviour change:** `:bindings` today (via `binding_names/0`) *shows* `bind:as:` names mixed in; under this ADR they move to `Session globals` and no longer appear in `Session bindings`. |
 | `:clear` | `Session clear` |
 | (no equivalent) | `Session bindings at: #x put: 99` (live mutation) |
 | (no equivalent) | `Session bindings removeKey: #x` |
@@ -423,6 +492,7 @@ The meta-commands existed only on the REPL surface. Removing them is a small los
 - ADR 0004 — Persistent Workspace Management (workspace lifecycle context)
 - `runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl:62-77` — current `:bindings` / `:clear` handlers
 - `runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl:155-244` — shell init and binding lifecycle
-- `runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl:765-786` — workspace-globals injection
+- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl:432` — `inject_workspace_bindings/1` (the actual injection of workspace globals into session bindings at init)
+- `runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl:765-786` — `handle_session_bindings/1` (resolves singletons + `bind:as:` entries that injection copies in)
 - `runtime/apps/beamtalk_workspace/src/beamtalk_session_table.erl` — session registry
 - Pharo Workspace `bindings` accessor; Squeak `Environment`; IPython `get_ipython()` — prior art for first-class binding scope objects

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -64,6 +64,9 @@ sealed typed Object subclass: Session
 
   /// Walk binding layers, return first match or nil.
   /// Lookup order: session locals → workspace globals.
+  /// Primarily a REPL debugging tool: answers "where does this name
+  /// resolve from?" interactively. Compiled code uses normal scope
+  /// resolution; this method is for introspection, not dispatch.
   resolve: aName :: Symbol -> Object =>
     (Erlang beamtalk_session_primitives) resolve: aName
 
@@ -71,7 +74,10 @@ sealed typed Object subclass: Session
   clear -> Nil =>
     (Erlang beamtalk_session_primitives) clear
 
-  /// Layer name symbols, in resolution order.
+  /// Layer name symbols, in resolution order. Stable — Beamtalk's binding
+  /// model has exactly two layers (session locals over workspace globals)
+  /// and no plan for additional layers. Package-level encapsulation
+  /// (ADR 0070) is class-scoped, not a binding-resolution layer.
   layers -> List(Symbol) => #(#session, #workspace)
 
   /// Stable session identifier (matches the protocol session ID).
@@ -166,7 +172,7 @@ The session-as-object model is recognisably Smalltalk: `Session` is to a Beamtal
 `Workspace sessions` (a follow-up extension) can return a list of `Session` objects, each individually inspectable. Compared to opaque PIDs in `supervisor:which_children`, this gives operators a structured view of who is connected and what they have bound.
 
 **Tooling developer (LSP / VS Code).**
-LSP completions can call `Session resolve: aSymbol` to mirror the runtime resolution path exactly, instead of duplicating the merge-and-shadow logic. The MCP server can call `Session bindings` directly via `evaluate` to display per-session state in the inspector panel.
+The MCP server can call `Session bindings` and `Session globals` via `evaluate` to display per-session state in the inspector panel. Tooling that needs the merged binding map (e.g. completions) merges those two Dictionaries in resolution order — no separate primitive needed.
 
 ## Steelman Analysis
 

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -84,11 +84,12 @@ sealed typed Object subclass: Session
   bindings -> BindingsView =>
     (Erlang beamtalk_session_primitives) bindingsViewFor: self
 
-  /// Walk both binding layers, return first match or nil.
-  /// Lookup order: session locals → workspace globals.
-  /// Primarily a REPL debugging tool: answers "where does this name
-  /// resolve from?" interactively. Reads workspace globals internally
-  /// (the same registries name resolution uses).
+  /// Resolve a name exactly the way bare-name lookup does, returning the
+  /// first match or nil. Order: session locals → workspace globals
+  /// (bind:as: + singletons) → class registry. Primarily a REPL debugging
+  /// tool: answers "where does this name resolve from?" interactively.
+  /// Uses the one shared resolver (see "Binding storage model"), so it can
+  /// never disagree with how the name actually resolves.
   resolve: aName :: Symbol -> Object =>
     (Erlang beamtalk_session_primitives) resolveFor: self name: aName
 
@@ -162,7 +163,7 @@ userSession ifNotNil: [
   candidates := userSession bindings keys
 ]
 
-// Or for full search across all sessions (future):
+// Discover session ids without knowing them out-of-band (Phase 7):
 Workspace sessions collect: [:s | s id]
 ```
 
@@ -566,7 +567,9 @@ The meta-commands existed only on the REPL surface. Removing them is a small los
 - ADR 0004 — Persistent Workspace Management (workspace lifecycle context)
 - `runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl:62-77` — current `:bindings` / `:clear` handlers
 - `runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl:155-244` — shell init and binding lifecycle
-- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl:432` — `inject_workspace_bindings/1` (the actual injection of workspace globals into session bindings at init)
-- `runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl:765-786` — `handle_session_bindings/1` (resolves singletons + `bind:as:` entries that injection copies in)
+- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl:432` — `inject_workspace_bindings/1` (today's eager injection of workspace globals into session bindings at init; **removed in Phase 1** in favour of lazy resolution)
+- `runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl:765-786` — `handle_session_bindings/1` (resolves singletons + `bind:as:` entries that injection copies in today)
+- `runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl` — `globals/0` (the `Workspace globals` primitive, upgraded to a live `BindingsView` in Phase 4)
+- `crates/beamtalk-mcp/src/server.rs` — the `get_bindings` MCP tool (removed in Phase 6)
 - `runtime/apps/beamtalk_workspace/src/beamtalk_session_table.erl` — session registry
 - Pharo Workspace `bindings` accessor; Squeak `Environment`; IPython `get_ipython()` — prior art for first-class binding scope objects

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -1,7 +1,7 @@
 # ADR 0081: First-Class Session Object — Walkable Binding Layers
 
 ## Status
-Proposed (2026-05-09)
+Accepted (2026-06-01)
 
 ## Context
 

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -38,63 +38,106 @@ The CLI REPL has one session. WebSocket and MCP clients can have many — `beamt
 - **Hot reload safety.** Session locals must persist across `Workspace sync` and class reloads (current behaviour).
 - **Existing infrastructure.** `beamtalk_session_table`, `beamtalk_session_sup`, and the `sessions` protocol op already exist — the design should build on them rather than replace.
 - **Surface parity.** `:bindings` / `:clear` work in the REPL surface only; the object-level replacement must be reachable from MCP `evaluate`, LSP eval, and any future client.
-- **Call safety.** Session primitives call back to the shell gen_server via `gen_server:call`. This is safe from eval worker processes (the shell is in `noreply` state, processing its mailbox). It is NOT safe from `handle_call`/`handle_cast` handlers running directly on the shell process (would deadlock). Session methods must only be called from eval context, never from shell-internal dispatch.
+- **Call safety.** Session primitives call back to the shell gen_server via `gen_server:call`. This is safe from eval worker processes (the shell is in `noreply` state, processing its mailbox), but unsafe from `handle_call`/`handle_cast` handlers running directly on the shell process (would deadlock). Session methods are intended for eval context, not shell-internal dispatch.
 
 ## Decision
 
-Introduce a new `Session` class — a lightweight `Object subclass` that wraps a session shell PID — and make it accessible via two paths:
+Introduce a new `Session` class with a **class-side API** as the primary interface. The class itself is the entry point — `Session bindings` is a class-side message send, mirroring Smalltalk patterns like `Date today`, `Time now`, and `Smalltalk current`. There is **no injected `Session` binding** at the shell level; the class is reachable because it is loaded, not because it was singled out.
 
-1. **Per-session binding `Session`**, injected into the shell's binding map at startup (alongside `Transcript`, `Beamtalk`, `Workspace`). Each shell sees a `Session` binding pointing to *its own* session object.
-2. **`Workspace currentSession`**, a method on the existing `WorkspaceInterface` singleton that resolves the current eval's session via process context. Returns `nil` outside a REPL eval context. A companion **`Workspace hasSession`** predicate returns `true` or `false`, allowing library code to guard session-dependent logic without nil-checking.
+`Session` is **not** an Actor (gen_server). It is a Beamtalk class whose class-side methods delegate to `beamtalk_session_primitives`, which uses process-context resolution (process dictionary seeded during eval worker spawn) to find the calling session.
 
-`Session` is **not** an Actor (gen_server). It is a handle object whose methods delegate to the shell process via `gen_server:call`. Similar to how `Ets` wraps a table reference without exposing it as a Beamtalk field, Session's internal shell PID is managed by the primitives module, not stored in a user-visible `field:`.
+`Session bindings` and `Session globals` return **live binding views** — mutating them writes through to the underlying state. `view at: #x put: 42` sets a session-local; `view removeKey: #x` removes it. Globals mutations route through the existing `bind:as:` / `unbind:` machinery and inherit those conflict checks.
 
 ### API
 
 ```beamtalk
 sealed typed Object subclass: Session
 
-  /// Session-local bindings only (the `x := 42` layer).
-  bindings -> Dictionary(Symbol, Object) =>
-    (Erlang beamtalk_session_primitives) bindings
+  /// Live view of session-local bindings. Reads return current values;
+  /// `at:put:` and `removeKey:` mutate session state directly.
+  class bindings -> BindingsView =>
+    (Erlang beamtalk_session_primitives) bindingsView
 
-  /// Workspace globals visible to this session (singletons + bind:as:).
-  globals -> Dictionary(Symbol, Object) =>
-    (Erlang beamtalk_session_primitives) globals
+  /// Live view of workspace globals (singletons + bind:as: entries).
+  /// Mutations route through `Workspace bind:as:` / `unbind:`, including
+  /// the existing protected-name conflict checks for system singletons.
+  class globals -> BindingsView =>
+    (Erlang beamtalk_session_primitives) globalsView
 
   /// Walk binding layers, return first match or nil.
   /// Lookup order: session locals → workspace globals.
   /// Primarily a REPL debugging tool: answers "where does this name
-  /// resolve from?" interactively. Compiled code uses normal scope
-  /// resolution; this method is for introspection, not dispatch.
-  resolve: aName :: Symbol -> Object =>
+  /// resolve from?" interactively.
+  class resolve: aName :: Symbol -> Object =>
     (Erlang beamtalk_session_primitives) resolve: aName
 
-  /// Clear session-local bindings. Workspace globals remain.
-  clear -> Nil =>
+  /// Clear all session-local bindings. Workspace globals remain.
+  class clear -> Nil =>
     (Erlang beamtalk_session_primitives) clear
 
-  /// Layer name symbols, in resolution order. Stable — Beamtalk's binding
-  /// model has exactly two layers (session locals over workspace globals)
-  /// and no plan for additional layers. Package-level encapsulation
-  /// (ADR 0070) is class-scoped, not a binding-resolution layer.
-  layers -> List(Symbol) => #(#session, #workspace)
-
   /// Stable session identifier (matches the protocol session ID).
-  id -> String => (Erlang beamtalk_session_primitives) id
+  class id -> String =>
+    (Erlang beamtalk_session_primitives) id
+
+  /// Return the calling process's session as a value, for pass-by-reference.
+  /// Returns `nil` outside a REPL eval context.
+  class current -> Session | Nil =>
+    (Erlang beamtalk_session_primitives) current
+
+  /// Look up a session by its protocol session ID (returns nil if no
+  /// such session). Used for cross-session access — see "Cross-session
+  /// access (LSP, VS Code)" below.
+  class withId: aSessionId :: String -> Session | Nil =>
+    (Erlang beamtalk_session_primitives) withId: aSessionId
+
+  // Instance-side methods (used when a Session value is passed around):
+  bindings -> BindingsView =>
+    (Erlang beamtalk_session_primitives) bindingsViewFor: self
+  globals -> BindingsView =>
+    (Erlang beamtalk_session_primitives) globalsView
+  resolve: aName :: Symbol -> Object =>
+    (Erlang beamtalk_session_primitives) resolve: aName for: self
+  clear -> Nil =>
+    (Erlang beamtalk_session_primitives) clearFor: self
+  id -> String => self.id
 ```
 
-The shell PID is not stored in Beamtalk-level fields. Primitives resolve the calling session from process context (process dictionary seeded during eval worker spawn), matching the pattern used by `Ets` and other runtime-backed objects.
+`BindingsView` is a small Dictionary-protocol-compatible class backed by primitives that read/write session or workspace state. It implements `at:`, `at:put:`, `removeKey:`, `includesKey:`, `keys`, `values`, `size`, and `do:`. Mutations via `at:put:` / `removeKey:` are write-through.
 
-**`Session` itself is a system-injected binding.** It does not appear in `Session bindings` (that shows user-typed locals only) and does not appear in `Session globals` (that shows workspace-level globals from ETS). It is part of the `injected_ws_keys` set — visible during normal name resolution, but excluded from the per-layer introspection views. `Session resolve: #Session` returns the Session object (it walks the merged binding map). This is consistent with how `Transcript`, `Beamtalk`, and `Workspace` are treated by the existing `:bindings` meta-command, which already strips system bindings from its output.
+**No injected binding.** `Session` is a class name resolved through the class registry, like `Counter` or `Integer`. It cannot be shadowed by a user `:=` assignment because class names are not in the binding map; assigning `Session := foo` creates a local binding that shadows the class reference *only in that local scope*, the same way assigning `Counter := foo` works. This is normal Smalltalk behaviour and not a footgun specific to Session.
+
+`Workspace currentSession` is **also** retained on `WorkspaceInterface` as a navigation method — Workspace is a discovery entry point, and "find the current session" fits the pattern of `Workspace actors`, `Workspace supervisor`, etc. It returns the same value as `Session current`. A companion `Workspace hasSession` predicate returns true/false, useful for library code that conditionally uses session state.
+
+### Cross-session access (LSP, VS Code)
+
+The VS Code extension and LSP open their own protocol sessions for completion queries, but need to read bindings from the *user's* REPL session. This is currently handled at the protocol layer (BT-1045): the `bindings` op carries a `session` parameter and `beamtalk_session_table:resolve_pid/2` looks up the target shell.
+
+The new Session API supports this cleanly:
+
+```beamtalk
+// On the LSP completion session:
+userSession := Session withId: "user-repl-abc-123"  // returns Session | Nil
+userSession ifNotNil: [
+  candidates := userSession bindings keys
+]
+
+// Or for full search across all sessions (future):
+Workspace sessions collect: [:s | s id]
+```
+
+The class-side methods (`Session bindings`) operate on the calling process's session — semantically "my session". The instance-side methods (`aSession bindings`) operate on whichever session the value represents, including ones owned by other connections. This is the load-bearing reason for instance methods on `Session`: cross-session access from tooling.
+
+The LSP and any other client that previously called the `bindings` / `clear` protocol ops moves to `Session withId:` + instance methods in the same release.
 
 ### REPL Examples
 
 ```text
 beamtalk> x := 42
 42
-beamtalk> Session bindings
-#{#x => 42}
+beamtalk> Session bindings keys
+#(#x)
+beamtalk> Session bindings at: #x
+42
 beamtalk> Session globals keys
 #(#Transcript, #Beamtalk, #Workspace)
 beamtalk> Session resolve: #x
@@ -103,52 +146,89 @@ beamtalk> Session resolve: #Transcript
 #<TranscriptStream>
 beamtalk> Session resolve: #notDefined
 nil
-beamtalk> Session layers
-#(#session, #workspace)
+
+// Live mutations write through:
+beamtalk> Session bindings at: #y put: 99
+99
+beamtalk> y
+99
+beamtalk> Session bindings removeKey: #x
+nil
+beamtalk> x
+// => #beamtalk_error{kind: undefined_variable, name: #x}
+
+// Globals mutations route through bind:as: / unbind:
+beamtalk> Session globals at: #MyTool put: someActor
+nil
+beamtalk> MyTool
+#<Counter @ <0.123.0>>
+beamtalk> Session globals removeKey: #MyTool
+nil
+
+// Pass-by-reference (cross-session access from LSP / tooling):
+beamtalk> userSession := Session withId: "user-repl-abc-123"
+#<Session: "user-repl-abc-123">
+beamtalk> userSession bindings keys
+#(#x, #y, #counter)
+
 beamtalk> Workspace currentSession id
 "abc123-..."
 beamtalk> Session clear
 nil
-beamtalk> Session bindings
-#{}
-beamtalk> Session globals keys
-#(#Transcript, #Beamtalk, #Workspace)
+beamtalk> Session bindings keys
+#()
 ```
 
 ### Error Examples
 
-Outside a REPL eval (compiled program code), `Workspace currentSession` returns `nil`:
+Outside a REPL eval, `Session current` and `Workspace currentSession` return `nil`:
 
 ```beamtalk
 // In a .bt file run via `beamtalk run`:
+Session current        // => nil
 Workspace currentSession  // => nil
-Workspace currentSession bindings
-// => #beamtalk_error{kind: does_not_understand, selector: #bindings, receiver: nil}
+Workspace hasSession   // => false
 ```
 
-Calling `Session` from a context where it is not bound:
+Class-side `Session bindings` outside a REPL session raises a structured error:
 
 ```beamtalk
-// In compiled program code, Session is not in scope:
 Session bindings
-// => #beamtalk_error{kind: undefined_variable, name: #Session}
+// => #beamtalk_error{kind: no_session, message: "no session in scope"}
+```
+
+Cross-session `withId:` for an unknown session ID returns nil:
+
+```beamtalk
+Session withId: "nonexistent"  // => nil
+```
+
+Globals mutations that violate protected-name rules raise the existing `bind:as:` error:
+
+```beamtalk
+Session globals at: #Workspace put: nil
+// => #beamtalk_error{kind: name_conflict, selector: #'bind:as:',
+//    message: "Workspace is a system name and cannot be shadowed"}
 ```
 
 ### Open Design Questions — Resolved
 
 | Question | Decision | Rationale |
 |----------|----------|-----------|
-| Singleton or per-PID? | **Per-PID** | CLI has one session, but WebSocket/MCP clients have many. Each shell injects its own `Session` binding; `Workspace currentSession` resolves from eval context. |
-| What outside REPL eval? | **`nil`** for `Workspace currentSession`; `Session` binding not present. | Compiled program code has no session. Returning a stub object would mask the meaningful absence. |
+| Singleton or per-PID? | **Per-PID** | CLI has one session, WebSocket/MCP clients can have many. Class-side methods use process-context resolution to find the calling session; instance methods carry their own session ID for cross-session access. |
+| What outside REPL eval? | **`Session current` returns `nil`**; class-side methods like `Session bindings` raise a structured `no_session` error. | Compiled program code has no session. Returning a stub or nil from `bindings` would mask the meaningful absence; an error is louder. |
 | Persist across `:sync` / reload? | **Yes** — unchanged from current behaviour. | Session locals are shell-process state, owned independently of class definitions. Sync rebuilds modules; the session keeps its bindings. |
-| Expose `parent` for layer walking? | **No, not initially.** | Two layers; `bindings` and `globals` cover both. Parent links can be added later if a third layer (e.g. per-module scope) appears. Keeps the initial surface small. |
-| `bind:as:` interaction? | **Unchanged.** `Workspace bind:value as:#name` continues to write to the workspace ETS layer. Visible via `Session globals`. | `bind:as:` is workspace-scoped (shared across sessions). Confirms the layer separation: session = per-PID, workspace = shared. |
+| Are bindings/globals views live or snapshots? | **Live views.** Mutations write through. | Matches Pharo semantics (`Smalltalk globals at:put:`). A snapshot would force a parallel setter API (`Session at:put:`); the live view collapses both into one Dictionary protocol. |
+| Layer-walking abstraction? | **Dropped.** No `layers` method, no recursive `parent`. | Beamtalk has settled on exactly two layers; package encapsulation (ADR 0070) is class-scoped, not a binding-resolution layer. A `layers` constant would be pure decoration. |
+| `bind:as:` interaction? | **Unchanged.** `Session globals at:put:` is equivalent to `Workspace bind:as:`, including conflict checks. | One write path through the existing primitives; the new view is sugar over the established API. |
+| Cross-session access? | **Instance methods + `Session withId:`** | LSP/VS Code completion sessions need to query the user's session. Class-side methods are "my session"; instance methods are "that session". |
 
 ## Prior Art
 
 | System | Binding model | What we adopt | What we reject |
 |--------|---------------|---------------|----------------|
-| **Pharo / Squeak Workspace** | `Dictionary` of bindings on the workspace, with fallback to `Smalltalk globals`. Methods: `bindings`, `bindingOf:`, `removeBinding:`, `resetBindings`. | The flat-Dictionary shape and the `bindings` accessor name. | Pharo merges workspace and session — Beamtalk has separate workspace (shared) and session (per-PID) layers because of multi-client BEAM hosting. |
+| **Pharo `Smalltalk current` / `Date today` / `Time now`** | Class-side methods that return a "current" instance — the class itself is the entry point. | The class-as-entry-point pattern (`Session bindings` is a class-side message, like `Date today`). | None — this is the load-bearing prior art for Option F. |
+| **Pharo / Squeak Workspace** | `Dictionary` of bindings on the workspace, mutable via `at:put:`, with fallback to `Smalltalk globals`. Methods: `bindings`, `bindingOf:`, `removeBinding:`, `resetBindings`. | The mutable-Dictionary shape (`Session bindings at:put:` writes through, matching `Smalltalk globals at:put:`). | Pharo merges workspace and session — Beamtalk has separate workspace (shared) and session (per-PID) layers because of multi-client BEAM hosting. |
 | **Pharo Environment** | Wraps a `Dictionary` of globals; multiple Environments allowed. | Layer reification via named accessors. | Beamtalk does not need user-creatable environments — workspace is bootstrapped once per BEAM node. |
 | **Newspeak** | Lexical nesting only; no global namespace; capability passing via constructor parameter. | The principle that scope is explicit, not magic. | Beamtalk has Smalltalk-style globals (`Transcript`, classes); a fully-lexical model would invalidate the existing namespace design. |
 | **Self** | Parent slot chain; scope walks via `parent*` slots. | Layer ordering as a first-class concept (`layers` returns the resolution order). | Recursive `parent` chains overstate the complexity for two layers. |
@@ -188,12 +268,12 @@ The MCP server can call `Session bindings` and `Session globals` via `evaluate` 
 
 **Language designer:** "Adding methods is cheaper than adding classes. The composability argument for first-class Session is partly speculative — today nobody writes `Workspace sessions collect: [:s | s bindings]`. YAGNI."
 
-**Why not adopted:** The BEAM-veteran argument is the strongest — Option B *works* for the common case and avoids the injected-binding shadowing problem. Two factors push us to A despite this:
+**Why not adopted:** Option B *works* for the common case and is genuinely simpler. Two factors push us to F (class-side Session) despite this:
 
-1. **Pass-by-reference.** `Session` as a value can be stored, passed to library code, or returned from `Workspace sessions`. Option B cannot express `analyzer analyze: aSession` — there's no first-class session value to pass.
-2. **Workspace's role.** `Workspace` is a navigation entry point — `Workspace actors`, `Workspace classes`, `Workspace supervisor`, `Workspace dependencies` — each method *finds you something*. Session bindings are not something you navigate to from the workspace; they belong to a session, which has its own identity. Loading session-state methods directly onto `Workspace` would be the same category error as putting `Counter increment` on `Workspace`. Four new session-state methods on `Workspace` is too much.
+1. **Pass-by-reference.** `Session` as a value can be stored, passed to library code, or used for cross-session access — `Session withId:` for LSP completion against the user's session, `Workspace sessions collect: [:s | s id]` for multi-session enumeration. Option B cannot express any of these without inventing per-call session-id parameters.
+2. **Workspace's role.** `Workspace` is a navigation entry point — `Workspace actors`, `Workspace classes`, `Workspace supervisor`, `Workspace dependencies` — each method *finds you something*. Session bindings are not something you navigate to from the workspace; they belong to a session, which has its own identity. Loading four session-state methods (`sessionBindings`, `sessionGlobals`, `clearSession`, `resolveBinding:`) directly onto `Workspace` would be the same category error as putting `Counter increment` on `Workspace`. The class-side `Session` API keeps the surface focused.
 
-The shadowing footgun (Option B's genuine advantage) is mitigated by the proposed shadowing warning. The ergonomic loss in Option B (no first-class session value) is permanent and not mitigable.
+Option F gives us almost all of B's simplicity (no injection, no shadowing, no `injected_ws_keys` plumbing) plus pass-by-reference for the cross-session and multi-session cases that B cannot express.
 
 ### Option C: Recursive Scope Chain (rejected)
 
@@ -211,12 +291,22 @@ The shadowing footgun (Option B's genuine advantage) is mitigated by the propose
 
 ### Tension Points
 
-- **Common-case ergonomics vs. composability.** Option B genuinely wins for the introspect-your-own-session case (no injected binding to shadow, no new class to learn). Option A wins when sessions need to be passed as values or enumerated. The decision turns on whether composability matters enough to pay the shadowing-warning cost.
-- **`Session` as injected binding** is the load-bearing footgun. Without it, Option A loses much of its ergonomic advantage (you'd always type `Workspace currentSession bindings`). With it, we add a name that can be shadowed by `:=`. The shadowing warning is the bridge.
-- **Speculative future use.** `Workspace sessions collect: [:s | s bindings]` is not exercised by any current caller. We're paying class-design complexity for a use case that today only appears in the Consequences section. Honest assessment: if this stays unused for 12 months, the value of a first-class Session over Option B is substantially weaker.
-- **Two layers is settled.** Option C's strongest argument (future layer flexibility) requires bet-against-settled-design. Both A and C agree the current need is two layers; A says "two named accessors", C says "n-arity chain". Given Beamtalk's commitment to two layers, A is the right level of generality.
+- **Class-side vs. injected-binding ergonomics.** Both are two words to type (`Session bindings` either way). The class-side approach wins on principled grounds — Pharo's `Date today` / `Smalltalk current` pattern is the right precedent for a per-PID "current" value. The injected-binding approach (Alternative A) was the original sketch but pretends Session is a singleton when it isn't.
+- **The LSP cross-session case is real, not speculative.** BT-1045 already established the protocol-level cross-session pattern; the LSP runs its own completion session and queries the user's session for bindings. Option B has no Beamtalk-native expression of this; Option F's `Session withId:` does.
+- **Live mutation cost.** Pharo-style `Smalltalk globals at:put:` write-through is genuinely useful, but adds a `pending_mutations` queue to `beamtalk_repl_state` to handle eval-ordering. This complexity is paid regardless of class-side vs. injected-binding — it's a property of the live-view decision, not the entry-point decision.
+- **Two layers is settled.** Option C's strongest argument (future layer flexibility) requires bet-against-settled-design. Beamtalk has committed to exactly two binding layers; package encapsulation (ADR 0070) is class-scoped, not a binding-resolution layer.
 
 ## Alternatives Considered
+
+### Alternative A: Per-session injected `Session` binding
+
+The original sketch in BT-2092 — inject `Session` as a per-shell binding (alongside `Transcript`, `Beamtalk`, `Workspace`) so `Session bindings` resolves to an instance method on the injected value.
+
+Rejected because:
+- **Less Smalltalk than the class-side approach.** Pharo's pattern for "the current X" is class-side (`Date today`, `Time now`, `Smalltalk current`), not a top-level singleton binding. Sessions are per-PID, not singular — injecting them as if they were singletons is dishonest.
+- **Shadowing footgun.** `Session := MyThing new` in the shell silently overwrites the injected binding. The existing `bind:as:` conflict checks don't catch shell-level `:=`. Mitigating this requires a new compiler warning, which is cost we don't pay if there is no injected binding.
+- **Implementation complexity.** Requires extending `injected_ws_keys`, modifying `inject_workspace_bindings`, adding `Session` to `is_protected_name/1`, and a clear-and-reinject loop. The class-side approach skips all of this.
+- **Tooling parity is messier.** Cross-session access (LSP completion against the user's session) doesn't fit naturally — the LSP's session sees its own injected `Session`, not the user's. Class-side methods plus `Session withId:` separate "my session" from "that session" cleanly.
 
 ### Alternative B: Workspace extension methods (no new class)
 
@@ -242,16 +332,6 @@ Accept the surface asymmetry permanently and document `bindings` / `clear` as RE
 
 Rejected because it locks in the violation of Principle 6 (messages all the way down) and ADR 0040 (workspace-native commands), and leaves the session layer permanently invisible to MCP and other clients.
 
-### Alternative E: Hybrid — Session class with no injected binding
-
-Define the `Session` class (as in Option A) so that `Workspace currentSession` can return one, but skip the per-shell `Session` binding injection. Users always type `Workspace currentSession bindings` — never the shorter `Session bindings`.
-
-This was considered as a way to capture A's composability (pass-by-reference, multi-session enumeration) while eliminating the shadowing footgun (no injected binding to overwrite via `:=`).
-
-Rejected because:
-- The 99% interactive case becomes verbose: `Workspace currentSession bindings` four words long for an operation users will type repeatedly.
-- It miscategorises `Workspace`'s role. `Workspace` is a navigation entry point — methods on `Workspace` *find you something*. `currentSession` fits that pattern; making it the *only* path to session ops loses the directness of `Session bindings`.
-- The shadowing footgun is mitigable via the proposed compiler warning. The verbosity cost of E is permanent and not mitigable.
 
 ## Consequences
 
@@ -265,66 +345,75 @@ Rejected because:
 
 ### Negative
 
-- **One more top-level binding name.** `Session` joins `Transcript`, `Beamtalk`, `Workspace` as an injected per-session global. Users could shadow it via `Session := MyThing new` in the shell — the existing `bind:as:` conflict checks only protect workspace-level assignments, not shell-level `:=`. The implementation should add a guard in `beamtalk_repl_eval` that emits a compiler warning (not an error) when a user assignment shadows an injected system binding, consistent with the project's footgun-warning philosophy (emit a compiler warning whenever we detect a footgun, rather than leaving it as a known limitation).
-- **`Session clear` during eval has ordering constraints.** The eval worker has a state snapshot; when it completes, the shell merges the worker's state back. A naive `gen_server:call(ShellPid, clear_bindings)` during eval would be overwritten by the worker's stale snapshot. The implementation must add a `clear_requested` flag to `beamtalk_repl_state`: `clear` sets the flag via the shell; eval-result processing checks the flag and applies the clear after merging the worker's state. This ensures `Session clear` followed by more expressions in the same eval works correctly (the clear takes effect for the *next* eval, not mid-expression).
-- **Outside-REPL `nil`.** `Workspace currentSession` returns `nil` in compiled program code, which means `Workspace currentSession bindings` raises `does_not_understand` (correct DNU semantics, but a footgun if users assume the API is always available). Documentation must call this out.
+- **New `BindingsView` class.** A small Dictionary-protocol class is required to support live read/write views. Implementation cost is moderate (one class plus primitives for read/write/iterate). The class is simple — every method delegates to a primitive — but it is a new public surface that has to be documented and tested.
+- **Mutation during eval has ordering constraints.** Both `Session clear` and `Session bindings at:put:` mutate shell state via gen_server calls. The eval worker holds a state snapshot; without reconciliation the worker's writeback would overwrite the mutation. The implementation must add a `pending_mutations` queue to `beamtalk_repl_state`: mutations append to the queue (instead of being applied directly); the eval-result handler drains the queue after merging the worker's state. This ensures `Session bindings at: #x put: 99. x + 1` evaluates `x + 1` against the original `x` (the mutation takes effect for the *next* eval), which matches user expectations that an expression sees its own pre-state.
+- **Outside-REPL behaviour.** `Session current` returns `nil`; class-side methods like `Session bindings` raise a structured `no_session` error. Library code that wants graceful degradation must check `Workspace hasSession` first.
+- **`Session clear` is asymmetric with the view.** `Session bindings removeKey: #x` removes one binding; `Session clear` removes all. There is no `Session bindings clear` because the view's protocol is generic Dictionary semantics — `Session bindings` returns a *view*, not a Dictionary the user owns, so a `clear` on the view would be ambiguous (clear-the-view or clear-the-state). Keeping `Session clear` as a top-level method avoids this ambiguity.
 
 ### Neutral
 
 - **`bind:as:` semantics unchanged.** Continues to write to the workspace ETS layer. `Session bindings` will not include `bind:as:` entries (those appear in `Session globals`). This is a clarification, not a behaviour change.
 - **Session persistence across sync unchanged.** Existing behaviour preserved: session locals survive `Workspace sync`.
-- **Protocol surface unchanged initially.** The existing `bindings` and `clear` ops continue to work, redirected to `Session bindings` / `Session clear` semantics. Hard removal is a follow-up after the new API has soaked.
+- **Protocol `bindings` / `clear` ops are removed** in Phase 5, alongside the rest of the work. The Session API ships first (Phases 1–4), so when the meta-commands disappear the replacement is already in place. There is no deprecation window — single coordinated release.
 
 ## Implementation
 
-The implementation breaks down into four phases. Each is independently shippable.
+The implementation breaks down into five phases. Each is independently shippable.
 
-### Phase 1: Runtime primitives module (S)
+### Phase 1: Process-context plumbing (S)
 
-Create `beamtalk_session_primitives.erl` in `runtime/apps/beamtalk_workspace/src/` with the four primitive operations. Each primitive reads the calling process's session PID from process dictionary (seeded during eval worker spawn in Phase 2):
+Modify `beamtalk_repl_shell:handle_call({eval, _}, ...)` to seed the eval worker's process dictionary with `beamtalk_session_pid` (the shell's `self()`) and `beamtalk_session_id` (the protocol session ID) before calling `do_eval`. This makes the calling session reachable from any primitive without explicit threading.
 
-- `bindings/0` — reads the process dictionary session PID, calls `beamtalk_repl_shell:get_bindings/1`, then strips workspace-injected keys using the `injected_ws_keys` tracking already present in `beamtalk_repl_state`. Returns session-locals only.
-- `globals/0` — calls `beamtalk_workspace_interface_primitives:get_session_bindings/0`, the existing workspace-globals accessor.
-- `resolve/1` — combines the two; session locals first, workspace globals second. Returns `nil` if name not found.
-- `clear/0` — calls `beamtalk_repl_shell:clear_bindings/1` on the session PID. Note: during eval, this clears the shell's state via gen_server:call. The eval worker's snapshot is stale after clear, but clear is typically the final expression in an eval. If the cleared state is overwritten by the worker's return, the shell must reconcile by checking a `clear_requested` flag (set by the clear handler) during eval-result processing.
-- `id/0` — reads the session ID from process dictionary.
+Add `pending_mutations` to `beamtalk_repl_state` — a queue of `{op, key, value}` tuples. Add an applicator that drains the queue at eval-result time, after merging the worker's returned state. This is the foundation for `Session clear` and `Session bindings at:put:` correctness during eval.
 
-EUnit tests for each primitive. Existing infrastructure (`beamtalk_repl_shell`, `beamtalk_session_table`) is reused.
+EUnit tests for the worker spawn seeding and the pending-mutation drain ordering.
 
-### Phase 2: Stdlib `Session` class and binding injection (M)
+### Phase 2: Runtime primitives module (M)
 
-Add `stdlib/src/Session.bt` with the API defined above. Session is NOT a workspace singleton (it varies per shell), so it cannot be added to `beamtalk_workspace_config:singletons/0`.
+Create `beamtalk_session_primitives.erl` in `runtime/apps/beamtalk_workspace/src/`. Each primitive resolves the session via `get(beamtalk_session_pid)` (or the explicit Session instance for the `*For:` variants):
 
-Injection path: modify `beamtalk_repl_shell:init/1` to construct a Session object (via `beamtalk_object:create/2`) with the shell's PID and session ID, and inject it as a binding alongside workspace globals. Add `'Session'` to the `injected_ws_keys` set so that `clear` preserves it and `Session bindings` excludes it from user-locals.
+- `current/0` — returns a Session value with the calling session's PID and ID, or `nil`.
+- `withId/1` — looks up a session by protocol ID via `beamtalk_session_table:lookup/1`, returns Session or nil.
+- `bindingsView/0` — returns a `BindingsView` value tagged for session-local scope, bound to the calling session.
+- `globalsView/0` — returns a `BindingsView` value tagged for workspace scope (shared across sessions).
+- `bindingsViewFor/1`, `clearFor/1` — instance variants (target a specific Session value).
+- `resolve/1`, `resolve/2` — walk session locals first, then workspace globals; return value or nil.
+- `clear/0`, `clearFor/1` — enqueue a clear mutation via the shell's pending-mutations API (Phase 1).
+- `id/0` — reads `beamtalk_session_id` from process dictionary.
 
-Seed process dictionary: modify the eval worker spawn (`handle_call({eval, ...})`) to set `beamtalk_session_pid` and `beamtalk_session_id` in the worker's process dictionary before calling `do_eval`. This allows Phase 1 primitives to resolve the session context.
+Plus the BindingsView read/write primitives: `view_at/2`, `view_at_put/3`, `view_remove/2`, `view_keys/1`, `view_size/1`. Session-scope writes enqueue against the shell's pending-mutations queue; workspace-scope writes route through `beamtalk_workspace_interface_primitives:bind/2` and `unbind/1`, inheriting protected-name conflict checks.
 
-Add `'Session'` to `is_protected_name/1` in `beamtalk_workspace_interface_primitives.erl` so `bind:as:` cannot shadow it.
+EUnit tests for each primitive, including cross-session access via `withId/1`.
 
-### Phase 3: `Workspace currentSession` and process-context resolution (S)
+### Phase 3: Stdlib `Session` and `BindingsView` classes (M)
 
-Add `currentSession` to `WorkspaceInterface` (Beamtalk class) with an Erlang primitive that:
-1. Reads `beamtalk_session_pid` from the calling process's dictionary, or
-2. Returns `nil` if no session marker is set (compiled program code, non-REPL contexts).
+Add `stdlib/src/Session.bt` with the class-side and instance-side methods defined in the API. Add `stdlib/src/BindingsView.bt` implementing the Dictionary protocol (`at:`, `at:put:`, `removeKey:`, `includesKey:`, `keys`, `values`, `size`, `do:`, `printOn:`).
 
-This uses the same process dictionary key seeded in Phase 2 — no additional plumbing needed.
+No binding injection: `Session` is reachable as a class name through the class registry, no special-case handling. No protected-name additions, no `injected_ws_keys` changes.
 
-### Phase 4: Migration and meta-command deprecation (M)
+### Phase 4: `Workspace currentSession` / `hasSession` (S)
 
-Re-deprecate `:bindings` and `:clear` in `beamtalk_repl_ops_dev.erl` with `migrate_to` hints pointing at `Session bindings` and `Session clear`. Update `surface-parity.md` rows for `bindings` and `clear` to cite `via Session bindings` / `via Session clear`. Add an e2e btscript test under `tests/repl-protocol/cases/` covering the full Session API. Hard removal of the meta-commands is a separate follow-up issue once the new API has been validated in real use.
+Add `currentSession` and `hasSession` to `WorkspaceInterface` (Beamtalk class), each delegating to a one-line primitive that reads the same `beamtalk_session_pid` process dictionary key seeded in Phase 1. Returns the same value as `Session current` (or its boolean).
+
+### Phase 5: Remove `:bindings` and `:clear` meta-commands (S)
+
+Delete the `<<"bindings">>` and `<<"clear">>` op handlers in `beamtalk_repl_ops_eval.erl` and remove their entries from `beamtalk_repl_ops_dev.erl`'s op map. Update `surface-parity.md` rows for `bindings` and `clear` to cite `via Session bindings` / `via Session clear`. Update any existing e2e tests that exercised the meta-commands to use the new Session API. Add an e2e btscript test under `tests/repl-protocol/cases/` covering the full Session API including cross-session access (`Session withId:`).
 
 ## Migration Path
 
-For users of `:bindings` and `:clear`:
+The `:bindings` and `:clear` meta-commands are removed in Phase 5; the replacement API is shipped in Phases 1–4 first so they land in the same release.
 
 | Before | After |
 |--------|-------|
-| `:bindings` | `Session bindings` (session locals only) <br> `Session globals` (workspace globals) |
+| `:bindings` | `Session bindings keys` (session locals only) <br> `Session globals keys` (workspace globals) |
 | `:clear` | `Session clear` |
-| (no equivalent) | `Session resolve: #name` |
-| (no equivalent) | `Workspace currentSession` |
+| (no equivalent) | `Session bindings at: #x put: 99` (live mutation) |
+| (no equivalent) | `Session bindings removeKey: #x` |
+| (no equivalent) | `Session resolve: #name` (REPL debugging tool) |
+| (no equivalent) | `Workspace currentSession` / `Session current` |
+| (no equivalent) | `Session withId: aSessionId` (LSP cross-session) |
 
-The meta-commands continue to work during the deprecation window. CLI users see a `migrate_to` hint in the deprecated-op response. MCP and WebSocket clients gain a new capability (the meta-commands were REPL-only; the object API works on every surface).
+The meta-commands existed only on the REPL surface. Removing them is a small loss for muscle-memory CLI users (one `migrate_to` shell-side error message in the release notes is sufficient) and a strict gain for MCP and WebSocket clients, which now have a Beamtalk-native path to per-session state with both reads and write-through mutations.
 
 ## References
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -107,6 +107,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0078](0078-actor-initialize-inheritance.md) | Actor Initialize Inheritance | Implemented | 2026-04-12 |
 | [0079](0079-named-actor-registration.md) | Named Actor Registration | Implemented | 2026-04-15 |
 | [0080](0080-supervisor-lifecycle-result.md) | Migrate Supervisor Lifecycle to Result | Implemented | 2026-04-16 |
+| [0081](0081-first-class-session-object.md) | First-Class Session Object — Walkable Binding Layers | Proposed | 2026-05-09 |
 | [0082](0082-method-level-edit-save-and-changelog.md) | Method-Level Edit and Save in the Live Workspace | Implemented | 2026-05-17 |
 | [0083](0083-metaclass-aware-type-inference.md) | Metaclass-Aware Type Inference | Implemented | 2026-05-23 |
 | [0084](0084-class-side-runtime-method-fun-dispatch.md) | Class-Side Runtime Method Installation and Fun Dispatch | Accepted (in progress) | 2026-05-24 |


### PR DESCRIPTION
## Summary

Drafts ADR 0081 proposing a first-class `Session` class — `Object subclass: Session` wrapping the REPL shell PID — to replace the `:bindings` and `:clear` meta-commands with object-level messages and expose the two-layer binding model (session locals + workspace globals) as inspectable, walkable Smalltalk objects.

Linear: https://linear.app/beamtalk/issue/BT-2092

## Key decisions in the ADR

- **`Session` is not an Actor** — it's a lightweight handle wrapping the shell PID, same pattern as `Supervisor` wrapping an OTP supervisor.
- **Per-PID, not singleton** — each shell injects its own `Session` binding; multi-session deployments (MCP, WebSocket) get individually inspectable sessions.
- **`Workspace currentSession`** also available, returns `nil` outside a REPL eval.
- **`bind:as:` semantics unchanged** — continues to write to the workspace ETS layer (`Session globals`).
- **Session locals persist across `Workspace sync`** — unchanged behaviour.
- **No `parent` accessor initially** — two layers, `bindings` + `globals` cover both. Recursive scope chains rejected as premature generalisation.

## API

```beamtalk
Session bindings        // session-locals only
Session globals         // workspace globals (singletons + bind:as:)
Session resolve: #x     // walks layers, returns first match or nil
Session clear           // clear session locals
Session layers          // #(#session #workspace)
Session id              // session identifier
Workspace currentSession  // also reachable here
```

## Test plan

- [ ] Review prior art comparison (Pharo, Newspeak, Self, IPython, Elixir/Livebook)
- [ ] Confirm open design questions are resolved appropriately
- [ ] Confirm steelman analysis fairly represents Option B (Workspace extension) and Option C (recursive scope chain)
- [ ] Once accepted, run `/plan-adr 0081` to break implementation into agent-ready issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR 0081 proposing a first-class Session object to clarify REPL/session semantics and usage.

* **New Features (Proposed)**
  * Introduces a Session concept exposing session-local bindings, workspace-level globals, layered resolution order, a clear operation, and a stable session id.
  * Adds workspace APIs to retrieve the current session and to check session presence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2188)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->