### PR TITLE
docs: daily refresh 2026-05-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Add missing `domain => [beamtalk, stdlib]` metadata to nine `?LOG_*` calls across five stdlib modules (BT-2141).
 - Extract duplicated analysis pipeline in MCP server into shared `run_module_analysis` helper (BT-2152).
 - Extract duplicated NLR catch-var allocation into shared `NlrCatchVars` struct/helper (BT-2155).
+- Replace `format!()` calls with `Document` API in `core_erlang_binary_string` — continues the BT-875 cleanup (BT-2163).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

- Add CHANGELOG "Internal" entry for BT-2163 (`format!()` → `Document` API in `core_erlang_binary_string`, continuing BT-875 cleanup)

## Commits reviewed

| SHA | Title | Classification | Doc change |
|-----|-------|---------------|------------|
| `4e57583` | Fix format!() violations in core_erlang_binary_string (BT-2163) | Internal | CHANGELOG entry added |
| `08dcf83` | Fix hardcoded /tmp/ paths in beamtalk_repl_server_tests.erl (BT-2165) | Test-only (excluded) | None — diff is purely under `runtime/apps/*/test/` |

## Skipped

- **08dcf83 (BT-2165)** — test-only change under `runtime/apps/beamtalk_workspace/test/`, excluded per scope rules

## Needs human judgment

None.

https://claude.ai/code/session_01Sf2zvbD3VVvXAQgixvfCA8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sf2zvbD3VVvXAQgixvfCA8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Internal Updates**
  * Documentation update for internal code refactoring.

*No user-facing changes in this release.*

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2194)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->