### PR TITLE
Extract repeated setUp in do_accumulator_test.bt (BT-2200)

### DIFF
--- a/stdlib/test/do_accumulator_test.bt
+++ b/stdlib/test/do_accumulator_test.bt
@@ -16,14 +16,12 @@ TestCase subclass: DoAccumulatorTest
   // =========================================================================
   // sumList: — basic single-variable accumulation
   // =========================================================================
-  testSumListBasic =>
-    self assert: (self.helper sumList: #(1, 2, 3)) equals: 6
+  testSumListBasic => self assert: (self.helper sumList: #(1, 2, 3)) equals: 6
 
   testSumListSingleElement =>
     self assert: (self.helper sumList: #(42)) equals: 42
 
-  testSumListEmptyList =>
-    self assert: (self.helper sumList: #()) equals: 0
+  testSumListEmptyList => self assert: (self.helper sumList: #()) equals: 0
 
   testSumListNegativeNumbers =>
     self assert: (self.helper sumList: #(-1, -2, -3)) equals: -6
@@ -53,7 +51,9 @@ TestCase subclass: DoAccumulatorTest
     ]) equals: 3
 
   testCountMatchingEmptyList =>
-    self assert: (self.helper countMatching: #() predicate: [:x | x > 0]) equals: 0
+    self assert: (self.helper countMatching: #() predicate: [:x |
+      x > 0
+    ]) equals: 0
 
   // =========================================================================
   // findMax: — accumulator initialized from first element, updated via branch
@@ -79,8 +79,7 @@ TestCase subclass: DoAccumulatorTest
   testFindMinBasic =>
     self assert: (self.helper findMin: #(3, 1, 4, 1, 5, 9, 2, 6)) equals: 1
 
-  testFindMinSingleElement =>
-    self assert: (self.helper findMin: #(7)) equals: 7
+  testFindMinSingleElement => self assert: (self.helper findMin: #(7)) equals: 7
 
   testFindMinAlreadySorted =>
     self assert: (self.helper findMin: #(1, 2, 3, 4, 5)) equals: 1

--- a/stdlib/test/do_accumulator_test.bt
+++ b/stdlib/test/do_accumulator_test.bt
@@ -9,149 +9,124 @@
 // that the new value-type mutation-threading path is exercised.
 
 TestCase subclass: DoAccumulatorTest
+  field: helper = nil
+
+  setUp => self withHelper: DoAccumulatorValue new
 
   // =========================================================================
   // sumList: — basic single-variable accumulation
   // =========================================================================
   testSumListBasic =>
-    helper := DoAccumulatorValue new
-    self assert: (helper sumList: #(1, 2, 3)) equals: 6
+    self assert: (self.helper sumList: #(1, 2, 3)) equals: 6
 
   testSumListSingleElement =>
-    helper := DoAccumulatorValue new
-    self assert: (helper sumList: #(42)) equals: 42
+    self assert: (self.helper sumList: #(42)) equals: 42
 
   testSumListEmptyList =>
-    helper := DoAccumulatorValue new
-    self assert: (helper sumList: #()) equals: 0
+    self assert: (self.helper sumList: #()) equals: 0
 
   testSumListNegativeNumbers =>
-    helper := DoAccumulatorValue new
-    self assert: (helper sumList: #(-1, -2, -3)) equals: -6
+    self assert: (self.helper sumList: #(-1, -2, -3)) equals: -6
 
   testSumListMixedNumbers =>
-    helper := DoAccumulatorValue new
-    self assert: (helper sumList: #(10, -3, 7, -4)) equals: 10
+    self assert: (self.helper sumList: #(10, -3, 7, -4)) equals: 10
 
   testSumListLargerList =>
-    helper := DoAccumulatorValue new
-    self assert: (helper sumList: #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) equals: 55
+    self assert: (self.helper sumList: #(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)) equals: 55
 
   // =========================================================================
   // countMatching: — conditional accumulation (accumulator updated in branch)
   // =========================================================================
   testCountMatchingAllMatch =>
-    helper := DoAccumulatorValue new
-    self assert: (helper countMatching: #(2, 4, 6) predicate: [:x |
+    self assert: (self.helper countMatching: #(2, 4, 6) predicate: [:x |
       x > 0
     ]) equals: 3
 
   testCountMatchingNoneMatch =>
-    helper := DoAccumulatorValue new
-    self assert: (helper countMatching: #(1, 2, 3) predicate: [:x |
+    self assert: (self.helper countMatching: #(1, 2, 3) predicate: [:x |
       x > 10
     ]) equals: 0
 
   testCountMatchingSomeMatch =>
-    helper := DoAccumulatorValue new
-    self assert: (helper countMatching: #(1, 2, 3, 4, 5) predicate: [:x |
+    self assert: (self.helper countMatching: #(1, 2, 3, 4, 5) predicate: [:x |
       x > 2
     ]) equals: 3
 
   testCountMatchingEmptyList =>
-    helper := DoAccumulatorValue new
-    self assert: (helper countMatching: #() predicate: [:x | x > 0]) equals: 0
+    self assert: (self.helper countMatching: #() predicate: [:x | x > 0]) equals: 0
 
   // =========================================================================
   // findMax: — accumulator initialized from first element, updated via branch
   // =========================================================================
   testFindMaxBasic =>
-    helper := DoAccumulatorValue new
-    self assert: (helper findMax: #(3, 1, 4, 1, 5, 9, 2, 6)) equals: 9
+    self assert: (self.helper findMax: #(3, 1, 4, 1, 5, 9, 2, 6)) equals: 9
 
   testFindMaxSingleElement =>
-    helper := DoAccumulatorValue new
-    self assert: (helper findMax: #(42)) equals: 42
+    self assert: (self.helper findMax: #(42)) equals: 42
 
   testFindMaxAlreadySorted =>
-    helper := DoAccumulatorValue new
-    self assert: (helper findMax: #(1, 2, 3, 4, 5)) equals: 5
+    self assert: (self.helper findMax: #(1, 2, 3, 4, 5)) equals: 5
 
   testFindMaxReverseSorted =>
-    helper := DoAccumulatorValue new
-    self assert: (helper findMax: #(5, 4, 3, 2, 1)) equals: 5
+    self assert: (self.helper findMax: #(5, 4, 3, 2, 1)) equals: 5
 
   testFindMaxAllEqual =>
-    helper := DoAccumulatorValue new
-    self assert: (helper findMax: #(7, 7, 7)) equals: 7
+    self assert: (self.helper findMax: #(7, 7, 7)) equals: 7
 
   // =========================================================================
   // findMin: — symmetric with findMax:
   // =========================================================================
   testFindMinBasic =>
-    helper := DoAccumulatorValue new
-    self assert: (helper findMin: #(3, 1, 4, 1, 5, 9, 2, 6)) equals: 1
+    self assert: (self.helper findMin: #(3, 1, 4, 1, 5, 9, 2, 6)) equals: 1
 
   testFindMinSingleElement =>
-    helper := DoAccumulatorValue new
-    self assert: (helper findMin: #(7)) equals: 7
+    self assert: (self.helper findMin: #(7)) equals: 7
 
   testFindMinAlreadySorted =>
-    helper := DoAccumulatorValue new
-    self assert: (helper findMin: #(1, 2, 3, 4, 5)) equals: 1
+    self assert: (self.helper findMin: #(1, 2, 3, 4, 5)) equals: 1
 
   // =========================================================================
   // productList: — multiplicative accumulation
   // =========================================================================
   testProductListBasic =>
-    helper := DoAccumulatorValue new
-    self assert: (helper productList: #(1, 2, 3, 4)) equals: 24
+    self assert: (self.helper productList: #(1, 2, 3, 4)) equals: 24
 
   testProductListSingleElement =>
-    helper := DoAccumulatorValue new
-    self assert: (helper productList: #(7)) equals: 7
+    self assert: (self.helper productList: #(7)) equals: 7
 
   testProductListEmptyList =>
-    helper := DoAccumulatorValue new
-    self assert: (helper productList: #()) equals: 1
+    self assert: (self.helper productList: #()) equals: 1
 
   testProductListWithOne =>
-    helper := DoAccumulatorValue new
-    self assert: (helper productList: #(2, 1, 3, 1)) equals: 6
+    self assert: (self.helper productList: #(2, 1, 3, 1)) equals: 6
 
   // =========================================================================
   // buildList: — list accumulation (non-numeric accumulator)
   // =========================================================================
   testBuildListBasic =>
-    helper := DoAccumulatorValue new
-    self assert: (helper buildList: #(1, 2, 3)) equals: #(1, 2, 3)
+    self assert: (self.helper buildList: #(1, 2, 3)) equals: #(1, 2, 3)
 
   testBuildListEmptyList =>
-    helper := DoAccumulatorValue new
-    self assert: (helper buildList: #()) equals: #()
+    self assert: (self.helper buildList: #()) equals: #()
 
   testBuildListSingleElement =>
-    helper := DoAccumulatorValue new
-    self assert: (helper buildList: #(42)) equals: #(42)
+    self assert: (self.helper buildList: #(42)) equals: #(42)
 
   // =========================================================================
   // sumAndCount: — two local variables threaded through a single do: loop
   // =========================================================================
   testSumAndCountBasic =>
-    helper := DoAccumulatorValue new
-    result := helper sumAndCount: #(1, 2, 3, 4, 5)
+    result := self.helper sumAndCount: #(1, 2, 3, 4, 5)
     self assert: (result at: 1) equals: 15
     self assert: (result at: 2) equals: 5
 
   testSumAndCountEmptyList =>
-    helper := DoAccumulatorValue new
-    result := helper sumAndCount: #()
+    result := self.helper sumAndCount: #()
     self assert: (result at: 1) equals: 0
     self assert: (result at: 2) equals: 0
 
   testSumAndCountSingleElement =>
-    helper := DoAccumulatorValue new
-    result := helper sumAndCount: #(10)
+    result := self.helper sumAndCount: #(10)
     self assert: (result at: 1) equals: 10
     self assert: (result at: 2) equals: 1
 
@@ -160,45 +135,40 @@ TestCase subclass: DoAccumulatorTest
   // (the core fix: do: block mutates `acc` which is read after the loop)
   // =========================================================================
   testInjectWithDoSum =>
-    helper := DoAccumulatorValue new
     self
-      assert: (helper
+      assert: (self.helper
         injectWithDo: #(1, 2, 3)
         initial: 0
         into: [:acc :x | acc + x])
       equals: 6
 
   testInjectWithDoProduct =>
-    helper := DoAccumulatorValue new
     self
-      assert: (helper
+      assert: (self.helper
         injectWithDo: #(1, 2, 3, 4)
         initial: 1
         into: [:acc :x | acc * x])
       equals: 24
 
   testInjectWithDoStringConcat =>
-    helper := DoAccumulatorValue new
     self
-      assert: (helper
+      assert: (self.helper
         injectWithDo: #("a", "b", "c")
         initial: ""
         into: [:acc :x | acc ++ x])
       equals: "abc"
 
   testInjectWithDoEmptyList =>
-    helper := DoAccumulatorValue new
     self
-      assert: (helper
+      assert: (self.helper
         injectWithDo: #()
         initial: 42
         into: [:acc :x | acc + x])
       equals: 42
 
   testInjectWithDoSingleElement =>
-    helper := DoAccumulatorValue new
     self
-      assert: (helper
+      assert: (self.helper
         injectWithDo: #(10)
         initial: 5
         into: [:acc :x | acc + x])
@@ -206,20 +176,18 @@ TestCase subclass: DoAccumulatorTest
 
   // Non-commutative: verifies correct argument order is (accumulator, element)
   testInjectWithDoOrderMatters =>
-    helper := DoAccumulatorValue new
     // Builds list in reverse via addFirst:
     self
-      assert: (helper
+      assert: (self.helper
         injectWithDo: #(1, 2, 3)
         initial: #()
         into: [:acc :x | acc addFirst: x])
       equals: #(3, 2, 1)
 
   testInjectWithDoSubtraction =>
-    helper := DoAccumulatorValue new
     // ((10 - 1) - 2) - 3 = 4  (left-fold, not right-fold)
     self
-      assert: (helper
+      assert: (self.helper
         injectWithDo: #(1, 2, 3)
         initial: 10
         into: [:acc :x | acc - x])
@@ -229,7 +197,6 @@ TestCase subclass: DoAccumulatorTest
   // Multiple invocations — verifies that the value type is stateless between calls
   // =========================================================================
   testSumListIsStateless =>
-    helper := DoAccumulatorValue new
-    self assert: (helper sumList: #(1, 2, 3)) equals: 6
-    self assert: (helper sumList: #(10, 20)) equals: 30
-    self assert: (helper sumList: #(1, 2, 3)) equals: 6
+    self assert: (self.helper sumList: #(1, 2, 3)) equals: 6
+    self assert: (self.helper sumList: #(10, 20)) equals: 30
+    self assert: (self.helper sumList: #(1, 2, 3)) equals: 6


### PR DESCRIPTION
## Summary

Lifts the repeated `helper := DoAccumulatorValue new` line that appeared at the top of every test method in `DoAccumulatorTest` into a `setUp` method, following the standard BUnit `field:` + `self withXxx:` pattern.

**Before:** 36 identical `helper := DoAccumulatorValue new` lines across 35 test methods  
**After:** one `field: helper = nil` + one `setUp => self withHelper: DoAccumulatorValue new`

## Changes

- `stdlib/test/do_accumulator_test.bt` — add `field: helper`, add `setUp`, remove 36 local-variable lines, replace all `helper` refs with `self.helper`

## Why it's safe

- `DoAccumulatorValue` is a `Value subclass:` (pure value type, no actor state, no teardown needed)
- `setUp` is called fresh before every test — isolation is preserved
- `testSumListIsStateless` calls the helper three times within one invocation — still correct with `self.helper`
- 1922 BUnit tests pass, 0 failures

## Linear

https://linear.app/beamtalk/issue/BT-2200/extract-repeated-setup-in-do-accumulator-testbt

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTrgbc4P2gtSbZeMweAjZv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure and organization for the accumulator test suite to enhance maintainability and consistency across test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->