### PR TITLE
tests: skip POSIX-permission-denied tests when running as root

### DIFF
--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -2159,6 +2159,20 @@ mod tests {
     use super::*;
     use camino::Utf8PathBuf;
 
+    /// True when the test process is running as Unix root. Root bypasses
+    /// POSIX permission bits, so `chmod 000` fixtures cannot produce the
+    /// expected `permission_denied` errors. Tests that rely on those
+    /// fixtures bail early when this returns true (e.g. CI sandboxes).
+    #[cfg(unix)]
+    fn running_as_root() -> bool {
+        std::process::Command::new("id")
+            .arg("-u")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .is_some_and(|s| s.trim() == "0")
+    }
+
     // --- run_lint_structured ---
 
     #[test]
@@ -2316,6 +2330,11 @@ mod tests {
     fn run_lint_structured_unreadable_package_file_warns() {
         use std::os::unix::fs::PermissionsExt;
 
+        if running_as_root() {
+            eprintln!("skipped: running as root, chmod 000 doesn't apply");
+            return;
+        }
+
         let dir = std::env::temp_dir().join(format!(
             "beamtalk-mcp-lint-unreadable-{}",
             std::process::id()
@@ -2362,6 +2381,11 @@ mod tests {
     fn compute_diagnostic_summary_unreadable_package_file() {
         use std::os::unix::fs::PermissionsExt;
 
+        if running_as_root() {
+            eprintln!("skipped: running as root, chmod 000 doesn't apply");
+            return;
+        }
+
         let dir = std::env::temp_dir().join(format!(
             "beamtalk-mcp-summary-unreadable-{}",
             std::process::id()
@@ -2406,6 +2430,11 @@ mod tests {
     fn compute_diagnostic_summary_unreadable_direct_target() {
         use std::os::unix::fs::PermissionsExt;
 
+        if running_as_root() {
+            eprintln!("skipped: running as root, chmod 000 doesn't apply");
+            return;
+        }
+
         let dir = std::env::temp_dir().join(format!(
             "beamtalk-mcp-summary-unreadable-target-{}",
             std::process::id()
@@ -2443,6 +2472,11 @@ mod tests {
     #[test]
     fn compute_diagnostic_summary_directory_with_unreadable_target() {
         use std::os::unix::fs::PermissionsExt;
+
+        if running_as_root() {
+            eprintln!("skipped: running as root, chmod 000 doesn't apply");
+            return;
+        }
 
         let dir = std::env::temp_dir().join(format!(
             "beamtalk-mcp-summary-dir-unreadable-{}",
@@ -2484,6 +2518,11 @@ mod tests {
     #[test]
     fn run_lint_structured_directory_with_unreadable_target_errors() {
         use std::os::unix::fs::PermissionsExt;
+
+        if running_as_root() {
+            eprintln!("skipped: running as root, chmod 000 doesn't apply");
+            return;
+        }
 
         let dir = std::env::temp_dir().join(format!(
             "beamtalk-mcp-lint-dir-unreadable-{}",

--- a/crates/beamtalk-parity-tests/tests/diagnostic_parity.rs
+++ b/crates/beamtalk-parity-tests/tests/diagnostic_parity.rs
@@ -68,10 +68,20 @@ async fn diagnostic_parity_corpus() {
     let mut mcp = McpDriver::spawn(&repl).await.expect("spawn mcp driver");
 
     let cases = corpus_cases();
+    let skip_chmod_cases = running_as_root();
     let mut failures: Vec<String> = Vec::new();
     for case in &cases {
         if !case.unreadable_files.is_empty() && !cfg!(unix) {
             // Fixtures relying on `chmod 000` are Unix-only; skip on Windows.
+            continue;
+        }
+        if !case.unreadable_files.is_empty() && skip_chmod_cases {
+            // Root bypasses POSIX permission bits, so `chmod 000` fixtures
+            // can still be read. Skip when running as root (e.g. sandboxes).
+            eprintln!(
+                "[{}] skipped: running as root, chmod-based fixtures bypass POSIX permissions",
+                case.name
+            );
             continue;
         }
         let staged = match stage_fixture(&corpus_root, case) {
@@ -97,6 +107,25 @@ async fn diagnostic_parity_corpus() {
         "diagnostic parity assertions failed:\n  - {}",
         failures.join("\n  - ")
     );
+}
+
+/// True when the test process is running as Unix root. Root bypasses POSIX
+/// permission bits, so `chmod 000` fixtures (BT-2056 / BT-2067) cannot
+/// produce the expected `permission_denied` diagnostics under root.
+fn running_as_root() -> bool {
+    #[cfg(unix)]
+    {
+        Command::new("id")
+            .arg("-u")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .is_some_and(|s| s.trim() == "0")
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
 }
 
 /// Per-surface expected counts. Each surface field is checked with `>=` so

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_file_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_file_tests.erl
@@ -40,6 +40,19 @@ with_temp_file(Name, Contents, Fun) ->
         file:delete(Name)
     end.
 
+%% Returns true when the EUnit process is running as the Unix root user.
+%% Root bypasses POSIX permission bits, so tests that chmod a file to 0o000
+%% (or a directory to 0o555) and expect `permission_denied` would otherwise
+%% spuriously fail. Used by the *_permission_denied_test cases below to
+%% short-circuit when running inside a sandbox / container that runs as root.
+running_as_root() ->
+    case os:type() of
+        {unix, _} ->
+            string:trim(os:cmd("id -u")) =:= "0";
+        _ ->
+            false
+    end.
+
 %%% ============================================================================
 %%% FFI shims
 %%% ============================================================================
@@ -279,8 +292,8 @@ readAll_absolute_path_test() ->
     end.
 
 readAll_permission_denied_test() ->
-    case os:type() of
-        {win32, _} ->
+    case {os:type(), running_as_root()} of
+        {{win32, _}, _} ->
             %% Windows: Use icacls to deny read permissions via ACL
             FileName = "_bt_test_noperm_read.txt",
             ok = file:write_file(FileName, <<"secret">>),
@@ -310,7 +323,7 @@ readAll_permission_denied_test() ->
                 _ = os:cmd(ResetCmd),
                 file:delete(FileName)
             end;
-        _ ->
+        {{unix, _}, false} ->
             %% Unix: Use chmod to remove read permissions
             FileName = "_bt_test_noperm_read.txt",
             ok = file:write_file(FileName, <<"secret">>),
@@ -333,7 +346,10 @@ readAll_permission_denied_test() ->
             after
                 file:change_mode(FileName, 8#644),
                 file:delete(FileName)
-            end
+            end;
+        _ ->
+            %% Running as root: skip (root bypasses POSIX permission bits).
+            ok
     end.
 
 %%% ============================================================================
@@ -410,8 +426,8 @@ writeAll_creates_subdirectory_test() ->
     end.
 
 writeAll_permission_denied_test() ->
-    case os:type() of
-        {win32, _} ->
+    case {os:type(), running_as_root()} of
+        {{win32, _}, _} ->
             %% Windows: Create a file first, then deny write access to it
             FileName = "_bt_test_readonly_file.txt",
             ok = file:write_file(FileName, <<"initial">>),
@@ -443,7 +459,7 @@ writeAll_permission_denied_test() ->
                 _ = os:cmd(ResetCmd),
                 file:delete(FileName)
             end;
-        _ ->
+        {{unix, _}, false} ->
             %% Unix: Use chmod to make directory read-only
             Dir = "_bt_test_readonly_dir",
             FileName = Dir ++ "/test.txt",
@@ -470,7 +486,10 @@ writeAll_permission_denied_test() ->
                 file:change_mode(Dir, 8#755),
                 file:delete(FileName),
                 file:del_dir(Dir)
-            end
+            end;
+        _ ->
+            %% Running as root: skip (root bypasses POSIX permission bits).
+            ok
     end.
 
 %%% ============================================================================
@@ -1461,8 +1480,8 @@ writeAll_overwrite_existing_test() ->
 %%% ============================================================================
 
 readBinary_permission_denied_test() ->
-    case os:type() of
-        {unix, _} ->
+    case {os:type(), running_as_root()} of
+        {{unix, _}, false} ->
             FileName = "_bt_test_noperm_readbin.dat",
             ok = file:write_file(FileName, <<1, 2, 3>>),
             ok = file:change_mode(FileName, 8#000),
@@ -1496,8 +1515,8 @@ readBinary_permission_denied_test() ->
 %%% ============================================================================
 
 writeBinary_permission_denied_test() ->
-    case os:type() of
-        {unix, _} ->
+    case {os:type(), running_as_root()} of
+        {{unix, _}, false} ->
             Dir = "_bt_test_readonly_bindir",
             FileName = Dir ++ "/test.dat",
             ok = filelib:ensure_dir(FileName),
@@ -1533,8 +1552,8 @@ writeBinary_permission_denied_test() ->
 %%% ============================================================================
 
 appendBinary_permission_denied_test() ->
-    case os:type() of
-        {unix, _} ->
+    case {os:type(), running_as_root()} of
+        {{unix, _}, false} ->
             Dir = "_bt_test_readonly_appenddir",
             FileName = Dir ++ "/test.dat",
             ok = filelib:ensure_dir(FileName),
@@ -1572,8 +1591,8 @@ appendBinary_permission_denied_test() ->
 %%% ============================================================================
 
 lines_permission_denied_test() ->
-    case os:type() of
-        {unix, _} ->
+    case {os:type(), running_as_root()} of
+        {{unix, _}, false} ->
             FileName = "_bt_test_noperm_lines.txt",
             ok = file:write_file(FileName, <<"line1\nline2\n">>),
             ok = file:change_mode(FileName, 8#000),
@@ -1607,8 +1626,8 @@ lines_permission_denied_test() ->
 %%% ============================================================================
 
 open_do_permission_denied_test() ->
-    case os:type() of
-        {unix, _} ->
+    case {os:type(), running_as_root()} of
+        {{unix, _}, false} ->
             FileName = "_bt_test_noperm_open.txt",
             ok = file:write_file(FileName, <<"data\n">>),
             ok = file:change_mode(FileName, 8#000),
@@ -1645,8 +1664,8 @@ open_do_permission_denied_test() ->
 %%% ============================================================================
 
 listDirectory_permission_denied_test() ->
-    case os:type() of
-        {unix, _} ->
+    case {os:type(), running_as_root()} of
+        {{unix, _}, false} ->
             Dir = "_bt_eunit_listdir_noperm",
             ok = filelib:ensure_path(Dir),
             ok = file:write_file(Dir ++ "/a.txt", <<"a">>),
@@ -1692,8 +1711,8 @@ listDirectory_includes_subdirectories_test() ->
 %%% ============================================================================
 
 mkdir_permission_denied_test() ->
-    case os:type() of
-        {unix, _} ->
+    case {os:type(), running_as_root()} of
+        {{unix, _}, false} ->
             Dir = "_bt_eunit_mkdir_noperm",
             ok = file:make_dir(Dir),
             ok = file:change_mode(Dir, 8#555),
@@ -1727,8 +1746,8 @@ mkdir_permission_denied_test() ->
 %%% ============================================================================
 
 rename_to_permission_denied_test() ->
-    case os:type() of
-        {unix, _} ->
+    case {os:type(), running_as_root()} of
+        {{unix, _}, false} ->
             Dir = "_bt_eunit_rename_noperm",
             Src = Dir ++ "/src.txt",
             Dst = Dir ++ "/dst.txt",
@@ -1782,8 +1801,8 @@ rename_to_overwrites_destination_test() ->
 %%% ============================================================================
 
 delete_permission_denied_test() ->
-    case os:type() of
-        {unix, _} ->
+    case {os:type(), running_as_root()} of
+        {{unix, _}, false} ->
             Dir = "_bt_eunit_delete_noperm",
             FileName = Dir ++ "/protected.txt",
             ok = filelib:ensure_path(Dir),


### PR DESCRIPTION
## Summary

Sandboxes / CI containers often run as root, where root bypasses POSIX permission bits — `chmod 000` files remain readable and `chmod 555` directories remain writable. The tests below were spuriously failing in those environments and burning agent cycles re-trying them:

- **11 EUnit tests** in `runtime/apps/beamtalk_stdlib/test/beamtalk_file_tests.erl` (`readAll_`, `writeAll_`, `readBinary_`, `writeBinary_`, `appendBinary_`, `lines_`, `open_do_`, `listDirectory_`, `mkdir_`, `rename_to_`, `delete_permission_denied_test`).
- **5 Rust tests** in `crates/beamtalk-mcp/src/server.rs` for BT-2056 / BT-2067 unreadable-package / unreadable-target fixtures.
- **2 corpus cases** in `crates/beamtalk-parity-tests/tests/diagnostic_parity.rs` (`unreadable_target`, `unreadable_package`).

Each suite now has a small `running_as_root()` helper that parses `id -u`. Tests early-return when it returns `true`; on Windows the helper always returns `false` so existing ACL-based branches still run. Non-root Unix users see no behavior change.

## Verification

- Ran `rebar3 eunit --module=beamtalk_file_tests` as root → **159 passed, 0 failed**.
- Temporarily forced `running_as_root()` to `false` while still root → all 11 permission tests failed as expected (confirms the bodies still exercise the chmod path); reverted.
- `cargo test -p beamtalk-mcp --bin beamtalk-mcp` → **82 passed, 0 failed**.
- `just ci` → exit 0 (clippy, dialyzer, fmt, validate_specs, all tests).

## Test plan

- [x] EUnit `beamtalk_file_tests` passes as root
- [x] MCP `server::tests::*unreadable*` tests pass as root
- [x] `cargo clippy` / `cargo fmt` / `erlfmt` clean
- [x] `just ci` exit 0
- [ ] Confirm CI passes on the PR (non-root runner — full bodies should execute normally)

https://claude.ai/code/session_01ChnWgFkrAbnKarYcXmNSpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChnWgFkrAbnKarYcXmNSpj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite reliability by properly handling scenarios where tests run with root permissions on Unix systems. Tests that rely on file permission checks now skip appropriately when running as root to prevent misleading results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->