### PR TITLE
Tighten printString indirection in file_directory_test.bt (BT-2226)

### DIFF
--- a/stdlib/test/file_directory_test.bt
+++ b/stdlib/test/file_directory_test.bt
@@ -98,8 +98,8 @@ TestCase subclass: FileDirectoryTest
     self assert: (File writeAll: "target/bt-test-tmp/fdt/a.txt" contents: "a") isOk
     self assert: (File writeAll: "target/bt-test-tmp/fdt/b.txt" contents: "b") isOk
     entries := (File listDirectory: "target/bt-test-tmp/fdt") unwrap
-    self assert: (entries printString includesSubstring: "a.txt")
-    self assert: (entries printString includesSubstring: "b.txt")
+    self assert: (entries includes: "a.txt")
+    self assert: (entries includes: "b.txt")
 
   testListDirectoryContainsExpectedEntry =>
     self assert: (File writeAll: "target/bt-test-tmp/fdt/hello.txt" contents: "hi") isOk
@@ -213,15 +213,15 @@ TestCase subclass: FileDirectoryTest
   testAbsolutePath =>
     result := File absolutePath: "target/bt-test-tmp/fdt"
     self assert: result isOk
-    self assert: (result unwrap printString includesSubstring: "bt-test-tmp/fdt")
+    self assert: (result unwrap includesSubstring: "bt-test-tmp/fdt")
 
   testAbsolutePathIsAbsolute =>
     result := File absolutePath: "target/bt-test-tmp/fdt"
     self assert: result isOk
     // Absolute path must contain the OS path separator
     System osFamily == "unix" ifTrue: [
-      self assert: (result unwrap printString includesSubstring: "/")
-    ] ifFalse: [self assert: (result unwrap printString includesSubstring: ":")]
+      self assert: (result unwrap includesSubstring: "/")
+    ] ifFalse: [self assert: (result unwrap includesSubstring: ":")]
 
   testAbsolutePathOnAbsoluteInput =>
     // absolutePath: on an already-absolute path returns it unchanged (ADR 0063)


### PR DESCRIPTION
## Summary

Replaces five `printString includesSubstring:` assertions in `file_directory_test.bt` with more precise alternatives:

- **`testListDirectory`**: `entries printString includesSubstring: "a.txt"` → `entries includes: "a.txt"` — checks list membership directly instead of serialising the list to a string first. The `printString` form was fragile: a file named `"a.txtx"` would cause the `"a.txt"` substring check to pass spuriously.
- **`testAbsolutePath` / `testAbsolutePathIsAbsolute`**: `result unwrap printString includesSubstring:` → `result unwrap includesSubstring:` — `result unwrap` is already a String, so `printString` was redundant. The same file already uses the direct form correctly at lines 249–250.

No test intent changes. BUnit tests pass: 1960 tests, 0 failed.

## Linear Issue

https://linear.app/beamtalk/issue/BT-2226

## Test Plan

- [x] `just test-bunit` passes (1960 tests, 0 failed)
- [x] Diff touches only `stdlib/test/file_directory_test.bt`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbnsGBVu3imFnKJKTN1VZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test assertions for file directory operations and absolute path formatting validation to ensure more reliable verification of functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->