### PR TITLE
Centralize byte-offset→line-number logic into Span::line_number (BT-2160)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -1655,17 +1655,10 @@ impl CoreErlangGenerator {
     /// Returns `None` if source text is unavailable or the span is out of range.
     pub(super) fn span_to_line(&self, span: Span) -> Option<u32> {
         let source = self.source_text.as_deref()?;
-        let offset = span.start() as usize;
-        if offset > source.len() {
+        if span.start() as usize > source.len() {
             return None;
         }
-        let newline_count = source[..offset].bytes().filter(|&b| b == b'\n').count();
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "source files over 4GB (2^32 lines) are not supported"
-        )]
-        let line = newline_count as u32 + 1;
-        Some(line)
+        Some(span.line_number(source))
     }
 
     /// BT-940: Wraps a Document with a Core Erlang line annotation.

--- a/crates/beamtalk-core/src/source_analysis/span.rs
+++ b/crates/beamtalk-core/src/source_analysis/span.rs
@@ -96,7 +96,7 @@ impl Span {
             .take(offset)
             .filter(|&&b| b == b'\n')
             .count() as u32
-             1
+            + 1
     }
 }
 

--- a/crates/beamtalk-core/src/source_analysis/span.rs
+++ b/crates/beamtalk-core/src/source_analysis/span.rs
@@ -88,6 +88,10 @@ impl Span {
         self.start as usize..self.end as usize
     }
 
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "source files over 4GB are not supported"
+    )]
     pub fn line_number(self, source: &str) -> u32 {
         let offset = (self.start as usize).min(source.len());
         source

--- a/crates/beamtalk-core/src/source_analysis/span.rs
+++ b/crates/beamtalk-core/src/source_analysis/span.rs
@@ -90,7 +90,7 @@ impl Span {
 
     #[expect(
         clippy::cast_possible_truncation,
-        reason = "source files over 4GB are not supported"
+        reason = "offset is bounded by self.start (a u32), so the newline count cannot exceed u32::MAX"
     )]
     pub fn line_number(self, source: &str) -> u32 {
         let offset = (self.start as usize).min(source.len());

--- a/crates/beamtalk-core/src/source_analysis/span.rs
+++ b/crates/beamtalk-core/src/source_analysis/span.rs
@@ -87,6 +87,21 @@ impl Span {
     pub const fn as_range(self) -> Range<usize> {
         self.start as usize..self.end as usize
     }
+
+    /// Returns the 1-based line number of this span's start position in `source`.
+    ///
+    /// Counts the number of `\n` bytes before `self.start` and adds one.
+    /// The offset is clamped to `source.len()` so out-of-range spans safely
+    /// return the last line rather than panicking.
+    #[must_use]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "source files over 4GB (2^32 lines) are not supported"
+    )]
+    pub fn line_number(self, source: &str) -> u32 {
+        let offset = (self.start as usize).min(source.len());
+        source[..offset].bytes().filter(|&b| b == b'\n').count() as u32 + 1
+    }
 }
 
 impl From<Range<u32>> for Span {
@@ -162,5 +177,33 @@ mod tests {
         let span = Span::new(5, 15);
         let range: Range<usize> = span.into();
         assert_eq!(range, 5..15);
+    }
+
+    #[test]
+    fn line_number_empty_source() {
+        assert_eq!(Span::new(0, 0).line_number(""), 1);
+    }
+
+    #[test]
+    fn line_number_single_line() {
+        let src = "hello";
+        assert_eq!(Span::new(0, 0).line_number(src), 1);
+        assert_eq!(Span::new(5, 5).line_number(src), 1);
+    }
+
+    #[test]
+    fn line_number_multi_line() {
+        let src = "line1\nline2\nline3";
+        assert_eq!(Span::new(0, 0).line_number(src), 1); // start of line1
+        assert_eq!(Span::new(5, 5).line_number(src), 1); // end of line1 (before \n)
+        assert_eq!(Span::new(6, 6).line_number(src), 2); // start of line2
+        assert_eq!(Span::new(11, 11).line_number(src), 2); // end of line2 (before \n)
+        assert_eq!(Span::new(12, 12).line_number(src), 3); // start of line3
+    }
+
+    #[test]
+    fn line_number_clamps_past_end() {
+        let src = "hello";
+        assert_eq!(Span::new(999, 999).line_number(src), 1);
     }
 }

--- a/crates/beamtalk-core/src/source_analysis/span.rs
+++ b/crates/beamtalk-core/src/source_analysis/span.rs
@@ -88,19 +88,15 @@ impl Span {
         self.start as usize..self.end as usize
     }
 
-    /// Returns the 1-based line number of this span's start position in `source`.
-    ///
-    /// Counts the number of `\n` bytes before `self.start` and adds one.
-    /// The offset is clamped to `source.len()` so out-of-range spans safely
-    /// return the last line rather than panicking.
-    #[must_use]
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "source files over 4GB (2^32 lines) are not supported"
-    )]
     pub fn line_number(self, source: &str) -> u32 {
         let offset = (self.start as usize).min(source.len());
-        source[..offset].bytes().filter(|&b| b == b'\n').count() as u32 + 1
+        source
+            .as_bytes()
+            .iter()
+            .take(offset)
+            .filter(|&&b| b == b'\n')
+            .count() as u32
+             1
     }
 }
 

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -1738,14 +1738,6 @@ struct LintResult {
     total: usize,
 }
 
-/// Convert a byte offset into a 1-indexed line number.
-fn offset_to_line(source: &str, offset: usize) -> u32 {
-    let clamped = offset.min(source.len());
-    #[allow(clippy::cast_possible_truncation)]
-    let line = source[..clamped].bytes().filter(|&b| b == b'\n').count() as u32 + 1;
-    line
-}
-
 /// BT-2152: Run the shared three-step lint analysis pipeline for a single
 /// module. Callers pre-filter `parse_diags` per their severity requirements
 /// and pass them in; this helper appends lint-pass results, runs semantic
@@ -2099,7 +2091,7 @@ fn run_lint_structured(path: &str) -> LintResult {
 
         let file_name = file.to_string_lossy().into_owned();
         for diag in &lint_diags {
-            let line = offset_to_line(&source, diag.span.start() as usize);
+            let line = diag.span.line_number(&source);
             let severity = match diag.severity {
                 Severity::Error => "error",
                 Severity::Warning | Severity::Lint | Severity::Hint => "warning",
@@ -2166,38 +2158,6 @@ impl ServerHandler for BeamtalkMcp {
 mod tests {
     use super::*;
     use camino::Utf8PathBuf;
-
-    // --- offset_to_line ---
-
-    #[test]
-    fn offset_to_line_empty_string() {
-        assert_eq!(offset_to_line("", 0), 1);
-    }
-
-    #[test]
-    fn offset_to_line_single_line() {
-        let src = "hello world";
-        assert_eq!(offset_to_line(src, 0), 1);
-        assert_eq!(offset_to_line(src, 5), 1);
-        assert_eq!(offset_to_line(src, src.len()), 1);
-    }
-
-    #[test]
-    fn offset_to_line_multi_line() {
-        let src = "line1\nline2\nline3";
-        assert_eq!(offset_to_line(src, 0), 1); // start of line1
-        assert_eq!(offset_to_line(src, 5), 1); // end of line1 (before \n)
-        assert_eq!(offset_to_line(src, 6), 2); // start of line2
-        assert_eq!(offset_to_line(src, 11), 2); // end of line2 (before \n)
-        assert_eq!(offset_to_line(src, 12), 3); // start of line3
-    }
-
-    #[test]
-    fn offset_to_line_clamps_past_end() {
-        let src = "abc";
-        // Offset beyond source length should clamp and not panic.
-        assert_eq!(offset_to_line(src, 999), 1);
-    }
 
     // --- run_lint_structured ---
 


### PR DESCRIPTION
## Summary\n\n- Add `Span::line_number(source: &str) -> u32` method to `beamtalk-core` that converts a span's start offset to a 1-based line number (with clamping for safety)\n- Delegate `CodegenContext::span_to_line` to the new method, removing inline newline-counting logic\n- Remove duplicated `offset_to_line` function from `beamtalk-mcp` server and use `diag.span.line_number(&source)` directly\n- Migrate tests from MCP to `span.rs` (empty, single-line, multi-line, clamp-past-end)\n\n## Motivation\n\nThe same algorithm (count `\\n` bytes before an offset, return 1-based line) was implemented independently in two crates:\n1. `beamtalk-core/src/codegen/core_erlang/mod.rs:1662` — `span_to_line()`\n2. `beamtalk-mcp/src/server.rs:1742` — `offset_to_line()`\n\n`Span` is the natural home since it already owns the byte offset.\n\n## Linear Issue\n\nhttps://linear.app/beamtalk/issue/BT-2160/centralize-byte-offsetline-number-logic-into-spanline-number\n\nhttps://claude.ai/code/session_014W7aWva1QhDVAyXrL3U8q9

---
_Generated by [Claude Code](https://claude.ai/code/session_014W7aWva1QhDVAyXrL3U8q9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized line-number computation with safer bounds checking and clamping for out-of-range offsets.
  * Removed redundant offset helper; diagnostic reporting now derives line numbers directly from span-aware logic.

* **Tests**
  * Added unit tests covering empty, single-line, multi-line, and out-of-range positions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2190)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->