### PR TITLE
Tighten notNil assertions in bag_test.bt testPrintString (BT-2183)

### DIFF
--- a/stdlib/test/bag_test.bt
+++ b/stdlib/test/bag_test.bt
@@ -105,8 +105,8 @@ TestCase subclass: BagTest
     self assert: (b2 occurrencesOf: 2) equals: 1
 
   testPrintString =>
-    self assert: Bag new printString notNil
-    self assert: (Bag withAll: #(1, 2)) printString notNil
+    self assert: Bag new printString equals: "a Bag"
+    self assert: (Bag withAll: #(1, 2)) printString equals: "a Bag"
 
   testAddWithCountZeroIsNoop =>
     b := (Bag new) add: 1 withCount: 0


### PR DESCRIPTION
## Summary\n\nReplace two loose `notNil` assertions in `BagTest>>testPrintString` with exact `equals: \"a Bag\"` checks.\n\n`Bag.bt:117` explicitly defines `printString -> String => \"a Bag\"` — the value is deterministic. The previous `notNil` assertions would pass for any non-nil string, missing regressions if `printString` were accidentally changed.\n\n## Changes\n\n- `self assert: Bag new printString notNil` → `self assert: Bag new printString equals: \"a Bag\"`\n- `self assert: (Bag withAll: #(1, 2)) printString notNil` → `self assert: (Bag withAll: #(1, 2)) printString equals: \"a Bag\"`\n\n## Test plan\n\n- [x] `beamtalk test stdlib/test/bag_test.bt` — 25 tests, 0 failures\n- [x] Full BUnit suite: 1904 tests pass (18 pre-existing FileStreamTest failures unrelated to this change)\n- [x] `cargo run --bin beamtalk -- fmt-check stdlib/test/bag_test.bt` passes\n\nLinear: https://linear.app/beamtalk/issue/BT-2183\n\nhttps://claude.ai/code/session_011FYjg8gUHPNKjmeh5bc6ev

---
_Generated by [Claude Code](https://claude.ai/code/session_011FYjg8gUHPNKjmeh5bc6ev)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation for bag printing functionality to ensure precise output formatting for both empty and populated bags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->