### PR TITLE
docs: daily refresh 2026-05-15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Replace 6 `Document::String(format!())` calls with `docvec!` in `callbacks.rs`, `mod.rs`, `while_loops.rs`, and `control_flow/mod.rs` — continues the BT-875 cleanup (BT-2166).
 - Replace all 44 `Document::String(format!())` violations with `docvec!` equivalents in `exception_handling.rs`, extract `on_do_catch_preamble` and `make_handler_apply` helpers — continues the BT-875 cleanup (BT-2169).
 - Centralize byte-offset→line-number logic into `Span::line_number`, removing duplicate implementations from codegen and MCP server (BT-2160).
+- Extract duplicate `build.rs` version-injection logic into shared `beamtalk-build` workspace crate — single source of truth for `BEAMTALK_VERSION` emission (BT-2172).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

- Add 1 CHANGELOG "Internal" entry for commits merged to main in the last 24 hours

## Commits reviewed

| SHA | Title | Classification | Doc change |
|-----|-------|---------------|------------|
| `4a6522e` | Extract duplicate build.rs version-injection into beamtalk-build crate (BT-2172) | Internal | CHANGELOG entry added |

## Skipped

- **f9d7429 (BT-2173)** — test-only change (file purely under `runtime/apps/*/test/`), excluded per scope rules
- **39af5cb** — previous daily refresh commit, no user-facing changes

## Needs human judgment

None.

https://claude.ai/code/session_01RWhY53eVBzknc9oA5WufNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWhY53eVBzknc9oA5WufNK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code organization and maintainability through refactoring of build-time processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2203)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->