### PR TITLE
Tests: stabilise SystemNavigation E2E tests against stdlib churn (BT-2220)

### DIFF
--- a/tests/repl-protocol/cases/workspace_native_api.btscript
+++ b/tests/repl-protocol/cases/workspace_native_api.btscript
@@ -170,21 +170,27 @@ wsGlobals includesKey: #Counter
 // (BT-2214; originally added on Beamtalk in BT-2189, moved here in BT-2214)
 // ===========================================================================
 
-// implementorsOf: returns a non-empty list for a widely-implemented selector
+// Load the stable fixture classes for SystemNavigation tests (BT-2220).
+// These give us controlled, test-owned classes/selectors so assertions do
+// not depend on live stdlib content that may churn across unrelated edits.
+:load tests/repl-protocol/fixtures/sysnavigation_fixture.bt
+// => _
+
+// implementorsOf: returns a non-empty list for a selector with known implementors.
+// SysnavFixture and SysnavFixtureB both define #asString locally (see fixture),
+// so the result must include at least these two fixture-controlled classes.
 asStringImpls := SystemNavigation default implementorsOf: #asString
 // => _
 
 asStringImpls isEmpty
 // => false
 
-// Stdlib classes participate — Integer/Float/String all locally define asString
-asStringImpls includes: Integer
+// Fixture-controlled: SysnavFixture locally defines #asString.
+asStringImpls includes: SysnavFixture
 // => true
 
-asStringImpls includes: String
-// => true
-
-asStringImpls includes: Float
+// Fixture-controlled: SysnavFixtureB also locally defines #asString.
+asStringImpls includes: SysnavFixtureB
 // => true
 
 // User-loaded classes show up in results when they implement the selector.
@@ -205,11 +211,14 @@ classImpls includes: Integer
 // => false
 
 // implementorsOf: also finds class-side implementors as metaclass objects.
-// `Bag` defines `class withAll:` — that hit appears as `Bag class`.
-withAllImpls := SystemNavigation default implementorsOf: #withAll:
+// `SystemNavigation class` defines `class default` — that hit appears as
+// `SystemNavigation class` (the metaclass object). This is a stable fixture
+// anchor: `default` is a class-side method on SystemNavigation itself, which
+// is the feature under test, so it cannot disappear without breaking this suite.
+withDefaultImpls := SystemNavigation default implementorsOf: #default
 // => _
 
-withAllImpls includes: Bag class
+withDefaultImpls includes: SystemNavigation class
 // => true
 
 // superclassChain works on metaclass receivers — walks the parallel hierarchy.
@@ -372,36 +381,36 @@ Erlang ets delete: #beamtalk_extension_sources key: #(#'Integer class', #btTwoTw
 // SYSTEMNAVIGATION REFERENCESTO: — find class-reference sites (BT-2203)
 // ===========================================================================
 
-// referencesTo: returns a non-empty list for a widely-referenced class.
-// Integer is named in many stdlib method sources (return types, generic
-// parameters, examples wrapped in doc-comments are stripped, but the
-// signature mentions remain). In a workspace where stdlib classes are
-// loaded, at least one reference must exist.
-integerRefs := SystemNavigation default referencesTo: Integer
+// referencesTo: returns a non-empty list for a class that the loaded fixture
+// references by name. SysnavFixture >> #btReferencesFixture contains the
+// literal class name `SysnavFixture` in its body, so referencesTo: must find
+// at least one hit. This avoids depending on stdlib mentioning Integer
+// (fragile to stdlib churn — BT-2220).
+fixtureRefs := SystemNavigation default referencesTo: SysnavFixture
 // => _
 
-integerRefs isEmpty
+fixtureRefs isEmpty
 // => false
 
 // Each record is a Dictionary with #class, #selector, #line keys —
 // same shape as sendersOf:.
-intRecord := integerRefs first
+fixtureRecord := fixtureRefs first
 // => _
 
-intRecord includesKey: #class
+fixtureRecord includesKey: #class
 // => true
 
-intRecord includesKey: #selector
+fixtureRecord includesKey: #selector
 // => true
 
-intRecord includesKey: #line
+fixtureRecord includesKey: #line
 // => true
 
 // Line numbers are 1-based positive integers.
-intLineList := integerRefs collect: [:r | r at: #line]
+fixtureLineList := fixtureRefs collect: [:r | r at: #line]
 // => _
 
-intLineList allSatisfy: [:n | n > 0]
+fixtureLineList allSatisfy: [:n | n > 0]
 // => true
 
 // referencesTo: with a class that nothing mentions returns an empty list.
@@ -476,9 +485,10 @@ Erlang ets delete: #beamtalk_extensions key: #(#String, #btTwoTwoOneSixBareRefEx
 // SYSTEMNAVIGATION METHODSMATCHING: — source-text grep (BT-2205)
 // ===========================================================================
 
-// methodsMatching: returns a non-empty list when the pattern hits a stdlib
-// method body. `ifTrue:` is sent from dozens of stdlib methods, so the
-// search must produce hits.
+// methodsMatching: returns a non-empty list when the pattern hits a loaded
+// method body. SysnavFixture >> #btIfTrueBodyMarker sends `ifTrue:` in its
+// body (see fixture), so the search must produce at least one hit. Using a
+// fixture-controlled method avoids depending on stdlib bodies (BT-2220).
 ifTrueMethods := SystemNavigation default methodsMatching: (Regex from: "ifTrue:") unwrap
 // => _
 
@@ -497,16 +507,16 @@ ifTrueMethodRecord includesKey: #class
 ifTrueMethodRecord includesKey: #selector
 // => true
 
-// Integer >> #abs has body `(self < 0) ifTrue: [self negated] ifFalse:
-// [self]`, so a pattern that targets the `self negated` literal must
-// produce an Integer / #abs record.
+// SysnavFixture >> #btNegatedBodyMarker contains `self negated` in its body
+// (see fixture). Confirm the record appears — this is fixture-controlled and
+// stable against stdlib refactoring (BT-2220).
 negatedMatches := SystemNavigation default methodsMatching: (Regex from: "self negated") unwrap
 // => _
 
-(negatedMatches collect: [:r | r at: #class]) includes: Integer
+(negatedMatches collect: [:r | r at: #class]) includes: SysnavFixture
 // => true
 
-(negatedMatches collect: [:r | r at: #selector]) includes: #abs
+(negatedMatches collect: [:r | r at: #selector]) includes: #btNegatedBodyMarker
 // => true
 
 // methodsMatching: with a pattern that nobody's source contains returns an
@@ -561,8 +571,10 @@ Erlang ets delete: #beamtalk_extension_sources key: #(#Integer, #btTwoTwoOneSixM
 // SYSTEMNAVIGATION SELECTORSMATCHING: — fuzzy selector search (BT-2204)
 // ===========================================================================
 
-// Substring match across the stdlib — `append` hits selectors like
-// `#appendBinary:contents:` on File. Result is non-empty.
+// Substring match for a fixture-controlled selector. SysnavFixture defines
+// `#btAppendMarker` (see fixture), so a search for "append" must produce at
+// least this hit. Using a fixture-controlled selector avoids depending on
+// stdlib having selectors that contain "append" (BT-2220).
 appendHits := SystemNavigation default selectorsMatching: "append"
 // => _
 

--- a/tests/repl-protocol/cases/workspace_native_api.btscript
+++ b/tests/repl-protocol/cases/workspace_native_api.btscript
@@ -176,6 +176,9 @@ wsGlobals includesKey: #Counter
 :load tests/repl-protocol/fixtures/sysnavigation_fixture.bt
 // => _
 
+:load tests/repl-protocol/fixtures/sysnavigation_fixture_b.bt
+// => _
+
 // implementorsOf: returns a non-empty list for a selector with known implementors.
 // SysnavFixture and SysnavFixtureB both define #asString locally (see fixture),
 // so the result must include at least these two fixture-controlled classes.

--- a/tests/repl-protocol/fixtures/sysnavigation_fixture.bt
+++ b/tests/repl-protocol/fixtures/sysnavigation_fixture.bt
@@ -28,9 +28,7 @@ Object subclass: SysnavFixture
 
   // Body contains `ifTrue:` — gives methodsMatching: (Regex from: "ifTrue:") a hit.
   btIfTrueBodyMarker =>
-    | x |
-    x := true.
-    x ifTrue: ["hit"] ifFalse: ["miss"]
+    true ifTrue: ["hit"] ifFalse: ["miss"]
 
   // Body contains the text `self negated` in the expression — gives
   // methodsMatching: (Regex from: "self negated") a fixture-controlled hit.
@@ -40,9 +38,4 @@ Object subclass: SysnavFixture
     self negated
 
   // References SysnavFixture by name — gives referencesTo: SysnavFixture a hit.
-  btReferencesFixture => SysnavFixture new
-
-Object subclass: SysnavFixtureB
-
-  // A second implementor of asString — kept separate to avoid coupling to SysnavFixture.
-  asString => "SysnavFixtureB"
+  btReferencesFixture => SysnavFixture name

--- a/tests/repl-protocol/fixtures/sysnavigation_fixture.bt
+++ b/tests/repl-protocol/fixtures/sysnavigation_fixture.bt
@@ -27,15 +27,13 @@ Object subclass: SysnavFixture
   btAppendMarker => "append marker"
 
   // Body contains `ifTrue:` — gives methodsMatching: (Regex from: "ifTrue:") a hit.
-  btIfTrueBodyMarker =>
-    true ifTrue: ["hit"] ifFalse: ["miss"]
+  btIfTrueBodyMarker => true ifTrue: ["hit"] ifFalse: ["miss"]
 
   // Body contains the text `self negated` in the expression — gives
   // methodsMatching: (Regex from: "self negated") a fixture-controlled hit.
   // The method is not called in tests; the source-text scan is the only use.
   // STABLE: do not rename this method or edit its body (BT-2220).
-  btNegatedBodyMarker =>
-    self negated
+  btNegatedBodyMarker => self negated
 
   // References SysnavFixture by name — gives referencesTo: SysnavFixture a hit.
   btReferencesFixture => SysnavFixture name

--- a/tests/repl-protocol/fixtures/sysnavigation_fixture.bt
+++ b/tests/repl-protocol/fixtures/sysnavigation_fixture.bt
@@ -1,0 +1,48 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2220: Stable fixture for SystemNavigation E2E tests.
+//
+// This fixture provides test-owned classes/selectors so that
+// SystemNavigation assertions do not depend on live stdlib content
+// (which can churn across unrelated refactors).
+//
+// Design choices:
+//   - `asString` is defined here to give implementorsOf: a fixture-controlled hit.
+//   - `btAppendMarker` has a uniquely-named selector so selectorsMatching: can
+//     find it without depending on stdlib selectors containing "append".
+//   - `btIfTrueBodyMarker` contains `ifTrue:` in its source body, giving
+//     methodsMatching: a fixture-controlled hit.
+//   - `btNegatedBodyMarker` contains `self negated` in its source body, giving
+//     methodsMatching: a fixture-controlled hit.
+//   - `referencesTo: SysnavFixture` is controlled: the method below references
+//     this class by name.
+
+Object subclass: SysnavFixture
+
+  // Defines asString locally — gives implementorsOf: #asString a fixture hit.
+  asString => "SysnavFixture"
+
+  // Uniquely-named selector containing "append" — used by selectorsMatching: tests.
+  btAppendMarker => "append marker"
+
+  // Body contains `ifTrue:` — gives methodsMatching: (Regex from: "ifTrue:") a hit.
+  btIfTrueBodyMarker =>
+    | x |
+    x := true.
+    x ifTrue: ["hit"] ifFalse: ["miss"]
+
+  // Body contains the text `self negated` in the expression — gives
+  // methodsMatching: (Regex from: "self negated") a fixture-controlled hit.
+  // The method is not called in tests; the source-text scan is the only use.
+  // STABLE: do not rename this method or edit its body (BT-2220).
+  btNegatedBodyMarker =>
+    self negated
+
+  // References SysnavFixture by name — gives referencesTo: SysnavFixture a hit.
+  btReferencesFixture => SysnavFixture new
+
+Object subclass: SysnavFixtureB
+
+  // A second implementor of asString — kept separate to avoid coupling to SysnavFixture.
+  asString => "SysnavFixtureB"

--- a/tests/repl-protocol/fixtures/sysnavigation_fixture_b.bt
+++ b/tests/repl-protocol/fixtures/sysnavigation_fixture_b.bt
@@ -1,0 +1,14 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2220: Companion fixture class for SystemNavigation E2E tests.
+//
+// Beamtalk requires one class per .bt file, so this second implementor of
+// #asString lives apart from SysnavFixture (sysnavigation_fixture.bt). Having
+// two fixture-controlled implementors lets implementorsOf: #asString assert
+// against more than one class without depending on live stdlib content.
+
+Object subclass: SysnavFixtureB
+
+  // A second implementor of asString — kept separate to avoid coupling to SysnavFixture.
+  asString => "SysnavFixtureB"


### PR DESCRIPTION
## Summary

- Audit and fix fragile SystemNavigation E2E assertions in `tests/repl-protocol/cases/workspace_native_api.btscript` that depended on live stdlib content (class names mentioned in methods, selectors present in stdlib, etc.)
- Add new fixture `tests/repl-protocol/fixtures/sysnavigation_fixture.bt` with `SysnavFixture` and `SysnavFixtureB` classes providing test-owned controlled anchors
- Replace 6 fragile stdlib-dependent assertions with fixture-controlled equivalents — no assertion silently regresses from an unrelated stdlib edit

**Specific changes:**
- `implementorsOf: #asString` — now checks `SysnavFixture`/`SysnavFixtureB` instead of `Integer`/`String`/`Float`
- `implementorsOf: #withAll:` → `Bag class` — replaced with `#default` → `SystemNavigation class` (stable: it's the feature under test)
- `referencesTo: Integer` non-empty — replaced with `referencesTo: SysnavFixture` (fixture's `#btReferencesFixture` body references it)
- `methodsMatching: "ifTrue:"` non-empty — anchored to `SysnavFixture >> #btIfTrueBodyMarker`
- `methodsMatching: "self negated"` → `Integer/#abs` — replaced with `SysnavFixture >> #btNegatedBodyMarker`
- `selectorsMatching: "append"` non-empty — guaranteed by `#btAppendMarker` selector (contains "append" case-insensitively)

All record-shape, key-presence, and line-number-positivity coverage is preserved.

## Test plan

- [x] `just test-repl-protocol` passes (3/3 tests ok, including `e2e_language_tests` which runs `workspace_native_api.btscript`)
- [x] New fixture file has correct license header per CLAUDE.md rules
- [x] All expressions in test file have `// =>` assertions

Closes BT-2220. Part of epic BT-2201.

https://claude.ai/code/session_01KMXoP8FzzDFgpbRQbEDeVC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced system navigation tests to avoid relying on standard library content; expectations now target fixture-controlled results for determinism.
  * Added two stable E2E fixtures that provide distinct, predictable implementors and reference targets for navigation scenarios.
  * Updated selector, method body, and reference checks to anchor to fixture markers, improving isolation and test stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->