### PR TITLE
docs: daily refresh 2026-05-13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Extract duplicated analysis pipeline in MCP server into shared `run_module_analysis` helper (BT-2152).
 - Extract duplicated NLR catch-var allocation into shared `NlrCatchVars` struct/helper (BT-2155).
 - Replace `format!()` calls with `Document` API in `core_erlang_binary_string` — continues the BT-875 cleanup (BT-2163).
+- Replace 6 `Document::String(format!())` calls with `docvec!` in `callbacks.rs`, `mod.rs`, `while_loops.rs`, and `control_flow/mod.rs` — continues the BT-875 cleanup (BT-2166).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

- Add CHANGELOG "Internal" entry for BT-2166 (`Document::String(format!())` → `docvec!` in `callbacks.rs`, `mod.rs`, `while_loops.rs`, and `control_flow/mod.rs` — continues the BT-875 cleanup)

## Commits reviewed

| SHA | Title | Classification | Doc change |
|-----|-------|---------------|------------|
| `7e90a87` | Fix Document::String(format!()) Core Erlang fragment violations in 4 codegen files (BT-2166) | Internal | CHANGELOG entry added |
| `a2fc5b0` | Add EUnit tests for join/1 and from_iolist/1 in beamtalk_string (BT-2167) | Test-only (excluded) | None — diff is purely under `test/` |
| `7b24bf7` | docs: daily refresh 2026-05-12 | Docs (previous refresh) | None — skip |

## Skipped

- **a2fc5b0 (BT-2167)** — test-only change under `runtime/apps/beamtalk_stdlib/test/`, excluded per scope rules
- **7b24bf7** — previous daily refresh commit, no user-facing changes

## Needs human judgment

None.

https://claude.ai/code/session_01MQzKzy6TrHgXdKTVHh76Ae

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQzKzy6TrHgXdKTVHh76Ae)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code consolidation and refactoring improvements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2197)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->