### PR TITLE
Add unit tests for beamtalk_workspace_config (BT-2173)

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_config_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_config_tests.erl
@@ -92,13 +92,22 @@ binding_names_contains_workspace_test() ->
 %%% ============================================================================
 
 binding_name_for_class_transcript_stream_test() ->
-    ?assertEqual({ok, 'Transcript'}, beamtalk_workspace_config:binding_name_for_class('TranscriptStream')).
+    ?assertEqual(
+        {ok, 'Transcript'},
+        beamtalk_workspace_config:binding_name_for_class('TranscriptStream')
+    ).
 
 binding_name_for_class_beamtalk_interface_test() ->
-    ?assertEqual({ok, 'Beamtalk'}, beamtalk_workspace_config:binding_name_for_class('BeamtalkInterface')).
+    ?assertEqual(
+        {ok, 'Beamtalk'},
+        beamtalk_workspace_config:binding_name_for_class('BeamtalkInterface')
+    ).
 
 binding_name_for_class_workspace_interface_test() ->
-    ?assertEqual({ok, 'Workspace'}, beamtalk_workspace_config:binding_name_for_class('WorkspaceInterface')).
+    ?assertEqual(
+        {ok, 'Workspace'},
+        beamtalk_workspace_config:binding_name_for_class('WorkspaceInterface')
+    ).
 
 binding_name_for_class_unknown_returns_undefined_test() ->
     ?assertEqual(undefined, beamtalk_workspace_config:binding_name_for_class('Counter')).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_config_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_config_tests.erl
@@ -1,0 +1,110 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_workspace_config_tests).
+
+%%% **DDD Context:** Workspace Context
+
+-moduledoc """
+Unit tests for beamtalk_workspace_config (BT-2173).
+
+Covers all 4 exported pure functions: singletons/0, value_singletons/0,
+binding_names/0, and binding_name_for_class/1.
+""".
+-include_lib("eunit/include/eunit.hrl").
+
+%%% ============================================================================
+%%% singletons/0
+%%% ============================================================================
+
+singletons_returns_list_test() ->
+    Result = beamtalk_workspace_config:singletons(),
+    ?assert(is_list(Result)).
+
+singletons_has_one_entry_test() ->
+    Result = beamtalk_workspace_config:singletons(),
+    ?assertEqual(1, length(Result)).
+
+singletons_transcript_binding_name_test() ->
+    [Singleton] = beamtalk_workspace_config:singletons(),
+    ?assertEqual('Transcript', maps:get(binding_name, Singleton)).
+
+singletons_transcript_class_name_test() ->
+    [Singleton] = beamtalk_workspace_config:singletons(),
+    ?assertEqual('TranscriptStream', maps:get(class_name, Singleton)).
+
+singletons_transcript_module_test() ->
+    [Singleton] = beamtalk_workspace_config:singletons(),
+    ?assertEqual(beamtalk_transcript_stream, maps:get(module, Singleton)).
+
+singletons_transcript_start_args_test() ->
+    [Singleton] = beamtalk_workspace_config:singletons(),
+    ?assertEqual([1000], maps:get(start_args, Singleton)).
+
+%%% ============================================================================
+%%% value_singletons/0
+%%% ============================================================================
+
+value_singletons_returns_list_test() ->
+    Result = beamtalk_workspace_config:value_singletons(),
+    ?assert(is_list(Result)).
+
+value_singletons_has_two_entries_test() ->
+    Result = beamtalk_workspace_config:value_singletons(),
+    ?assertEqual(2, length(Result)).
+
+value_singletons_beamtalk_binding_test() ->
+    [Beamtalk, _Workspace] = beamtalk_workspace_config:value_singletons(),
+    ?assertEqual('Beamtalk', maps:get(binding_name, Beamtalk)),
+    ?assertEqual('BeamtalkInterface', maps:get(class_name, Beamtalk)).
+
+value_singletons_workspace_binding_test() ->
+    [_Beamtalk, Workspace] = beamtalk_workspace_config:value_singletons(),
+    ?assertEqual('Workspace', maps:get(binding_name, Workspace)),
+    ?assertEqual('WorkspaceInterface', maps:get(class_name, Workspace)).
+
+%%% ============================================================================
+%%% binding_names/0
+%%% ============================================================================
+
+binding_names_returns_three_test() ->
+    Names = beamtalk_workspace_config:binding_names(),
+    ?assertEqual(3, length(Names)).
+
+binding_names_exact_order_test() ->
+    Names = beamtalk_workspace_config:binding_names(),
+    ?assertEqual(['Transcript', 'Beamtalk', 'Workspace'], Names).
+
+binding_names_contains_transcript_test() ->
+    Names = beamtalk_workspace_config:binding_names(),
+    ?assert(lists:member('Transcript', Names)).
+
+binding_names_contains_beamtalk_test() ->
+    Names = beamtalk_workspace_config:binding_names(),
+    ?assert(lists:member('Beamtalk', Names)).
+
+binding_names_contains_workspace_test() ->
+    Names = beamtalk_workspace_config:binding_names(),
+    ?assert(lists:member('Workspace', Names)).
+
+%%% ============================================================================
+%%% binding_name_for_class/1
+%%% ============================================================================
+
+binding_name_for_class_transcript_stream_test() ->
+    ?assertEqual({ok, 'Transcript'}, beamtalk_workspace_config:binding_name_for_class('TranscriptStream')).
+
+binding_name_for_class_beamtalk_interface_test() ->
+    ?assertEqual({ok, 'Beamtalk'}, beamtalk_workspace_config:binding_name_for_class('BeamtalkInterface')).
+
+binding_name_for_class_workspace_interface_test() ->
+    ?assertEqual({ok, 'Workspace'}, beamtalk_workspace_config:binding_name_for_class('WorkspaceInterface')).
+
+binding_name_for_class_unknown_returns_undefined_test() ->
+    ?assertEqual(undefined, beamtalk_workspace_config:binding_name_for_class('Counter')).
+
+binding_name_for_class_object_returns_undefined_test() ->
+    ?assertEqual(undefined, beamtalk_workspace_config:binding_name_for_class('Object')).
+
+binding_name_for_class_nonexistent_atom_test() ->
+    ?assertEqual(undefined, beamtalk_workspace_config:binding_name_for_class('NoSuchClass')).


### PR DESCRIPTION
## Summary

- Adds `beamtalk_workspace_config_tests.erl` with 21 EUnit tests covering all 4 exported functions at 0% → 100% coverage
- Tests are pure (no OTP setup needed) — `singletons/0`, `value_singletons/0`, `binding_names/0`, and `binding_name_for_class/1`
- All 4 branches of `binding_name_for_class/1` exercised (3 known classes + unknown → `undefined`)

## Test plan

- [x] All 21 tests pass via direct `erl -eval "eunit:test(beamtalk_workspace_config_tests, [verbose])"`
- [x] Both source and test compile cleanly with `erlc`
- [ ] CI `rebar3 eunit --app=beamtalk_workspace` passes (needs network for cowboy dep)

Closes BT-2173
https://linear.app/beamtalk/issue/BT-2173

https://claude.ai/code/session_01PEU6j8Jmf16eRS7vWhbDYQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEU6j8Jmf16eRS7vWhbDYQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test suite validating workspace configuration behavior: singleton entries, expected binding-list order, detailed singleton metadata, and class-name lookup responses (including handling of unknown or non-class inputs).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2202)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2202)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->