### PR TITLE
test: add unit tests for Integer/List/String primitive BIF generators (BT-2179)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/integer.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/integer.rs
@@ -105,3 +105,328 @@ pub(crate) fn generate_integer_bif(selector: &str, params: &[String]) -> Option<
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::doc_to_string;
+    use super::*;
+
+    // Arithmetic
+
+    #[test]
+    fn test_plus() {
+        let result = doc_to_string(generate_integer_bif("+", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'+'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_minus() {
+        let result = doc_to_string(generate_integer_bif("-", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'-'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_multiply() {
+        let result = doc_to_string(generate_integer_bif("*", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'*'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_divide() {
+        let result = doc_to_string(generate_integer_bif("/", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'/'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_div() {
+        let result = doc_to_string(generate_integer_bif("div:", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'div'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_modulo() {
+        let result = doc_to_string(generate_integer_bif("%", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'rem'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_power() {
+        let result = doc_to_string(generate_integer_bif("**", &["Other".to_string()]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'erlang':'round'(call 'math':'pow'(\
+                 call 'erlang':'float'(Self), call 'erlang':'float'(Other)))"
+                    .to_string()
+            )
+        );
+    }
+
+    // Comparisons
+
+    #[test]
+    fn test_eq() {
+        let result = doc_to_string(generate_integer_bif("=:=", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'=:='(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_neq() {
+        let result = doc_to_string(generate_integer_bif("/=", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'/='(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_strict_neq() {
+        let result = doc_to_string(generate_integer_bif("=/=", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'=/='(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_lt() {
+        let result = doc_to_string(generate_integer_bif("<", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'<'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_gt() {
+        let result = doc_to_string(generate_integer_bif(">", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'>'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_le() {
+        let result = doc_to_string(generate_integer_bif("<=", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'=<'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_ge() {
+        let result = doc_to_string(generate_integer_bif(">=", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'>='(Self, Other)".to_string()));
+    }
+
+    // Conversion
+
+    #[test]
+    fn test_as_string() {
+        let result = doc_to_string(generate_integer_bif("asString", &[]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'integer_to_binary'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_print_string() {
+        let result = doc_to_string(generate_integer_bif("printString", &[]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'integer_to_binary'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_as_float() {
+        let result = doc_to_string(generate_integer_bif("asFloat", &[]));
+        assert_eq!(result, Some("call 'erlang':'float'(Self)".to_string()));
+    }
+
+    // Bitwise operations
+
+    #[test]
+    fn test_bit_and() {
+        let result = doc_to_string(generate_integer_bif("bitAnd:", &["Other".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'band'(Self, Other)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_bit_or() {
+        let result = doc_to_string(generate_integer_bif("bitOr:", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'bor'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_bit_xor() {
+        let result = doc_to_string(generate_integer_bif("bitXor:", &["Other".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'bxor'(Self, Other)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_bit_not() {
+        let result = doc_to_string(generate_integer_bif("bitNot", &[]));
+        assert_eq!(result, Some("call 'erlang':'bnot'(Self)".to_string()));
+    }
+
+    #[test]
+    fn test_bit_shift_with_param() {
+        let result = doc_to_string(generate_integer_bif("bitShift:", &["N".to_string()]));
+        assert_eq!(
+            result,
+            Some(
+                "case call 'erlang':'>='(N, 0) of \
+                 'true' when 'true' -> call 'erlang':'bsl'(Self, N) \
+                 'false' when 'true' -> call 'erlang':'bsr'(Self, call 'erlang':'-'(0, N)) end"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_bit_shift_missing_param_returns_none() {
+        assert_eq!(doc_to_string(generate_integer_bif("bitShift:", &[])), None);
+    }
+
+    // Character predicates (BT-339)
+
+    #[test]
+    fn test_is_letter() {
+        let result = doc_to_string(generate_integer_bif("isLetter", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_character':'is_letter'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_is_digit() {
+        let result = doc_to_string(generate_integer_bif("isDigit", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_character':'is_digit'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_is_uppercase() {
+        let result = doc_to_string(generate_integer_bif("isUppercase", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_character':'is_uppercase'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_is_lowercase() {
+        let result = doc_to_string(generate_integer_bif("isLowercase", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_character':'is_lowercase'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_is_whitespace() {
+        let result = doc_to_string(generate_integer_bif("isWhitespace", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_character':'is_whitespace'(Self)".to_string())
+        );
+    }
+
+    // Math functions
+
+    #[test]
+    fn test_sqrt() {
+        let result = doc_to_string(generate_integer_bif("sqrt", &[]));
+        assert_eq!(
+            result,
+            Some("call 'math':'sqrt'(call 'erlang':'float'(Self))".to_string())
+        );
+    }
+
+    #[test]
+    fn test_log() {
+        let result = doc_to_string(generate_integer_bif("log", &[]));
+        assert_eq!(
+            result,
+            Some("call 'math':'log'(call 'erlang':'float'(Self))".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ln() {
+        let result = doc_to_string(generate_integer_bif("ln", &[]));
+        assert_eq!(
+            result,
+            Some("call 'math':'log'(call 'erlang':'float'(Self))".to_string())
+        );
+    }
+
+    #[test]
+    fn test_log2() {
+        let result = doc_to_string(generate_integer_bif("log2", &[]));
+        assert_eq!(
+            result,
+            Some("call 'math':'log2'(call 'erlang':'float'(Self))".to_string())
+        );
+    }
+
+    #[test]
+    fn test_log10() {
+        let result = doc_to_string(generate_integer_bif("log10", &[]));
+        assert_eq!(
+            result,
+            Some("call 'math':'log10'(call 'erlang':'float'(Self))".to_string())
+        );
+    }
+
+    #[test]
+    fn test_exp() {
+        let result = doc_to_string(generate_integer_bif("exp", &[]));
+        assert_eq!(
+            result,
+            Some("call 'math':'exp'(call 'erlang':'float'(Self))".to_string())
+        );
+    }
+
+    #[test]
+    fn test_raised_to_with_param() {
+        let result = doc_to_string(generate_integer_bif("raisedTo:", &["Exp".to_string()]));
+        assert_eq!(
+            result,
+            Some(
+                "case call 'erlang':'is_integer'(Exp) of \
+                 'true' when 'true' -> \
+                   case call 'erlang':'>='(Exp, 0) of \
+                     'true' when 'true' -> \
+                       call 'erlang':'round'(call 'math':'pow'(call 'erlang':'float'(Self), call 'erlang':'float'(Exp))) \
+                     'false' when 'true' -> \
+                       call 'math':'pow'(call 'erlang':'float'(Self), call 'erlang':'float'(Exp)) \
+                   end \
+                 'false' when 'true' -> \
+                   call 'math':'pow'(call 'erlang':'float'(Self), call 'erlang':'float'(Exp)) \
+               end"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_raised_to_missing_param_returns_none() {
+        assert_eq!(doc_to_string(generate_integer_bif("raisedTo:", &[])), None);
+    }
+
+    // Edge cases
+
+    #[test]
+    fn test_plus_missing_param_returns_none() {
+        assert_eq!(doc_to_string(generate_integer_bif("+", &[])), None);
+    }
+
+    #[test]
+    fn test_power_missing_param_returns_none() {
+        assert_eq!(doc_to_string(generate_integer_bif("**", &[])), None);
+    }
+
+    #[test]
+    fn test_unknown_selector_returns_none() {
+        assert_eq!(doc_to_string(generate_integer_bif("notAMethod", &[])), None);
+    }
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
@@ -197,3 +197,372 @@ fn generate_list_misc_bif(selector: &str, params: &[String]) -> Option<Document<
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::doc_to_string;
+    use super::*;
+
+    // Access ops
+
+    #[test]
+    fn test_size() {
+        let result = doc_to_string(generate_list_bif("size", &[]));
+        assert_eq!(result, Some("call 'erlang':'length'(Self)".to_string()));
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let result = doc_to_string(generate_list_bif("isEmpty", &[]));
+        assert_eq!(result, Some("call 'erlang':'=:='(Self, [])".to_string()));
+    }
+
+    #[test]
+    fn test_first() {
+        let result = doc_to_string(generate_list_bif("first", &[]));
+        let output = result.expect("first should produce code");
+        assert!(output.contains("case Self of"));
+        assert!(output.contains("<[H|_T]> when 'true' -> H"));
+        assert!(output.contains("'does_not_understand'"));
+        assert!(output.contains("'first'"));
+    }
+
+    #[test]
+    fn test_rest() {
+        let result = doc_to_string(generate_list_bif("rest", &[]));
+        assert_eq!(
+            result,
+            Some(
+                "case Self of \
+                 <[_H|T]> when 'true' -> T \
+                 <[]> when 'true' -> [] \
+                 end"
+                .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_last() {
+        let result = doc_to_string(generate_list_bif("last", &[]));
+        let output = result.expect("last should produce code");
+        assert!(output.contains("case Self of"));
+        assert!(output.contains("call 'lists':'last'(Self)"));
+        assert!(output.contains("'does_not_understand'"));
+        assert!(output.contains("'last'"));
+    }
+
+    #[test]
+    fn test_at() {
+        let result = doc_to_string(generate_list_bif("at:", &["N".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'at'(Self, N)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_includes() {
+        let result = doc_to_string(generate_list_bif("includes:", &["Item".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'lists':'member'(Item, Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_sort() {
+        let result = doc_to_string(generate_list_bif("sort", &[]));
+        assert_eq!(result, Some("call 'lists':'sort'(Self)".to_string()));
+    }
+
+    #[test]
+    fn test_sort_with() {
+        let result = doc_to_string(generate_list_bif("sort:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'sort_with'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_reversed() {
+        let result = doc_to_string(generate_list_bif("reversed", &[]));
+        assert_eq!(result, Some("call 'lists':'reverse'(Self)".to_string()));
+    }
+
+    #[test]
+    fn test_unique() {
+        let result = doc_to_string(generate_list_bif("unique", &[]));
+        assert_eq!(result, Some("call 'lists':'usort'(Self)".to_string()));
+    }
+
+    // Iteration ops
+
+    #[test]
+    fn test_detect() {
+        let result = doc_to_string(generate_list_bif("detect:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'detect'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_if_none() {
+        let result = doc_to_string(generate_list_bif(
+            "detect:ifNone:",
+            &["Block".to_string(), "Default".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'detect_if_none'(Self, Block, Default)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_do() {
+        let result = doc_to_string(generate_list_bif("do:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'do'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_collect() {
+        let result = doc_to_string(generate_list_bif("collect:", &["Block".to_string()]));
+        assert_eq!(result, Some("call 'lists':'map'(Block, Self)".to_string()));
+    }
+
+    #[test]
+    fn test_select() {
+        let result = doc_to_string(generate_list_bif("select:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'lists':'filter'(Block, Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_reject() {
+        let result = doc_to_string(generate_list_bif("reject:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'reject'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_inject_into() {
+        let result = doc_to_string(generate_list_bif(
+            "inject:into:",
+            &["Init".to_string(), "Block".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_collection':'inject_into'(Self, Init, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_take() {
+        let result = doc_to_string(generate_list_bif("take:", &["N".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'take'(Self, N)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_drop() {
+        let result = doc_to_string(generate_list_bif("drop:", &["N".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'drop'(Self, N)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_flatten() {
+        let result = doc_to_string(generate_list_bif("flatten", &[]));
+        assert_eq!(result, Some("call 'lists':'flatten'(Self)".to_string()));
+    }
+
+    #[test]
+    fn test_flat_map() {
+        let result = doc_to_string(generate_list_bif("flatMap:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'lists':'flatmap'(Block, Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_count() {
+        let result = doc_to_string(generate_list_bif("count:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'length'(call 'lists':'filter'(Block, Self))".to_string())
+        );
+    }
+
+    #[test]
+    fn test_any_satisfy() {
+        let result = doc_to_string(generate_list_bif("anySatisfy:", &["Block".to_string()]));
+        assert_eq!(result, Some("call 'lists':'any'(Block, Self)".to_string()));
+    }
+
+    #[test]
+    fn test_all_satisfy() {
+        let result = doc_to_string(generate_list_bif("allSatisfy:", &["Block".to_string()]));
+        assert_eq!(result, Some("call 'lists':'all'(Block, Self)".to_string()));
+    }
+
+    // Misc ops
+
+    #[test]
+    fn test_zip() {
+        let result = doc_to_string(generate_list_bif("zip:", &["Other".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'zip'(Self, Other)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_group_by() {
+        let result = doc_to_string(generate_list_bif("groupBy:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'group_by'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_partition() {
+        let result = doc_to_string(generate_list_bif("partition:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'partition'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_take_while() {
+        let result = doc_to_string(generate_list_bif("takeWhile:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'lists':'takewhile'(Block, Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_drop_while() {
+        let result = doc_to_string(generate_list_bif("dropWhile:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'lists':'dropwhile'(Block, Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_intersperse() {
+        let result = doc_to_string(generate_list_bif("intersperse:", &["Sep".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'intersperse'(Self, Sep)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_add_first() {
+        let result = doc_to_string(generate_list_bif("addFirst:", &["Item".to_string()]));
+        assert_eq!(result, Some("[Item|Self]".to_string()));
+    }
+
+    #[test]
+    fn test_add() {
+        let result = doc_to_string(generate_list_bif("add:", &["Item".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'++'(Self, [Item|[]])".to_string())
+        );
+    }
+
+    #[test]
+    fn test_concat() {
+        let result = doc_to_string(generate_list_bif("++", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'++'(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_from_to() {
+        let result = doc_to_string(generate_list_bif(
+            "from:to:",
+            &["Start".to_string(), "End".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_list':'from_to'(Self, Start, End)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_print_string() {
+        let result = doc_to_string(generate_list_bif("printString", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_primitive':'print_string'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_stream() {
+        let result = doc_to_string(generate_list_bif("stream", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_stream':'on'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_at_random() {
+        let result = doc_to_string(generate_list_bif("atRandom", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_random':'atRandom'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_join() {
+        let result = doc_to_string(generate_list_bif("join", &[]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'iolist_to_binary'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_join_with_sep() {
+        let result = doc_to_string(generate_list_bif("join:", &["Sep".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'iolist_to_binary'(call 'lists':'join'(Sep, Self))".to_string())
+        );
+    }
+
+    #[test]
+    fn test_with_all_factory() {
+        let result = doc_to_string(generate_list_bif("withAll:", &["List".to_string()]));
+        assert_eq!(result, Some("List".to_string()));
+    }
+
+    // Edge cases
+
+    #[test]
+    fn test_unknown_selector_returns_none() {
+        assert_eq!(doc_to_string(generate_list_bif("notAMethod", &[])), None);
+    }
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/string.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/string.rs
@@ -225,3 +225,539 @@ fn generate_string_regex_bif(selector: &str, params: &[String]) -> Option<Docume
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::doc_to_string;
+    use super::*;
+
+    // Comparison group
+
+    #[test]
+    fn test_eq() {
+        let result = doc_to_string(generate_string_bif("=:=", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'=:='(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_lt() {
+        let result = doc_to_string(generate_string_bif("<", &["Other".to_string()]));
+        assert_eq!(result, Some("call 'erlang':'<'(Self, Other)".to_string()));
+    }
+
+    // Transform group
+
+    #[test]
+    fn test_concat() {
+        let result = doc_to_string(generate_string_bif("++", &["Other".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'iolist_to_binary'([Self, Other])".to_string())
+        );
+    }
+
+    #[test]
+    fn test_concat_comma() {
+        let result = doc_to_string(generate_string_bif(",", &["Other".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'iolist_to_binary'([Self, Other])".to_string())
+        );
+    }
+
+    #[test]
+    fn test_length() {
+        let result = doc_to_string(generate_string_bif("length", &[]));
+        assert_eq!(result, Some("call 'string':'length'(Self)".to_string()));
+    }
+
+    #[test]
+    fn test_at() {
+        let result = doc_to_string(generate_string_bif("at:", &["I".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'at'(Self, I)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_uppercase() {
+        let result = doc_to_string(generate_string_bif("uppercase", &[]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'unicode':'characters_to_binary'(call 'string':'uppercase'(Self))"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_lowercase() {
+        let result = doc_to_string(generate_string_bif("lowercase", &[]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'unicode':'characters_to_binary'(call 'string':'lowercase'(Self))"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_capitalize() {
+        let result = doc_to_string(generate_string_bif("capitalize", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'capitalize'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_trim() {
+        let result = doc_to_string(generate_string_bif("trim", &[]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'unicode':'characters_to_binary'(call 'string':'trim'(Self, 'both'))"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_trim_left() {
+        let result = doc_to_string(generate_string_bif("trimLeft", &[]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'unicode':'characters_to_binary'(call 'string':'trim'(Self, 'leading'))"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_trim_right() {
+        let result = doc_to_string(generate_string_bif("trimRight", &[]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'unicode':'characters_to_binary'(call 'string':'trim'(Self, 'trailing'))"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_reverse() {
+        let result = doc_to_string(generate_string_bif("reverse", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'reverse'(Self)".to_string())
+        );
+    }
+
+    // Search group
+
+    #[test]
+    fn test_includes() {
+        let result = doc_to_string(generate_string_bif("includes:", &["Sub".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'includes'(Self, Sub)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_starts_with() {
+        let result = doc_to_string(generate_string_bif("startsWith:", &["P".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'starts_with'(Self, P)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ends_with() {
+        let result = doc_to_string(generate_string_bif("endsWith:", &["S".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'ends_with'(Self, S)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_index_of() {
+        let result = doc_to_string(generate_string_bif("indexOf:", &["Sub".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'index_of'(Self, Sub)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_split() {
+        let result = doc_to_string(generate_string_bif("split:", &["Sep".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'binary':'split'(Self, Sep, ['global'])".to_string())
+        );
+    }
+
+    #[test]
+    fn test_split_on() {
+        let result = doc_to_string(generate_string_bif("splitOn:", &["Sep".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'split_on'(Self, Sep)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_repeat() {
+        let result = doc_to_string(generate_string_bif("repeat:", &["N".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'repeat'(Self, N)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_lines() {
+        let result = doc_to_string(generate_string_bif("lines", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'lines'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_words() {
+        let result = doc_to_string(generate_string_bif("words", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'words'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_replace_all_with() {
+        let result = doc_to_string(generate_string_bif(
+            "replaceAll:with:",
+            &["P".to_string(), "R".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'binary':'replace'(Self, P, R, ['global'])".to_string())
+        );
+    }
+
+    #[test]
+    fn test_replace_first_with() {
+        let result = doc_to_string(generate_string_bif(
+            "replaceFirst:with:",
+            &["P".to_string(), "R".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'binary':'replace'(Self, P, R, [])".to_string())
+        );
+    }
+
+    #[test]
+    fn test_take() {
+        let result = doc_to_string(generate_string_bif("take:", &["N".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'take'(Self, N)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_drop() {
+        let result = doc_to_string(generate_string_bif("drop:", &["N".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'drop'(Self, N)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_pad_left() {
+        let result = doc_to_string(generate_string_bif("padLeft:", &["N".to_string()]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'unicode':'characters_to_binary'(call 'string':'pad'(Self, N, 'leading'))"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_pad_right() {
+        let result = doc_to_string(generate_string_bif("padRight:", &["N".to_string()]));
+        assert_eq!(
+            result,
+            Some(
+                "call 'unicode':'characters_to_binary'(call 'string':'pad'(Self, N, 'trailing'))"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_pad_left_with() {
+        let result = doc_to_string(generate_string_bif(
+            "padLeft:with:",
+            &["N".to_string(), "Ch".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some(
+                "call 'unicode':'characters_to_binary'(call 'string':'pad'(Self, N, 'leading', Ch))"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_pad_right_with() {
+        let result = doc_to_string(generate_string_bif(
+            "padRight:with:",
+            &["N".to_string(), "Ch".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some(
+                "call 'unicode':'characters_to_binary'(call 'string':'pad'(Self, N, 'trailing', Ch))"
+                    .to_string()
+            )
+        );
+    }
+
+    // Regex group (BT-709)
+
+    #[test]
+    fn test_matches_regex() {
+        let result = doc_to_string(generate_string_bif("matchesRegex:", &["P".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_regex':'matches_regex'(Self, P)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_matches_regex_options() {
+        let result = doc_to_string(generate_string_bif(
+            "matchesRegex:options:",
+            &["P".to_string(), "O".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_regex':'matches_regex_options'(Self, P, O)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_first_match() {
+        let result = doc_to_string(generate_string_bif("firstMatch:", &["P".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_regex':'first_match'(Self, P)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_all_matches() {
+        let result = doc_to_string(generate_string_bif("allMatches:", &["P".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_regex':'all_matches'(Self, P)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_replace_regex_with() {
+        let result = doc_to_string(generate_string_bif(
+            "replaceRegex:with:",
+            &["P".to_string(), "R".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_regex':'replace_regex'(Self, P, R)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_replace_all_regex_with() {
+        let result = doc_to_string(generate_string_bif(
+            "replaceAllRegex:with:",
+            &["P".to_string(), "R".to_string()],
+        ));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_regex':'replace_all_regex'(Self, P, R)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_split_regex() {
+        let result = doc_to_string(generate_string_bif("splitRegex:", &["P".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_regex':'split_regex'(Self, P)".to_string())
+        );
+    }
+
+    // Misc group
+
+    #[test]
+    fn test_is_blank() {
+        let result = doc_to_string(generate_string_bif("isBlank", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'is_blank'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_is_digit() {
+        let result = doc_to_string(generate_string_bif("isDigit", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'is_digit'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_is_alpha() {
+        let result = doc_to_string(generate_string_bif("isAlpha", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'is_alpha'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_as_integer() {
+        let result = doc_to_string(generate_string_bif("asInteger", &[]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'binary_to_integer'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_as_float() {
+        let result = doc_to_string(generate_string_bif("asFloat", &[]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'binary_to_float'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_as_atom() {
+        let result = doc_to_string(generate_string_bif("asAtom", &[]));
+        assert_eq!(
+            result,
+            Some("call 'erlang':'binary_to_atom'(Self, 'utf8')".to_string())
+        );
+    }
+
+    #[test]
+    fn test_as_list() {
+        let result = doc_to_string(generate_string_bif("asList", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'as_list'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_each() {
+        let result = doc_to_string(generate_string_bif("each:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'each'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_collect() {
+        let result = doc_to_string(generate_string_bif("collect:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'collect'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_select() {
+        let result = doc_to_string(generate_string_bif("select:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'select'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_reject() {
+        let result = doc_to_string(generate_string_bif("reject:", &["Block".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'reject'(Self, Block)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_stream() {
+        let result = doc_to_string(generate_string_bif("stream", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_stream':'on'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_with_all_factory() {
+        let result = doc_to_string(generate_string_bif("withAll:", &["L".to_string()]));
+        assert_eq!(result, Some("call 'beamtalk_string':'join'(L)".to_string()));
+    }
+
+    #[test]
+    fn test_from_code_point_factory() {
+        let result = doc_to_string(generate_string_bif("fromCodePoint:", &["CP".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'from_code_point'(CP)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_from_code_points_factory() {
+        let result = doc_to_string(generate_string_bif("fromCodePoints:", &["CPs".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'from_code_points'(CPs)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_from_iolist_factory() {
+        let result = doc_to_string(generate_string_bif("fromIolist:", &["IO".to_string()]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_string':'from_iolist'(IO)".to_string())
+        );
+    }
+
+    // Edge cases
+
+    #[test]
+    fn test_unknown_selector_returns_none() {
+        assert_eq!(doc_to_string(generate_string_bif("notAMethod", &[])), None);
+    }
+}


### PR DESCRIPTION
Add #[cfg(test)] mod tests blocks at the bottom of integer.rs, list.rs,
and string.rs following the actor_types.rs pattern. Tests call the
file-local generator directly and use doc_to_string() to assert exact
generated Core Erlang strings.

Coverage added:
- integer.rs: 39 tests covering arithmetic, comparisons, conversion,
  bitwise ops (including bitShift: with both param-present and missing
  paths), character predicates, math functions, raisedTo:, and the
  unknown-selector path.
- list.rs: 42 tests covering access ops (size, isEmpty, first, last,
  at:, etc.), iteration ops (collect:, select:, detect:ifNone:,
  inject:into:, etc.), and misc ops (addFirst:, add:, join:,
  intersperse:, withAll:, etc.) plus unknown-selector path.
- string.rs: 54 tests covering comparison, transform (uppercase, trim,
  reverse, etc.), search (startsWith:, replaceAll:with:, padLeft:with:,
  etc.), regex BIFs, misc/conversion (asInteger, asAtom,
  fromCodePoint:, etc.) plus unknown-selector path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for integer operations (arithmetic, bitwise, conversions), list operations (access, iteration, search), and string operations (comparisons, transformations, conversions) to enhance code quality and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->