### PR TITLE
docs: daily refresh 2026-05-14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 - Extract duplicated NLR catch-var allocation into shared `NlrCatchVars` struct/helper (BT-2155).
 - Replace `format!()` calls with `Document` API in `core_erlang_binary_string` — continues the BT-875 cleanup (BT-2163).
 - Replace 6 `Document::String(format!())` calls with `docvec!` in `callbacks.rs`, `mod.rs`, `while_loops.rs`, and `control_flow/mod.rs` — continues the BT-875 cleanup (BT-2166).
+- Replace all 44 `Document::String(format!())` violations with `docvec!` equivalents in `exception_handling.rs`, extract `on_do_catch_preamble` and `make_handler_apply` helpers — continues the BT-875 cleanup (BT-2169).
+- Centralize byte-offset→line-number logic into `Span::line_number`, removing duplicate implementations from codegen and MCP server (BT-2160).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

- Add 2 CHANGELOG "Internal" entries for commits merged to main in the last 24 hours

## Commits reviewed

| SHA | Title | Classification | Doc change |
|-----|-------|---------------|------------|
| `dbbdc6a` | refactor: fix format!() Core Erlang violations in exception_handling.rs (BT-2169) | Internal | CHANGELOG entry added |
| `8ff610e` | Centralize byte-offset→line-number logic into Span::line_number (BT-2160) | Internal | CHANGELOG entry added |

## Skipped

- **5fcc007 (BT-2170)** — test-only change (file purely under `runtime/apps/*/test/`), excluded per scope rules
- **421c385** — previous daily refresh commit, no user-facing changes

## Needs human judgment

None.

https://claude.ai/code/session_01Gg86jvxbNDDHntWYDUGn55

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gg86jvxbNDDHntWYDUGn55)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation to reflect internal code maintenance and optimization improvements for better codebase consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2200)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->