### PR TITLE
Remove orphaned classCanUnderstand/2 and classWhichIncludesSelector/2

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/behaviour.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/behaviour.rs
@@ -66,12 +66,7 @@ pub fn generate_behaviour_bif(selector: &str, params: &[String]) -> Option<Docum
 
     // Parameterized intrinsics
     match selector {
-        "classIncludesSelector"
-        | "classCanUnderstand"
-        | "classWhichIncludesSelector"
-        | "classDocForMethod"
-        | "classSetDoc"
-        | "classConformsTo" => {
+        "classIncludesSelector" | "classDocForMethod" | "classSetDoc" | "classConformsTo" => {
             let arg = params.first()?;
             Some(intrinsic_self_arg(selector, arg))
         }

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -29,8 +29,6 @@ that the Behaviour/Class libraries can rely on.
 | classLocalMethods/1         | Local method dictionary from class gen_server state       |
 | classMethods/1              | Combined local + inherited methods via superclass chain   |
 | classIncludesSelector/2     | Membership check in local method dictionary               |
-| classCanUnderstand/2        | Selector lookup against full method dictionary (classMethods/1) |
-| classWhichIncludesSelector/2| First class in hierarchy whose local methods include selector |
 | classFieldNames/1           | Field names from class gen_server state                   |
 | classAllFieldNames/1        | Combined field names via superclass chain                 |
 | className/1                 | Class name from class gen_server state                    |
@@ -57,9 +55,7 @@ that the Behaviour/Class libraries can rely on.
     classLocalMethods/1,
     classMethods/1,
     classIncludesSelector/2,
-    classCanUnderstand/2,
     classCanUnderstandFromName/2,
-    classWhichIncludesSelector/2,
     classFieldNames/1,
     classAllFieldNames/1,
     className/1,
@@ -276,29 +272,12 @@ classMethods(Self) ->
     ),
     ordsets:to_list(Acc).
 
--doc "Test whether instances understand the selector (full inheritance chain).".
--spec classCanUnderstand(#beamtalk_object{}, atom()) -> boolean().
-classCanUnderstand(Self, Selector) ->
-    ClassPid = erlang:element(4, Self),
-    ClassName = gen_server:call(ClassPid, class_name),
-    walk_hierarchy(
-        ClassName,
-        fun(_CN, CPid, _Acc) ->
-            case beamtalk_object_class:has_method(CPid, Selector) of
-                true -> {halt, true};
-                false -> {cont, false}
-            end
-        end,
-        false
-    ).
-
 -doc """
 Test whether the class named ClassName has instances that understand Selector.
 
 ADR 0032 Phase 3: Canonical single-source hierarchy walk used by
 beamtalk_dispatch:responds_to/2. Takes ClassName directly (not a class object)
-to avoid the extra gen_server:call that classCanUnderstand/2 needs to re-fetch
-the class name from the pid.
+to avoid an extra gen_server:call needed to re-fetch the class name from a pid.
 """.
 -spec classCanUnderstandFromName(atom(), atom()) -> boolean().
 classCanUnderstandFromName(ClassName, Selector) ->
@@ -311,28 +290,6 @@ classCanUnderstandFromName(ClassName, Selector) ->
             end
         end,
         false
-    ).
-
--doc """
-Walk the hierarchy and return the class object that defines the selector, or nil.
-""".
--spec classWhichIncludesSelector(#beamtalk_object{}, atom()) -> #beamtalk_object{} | 'nil'.
-classWhichIncludesSelector(Self, Selector) ->
-    ClassPid = erlang:element(4, Self),
-    ClassName = gen_server:call(ClassPid, class_name),
-    walk_hierarchy(
-        ClassName,
-        fun(CN, CPid, _Acc) ->
-            case beamtalk_object_class:has_method(CPid, Selector) of
-                true ->
-                    Module = gen_server:call(CPid, module_name),
-                    Tag = beamtalk_class_registry:class_object_tag(CN),
-                    {halt, #beamtalk_object{class = Tag, class_mod = Module, pid = CPid}};
-                false ->
-                    {cont, nil}
-            end
-        end,
-        nil
     ).
 
 -doc """
@@ -365,7 +322,8 @@ classAllFieldNames(Self) ->
 Test whether the selector is defined locally in this class.
 
 Does NOT check superclasses — local containment only.
-Full chain walk for canUnderstand: is implemented via classCanUnderstand.
+Full chain walk for `canUnderstand:` is implemented in pure Beamtalk
+(`Behaviour>>canUnderstand:`) on top of `classMethods/1`.
 
 BT-1635: When called on a metaclass object, checks class methods instead
 of instance methods.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
@@ -11,8 +11,8 @@ EUnit tests for beamtalk_behaviour_intrinsics module (BT-1088, BT-1959).
 Tests intrinsic functions for class reflection: metaclassNew, classClass,
 className, classLocalMethods, classFieldNames, classIncludesSelector,
 classDoc, classSetDoc, classSetMethodDoc, classSubclasses, classAllSubclasses,
-classMethods (including inheritance and deduplication), classCanUnderstand
-(including inherited selectors), classWhichIncludesSelector (inherited),
+classMethods (including inheritance and deduplication),
+classCanUnderstandFromName (including inherited selectors),
 classAllFieldNames (inherited),
 classRemoveFromSystem, classRemoveFromSystemByName, metaclass primitives
 (thisClass, classMethods, localClassMethods, includesSelector, allMethods).
@@ -805,55 +805,6 @@ class_methods_includes_local_test_() ->
     end}.
 
 %%% ============================================================================
-%%% classCanUnderstand/2
-%%% ============================================================================
-
-class_can_understand_true_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(_) ->
-        [
-            ?_test(begin
-                MethodFun = fun(_Self, _Args, State) -> {reply, ok, State, _Self} end,
-                {ClassObj, Pid} = register_class(
-                    'BT1792BiCanUnderstand',
-                    #{},
-                    #{'quux' => MethodFun}
-                ),
-                try
-                    ?assert(
-                        beamtalk_behaviour_intrinsics:classCanUnderstand(ClassObj, 'quux')
-                    )
-                after
-                    try
-                        gen_server:stop(Pid, normal, 5000)
-                    catch
-                        _:_ -> ok
-                    end
-                end
-            end)
-        ]
-    end}.
-
-class_can_understand_false_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(_) ->
-        [
-            ?_test(begin
-                {ClassObj, Pid} = register_class('BT1792BiCanUnderstandNo', #{}, #{}),
-                try
-                    ?assertNot(
-                        beamtalk_behaviour_intrinsics:classCanUnderstand(ClassObj, 'nope')
-                    )
-                after
-                    try
-                        gen_server:stop(Pid, normal, 5000)
-                    catch
-                        _:_ -> ok
-                    end
-                end
-            end)
-        ]
-    end}.
-
-%%% ============================================================================
 %%% classCanUnderstandFromName/2
 %%% ============================================================================
 
@@ -913,61 +864,6 @@ class_can_understand_from_name_unregistered_test() ->
             'BT1792NoSuchClass', 'anything'
         )
     ).
-
-%%% ============================================================================
-%%% classWhichIncludesSelector/2
-%%% ============================================================================
-
-class_which_includes_selector_found_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(_) ->
-        [
-            ?_test(begin
-                MethodFun = fun(_Self, _Args, State) -> {reply, ok, State, _Self} end,
-                {ClassObj, Pid} = register_class(
-                    'BT1792BiWhichInclSel',
-                    #{},
-                    #{'findMe' => MethodFun}
-                ),
-                try
-                    Result = beamtalk_behaviour_intrinsics:classWhichIncludesSelector(
-                        ClassObj, 'findMe'
-                    ),
-                    ?assertMatch(#beamtalk_object{}, Result),
-                    ?assertEqual(
-                        'BT1792BiWhichInclSel',
-                        beamtalk_behaviour_intrinsics:className(Result)
-                    )
-                after
-                    try
-                        gen_server:stop(Pid, normal, 5000)
-                    catch
-                        _:_ -> ok
-                    end
-                end
-            end)
-        ]
-    end}.
-
-class_which_includes_selector_nil_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(_) ->
-        [
-            ?_test(begin
-                {ClassObj, Pid} = register_class('BT1792BiWhichInclNil', #{}, #{}),
-                try
-                    Result = beamtalk_behaviour_intrinsics:classWhichIncludesSelector(
-                        ClassObj, 'noSuchMethod'
-                    ),
-                    ?assertEqual(nil, Result)
-                after
-                    try
-                        gen_server:stop(Pid, normal, 5000)
-                    catch
-                        _:_ -> ok
-                    end
-                end
-            end)
-        ]
-    end}.
 
 %%% ============================================================================
 %%% classAllFieldNames/1
@@ -1432,46 +1328,6 @@ class_methods_metaclass_receiver_test_() ->
         ]
     end}.
 
-%%% --- classCanUnderstand/2 — inherited selectors ---
-
-class_can_understand_inherited_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(_) ->
-        [
-            ?_test(begin
-                MethodFun = fun(_Self, _Args, State) -> {reply, ok, State, _Self} end,
-                {_ParentObj, ParentPid} = register_class(
-                    'BT1959CanUndParent',
-                    #{},
-                    #{'inherited' => MethodFun}
-                ),
-                {ChildObj, ChildPid} = register_class_with_super(
-                    'BT1959CanUndChild', 'BT1959CanUndParent', #{}, #{}
-                ),
-                try
-                    %% Child can understand parent's method via inheritance
-                    ?assert(
-                        beamtalk_behaviour_intrinsics:classCanUnderstand(ChildObj, 'inherited')
-                    ),
-                    %% But not a nonexistent method
-                    ?assertNot(
-                        beamtalk_behaviour_intrinsics:classCanUnderstand(ChildObj, 'bogus')
-                    )
-                after
-                    (try
-                        gen_server:stop(ChildPid, normal, 5000)
-                    catch
-                        _:_ -> ok
-                    end),
-                    (try
-                        gen_server:stop(ParentPid, normal, 5000)
-                    catch
-                        _:_ -> ok
-                    end)
-                end
-            end)
-        ]
-    end}.
-
 %%% --- classCanUnderstandFromName/2 — inherited selectors ---
 
 class_can_understand_from_name_inherited_test_() ->
@@ -1492,46 +1348,6 @@ class_can_understand_from_name_inherited_test_() ->
                         beamtalk_behaviour_intrinsics:classCanUnderstandFromName(
                             'BT1959CanUndNameChild', 'fromParent'
                         )
-                    )
-                after
-                    (try
-                        gen_server:stop(ChildPid, normal, 5000)
-                    catch
-                        _:_ -> ok
-                    end),
-                    (try
-                        gen_server:stop(ParentPid, normal, 5000)
-                    catch
-                        _:_ -> ok
-                    end)
-                end
-            end)
-        ]
-    end}.
-
-%%% --- classWhichIncludesSelector/2 — found in parent ---
-
-class_which_includes_selector_in_parent_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(_) ->
-        [
-            ?_test(begin
-                MethodFun = fun(_Self, _Args, State) -> {reply, ok, State, _Self} end,
-                {_ParentObj, ParentPid} = register_class(
-                    'BT1959WhichInclParent',
-                    #{},
-                    #{'parentOnly' => MethodFun}
-                ),
-                {ChildObj, ChildPid} = register_class_with_super(
-                    'BT1959WhichInclChild', 'BT1959WhichInclParent', #{}, #{}
-                ),
-                try
-                    Result = beamtalk_behaviour_intrinsics:classWhichIncludesSelector(
-                        ChildObj, 'parentOnly'
-                    ),
-                    ?assertMatch(#beamtalk_object{}, Result),
-                    ?assertEqual(
-                        'BT1959WhichInclParent',
-                        beamtalk_behaviour_intrinsics:className(Result)
                     )
                 after
                     (try


### PR DESCRIPTION
## Summary

Follow-up cleanup after BT-2194. Removes two more `beamtalk_behaviour_intrinsics` functions that were listed in the codegen's `@primitive`-callable map but had no Beamtalk caller, only their own EUnit tests:

- `classCanUnderstand/2` — `Behaviour>>canUnderstand:` is pure BT (`self allMethods includes:`)
- `classWhichIncludesSelector/2` — `Behaviour>>whichClassIncludesSelector:` is pure BT (`self allSuperclasses detect: [:c | c includesSelector: ...]`)

`classCanUnderstandFromName/2` is kept — `beamtalk_dispatch:responds_to/2` calls it directly.

## What changed

- Drop both functions, their exports, and their doc-table rows in `beamtalk_behaviour_intrinsics.erl`.
- Drop both entries from the codegen primitive match in `behaviour.rs`.
- Drop 6 EUnit tests (`class_can_understand_{true,false,inherited}`, `class_which_includes_selector_{found,nil,in_parent}`) and the corresponding section headers in `beamtalk_behaviour_intrinsics_tests.erl`.
- Fix a stale cross-reference in the `classIncludesSelector` doc that pointed at `classCanUnderstand`.

## Test plan

- [x] `just build` — clean
- [x] `rebar3 eunit --app=beamtalk_runtime` — 2101 tests, 0 failures (was 2107 before — 6 removed match the 6 deleted tests)
- [x] `just test-bunit` — 1931/1931 pass
- [x] `cargo test --package beamtalk-core` — 3725 pass
- [x] Pre-push hooks: clippy ✅, dialyzer ✅, dialyzer-specs ✅, erlfmt ✅, beamtalk lint ✅

Net diff: -237 / +6.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3NQoRGm9vNpW1qdC7FPoo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized class method resolution by updating internal intrinsics to accept class names instead of class objects.
  * Simplified pattern matching for improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->