### PR TITLE
Tighten loose Stream printString assertions in language_features_doc_test.bt (BT-2180)

### DIFF
--- a/stdlib/test/language_features_doc_test.bt
+++ b/stdlib/test/language_features_doc_test.bt
@@ -144,9 +144,9 @@ TestCase subclass: LanguageFeaturesDocTest
       sum + n
     ]) equals: 10
     // Stream printString — pipeline inspection
-    self assert: ((Stream from: 1) printString) notNil
-    self assert: ((Stream on: #(1, 2, 3)) printString) notNil
-    self assert: (((Stream from: 1) select: [:n | n isEven]) printString) notNil
+    self assert: ((Stream from: 1) printString) equals: "Stream(from: 1)"
+    self assert: ((Stream on: #(1, 2, 3)) printString) equals: "Stream(on: [...])"
+    self assert: (((Stream from: 1) select: [:n | n isEven]) printString) equals: "Stream(from: 1) | select: [...]"
     // Eager vs Lazy boundary
     self assert: (#(1, 2, 3, 4, 5) select: [:n | n > 2]) equals: #(3, 4, 5)
 

--- a/stdlib/test/language_features_doc_test.bt
+++ b/stdlib/test/language_features_doc_test.bt
@@ -146,7 +146,9 @@ TestCase subclass: LanguageFeaturesDocTest
     // Stream printString — pipeline inspection
     self assert: ((Stream from: 1) printString) equals: "Stream(from: 1)"
     self assert: ((Stream on: #(1, 2, 3)) printString) equals: "Stream(on: [...])"
-    self assert: (((Stream from: 1) select: [:n | n isEven]) printString) equals: "Stream(from: 1) | select: [...]"
+    self assert: (((Stream from: 1) select: [:n |
+      n isEven
+    ]) printString) equals: "Stream(from: 1) | select: [...]"
     // Eager vs Lazy boundary
     self assert: (#(1, 2, 3, 4, 5) select: [:n | n > 2]) equals: #(3, 4, 5)
 


### PR DESCRIPTION
## Summary

Replaces three loose `assert: ... notNil` checks in `testStandardLibraryStream` with exact expected string values. This doc-test file validates examples from `docs/beamtalk-language-features.md` — loose `notNil` checks can't catch format regressions.

**Before:**
```beamtalk
self assert: ((Stream from: 1) printString) notNil
self assert: ((Stream on: #(1, 2, 3)) printString) notNil
self assert: (((Stream from: 1) select: [:n | n isEven]) printString) notNil
```

**After:**
```beamtalk
self assert: ((Stream from: 1) printString) equals: "Stream(from: 1)"
self assert: ((Stream on: #(1, 2, 3)) printString) equals: "Stream(on: [...])"
self assert: (((Stream from: 1) select: [:n |
  n isEven
]) printString) equals: "Stream(from: 1) | select: [...]"
```

Expected values come directly from `stdlib/src/Stream.bt` doc comment and `runtime/apps/beamtalk_stdlib/src/beamtalk_stream.erl` (lines 97, 122, 158) — these are string constants, not runtime-varying.

## Test plan

- [x] `just test-bunit` — 1904 tests, 0 failures
- [x] `just fmt-check` — passes (formatter applied to the `select:` block)
- [x] Pre-push hooks — clippy ✅ dialyzer ✅ spec validation ✅ erlfmt ✅

https://linear.app/beamtalk/issue/BT-2180

https://claude.ai/code/session_01NPhtJm3HW7h6xZb3oHGDys

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPhtJm3HW7h6xZb3oHGDys)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test assertions with more precise output validation for Stream operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->