### PR TITLE
Queries: walk match-arm patterns in references_to and senders (BT-2221)

### DIFF
--- a/crates/beamtalk-core/src/queries/references_to_query.rs
+++ b/crates/beamtalk-core/src/queries/references_to_query.rs
@@ -30,7 +30,7 @@
 //! contribute results. A completely unparseable source returns an empty list.
 //! Callers treat "no references found" identically to "could not parse".
 
-use crate::ast::{Expression, StringSegment, TypeAnnotation};
+use crate::ast::{Expression, Pattern, StringSegment, TypeAnnotation};
 use crate::source_analysis::{lex_with_eof, parse};
 
 /// Number of newlines in the synthetic class header that wraps the input.
@@ -166,6 +166,7 @@ fn collect_reference_lines(
         Expression::Match { value, arms, .. } => {
             collect_reference_lines(value, class_name, source, lines);
             for arm in arms {
+                collect_pattern_reference_lines(&arm.pattern, class_name, source, lines);
                 if let Some(guard) = &arm.guard {
                     collect_reference_lines(guard, class_name, source, lines);
                 }
@@ -205,6 +206,68 @@ fn collect_reference_lines(
         | Expression::ExpectDirective { .. }
         | Expression::Spread { .. }
         | Expression::Error { .. } => {}
+    }
+}
+
+/// Recursively collect line numbers of class references inside a [`Pattern`].
+///
+/// `Constructor` patterns carry an explicit class name (e.g. `Result ok: v`);
+/// container patterns recurse into their nested patterns so a class mentioned
+/// only inside a nested constructor (e.g. `Result ok: (Wrapper value: v)`) is
+/// still reported. `BinarySegment::size` is a full expression and is walked
+/// via `collect_reference_lines`.
+fn collect_pattern_reference_lines(
+    pattern: &Pattern,
+    class_name: &str,
+    source: &str,
+    lines: &mut Vec<u32>,
+) {
+    match pattern {
+        Pattern::Constructor {
+            class, keywords, ..
+        } => {
+            if class.name.as_str() == class_name {
+                lines.push(class.span.line_number(source));
+            }
+            for (_selector, inner) in keywords {
+                collect_pattern_reference_lines(inner, class_name, source, lines);
+            }
+        }
+        Pattern::Tuple { elements, .. } => {
+            for element in elements {
+                collect_pattern_reference_lines(element, class_name, source, lines);
+            }
+        }
+        Pattern::Array { elements, rest, .. } => {
+            for element in elements {
+                collect_pattern_reference_lines(element, class_name, source, lines);
+            }
+            if let Some(rest_pattern) = rest {
+                collect_pattern_reference_lines(rest_pattern, class_name, source, lines);
+            }
+        }
+        Pattern::List { elements, tail, .. } => {
+            for element in elements {
+                collect_pattern_reference_lines(element, class_name, source, lines);
+            }
+            if let Some(tail_pattern) = tail {
+                collect_pattern_reference_lines(tail_pattern, class_name, source, lines);
+            }
+        }
+        Pattern::Map { pairs, .. } => {
+            for pair in pairs {
+                collect_pattern_reference_lines(&pair.value, class_name, source, lines);
+            }
+        }
+        Pattern::Binary { segments, .. } => {
+            for segment in segments {
+                collect_pattern_reference_lines(&segment.value, class_name, source, lines);
+                if let Some(size) = &segment.size {
+                    collect_reference_lines(size, class_name, source, lines);
+                }
+            }
+        }
+        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) => {}
     }
 }
 
@@ -369,6 +432,24 @@ mod tests {
         let src = "/// Builds an Integer.\nmake => Integer new";
         let lines = find_references_to_in_source(src, "Integer");
         assert_eq!(lines, vec![2]);
+    }
+
+    #[test]
+    fn finds_reference_in_match_arm_pattern() {
+        // The only mention of `Result` is inside a match-arm constructor
+        // pattern. Without walking patterns this would be missed.
+        let src = "classify: x =>\n  x match: [\n    Result ok: v -> v;\n    _ -> nil]";
+        let lines = find_references_to_in_source(src, "Result");
+        assert_eq!(lines, vec![3]);
+    }
+
+    #[test]
+    fn finds_reference_in_nested_match_arm_pattern() {
+        // Class appears only inside a nested constructor pattern.
+        let src =
+            "unwrap: x =>\n  x match: [\n    Result ok: (Wrapper value: v) -> v;\n    _ -> nil]";
+        let lines = find_references_to_in_source(src, "Wrapper");
+        assert_eq!(lines, vec![3]);
     }
 
     #[test]

--- a/crates/beamtalk-core/src/queries/senders_query.rs
+++ b/crates/beamtalk-core/src/queries/senders_query.rs
@@ -28,7 +28,7 @@
 //! contribute results. A completely unparseable source returns an empty list.
 //! Callers treat "no senders found" identically to "could not parse".
 
-use crate::ast::{Expression, StringSegment};
+use crate::ast::{Expression, Pattern, StringSegment};
 use crate::source_analysis::{Span, lex_with_eof, parse};
 
 /// Number of newlines in the synthetic class header that wraps the input.
@@ -151,6 +151,7 @@ fn collect_send_lines(expr: &Expression, selector_name: &str, source: &str, line
         Expression::Match { value, arms, .. } => {
             collect_send_lines(value, selector_name, source, lines);
             for arm in arms {
+                collect_pattern_send_lines(&arm.pattern, selector_name, source, lines);
                 if let Some(guard) = &arm.guard {
                     collect_send_lines(guard, selector_name, source, lines);
                 }
@@ -191,6 +192,67 @@ fn collect_send_lines(expr: &Expression, selector_name: &str, source: &str, line
         | Expression::ExpectDirective { .. }
         | Expression::Spread { .. }
         | Expression::Error { .. } => {}
+    }
+}
+
+/// Recursively collect line numbers of message sends inside a [`Pattern`].
+///
+/// Patterns are themselves name-binding/literal-matching constructs and carry
+/// no message sends today — `BinarySegment::size` is the only expression slot
+/// in the [`Pattern`] enum, and the parser currently restricts it to an
+/// integer literal or a bare identifier (see
+/// `parse_binary_segment_size`). The walker is defensive: it traverses
+/// container patterns (Tuple/Array/List/Map/Constructor) and the binary
+/// segment size expression so that loosening the parser later does not
+/// silently regress `sendersOf:`. Constructor-pattern selector keywords (e.g.
+/// the `ok:` in `Result ok: v`) are *not* sends and are skipped here.
+fn collect_pattern_send_lines(
+    pattern: &Pattern,
+    selector_name: &str,
+    source: &str,
+    lines: &mut Vec<u32>,
+) {
+    match pattern {
+        Pattern::Binary { segments, .. } => {
+            for segment in segments {
+                collect_pattern_send_lines(&segment.value, selector_name, source, lines);
+                if let Some(size) = &segment.size {
+                    collect_send_lines(size, selector_name, source, lines);
+                }
+            }
+        }
+        Pattern::Tuple { elements, .. } => {
+            for element in elements {
+                collect_pattern_send_lines(element, selector_name, source, lines);
+            }
+        }
+        Pattern::Array { elements, rest, .. } => {
+            for element in elements {
+                collect_pattern_send_lines(element, selector_name, source, lines);
+            }
+            if let Some(rest_pattern) = rest {
+                collect_pattern_send_lines(rest_pattern, selector_name, source, lines);
+            }
+        }
+        Pattern::List { elements, tail, .. } => {
+            for element in elements {
+                collect_pattern_send_lines(element, selector_name, source, lines);
+            }
+            if let Some(tail_pattern) = tail {
+                collect_pattern_send_lines(tail_pattern, selector_name, source, lines);
+            }
+        }
+        Pattern::Map { pairs, .. } => {
+            for pair in pairs {
+                collect_pattern_send_lines(&pair.value, selector_name, source, lines);
+            }
+        }
+        Pattern::Constructor { keywords, .. } => {
+            for (_selector, inner) in keywords {
+                collect_pattern_send_lines(inner, selector_name, source, lines);
+            }
+        }
+        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) => {}
     }
 }
 
@@ -278,6 +340,16 @@ mod tests {
         // Garbage source — parser produces diagnostics but does not crash.
         let lines = find_senders_in_source(")@!", "anything");
         assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn constructor_pattern_keyword_is_not_a_send() {
+        // `ok:` in `Result ok: v` is a constructor-pattern selector keyword,
+        // not a message send. A query for `ok:` should not report it. The
+        // body's `ok:` *send* still counts.
+        let src = "wrap: x =>\n  x match: [\n    Result ok: v -> Result ok: v;\n    _ -> nil]";
+        let lines = find_senders_in_source(src, "ok:");
+        assert_eq!(lines, vec![3]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes [BT-2221](https://linear.app/beamtalk/issue/BT-2221/queries-walk-match-arm-patterns-in-references-to-query-and-senders).

`Expression::Match` handling in both `references_to_query.rs` and `senders_query.rs` walked the match value, `arm.guard`, and `arm.body`, but not `arm.pattern`. Patterns can carry class references via `Constructor` variants (e.g. `Result ok: v`), so any class mentioned **only** inside a match-arm pattern was missed by `referencesTo:`. Pre-existing limitation — flagged by CodeRabbit on PR #2239 — affecting both queries symmetrically.

## Key Changes

**`crates/beamtalk-core/src/queries/references_to_query.rs`**
- Added `collect_pattern_reference_lines` helper that recurses through container patterns (Tuple / Array / List / Map / Constructor / Binary) and reports the class name of each `Constructor` pattern (including nested ones like `Result ok: (Wrapper value: v)`).
- `BinarySegment::size` expressions are walked via `collect_reference_lines` so a class mentioned in a segment size is also covered.
- `Expression::Match` arm handling now invokes the new helper before walking guard / body.

**`crates/beamtalk-core/src/queries/senders_query.rs`**
- Added symmetric `collect_pattern_send_lines` helper.
- The parser currently restricts `BinarySegment::size` to integer literals or bare identifiers (see `parse_binary_segment_size`), so patterns hold no sends today — but the AST permits expressions there. The walker is **defensive**: it traverses pattern subtrees so a future parser loosening doesn't silently regress `sendersOf:`. Doc comment explains the rationale.
- Constructor-pattern selector keywords (the `ok:` in `Result ok: v`) are intentionally **not** treated as sends.

## Tests

Three new unit tests:
- `references_to_query::finds_reference_in_match_arm_pattern` — class mentioned only in a constructor pattern is reported.
- `references_to_query::finds_reference_in_nested_match_arm_pattern` — class inside a nested constructor pattern is reported.
- `senders_query::constructor_pattern_keyword_is_not_a_send` — verifies the pattern keyword `ok:` does not produce a false positive while the body's `ok:` send still counts.

Full suite green: 250 stdlib, 1949 BUnit, 3808 + 1262 runtime EUnit, all Rust unit tests pass. Clippy and fmt clean.

## Test Plan

- [x] `cargo test --lib -p beamtalk-core queries::` — 282 passed
- [x] `just test` — full suite green
- [x] `just clippy` — passed
- [x] `just fmt` — clean

https://claude.ai/code/session_01EbaGSMmdq81Nre9HkhNMMJ


---
_Generated by [Claude Code](https://claude.ai/code/session_01KPeihW6dBqwhb2Y6rrFynD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of class references within match expressions for more comprehensive search results
  * Enhanced message send detection in match arms, eliminating false positives from expression syntax

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->