### PR TITLE
Add `:erlang` BIFs to NativeTypeRegistry via erts ebin discovery (BT-2159)

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -1558,18 +1558,33 @@ fn read_specs_protocol(
 ///
 /// Returns an error if `erl` cannot be invoked to discover the OTP lib directory.
 pub fn discover_otp_beam_files() -> Result<Vec<Utf8PathBuf>> {
-    // Use `erl -noshell -noinput -eval '...'` to find the OTP lib directory.
-    // We clear the environment to avoid user-specific Erlang config affecting the probe.
+    // Apps we want type specs from. `erts` is included so `erlang.beam`
+    // (BIFs like `whereis/1`, `spawn/3`, `self/0`) gets covered — its specs
+    // are on disk even though `code:which(erlang)` returns `preloaded`. BT-2159.
+    //
+    // We probe `code:lib_dir(App)` per app rather than globbing `<lib_dir>/<app>-*`
+    // because OTP layouts differ: upstream/kerl/brew put `erts-<vsn>` directly
+    // under the OTP root, while Debian also mirrors it under `lib/`. `code:lib_dir/1`
+    // is Erlang's canonical resolution and handles both.
+    const COMMON_APPS: &[&str] = &[
+        "stdlib", "kernel", "erts", "crypto", "ssl", "inets", "mnesia", "os_mon",
+    ];
+
+    let apps_atom_list = COMMON_APPS.join(",");
+    let probe = format!(
+        "lists:foreach(fun(App) -> case code:lib_dir(App) of {{error,_}} -> ok; Dir -> io:format(\"~s~n\", [filename:join(Dir, \"ebin\")]) end end, [{apps_atom_list}]), halt()."
+    );
+
     let output = Command::new("erl")
         .arg("-noshell")
         .arg("-noinput")
         .arg("-boot")
         .arg("no_dot_erlang")
         .arg("-eval")
-        .arg("io:format(\"~s\", [code:lib_dir()]), halt().")
+        .arg(&probe)
         .output()
         .into_diagnostic()
-        .wrap_err("Failed to run erl to discover OTP lib directory")?;
+        .wrap_err("Failed to run erl to discover OTP ebin directories")?;
 
     if !output.status.success() {
         let stderr_msg = String::from_utf8_lossy(&output.stderr);
@@ -1581,48 +1596,19 @@ pub fn discover_otp_beam_files() -> Result<Vec<Utf8PathBuf>> {
         return Ok(Vec::new());
     }
 
-    let lib_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if lib_dir.is_empty() {
-        warn!("erl probe returned empty lib_dir");
-        return Ok(Vec::new());
-    }
-
-    // Collect .beam files from common OTP application ebin directories.
-    // Each app lives in `lib_dir/<app>-<version>/ebin/`.
-    //
-    // `erts` is included because `erts-<version>/ebin/erlang.beam` carries
-    // Dialyzer specs for the BIFs (`whereis/1`, `spawn/3`, `self/0`, etc.)
-    // even though `code:which(erlang)` returns `preloaded`. Without `erts`,
-    // every `(Erlang erlang) ...` call resolves to `Dynamic`. BT-2159.
-    let common_apps = [
-        "stdlib", "kernel", "erts", "crypto", "ssl", "inets", "mnesia", "os_mon",
-    ];
-
+    let stdout = String::from_utf8_lossy(&output.stdout);
     let mut beam_files = Vec::new();
-    let lib_path = std::path::Path::new(&lib_dir);
-    if let Ok(entries) = std::fs::read_dir(lib_path) {
-        for entry in entries.flatten() {
-            let dir_name = entry.file_name();
-            let dir_name_str = dir_name.to_string_lossy();
-            // Check if this directory matches one of our common apps (e.g., "stdlib-5.2")
-            let matches_app = common_apps.iter().any(|app| {
-                dir_name_str.starts_with(app)
-                    && dir_name_str.as_bytes().get(app.len()) == Some(&b'-')
-            });
-            if !matches_app {
-                continue;
-            }
-            let ebin_dir = entry.path().join("ebin");
-            if !ebin_dir.is_dir() {
-                continue;
-            }
-            if let Ok(ebin_entries) = std::fs::read_dir(&ebin_dir) {
-                for file in ebin_entries.flatten() {
-                    let path = file.path();
-                    if path.extension().is_some_and(|e| e == "beam") {
-                        if let Ok(utf8) = Utf8PathBuf::from_path_buf(path) {
-                            beam_files.push(utf8);
-                        }
+    for line in stdout.lines() {
+        let ebin_dir = std::path::Path::new(line.trim());
+        if !ebin_dir.is_dir() {
+            continue;
+        }
+        if let Ok(entries) = std::fs::read_dir(ebin_dir) {
+            for file in entries.flatten() {
+                let path = file.path();
+                if path.extension().is_some_and(|e| e == "beam") {
+                    if let Ok(utf8) = Utf8PathBuf::from_path_buf(path) {
+                        beam_files.push(utf8);
                     }
                 }
             }
@@ -2219,23 +2205,24 @@ end
 
     /// BT-2159: `erts` must be in the OTP discovery set so `erlang.beam`
     /// (BIFs like `whereis/1`, `spawn/3`, `self/0`) gets spec extraction.
-    /// `code:which(erlang)` returns `preloaded`, but the `.beam` exists at
-    /// `<lib_dir>/erts-<version>/ebin/erlang.beam` with full abstract code.
+    /// `code:which(erlang)` returns `preloaded`, but the `.beam` exists in
+    /// `<erts-app>/ebin/erlang.beam` with full abstract code.
     #[test]
     fn discover_otp_beam_files_includes_erts() {
         let Ok(beams) = discover_otp_beam_files() else {
-            // Skip when `erl` is unavailable in the test environment.
+            // Skip only when `erl` cannot be spawned (test env without Erlang).
+            // A successful probe that returns zero beams is a real failure and
+            // is caught by the assert below.
             return;
         };
-        if beams.is_empty() {
-            return;
-        }
         let has_erlang = beams
             .iter()
             .any(|p| p.file_stem().is_some_and(|s| s == "erlang"));
         assert!(
             has_erlang,
-            "discover_otp_beam_files must include erts/ebin/erlang.beam so BIF specs reach NativeTypeRegistry (BT-2159). Got: {beams:?}"
+            "discover_otp_beam_files must include erts/ebin/erlang.beam so BIF specs reach NativeTypeRegistry (BT-2159). Got {} beams: {:?}",
+            beams.len(),
+            beams
         );
     }
 

--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -1589,8 +1589,13 @@ pub fn discover_otp_beam_files() -> Result<Vec<Utf8PathBuf>> {
 
     // Collect .beam files from common OTP application ebin directories.
     // Each app lives in `lib_dir/<app>-<version>/ebin/`.
+    //
+    // `erts` is included because `erts-<version>/ebin/erlang.beam` carries
+    // Dialyzer specs for the BIFs (`whereis/1`, `spawn/3`, `self/0`, etc.)
+    // even though `code:which(erlang)` returns `preloaded`. Without `erts`,
+    // every `(Erlang erlang) ...` call resolves to `Dynamic`. BT-2159.
     let common_apps = [
-        "stdlib", "kernel", "crypto", "ssl", "inets", "mnesia", "os_mon",
+        "stdlib", "kernel", "erts", "crypto", "ssl", "inets", "mnesia", "os_mon",
     ];
 
     let mut beam_files = Vec::new();
@@ -2209,6 +2214,28 @@ end
             cache.lookup("my_app", path_b, 100, 0),
             Some("specs_from_b".to_string()),
             "Path B should return its own cached specs"
+        );
+    }
+
+    /// BT-2159: `erts` must be in the OTP discovery set so `erlang.beam`
+    /// (BIFs like `whereis/1`, `spawn/3`, `self/0`) gets spec extraction.
+    /// `code:which(erlang)` returns `preloaded`, but the `.beam` exists at
+    /// `<lib_dir>/erts-<version>/ebin/erlang.beam` with full abstract code.
+    #[test]
+    fn discover_otp_beam_files_includes_erts() {
+        let Ok(beams) = discover_otp_beam_files() else {
+            // Skip when `erl` is unavailable in the test environment.
+            return;
+        };
+        if beams.is_empty() {
+            return;
+        }
+        let has_erlang = beams
+            .iter()
+            .any(|p| p.file_stem().is_some_and(|s| s == "erlang"));
+        assert!(
+            has_erlang,
+            "discover_otp_beam_files must include erts/ebin/erlang.beam so BIF specs reach NativeTypeRegistry (BT-2159). Got: {beams:?}"
         );
     }
 

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
@@ -78,6 +78,55 @@ read_specs_nonexistent_file_test() ->
     Result = beamtalk_spec_reader:read_specs("/nonexistent/path/fake.beam"),
     ?assertMatch({error, {beam_lib, _}}, Result).
 
+%% BT-2159: `:erlang` BIFs (whereis/1, is_process_alive/1, spawn/3, self/0, etc.)
+%% live in `erts-<vsn>/ebin/erlang.beam` even though `code:which(erlang)` is
+%% `preloaded`. Verify the spec reader extracts them when handed the file path
+%% directly — the Rust discovery side (BT-2159) now finds it via the `erts`
+%% app entry in `discover_otp_beam_files`.
+read_specs_erlang_bifs_test() ->
+    case find_erlang_beam() of
+        not_found ->
+            %% Unusual OTP layout — skip rather than fail.
+            ok;
+        BeamFile ->
+            {ok, Specs} = beamtalk_spec_reader:read_specs(BeamFile),
+            Required = [
+                {<<"whereis">>, 1},
+                {<<"is_process_alive">>, 1},
+                {<<"spawn">>, 1},
+                {<<"spawn">>, 3},
+                {<<"register">>, 2},
+                {<<"unregister">>, 1},
+                {<<"self">>, 0},
+                {<<"node">>, 0},
+                {<<"monotonic_time">>, 0},
+                {<<"system_time">>, 0}
+            ],
+            SpecKeys = [{maps:get(name, S), maps:get(arity, S)} || S <- Specs],
+            Missing = [K || K <- Required, not lists:member(K, SpecKeys)],
+            ?assertEqual([], Missing),
+            %% whereis/1 must return a known type (not just Dynamic) so typed
+            %% callers in beamtalk-watcher can drop the `@expect type` pragma.
+            [WhereisSpec | _] = [
+                S
+             || S <- Specs,
+                maps:get(name, S) =:= <<"whereis">>,
+                maps:get(arity, S) =:= 1
+            ],
+            [WhereisParam] = maps:get(params, WhereisSpec),
+            ?assertEqual(<<"Symbol">>, maps:get(type, WhereisParam))
+    end.
+
+%% Locate erlang.beam on disk. `code:which(erlang)` returns `preloaded` because
+%% the BIF module is loaded into the VM at boot, but the .beam file with
+%% abstract code still ships in `erts-<vsn>/ebin/`.
+find_erlang_beam() ->
+    LibDir = code:lib_dir(),
+    case filelib:wildcard("erts-*/ebin/erlang.beam", LibDir) of
+        [Rel | _] -> filename:join(LibDir, Rel);
+        [] -> not_found
+    end.
+
 %%% ---------------------------------------------------------------
 %%% map_type/1 — Erlang type to Beamtalk type mapping
 %%% ---------------------------------------------------------------

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
@@ -119,12 +119,21 @@ read_specs_erlang_bifs_test() ->
 
 %% Locate erlang.beam on disk. `code:which(erlang)` returns `preloaded` because
 %% the BIF module is loaded into the VM at boot, but the .beam file with
-%% abstract code still ships in `erts-<vsn>/ebin/`.
+%% abstract code still ships in `<erts>/ebin/`.
+%%
+%% Use `code:lib_dir(erts)` rather than globbing — OTP layouts differ
+%% (upstream/kerl/brew put `erts-<vsn>` under the OTP root; Debian also
+%% mirrors it under `lib/`). `code:lib_dir/1` is Erlang's canonical resolution.
 find_erlang_beam() ->
-    LibDir = code:lib_dir(),
-    case filelib:wildcard("erts-*/ebin/erlang.beam", LibDir) of
-        [Rel | _] -> filename:join(LibDir, Rel);
-        [] -> not_found
+    case code:lib_dir(erts) of
+        {error, _} ->
+            not_found;
+        Dir ->
+            Path = filename:join([Dir, "ebin", "erlang.beam"]),
+            case filelib:is_regular(Path) of
+                true -> Path;
+                false -> not_found
+            end
     end.
 
 %%% ---------------------------------------------------------------


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2159

## Summary

`discover_otp_beam_files` only iterated a hand-picked set of OTP apps (`stdlib`, `kernel`, `crypto`, `ssl`, `inets`, `mnesia`, `os_mon`) and skipped `erts-<vsn>/ebin/`. That meant `erlang.beam` — which carries the Dialyzer specs for the BIFs (`whereis/1`, `is_process_alive/1`, `spawn/3`, `self/0`, `node/0`, `monotonic_time/0`, `system_time/0`, …) — was never extracted, and every `(Erlang erlang) ...` call typechecked to `Dynamic`.

`code:which(erlang)` returns `preloaded` because the BIF module is loaded into the VM at boot, but the `.beam` file with full abstract code does ship on disk under the OTP `lib_dir` — same layout as any other OTP app. Adding `erts` to the `common_apps` list is enough: the existing apps glob matches `erts-<vsn>` like everything else, and `beam_lib:chunks/2` reads the abstract code chunk the same way it does for `lists`/`maps`.

## Verification

End-to-end on a fresh `beamtalk build`:

- Type cache now includes `erlang_*.json` (~56 KB of specs) plus typed entries for `init`, `erts_internal`, `atomics`, `counters`, `persistent_term`, and `prim_file`.
- All 12 acceptance-criteria BIFs extract with expected types — e.g. `whereis: regname :: Symbol -> Pid | Dynamic | Symbol`, `is_process_alive: pid :: Pid -> Boolean`, `spawn: module :: Symbol function: function :: Symbol args: args :: List -> Pid`.

## Tests

- `beam_compiler::tests::discover_otp_beam_files_includes_erts` — guards the apps list against future shrinkage. Skips gracefully if `erl` is unavailable in the test env.
- `beamtalk_spec_reader_tests:read_specs_erlang_bifs_test` — extracts directly from `erlang.beam` and verifies the 10 acceptance-criteria BIFs are present and `whereis/1` reports `Symbol` for its argument. Skips gracefully if `erlang.beam` is not found.

## Out of scope

- Removing the two `@expect type` pragmas in `beamtalk-watcher/src/checks/ProcessCheck.bt` is a separate downstream change in the watcher repo.
- Pre-existing failures in `beamtalk_spec_reader_tests` (5 stale `Result(T, Dynamic)` assertions) tracked in BT-2184 — they predate this change and aren't exercised by CI's `test-runtime` recipe.

## Test plan

- [x] `cargo test -p beamtalk-cli beam_compiler` — 43/43 pass
- [x] `cargo test -p beamtalk-core --lib` — 3576/3576 pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p beamtalk-cli --all-targets` — clean
- [x] `rebar3 fmt --check` — clean
- [x] `rebar3 eunit --module=beamtalk_spec_reader` — new `read_specs_erlang_bifs_test` passes (the 5 pre-existing failures are unchanged in count and unrelated, tracked in BT-2184)
- [x] End-to-end: `beamtalk build` on a fresh package produces a typed `erlang_*.json` cache entry

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1HgZuBJRcfHBSUMP9Xvsm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded OTP discovery to include the runtime (erts) and to locate ebin directories by probing each OTP app, improving BEAM file coverage.

* **Tests**
  * Added tests ensuring the runtime's BEAMs are discovered and that spec/type extraction reads Erlang built-in functions and their parameter types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->