### PR TITLE
docs: daily refresh 2026-05-18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Tooling
 
+- OTP type discovery now includes `erts`, so `:erlang` module BIFs (`whereis/1`, `spawn/3`, `self/0`, `node/0`, `monotonic_time/0`, etc.) type-check with proper specs instead of `Dynamic` (BT-2159).
 - **REPL `:interrupt` / `:int` meta-command** — sends an out-of-band interrupt over a separate connection to cancel a running evaluation. This is the one REPL operation that cannot be expressed as a normal message-send (the session is blocked while an eval is in-flight) (BT-2090).
 - `beamtalk lint` now loads the FFI type cache from `_build/type_cache/`, so lint and build agree on FFI return types — previously lint always inferred untyped-FFI for Erlang calls (BT-2134).
 - `beamtalk lint` validates cache entries against live `.beam` file mtimes, skipping stale entries when the underlying module has been recompiled (BT-2139).
@@ -40,6 +41,7 @@
 - Extract duplicate `build.rs` version-injection logic into shared `beamtalk-build` workspace crate — single source of truth for `BEAMTALK_VERSION` emission (BT-2172).
 - Replace 5 `format!()` calls with `fresh_temp_var` / `write!` in `repl/codegen.rs` and `value_type_codegen.rs` — continues the BT-875 cleanup (BT-2175).
 - Extract shared `parse_and_check_expression` helper in compiler-port — deduplicates ~20-line lex/parse/validate preamble from `handle_compile_expression` and `handle_compile_expression_trace` (BT-2178).
+- Replace `format!()` violations with `Document`/`docvec!` API in `value_type_codegen.rs` module header — continues the BT-875 cleanup (BT-2181).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

Daily documentation refresh for 2026-05-18.

- Added 1 CHANGELOG "Tooling" entry for BT-2159 (`:erlang` BIFs now type-checked via erts ebin discovery)
- Added 1 CHANGELOG "Internal" entry for BT-2181 (format!() cleanup in value_type_codegen)

### Commits reviewed (9)

| SHA | Title | Classification | Doc change |
|-----|-------|---------------|------------|
| `0b67c2b` | Add `:erlang` BIFs to NativeTypeRegistry via erts ebin discovery (BT-2159) | Tooling | CHANGELOG entry added |
| `cfcee05` | test: add unit tests for Integer/List/String primitive BIF generators (BT-2179) | Test-only | Skipped |
| `118dc2c` | Replace placeholder assertions in chat_room.btscript (BT-2168) | Test-only | Skipped |
| `db7ce4c` | refactor: tighten 6 placeholder assertions in tracing.btscript (BT-2171) | Test-only | Skipped |
| `bc49c6e` | Start hex bridge in Claude Code cloud sandbox (#2214) | `.claude/` infra | Skipped |
| `4800010` | Tighten notNil assertions in bag_test.bt (BT-2183) | Test-only | Skipped |
| `1623609` | Add unit tests for semantic_analysis/facts.rs (BT-2182) | Test-only | Skipped |
| `9b91100` | Fix format!() violations in value_type_codegen (BT-2181) | Internal | CHANGELOG entry added |
| `637a842` | docs: daily refresh 2026-05-17 (#2210) | Previous refresh | Skipped |

### Skipped — reasons

- **5 test-only commits** (BT-2179, BT-2168, BT-2171, BT-2183, BT-2182): diffs purely under test directories, no user-visible changes.
- **1 `.claude/` infra commit** (#2214): cloud sandbox hook config, no user-facing docs impact.
- **1 previous docs refresh** (#2210): meta-docs, no new behavior.

https://claude.ai/code/session_01EbaGSMmdq81Nre9HkhNMMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbaGSMmdq81Nre9HkhNMMJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced type discovery for Erlang module functions, improving type-checking accuracy.

* **Chores**
  * Updated internal documentation methodology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->