### PR TITLE
Fix format!() violations for Core Erlang variable names (BT-2175)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -755,11 +755,19 @@ impl CoreErlangGenerator {
     ) -> Document<'static> {
         let arity = slots.len() + 2; // _ClassSelf + _ClassVars + N slot args
 
+        // Pre-compute slot argument names once; write! instead of format! per codegen rules.
+        let slot_arg_names: Vec<String> = (0..slots.len())
+            .map(|i| {
+                let mut name = String::from("SlotArg");
+                let _ = write!(&mut name, "{i}");
+                name
+            })
+            .collect();
+
         // Extra slot parameters appended after "_ClassSelf, _ClassVars": ", SlotArg0", ...
-        let slot_param_docs: Vec<Document<'static>> = slots
+        let slot_param_docs: Vec<Document<'static>> = slot_arg_names
             .iter()
-            .enumerate()
-            .flat_map(|(i, _)| [Document::Str(", "), Document::String(format!("SlotArg{i}"))])
+            .flat_map(|name| [Document::Str(", "), Document::String(name.clone())])
             .collect();
 
         // BT-1408: Hash long keyword constructor atoms to stay within Erlang's
@@ -778,7 +786,7 @@ impl CoreErlangGenerator {
                     Document::Str("'"),
                     Document::String(slot_name.clone()),
                     Document::Str("' => "),
-                    Document::String(format!("SlotArg{i}")),
+                    Document::String(slot_arg_names[i].clone()),
                 ]);
             }
 
@@ -810,7 +818,7 @@ impl CoreErlangGenerator {
                 Document::Str(", '"),
                 Document::String(slot_name.clone()),
                 Document::Str("' => "),
-                Document::String(format!("SlotArg{i}")),
+                Document::String(slot_arg_names[i].clone()),
             ]);
         }
 

--- a/crates/beamtalk-core/src/repl/codegen.rs
+++ b/crates/beamtalk-core/src/repl/codegen.rs
@@ -340,7 +340,7 @@ impl<'a> ReplAssembler<'a> {
         let mut step_pairs: Vec<(String, Document<'static>)> = Vec::new();
 
         for (i, expr) in expressions[..n - 1].iter().enumerate() {
-            let result_var = format!("_R{}", i + 1);
+            let result_var = self.generator.fresh_temp_var("R");
             let (part, repl_mutated) = self.generate_repl_intermediate_expr(expr, &result_var)?;
             body_parts.push(part);
             let step_val: Document<'static> = if repl_mutated {
@@ -626,8 +626,8 @@ impl<'a> ReplAssembler<'a> {
         let mut body_parts: Vec<Document<'static>> = Vec::new();
 
         // Process all but the last expression
-        for (i, expr) in expressions[..n - 1].iter().enumerate() {
-            let result_var = format!("_R{}", i + 1);
+        for expr in &expressions[..n - 1] {
+            let result_var = self.generator.fresh_temp_var("R");
             let (part, _repl_mutated) = self.generate_repl_intermediate_expr(expr, &result_var)?;
             body_parts.push(part);
         }


### PR DESCRIPTION
## Summary

Fixes 5 lingering BT-875-class `format!()` violations that construct Core Erlang variable names instead of using the proper codegen API.

- **`repl/codegen.rs`** (2 occurrences): Replace `format!("_R{}", i + 1)` with `self.generator.fresh_temp_var("R")` — uses the generator's shared var counter for guaranteed-unique names
- **`value_type_codegen.rs`** (3 occurrences): Pre-compute `SlotArg{i}` names once using `write!` (matching the `variable_context.rs:114-115` pattern), then reuse in both parameter lists and map bodies

No behavior change — generated Core Erlang variable names remain valid and unique.

[Linear: BT-2175](https://linear.app/beamtalk/issue/BT-2175)

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 3536 tests pass
- [x] `just clippy` — zero warnings
- [x] `cargo fmt -- --check` — clean
- [x] Pre-existing failures (`cli_doc`, `beamtalk-mcp`) confirmed on main — unrelated

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRUdd3PSSRx3EhV91E6HTa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized code generation efficiency through improved variable naming strategies.
  * Enhanced internal variable handling in the REPL to reduce redundant operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2204)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->