### PR TITLE
Fix hardcoded /tmp/ paths in beamtalk_repl_server_tests.erl (BT-2165)

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_server_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_server_tests.erl
@@ -433,9 +433,10 @@ tcp_start_workspace(Retries) ->
     {ok, Port} = inet:port(LSock),
     gen_tcp:close(LSock),
     timer:sleep(50),
+    TmpDir = beamtalk_file:'tempDirectory'(),
     Config = #{
         workspace_id => <<"tcp_test_ws">>,
-        project_path => <<"/tmp/bt_tcp_test">>,
+        project_path => <<TmpDir/binary, "/bt_tcp_test">>,
         tcp_port => Port,
         auto_cleanup => false
     },
@@ -2298,7 +2299,7 @@ ensure_structured_error_undefined_variable_test() ->
     ?assertEqual(undefined_variable, Err#beamtalk_error.kind).
 
 ensure_structured_error_file_not_found_test() ->
-    Err = beamtalk_repl_server:ensure_structured_error({file_not_found, "/tmp/foo.bt"}),
+    Err = beamtalk_repl_server:ensure_structured_error({file_not_found, "/nonexistent/foo.bt"}),
     ?assertEqual(file_not_found, Err#beamtalk_error.kind).
 
 ensure_structured_error_read_error_test() ->


### PR DESCRIPTION
## Summary\n\nFix two hardcoded `/tmp/` paths in `beamtalk_repl_server_tests.erl` that violate the CLAUDE.md cross-platform temp path rule.\n\n- `tcp_start_workspace/1`: `project_path` now uses `beamtalk_file:'tempDirectory'()` binary concat instead of `<<\"/tmp/bt_tcp_test\">>`\n- `ensure_structured_error_file_not_found_test/0`: fake path changed from `\"/tmp/foo.bt\"` to `\"/nonexistent/foo.bt\"` (only error kind is asserted, path is never accessed)\n\nFollows the exact pattern already used in `beamtalk_workspace_tests.erl`, `beamtalk_workspace_sup_tests.erl`, and `beamtalk_idle_monitor_tests.erl`.\n\n## Test plan\n\n- [ ] `cd runtime && rebar3 eunit --app=beamtalk_workspace` passes\n- [ ] No remaining `/tmp/` references in the file\n\nLinear: https://linear.app/beamtalk/issue/BT-2165\n\nhttps://claude.ai/code/session_0155PDgHvTyeNsud8GSrVpPV

---
_Generated by [Claude Code](https://claude.ai/code/session_0155PDgHvTyeNsud8GSrVpPV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test robustness by using temporary directories for workspace configuration instead of fixed paths.
  * Updated file not found error test assertions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2193)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->