### PR TITLE
test: cover beamtalk_result FFI shims and fromTuple: clauses (BT-2187)

### DIFF
--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_result_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_result_tests.erl
@@ -6,11 +6,14 @@
 %%% **DDD Context:** Object System Context
 
 -moduledoc """
-EUnit tests for beamtalk_result module (BT-1254).
+EUnit tests for beamtalk_result module (BT-1254, BT-2187).
 
 Tests cover:
 - from_tagged_tuple/1 — ok tuple, error tuple (atom, #beamtalk_error{}, wrapped map)
-- class_tryDo:/3 — success path, exception path
+- 'fromTuple:'/1 — ok, error, and invalid-input clauses
+- class_tryDo:/3 — success path, exception path, NLR re-raise
+- 'unwrapError:'/2 — wrapped exception re-raise, raw symbol signal, raw map
+- FFI shims: ok/1, makeError/1, fromTuple/1, tryDo/1, unwrapError/1
 """.
 
 -include_lib("eunit/include/eunit.hrl").
@@ -277,3 +280,101 @@ try_do_nlr_reraise_3tuple_test() ->
         {'$bt_nlr', FakeToken, hello},
         beamtalk_result:'tryDo:'(fun() -> throw({'$bt_nlr', FakeToken, hello}) end)
     ).
+
+%%% ============================================================================
+%%% 'fromTuple:'/1 — all three clauses
+%%% ============================================================================
+
+from_tuple_ok_returns_ok_result_test() ->
+    %% {ok, Value} clause → delegates to from_tagged_tuple/1
+    Result = beamtalk_result:'fromTuple:'({ok, hello}),
+    ?assertMatch(
+        #{'$beamtalk_class' := 'Result', 'isOk' := true, 'okValue' := hello, 'errReason' := nil},
+        Result
+    ).
+
+from_tuple_error_wraps_reason_test() ->
+    %% {error, Reason} clause → delegates to from_tagged_tuple/1, reason is wrapped
+    Result = beamtalk_result:'fromTuple:'({error, enoent}),
+    ?assertMatch(
+        #{'$beamtalk_class' := 'Result', 'isOk' := false, 'okValue' := nil},
+        Result
+    ),
+    #{'errReason' := ErrReason} = Result,
+    %% ensure_wrapped/1 promotes the bare atom to a Beamtalk Exception map
+    ?assertMatch(#{'$beamtalk_class' := _, 'error' := #beamtalk_error{}}, ErrReason).
+
+from_tuple_invalid_raises_type_error_test() ->
+    %% Any other value raises type_error with class='Result', selector='fromTuple:'
+    try
+        beamtalk_result:'fromTuple:'({foo, bar}),
+        ?assert(false, "'fromTuple:' should have raised a type_error")
+    catch
+        error:Caught ->
+            ?assertMatch(
+                #{'$beamtalk_class' := _, error := #beamtalk_error{kind = type_error}},
+                Caught
+            ),
+            #{error := Inner} = Caught,
+            ?assertEqual('Result', Inner#beamtalk_error.class),
+            ?assertEqual('fromTuple:', Inner#beamtalk_error.selector),
+            ?assertNotEqual(nomatch, binary:match(Inner#beamtalk_error.message, <<"fromTuple:">>))
+    end.
+
+%%% ============================================================================
+%%% FFI shims — delegate to canonical colon-suffixed functions
+%%% ============================================================================
+
+ok_shim_returns_ok_result_test() ->
+    %% ok/1 is the FFI shim for 'ok:'(Value)
+    Result = beamtalk_result:ok(99),
+    ?assertMatch(
+        #{'$beamtalk_class' := 'Result', 'isOk' := true, 'okValue' := 99, 'errReason' := nil},
+        Result
+    ).
+
+make_error_shim_stores_reason_as_is_test() ->
+    %% makeError/1 is the FFI shim for 'makeError:'(Reason) — does NOT wrap
+    Result = beamtalk_result:makeError(not_found),
+    ?assertMatch(
+        #{
+            '$beamtalk_class' := 'Result',
+            'isOk' := false,
+            'okValue' := nil,
+            'errReason' := not_found
+        },
+        Result
+    ).
+
+from_tuple_shim_delegates_to_from_tuple_test() ->
+    %% fromTuple/1 is the FFI shim for 'fromTuple:'(Tuple)
+    Result = beamtalk_result:fromTuple({ok, 7}),
+    ?assertMatch(
+        #{'$beamtalk_class' := 'Result', 'isOk' := true, 'okValue' := 7, 'errReason' := nil},
+        Result
+    ).
+
+try_do_shim_delegates_to_try_do_test() ->
+    %% tryDo/1 is the FFI shim for 'tryDo:'(Block)
+    Result = beamtalk_result:tryDo(fun() -> 42 end),
+    ?assertMatch(
+        #{'$beamtalk_class' := 'Result', 'isOk' := true, 'okValue' := 42, 'errReason' := nil},
+        Result
+    ).
+
+unwrap_error_shim_raises_signal_test() ->
+    %% unwrapError/1 shim calls 'unwrapError:'(undefined, ErrReason)
+    %% For a raw symbol, this raises a signal error.
+    try
+        beamtalk_result:unwrapError(bad_value),
+        ?assert(false, "unwrapError/1 should have raised an exception")
+    catch
+        error:Caught ->
+            ?assertMatch(
+                #{'$beamtalk_class' := _, error := #beamtalk_error{kind = signal}},
+                Caught
+            ),
+            #{error := Inner} = Caught,
+            ?assertEqual('Result', Inner#beamtalk_error.class),
+            ?assertEqual('unwrap', Inner#beamtalk_error.selector)
+    end.


### PR DESCRIPTION
## Summary

Closes the 8 uncovered executable lines in `beamtalk_result.erl`, raising line coverage from 68% to 100% (measured via `rebar3 eunit --cover`).

**Linear:** https://linear.app/beamtalk/issue/BT-2187

## What changed

Single file: `runtime/apps/beamtalk_stdlib/test/beamtalk_result_tests.erl` (+103 lines, no production code touched).

**New tests for `'fromTuple:'/1` (lines 167, 169, 171 were uncovered):**
- `from_tuple_ok_returns_ok_result_test` — `{ok, Value}` clause delegates to `from_tagged_tuple/1`
- `from_tuple_error_wraps_reason_test` — `{error, Reason}` clause wraps reason via `ensure_wrapped/1`
- `from_tuple_invalid_raises_type_error_test` — `Other` clause raises `type_error` with correct class/selector/message

**New tests for FFI shims (lines 69, 71, 73, 75, 77 were uncovered):**
- `ok_shim_returns_ok_result_test` — `ok/1` → ok Result
- `make_error_shim_stores_reason_as_is_test` — `makeError/1` stores reason verbatim (not wrapped)
- `from_tuple_shim_delegates_to_from_tuple_test` — `fromTuple/1` → ok Result
- `try_do_shim_delegates_to_try_do_test` — `tryDo/1` → ok Result from success block
- `unwrap_error_shim_raises_signal_test` — `unwrapError/1` → signal error for raw symbol

Also updated the module `-moduledoc` to list all test areas.

## Test plan

- [x] `rebar3 eunit --module=beamtalk_result_tests` → 24 tests, 0 failures
- [x] `rebar3 eunit --module=beamtalk_result_tests --cover` + `rebar3 cover` → `beamtalk_result | 100%`
- [x] `just test-bunit` → 1904 tests, 0 failures
- [x] `just test-stdlib` → 250 tests, 0 failures
- [x] `just build && just clippy && just fmt-check` → all pass
- [x] Pre-existing `beamtalk-mcp` permission failures confirmed present on `main` (not introduced here)

---
_Generated by [Claude Code](https://claude.ai/code/session_015epQAGhkhV14DqMJFt84VM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for result handling with additional cases for success, error, and invalid input scenarios.
  * Added integration tests to verify behavior across FFI shim layers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->