### PR TITLE
Extract shared parse-and-validate helper in compiler-port (BT-2178)

### DIFF
--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -676,9 +676,6 @@ fn partition_diagnostics(
 ///
 /// Returns `Ok((module, warnings))` on success, or `Err(response_term)` containing a
 /// formatted `diagnostic_error_response` that the caller should return directly.
-///
-/// Shared by `handle_compile_expression` and `handle_compile_expression_trace` to
-/// eliminate the identical parse → analyse → validate → filter pipeline.
 fn parse_and_check_expression(
     source: &str,
     known_vars: &[String],

--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -672,6 +672,47 @@ fn partition_diagnostics(
     (errors, warnings)
 }
 
+/// Parse a Beamtalk expression source and run full diagnostics with primitive validation.
+///
+/// Returns `Ok((module, warnings))` on success, or `Err(response_term)` containing a
+/// formatted `diagnostic_error_response` that the caller should return directly.
+///
+/// Shared by `handle_compile_expression` and `handle_compile_expression_trace` to
+/// eliminate the identical parse → analyse → validate → filter pipeline.
+fn parse_and_check_expression(
+    source: &str,
+    known_vars: &[String],
+    pre_class_hierarchy: Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
+) -> Result<(beamtalk_core::ast::Module, Vec<String>), Term> {
+    let tokens = beamtalk_core::source_analysis::lex_with_eof(source);
+    let (module, parse_diagnostics) = beamtalk_core::source_analysis::parse(tokens);
+
+    let known_var_refs: Vec<&str> = known_vars.iter().map(String::as_str).collect();
+    let mut all_diagnostics =
+        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_with_known_vars_and_classes(
+            &module,
+            parse_diagnostics,
+            &known_var_refs,
+            pre_class_hierarchy,
+        );
+
+    let options = beamtalk_core::CompilerOptions::default();
+    let primitive_diags =
+        beamtalk_core::semantic_analysis::primitive_validator::validate_primitives(
+            &module, &options,
+        );
+    all_diagnostics.extend(primitive_diags);
+
+    let error_diags = filter_error_diagnostics(&all_diagnostics);
+    let warnings = collect_warning_messages(&all_diagnostics);
+
+    if !error_diags.is_empty() {
+        return Err(diagnostic_error_response(&error_diags, source));
+    }
+
+    Ok((module, warnings))
+}
+
 /// Handle a single `compile_expression` request.
 fn handle_compile_expression(request: &Map) -> Term {
     // Extract required fields
@@ -698,35 +739,11 @@ fn handle_compile_expression(request: &Map) -> Term {
     };
     let pre_class_hierarchy = extract_class_hierarchy(request);
 
-    // Parse the expression
-    let tokens = beamtalk_core::source_analysis::lex_with_eof(&source);
-    let (module, parse_diagnostics) = beamtalk_core::source_analysis::parse(tokens);
-
-    // Run semantic analysis with known REPL variables
-    let known_var_refs: Vec<&str> = known_vars.iter().map(String::as_str).collect();
-    let mut all_diagnostics =
-        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_with_known_vars_and_classes(
-            &module,
-            parse_diagnostics,
-            &known_var_refs,
-            pre_class_hierarchy.clone(),
-        );
-
-    // Run @primitive validation
-    let options = beamtalk_core::CompilerOptions::default();
-    let primitive_diags =
-        beamtalk_core::semantic_analysis::primitive_validator::validate_primitives(
-            &module, &options,
-        );
-    all_diagnostics.extend(primitive_diags);
-
-    // Separate errors and warnings
-    let error_diags = filter_error_diagnostics(&all_diagnostics);
-    let warnings = collect_warning_messages(&all_diagnostics);
-
-    if !error_diags.is_empty() {
-        return diagnostic_error_response(&error_diags, &source);
-    }
+    let (module, warnings) =
+        match parse_and_check_expression(&source, &known_vars, pre_class_hierarchy.clone()) {
+            Ok(r) => r,
+            Err(resp) => return resp,
+        };
 
     // BT-1670: Extract optional module_name override for inline class definitions
     // so they produce the same module name as file-based compilation in package mode.
@@ -825,32 +842,11 @@ fn handle_compile_expression_trace(request: &Map) -> Term {
     };
     let pre_class_hierarchy = extract_class_hierarchy(request);
 
-    let tokens = beamtalk_core::source_analysis::lex_with_eof(&source);
-    let (module, parse_diagnostics) = beamtalk_core::source_analysis::parse(tokens);
-
-    let known_var_refs: Vec<&str> = known_vars.iter().map(String::as_str).collect();
-    let mut all_diagnostics =
-        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_with_known_vars_and_classes(
-            &module,
-            parse_diagnostics,
-            &known_var_refs,
-            pre_class_hierarchy,
-        );
-
-    // Run @primitive validation (parity with compile_expression).
-    let options = beamtalk_core::CompilerOptions::default();
-    let primitive_diags =
-        beamtalk_core::semantic_analysis::primitive_validator::validate_primitives(
-            &module, &options,
-        );
-    all_diagnostics.extend(primitive_diags);
-
-    let error_diags = filter_error_diagnostics(&all_diagnostics);
-    let warnings = collect_warning_messages(&all_diagnostics);
-
-    if !error_diags.is_empty() {
-        return diagnostic_error_response(&error_diags, &source);
-    }
+    let (module, warnings) =
+        match parse_and_check_expression(&source, &known_vars, pre_class_hierarchy) {
+            Ok(r) => r,
+            Err(resp) => return resp,
+        };
 
     if !module.classes.is_empty()
         || !module.method_definitions.is_empty()


### PR DESCRIPTION
## Summary

Eliminates an identical ~20-line preamble duplicated in `handle_compile_expression` and `handle_compile_expression_trace` in `crates/beamtalk-compiler-port/src/main.rs`.

Both handlers previously inlined the same lex → parse → `compute_diagnostics_with_known_vars_and_classes` → primitive validation → filter errors → early-return pipeline. Any bug fix or enhancement to this logic required two edits.

## Changes

- Added private helper `parse_and_check_expression(source, known_vars, pre_class_hierarchy)` that returns `Ok((module, warnings))` on success or `Err(response_term)` for the caller to return directly
- Replaced the duplicated preamble in both handlers with a single call
- `handle_compile_expression` passes `pre_class_hierarchy.clone()` (needs it again for `handle_inline_class_definition`); `handle_compile_expression_trace` moves it in directly — both semantics preserved

## Testing

All 26 `beamtalk-compiler-port` tests pass. No behavioral change — purely structural.

Linear: https://linear.app/beamtalk/issue/BT-2178

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjahhU4cwAvki24dV6rJcJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization in the Beamtalk compiler by consolidating shared validation and diagnostics logic, reducing code duplication across expression compilation handlers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->