### PR TITLE
Add module_to_class/1 tests to beamtalk_stack_frame_tests (BT-2199)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_stack_frame_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_stack_frame_tests.erl
@@ -193,3 +193,59 @@ format_frame_file_no_line_test() ->
     Frame = (make_test_frame())#{line => nil},
     Result = beamtalk_stack_frame:dispatch('printString', [], Frame),
     ?assertEqual(<<"Integer>>+/2 (src/beamtalk_integer.erl)">>, Result).
+
+%%% ===================================================================
+%%% module_to_class/1 tests
+%%%
+%%% These tests directly exercise the three pattern-match branches in
+%%% module_to_class/1 (bt@ prefix, beamtalk_ prefix, fallback) and the
+%%% non-atom guard clause. No OTP application or registry process is
+%%% required because:
+%%%   - bt@ and beamtalk_ paths return snake_to_class directly, no registry.
+%%%   - The fallback nil-return path exits before the registry call.
+%%%   - erlang:whereis/1 returns undefined safely when no process is registered.
+%%% ===================================================================
+
+%% bt@ prefix, single-segment: 'bt@counter' → 'Counter'
+%% 'Counter' atom is in the table via tagged_map_tests.
+module_to_class_bt_prefix_single_word_test() ->
+    ?assertEqual('Counter', beamtalk_stack_frame:module_to_class('bt@counter')).
+
+%% bt@ prefix, multi-segment stdlib: 'bt@stdlib@integer' → 'Integer'
+%% The last '@'-separated segment determines the class name.
+module_to_class_bt_prefix_stdlib_test() ->
+    ?assertEqual('Integer', beamtalk_stack_frame:module_to_class('bt@stdlib@integer')).
+
+%% bt@ prefix, alt stdlib format: 'bt@integer' → 'Integer'
+module_to_class_bt_prefix_alt_format_test() ->
+    ?assertEqual('Integer', beamtalk_stack_frame:module_to_class('bt@integer')).
+
+%% beamtalk_ prefix, single word: 'beamtalk_integer' → 'Integer'
+module_to_class_beamtalk_prefix_single_word_test() ->
+    ?assertEqual('Integer', beamtalk_stack_frame:module_to_class('beamtalk_integer')).
+
+%% beamtalk_ prefix, multi-word: 'beamtalk_stack_frame' → 'StackFrame'
+%% Exercises snake_to_class multi-word capitalization.
+%% 'StackFrame' atom is already in the table from make_test_frame/0 above.
+module_to_class_beamtalk_prefix_multi_word_test() ->
+    ?assertEqual('StackFrame', beamtalk_stack_frame:module_to_class('beamtalk_stack_frame')).
+
+%% beamtalk_ prefix, unknown atom: capitalized form not in atom table → nil
+%% Exercises the snake_to_class badarg catch (line 134 of source).
+module_to_class_beamtalk_prefix_unknown_atom_test() ->
+    ?assertEqual(nil, beamtalk_stack_frame:module_to_class('beamtalk_xyzzy_q123_unique_abc')).
+
+%% Fallback (_) case, snake_to_class → nil: no registry call, returns nil
+%% Capitalized 'XyzzyQ123UniqueModuleDef' is not in the atom table.
+module_to_class_plain_unknown_module_test() ->
+    ?assertEqual(nil, beamtalk_stack_frame:module_to_class('xyzzy_q123_unique_module_def')).
+
+%% Fallback (_) case, class in atom table but not registered → nil
+%% 'Counter' resolves via snake_to_class; erlang:whereis returns undefined.
+module_to_class_plain_known_atom_not_registered_test() ->
+    ?assertEqual(nil, beamtalk_stack_frame:module_to_class('counter')).
+
+%% Non-atom input: guard clause returns nil without touching ModStr (line 119).
+module_to_class_non_atom_test() ->
+    ?assertEqual(nil, beamtalk_stack_frame:module_to_class(42)),
+    ?assertEqual(nil, beamtalk_stack_frame:module_to_class(<<"counter">>)).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_stack_frame_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_stack_frame_tests.erl
@@ -204,12 +204,14 @@ format_frame_file_no_line_test() ->
 %%%   - bt@ and beamtalk_ paths return snake_to_class directly, no registry.
 %%%   - The fallback nil-return path exits before the registry call.
 %%%   - erlang:whereis/1 returns undefined safely when no process is registered.
+%%% All atoms used in assertions ('Integer', 'StackFrame') are guaranteed to be
+%%% in the atom table by make_test_frame/0 defined earlier in this file.
 %%% ===================================================================
 
-%% bt@ prefix, single-segment: 'bt@counter' → 'Counter'
-%% 'Counter' atom is in the table via tagged_map_tests.
+%% bt@ prefix, single-segment: 'bt@stack_frame' → 'StackFrame'
+%% 'StackFrame' atom is in the table from make_test_frame/0 in this file.
 module_to_class_bt_prefix_single_word_test() ->
-    ?assertEqual('Counter', beamtalk_stack_frame:module_to_class('bt@counter')).
+    ?assertEqual('StackFrame', beamtalk_stack_frame:module_to_class('bt@stack_frame')).
 
 %% bt@ prefix, multi-segment stdlib: 'bt@stdlib@integer' → 'Integer'
 %% The last '@'-separated segment determines the class name.


### PR DESCRIPTION
## Summary

`beamtalk_stack_frame:module_to_class/1` is an exported function called by `beamtalk_test_case.erl` for test-output formatting and internally by `wrap_frame/1`. All three pattern-match branches (`"bt@"` prefix, `"beamtalk_"` prefix, fallback) plus the non-atom guard clause had **zero direct EUnit tests**.

This PR adds 9 focused test functions covering those branches without requiring any OTP application startup.

## Changes

- Added 9 EUnit tests to `runtime/apps/beamtalk_runtime/test/beamtalk_stack_frame_tests.erl`
  - `bt@` prefix: single-segment, multi-segment stdlib, alt format
  - `beamtalk_` prefix: single-word known atom, multi-word known atom, unknown atom (→ `nil`)
  - Fallback `_` case: `snake_to_class` returns `nil` (no registry call), known atom not registered (→ `nil`)
  - Non-atom guard clause

## Test Results

2113 tests, 0 failures (48 tests in the stack_frame module specifically).

## Linear

https://linear.app/beamtalk/issue/BT-2199/add-module-to-class1-tests-to-beamtalk-stack-frame-tests-0percent

https://claude.ai/code/session_01AJuhwMguTJQeemob4fhxjA

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJuhwMguTJQeemob4fhxjA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for module-name classification and conversion logic, validating multiple naming conventions, prefixed formats, unknown/edge cases, fallback behavior for unrecognized names, and type-safety guards to ensure predictable results for non-string inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->