### PR TITLE
Resolve type references into preloaded modules (BT-2185)

### DIFF
--- a/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
@@ -600,8 +600,17 @@ resolve_remote_type(Mod, TypeName, Args) ->
                 non_existing ->
                     <<"Dynamic">>;
                 preloaded ->
-                    %% Preloaded modules (erlang, init, etc.) have no .beam on disk
-                    <<"Dynamic">>;
+                    %% Preloaded modules (erlang, init, erts_internal, ...) are
+                    %% loaded into the VM at boot, but the .beam file ships on
+                    %% disk under <lib_dir>/erts-<vsn>/ebin/ with abstract code.
+                    %% `code:get_object_code/1` returns its binary directly;
+                    %% `beam_lib:chunks/2` accepts a binary in place of a path.
+                    case code:get_object_code(Mod) of
+                        {_, Bin, _} ->
+                            resolve_remote_type_from_beam(Bin, Mod, TypeName, Arity, Depth);
+                        error ->
+                            <<"Dynamic">>
+                    end;
                 cover_compiled ->
                     <<"Dynamic">>;
                 BeamFile ->
@@ -612,10 +621,10 @@ resolve_remote_type(Mod, TypeName, Args) ->
     end.
 
 -spec resolve_remote_type_from_beam(
-    file:filename_all(), atom(), atom(), non_neg_integer(), non_neg_integer()
+    file:filename_all() | binary(), atom(), atom(), non_neg_integer(), non_neg_integer()
 ) -> binary().
-resolve_remote_type_from_beam(BeamFile, _Mod, TypeName, Arity, Depth) ->
-    case beam_lib:chunks(BeamFile, [abstract_code]) of
+resolve_remote_type_from_beam(BeamRef, _Mod, TypeName, Arity, Depth) ->
+    case beam_lib:chunks(BeamRef, [abstract_code]) of
         {ok, {_, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
             RemoteOpaqueSet = build_opaque_set(Forms),
             case sets:is_element({TypeName, Arity}, RemoteOpaqueSet) of

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
@@ -601,10 +601,12 @@ resolve_remote_type(Mod, TypeName, Args) ->
                     <<"Dynamic">>;
                 preloaded ->
                     %% Preloaded modules (erlang, init, erts_internal, ...) are
-                    %% loaded into the VM at boot, but the .beam file ships on
-                    %% disk under <lib_dir>/erts-<vsn>/ebin/ with abstract code.
-                    %% `code:get_object_code/1` returns its binary directly;
-                    %% `beam_lib:chunks/2` accepts a binary in place of a path.
+                    %% loaded into the VM at boot. The .beam files ship on disk
+                    %% under <lib_dir>/erts-<vsn>/ebin/ and typically include
+                    %% abstract code; stripped distributions may omit it, in
+                    %% which case resolve_remote_type_from_beam falls back to
+                    %% Dynamic. `code:get_object_code/1` returns the binary
+                    %% directly; `beam_lib:chunks/2` accepts a binary or path.
                     case code:get_object_code(Mod) of
                         {_, Bin, _} ->
                             resolve_remote_type_from_beam(Bin, Mod, TypeName, Arity, Depth);

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
@@ -1177,16 +1177,20 @@ resolve_remote_type_disk_log_test() ->
 resolve_remote_type_erlang_preloaded_test() ->
     case code:get_object_code(erlang) of
         error ->
-            %% erts-stripped distribution — preloaded fallback path is
-            %% covered by code; we just can't exercise the happy path here.
             ok;
-        {_, _, _} ->
-            ?assertEqual(
-                <<"Tuple">>,
-                beamtalk_spec_reader:map_type(
-                    {remote_type, 0, [{atom, 0, erlang}, {atom, 0, timestamp}, []]}
-                )
-            )
+        {_, Bin, _} ->
+            case beam_lib:chunks(Bin, [abstract_code]) of
+                {ok, {_, [{abstract_code, {raw_abstract_v1, _}}]}} ->
+                    ?assertEqual(
+                        <<"Tuple">>,
+                        beamtalk_spec_reader:map_type(
+                            {remote_type, 0, [{atom, 0, erlang}, {atom, 0, timestamp}, []]}
+                        )
+                    );
+                _ ->
+                    %% Abstract code stripped — can't exercise the happy path.
+                    ok
+            end
     end.
 
 %% map_type/1 without context still returns Dynamic for user_type.

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
@@ -1193,6 +1193,33 @@ resolve_remote_type_erlang_preloaded_test() ->
             end
     end.
 
+%% BT-2185: Also verify that a Result-shaped union type in a preloaded module
+%% resolves through the new code path. `prim_file:prim_file_name_error()` is
+%% defined as `error | ignore | warning` — the bare `error` atom should be
+%% classified as a Result error branch (with Nil reason), and the remaining
+%% `ignore | warning` atoms fall through to the Symbol union.
+resolve_remote_type_prim_file_preloaded_test() ->
+    case code:get_object_code(prim_file) of
+        error ->
+            ok;
+        {_, Bin, _} ->
+            case beam_lib:chunks(Bin, [abstract_code]) of
+                {ok, {_, [{abstract_code, {raw_abstract_v1, _}}]}} ->
+                    ?assertEqual(
+                        <<"Result(Dynamic, Nil) | Symbol">>,
+                        beamtalk_spec_reader:map_type(
+                            {remote_type, 0, [
+                                {atom, 0, prim_file},
+                                {atom, 0, prim_file_name_error},
+                                []
+                            ]}
+                        )
+                    );
+                _ ->
+                    ok
+            end
+    end.
+
 %% map_type/1 without context still returns Dynamic for user_type.
 map_type_user_type_no_context_test() ->
     %% When called outside read_specs, no type registry is set

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
@@ -1166,6 +1166,29 @@ resolve_remote_type_disk_log_test() ->
             ?assertEqual(<<"Result(Nil, Symbol | Tuple)">>, RetType)
     end.
 
+%% BT-2185: Remote type references into preloaded modules (`erlang`, `init`,
+%% `erts_internal`, ...) resolve via `code:get_object_code/1`. Previously this
+%% arm short-circuited to Dynamic because the comment claimed preloaded
+%% modules had no .beam on disk — they do, the file just isn't what
+%% `code:which/1` returns.
+%%
+%% `erlang:timestamp()` is defined as `{non_neg_integer(), non_neg_integer(),
+%% non_neg_integer()}`, which maps to Tuple.
+resolve_remote_type_erlang_preloaded_test() ->
+    case code:get_object_code(erlang) of
+        error ->
+            %% erts-stripped distribution — preloaded fallback path is
+            %% covered by code; we just can't exercise the happy path here.
+            ok;
+        {_, _, _} ->
+            ?assertEqual(
+                <<"Tuple">>,
+                beamtalk_spec_reader:map_type(
+                    {remote_type, 0, [{atom, 0, erlang}, {atom, 0, timestamp}, []]}
+                )
+            )
+    end.
+
 %% map_type/1 without context still returns Dynamic for user_type.
 map_type_user_type_no_context_test() ->
     %% When called outside read_specs, no type registry is set


### PR DESCRIPTION
## Summary

`resolve_remote_type/3` short-circuited to `Dynamic` whenever `code:which/1` returned `preloaded`, on the stale assumption that preloaded BIF modules have no `.beam` on disk. They do — `erlang.beam`, `init.beam`, `erts_internal.beam`, etc. all ship under `<lib_dir>/erts-<vsn>/ebin/` with full abstract code.

Uses `code:get_object_code/1` to grab the binary and hand it to `beam_lib:chunks/2` (which already accepts a binary in place of a path) via the existing `resolve_remote_type_from_beam/5` helper. Falls back to `Dynamic` cleanly when `code:get_object_code/1` returns `error` (erts-stripped distributions).

## Changes

- **`beamtalk_spec_reader.erl`**: Replace the `preloaded -> <<"Dynamic">>` arm with `code:get_object_code/1` lookup + delegation to `resolve_remote_type_from_beam/5`. Update the stale comment. Widen the type spec and rename param `BeamFile` → `BeamRef`.
- **`beamtalk_spec_reader_tests.erl`**: New `resolve_remote_type_erlang_preloaded_test` that resolves `erlang:timestamp()` end-to-end and asserts `Tuple` (not `Dynamic`).

## Linear issue

https://linear.app/beamtalk/issue/BT-2185

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHpn2u9LKoQgshwJAUxheo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced remote type resolution to map types from preloaded module binaries, improving type inference for shipped modules.

* **Tests**
  * Added tests that validate remote type mapping for preloaded modules, including checks for tuple/result/symbol shapes; tests skip gracefully when module abstract code is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->