### PR TITLE
Runtime: expose reverse extension index for SystemNavigation (BT-2202)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_extensions.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_extensions.erl
@@ -74,6 +74,8 @@ See: docs/internal/design-self-as-object.md Section "Extension Registry Design"
     register/5,
     lookup/2,
     list/1,
+    extenders_of/1,
+    extensions_by/1,
     listAllWithSource/0,
     getSource/2,
     conflicts/0,
@@ -249,6 +251,62 @@ list('String').
 list(Class) when is_atom(Class) ->
     MatchPattern = {{Class, '$1'}, '_', '$2'},
     ets:select(?EXTENSIONS_TABLE, [{MatchPattern, [], [{{'$1', '$2'}}]}]).
+
+-doc """
+Return the unique set of owner classes that contribute any extension to the given target class.
+
+Scans the ETS extension table (`O(table size)`) for all entries whose key
+`{ClassName, _}` matches the given `TargetClass`, then collects the unique
+`Owner` atoms. Returns `[]` when no class extends `TargetClass`.
+
+This backs the `SystemNavigation extendersOf:` query: "which classes add
+extension methods to class X?"
+
+Examples:
+```
+extenders_of('Integer').
+% => [mylib, stdlib]   -- all owners that extend Integer
+extenders_of('NotExtended').
+% => []
+```
+""".
+-spec extenders_of(atom()) -> [atom()].
+extenders_of(TargetClass) when is_atom(TargetClass) ->
+    MatchPattern = {{TargetClass, '_'}, '_', '$1'},
+    Owners = ets:select(?EXTENSIONS_TABLE, [{MatchPattern, [], ['$1']}]),
+    lists:usort(Owners).
+
+-doc """
+Return all extensions contributed by the given owner class.
+
+Scans the ETS extension table (`O(table size)`) for all entries whose
+`Owner` field matches `OwnerClass`, then returns `{TargetClass, Selector}`
+tuples for every matching entry. Returns `[]` when `OwnerClass` contributes
+no extensions.
+
+This backs the `SystemNavigation extensionsBy:` query: "which extension
+methods does class Y contribute, and to which target classes?"
+
+Examples:
+```
+extensions_by(mylib).
+% => [{'Integer', double}, {'String', json}]
+extensions_by(unknown_owner).
+% => []
+```
+""".
+-spec extensions_by(atom()) -> [{atom(), atom()}].
+extensions_by(OwnerClass) when is_atom(OwnerClass) ->
+    ets:foldl(
+        fun
+            ({{TargetClass, Selector}, _Fun, Owner}, Acc) when Owner =:= OwnerClass ->
+                [{TargetClass, Selector} | Acc];
+            (_, Acc) ->
+                Acc
+        end,
+        [],
+        ?EXTENSIONS_TABLE
+    ).
 
 -doc """
 Show all methods that have been registered by multiple owners.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_extensions_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_extensions_tests.erl
@@ -599,3 +599,194 @@ get_source_handles_uninitialised_table_test() ->
     after
         beamtalk_extensions:init()
     end.
+
+%%% ============================================================================
+%%% BT-2202: extenders_of/1 tests
+%%% ============================================================================
+
+extenders_of_empty_table_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            %% No extensions registered — must return [] not an error.
+            ?assertEqual([], beamtalk_extensions:extenders_of('Integer'))
+        end
+    end}.
+
+extenders_of_single_extender_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            Fun = fun([], X) -> X * 2 end,
+            beamtalk_extensions:register('Integer', 'double', Fun, mylib),
+
+            ?assertEqual([mylib], beamtalk_extensions:extenders_of('Integer'))
+        end
+    end}.
+
+extenders_of_multiple_extenders_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            Fun = fun([], X) -> X end,
+            beamtalk_extensions:register('Integer', 'double', Fun, mylib),
+            beamtalk_extensions:register('Integer', 'triple', Fun, stdlib),
+            beamtalk_extensions:register('Integer', 'negate', Fun, otherlib),
+
+            Result = beamtalk_extensions:extenders_of('Integer'),
+            %% Three distinct owners.
+            ?assertEqual(3, length(Result)),
+            ?assert(lists:member(mylib, Result)),
+            ?assert(lists:member(stdlib, Result)),
+            ?assert(lists:member(otherlib, Result))
+        end
+    end}.
+
+extenders_of_deduplicates_same_owner_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            Fun = fun([], X) -> X end,
+            %% Same owner registers multiple methods on the same class.
+            beamtalk_extensions:register('Integer', 'double', Fun, mylib),
+            beamtalk_extensions:register('Integer', 'triple', Fun, mylib),
+            beamtalk_extensions:register('Integer', 'negate', Fun, mylib),
+
+            %% Owner should appear only once despite multiple methods.
+            ?assertEqual([mylib], beamtalk_extensions:extenders_of('Integer'))
+        end
+    end}.
+
+extenders_of_does_not_include_other_class_owners_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            Fun = fun([], X) -> X end,
+            beamtalk_extensions:register('String', 'json', Fun, lib1),
+            beamtalk_extensions:register('Integer', 'double', Fun, lib2),
+            beamtalk_extensions:register('Float', 'ceil', Fun, lib3),
+
+            %% Query for String should only return lib1, not lib2 or lib3.
+            ?assertEqual([lib1], beamtalk_extensions:extenders_of('String'))
+        end
+    end}.
+
+extenders_of_no_match_returns_empty_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            Fun = fun([], X) -> X end,
+            beamtalk_extensions:register('Integer', 'double', Fun, mylib),
+
+            %% Asking about a class with no extensions returns [].
+            ?assertEqual([], beamtalk_extensions:extenders_of('Float'))
+        end
+    end}.
+
+%%% ============================================================================
+%%% BT-2202: extensions_by/1 tests
+%%% ============================================================================
+
+extensions_by_empty_table_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            %% No extensions registered — must return [] not an error.
+            ?assertEqual([], beamtalk_extensions:extensions_by(mylib))
+        end
+    end}.
+
+extensions_by_single_extension_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            Fun = fun([], X) -> X * 2 end,
+            beamtalk_extensions:register('Integer', 'double', Fun, mylib),
+
+            ?assertEqual([{'Integer', double}], beamtalk_extensions:extensions_by(mylib))
+        end
+    end}.
+
+extensions_by_multiple_targets_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            Fun = fun([], X) -> X end,
+            beamtalk_extensions:register('Integer', 'double', Fun, mylib),
+            beamtalk_extensions:register('String', 'json', Fun, mylib),
+            beamtalk_extensions:register('Float', 'ceil', Fun, mylib),
+
+            Result = beamtalk_extensions:extensions_by(mylib),
+            %% Three extensions contributed by mylib across different classes.
+            ?assertEqual(3, length(Result)),
+            ?assert(lists:member({'Integer', double}, Result)),
+            ?assert(lists:member({'String', json}, Result)),
+            ?assert(lists:member({'Float', ceil}, Result))
+        end
+    end}.
+
+extensions_by_excludes_other_owners_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            Fun = fun([], X) -> X end,
+            beamtalk_extensions:register('Integer', 'double', Fun, mylib),
+            beamtalk_extensions:register('String', 'json', Fun, otherlib),
+            beamtalk_extensions:register('Float', 'ceil', Fun, mylib),
+
+            %% Only mylib's extensions, not otherlib's.
+            Result = beamtalk_extensions:extensions_by(mylib),
+            ?assertEqual(2, length(Result)),
+            ?assert(lists:member({'Integer', double}, Result)),
+            ?assert(lists:member({'Float', ceil}, Result)),
+            ?assertNot(lists:member({'String', json}, Result))
+        end
+    end}.
+
+extensions_by_no_match_returns_empty_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            Fun = fun([], X) -> X end,
+            beamtalk_extensions:register('Integer', 'double', Fun, mylib),
+
+            %% Unknown owner has no extensions.
+            ?assertEqual([], beamtalk_extensions:extensions_by(unknown_owner))
+        end
+    end}.
+
+%%% ============================================================================
+%%% BT-2202: Symmetric round-trip tests
+%%% ============================================================================
+
+extenders_of_extensions_by_round_trip_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_) ->
+        fun() ->
+            Fun = fun([], X) -> X end,
+            %% lib1 extends Integer and String.
+            beamtalk_extensions:register('Integer', 'double', Fun, lib1),
+            beamtalk_extensions:register('String', 'json', Fun, lib1),
+            %% lib2 extends Integer only.
+            beamtalk_extensions:register('Integer', 'triple', Fun, lib2),
+
+            %% extenders_of('Integer') should include both lib1 and lib2.
+            IntExtenders = beamtalk_extensions:extenders_of('Integer'),
+            ?assertEqual(2, length(IntExtenders)),
+            ?assert(lists:member(lib1, IntExtenders)),
+            ?assert(lists:member(lib2, IntExtenders)),
+
+            %% extenders_of('String') should include only lib1.
+            StrExtenders = beamtalk_extensions:extenders_of('String'),
+            ?assertEqual([lib1], StrExtenders),
+
+            %% extensions_by(lib1) should include both {Integer,double} and {String,json}.
+            Lib1Exts = beamtalk_extensions:extensions_by(lib1),
+            ?assertEqual(2, length(Lib1Exts)),
+            ?assert(lists:member({'Integer', double}, Lib1Exts)),
+            ?assert(lists:member({'String', json}, Lib1Exts)),
+
+            %% extensions_by(lib2) should include only {Integer,triple}.
+            Lib2Exts = beamtalk_extensions:extensions_by(lib2),
+            ?assertEqual([{'Integer', triple}], Lib2Exts),
+
+            %% Symmetry: every owner returned by extenders_of/1 for a class
+            %% must include that class in extensions_by/1 for that owner.
+            lists:foreach(
+                fun(Owner) ->
+                    OwnerExts = beamtalk_extensions:extensions_by(Owner),
+                    TargetClasses = [TC || {TC, _Sel} <- OwnerExts],
+                    ?assert(lists:member('Integer', TargetClasses))
+                end,
+                IntExtenders
+            )
+        end
+    end}.


### PR DESCRIPTION
## Summary

- Add `beamtalk_extensions:extenders_of/1` — given a target class name, returns unique owner atoms that contribute extensions to it (ETS scan, `O(table size)`)
- Add `beamtalk_extensions:extensions_by/1` — given an owner class name, returns `{TargetClass, Selector}` tuples for every extension it contributes (ETS fold)
- Both return `[]` when no match, never an error
- Expose both as `extendersOf:` and `extensionsBy:` methods on `SystemNavigation` via direct Erlang FFI calls, matching the existing pattern (`(Erlang beamtalk_extensions) list:`, `listAllWithSource`)
- Add 12 EUnit tests in `beamtalk_extensions_tests` covering: empty table, single extender, multiple extenders, deduplication of same-owner methods, cross-class isolation, and a symmetric round-trip test

## Test plan

- [x] `rebar3 eunit --module beamtalk_extensions_tests` — 44 tests, 0 failures (32 pre-existing + 12 new)
- [x] `just build` — all 77 stdlib modules compiled, including updated `SystemNavigation.bt`
- [x] `just clippy` — no warnings
- [x] `just test` — stdlib (250/250) and BUnit (1992/1994) pass; 4 pre-existing runtime EUnit failures unrelated to this change (confirmed same failures on main)

## Files changed

- `runtime/apps/beamtalk_runtime/src/beamtalk_extensions.erl` — two new exports with `-doc` and `-spec`
- `runtime/apps/beamtalk_runtime/test/beamtalk_extensions_tests.erl` — 12 new EUnit test cases
- `stdlib/src/SystemNavigation.bt` — `extendersOf:` and `extensionsBy:` methods
- `crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs` — auto-regenerated from stdlib build

Closes BT-2202.

https://claude.ai/code/session_01KMXoP8FzzDFgpbRQbEDeVC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `extenders_of/1` query function to retrieve all owners with extensions targeting a specific class
  * Added `extensions_by/1` query function to retrieve all extensions registered by a given owner

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->