### PR TITLE
codegen: replace format!() with Document API in value type method generation (BT-2197)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -1253,16 +1253,19 @@ impl CoreErlangGenerator {
         // BT-754/BT-764: Wrap the method body in try/catch to catch non-local
         // returns thrown by ^ inside block closures.
         let body_doc = Document::Vec(body_parts);
+        let params_str = params.join(", ");
         let fun_doc = if let Some(token_var) = nlr_token_var {
             let catch_vars = self.wrap_value_type_body_with_nlr_catch(&token_var);
             docvec![
-                format!("fun ({}) ->\n", params.join(", ")),
+                "fun (",
+                Document::String(params_str),
+                ") ->\n",
                 catch_vars.format_try_prefix(),
                 body_doc,
                 catch_vars.format_catch_suffix(),
             ]
         } else {
-            docvec![format!("fun ({}) ->\n", params.join(", ")), body_doc]
+            docvec!["fun (", Document::String(params_str), ") ->\n", body_doc,]
         };
         let fun_doc = if let Some(line_num) = line_annotation {
             self.annotate_with_line(fun_doc, line_num)
@@ -1270,7 +1273,11 @@ impl CoreErlangGenerator {
             fun_doc
         };
         Ok(docvec![
-            format!("'{}'/{} = ", mangled, arity),
+            "'",
+            Document::String(mangled),
+            "'/",
+            Document::String(arity.to_string()),
+            " = ",
             fun_doc,
             "\n",
         ])
@@ -1298,22 +1305,32 @@ impl CoreErlangGenerator {
                 let val_doc = self.expression_doc(value)?;
                 let new_self = self.next_self_var();
                 return Ok(docvec![
-                    "    ",
-                    format!("let {val_var} = "),
+                    "    let ",
+                    Document::String(val_var.clone()),
+                    " = ",
                     val_doc,
-                    format!(
-                        " in let {new_self} = call 'maps':'put'('{}', {val_var}, {current_self}) in\n",
-                        field.name
-                    ),
+                    " in let ",
+                    Document::String(new_self),
+                    " = call 'maps':'put'('",
+                    Document::Eco(field.name.clone()),
+                    "', ",
+                    Document::String(val_var),
+                    ", ",
+                    Document::String(current_self),
+                    ") in\n",
                 ]);
             }
         }
         // Fallback: sequence as a side-effecting expression
         let tmp_var = self.fresh_temp_var("seq");
         let expr_code = self.capture_expression(expr)?;
-        Ok(Document::String(format!(
-            "    let {tmp_var} = {expr_code} in\n"
-        )))
+        Ok(docvec![
+            "    let ",
+            Document::String(tmp_var),
+            " = ",
+            Document::String(expr_code),
+            " in\n",
+        ])
     }
 
     /// BT-1213: Generate an open let-chain for a non-last `[block_withmutations] value`


### PR DESCRIPTION
## Summary

Removes six `format!()` calls from `generate_value_type_method` and `generate_vt_field_assignment_open` in `value_type_codegen.rs` that were producing raw Core Erlang text fragments, violating the BT-875 rule (all Core Erlang codegen must use the `Document`/`docvec!` API).

Closes [BT-2197](https://linear.app/beamtalk/issue/BT-2197/fix-format-in-core-erlang-violations-in-generate-value-type-method)

## Changes

- **`generate_value_type_method`**: Replaced `format!("fun ({}) ->\n", params.join(", "))` (×2) and `format!("'{}'/{} = ", mangled, arity)` with proper `docvec[..., Document::String(...), ...]` composition, following the pattern already established by `generate_keyword_constructor_fn` in the same file.

- **`generate_vt_field_assignment_open`**: Replaced three `format!()` calls producing Core Erlang `let`/`maps:put` fragments with equivalent `docvec!` document pieces.

## Safety

This is a purely mechanical refactor — the generated Core Erlang output is **character-for-character identical**. No logic changes.

## Test Plan

- [x] `cargo build -p beamtalk-core` — clean compile, no warnings
- [x] `cargo test -p beamtalk-core` — all unit tests pass
- [x] `just test-stdlib` — 250/250 stdlib tests pass
- [x] `just test-bunit` — 1922/1922 BUnit tests pass
- [x] Clippy and `cargo fmt` clean
- [x] Pre-existing MCP test failures confirmed on `main` (not introduced by this PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_011htzEN4v2vJa6mc1J2xfag)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements to enhance code maintainability and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->