### PR TITLE
Extract TempDir+Utf8PathBuf boilerplate into local test helpers (BT-2186)

### DIFF
--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -1287,10 +1287,15 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    fn temp_utf8_dir() -> (TempDir, Utf8PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        (temp, dir)
+    }
+
     #[test]
     fn test_find_stdlib_files() {
-        let temp = TempDir::new().unwrap();
-        let lib_dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, lib_dir) = temp_utf8_dir();
 
         fs::write(lib_dir.join("Integer.bt"), "// stub").unwrap();
         fs::write(lib_dir.join("String.bt"), "// stub").unwrap();
@@ -1304,8 +1309,7 @@ mod tests {
 
     #[test]
     fn test_find_stdlib_files_sorted() {
-        let temp = TempDir::new().unwrap();
-        let lib_dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, lib_dir) = temp_utf8_dir();
 
         fs::write(lib_dir.join("Zebra.bt"), "// stub").unwrap();
         fs::write(lib_dir.join("Alpha.bt"), "// stub").unwrap();
@@ -1317,8 +1321,7 @@ mod tests {
 
     #[test]
     fn test_find_stdlib_files_empty_dir() {
-        let temp = TempDir::new().unwrap();
-        let lib_dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, lib_dir) = temp_utf8_dir();
 
         let files = find_stdlib_files(&lib_dir).unwrap();
         assert!(files.is_empty());
@@ -1357,8 +1360,7 @@ mod tests {
 
     #[test]
     fn test_clean_ebin_dir() {
-        let temp = TempDir::new().unwrap();
-        let ebin_dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, ebin_dir) = temp_utf8_dir();
 
         fs::write(ebin_dir.join("beamtalk_integer.beam"), "fake").unwrap();
         fs::write(ebin_dir.join("beamtalk_stdlib.app"), "fake").unwrap();
@@ -1373,8 +1375,7 @@ mod tests {
 
     #[test]
     fn test_generate_app_file() {
-        let temp = TempDir::new().unwrap();
-        let ebin_dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, ebin_dir) = temp_utf8_dir();
 
         let source_files = vec![
             Utf8PathBuf::from("lib/Integer.bt"),
@@ -1395,8 +1396,7 @@ mod tests {
 
     #[test]
     fn test_generate_app_file_empty() {
-        let temp = TempDir::new().unwrap();
-        let ebin_dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, ebin_dir) = temp_utf8_dir();
 
         generate_app_file(&ebin_dir, &[], &[], &[]).unwrap();
 
@@ -1406,8 +1406,7 @@ mod tests {
 
     #[test]
     fn test_generate_app_file_invalid_name_errors() {
-        let temp = TempDir::new().unwrap();
-        let ebin_dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, ebin_dir) = temp_utf8_dir();
 
         let source_files = vec![
             Utf8PathBuf::from("lib/Integer.bt"),
@@ -1420,8 +1419,7 @@ mod tests {
 
     #[test]
     fn test_generate_app_file_with_protocol_modules() {
-        let temp = TempDir::new().unwrap();
-        let ebin_dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, ebin_dir) = temp_utf8_dir();
 
         let source_files = vec![Utf8PathBuf::from("lib/Integer.bt")];
         let protocol_modules = vec!["bt@stdlib@printable".to_string()];

--- a/crates/beamtalk-cli/src/commands/test.rs
+++ b/crates/beamtalk-cli/src/commands/test.rs
@@ -2091,11 +2091,22 @@ fn report_results(
 mod tests {
     use super::*;
 
+    fn write_bt_file(name: &str, content: &str) -> (tempfile::TempDir, Utf8PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let file = Utf8PathBuf::from_path_buf(temp.path().join(name)).unwrap();
+        fs::write(&file, content).unwrap();
+        (temp, file)
+    }
+
+    fn temp_utf8_dir() -> (tempfile::TempDir, Utf8PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        (temp, dir)
+    }
+
     #[test]
     fn test_discover_no_test_classes() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let file = Utf8PathBuf::from_path_buf(temp.path().join("plain.bt")).unwrap();
-        fs::write(&file, "Object subclass: Plain\n  foo => 42\n").unwrap();
+        let (_temp, file) = write_bt_file("plain.bt", "Object subclass: Plain\n  foo => 42\n");
 
         let (classes, loads) = discover_test_classes(&file).unwrap();
         assert!(classes.is_empty());
@@ -2104,13 +2115,10 @@ mod tests {
 
     #[test]
     fn test_discover_test_case_subclass() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let file = Utf8PathBuf::from_path_buf(temp.path().join("my_test.bt")).unwrap();
-        fs::write(
-            &file,
+        let (_temp, file) = write_bt_file(
+            "my_test.bt",
             "TestCase subclass: MyTest\n  testAdd => self assert: (1 + 2) equals: 3\n  helper => nil\n",
-        )
-        .unwrap();
+        );
 
         let (classes, _) = discover_test_classes(&file).unwrap();
         assert_eq!(classes.len(), 1);
@@ -2120,13 +2128,10 @@ mod tests {
 
     #[test]
     fn test_discover_setup_teardown() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let file = Utf8PathBuf::from_path_buf(temp.path().join("lifecycle.bt")).unwrap();
-        fs::write(
-            &file,
+        let (_temp, file) = write_bt_file(
+            "lifecycle.bt",
             "TestCase subclass: LifecycleTest\n  setUp => nil\n  tearDown => nil\n  testIt => self assert: true\n",
-        )
-        .unwrap();
+        );
 
         let (classes, _) = discover_test_classes(&file).unwrap();
         assert_eq!(classes.len(), 1);
@@ -2137,13 +2142,10 @@ mod tests {
 
     #[test]
     fn test_discover_load_directives() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let file = Utf8PathBuf::from_path_buf(temp.path().join("with_load.bt")).unwrap();
-        fs::write(
-            &file,
+        let (_temp, file) = write_bt_file(
+            "with_load.bt",
             "// @load stdlib/test/fixtures/counter.bt\nTestCase subclass: T\n  testX => nil\n",
-        )
-        .unwrap();
+        );
 
         let (_, loads) = discover_test_classes(&file).unwrap();
         assert_eq!(loads, vec!["stdlib/test/fixtures/counter.bt"]);
@@ -2154,8 +2156,7 @@ mod tests {
 
     #[test]
     fn test_collect_beam_module_names() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, dir) = temp_utf8_dir();
 
         // Create some .beam files and non-.beam files
         fs::write(dir.join("bt@my_app@counter.beam"), b"fake beam").unwrap();
@@ -2171,8 +2172,7 @@ mod tests {
 
     #[test]
     fn test_collect_beam_module_names_empty_dir() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, dir) = temp_utf8_dir();
 
         let modules = collect_beam_module_names(&dir).unwrap();
         assert!(modules.is_empty());
@@ -2180,8 +2180,7 @@ mod tests {
 
     #[test]
     fn test_build_fixture_class_module_index_flat() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, dir) = temp_utf8_dir();
 
         // BT-2006: fixture also declares a protocol so we can assert the
         // returned `protocol_infos` carries it through.
@@ -2248,8 +2247,7 @@ mod tests {
 
     #[test]
     fn test_find_package_root_found() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, dir) = temp_utf8_dir();
 
         // Create nested structure: pkg/test/my_test.bt with beamtalk.toml at pkg/
         let pkg_dir = dir.join("pkg");
@@ -2268,8 +2266,7 @@ mod tests {
 
     #[test]
     fn test_find_package_root_not_found() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, dir) = temp_utf8_dir();
 
         // No beamtalk.toml anywhere
         fs::create_dir_all(dir.join("sub")).unwrap();
@@ -2330,8 +2327,7 @@ mod tests {
 
     #[test]
     fn test_find_package_root_directory_input() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, dir) = temp_utf8_dir();
 
         fs::write(
             dir.join("beamtalk.toml"),
@@ -2345,8 +2341,7 @@ mod tests {
 
     #[test]
     fn test_class_index_for_file_uses_own_package() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, dir) = temp_utf8_dir();
 
         // Two packages, each defining a class named "Counter"
         let pkg_a = dir.join("pkg_a");
@@ -2414,8 +2409,7 @@ mod tests {
 
     #[test]
     fn test_class_index_for_file_fixture_classes_available() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, dir) = temp_utf8_dir();
 
         let pkg_a = dir.join("pkg_a");
         fs::create_dir_all(pkg_a.join("test")).unwrap();
@@ -2521,8 +2515,7 @@ mod tests {
     /// This test verifies the renaming logic that produces those unique names.
     #[test]
     fn test_module_name_prefixed_for_multi_package_collision_avoidance() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let (_temp, dir) = temp_utf8_dir();
 
         // Two packages, each with a SmokeTest class
         let pkg_a = dir.join("pkg_a");


### PR DESCRIPTION
## Summary

Eliminates 22 repeated 2–3 line TempDir setup sequences across two CLI command test modules by extracting two local helpers that `build.rs` already had but `test.rs` and `build_stdlib.rs` were missing.

**Helpers added:**
- `temp_utf8_dir() -> (TempDir, Utf8PathBuf)` — creates a temp dir and returns it as a `Utf8PathBuf`
- `write_bt_file(name, content) -> (TempDir, Utf8PathBuf)` — creates a temp dir, writes a `.bt` file, returns both

**Call sites replaced:**
- `crates/beamtalk-cli/src/commands/test.rs` — 9× `temp_utf8_dir`, 4× `write_bt_file`
- `crates/beamtalk-cli/src/commands/build_stdlib.rs` — 8× `temp_utf8_dir`

All changes are inside `#[cfg(test)]` blocks. No production code is touched.

## Test plan

- [x] `cargo test -p beamtalk-cli --bin beamtalk` — 851 passed, 0 failed
- [x] `just clippy` — no warnings
- [x] `just fmt-check` — clean

Linear: https://linear.app/beamtalk/issue/BT-2186

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMkYN6dK7zt1G8j1SR8o7e)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal test infrastructure to reduce code duplication in test setup and temporary file handling.

**Note:** No user-facing changes in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->