### PR TITLE
Replace placeholder assertions in chat_room.btscript (BT-2168)

### DIFF
--- a/tests/repl-protocol/cases/chat_room.btscript
+++ b/tests/repl-protocol/cases/chat_room.btscript
@@ -135,7 +135,7 @@ room say: "Hello everyone!" from: "Alice"
 
 // Check message history — formatted as "sender: text" strings
 history := room getHistory
-// => _
+// => ["Alice: Hello everyone!"]
 
 history size
 // => 1
@@ -145,7 +145,7 @@ history first
 
 // Check that alice received the message (via do: broadcast)
 aliceInbox := alice getInbox
-// => _
+// => ["Alice: Hello everyone!"]
 
 aliceInbox size
 // => 1
@@ -155,7 +155,7 @@ aliceInbox first
 
 // Check that bob also received it
 bobInbox := bob getInbox
-// => _
+// => ["Alice: Hello everyone!"]
 
 bobInbox size
 // => 1
@@ -173,7 +173,7 @@ room say: "Hey Alice!" from: "Bob"
 
 // History now has 2 messages
 history2 := room getHistory
-// => _
+// => ["Alice: Hello everyone!","Bob: Hey Alice!"]
 
 history2 size
 // => 2
@@ -183,13 +183,13 @@ history2 last
 
 // Both members received both messages
 aliceInbox2 := alice getInbox
-// => _
+// => ["Alice: Hello everyone!","Bob: Hey Alice!"]
 
 aliceInbox2 size
 // => 2
 
 bobInbox2 := bob getInbox
-// => _
+// => ["Alice: Hello everyone!","Bob: Hey Alice!"]
 
 bobInbox2 size
 // => 2
@@ -221,14 +221,14 @@ room say: "Anyone there?" from: "Bob"
 
 // Alice doesn't receive the new message
 aliceInbox3 := alice getInbox
-// => _
+// => ["Alice: Hello everyone!","Bob: Hey Alice!"]
 
 aliceInbox3 size
 // => 2
 
 // Bob receives it
 bobInbox3 := bob getInbox
-// => _
+// => ["Alice: Hello everyone!","Bob: Hey Alice!","Bob: Anyone there?"]
 
 bobInbox3 size
 // => 3
@@ -293,7 +293,7 @@ membersBefore includes: bob
 
 // Moderator kicks bob from the room
 mod kick: bob
-// => _
+// => Set(_)
 
 membersAfter := room online
 // => Set(_)
@@ -317,14 +317,14 @@ mod say: "Welcome!"
 
 // Room history should contain the prefixed message
 modHistory := room getHistory
-// => _
+// => ["Alice: Hello everyone!","Bob: Hey Alice!","Bob: Anyone there?","Admin: [MOD] Welcome!"]
 
 modHistory last
 // => Admin: [MOD] Welcome!
 
 // Bob should have received the prefixed message
 bobInboxMod := bob getInbox
-// => _
+// => ["Alice: Hello everyone!","Bob: Hey Alice!","Bob: Anyone there?","Admin: [MOD] Welcome!"]
 
 bobInboxMod last
 // => Admin: [MOD] Welcome!


### PR DESCRIPTION
## Summary

Tightens 11 placeholder `// => _` assertions in `tests/repl-protocol/cases/chat_room.btscript` to assert exact values, removing test smell where the assertion is wildcarded despite the value being fully deterministic.

Linear: https://linear.app/beamtalk/issue/BT-2168

## Changes

- 4 `room getHistory` results now assert the full list of formatted `"sender: text"` strings
- 5 `getInbox` results (alice/bob across multiple checkpoints) now assert the full inbox contents
- `mod kick: bob` tightened from `// => _` to `// => Set(_)` to match the `join:` / `leave:` return convention
- Wildcards intentionally kept on `Message new`, `msgArgs` map literal, and `msg := Message new:` — no Value/Map display format convention has been established in the codebase yet (per the issue's acceptance criteria)

List display format (`["a","b","c"]` — bracketed, comma-separated, no spaces) confirmed against `tests/repl-protocol/cases/file_stream.btscript`.

## Test plan

- [x] `just test-repl-protocol` passes (3/3 tests; `e2e_language_tests` exercises every `.btscript` case including `chat_room.btscript`)


---
_Generated by [Claude Code](https://claude.ai/code/session_019k4hRrLUjYz7G1Hj79c1pR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for chat room protocol to reflect accurate message broadcast and moderator action behavior, including inbox contents, room history, and online member lists after various operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->