### PR TITLE
Extract duplicate build.rs version-injection into beamtalk-build crate (BT-2172)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ repository = "https://github.com/jamesc/beamtalk"
 
 [workspace.dependencies]
 # Workspace crates
+beamtalk-build = { path = "crates/beamtalk-build" }
 beamtalk-core = { path = "crates/beamtalk-core" }
 beamtalk-etf = { path = "crates/beamtalk-etf" }
 beamtalk-examples = { path = "crates/beamtalk-examples" }

--- a/crates/beamtalk-build/Cargo.toml
+++ b/crates/beamtalk-build/Cargo.toml
@@ -1,0 +1,22 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "beamtalk-build"
+description = "Shared build-script helpers for beamtalk crates (version injection)"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords = ["build", "beam", "version"]
+categories = ["development-tools"]
+
+[lib]
+name = "beamtalk_build"
+path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/crates/beamtalk-build/README.md
+++ b/crates/beamtalk-build/README.md
@@ -1,0 +1,7 @@
+# beamtalk-build
+
+Shared build-script helpers for beamtalk workspace crates.
+
+Provides `emit_beamtalk_version`, which reads the workspace `VERSION` file and git
+state and exposes a `BEAMTALK_VERSION` compile-time env var. Used in the `build.rs`
+of `beamtalk-cli` and `beamtalk-compiler-port`.

--- a/crates/beamtalk-build/src/lib.rs
+++ b/crates/beamtalk-build/src/lib.rs
@@ -1,0 +1,102 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared build-script helpers for beamtalk crates.
+//!
+//! Provides `emit_beamtalk_version` which reads the workspace `VERSION` file
+//! and git state, then exposes the `BEAMTALK_VERSION` compile-time env var.
+//!
+//! # Usage
+//!
+//! In a crate's `build.rs`:
+//!
+//! ```rust,ignore
+//! fn main() {
+//!     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+//!     let workspace_root = std::path::Path::new(&manifest_dir)
+//!         .parent()
+//!         .and_then(std::path::Path::parent)
+//!         .expect("Cannot find workspace root");
+//!     beamtalk_build::emit_beamtalk_version(workspace_root);
+//! }
+//! ```
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Read VERSION file and git state, then expose `BEAMTALK_VERSION` at compile time.
+///
+/// On a release tag: `0.2.0`
+/// Off a tag:        `0.2.0-dev+abc1234`
+///
+/// # Panics
+///
+/// Panics if the `VERSION` file cannot be read, is empty, or contains
+/// characters outside `[A-Za-z0-9.+-]`.
+pub fn emit_beamtalk_version(workspace_root: &Path) {
+    let version_file = workspace_root.join("VERSION");
+    println!("cargo:rerun-if-changed={}", version_file.display());
+
+    // Track git state so version is recomputed on new commits/tags.
+    // Uses `git rev-parse --git-path` to resolve each path correctly in both
+    // regular repos and worktrees (where HEAD is worktree-private but refs
+    // and packed-refs live in the shared git-common-dir).
+    for p in ["HEAD", "refs/heads", "refs/tags", "packed-refs"] {
+        if let Some(path) = git_path(p) {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+
+    let base = fs::read_to_string(&version_file)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", version_file.display()));
+    let base = base.trim();
+    assert!(
+        !base.is_empty(),
+        "VERSION file is empty: {}",
+        version_file.display()
+    );
+    assert!(
+        base.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+')),
+        "VERSION contains invalid characters (allowed: [A-Za-z0-9.+-]): {}",
+        version_file.display()
+    );
+
+    let version = if git_on_tag() {
+        base.to_string()
+    } else if let Some(sha) = git_short_sha() {
+        format!("{base}-dev+{sha}")
+    } else {
+        base.to_string()
+    };
+
+    println!("cargo:rustc-env=BEAMTALK_VERSION={version}");
+}
+
+fn git_on_tag() -> bool {
+    Command::new("git")
+        .args(["describe", "--exact-match", "--tags", "HEAD"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+fn git_path(path: &str) -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "--git-path", path])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+}
+
+fn git_short_sha() -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+}

--- a/crates/beamtalk-cli/Cargo.toml
+++ b/crates/beamtalk-cli/Cargo.toml
@@ -68,5 +68,8 @@ predicates = "3"
 name = "build_bench"
 harness = false
 
+[build-dependencies]
+beamtalk-build.workspace = true
+
 [lints]
 workspace = true

--- a/crates/beamtalk-cli/build.rs
+++ b/crates/beamtalk-cli/build.rs
@@ -7,9 +7,7 @@
 //! The Erlang runtime is built by `just build-erlang`, not here.
 
 use std::env;
-use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
@@ -18,77 +16,5 @@ fn main() {
         .and_then(Path::parent)
         .expect("Cannot find workspace root");
 
-    // --- Version injection from VERSION file + git state ---
-    emit_beamtalk_version(workspace_root);
-}
-
-/// Read VERSION file and git state, then expose `BEAMTALK_VERSION` at compile time.
-///
-/// On a release tag: `0.2.0`
-/// Off a tag:        `0.2.0-dev+abc1234`
-fn emit_beamtalk_version(workspace_root: &Path) {
-    let version_file = workspace_root.join("VERSION");
-    println!("cargo:rerun-if-changed={}", version_file.display());
-
-    // Track git state so version is recomputed on new commits/tags.
-    // Uses `git rev-parse --git-path` to resolve each path correctly in both
-    // regular repos and worktrees (where HEAD is worktree-private but refs
-    // and packed-refs live in the shared git-common-dir).
-    for p in ["HEAD", "refs/heads", "refs/tags", "packed-refs"] {
-        if let Some(path) = git_path(p) {
-            println!("cargo:rerun-if-changed={path}");
-        }
-    }
-
-    let base = fs::read_to_string(&version_file)
-        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", version_file.display()));
-    let base = base.trim();
-    assert!(
-        !base.is_empty(),
-        "VERSION file is empty: {}",
-        version_file.display()
-    );
-    assert!(
-        base.chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+')),
-        "VERSION contains invalid characters (allowed: [A-Za-z0-9.+-]): {}",
-        version_file.display()
-    );
-
-    let version = if git_on_tag() {
-        base.to_string()
-    } else if let Some(sha) = git_short_sha() {
-        format!("{base}-dev+{sha}")
-    } else {
-        base.to_string()
-    };
-
-    println!("cargo:rustc-env=BEAMTALK_VERSION={version}");
-}
-
-fn git_on_tag() -> bool {
-    Command::new("git")
-        .args(["describe", "--exact-match", "--tags", "HEAD"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .is_ok_and(|s| s.success())
-}
-
-fn git_path(path: &str) -> Option<String> {
-    Command::new("git")
-        .args(["rev-parse", "--git-path", path])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-}
-
-fn git_short_sha() -> Option<String> {
-    Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+    beamtalk_build::emit_beamtalk_version(workspace_root);
 }

--- a/crates/beamtalk-compiler-port/Cargo.toml
+++ b/crates/beamtalk-compiler-port/Cargo.toml
@@ -37,5 +37,8 @@ tracing-subscriber = { workspace = true }
 # why: property-based testing for compiler port robustness (ADR 0011 Phase 4)
 proptest = { workspace = true }
 
+[build-dependencies]
+beamtalk-build.workspace = true
+
 [lints]
 workspace = true

--- a/crates/beamtalk-compiler-port/build.rs
+++ b/crates/beamtalk-compiler-port/build.rs
@@ -4,9 +4,7 @@
 //! Build script to inject `BEAMTALK_VERSION` from the workspace VERSION file.
 
 use std::env;
-use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
@@ -15,76 +13,5 @@ fn main() {
         .and_then(Path::parent)
         .expect("Cannot find workspace root");
 
-    emit_beamtalk_version(workspace_root);
-}
-
-/// Read VERSION file and git state, then expose `BEAMTALK_VERSION` at compile time.
-///
-/// On a release tag: `0.2.0`
-/// Off a tag:        `0.2.0-dev+abc1234`
-fn emit_beamtalk_version(workspace_root: &Path) {
-    let version_file = workspace_root.join("VERSION");
-    println!("cargo:rerun-if-changed={}", version_file.display());
-
-    // Track git state so version is recomputed on new commits/tags.
-    // Uses `git rev-parse --git-path` to resolve each path correctly in both
-    // regular repos and worktrees (where HEAD is worktree-private but refs
-    // and packed-refs live in the shared git-common-dir).
-    for p in ["HEAD", "refs/heads", "refs/tags", "packed-refs"] {
-        if let Some(path) = git_path(p) {
-            println!("cargo:rerun-if-changed={path}");
-        }
-    }
-
-    let base = fs::read_to_string(&version_file)
-        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", version_file.display()));
-    let base = base.trim();
-    assert!(
-        !base.is_empty(),
-        "VERSION file is empty: {}",
-        version_file.display()
-    );
-    assert!(
-        base.chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+')),
-        "VERSION contains invalid characters (allowed: [A-Za-z0-9.+-]): {}",
-        version_file.display()
-    );
-
-    let version = if git_on_tag() {
-        base.to_string()
-    } else if let Some(sha) = git_short_sha() {
-        format!("{base}-dev+{sha}")
-    } else {
-        base.to_string()
-    };
-
-    println!("cargo:rustc-env=BEAMTALK_VERSION={version}");
-}
-
-fn git_on_tag() -> bool {
-    Command::new("git")
-        .args(["describe", "--exact-match", "--tags", "HEAD"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .is_ok_and(|s| s.success())
-}
-
-fn git_path(path: &str) -> Option<String> {
-    Command::new("git")
-        .args(["rev-parse", "--git-path", path])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-}
-
-fn git_short_sha() -> Option<String> {
-    Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+    beamtalk_build::emit_beamtalk_version(workspace_root);
 }


### PR DESCRIPTION
## Summary

- Extract the four identical version-injection functions (`emit_beamtalk_version`, `git_on_tag`, `git_path`, `git_short_sha`) from `beamtalk-cli/build.rs` and `beamtalk-compiler-port/build.rs` into a new shared `beamtalk-build` workspace crate
- Both build scripts are reduced to trivial wrappers that call `beamtalk_build::emit_beamtalk_version(workspace_root)`
- Net result: -16 lines, single source of truth for version injection logic

## Key changes

- **New:** `crates/beamtalk-build/` — library crate with shared build-script helpers
- **Simplified:** `crates/beamtalk-cli/build.rs` (94 → 20 lines)
- **Simplified:** `crates/beamtalk-compiler-port/build.rs` (90 → 18 lines)
- **Updated:** Workspace `Cargo.toml` + both crate `Cargo.toml` files for `[build-dependencies]`

Resolves https://linear.app/beamtalk/issue/BT-2172

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvJQdY1v37AkwNRFcUjX1A)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated build-script utilities into a shared workspace crate and updated crates to use it, reducing duplication across the workspace.
* **Documentation**
  * Added README documenting the shared build helper and its usage by the workspace build scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2201)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->