### PR TITLE
Fix format!() violations in core_erlang_binary_string (BT-2163)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs
@@ -234,11 +234,17 @@ pub(crate) fn core_erlang_binary_string(s: &str) -> Document<'static> {
     if s.is_empty() {
         return Document::Str("#{}#");
     }
-    let segments: Vec<String> = s
-        .bytes()
-        .map(|b| format!("#<{b}>(8,1,'integer',['unsigned'|['big']])"))
-        .collect();
-    Document::String(format!("#{{{}}}#", segments.join(",")))
+    let mut parts: Vec<Document<'static>> = vec![Document::Str("#{")];
+    for (i, b) in s.bytes().enumerate() {
+        if i > 0 {
+            parts.push(Document::Str(","));
+        }
+        parts.push(Document::Str("#<"));
+        parts.push(Document::String(b.to_string()));
+        parts.push(Document::Str(">(8,1,'integer',['unsigned'|['big']])"));
+    }
+    parts.push(Document::Str("}#"));
+    Document::Vec(parts)
 }
 
 /// Converts an `Option<Document>` to an `Option<String>` for test assertions.
@@ -2012,5 +2018,31 @@ mod tests {
         // raisedTo: returns None when params is empty
         let result = doc_to_string(generate_primitive_bif("Integer", "raisedTo:", &[]));
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_core_erlang_binary_string_empty() {
+        let doc = core_erlang_binary_string("");
+        assert_eq!(doc.to_pretty_string(), "#{}#");
+    }
+
+    #[test]
+    fn test_core_erlang_binary_string_single_byte() {
+        // 'a' = 97
+        let doc = core_erlang_binary_string("a");
+        assert_eq!(
+            doc.to_pretty_string(),
+            "#{#<97>(8,1,'integer',['unsigned'|['big']])}#"
+        );
+    }
+
+    #[test]
+    fn test_core_erlang_binary_string_multi_byte() {
+        // "hi" = bytes [104, 105]
+        let doc = core_erlang_binary_string("hi");
+        assert_eq!(
+            doc.to_pretty_string(),
+            "#{#<104>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']])}#"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Replace `format!()` calls in `core_erlang_binary_string` with `Document`/`docvec!` API, fixing a CLAUDE.md codegen rule violation
- Add unit tests for empty string, single-byte, and multi-byte binary encoding cases

## Details

The `core_erlang_binary_string` function in `primitives/mod.rs` constructed Core Erlang binary literal syntax (`#{#<byte>(8,1,'integer',['unsigned'|['big']]), ...}#`) using `format!()` at two sites. This violates the documented rule: "All Core Erlang codegen MUST use Document / docvec! API. NEVER use format!() or string concatenation to produce Core Erlang fragments."

The fix decomposes the binary literal into `Document::Str` nodes for static Core Erlang syntax and `Document::String` nodes for dynamic byte values, assembled via `Document::Vec`.

## Test plan

- [x] 3 new unit tests: empty string, single byte ('a' → 97), multi-byte ("hi" → [104, 105])
- [x] All 288 existing primitives tests pass
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean

Linear: https://linear.app/beamtalk/issue/BT-2163

https://claude.ai/code/session_01TPb1XpsFvAvC2WRGFHbPUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPb1XpsFvAvC2WRGFHbPUA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated binary literal generation to use an improved construction approach.

* **Tests**
  * Added comprehensive unit tests for binary string handling across multiple scenarios (empty, single-byte, and multi-byte strings).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2192)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->