### PR TITLE
Propagate typed block parameters from callee signature to call-site blocks (BT-2158)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1012,8 +1012,10 @@ impl TypeChecker {
             }
         }
 
-        // If receiver is a class reference, check class-side methods
-        if let Expression::ClassReference { name, .. } = receiver {
+        // If receiver is a class reference, check class-side methods.
+        // BT-2158: unwrap parens so `(HTTPRouter) foo:` dispatches class-side
+        // — matches the block-param inference normalisation above.
+        if let Expression::ClassReference { name, .. } = unwrap_parens(receiver) {
             let class_name = &name.name;
 
             // ADR 0075: `Erlang <module>` — return ErlangModule<module_name> type
@@ -1066,8 +1068,9 @@ impl TypeChecker {
             ..
         } = receiver_ty
         {
-            // In class methods, self sends should check class-side methods
-            if env.in_class_method && Self::is_self_receiver(receiver) {
+            // In class methods, self sends should check class-side methods.
+            // BT-2158: unwrap parens so `(self) foo:` dispatches class-side.
+            if env.in_class_method && Self::is_self_receiver(unwrap_parens(receiver)) {
                 if !in_abstract_method {
                     self.check_argument_types(
                         class_name,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -593,6 +593,11 @@ impl TypeChecker {
                     (send_ty.clone(), receiver.as_ref(), send_ty)
                 };
                 let is_class_ref = matches!(cascade_target, Expression::ClassReference { .. });
+                // BT-2158: same class-side detection as `infer_message_send_with_receiver_ty`
+                // so cascade messages also resolve block-typed params from the
+                // class-side method.
+                let is_class_side_send =
+                    is_class_ref || (env.in_class_method && Self::is_self_receiver(cascade_target));
                 for msg in messages {
                     let selector_name = msg.selector.name();
                     self.infer_args_with_block_context(
@@ -602,6 +607,7 @@ impl TypeChecker {
                         hierarchy,
                         env,
                         in_abstract_method,
+                        is_class_side_send,
                     );
                     if is_class_ref {
                         if let Expression::ClassReference { name, .. } = cascade_target {
@@ -920,6 +926,13 @@ impl TypeChecker {
                 in_abstract_method,
             )
         } else {
+            // BT-2158: detect class-side sends so block-param propagation
+            // uses `find_class_method` instead of `find_method`. Mirrors the
+            // `is_class_side_receiver` computation below (which runs after
+            // arg inference for other purposes).
+            let unwrapped = unwrap_parens(receiver);
+            let is_class_side = matches!(unwrapped, Expression::ClassReference { .. })
+                || (env.in_class_method && Self::is_self_receiver(unwrapped));
             self.infer_args_with_block_context(
                 arguments,
                 &receiver_ty,
@@ -927,6 +940,7 @@ impl TypeChecker {
                 hierarchy,
                 env,
                 in_abstract_method,
+                is_class_side,
             )
         };
 
@@ -2318,6 +2332,7 @@ impl TypeChecker {
         hierarchy: &ClassHierarchy,
         env: &mut TypeEnv,
         in_abstract_method: bool,
+        is_class_side_send: bool,
     ) -> Vec<InferredType> {
         // Fast path: receiver must be Known to look up method signatures.
         // For non-Known receivers (Dynamic, Never, etc.), we can't resolve block
@@ -2339,10 +2354,17 @@ impl TypeChecker {
             );
         };
 
-        // Look up the method to get param types. If the selector isn't defined on
-        // the receiver's class, block params likewise have no resolvable type;
-        // use the Dynamic-block-param fallback so usages don't double-warn.
-        let Some(method) = hierarchy.find_method(class_name, selector_name) else {
+        // Look up the method to get param types. For class-side sends
+        // (`ClassName foo:` or `self foo:` inside a class method), look up the
+        // class-side method; otherwise the instance method. BT-2158: without
+        // this split, class-side block parameters never get their declared
+        // types propagated to the call-site block params.
+        let method_lookup = if is_class_side_send {
+            hierarchy.find_class_method(class_name, selector_name)
+        } else {
+            hierarchy.find_method(class_name, selector_name)
+        };
+        let Some(method) = method_lookup else {
             return self.infer_args_with_dynamic_block_params(
                 arguments,
                 receiver_ty,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -592,12 +592,13 @@ impl TypeChecker {
                     let send_ty = self.infer_expr(receiver, hierarchy, env, in_abstract_method);
                     (send_ty.clone(), receiver.as_ref(), send_ty)
                 };
-                let is_class_ref = matches!(cascade_target, Expression::ClassReference { .. });
-                // BT-2158: same class-side detection as `infer_message_send_with_receiver_ty`
-                // so cascade messages also resolve block-typed params from the
-                // class-side method.
-                let is_class_side_send =
-                    is_class_ref || (env.in_class_method && Self::is_self_receiver(cascade_target));
+                // BT-2158: normalise the cascade target so parenthesised
+                // class references (`(HTTPRouter) build: [...]; ...`) are
+                // treated as class-side both for block-param inference and
+                // downstream selector validation.
+                let unwrapped_target = unwrap_parens(cascade_target);
+                let is_class_ref = matches!(unwrapped_target, Expression::ClassReference { .. });
+                let is_class_side_send = Self::is_class_side_receiver(cascade_target, env);
                 for msg in messages {
                     let selector_name = msg.selector.name();
                     self.infer_args_with_block_context(
@@ -610,7 +611,7 @@ impl TypeChecker {
                         is_class_side_send,
                     );
                     if is_class_ref {
-                        if let Expression::ClassReference { name, .. } = cascade_target {
+                        if let Expression::ClassReference { name, .. } = unwrapped_target {
                             self.check_class_side_send(
                                 &name.name,
                                 &selector_name,
@@ -620,7 +621,7 @@ impl TypeChecker {
                             );
                         }
                     } else if let InferredType::Known { ref class_name, .. } = dispatch_ty {
-                        if env.in_class_method && Self::is_self_receiver(cascade_target) {
+                        if env.in_class_method && Self::is_self_receiver(unwrapped_target) {
                             if !in_abstract_method {
                                 self.check_class_side_send(
                                     class_name,
@@ -927,12 +928,9 @@ impl TypeChecker {
             )
         } else {
             // BT-2158: detect class-side sends so block-param propagation
-            // uses `find_class_method` instead of `find_method`. Mirrors the
-            // `is_class_side_receiver` computation below (which runs after
-            // arg inference for other purposes).
-            let unwrapped = unwrap_parens(receiver);
-            let is_class_side = matches!(unwrapped, Expression::ClassReference { .. })
-                || (env.in_class_method && Self::is_self_receiver(unwrapped));
+            // uses `find_class_method` instead of `find_method`. Shares the
+            // helper with the downstream `is_class_side_receiver` check below.
+            let is_class_side = Self::is_class_side_receiver(receiver, env);
             self.infer_args_with_block_context(
                 arguments,
                 &receiver_ty,
@@ -964,12 +962,9 @@ impl TypeChecker {
         // Restricted to non-class-side receivers: `ClassName ifNil: ... ifNotNil: ...`
         // and `self ifNil: ... ifNotNil: ...` inside a class method must
         // flow through `check_class_side_send` so an invalid metaclass send
-        // still emits DNU. Unwrap parens first so `(ClassName) ifNil: ...`
+        // still emits DNU. The helper unwraps parens so `(ClassName) ifNil: ...`
         // and `(self) ifNil: ...` aren't accidentally treated as non-class-side.
-        let unwrapped_receiver = unwrap_parens(receiver);
-        let is_class_side_receiver =
-            matches!(unwrapped_receiver, Expression::ClassReference { .. })
-                || (env.in_class_method && Self::is_self_receiver(unwrapped_receiver));
+        let is_class_side_receiver = Self::is_class_side_receiver(receiver, env);
         if !is_class_side_receiver
             && matches!(
                 selector_name.as_str(),
@@ -1532,6 +1527,16 @@ impl TypeChecker {
     /// Returns true if the expression is `self` (direct identifier reference).
     fn is_self_receiver(expr: &Expression) -> bool {
         matches!(expr, Expression::Identifier(ident) if ident.name == "self")
+    }
+
+    /// Returns true if `expr` resolves to a class-side receiver — either a
+    /// direct `ClassReference` or `self` inside a class method. Unwraps
+    /// parentheses so `(HTTPRouter) foo:` and `(self) foo:` are treated
+    /// identically to the un-parenthesised forms (BT-2158).
+    fn is_class_side_receiver(expr: &Expression, env: &TypeEnv) -> bool {
+        let unwrapped = unwrap_parens(expr);
+        matches!(unwrapped, Expression::ClassReference { .. })
+            || (env.in_class_method && Self::is_self_receiver(unwrapped))
     }
 
     /// Describes where an expression's type originated (BT-1588).

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2324,6 +2324,8 @@ impl TypeChecker {
     /// `Dynamic(DynamicReceiver)` into block params in the fallback paths so
     /// downstream uses propagate that reason (which is filtered from the warning),
     /// matching how the send result itself is already classified.
+    #[allow(clippy::too_many_arguments)] // class-side flag (BT-2158) added to existing 7 args
+    #[allow(clippy::too_many_lines)] // two-phase block-arg inference adds necessary branches
     fn infer_args_with_block_context(
         &mut self,
         arguments: &[Expression],

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
@@ -372,6 +372,123 @@ fn block_params_more_than_signature_extra_stays_dynamic() {
 }
 
 #[test]
+fn block_params_typed_from_user_defined_class_method_signature_bt2158() {
+    // BT-2158: When a method's block parameter has a concrete (non-generic)
+    // class type, calling the method should propagate that type to the block's
+    // parameter. Mirrors `HTTPRouter build: [:r | ...]` from the watcher.
+    let source = "\
+typed Object subclass: HTTPRequest\n\
+  body -> String => \"hi\"\n\
+typed Object subclass: HTTPRouteBuilder\n\
+  get: path :: String handler: handler :: Block(HTTPRequest, Object) -> HTTPRouteBuilder => self\n\
+typed Object subclass: HTTPRouter\n\
+  build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
+    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
+    aBlock value: builder\n\
+typed Object subclass: App\n\
+  go -> HTTPRouter => HTTPRouter new build: [:r | r get: \"/\" handler: [:req | req body]]\n";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let dynamic_warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expression inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "BT-2158: block params `r` (HTTPRouteBuilder) and `req` (HTTPRequest) should be typed from method signatures, got: {dynamic_warnings:?}"
+    );
+}
+
+#[test]
+fn block_params_typed_for_class_method_bt2158() {
+    // BT-2158: class-method block parameter propagation.
+    // The watcher style is often `HTTPRouter build: [:r | ...]` where `build:`
+    // is a class-side message.
+    let source = "\
+typed Object subclass: HTTPRouteBuilder\n\
+  get: path :: String -> HTTPRouteBuilder => self\n\
+typed Object subclass: HTTPRouter\n\
+  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
+    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
+    aBlock value: builder\n\
+    HTTPRouter new\n\
+typed Object subclass: App\n\
+  go -> HTTPRouter => HTTPRouter build: [:r | r get: \"/\"]\n";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let dynamic_warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expression inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "BT-2158: class-method block param `r` should be typed as HTTPRouteBuilder, got: {dynamic_warnings:?}"
+    );
+}
+
+#[test]
+fn block_params_typed_for_class_method_via_self_bt2158() {
+    // BT-2158: `self build:` inside a class method should propagate block-param
+    // types from the class-side method's signature too.
+    let source = "\
+typed Object subclass: HTTPRouteBuilder\n\
+  get: path :: String -> HTTPRouteBuilder => self\n\
+typed Object subclass: HTTPRouter\n\
+  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
+    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
+    aBlock value: builder\n\
+    HTTPRouter new\n\
+  class buildHello -> HTTPRouter => self build: [:r | r get: \"/hello\"]\n";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let dynamic_warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expression inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "BT-2158: `self build:` in class method should propagate block-param type, got: {dynamic_warnings:?}"
+    );
+}
+
+#[test]
+fn block_params_typed_for_class_method_in_cascade_bt2158() {
+    // BT-2158: cascade sends to a class reference should also propagate
+    // block-param types from class-side methods.
+    let source = "\
+typed Object subclass: HTTPRouteBuilder\n\
+  get: path :: String -> HTTPRouteBuilder => self\n\
+typed Object subclass: HTTPRouter\n\
+  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
+    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
+    aBlock value: builder\n\
+    HTTPRouter new\n\
+  class buildMore: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
+    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
+    aBlock value: builder\n\
+    HTTPRouter new\n\
+typed Object subclass: App\n\
+  go -> HTTPRouter =>\n\
+    HTTPRouter\n\
+      build: [:r | r get: \"/\"];\n\
+      buildMore: [:r2 | r2 get: \"/more\"]\n";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let dynamic_warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expression inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "BT-2158: cascade sends to a class reference should propagate block-param types, got: {dynamic_warnings:?}"
+    );
+}
+
+#[test]
 fn block_params_typed_via_method_parameter_annotation() {
     // Method parameter `items :: List(Dictionary)` — sort: block params should get Dictionary.
     let source = "typed Object subclass: T\n  m: items :: List(Dictionary) -> List(Dictionary) => items sort: [:a :b | (a at: \"x\" ifAbsent: [0]) < (b at: \"x\" ifAbsent: [0])]";

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
@@ -489,6 +489,37 @@ typed Object subclass: App\n\
 }
 
 #[test]
+fn block_params_typed_for_parenthesised_class_reference_cascade_bt2158() {
+    // BT-2158: `(HTTPRouter) build: [...]; ...` (cascade on a parenthesised
+    // class reference) should still be detected as class-side and propagate
+    // block-param types. Pre-fix the cascade path didn't unwrap parens.
+    let source = "\
+typed Object subclass: HTTPRouteBuilder\n\
+  get: path :: String -> HTTPRouteBuilder => self\n\
+typed Object subclass: HTTPRouter\n\
+  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
+    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
+    aBlock value: builder\n\
+    HTTPRouter new\n\
+typed Object subclass: App\n\
+  go -> HTTPRouter =>\n\
+    (HTTPRouter)\n\
+      build: [:r | r get: \"/\"];\n\
+      yourself\n";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let dynamic_warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expression inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "BT-2158: cascade on parenthesised class reference should propagate block-param types, got: {dynamic_warnings:?}"
+    );
+}
+
+#[test]
 fn block_params_typed_via_method_parameter_annotation() {
     // Method parameter `items :: List(Dictionary)` — sort: block params should get Dictionary.
     let source = "typed Object subclass: T\n  m: items :: List(Dictionary) -> List(Dictionary) => items sort: [:a :b | (a at: \"x\" ifAbsent: [0]) < (b at: \"x\" ifAbsent: [0])]";

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
@@ -371,151 +371,125 @@ fn block_params_more_than_signature_extra_stays_dynamic() {
     );
 }
 
+// ── BT-2158 ───────────────────────────────────────────────────────────────────
+//
+// Block-param type propagation for user-defined classes. Fixtures are kept
+// minimal (no `new` calls, return types match) so the assertions can demand
+// **zero** diagnostics — any unrelated warning would otherwise hide a
+// regression in block-param typing.
+
 #[test]
-fn block_params_typed_from_user_defined_class_method_signature_bt2158() {
-    // BT-2158: When a method's block parameter has a concrete (non-generic)
-    // class type, calling the method should propagate that type to the block's
-    // parameter. Mirrors `HTTPRouter build: [:r | ...]` from the watcher.
+fn block_params_typed_from_user_defined_instance_method_signature_bt2158() {
+    // Instance-method baseline: `router build: [:r | ...]` infers `r` from
+    // build:'s `Block(HTTPRouteBuilder, Object)`. This case already worked
+    // before BT-2158 — kept as a regression guard. Also exercises a nested
+    // block (`handler: [:req | ...]`) whose param comes from the inner
+    // signature.
     let source = "\
 typed Object subclass: HTTPRequest\n\
   body -> String => \"hi\"\n\
 typed Object subclass: HTTPRouteBuilder\n\
   get: path :: String handler: handler :: Block(HTTPRequest, Object) -> HTTPRouteBuilder => self\n\
 typed Object subclass: HTTPRouter\n\
-  build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
-    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
-    aBlock value: builder\n\
+  build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter => self\n\
 typed Object subclass: App\n\
-  go -> HTTPRouter => HTTPRouter new build: [:r | r get: \"/\" handler: [:req | req body]]\n";
+  m: router :: HTTPRouter -> HTTPRouter =>\n\
+    router build: [:r | r get: \"/\" handler: [:req | req body]]\n";
     let module = parse_source(source);
     let hierarchy = ClassHierarchy::build(&module).0.unwrap();
     let diags = run_with_expect(&module, &hierarchy);
-    let dynamic_warnings: Vec<_> = diags
-        .iter()
-        .filter(|d| d.message.contains("expression inferred as Dynamic"))
-        .collect();
     assert!(
-        dynamic_warnings.is_empty(),
-        "BT-2158: block params `r` (HTTPRouteBuilder) and `req` (HTTPRequest) should be typed from method signatures, got: {dynamic_warnings:?}"
+        diags.is_empty(),
+        "BT-2158 (instance method): expected no diagnostics, got: {diags:#?}"
     );
 }
 
 #[test]
 fn block_params_typed_for_class_method_bt2158() {
-    // BT-2158: class-method block parameter propagation.
-    // The watcher style is often `HTTPRouter build: [:r | ...]` where `build:`
-    // is a class-side message.
+    // Class-method propagation — the actual BT-2158 fix. `HTTPRouter build:`
+    // is a class-side send; before the fix `find_method` was used and missed
+    // the class-side declaration, leaving `r` as Dynamic.
     let source = "\
 typed Object subclass: HTTPRouteBuilder\n\
   get: path :: String -> HTTPRouteBuilder => self\n\
 typed Object subclass: HTTPRouter\n\
-  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
-    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
-    aBlock value: builder\n\
-    HTTPRouter new\n\
+  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> Integer => 42\n\
 typed Object subclass: App\n\
-  go -> HTTPRouter => HTTPRouter build: [:r | r get: \"/\"]\n";
+  go -> Integer => HTTPRouter build: [:r | r get: \"/\"]\n";
     let module = parse_source(source);
     let hierarchy = ClassHierarchy::build(&module).0.unwrap();
     let diags = run_with_expect(&module, &hierarchy);
-    let dynamic_warnings: Vec<_> = diags
-        .iter()
-        .filter(|d| d.message.contains("expression inferred as Dynamic"))
-        .collect();
     assert!(
-        dynamic_warnings.is_empty(),
-        "BT-2158: class-method block param `r` should be typed as HTTPRouteBuilder, got: {dynamic_warnings:?}"
+        diags.is_empty(),
+        "BT-2158 (class method): expected no diagnostics, got: {diags:#?}"
     );
 }
 
 #[test]
 fn block_params_typed_for_class_method_via_self_bt2158() {
-    // BT-2158: `self build:` inside a class method should propagate block-param
-    // types from the class-side method's signature too.
+    // `self build:` inside a class method must also route through
+    // find_class_method.
     let source = "\
 typed Object subclass: HTTPRouteBuilder\n\
   get: path :: String -> HTTPRouteBuilder => self\n\
 typed Object subclass: HTTPRouter\n\
-  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
-    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
-    aBlock value: builder\n\
-    HTTPRouter new\n\
-  class buildHello -> HTTPRouter => self build: [:r | r get: \"/hello\"]\n";
+  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> Integer => 42\n\
+  class buildHello -> Integer => self build: [:r | r get: \"/hello\"]\n";
     let module = parse_source(source);
     let hierarchy = ClassHierarchy::build(&module).0.unwrap();
     let diags = run_with_expect(&module, &hierarchy);
-    let dynamic_warnings: Vec<_> = diags
-        .iter()
-        .filter(|d| d.message.contains("expression inferred as Dynamic"))
-        .collect();
     assert!(
-        dynamic_warnings.is_empty(),
-        "BT-2158: `self build:` in class method should propagate block-param type, got: {dynamic_warnings:?}"
+        diags.is_empty(),
+        "BT-2158 (self in class method): expected no diagnostics, got: {diags:#?}"
     );
 }
 
 #[test]
 fn block_params_typed_for_class_method_in_cascade_bt2158() {
-    // BT-2158: cascade sends to a class reference should also propagate
-    // block-param types from class-side methods.
+    // Cascade on a class reference: every cascade message dispatches to the
+    // class-side, so every cascaded block must be typed from the class
+    // method's signature.
     let source = "\
 typed Object subclass: HTTPRouteBuilder\n\
   get: path :: String -> HTTPRouteBuilder => self\n\
 typed Object subclass: HTTPRouter\n\
-  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
-    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
-    aBlock value: builder\n\
-    HTTPRouter new\n\
-  class buildMore: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
-    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
-    aBlock value: builder\n\
-    HTTPRouter new\n\
+  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> Integer => 42\n\
+  class buildMore: aBlock :: Block(HTTPRouteBuilder, Object) -> Integer => 43\n\
 typed Object subclass: App\n\
-  go -> HTTPRouter =>\n\
+  go -> Object =>\n\
     HTTPRouter\n\
       build: [:r | r get: \"/\"];\n\
       buildMore: [:r2 | r2 get: \"/more\"]\n";
     let module = parse_source(source);
     let hierarchy = ClassHierarchy::build(&module).0.unwrap();
     let diags = run_with_expect(&module, &hierarchy);
-    let dynamic_warnings: Vec<_> = diags
-        .iter()
-        .filter(|d| d.message.contains("expression inferred as Dynamic"))
-        .collect();
     assert!(
-        dynamic_warnings.is_empty(),
-        "BT-2158: cascade sends to a class reference should propagate block-param types, got: {dynamic_warnings:?}"
+        diags.is_empty(),
+        "BT-2158 (cascade on class ref): expected no diagnostics, got: {diags:#?}"
     );
 }
 
 #[test]
 fn block_params_typed_for_parenthesised_class_reference_cascade_bt2158() {
-    // BT-2158: `(HTTPRouter) build: [...]; ...` (cascade on a parenthesised
-    // class reference) should still be detected as class-side and propagate
-    // block-param types. Pre-fix the cascade path didn't unwrap parens.
+    // `(HTTPRouter) build: ...; ...` — pre-fix the cascade path didn't unwrap
+    // parens, so the parenthesised class reference fell through to instance
+    // dispatch.
     let source = "\
 typed Object subclass: HTTPRouteBuilder\n\
   get: path :: String -> HTTPRouteBuilder => self\n\
 typed Object subclass: HTTPRouter\n\
-  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> HTTPRouter =>\n\
-    builder :: HTTPRouteBuilder := HTTPRouteBuilder new\n\
-    aBlock value: builder\n\
-    HTTPRouter new\n\
+  class build: aBlock :: Block(HTTPRouteBuilder, Object) -> Integer => 42\n\
 typed Object subclass: App\n\
-  go -> HTTPRouter =>\n\
+  go -> Object =>\n\
     (HTTPRouter)\n\
       build: [:r | r get: \"/\"];\n\
       yourself\n";
     let module = parse_source(source);
     let hierarchy = ClassHierarchy::build(&module).0.unwrap();
     let diags = run_with_expect(&module, &hierarchy);
-    let dynamic_warnings: Vec<_> = diags
-        .iter()
-        .filter(|d| d.message.contains("expression inferred as Dynamic"))
-        .collect();
     assert!(
-        dynamic_warnings.is_empty(),
-        "BT-2158: cascade on parenthesised class reference should propagate block-param types, got: {dynamic_warnings:?}"
+        diags.is_empty(),
+        "BT-2158 (parenthesised cascade): expected no diagnostics, got: {diags:#?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Fix class-side block parameter type propagation: `infer_args_with_block_context` now dispatches to `find_class_method` for class-side sends (`ClassName foo:` or `self foo:` in a class method), instead of always using `find_method` (instance-only)
- This allows patterns like `HTTPRouter build: [:r | r get: "/" handler: [:req | req body]]` to infer `r :: HTTPRouteBuilder` and `req :: HTTPRequest` from the method's `Block(T, U)` parameter type, eliminating the need for `@expect type` pragmas

## Key changes

- **`inference.rs`**: Added `is_class_side_send` parameter to `infer_args_with_block_context`; both call sites (message send and cascade) compute and pass the flag using the same `ClassReference` / `self`-in-class-method detection used elsewhere in the type checker
- **`dynamic_and_blocks.rs`**: 4 new tests covering instance method (baseline), class method via `ClassName`, class method via `self`, and cascade to class reference

## Impact

Removes the root cause of 10 `@expect type` pragmas in the beamtalk-watcher (`Dashboard.bt`, `WebhookReceiver.bt`) and any other consumer of class-side methods with `Block(T, R)` parameter types.

## Test plan

- [x] All 4 new BT-2158 tests pass
- [x] All 684 type checker tests pass (no regressions)
- [x] All 3715 beamtalk-core tests pass
- [x] Clippy clean
- [x] Rust/Erlang fmt clean

https://linear.app/beamtalk/issue/BT-2158/propagate-typed-block-parameters-from-callee-signature-to-call-site

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7HTNC3yhz3Jy7iayxuEr8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for message sends with block parameters: correctly distinguishes class-side vs instance-side sends, normalizes parenthesized targets, and fixes class-side gating so cascaded and class-method calls no longer infer "Dynamic".
* **Tests**
  * Added tests verifying block-parameter types propagate from class-side method signatures, including cascades and parenthesized targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->