### PR TITLE
Replace 5 placeholder assertions in cross_file_value_object_inheritance.btscript (BT-2188)

### DIFF
--- a/tests/repl-protocol/cases/cross_file_value_object_inheritance.btscript
+++ b/tests/repl-protocol/cases/cross_file_value_object_inheritance.btscript
@@ -34,7 +34,7 @@ c class name
 
 // Field access works on the value object
 c radius
-// => _
+// => 5.0
 
 // Inherited area method computes correctly
 c area
@@ -56,13 +56,13 @@ r class name
 // => Rectangle
 
 r width
-// => _
+// => 4.0
 
 r height
-// => _
+// => 3.0
 
 r area
-// => _
+// => 12.0
 
 r perimeter
-// => _
+// => 14.0


### PR DESCRIPTION
## Summary

Nightly test-quality pass: tighten 5 of 9 `// => _` placeholder assertions in `cross_file_value_object_inheritance.btscript` with exact expected values derived from the fixture source code.\n\n- `c radius` → `5.0` (stored field value)\n- `r width` → `4.0` (stored field value)\n- `r height` → `3.0` (stored field value)\n- `r area` → `12.0` (4.0 × 3.0, exact IEEE 754)\n- `r perimeter` → `14.0` (2.0 × 7.0, exact IEEE 754)\n\nRemaining 4 `// => _` are intentionally kept: object constructors (display format not pinned) and circle area/perimeter (π-constant float ambiguity).\n\nLinear: https://linear.app/beamtalk/issue/BT-2188\n\n## Test plan\n\n- [x] `just test-repl-protocol` passes — test case ran with new assertions\n- [x] All 5 values verified against fixture source (`circle.bt`, `rectangle.bt`)\n- [x] No logic or fixture changes\n\nhttps://claude.ai/code/session_01Whcwhx66ehakaAKx5vF8AG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Whcwhx66ehakaAKx5vF8AG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for value-object inheritance functionality to verify correct numeric output handling across files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->