### PR TITLE
Fix remaining format!()-in-Core-Erlang violations BT-2198

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -1431,6 +1431,7 @@ impl CoreErlangGenerator {
     /// it's discarded since this is used for non-last expressions in block bodies.
     ///
     /// Uses Document/docvec! (ADR 0018) for composable rendering.
+    #[allow(clippy::too_many_lines)] // Document-based sealed/normal dispatch branches
     pub(super) fn generate_self_dispatch_open(
         &mut self,
         expr: &Expression,

--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -759,7 +759,9 @@ impl CoreErlangGenerator {
         let call_doc = docvec![
             "call 'beamtalk_message_dispatch':'send'(",
             actual_receiver,
-            Document::String(format!(", '{selector_atom}', [")),
+            ", '",
+            Document::String(selector_atom),
+            "', [",
             args_doc,
             "])"
         ];
@@ -888,9 +890,11 @@ impl CoreErlangGenerator {
                 MessageSelector::Unary(module_name)
                     if !CLASS_PROTOCOL_SELECTORS.contains(&module_name.as_str()) =>
                 {
-                    let doc = docvec![Document::String(format!(
-                        "~{{'$beamtalk_class' => 'ErlangModule', 'module' => '{module_name}'}}~"
-                    ))];
+                    let doc = docvec![
+                        "~{'$beamtalk_class' => 'ErlangModule', 'module' => '",
+                        Document::Eco(module_name.clone()),
+                        "'}~",
+                    ];
                     Ok(Some(doc))
                 }
                 _ => {
@@ -1318,7 +1322,9 @@ impl CoreErlangGenerator {
     ) -> Result<Document<'static>> {
         let (args_preamble, args_doc) = self.capture_args_with_preamble(arguments)?;
         let call_doc = docvec![
-            Document::String(format!("call 'beamtalk_class_instantiation':'{helper}'(")),
+            "call 'beamtalk_class_instantiation':'",
+            Document::Str(helper),
+            "'(",
             "call 'erlang':'get'('beamtalk_class_name'), ",
             "call 'erlang':'get'('beamtalk_class_module'), ",
             "call 'erlang':'get'('beamtalk_class_is_abstract'), ",
@@ -1379,17 +1385,27 @@ impl CoreErlangGenerator {
         let args_doc = self.capture_argument_list_doc(arguments)?;
 
         let doc = docvec![
-            Document::String(format!(
-                "case call '{module}':'safe_dispatch'('{selector_atom}', ["
-            )),
+            "case call '",
+            Document::Eco(module),
+            "':'safe_dispatch'('",
+            Document::String(selector_atom),
+            "', [",
             args_doc,
-            Document::String(format!("], {current_state}) of ")),
-            Document::String(format!(
-                "<{{'reply', {result_var}, {state_var}}}> when 'true' -> {result_var} "
-            )),
-            Document::String(format!(
-                "<{{'error', {error_var}, _}}> when 'true' -> call 'beamtalk_error':'raise'({error_var}) "
-            )),
+            "], ",
+            Document::String(current_state),
+            ") of ",
+            "<{'reply', ",
+            Document::String(result_var.clone()),
+            ", ",
+            Document::String(state_var),
+            "}> when 'true' -> ",
+            Document::String(result_var),
+            " ",
+            "<{'error', ",
+            Document::String(error_var.clone()),
+            ", _}> when 'true' -> call 'beamtalk_error':'raise'(",
+            Document::String(error_var),
+            ") ",
             "end"
         ];
 
@@ -1444,39 +1460,65 @@ impl CoreErlangGenerator {
                     let module = self.module_name.clone();
                     let comma = if arguments.is_empty() { "" } else { ", " };
                     docvec![
-                        Document::String(format!(
-                            "let {self_var} = call 'beamtalk_actor':'make_self'({current_state}) in "
-                        )),
-                        Document::String(format!(
-                            "let {dispatch_var} = case call '{module}':'__sealed_{selector_name}'("
-                        )),
+                        "let ",
+                        Document::String(self_var.clone()),
+                        " = call 'beamtalk_actor':'make_self'(",
+                        Document::String(current_state.clone()),
+                        ") in ",
+                        "let ",
+                        Document::String(dispatch_var.clone()),
+                        " = case call '",
+                        Document::Eco(module),
+                        "':'__sealed_",
+                        Document::String(selector_name),
+                        "'(",
                         args_doc,
-                        Document::String(format!("{comma}{self_var}, {current_state}) of "))
+                        Document::Str(comma),
+                        Document::String(self_var),
+                        ", ",
+                        Document::String(current_state),
+                        ") of ",
                     ]
                 } else {
                     // Level 2: Direct dispatch/4 call
                     let self_var = self.fresh_temp_var("SealedSelf");
                     let module = self.module_name.clone();
                     docvec![
-                        Document::String(format!(
-                            "let {self_var} = call 'beamtalk_actor':'make_self'({current_state}) in "
-                        )),
-                        Document::String(format!(
-                            "let {dispatch_var} = case call '{module}':'dispatch'('{selector_atom}', ["
-                        )),
+                        "let ",
+                        Document::String(self_var.clone()),
+                        " = call 'beamtalk_actor':'make_self'(",
+                        Document::String(current_state.clone()),
+                        ") in ",
+                        "let ",
+                        Document::String(dispatch_var.clone()),
+                        " = case call '",
+                        Document::Eco(module),
+                        "':'dispatch'('",
+                        Document::String(selector_atom),
+                        "', [",
                         args_doc,
-                        Document::String(format!("], {self_var}, {current_state}) of "))
+                        "], ",
+                        Document::String(self_var),
+                        ", ",
+                        Document::String(current_state),
+                        ") of ",
                     ]
                 }
             } else {
                 // Normal: safe_dispatch/3
                 let module = self.module_name.clone();
                 docvec![
-                    Document::String(format!(
-                        "let {dispatch_var} = case call '{module}':'safe_dispatch'('{selector_atom}', ["
-                    )),
+                    "let ",
+                    Document::String(dispatch_var.clone()),
+                    " = case call '",
+                    Document::Eco(module),
+                    "':'safe_dispatch'('",
+                    Document::String(selector_atom),
+                    "', [",
                     args_doc,
-                    Document::String(format!("], {current_state}) of "))
+                    "], ",
+                    Document::String(current_state),
+                    ") of ",
                 ]
             };
 
@@ -1484,16 +1526,26 @@ impl CoreErlangGenerator {
             let new_state = self.next_state_var();
             let doc = docvec![
                 call_doc,
-                Document::String(format!(
-                    "<{{'reply', {result_var}, {state_var}}}> when 'true' -> {{{result_var}, {state_var}}} "
-                )),
-                Document::String(format!(
-                    "<{{'error', {error_var}, _}}> when 'true' -> call 'beamtalk_error':'raise'({error_var}) "
-                )),
+                "<{'reply', ",
+                Document::String(result_var.clone()),
+                ", ",
+                Document::String(state_var.clone()),
+                "}> when 'true' -> {",
+                Document::String(result_var),
+                ", ",
+                Document::String(state_var),
+                "} ",
+                "<{'error', ",
+                Document::String(error_var.clone()),
+                ", _}> when 'true' -> call 'beamtalk_error':'raise'(",
+                Document::String(error_var),
+                ") ",
                 "end in ",
-                Document::String(format!(
-                    "let {new_state} = call 'erlang':'element'(2, {dispatch_var}) in "
-                ))
+                "let ",
+                Document::String(new_state),
+                " = call 'erlang':'element'(2, ",
+                Document::String(dispatch_var.clone()),
+                ") in "
             ];
 
             return Ok((doc, dispatch_var));
@@ -1531,20 +1583,32 @@ impl CoreErlangGenerator {
         let args_doc = self.capture_argument_list_doc(arguments)?;
 
         let doc = docvec![
-            Document::String(format!(
-                "let {self_var} = call 'beamtalk_actor':'make_self'({current_state}) in "
-            )),
-            Document::String(format!(
-                "case call '{module}':'dispatch'('{selector_atom}', ["
-            )),
+            "let ",
+            Document::String(self_var.clone()),
+            " = call 'beamtalk_actor':'make_self'(",
+            Document::String(current_state.clone()),
+            ") in ",
+            "case call '",
+            Document::Eco(module),
+            "':'dispatch'('",
+            Document::String(selector_atom),
+            "', [",
             args_doc,
-            Document::String(format!("], {self_var}, {current_state}) of ")),
-            Document::String(format!(
-                "<{{'reply', {result_var}, _}}> when 'true' -> {result_var} "
-            )),
-            Document::String(format!(
-                "<{{'error', {error_var}, _}}> when 'true' -> call 'beamtalk_error':'raise'({error_var}) "
-            )),
+            "], ",
+            Document::String(self_var),
+            ", ",
+            Document::String(current_state),
+            ") of ",
+            "<{'reply', ",
+            Document::String(result_var.clone()),
+            ", _}> when 'true' -> ",
+            Document::String(result_var),
+            " ",
+            "<{'error', ",
+            Document::String(error_var.clone()),
+            ", _}> when 'true' -> call 'beamtalk_error':'raise'(",
+            Document::String(error_var),
+            ") ",
             "end"
         ];
 
@@ -1570,18 +1634,32 @@ impl CoreErlangGenerator {
         let comma = if arguments.is_empty() { "" } else { ", " };
 
         let doc = docvec![
-            Document::String(format!(
-                "let {self_var} = call 'beamtalk_actor':'make_self'({current_state}) in "
-            )),
-            Document::String(format!("case call '{module}':'__sealed_{selector_name}'(")),
+            "let ",
+            Document::String(self_var.clone()),
+            " = call 'beamtalk_actor':'make_self'(",
+            Document::String(current_state.clone()),
+            ") in ",
+            "case call '",
+            Document::Eco(module),
+            "':'__sealed_",
+            Document::String(selector_name.to_string()),
+            "'(",
             args_doc,
-            Document::String(format!("{comma}{self_var}, {current_state}) of ")),
-            Document::String(format!(
-                "<{{'reply', {result_var}, _}}> when 'true' -> {result_var} "
-            )),
-            Document::String(format!(
-                "<{{'error', {error_var}, _}}> when 'true' -> call 'beamtalk_error':'raise'({error_var}) "
-            )),
+            Document::Str(comma),
+            Document::String(self_var),
+            ", ",
+            Document::String(current_state),
+            ") of ",
+            "<{'reply', ",
+            Document::String(result_var.clone()),
+            ", _}> when 'true' -> ",
+            Document::String(result_var),
+            " ",
+            "<{'error', ",
+            Document::String(error_var.clone()),
+            ", _}> when 'true' -> call 'beamtalk_error':'raise'(",
+            Document::String(error_var),
+            ") ",
             "end"
         ];
 
@@ -1845,12 +1923,19 @@ impl CoreErlangGenerator {
                 let new_state = self.next_state_var();
 
                 let doc = docvec![
-                    Document::String(format!("let {val_var} = ")),
+                    "let ",
+                    Document::String(val_var.clone()),
+                    " = ",
                     val_doc,
-                    Document::String(format!(
-                        " in let {new_state} = call 'maps':'put'('{}', {val_var}, {current_state}) in ",
-                        field.name
-                    ))
+                    " in let ",
+                    Document::String(new_state),
+                    " = call 'maps':'put'('",
+                    Document::Eco(field.name.clone()),
+                    "', ",
+                    Document::String(val_var.clone()),
+                    ", ",
+                    Document::String(current_state),
+                    ") in ",
                 ];
 
                 // BT-884: Return the val var so callers (e.g. cascade codegen) can
@@ -1977,11 +2062,15 @@ impl CoreErlangGenerator {
         let args_doc = self.capture_argument_list_doc(arguments)?;
 
         let doc = docvec![
-            Document::String(format!(
-                "call 'beamtalk_dispatch':'super'('{selector_atom}', ["
-            )),
+            "call 'beamtalk_dispatch':'super'('",
+            Document::String(selector_atom),
+            "', [",
             args_doc,
-            Document::String(format!("], Self, {current_state}, '{class_name}')"))
+            "], Self, ",
+            Document::String(current_state),
+            ", '",
+            Document::String(class_name),
+            "')",
         ];
         Ok(doc)
     }
@@ -2046,26 +2135,30 @@ impl CoreErlangGenerator {
         if in_repl_context {
             let doc = docvec![
                 "case call 'maps':'get'('__repl_actor_registry__', Bindings, 'undefined') of ",
-                Document::String(format!(
-                    "<'undefined'> when 'true' -> call '{module_name}':'spawn'("
-                )),
+                "<'undefined'> when 'true' -> call '",
+                Document::String(module_name.clone()),
+                "':'spawn'(",
                 args_doc.clone(),
-                Document::String(format!(
-                    ") <RegistryPid> when 'true' -> let SpawnResult = call '{module_name}':'spawn'("
-                )),
+                ") <RegistryPid> when 'true' -> let SpawnResult = call '",
+                Document::String(module_name.clone()),
+                "':'spawn'(",
                 args_doc,
                 ") in ",
                 "let SpawnPid = call 'erlang':'element'(4, SpawnResult) in ",
-                Document::String(format!(
-                    "let _RegResult = call 'beamtalk_actor':'register_spawned'(RegistryPid, SpawnPid, '{class_name}', '{module_name}') in "
-                )),
+                "let _RegResult = call 'beamtalk_actor':'register_spawned'(RegistryPid, SpawnPid, '",
+                Document::String(class_name.to_string()),
+                "', '",
+                Document::String(module_name),
+                "') in ",
                 "SpawnResult ",
                 "end"
             ];
             Ok(doc)
         } else {
             let doc = docvec![
-                Document::String(format!("call '{module_name}':'spawn'(")),
+                "call '",
+                Document::String(module_name),
+                "':'spawn'(",
                 args_doc,
                 ")"
             ];
@@ -2094,9 +2187,9 @@ impl CoreErlangGenerator {
         }
         let arg_doc = self.expression_doc(&arguments[0])?;
         let doc = docvec![
-            Document::String(format!(
-                "call 'beamtalk_method_resolver':'resolve'('{class_name}', "
-            )),
+            "call 'beamtalk_method_resolver':'resolve'('",
+            Document::String(class_name.to_string()),
+            "', ",
             arg_doc,
             ")"
         ];
@@ -2209,15 +2302,27 @@ impl CoreErlangGenerator {
 
         // BT-1942: `let Lookup = maps:find(...) in <arg_preamble> case Lookup of ...`
         // — lookup first, then args, then the dispatch branches.
-        let lookup_binding = Document::String(format!(
-            "let {lookup_var} = call 'maps':'find'('{class_name}', {state_var}) in "
-        ));
+        let lookup_binding = docvec![
+            "let ",
+            Document::String(lookup_var.clone()),
+            " = call 'maps':'find'('",
+            Document::String(class_name.to_string()),
+            "', ",
+            Document::String(state_var),
+            ") in ",
+        ];
         let case_doc = docvec![
-            Document::String(format!("case {lookup_var} of ")),
-            Document::String(format!("<{{'ok', {binding_val_var}}}> when 'true' -> ")),
-            Document::String(format!(
-                "call 'beamtalk_message_dispatch':'send'({binding_val_var}, '{instance_selector}', ["
-            )),
+            "case ",
+            Document::String(lookup_var),
+            " of ",
+            "<{'ok', ",
+            Document::String(binding_val_var.clone()),
+            "}> when 'true' -> ",
+            "call 'beamtalk_message_dispatch':'send'(",
+            Document::String(binding_val_var),
+            ", '",
+            Document::String(instance_selector),
+            "', [",
             args_doc,
             "]) ",
             "<'error'> when 'true' -> ",
@@ -2282,16 +2387,26 @@ impl CoreErlangGenerator {
             self.bind_args_to_temps(arguments, "WsArg")?;
         let args_doc = Self::join_docs_with_commas(arg_refs);
 
-        let lookup_binding = Document::String(format!(
-            "let {lookup_var} = call 'beamtalk_class_registry':'whereis_class'('{class_name}') in "
-        ));
+        let lookup_binding = docvec![
+            "let ",
+            Document::String(lookup_var.clone()),
+            " = call 'beamtalk_class_registry':'whereis_class'('",
+            Document::String(class_name.to_string()),
+            "') in ",
+        ];
         let case_doc = docvec![
-            Document::String(format!("case {lookup_var} of ")),
+            "case ",
+            Document::String(lookup_var),
+            " of ",
             "<'undefined'> when 'true' -> 'nil' ",
-            Document::String(format!("<{class_pid_var}> when 'true' -> ")),
-            Document::String(format!(
-                "call 'beamtalk_object_class':'class_send'({class_pid_var}, '{selector_atom}', ["
-            )),
+            "<",
+            Document::String(class_pid_var.clone()),
+            "> when 'true' -> ",
+            "call 'beamtalk_object_class':'class_send'(",
+            Document::String(class_pid_var),
+            ", '",
+            Document::String(selector_atom),
+            "', [",
             args_doc,
             "]) end"
         ];
@@ -2363,12 +2478,16 @@ impl CoreErlangGenerator {
         let (args_preamble, args_doc) = self.capture_args_with_preamble(arguments)?;
 
         let call_doc = docvec![
-            Document::String(format!(
-                "let {class_pid_var} = call 'beamtalk_class_registry':'whereis_class'('{class_name}') in "
-            )),
-            Document::String(format!(
-                "call 'beamtalk_object_class':'class_send'({class_pid_var}, '{selector_atom}', ["
-            )),
+            "let ",
+            Document::String(class_pid_var.clone()),
+            " = call 'beamtalk_class_registry':'whereis_class'('",
+            Document::String(class_name.to_string()),
+            "') in ",
+            "call 'beamtalk_object_class':'class_send'(",
+            Document::String(class_pid_var),
+            ", '",
+            Document::String(selector_atom),
+            "', [",
             args_doc,
             "])"
         ];

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -1639,6 +1639,7 @@ impl CoreErlangGenerator {
     /// this form emits the foldl and the `let X = maps:get(...)` extractions directly in
     /// the method body, ending with `in ` so the caller's next `body_part` provides the
     /// continuation.  This makes the updated locals visible to all subsequent expressions.
+    #[allow(clippy::too_many_lines)] // Document-based foldl scaffolding spans many lines
     pub(in crate::codegen::core_erlang) fn generate_value_type_do_open(
         &mut self,
         expr: &Expression,

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -503,15 +503,24 @@ impl CoreErlangGenerator {
             && superclass_name != "none"
         {
             if let Some(super_mod) = self.superclass_module_name(superclass_name) {
-                let mut own_field_parts = Vec::new();
-                own_field_parts.push(format!("'$beamtalk_class' => '{class_name}'"));
+                let mut own_field_parts: Vec<Document<'static>> = Vec::new();
+                own_field_parts.push(docvec![
+                    "'$beamtalk_class' => '",
+                    Document::String(class_name.clone()),
+                    "'",
+                ]);
                 for field in &class.state {
                     let default_code = if let Some(default_value) = &field.default_value {
                         self.capture_expression(default_value)?
                     } else {
                         "'nil'".to_string()
                     };
-                    own_field_parts.push(format!("'{}' => {}", field.name.name, default_code));
+                    own_field_parts.push(docvec![
+                        "'",
+                        Document::Eco(field.name.name.clone()),
+                        "' => ",
+                        Document::String(default_code),
+                    ]);
                 }
                 return Ok(docvec![
                     "'new'/0 = fun () ->\n",
@@ -519,7 +528,7 @@ impl CoreErlangGenerator {
                     Document::String(super_mod),
                     "':'new'() in\n",
                     "    call 'maps':'merge'(ParentState, ~{",
-                    Document::String(own_field_parts.join(", ")),
+                    join(own_field_parts, &Document::Str(", ")),
                     "}~)\n",
                     "\n",
                 ]);
@@ -527,7 +536,7 @@ impl CoreErlangGenerator {
         }
 
         // Direct Value subclass: build a flat map with all own fields.
-        let mut field_parts = Vec::new();
+        let mut field_parts: Vec<Document<'static>> = Vec::new();
 
         // Add each field with its default value
         for field in &class.state {
@@ -536,7 +545,12 @@ impl CoreErlangGenerator {
             } else {
                 "'nil'".to_string()
             };
-            field_parts.push(format!(", '{}' => {}", field.name.name, default_code));
+            field_parts.push(docvec![
+                ", '",
+                Document::Eco(field.name.name.clone()),
+                "' => ",
+                Document::String(default_code),
+            ]);
         }
 
         Ok(docvec![
@@ -544,7 +558,7 @@ impl CoreErlangGenerator {
             "    ~{'$beamtalk_class' => '",
             class_name,
             "'",
-            field_parts.join(""),
+            concat(field_parts),
             "}~\n",
             "\n",
         ])
@@ -1166,9 +1180,13 @@ impl CoreErlangGenerator {
                     // Non-last expressions: wrap in let to sequence side effects
                     let tmp_var = self.fresh_temp_var("seq");
                     let expr_code = self.capture_expression(expr)?;
-                    body_parts.push(Document::String(format!(
-                        "    let {tmp_var} = {expr_code} in\n"
-                    )));
+                    body_parts.push(docvec![
+                        "    let ",
+                        Document::String(tmp_var),
+                        " = ",
+                        Document::String(expr_code),
+                        " in\n",
+                    ]);
                 }
             }
         }
@@ -1653,8 +1671,11 @@ impl CoreErlangGenerator {
 
         // Phase 1: create a fresh map and pack each captured local into it.
         let init_map_var = self.fresh_temp_var("InitMap");
-        let mut pack_prefix = String::new();
-        let _ = write!(pack_prefix, "let {init_map_var} = call 'maps':'new'() in ");
+        let mut pack_docs: Vec<Document<'static>> = vec![docvec![
+            "let ",
+            Document::String(init_map_var.clone()),
+            " = call 'maps':'new'() in ",
+        ]];
         let mut current = init_map_var;
         for var_name in &threaded_locals {
             let packed_var = self.fresh_temp_var("Packed");
@@ -1663,10 +1684,17 @@ impl CoreErlangGenerator {
                 .cloned()
                 .unwrap_or_else(|| Self::to_core_erlang_var(var_name));
             let key = Self::local_state_key(var_name);
-            let _ = write!(
-                pack_prefix,
-                "let {packed_var} = call 'maps':'put'('{key}', {core_var}, {current}) in "
-            );
+            pack_docs.push(docvec![
+                "let ",
+                Document::String(packed_var.clone()),
+                " = call 'maps':'put'('",
+                Document::String(key),
+                "', ",
+                Document::String(core_var),
+                ", ",
+                Document::String(current),
+                ") in ",
+            ]);
             current = packed_var;
         }
         let init_state_code = current;
@@ -1680,17 +1708,25 @@ impl CoreErlangGenerator {
         let item_var = Self::to_core_erlang_var(item_param);
 
         let mut docs: Vec<Document<'static>> = vec![
-            Document::String(pack_prefix),
+            concat(pack_docs),
             docvec![
-                format!("let {list_var} = "),
+                "let ",
+                Document::String(list_var.clone()),
+                " = ",
                 recv_code,
-                format!(
-                    " in let {safe_list_var} = case call 'erlang':'is_list'({list_var}) of \
-                     <'true'> when 'true' -> {list_var} \
-                     <'false'> when 'true' -> \
-                     call 'beamtalk_collection':'to_list'({list_var}) end \
-                     in let {lambda_var} = fun ({item_var}, StateAcc) -> "
-                ),
+                " in let ",
+                Document::String(safe_list_var.clone()),
+                " = case call 'erlang':'is_list'(",
+                Document::String(list_var.clone()),
+                ") of <'true'> when 'true' -> ",
+                Document::String(list_var.clone()),
+                " <'false'> when 'true' -> call 'beamtalk_collection':'to_list'(",
+                Document::String(list_var),
+                ") end in let ",
+                Document::String(lambda_var.clone()),
+                " = fun (",
+                Document::String(item_var.clone()),
+                ", StateAcc) -> ",
             ],
         ];
 
@@ -1703,22 +1739,35 @@ impl CoreErlangGenerator {
         // expression, so they shadow the pre-loop bindings and are visible to all
         // subsequent `body_parts`.
         let fold_result = self.fresh_temp_var("FoldResult");
-        let mut post_code = format!(
-            " in let {fold_result} = call 'lists':'foldl'({lambda_var}, {init_state_code}, {safe_list_var}) in "
-        );
+        let mut post_docs: Vec<Document<'static>> = vec![docvec![
+            " in let ",
+            Document::String(fold_result.clone()),
+            " = call 'lists':'foldl'(",
+            Document::String(lambda_var),
+            ", ",
+            Document::String(init_state_code),
+            ", ",
+            Document::String(safe_list_var),
+            ") in ",
+        ]];
         for var_name in &threaded_locals {
             let core_var = Self::to_core_erlang_var(var_name);
             // Update the scope so subsequent method-body expressions look up
             // this Erlang variable name.
             self.bind_var(var_name, &core_var);
             let key = Self::local_state_key(var_name);
-            let _ = write!(
-                post_code,
-                "let {core_var} = call 'maps':'get'('{key}', {fold_result}) in "
-            );
+            post_docs.push(docvec![
+                "let ",
+                Document::String(core_var),
+                " = call 'maps':'get'('",
+                Document::String(key),
+                "', ",
+                Document::String(fold_result.clone()),
+                ") in ",
+            ]);
         }
         // Intentionally open — the caller's next body_part provides the continuation.
-        docs.push(Document::String(post_code));
+        docs.push(concat(post_docs));
 
         Ok(Document::Vec(docs))
     }
@@ -2203,9 +2252,11 @@ impl CoreErlangGenerator {
                 "':'doesNotUnderstand:args:'(Self, Selector, Args)\n",
             ]
         } else if let Some(ref super_mod) = superclass_mod {
-            Document::String(format!(
-                "                    call '{super_mod}':'dispatch'(Selector, Args, Self)\n"
-            ))
+            docvec![
+                "                    call '",
+                Document::String(super_mod.clone()),
+                "':'dispatch'(Selector, Args, Self)\n",
+            ]
         } else {
             // Root of hierarchy — raise does_not_understand
             let dnu_hint = Self::core_erlang_binary(
@@ -2215,9 +2266,9 @@ impl CoreErlangGenerator {
                 "                    let <DnuClass> = call 'beamtalk_primitive':'class_of'(Self) in\n",
                 "                    let <DnuErr0> = call 'beamtalk_error':'new'('does_not_understand', DnuClass) in\n",
                 "                    let <DnuErr1> = call 'beamtalk_error':'with_selector'(DnuErr0, Selector) in\n",
-                format!(
-                    "                    let <DnuErr2> = call 'beamtalk_error':'with_hint'(DnuErr1, {dnu_hint}) in\n"
-                ),
+                "                    let <DnuErr2> = call 'beamtalk_error':'with_hint'(DnuErr1, ",
+                Document::String(dnu_hint),
+                ") in\n",
                 "                    call 'beamtalk_error':'raise'(DnuErr2)\n",
             ]
         };
@@ -2227,13 +2278,15 @@ impl CoreErlangGenerator {
             "    case Selector of\n",
             // class
             "        <'class'> when 'true' ->\n",
-            format!("            '{class_name}'\n"),
+            "            '",
+            Document::String(class_name.clone()),
+            "'\n",
             // respondsTo:
             "        <'respondsTo:'> when 'true' ->\n",
             "            case Args of\n",
-            format!(
-                "                <[RtSelector | _]> when 'true' -> call '{mod_name}':'has_method'(RtSelector)\n"
-            ),
+            "                <[RtSelector | _]> when 'true' -> call '",
+            Document::String(mod_name.to_string()),
+            "':'has_method'(RtSelector)\n",
             "                <_> when 'true' -> 'false'\n",
             "            end\n",
             // asString (conditional)
@@ -2244,23 +2297,27 @@ impl CoreErlangGenerator {
             field_at_branch,
             // fieldAt:put:
             "        <'fieldAt:put:'> when 'true' ->\n",
-            format!(
-                "            let <ImmErr0> = call 'beamtalk_error':'new'('immutable_value', '{class_name}') in\n"
-            ),
+            "            let <ImmErr0> = call 'beamtalk_error':'new'('immutable_value', '",
+            Document::String(class_name.clone()),
+            "') in\n",
             "            let <ImmErr1> = call 'beamtalk_error':'with_selector'(ImmErr0, 'fieldAt:put:') in\n",
-            format!(
-                "            let <ImmErr2> = call 'beamtalk_error':'with_hint'(ImmErr1, {immutable_hint}) in\n"
-            ),
+            "            let <ImmErr2> = call 'beamtalk_error':'with_hint'(ImmErr1, ",
+            Document::String(immutable_hint),
+            ") in\n",
             "            call 'beamtalk_error':'raise'(ImmErr2)\n",
             // perform:
             "        <'perform:'> when 'true' ->\n",
             "            let <PerfSel> = call 'erlang':'hd'(Args) in\n",
-            format!("            call '{mod_name}':'dispatch'(PerfSel, [], Self)\n"),
+            "            call '",
+            Document::String(mod_name.to_string()),
+            "':'dispatch'(PerfSel, [], Self)\n",
             // perform:withArguments:
             "        <'perform:withArguments:'> when 'true' ->\n",
             "            let <PwaSel> = call 'erlang':'hd'(Args) in\n",
             "            let <PwaArgs> = call 'erlang':'hd'(call 'erlang':'tl'(Args)) in\n",
-            format!("            call '{mod_name}':'dispatch'(PwaSel, PwaArgs, Self)\n"),
+            "            call '",
+            Document::String(mod_name.to_string()),
+            "':'dispatch'(PwaSel, PwaArgs, Self)\n",
             // Class-defined method branches
             Document::Vec(method_branches),
             // BT-923: Auto-generated getter and with*: dispatch arms
@@ -2271,9 +2328,9 @@ impl CoreErlangGenerator {
             ),
             // Default case
             "        <_Other> when 'true' ->\n",
-            format!(
-                "            case call 'beamtalk_extensions':'lookup'('{class_name}', Selector) of\n"
-            ),
+            "            case call 'beamtalk_extensions':'lookup'('",
+            Document::String(class_name),
+            "', Selector) of\n",
             "                <{'ok', ExtFun, _ExtOwner}> when 'true' ->\n",
             "                    apply ExtFun(Args, Self)\n",
             "                <'not_found'> when 'true' ->\n",
@@ -2310,7 +2367,9 @@ impl CoreErlangGenerator {
             let binary = Self::core_erlang_binary(default_str);
             docvec![
                 "        <'asString'> when 'true' ->\n",
-                format!("            {binary}\n"),
+                "            ",
+                Document::String(binary),
+                "\n",
             ]
         }
     }
@@ -2373,9 +2432,11 @@ impl CoreErlangGenerator {
         let mut method_branches: Vec<Document<'static>> = Vec::new();
         for method in &class.methods {
             let mangled = method.selector.to_erlang_atom();
-            method_branches.push(Document::String(format!(
-                "        <'{mangled}'> when 'true' ->\n"
-            )));
+            method_branches.push(docvec![
+                "        <'",
+                Document::String(mangled.clone()),
+                "'> when 'true' ->\n",
+            ]);
 
             // BT-854: Methods with NLR return {Result, State} tuple — unwrap via case.
             let has_nlr = self
@@ -2387,15 +2448,19 @@ impl CoreErlangGenerator {
                 // Extract args from Args list: hd(Args), hd(tl(Args)), ...
                 for (i, _param) in method.parameters.iter().enumerate() {
                     let arg_var = format!("DispArg{i}");
-                    let mut access = "Args".to_string();
+                    let mut access: Document<'static> = Document::Str("Args");
                     for _ in 0..i {
-                        access = format!("call 'erlang':'tl'({access})");
+                        access = docvec![
+                            "call 'erlang':'tl'(",
+                            access,
+                            ")",
+                        ];
                     }
                     method_branches.push(docvec![
                         "            let <",
-                        arg_var,
+                        Document::String(arg_var),
                         "> = call 'erlang':'hd'(",
-                        Document::String(access),
+                        access,
                         ") in\n",
                     ]);
                 }
@@ -2404,14 +2469,19 @@ impl CoreErlangGenerator {
             // Build the call expression: call 'mod':'method'(Self, DispArg0, ...)
             let mut call_args: Vec<Document<'static>> = vec![Document::Str("Self")];
             for i in 0..method.parameters.len() {
-                call_args.push(Document::String(format!(", DispArg{i}")));
+                call_args.push(docvec![
+                    ", DispArg",
+                    Document::String(i.to_string()),
+                ]);
             }
             let call_doc = docvec![
-                Document::String(format!("call '{mod_name}':'")),
+                "call '",
+                Document::String(mod_name.to_string()),
+                "':'",
                 Document::String(mangled.clone()),
-                Document::Str("'("),
+                "'(",
                 Document::Vec(call_args),
-                Document::Str(")"),
+                ")",
             ];
 
             if has_nlr {

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -692,14 +692,14 @@ impl CoreErlangGenerator {
         Ok(docvec![
             function_head,
             "\n",
-            format!(
-                "    let Error0 = call 'beamtalk_error':'new'('instantiation_error', '{class_name}') in\n"
-            ),
-            format!(
-                "    let Error1 = call 'beamtalk_error':'with_selector'(Error0, '{selector}') in\n"
-            ),
+            "    let Error0 = call 'beamtalk_error':'new'('instantiation_error', '",
+            Document::String(class_name.to_string()),
+            "') in\n",
+            "    let Error1 = call 'beamtalk_error':'with_selector'(Error0, '",
+            Document::String(selector.to_string()),
+            "') in\n",
             "    let Error2 = call 'beamtalk_error':'with_hint'(Error1, ",
-            hint_binary,
+            Document::String(hint_binary),
             ") in\n",
             "    call 'beamtalk_error':'raise'(Error2)\n",
             "\n",
@@ -2602,12 +2602,10 @@ impl CoreErlangGenerator {
             "            end\n",
             // --- printString ---
             "        <'printString'> when 'true' ->\n",
-            format!(
-                "            let <PsClass4> = call 'beamtalk_tagged_map':'class_of'(State, 'Object') in\n"
-            ),
-            format!(
-                "            let <PsStr4> = call 'erlang':'iolist_to_binary'([{a_space_binary}|[call 'erlang':'atom_to_binary'(PsClass4, 'utf8')]]) in\n"
-            ),
+            "            let <PsClass4> = call 'beamtalk_tagged_map':'class_of'(State, 'Object') in\n",
+            "            let <PsStr4> = call 'erlang':'iolist_to_binary'([",
+            Document::String(a_space_binary),
+            "|[call 'erlang':'atom_to_binary'(PsClass4, 'utf8')]]) in\n",
             "            {'reply', PsStr4, State}\n",
             // --- perform: ---
             "        <'perform:'> when 'true' ->\n",
@@ -2645,7 +2643,9 @@ impl CoreErlangGenerator {
             "            end\n",
             // --- Default: delegate to dispatch/3 ---
             "        <_OtherSel4> when 'true' ->\n",
-            format!("            try call '{mod_name}':'dispatch'(Selector, Args, Self)\n"),
+            "            try call '",
+            Document::String(mod_name.to_string()),
+            "':'dispatch'(Selector, Args, Self)\n",
             "            of <D4Result> -> {'reply', D4Result, State}\n",
             "            catch <_D4Type, D4Error, _D4Stack> -> {'error', D4Error, State}\n",
             "    end\n",
@@ -2659,7 +2659,9 @@ impl CoreErlangGenerator {
     /// dispatch service.
     fn generate_dispatch_4_wrapper(mod_name: &str) -> Document<'static> {
         docvec![
-            format!("    try call '{mod_name}':'dispatch'(Selector, Args, Self)\n"),
+            "    try call '",
+            Document::String(mod_name.to_string()),
+            "':'dispatch'(Selector, Args, Self)\n",
             "    of <D4Result> -> {'reply', D4Result, State}\n",
             "    catch <_D4Type, D4Error, _D4Stack> -> {'error', D4Error, State}\n",
         ]
@@ -2676,17 +2678,21 @@ impl CoreErlangGenerator {
         let hint = Self::core_erlang_binary(&format!(
             "Expected {expected_arity} argument(s) for {selector}"
         ));
+        let indent_doc = || Document::String(indent.to_string());
+        let selector_doc = || Document::String(selector.to_string());
         docvec![
-            format!(
-                "{indent}let <ArErr0> = call 'beamtalk_error':'new'('arity_mismatch', call 'beamtalk_tagged_map':'class_of'(State, 'Object')) in\n"
-            ),
-            format!(
-                "{indent}let <ArErr1> = call 'beamtalk_error':'with_selector'(ArErr0, {selector}) in\n"
-            ),
-            format!(
-                "{indent}let <ArErr2> = call 'beamtalk_error':'with_hint'(ArErr1, {hint}) in\n"
-            ),
-            format!("{indent}{{'error', ArErr2, State}}"),
+            indent_doc(),
+            "let <ArErr0> = call 'beamtalk_error':'new'('arity_mismatch', call 'beamtalk_tagged_map':'class_of'(State, 'Object')) in\n",
+            indent_doc(),
+            "let <ArErr1> = call 'beamtalk_error':'with_selector'(ArErr0, ",
+            selector_doc(),
+            ") in\n",
+            indent_doc(),
+            "let <ArErr2> = call 'beamtalk_error':'with_hint'(ArErr1, ",
+            Document::String(hint),
+            ") in\n",
+            indent_doc(),
+            "{'error', ArErr2, State}",
         ]
     }
 
@@ -2699,17 +2705,21 @@ impl CoreErlangGenerator {
         indent: &str,
     ) -> Document<'static> {
         let hint = Self::core_erlang_binary(hint_msg);
+        let indent_doc = || Document::String(indent.to_string());
+        let selector_doc = || Document::String(selector.to_string());
         docvec![
-            format!(
-                "{indent}let <TyErr0> = call 'beamtalk_error':'new'('type_error', call 'beamtalk_tagged_map':'class_of'(State, 'Object')) in\n"
-            ),
-            format!(
-                "{indent}let <TyErr1> = call 'beamtalk_error':'with_selector'(TyErr0, {selector}) in\n"
-            ),
-            format!(
-                "{indent}let <TyErr2> = call 'beamtalk_error':'with_hint'(TyErr1, {hint}) in\n"
-            ),
-            format!("{indent}{{'error', TyErr2, State}}"),
+            indent_doc(),
+            "let <TyErr0> = call 'beamtalk_error':'new'('type_error', call 'beamtalk_tagged_map':'class_of'(State, 'Object')) in\n",
+            indent_doc(),
+            "let <TyErr1> = call 'beamtalk_error':'with_selector'(TyErr0, ",
+            selector_doc(),
+            ") in\n",
+            indent_doc(),
+            "let <TyErr2> = call 'beamtalk_error':'with_hint'(TyErr1, ",
+            Document::String(hint),
+            ") in\n",
+            indent_doc(),
+            "{'error', TyErr2, State}",
         ]
     }
 
@@ -2756,14 +2766,14 @@ impl CoreErlangGenerator {
         }
 
         // Build list of all known selectors
-        let mut selectors: Vec<String> = vec![
-            "'class'".to_string(),
-            "'respondsTo:'".to_string(),
-            "'fieldNames'".to_string(),
-            "'fieldAt:'".to_string(),
-            "'fieldAt:put:'".to_string(),
-            "'perform:'".to_string(),
-            "'perform:withArguments:'".to_string(),
+        let mut selectors: Vec<Document<'static>> = vec![
+            Document::Str("'class'"),
+            Document::Str("'respondsTo:'"),
+            Document::Str("'fieldNames'"),
+            Document::Str("'fieldAt:'"),
+            Document::Str("'fieldAt:put:'"),
+            Document::Str("'perform:'"),
+            Document::Str("'perform:withArguments:'"),
         ];
 
         // Include default asString if dispatch/3 generates one
@@ -2777,43 +2787,58 @@ impl CoreErlangGenerator {
                 "True" | "False" | "UndefinedObject" | "Block"
             )
         {
-            selectors.push("'asString'".to_string());
+            selectors.push(Document::Str("'asString'"));
         }
 
         // Add class-defined methods
         for method in &class.methods {
             let mangled = method.selector.to_erlang_atom();
-            selectors.push(format!("'{mangled}'"));
+            selectors.push(docvec![
+                "'",
+                Document::String(mangled),
+                "'",
+            ]);
         }
 
         // BT-923: Add auto-generated getter and with*: setter selectors
         if let Some(auto) = auto_methods {
             for field in &auto.getters {
-                selectors.push(format!("'{field}'"));
+                selectors.push(docvec![
+                    "'",
+                    Document::String(field.clone()),
+                    "'",
+                ]);
             }
             for field in &auto.setters {
                 let with_sel = AutoSlotMethods::with_star_selector(field);
-                selectors.push(format!("'{with_sel}'"));
+                selectors.push(docvec![
+                    "'",
+                    Document::String(with_sel),
+                    "'",
+                ]);
             }
         }
 
         let false_branch: Document<'static> = if let Some(ref super_mod) = superclass_mod {
-            Document::String(format!(
-                "<'false'> when 'true' -> call '{super_mod}':'has_method'(Selector)\n"
-            ))
+            docvec![
+                "<'false'> when 'true' -> call '",
+                Document::String(super_mod.clone()),
+                "':'has_method'(Selector)\n",
+            ]
         } else {
             Document::Str("<'false'> when 'true' -> 'false'\n")
         };
 
-        let selectors_list = selectors.join(", ");
         let doc = docvec![
             "'has_method'/1 = fun (Selector) ->\n",
-            format!("    case call 'lists':'member'(Selector, [{selectors_list}]) of\n"),
+            "    case call 'lists':'member'(Selector, [",
+            join(selectors, &Document::Str(", ")),
+            "]) of\n",
             "        <'true'> when 'true' -> 'true'\n",
             "        <'false'> when 'true' ->\n",
-            format!(
-                "            case call 'beamtalk_extensions':'has'('{class_name}', Selector) of\n"
-            ),
+            "            case call 'beamtalk_extensions':'has'('",
+            Document::String(class_name),
+            "', Selector) of\n",
             "                <'true'> when 'true' -> 'true'\n",
             "                ",
             false_branch,
@@ -2845,33 +2870,41 @@ impl CoreErlangGenerator {
             "    case Selector of\n",
             // class
             "        <'class'> when 'true' ->\n",
-            format!("            '{class_name}'\n"),
+            "            '",
+            Document::String(class_name.clone()),
+            "'\n",
             // respondsTo:
             "        <'respondsTo:'> when 'true' ->\n",
             "            case Args of\n",
-            format!(
-                "                <[RtSelector | _]> when 'true' -> call '{mod_name}':'has_method'(RtSelector)\n"
-            ),
+            "                <[RtSelector | _]> when 'true' -> call '",
+            Document::Eco(mod_name.clone()),
+            "':'has_method'(RtSelector)\n",
             "                <_> when 'true' -> 'false'\n",
             "            end\n",
             // perform:
             "        <'perform:'> when 'true' ->\n",
             "            let <PerfSel> = call 'erlang':'hd'(Args) in\n",
-            format!("            call '{mod_name}':'dispatch'(PerfSel, [], Self)\n"),
+            "            call '",
+            Document::Eco(mod_name.clone()),
+            "':'dispatch'(PerfSel, [], Self)\n",
             // perform:withArguments:
             "        <'perform:withArguments:'> when 'true' ->\n",
             "            let <PwaSel> = call 'erlang':'hd'(Args) in\n",
             "            let <PwaArgs> = call 'erlang':'hd'(call 'erlang':'tl'(Args)) in\n",
-            format!("            call '{mod_name}':'dispatch'(PwaSel, PwaArgs, Self)\n"),
+            "            call '",
+            Document::Eco(mod_name),
+            "':'dispatch'(PwaSel, PwaArgs, Self)\n",
             // Default: extension check, then superclass delegation
             "        <_Other> when 'true' ->\n",
-            format!(
-                "            case call 'beamtalk_extensions':'lookup'('{class_name}', Selector) of\n"
-            ),
+            "            case call 'beamtalk_extensions':'lookup'('",
+            Document::String(class_name),
+            "', Selector) of\n",
             "                <{'ok', ExtFun, _ExtOwner}> when 'true' ->\n",
             "                    apply ExtFun(Args, Self)\n",
             "                <'not_found'> when 'true' ->\n",
-            format!("                    call '{super_mod}':'dispatch'(Selector, Args, Self)\n"),
+            "                    call '",
+            Document::String(super_mod),
+            "':'dispatch'(Selector, Args, Self)\n",
             "            end\n",
             "    end\n",
             "\n",
@@ -2899,13 +2932,13 @@ impl CoreErlangGenerator {
             "    case call 'lists':'member'(Selector, ['class', 'respondsTo:', 'perform:', 'perform:withArguments:']) of\n",
             "        <'true'> when 'true' -> 'true'\n",
             "        <'false'> when 'true' ->\n",
-            format!(
-                "            case call 'beamtalk_extensions':'has'('{class_name}', Selector) of\n"
-            ),
+            "            case call 'beamtalk_extensions':'has'('",
+            Document::String(class_name),
+            "', Selector) of\n",
             "                <'true'> when 'true' -> 'true'\n",
-            format!(
-                "                <'false'> when 'true' -> call '{super_mod}':'has_method'(Selector)\n"
-            ),
+            "                <'false'> when 'true' -> call '",
+            Document::String(super_mod),
+            "':'has_method'(Selector)\n",
             "            end\n",
             "    end\n",
             "\n",

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -2451,11 +2451,7 @@ impl CoreErlangGenerator {
                     let arg_var = format!("DispArg{i}");
                     let mut access: Document<'static> = Document::Str("Args");
                     for _ in 0..i {
-                        access = docvec![
-                            "call 'erlang':'tl'(",
-                            access,
-                            ")",
-                        ];
+                        access = docvec!["call 'erlang':'tl'(", access, ")",];
                     }
                     method_branches.push(docvec![
                         "            let <",
@@ -2470,10 +2466,7 @@ impl CoreErlangGenerator {
             // Build the call expression: call 'mod':'method'(Self, DispArg0, ...)
             let mut call_args: Vec<Document<'static>> = vec![Document::Str("Self")];
             for i in 0..method.parameters.len() {
-                call_args.push(docvec![
-                    ", DispArg",
-                    Document::String(i.to_string()),
-                ]);
+                call_args.push(docvec![", DispArg", Document::String(i.to_string()),]);
             }
             let call_doc = docvec![
                 "call '",
@@ -2794,29 +2787,17 @@ impl CoreErlangGenerator {
         // Add class-defined methods
         for method in &class.methods {
             let mangled = method.selector.to_erlang_atom();
-            selectors.push(docvec![
-                "'",
-                Document::String(mangled),
-                "'",
-            ]);
+            selectors.push(docvec!["'", Document::String(mangled), "'",]);
         }
 
         // BT-923: Add auto-generated getter and with*: setter selectors
         if let Some(auto) = auto_methods {
             for field in &auto.getters {
-                selectors.push(docvec![
-                    "'",
-                    Document::String(field.clone()),
-                    "'",
-                ]);
+                selectors.push(docvec!["'", Document::String(field.clone()), "'",]);
             }
             for field in &auto.setters {
                 let with_sel = AutoSlotMethods::with_star_selector(field);
-                selectors.push(docvec![
-                    "'",
-                    Document::String(with_sel),
-                    "'",
-                ]);
+                selectors.push(docvec!["'", Document::String(with_sel), "'",]);
             }
         }
 


### PR DESCRIPTION
## Summary

- Replace all `format!()` calls that produce Core Erlang structural syntax with `Document`/`docvec!` API in `value_type_codegen.rs` and `dispatch_codegen.rs` (BT-875 rule compliance)
- ~90 violations fixed across ~24 functions in two files (452 insertions, 247 deletions)
- Generated Core Erlang output is character-for-character identical — verified by 250 stdlib + 1923 BUnit tests passing

## Details

Remaining `format!()` calls are all legitimate: error messages, variable name construction (`DispArg{i}`), module name assembly (`bt@stdlib@{snake}`), and hint message strings passed to `core_erlang_binary()`.

Two `#[allow(clippy::too_many_lines)]` annotations added for functions that expanded mechanically during the refactor (`generate_value_type_do_open`, `generate_self_dispatch_open`).

## Test plan

- [x] `just test-stdlib` — 250/250 pass
- [x] `just test-bunit` — 1923/1925 pass (2 expected failures)
- [x] `just clippy` — clean
- [x] Background codegen reviewer confirmed no correctness defects
- [x] All remaining `format!()` calls audited as non-CE-fragment

Closes BT-2198

---
_Generated by [Claude Code](https://claude.ai/code/session_01N73ZyfJWmc9ge5gm9Nyfio)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal code generation infrastructure for improved maintainability and consistency across Erlang output construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->