### PR TITLE
docs: daily refresh 2026-05-17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Centralize byte-offset→line-number logic into `Span::line_number`, removing duplicate implementations from codegen and MCP server (BT-2160).
 - Extract duplicate `build.rs` version-injection logic into shared `beamtalk-build` workspace crate — single source of truth for `BEAMTALK_VERSION` emission (BT-2172).
 - Replace 5 `format!()` calls with `fresh_temp_var` / `write!` in `repl/codegen.rs` and `value_type_codegen.rs` — continues the BT-875 cleanup (BT-2175).
+- Extract shared `parse_and_check_expression` helper in compiler-port — deduplicates ~20-line lex/parse/validate preamble from `handle_compile_expression` and `handle_compile_expression_trace` (BT-2178).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

Daily documentation refresh for 2026-05-17.

- Added 1 CHANGELOG "Internal" entry for BT-2178 (extract shared parse-and-validate helper in compiler-port)

### Commits reviewed (3)

| SHA | Title | Classification | Doc change |
|-----|-------|---------------|------------|
| `340e44b` | Extract shared parse-and-validate helper in compiler-port (BT-2178) | Internal | CHANGELOG entry added |
| `8ccac6d` | Tighten loose Stream printString assertions in language_features_doc_test.bt (BT-2180) | Excluded | None — diff purely under `stdlib/test/` |
| `b5b191e` | Add coverage for untested Integer primitive BIF selectors (BT-2161) | Test-only | None — purely `#[cfg(test)]` additions |

### Skipped (2)

- **BT-2180** — test file change under `stdlib/test/`, excluded per scope rules
- **BT-2161** — purely adds `#[cfg(test)]` unit tests to existing source file, no behavioral change

### Needs human judgment

None.

## Test plan

- [ ] CHANGELOG entry matches commit diff (BT-2178: extract `parse_and_check_expression` helper deduplicating ~20-line preamble)
- [ ] No other docs affected (grep confirmed no user-facing doc references to compiler-port internals)

https://claude.ai/code/session_01LEGWQU1ohJ4D283TSMemZp

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEGWQU1ohJ4D283TSMemZp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal compiler optimizations to improve code organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->