### PR TITLE
Remove duplicate Erlang string escape logic in beamtalk-cli (BT-2224)

### DIFF
--- a/crates/beamtalk-cli/src/commands/test.rs
+++ b/crates/beamtalk-cli/src/commands/test.rs
@@ -17,6 +17,7 @@
 use crate::beam_compiler::{
     BeamCompiler, ClassHierarchyContext, CompileContext, compile_source_with_bindings,
 };
+use crate::commands::erlang_eval::escape_for_erlang_string;
 use beamtalk_core::file_walker::FileWalker;
 use camino::{Utf8Path, Utf8PathBuf};
 use miette::{Context, IntoDiagnostic, Result};
@@ -701,8 +702,8 @@ fn generate_doc_test_eunit_wrapper(
     );
 
     for (i, (case, eval_mod)) in cases.iter().zip(eval_module_names.iter()).enumerate() {
-        let escaped_file = source_file.replace('\\', "\\\\").replace('"', "\\\"");
-        let escaped_expr = case.expression.replace('\\', "\\\\").replace('"', "\\\"");
+        let escaped_file = escape_for_erlang_string(source_file);
+        let escaped_expr = escape_for_erlang_string(&case.expression);
         let location = format!("{escaped_file}:{} `{escaped_expr}`", case.source_line);
         let location_bin = format!("<<\"{location}\"/utf8>>");
 

--- a/crates/beamtalk-cli/src/commands/test_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/test_stdlib.rs
@@ -12,6 +12,7 @@
 //! Part of ADR 0014 (Beamtalk Test Framework), Phase 1.
 
 use crate::beam_compiler::BeamCompiler;
+use crate::commands::erlang_eval::escape_for_erlang_string;
 use crate::commands::util;
 use camino::{Utf8Path, Utf8PathBuf};
 use miette::{Context, IntoDiagnostic, Result};
@@ -306,8 +307,8 @@ fn generate_eunit_wrapper(
 
     for (i, (case, eval_mod)) in cases.iter().zip(eval_module_names.iter()).enumerate() {
         // Build source location comment
-        let escaped_file = test_file_path.replace('\\', "\\\\").replace('"', "\\\"");
-        let escaped_expr = case.expression.replace('\\', "\\\\").replace('"', "\\\"");
+        let escaped_file = escape_for_erlang_string(test_file_path);
+        let escaped_expr = escape_for_erlang_string(&case.expression);
         let location = format!("{escaped_file}:{} `{escaped_expr}`", case.line);
         let location_bin = format!("<<\"{location}\"/utf8>>");
 

--- a/crates/beamtalk-cli/src/commands/workspace/process.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/process.rs
@@ -30,6 +30,7 @@ use super::node_state::{
 };
 use super::startup_command::{build_detached_node_command, write_cookie_args_file};
 
+use crate::commands::erlang_eval::escape_for_erlang_string;
 use crate::commands::protocol::ProtocolClient;
 use miette::{Result, miette};
 
@@ -95,17 +96,6 @@ const WS_HEALTH_MAX_DELAY_MS: u64 = 2000;
 /// loop uses its own fixed liveness-check interval.
 const LIVENESS_CHECK_INTERVAL: usize = 25;
 
-/// Escape a filesystem path for embedding in an Erlang double-quoted string literal.
-///
-/// Handles backslashes (Windows) and double quotes (all platforms) so the path
-/// can be safely interpolated into a `-eval` command without breaking syntax or
-/// enabling eval injection.
-fn escape_path_for_erlang(path: &str) -> String {
-    // Backslashes must be escaped first to avoid double-escaping quotes.
-    let s = path.replace('\\', "\\\\");
-    s.replace('"', "\\\"")
-}
-
 /// Prepare workspace paths and the eval command string for a detached node.
 ///
 /// Resolves the project path, cleans up stale runtime files, writes the
@@ -128,7 +118,7 @@ fn prepare_workspace_paths(
     let project_path_str = project_path
         .to_str()
         .ok_or_else(|| miette!("Project path contains invalid UTF-8: {:?}", project_path))?;
-    let project_path_str = escape_path_for_erlang(project_path_str);
+    let project_path_str = escape_for_erlang_string(project_path_str);
 
     // If a `starting` tombstone is present, a previous startup was interrupted
     // mid-flight (crash, OOM, SIGKILL, etc.).  Clean up all runtime files —
@@ -161,7 +151,7 @@ fn prepare_workspace_paths(
     let pid_file_path_str = pid_file_path
         .to_str()
         .ok_or_else(|| miette!("PID file path contains invalid UTF-8: {:?}", pid_file_path))?;
-    let pid_file_path_str = escape_path_for_erlang(pid_file_path_str);
+    let pid_file_path_str = escape_for_erlang_string(pid_file_path_str);
 
     // Compute the startup log path so the eval command's try/catch can write
     // crash diagnostics from within the VM (bypassing -detached's fd redirect).
@@ -172,7 +162,7 @@ fn prepare_workspace_paths(
             startup_log_path
         )
     })?;
-    let startup_log_path_str = escape_path_for_erlang(startup_log_path_str);
+    let startup_log_path_str = escape_for_erlang_string(startup_log_path_str);
 
     // Format bind address as Erlang tuple for cowboy socket_opts
     let bind_addr_erl = beamtalk_cli::repl_startup::format_bind_addr_erl(config.bind_addr);


### PR DESCRIPTION
## Summary

Three separate places in `beamtalk-cli` each re-implemented the same "escape a string for an Erlang double-quoted string literal" operation inline. This PR removes them all in favour of the canonical `escape_for_erlang_string` from `erlang_eval.rs`, which handles a strict superset of characters.

## Changes

- **`workspace/process.rs`** — delete the private `escape_path_for_erlang` function (was `replace('\\', "\\\\").replace('"', "\\\"")` only); update its 3 call sites to use `escape_for_erlang_string`
- **`test.rs`** — replace 2 inline escape chains with `escape_for_erlang_string`
- **`test_stdlib.rs`** — replace 2 inline escape chains with `escape_for_erlang_string`

No behaviour change on real inputs. `escape_for_erlang_string` additionally handles `\n`, `\r`, `\t`, `\0` — all of which are benign to escape for the path/snippet strings used at these call sites.

## Testing

- `cargo clippy -p beamtalk-cli` — clean
- `cargo test -p beamtalk-cli --lib` — all 22 unit tests pass
- Push hook: clippy ✅, dialyzer ✅, fmt ✅, all lint checks ✅
- Background `just ci` — exit code 0 ✅
- Pre-existing `test_docs_runs_on_passing_doctest` failure verified to also fail on `main` (unrelated)

## Linear

https://linear.app/beamtalk/issue/BT-2224/remove-duplicate-erlang-string-escape-logic-in-beamtalk-cli

https://claude.ai/code/session_018B4snY3WKAEygWYaF9azVr

---
_Generated by [Claude Code](https://claude.ai/code/session_018B4snY3WKAEygWYaF9azVr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal string escaping logic across test and workspace modules for improved code maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->