### PR TITLE
docs: daily refresh 2026-05-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Replace all 44 `Document::String(format!())` violations with `docvec!` equivalents in `exception_handling.rs`, extract `on_do_catch_preamble` and `make_handler_apply` helpers — continues the BT-875 cleanup (BT-2169).
 - Centralize byte-offset→line-number logic into `Span::line_number`, removing duplicate implementations from codegen and MCP server (BT-2160).
 - Extract duplicate `build.rs` version-injection logic into shared `beamtalk-build` workspace crate — single source of truth for `BEAMTALK_VERSION` emission (BT-2172).
+- Replace 5 `format!()` calls with `fresh_temp_var` / `write!` in `repl/codegen.rs` and `value_type_codegen.rs` — continues the BT-875 cleanup (BT-2175).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

Daily documentation refresh for 2026-05-16.

- Added CHANGELOG "Internal" entry for BT-2175 (`format!()` → `fresh_temp_var`/`write!` cleanup in `repl/codegen.rs` and `value_type_codegen.rs`)

### Commits reviewed (3)

| Commit | Description | Action |
|--------|-------------|--------|
| `58751ab` (BT-2175) | Fix `format!()` violations for Core Erlang variable names | CHANGELOG Internal entry added |
| `6bd8c15` (BT-2176) | Add coverage for `beamtalk_error` `format_reason/2` | Skipped — test-only (`runtime/apps/*/test/`) |
| `4281513` (BT-2177) | Remove hardcoded `/tmp/` paths from workspace EUnit tests | Skipped — test-only + CI (`runtime/apps/*/test/`, `.github/`) |

### Skipped (2)

- **BT-2176** — purely adds test files under `runtime/apps/beamtalk_runtime/test/`
- **BT-2177** — purely modifies test files under `runtime/apps/beamtalk_workspace/test/` and `.github/workflows/`

No user-visible language, stdlib, runtime, or tooling changes in the review window.

## Test plan

- [ ] CHANGELOG entry matches commit diff (BT-2175: 5 `format!()` calls replaced in 2 codegen files)
- [ ] No other docs affected (grep confirmed no user-facing doc references to `value_type_codegen` or `repl/codegen` variable naming)

https://claude.ai/code/session_01UGJSco9hSPYJooL1ehjGfi

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGJSco9hSPYJooL1ehjGfi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal changelog to document code maintenance and cleanup work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->