### PR TITLE
docs: daily refresh 2026-05-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `beamtalk lint` validates cache entries against live `.beam` file mtimes, skipping stale entries when the underlying module has been recompiled (BT-2139).
 - Fix false-positive `Unresolved class` warnings in the LSP for classes defined in fetched dependencies — the LSP now preloads `.bt` files from `_build/deps/*/src/` (BT-2137).
 - Fix LSP `is_protocol_type` always returning `false` for registered protocols, causing false-positive type warnings on protocol-typed parameters (BT-2135).
+- **Redundant type annotation lint** — `name :: T := <expr>` is flagged when the inferred type of `<expr>` exactly matches `T`, since the annotation adds no information the type checker doesn't already have. Suppressible with `@expect type_annotation`. Skips unions and widening annotations where the annotation does real work (BT-2140).
 
 ### Internal
 
@@ -30,6 +31,8 @@
 - Extract `call_self_p0`/`call_p0_self` helpers in primitives codegen — deduplicates ~56 matching arms across `string.rs`, `list.rs`, and `dictionary.rs` (BT-2146).
 - Extract `try_canonicalize` helper in `package.rs` — deduplicates 5 identical inline `canonicalize`-with-fallback patterns (BT-2149).
 - Add missing `domain => [beamtalk, stdlib]` metadata to nine `?LOG_*` calls across five stdlib modules (BT-2141).
+- Extract duplicated analysis pipeline in MCP server into shared `run_module_analysis` helper (BT-2152).
+- Extract duplicated NLR catch-var allocation into shared `NlrCatchVars` struct/helper (BT-2155).
 
 ## 0.4.0 — 2026-04-27
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -3369,6 +3369,7 @@ anything                    // any diagnostic suppressed (discouraged — use a 
 | `dnu` | Does-not-understand hints |
 | `type` | Type mismatch warnings *and* method-not-found (DNU) hints |
 | `unused` | Unused variable warnings |
+| `type_annotation` | Missing or redundant type annotation warnings in typed classes |
 | `inheritance` | Sealed-class/sealed-method constraint errors |
 | `all` | Any diagnostic on the following expression *(discouraged — use a specific category)* |
 


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 5 commits merged after the 2026-05-09 daily refresh.

### Commits reviewed

| SHA | Title | Doc change |
|-----|-------|------------|
| `4ff7cde` | Lint rule: flag redundant type annotation on local variables (BT-2140) | CHANGELOG "Tooling" entry + `type_annotation` added to `@expect` suppression table in language features doc |
| `1439f2c` | Extract duplicated analysis pipeline in beamtalk-mcp server (BT-2152) | CHANGELOG "Internal" entry |
| `9e20fbf` | Extract duplicated NLR catch-var allocation into shared helper (BT-2155) | CHANGELOG "Internal" entry |
| `2d938d3` | fix: use tempDirectory() instead of hardcoded /tmp/ in workspace tests (BT-2157) | Skipped — test-only |
| `a5f0bb2` | Bump fast-uri from 3.1.0 to 3.1.2 (dependabot) | Skipped — dependency bump, no user-visible change |

### Skipped (test-only / no doc impact)

- `2d938d3` — purely test file change (hardcoded /tmp/ → tempDirectory)
- `a5f0bb2` — dependabot security bump of VS Code extension transitive dep

### Doc changes

- **CHANGELOG.md**: Added redundant type annotation lint (Tooling), MCP pipeline extract + NLR helper extract (Internal)
- **docs/beamtalk-language-features.md**: Added `type_annotation` to `@expect` suppression categories table (was missing since BT-1918)

https://claude.ai/code/session_01NNFPosbHHiWHmeNVkFcRpz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNFPosbHHiWHmeNVkFcRpz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new lint that flags redundant local type annotations. Suppress with `@expect type_annotation`.

* **Documentation**
  * Updated language features guide with information about the new `@expect type_annotation` suppression category.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2189)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->