### PR TITLE
Fix Document::String(format!()) Core Erlang fragment violations in 4 codegen files (BT-2166)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -2303,12 +2303,13 @@ impl CoreErlangGenerator {
 
         // Recursive call + false arm + initial apply
         docs.push(docvec![
-            format!(
-                " apply '{fn_name}'/2 ({next}, {fstate}) ",
-                fn_name = frame.fn_name,
-                next = frame.next_counter,
-                fstate = final_state_var,
-            ),
+            " apply '",
+            Document::String(frame.fn_name.clone()),
+            "'/2 (",
+            Document::String(frame.next_counter.clone()),
+            ", ",
+            Document::String(final_state_var),
+            ") ",
             frame.false_arm.clone(),
             docvec![
                 "in apply '",

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -2269,10 +2269,11 @@ impl CoreErlangGenerator {
         let mut docs: Vec<Document<'static>> = Vec::new();
         docs.push(pack_doc);
         docs.push(frame.preamble.clone());
-        docs.push(Document::String(format!(
-            " letrec '{fn_name}'/2 = fun (I, StateAcc) -> ",
-            fn_name = frame.fn_name
-        )));
+        docs.push(docvec![
+            " letrec '",
+            Document::String(frame.fn_name.clone()),
+            "'/2 = fun (I, StateAcc) -> ",
+        ]);
 
         self.push_scope();
 
@@ -2309,11 +2310,15 @@ impl CoreErlangGenerator {
                 fstate = final_state_var,
             ),
             frame.false_arm.clone(),
-            Document::String(format!(
-                "in apply '{fn_name}'/2 ({init_ctr}, {init_state})",
-                fn_name = frame.fn_name,
-                init_ctr = frame.initial_counter,
-            )),
+            docvec![
+                "in apply '",
+                Document::String(frame.fn_name.clone()),
+                "'/2 (",
+                Document::String(frame.initial_counter.clone()),
+                ", ",
+                Document::String(init_state),
+                ")",
+            ],
         ]);
 
         Ok(Document::Vec(docs))

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
@@ -261,9 +261,11 @@ impl CoreErlangGenerator {
         self.pop_scope();
 
         // Initial call with packed state
-        docs.push(Document::String(format!(
-            "in apply 'while'/1 ({init_state})"
-        )));
+        docs.push(docvec![
+            "in apply 'while'/1 (",
+            Document::String(init_state),
+            ")"
+        ]);
 
         Ok(Document::Vec(docs))
     }

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -499,6 +499,7 @@ impl CoreErlangGenerator {
             let err_var1 = format!("_UErr{idx}b");
             let err_msg_var = format!("_UErrMsg{idx}");
             let class_name_var = format!("_UErrClass{idx}");
+            let fmt_var = format!("_UFmt{idx}");
             let hint_msg = format!(
                 "{owning_class} field '{field_name}' (:: {type_name}) was not initialized",
             );
@@ -550,7 +551,7 @@ impl CoreErlangGenerator {
                                 "':'class_name'() in",
                                 line(),
                                 "let ",
-                                Document::String(format!("_UFmt{idx}")),
+                                Document::String(fmt_var.clone()),
                                 " = call 'beamtalk_error':'format'(",
                                 Document::String(err_var1.clone()),
                                 ") in",
@@ -564,7 +565,7 @@ impl CoreErlangGenerator {
                                 ", 'domain' => ['beamtalk'|['runtime'|[]]]}~) in",
                                 line(),
                                 "{'stop', ",
-                                Document::String(format!("_UFmt{idx}")),
+                                Document::String(fmt_var),
                                 ", InitNewState}",
                             ]
                         ),

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -3015,9 +3015,17 @@ impl CoreErlangGenerator {
         } else {
             "Self"
         };
-        Ok(Document::String(format!(
-            "call '{runtime_module}':'dispatch'('{name}', [{params_str}], {self_var})"
-        )))
+        Ok(docvec![
+            "call '",
+            Document::String(runtime_module),
+            "':'dispatch'('",
+            Document::String(name.to_string()),
+            "', [",
+            Document::String(params_str),
+            "], ",
+            Document::Str(self_var),
+            ")"
+        ])
     }
 
     /// BT-1478: Generates inline `logger:log/3` code for Logger @intrinsic bodies.


### PR DESCRIPTION
## Summary

Fixes 6 `Document::String(format!())` calls that produce Core Erlang syntax via string interpolation — a violation of the CLAUDE.md rule enforced in BT-875. These four files were missed in the BT-875 cleanup sweep.

- **`gen_server/callbacks.rs:553,567`** — pre-compute `fmt_var = format!("_UFmt{idx}")` alongside the other indexed vars (`check_var`, `err_var0`, etc.); use `Document::String(fmt_var.clone())` in both sites instead of inline `format!()`
- **`mod.rs:3018`** — `call 'runtime_module':'dispatch'('name', [params], Self)` expression built with `format!()` → replaced with `docvec![]` composition
- **`control_flow/while_loops.rs:264`** — `in apply 'while'/1 (init_state)` expression → `docvec!["in apply 'while'/1 (", Document::String(init_state), ")"]`
- **`control_flow/mod.rs:2272,2312`** — `letrec 'fn_name'/2 = fun (I, StateAcc) ->` and `in apply 'fn_name'/2 (init_ctr, init_state)` expressions → `docvec![]` with `Document::String(frame.fn_name.clone())` etc.

The generated Core Erlang output is byte-for-byte identical. Only the document construction method changes.

## Test plan

- [x] `just clippy` passes
- [x] `cargo test -p beamtalk-core --lib` — 3532 tests pass
- [x] `cargo fmt --check` passes
- [x] Pre-push hook passes (Rust lint + JS lint + Beamtalk lint)
- [x] No remaining `Document::String(format!())` in these 4 files

## Follow-up

The larger violators — `exception_handling.rs` (44), `dispatch_codegen.rs` (47), `value_type_codegen.rs` (10) — each deserve a dedicated PR.

https://linear.app/beamtalk/issue/BT-2166

---
_Generated by [Claude Code](https://claude.ai/code/session_015pFE8d3eBuhoxhiHuwFCkK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal code-generation formatting and document composition for Core Erlang output, replacing ad-hoc string assembly with structured construction. Enhances maintainability and consistency without changing runtime behavior or user-visible functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2195)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->