### PR TITLE
Fix bit-rotted beamtalk_compiler eunit tests and wire into CI BT-2184

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -559,7 +559,7 @@ test-runtime: build-stdlib
     #!/usr/bin/env bash
     set -eo pipefail
     echo "🧪 Running Erlang runtime unit tests..."
-    if OUTPUT=$(BEAMTALK_NO_FILE_LOG=1 rebar3 eunit --cover=false --app=beamtalk_runtime,beamtalk_workspace 2>&1); then
+    if OUTPUT=$(BEAMTALK_NO_FILE_LOG=1 rebar3 eunit --cover=false --app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler 2>&1); then
         echo "$OUTPUT" | tail -2
     else
         echo "$OUTPUT"
@@ -577,7 +577,7 @@ test-runtime: build-stdlib
 [working-directory: 'runtime']
 test-runtime: build-stdlib
     @echo "🧪 Running Erlang runtime unit tests..."
-    @$env:BEAMTALK_NO_FILE_LOG = "1"; $output = rebar3 eunit '--cover=false' '--app=beamtalk_runtime,beamtalk_workspace' 2>&1 | Out-String; $exitCode = $LASTEXITCODE; if ($exitCode -ne 0) { Write-Output $output; exit $exitCode } else { ($output -split "`n") | Select-Object -Last 3 }
+    @$env:BEAMTALK_NO_FILE_LOG = "1"; $output = rebar3 eunit '--cover=false' '--app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler' 2>&1 | Out-String; $exitCode = $LASTEXITCODE; if ($exitCode -ne 0) { Write-Output $output; exit $exitCode } else { ($output -split "`n") | Select-Object -Last 3 }
     @$env:BEAMTALK_NO_FILE_LOG = "1"; $output = rebar3 eunit '--cover=false' '--dir=apps/beamtalk_stdlib/test' 2>&1 | Out-String; $exitCode = $LASTEXITCODE; if ($exitCode -ne 0) { Write-Output $output; exit $exitCode } else { ($output -split "`n") | Select-Object -Last 3 }
     @echo "✅ Runtime tests complete"
 
@@ -642,7 +642,7 @@ coverage-runtime: build-stdlib
     # Run 1: runtime + workspace tests.
     # bt@*.beam files are findable via apps/beamtalk_stdlib/ebin/ (project app ebin
     # stays on the code path when beamtalk_stdlib is not listed as an explicit --app).
-    if ! OUTPUT=$(rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace --cover 2>&1); then
+    if ! OUTPUT=$(rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler --cover 2>&1); then
         echo "$OUTPUT"
         echo "❌ EUnit tests (runtime+workspace) failed"
         exit 1

--- a/Justfile
+++ b/Justfile
@@ -639,12 +639,12 @@ coverage-runtime: build-stdlib
     set -euo pipefail
     cd runtime
     echo "📊 Generating Erlang runtime coverage..."
-    # Run 1: runtime + workspace tests.
+    # Run 1: runtime + workspace + compiler tests.
     # bt@*.beam files are findable via apps/beamtalk_stdlib/ebin/ (project app ebin
     # stays on the code path when beamtalk_stdlib is not listed as an explicit --app).
     if ! OUTPUT=$(rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler --cover 2>&1); then
         echo "$OUTPUT"
-        echo "❌ EUnit tests (runtime+workspace) failed"
+        echo "❌ EUnit tests (runtime+workspace+compiler) failed"
         exit 1
     fi
     echo "$OUTPUT" | grep -E "Finished in|[0-9]+ tests," || true

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
@@ -43,16 +43,16 @@ simple_expression_test() ->
     with_port(fun(Port) ->
         {ok, CoreErlang, []} =
             beamtalk_compiler_port:compile_expression(Port, <<"1 + 2">>, <<"test">>, []),
-        %% Verify the Core Erlang contains the expected addition
-        ?assert(binary:match(CoreErlang, <<"'+'(1, 2)">>) =/= nomatch)
+        %% Verify the Core Erlang contains the qualified BIF call.
+        ?assert(binary:match(CoreErlang, <<"'erlang':'+'">>) =/= nomatch)
     end).
 
 known_vars_test() ->
     with_port(fun(Port) ->
         {ok, CoreErlang, []} =
             beamtalk_compiler_port:compile_expression(Port, <<"x + 1">>, <<"test">>, [<<"x">>]),
-        %% Verify it references the variable x via maps:get
-        ?assert(binary:match(CoreErlang, <<"'get'('x'">>) =/= nomatch)
+        %% Verify it references variable x via the qualified maps:get/2 call.
+        ?assert(binary:match(CoreErlang, <<"'maps':'get'">>) =/= nomatch)
     end).
 
 invalid_expression_returns_error_test() ->
@@ -291,7 +291,7 @@ class_module_index_used_for_spawn_with_args_expression_test() ->
         },
         {ok, CoreErlang, []} =
             beamtalk_compiler_port:compile_expression(
-                Port, <<"Counter spawnWith: #{ value: 10 }">>, <<"repl_test">>, [], Options
+                Port, <<"Counter spawnWith: #{#value => 10}">>, <<"repl_test">>, [], Options
             ),
         ?assert(
             binary:match(CoreErlang, <<"'bt@getting_started@counter':'spawn'">>) =/= nomatch

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
@@ -43,16 +43,22 @@ simple_expression_test() ->
     with_port(fun(Port) ->
         {ok, CoreErlang, []} =
             beamtalk_compiler_port:compile_expression(Port, <<"1 + 2">>, <<"test">>, []),
-        %% Verify the Core Erlang contains the qualified BIF call.
-        ?assert(binary:match(CoreErlang, <<"'erlang':'+'">>) =/= nomatch)
+        %% The port emits `call 'erlang':'+'\n\t\t    (1, 2)`. Check both
+        %% the qualified BIF and the literal operand pair so that operand-order
+        %% regressions are still caught.
+        ?assert(binary:match(CoreErlang, <<"'erlang':'+'">>) =/= nomatch),
+        ?assert(binary:match(CoreErlang, <<"1, 2">>) =/= nomatch)
     end).
 
 known_vars_test() ->
     with_port(fun(Port) ->
         {ok, CoreErlang, []} =
             beamtalk_compiler_port:compile_expression(Port, <<"x + 1">>, <<"test">>, [<<"x">>]),
-        %% Verify it references variable x via the qualified maps:get/2 call.
-        ?assert(binary:match(CoreErlang, <<"'maps':'get'">>) =/= nomatch)
+        %% Variable x is fetched via `call 'maps':'get'\n\t\t\t ('x', State)`.
+        %% Assert both the qualified call and the `'x'` key are present so that
+        %% the test still guards variable-lookup specifically.
+        ?assert(binary:match(CoreErlang, <<"'maps':'get'">>) =/= nomatch),
+        ?assert(binary:match(CoreErlang, <<"'x'">>) =/= nomatch)
     end).
 
 invalid_expression_returns_error_test() ->

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
@@ -74,7 +74,10 @@ handle_compile_response_error_test() ->
 handle_compile_response_unexpected_test() ->
     Response = #{status => unknown_status, data => <<"garbage">>},
     Result = beamtalk_compiler_server:handle_compile_response(Response),
-    ?assertMatch({error, [<<"Unexpected compiler response">>]}, Result).
+    ?assertMatch(
+        {error, [#{message := <<"Unexpected compiler response">>}]},
+        Result
+    ).
 
 %%% ---------------------------------------------------------------
 %%% handle_diagnostics_response/1 — internal response handler
@@ -93,7 +96,10 @@ handle_diagnostics_response_error_test() ->
 handle_diagnostics_response_unexpected_test() ->
     Response = #{bogus => true},
     Result = beamtalk_compiler_server:handle_diagnostics_response(Response),
-    ?assertMatch({error, [<<"Unexpected compiler response">>]}, Result).
+    ?assertMatch(
+        {error, [#{message := <<"Unexpected compiler response">>}]},
+        Result
+    ).
 
 %%% ---------------------------------------------------------------
 %%% handle_version_response/1 — internal response handler

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl
@@ -57,15 +57,15 @@ compile_expression_succeeds() ->
         beamtalk_compiler:compile_expression(<<"1 + 2">>, <<"test_mod">>, []),
     ?assert(is_binary(CoreErlang)),
     ?assert(byte_size(CoreErlang) > 0),
-    %% Verify Core Erlang contains the addition
-    ?assert(binary:match(CoreErlang, <<"'+'(1, 2)">>) =/= nomatch).
+    %% Verify Core Erlang contains the addition via the qualified BIF call.
+    ?assert(binary:match(CoreErlang, <<"'erlang':'+'">>) =/= nomatch).
 
 compile_expression_known_vars() ->
     {ok, CoreErlang, []} =
         beamtalk_compiler:compile_expression(<<"x + 1">>, <<"test_mod">>, [<<"x">>]),
     ?assert(is_binary(CoreErlang)),
-    %% Variable x referenced via maps:get
-    ?assert(binary:match(CoreErlang, <<"'get'('x'">>) =/= nomatch).
+    %% Variable x referenced via the qualified maps:get/2 call.
+    ?assert(binary:match(CoreErlang, <<"'maps':'get'">>) =/= nomatch).
 
 compile_expression_error() ->
     {error, Diagnostics} =

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl
@@ -57,15 +57,21 @@ compile_expression_succeeds() ->
         beamtalk_compiler:compile_expression(<<"1 + 2">>, <<"test_mod">>, []),
     ?assert(is_binary(CoreErlang)),
     ?assert(byte_size(CoreErlang) > 0),
-    %% Verify Core Erlang contains the addition via the qualified BIF call.
-    ?assert(binary:match(CoreErlang, <<"'erlang':'+'">>) =/= nomatch).
+    %% The compiler emits `call 'erlang':'+'\n\t\t    (1, 2)`. Check both
+    %% the qualified BIF and the literal operand pair so that operand-order
+    %% regressions are still caught.
+    ?assert(binary:match(CoreErlang, <<"'erlang':'+'">>) =/= nomatch),
+    ?assert(binary:match(CoreErlang, <<"1, 2">>) =/= nomatch).
 
 compile_expression_known_vars() ->
     {ok, CoreErlang, []} =
         beamtalk_compiler:compile_expression(<<"x + 1">>, <<"test_mod">>, [<<"x">>]),
     ?assert(is_binary(CoreErlang)),
-    %% Variable x referenced via the qualified maps:get/2 call.
-    ?assert(binary:match(CoreErlang, <<"'maps':'get'">>) =/= nomatch).
+    %% Variable x is fetched via `call 'maps':'get'\n\t\t\t ('x', State)`.
+    %% Assert both the qualified call and the `'x'` key are present so that
+    %% the test still guards variable-lookup specifically.
+    ?assert(binary:match(CoreErlang, <<"'maps':'get'">>) =/= nomatch),
+    ?assert(binary:match(CoreErlang, <<"'x'">>) =/= nomatch).
 
 compile_expression_error() ->
     {error, Diagnostics} =

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
@@ -240,10 +240,10 @@ map_type_result_ok_error_test() ->
         )
     ).
 
-%% {ok, pid()} | {error, term()} → Result(Pid, Dynamic)
+%% {ok, pid()} | {error, term()} → Result(Pid) (Dynamic err is elided)
 map_type_result_pid_dynamic_test() ->
     ?assertEqual(
-        <<"Result(Pid, Dynamic)">>,
+        <<"Result(Pid)">>,
         beamtalk_spec_reader:map_type(
             {type, 0, union, [
                 {type, 0, tuple, [{atom, 0, ok}, {type, 0, pid, []}]},
@@ -264,11 +264,11 @@ map_type_result_bare_ok_test() ->
         )
     ).
 
-%% {ok, T} without error branch → Result(T, Dynamic)
+%% {ok, T} without error branch → Result(T) (Dynamic err is elided)
 map_type_result_ok_only_test() ->
     %% {ok, T} | other — ok branch present, no error branch
     ?assertEqual(
-        <<"Result(String | Binary, Dynamic) | Integer">>,
+        <<"Result(String | Binary) | Integer">>,
         beamtalk_spec_reader:map_type(
             {type, 0, union, [
                 {type, 0, tuple, [{atom, 0, ok}, {type, 0, binary, []}]},
@@ -280,7 +280,7 @@ map_type_result_ok_only_test() ->
 %% {ok, T} as the sole branch in a union with no error branch
 map_type_result_ok_only_pure_test() ->
     ?assertEqual(
-        <<"Result(String | Binary, Dynamic)">>,
+        <<"Result(String | Binary)">>,
         beamtalk_spec_reader:map_type(
             {type, 0, union, [
                 {type, 0, tuple, [{atom, 0, ok}, {type, 0, binary, []}]}
@@ -389,8 +389,10 @@ verify_timer_send_after_result_test() ->
     ?assert(length(SendAfterSpecs) > 0),
     [Spec | _] = SendAfterSpecs,
     RetType = maps:get(return_type, Spec),
-    %% Should be a Result type
-    ?assertMatch(<<"Result(", _/binary>>, RetType).
+    %% Should be a Result type. When both ok and err resolve to Dynamic
+    %% the formatter emits the bare `Result` form (no parentheses), so
+    %% match on the `Result` prefix to cover both shapes.
+    ?assertMatch(<<"Result", _/binary>>, RetType).
 
 %% application:start/1 → Result(Nil, ...) (bare ok in union)
 verify_application_start_result_test() ->
@@ -406,8 +408,10 @@ verify_application_start_result_test() ->
     ?assert(length(StartSpecs) > 0),
     [Spec | _] = StartSpecs,
     RetType = maps:get(return_type, Spec),
-    %% Should be Result(Nil, ...) because of bare ok atom
-    ?assertMatch(<<"Result(Nil,", _/binary>>, RetType).
+    %% Should start with Result(Nil because of the bare `ok` atom. The
+    %% formatter elides `, Dynamic` from the err position, so the value
+    %% may be either `Result(Nil)` or `Result(Nil, <ErrType>)`.
+    ?assertMatch(<<"Result(Nil", _/binary>>, RetType).
 
 %%% ---------------------------------------------------------------
 %%% Bounded fun with ok/error union (constraint resolution into Result)

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
@@ -389,10 +389,14 @@ verify_timer_send_after_result_test() ->
     ?assert(length(SendAfterSpecs) > 0),
     [Spec | _] = SendAfterSpecs,
     RetType = maps:get(return_type, Spec),
-    %% Should be a Result type. When both ok and err resolve to Dynamic
-    %% the formatter emits the bare `Result` form (no parentheses), so
-    %% match on the `Result` prefix to cover both shapes.
-    ?assertMatch(<<"Result", _/binary>>, RetType).
+    %% The formatter emits one of two shapes: bare `Result` (when both ok
+    %% and err resolve to Dynamic) or `Result(...)` (closing parenthesis).
+    %% Anything else — e.g. `ResultFoo` — should fail.
+    ?assert(
+        RetType =:= <<"Result">> orelse
+            (binary:match(RetType, <<"Result(">>) =:= {0, 7} andalso
+                binary:last(RetType) =:= $))
+    ).
 
 %% application:start/1 → Result(Nil, ...) (bare ok in union)
 verify_application_start_result_test() ->
@@ -408,10 +412,15 @@ verify_application_start_result_test() ->
     ?assert(length(StartSpecs) > 0),
     [Spec | _] = StartSpecs,
     RetType = maps:get(return_type, Spec),
-    %% Should start with Result(Nil because of the bare `ok` atom. The
-    %% formatter elides `, Dynamic` from the err position, so the value
-    %% may be either `Result(Nil)` or `Result(Nil, <ErrType>)`.
-    ?assertMatch(<<"Result(Nil", _/binary>>, RetType).
+    %% The formatter elides `, Dynamic` from the err position, so the only
+    %% two valid shapes here are `Result(Nil)` and `Result(Nil, <ErrType>)`.
+    %% Reject malformed values like `Result(NilThing` by checking the
+    %% delimiter explicitly.
+    ?assert(
+        RetType =:= <<"Result(Nil)">> orelse
+            (binary:match(RetType, <<"Result(Nil, ">>) =:= {0, 12} andalso
+                binary:last(RetType) =:= $))
+    ).
 
 %%% ---------------------------------------------------------------
 %%% Bounded fun with ok/error union (constraint resolution into Result)


### PR DESCRIPTION
The beamtalk_compiler app was not in test-runtime's --app= list, so its
eunit tests never ran in CI. As a result twelve tests drifted out of
sync with the production code on main:

  beamtalk_spec_reader_tests (5)
    Updated assertions to match format_result_type/2's elide-Dynamic
    behaviour from PR #1927: Result(T, Dynamic) collapses to Result(T),
    and Result(Dynamic, Dynamic) collapses to bare Result.

  beamtalk_compiler_tests, beamtalk_compiler_port_tests (4)
    Core Erlang output now emits fully qualified BIF calls
    (call 'erlang':'+', call 'maps':'get'), so the substring assertions
    were updated to look for the qualified module name rather than the
    bare function name.

  beamtalk_compiler_port_tests (1)
    The spawnWith: test used the legacy map literal syntax
    "#{ value: 10 }"; updated to the current "#{#value => 10}" form.

  beamtalk_compiler_server_tests (2)
    handle_*_response/1 now wraps the "Unexpected compiler response"
    diagnostic in a structured map; assertions updated.

Justfile: added beamtalk_compiler to the --app= argument of the
test-runtime recipe (bash and PowerShell variants) and the
coverage-runtime recipe so future bit-rot is caught.

After this change `rebar3 eunit --app=beamtalk_compiler` is green
locally: 181 tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test assertions across compiler suites to match current compiled output (qualified calls, map-literal forms, and richer error structures).
  * Added the compiler application to runtime test and coverage runs to extend test coverage.

* **Refactor**
  * Compiler error reporting now uses a more structured message format.
  * Type/result formatting refined in specification handling and related verifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->