### PR TITLE
Add coverage for beamtalk_error format_reason/2 and missing error kinds (BT-2176)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_error_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_error_tests.erl
@@ -362,3 +362,112 @@ extract_beamtalk_error_respects_depth_limit_test() ->
     %% Error nested 3 levels deep, but depth limit is 1
     Nested = {a, {b, Error}},
     ?assertEqual(undefined, beamtalk_error:extract_beamtalk_error(Nested, 1)).
+
+%%% Tests: format_reason/2
+
+format_reason_with_beamtalk_error_record_test() ->
+    Error = beamtalk_error:new(actor_dead, 'Counter'),
+    Result = beamtalk_error:format_reason(error, Error),
+    ?assert(is_binary(Result)),
+    ?assertEqual(<<"Counter actor process has terminated (Counter:actor_dead)">>, Result).
+
+format_reason_with_exception_tagged_map_test() ->
+    Error = beamtalk_error:new(does_not_understand, 'String'),
+    Error1 = beamtalk_error:with_selector(Error, 'push:'),
+    Wrapped = #{'$beamtalk_class' => 'NoSuchMethodError', error => Error1},
+    Result = beamtalk_error:format_reason(error, Wrapped),
+    ?assert(is_binary(Result)),
+    ?assertEqual(<<"String does not understand 'push:' (String:does_not_understand)">>, Result).
+
+format_reason_with_arbitrary_term_test() ->
+    Result = beamtalk_error:format_reason(error, {badmatch, 42}),
+    ?assert(is_binary(Result)),
+    ?assertEqual(<<"error:{badmatch,42}">>, Result).
+
+%%% Tests: with_message/2 (atom and fallback clauses)
+
+with_message_atom_converts_to_binary_test() ->
+    Error0 = beamtalk_error:new(user_error, 'Widget'),
+    Error = beamtalk_error:with_message(Error0, no_such_method),
+    ?assertEqual(<<"no_such_method">>, Error#beamtalk_error.message).
+
+with_message_tuple_formats_as_binary_test() ->
+    Error0 = beamtalk_error:new(user_error, 'Widget'),
+    Error = beamtalk_error:with_message(Error0, {badarg, 99}),
+    ?assertEqual(<<"{badarg,99}">>, Error#beamtalk_error.message).
+
+%%% Tests: generate_message/3 — missing error kinds
+
+actor_dead_message_test() ->
+    Error1 = beamtalk_error:new(actor_dead, 'Counter'),
+    ?assertEqual(<<"Counter actor process has terminated">>, Error1#beamtalk_error.message),
+
+    Error2 = beamtalk_error:with_selector(Error1, 'increment'),
+    ?assertEqual(
+        <<"Cannot send 'increment' to Counter (actor process has terminated)">>,
+        Error2#beamtalk_error.message
+    ).
+
+file_not_found_message_test() ->
+    Error1 = beamtalk_error:new(file_not_found, 'File'),
+    ?assertEqual(<<"File: file not found">>, Error1#beamtalk_error.message),
+
+    Error2 = beamtalk_error:with_selector(Error1, 'open'),
+    ?assertEqual(<<"File 'open': file not found">>, Error2#beamtalk_error.message).
+
+permission_denied_message_test() ->
+    Error1 = beamtalk_error:new(permission_denied, 'File'),
+    ?assertEqual(<<"File: permission denied">>, Error1#beamtalk_error.message),
+
+    Error2 = beamtalk_error:with_selector(Error1, 'write'),
+    ?assertEqual(<<"File 'write': permission denied">>, Error2#beamtalk_error.message).
+
+io_error_message_test() ->
+    Error1 = beamtalk_error:new(io_error, 'FileHandle'),
+    ?assertEqual(<<"FileHandle: I/O error">>, Error1#beamtalk_error.message),
+
+    Error2 = beamtalk_error:with_selector(Error1, 'read'),
+    ?assertEqual(<<"FileHandle 'read': I/O error">>, Error2#beamtalk_error.message).
+
+user_error_message_test() ->
+    Error1 = beamtalk_error:new(user_error, 'Widget'),
+    ?assertEqual(<<"Error">>, Error1#beamtalk_error.message),
+
+    Error2 = beamtalk_error:with_selector(Error1, badarg),
+    ?assertEqual(<<"badarg">>, Error2#beamtalk_error.message).
+
+stdlib_shadowing_message_test() ->
+    Error1 = beamtalk_error:new(stdlib_shadowing, 'Object'),
+    ?assertEqual(<<"Cannot redefine stdlib class 'Object'">>, Error1#beamtalk_error.message),
+
+    Error2 = beamtalk_error:with_selector(Error1, 'redefine'),
+    ?assertEqual(
+        <<"Cannot redefine stdlib class 'Object' (via 'redefine')">>,
+        Error2#beamtalk_error.message
+    ).
+
+uninitialized_state_error_message_test() ->
+    Error1 = beamtalk_error:new(uninitialized_state_error, 'Counter'),
+    ?assertEqual(<<"UninitializedStateError in Counter">>, Error1#beamtalk_error.message),
+
+    Error2 = beamtalk_error:with_selector(Error1, 'getValue'),
+    ?assertEqual(
+        <<"UninitializedStateError in 'getValue' on Counter">>,
+        Error2#beamtalk_error.message
+    ).
+
+class_already_exists_with_selector_message_test() ->
+    Error = beamtalk_error:new(class_already_exists, 'Counter'),
+    ErrorWithSel = beamtalk_error:with_selector(Error, 'load'),
+    ?assertEqual(
+        <<"Class 'Counter' already exists (via 'load')">>,
+        ErrorWithSel#beamtalk_error.message
+    ).
+
+generate_message_catchall_with_selector_test() ->
+    Error = beamtalk_error:new(custom_kind, 'Widget'),
+    ErrorWithSel = beamtalk_error:with_selector(Error, 'doSomething'),
+    ?assertEqual(
+        <<"custom_kind error in 'doSomething' on Widget">>,
+        ErrorWithSel#beamtalk_error.message
+    ).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_log_filter_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_log_filter_tests.erl
@@ -1,5 +1,6 @@
 %% Copyright 2026 James Casey
 %% SPDX-License-Identifier: Apache-2.0
+%%% **DDD Context:** Runtime Context
 
 -module(beamtalk_log_filter_tests).
 

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_log_filter_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_log_filter_tests.erl
@@ -1,0 +1,21 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_log_filter_tests).
+
+-moduledoc """
+EUnit tests for beamtalk_log_filter module.
+
+Tests both clauses of filter_proc_lib_crash/2:
+  - proc_lib crash reports are dropped (stop)
+  - all other log events are passed through (ignore)
+""".
+-include_lib("eunit/include/eunit.hrl").
+
+filter_proc_lib_crash_stops_proc_lib_crash_reports_test() ->
+    Event = #{msg => {report, #{label => {proc_lib, crash}}}},
+    ?assertEqual(stop, beamtalk_log_filter:filter_proc_lib_crash(Event, undefined)).
+
+filter_proc_lib_crash_ignores_other_events_test() ->
+    Event = #{msg => {report, #{label => {supervisor, child_terminated}}}},
+    ?assertEqual(ignore, beamtalk_log_filter:filter_proc_lib_crash(Event, undefined)).


### PR DESCRIPTION
## Summary

Closes BT-2176. Extends `beamtalk_error_tests.erl` with 14 new tests covering previously-untested exported functions and error-kind clauses, and adds a new test file for `beamtalk_log_filter`.

- **`format_reason/2`** — exported, used for debug logging in dispatch catch blocks, all 3 clauses were at 0% coverage. Tests added for: `#beamtalk_error{}` record, exception-tagged-map wrapper (delegates to clause 1), and arbitrary-term fallback.
- **`with_message/2`** — atom and tuple fallback clauses untested. Tests added.
- **`generate_message/3`** — 7 error kinds with 2 variants each (14 clauses) all untested: `actor_dead`, `file_not_found`, `permission_denied`, `io_error`, `user_error`, `stdlib_shadowing`, `uninitialized_state_error`. Tests added for both selector/no-selector variants.
- **`class_already_exists` with selector** — only the no-selector variant was tested. Test added.
- **Catch-all `generate_message/3` with selector** — test added.
- **`beamtalk_log_filter_tests.erl`** (new) — both clauses of `filter_proc_lib_crash/2` tested: `stop` on `proc_lib` crash reports, `ignore` on all other events.

All 16 new tests are pure (no OTP application startup, no gen_server, no class registry). Verified passing with direct `erlc` + `erl -eval eunit:test`.

## Test plan

- [x] 14 new tests in `beamtalk_error_tests.erl` pass (verified via direct `erlc`/`erl -eval`)
- [x] 2 new tests in `beamtalk_log_filter_tests.erl` pass (verified via direct `erlc`/`erl -eval`)
- [x] Rust clippy and fmt-check pass
- [ ] `rebar3 eunit --app=beamtalk_runtime` — blocked by pre-existing hexpm TLS issue in local environment (cowboy 2.12.0 fetch fails); CI has network access

https://linear.app/beamtalk/issue/BT-2176

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2peDKszJoN6HQPSaJCh4a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for error message handling and formatting.
  * Added tests for log filtering functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2205)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->