### PR TITLE
Runtime: log compiler-port diagnostics in findSendersIn/findReferencesToIn helpers (BT-2219)

### DIFF
--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
@@ -33,6 +33,7 @@ dictionary or ETS state is required.
 """.
 
 -include_lib("beamtalk_runtime/include/beamtalk.hrl").
+-include_lib("kernel/include/logger.hrl").
 
 -export([dispatch/3]).
 %% Direct exports for Erlang FFI calls from sealed Object BeamtalkInterface
@@ -48,6 +49,11 @@ dictionary or ETS state is required.
     allSendsIn/1,
     findReferencesToIn/2
 ]).
+
+-ifdef(TEST).
+%% Expose internal helper for EUnit testing (BT-2219).
+-export([log_compiler_diagnostics/2]).
+-endif.
 
 %%% ============================================================================
 %%% dispatch/3 — called from compiled bt@stdlib@beamtalk_interface for @primitives
@@ -211,11 +217,14 @@ findSendersIn(Source, Selector) when
     case beamtalk_compiler:find_senders_in_source(Source, SelectorBin) of
         {ok, Lines} ->
             Lines;
-        {error, _Diagnostics} ->
-            %% Compiler port unavailable — degrade to "no senders found"
-            %% rather than crashing the caller. Iteration in `sendersOf:`
-            %% should not be aborted by a transient port failure on one
-            %% method's source.
+        {error, Diagnostics} ->
+            %% Log the diagnostics before returning []. We still return [] because
+            %% the per-method fault-tolerance contract is unchanged: a transient port
+            %% failure on one method's source must not abort the whole `sendersOf:`
+            %% iteration. The log exists for systemic-failure visibility — if the
+            %% compiler port is wedged, every call will emit a warning and operators
+            %% can see the pattern in the log rather than getting silently empty results.
+            log_compiler_diagnostics(Diagnostics, 'findSendersIn:selector:'),
             []
     end;
 findSendersIn(_Source, _Selector) ->
@@ -304,11 +313,14 @@ findReferencesToIn(Source, ClassName) when
     case beamtalk_compiler:find_references_to_in_source(Source, ClassNameBin) of
         {ok, Lines} ->
             Lines;
-        {error, _Diagnostics} ->
-            %% Compiler port unavailable — degrade to "no references found"
-            %% rather than crashing the caller. Iteration in `referencesTo:'
-            %% should not be aborted by a transient port failure on one
-            %% method's source.
+        {error, Diagnostics} ->
+            %% Log the diagnostics before returning []. We still return [] because
+            %% the per-method fault-tolerance contract is unchanged: a transient port
+            %% failure on one method's source must not abort the whole `referencesTo:'
+            %% iteration. The log exists for systemic-failure visibility — if the
+            %% compiler port is wedged, every call will emit a warning and operators
+            %% can see the pattern in the log rather than getting silently empty results.
+            log_compiler_diagnostics(Diagnostics, 'findReferencesToIn:class:'),
             []
     end;
 findReferencesToIn(_Source, _ClassName) ->
@@ -326,6 +338,46 @@ findReferencesToIn(_Source, _ClassName) ->
 %%% ============================================================================
 %%% Internal method implementations
 %%% ============================================================================
+
+-doc """
+Log compiler-port diagnostics at the appropriate OTP logger level.
+
+Called when `beamtalk_compiler' returns `{error, Diagnostics}' from a source-
+analysis call (find_senders_in_source, find_references_to_in_source, etc.).
+
+Uses `?LOG_ERROR' if the diagnostics indicate port unavailability (messages
+containing "not available" or "timed out"), `?LOG_WARNING' otherwise (e.g. a
+parse failure on a specific method's source).
+
+Includes `domain => [beamtalk, stdlib]' metadata on every log call per project
+convention (CLAUDE.md).
+""".
+-spec log_compiler_diagnostics([map()], atom()) -> ok.
+log_compiler_diagnostics(Diagnostics, Selector) ->
+    IsPortUnavailable = lists:any(
+        fun(D) ->
+            Msg = maps:get(message, D, <<>>),
+            is_binary(Msg) andalso
+                (binary:match(Msg, <<"not available">>) =/= nomatch orelse
+                    binary:match(Msg, <<"timed out">>) =/= nomatch)
+        end,
+        Diagnostics
+    ),
+    Meta = #{selector => Selector, diagnostics => Diagnostics, domain => [beamtalk, stdlib]},
+    case IsPortUnavailable of
+        true ->
+            ?LOG_ERROR(
+                "Compiler port unavailable in ~p — returning [] (per-method fault-tolerance preserved)",
+                [Selector],
+                Meta
+            );
+        false ->
+            ?LOG_WARNING(
+                "Compiler port returned diagnostics in ~p — returning [] (per-method fault-tolerance preserved)",
+                [Selector],
+                Meta
+            )
+    end.
 
 -doc "Format Erlang module help via beamtalk_erlang_help (dynamic call).".
 -spec handle_erlang_help(binary()) -> binary().

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
@@ -359,9 +359,15 @@ log_compiler_diagnostics(Diagnostics, Selector) ->
     IsPortUnavailable = lists:any(
         fun(D) ->
             Msg = maps:get(message, D, <<>>),
-            is_binary(Msg) andalso
-                (binary:match(Msg, <<"not available">>) =/= nomatch orelse
-                    binary:match(Msg, <<"timed out">>) =/= nomatch)
+            %% Lowercase before matching so capitalised variants (e.g. "Timed out")
+            %% are still classified as port-unavailability (error, not warning).
+            MsgLc =
+                case is_binary(Msg) of
+                    true -> string:lowercase(Msg);
+                    false -> <<>>
+                end,
+            binary:match(MsgLc, <<"not available">>) =/= nomatch orelse
+                binary:match(MsgLc, <<"timed out">>) =/= nomatch
         end,
         Diagnostics
     ),

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
@@ -222,8 +222,9 @@ findSendersIn(Source, Selector) when
             %% the per-method fault-tolerance contract is unchanged: a transient port
             %% failure on one method's source must not abort the whole `sendersOf:`
             %% iteration. The log exists for systemic-failure visibility — if the
-            %% compiler port is wedged, every call will emit a warning and operators
-            %% can see the pattern in the log rather than getting silently empty results.
+            %% compiler port is wedged, every call will emit a warning (or an
+            %% error for port-unavailability) and operators can see the pattern
+            %% in the log rather than getting silently empty results.
             log_compiler_diagnostics(Diagnostics, 'findSendersIn:selector:'),
             []
     end;
@@ -318,8 +319,9 @@ findReferencesToIn(Source, ClassName) when
             %% the per-method fault-tolerance contract is unchanged: a transient port
             %% failure on one method's source must not abort the whole `referencesTo:'
             %% iteration. The log exists for systemic-failure visibility — if the
-            %% compiler port is wedged, every call will emit a warning and operators
-            %% can see the pattern in the log rather than getting silently empty results.
+            %% compiler port is wedged, every call will emit a warning (or an
+            %% error for port-unavailability) and operators can see the pattern
+            %% in the log rather than getting silently empty results.
             log_compiler_diagnostics(Diagnostics, 'findReferencesToIn:class:'),
             []
     end;
@@ -363,20 +365,43 @@ log_compiler_diagnostics(Diagnostics, Selector) ->
         end,
         Diagnostics
     ),
+    %% Include a short summary in the message body itself: in text log mode the
+    %% handler template renders only `msg`, so the full `diagnostics` payload in
+    %% metadata is invisible there (it only shows up in structured/JSON logs).
+    Summary = summarise_diagnostics(Diagnostics),
     Meta = #{selector => Selector, diagnostics => Diagnostics, domain => [beamtalk, stdlib]},
     case IsPortUnavailable of
         true ->
             ?LOG_ERROR(
-                "Compiler port unavailable in ~p — returning [] (per-method fault-tolerance preserved)",
-                [Selector],
+                "Compiler port unavailable in ~p: ~ts — returning [] (per-method fault-tolerance preserved)",
+                [Selector, Summary],
                 Meta
             );
         false ->
             ?LOG_WARNING(
-                "Compiler port returned diagnostics in ~p — returning [] (per-method fault-tolerance preserved)",
-                [Selector],
+                "Compiler port returned diagnostics in ~p: ~ts — returning [] (per-method fault-tolerance preserved)",
+                [Selector, Summary],
                 Meta
             )
+    end.
+
+-doc "Build a short human-readable summary of compiler diagnostics for a log message body.".
+-spec summarise_diagnostics([map()]) -> binary().
+summarise_diagnostics([]) ->
+    <<"(no diagnostics)">>;
+summarise_diagnostics([First | Rest]) ->
+    MsgBin = diagnostic_message(First),
+    case Rest of
+        [] -> MsgBin;
+        _ -> iolist_to_binary([MsgBin, " (+", integer_to_binary(length(Rest)), " more)"])
+    end.
+
+-doc "Extract a diagnostic's `message` as a binary, falling back to a printed term.".
+-spec diagnostic_message(map()) -> binary().
+diagnostic_message(D) ->
+    case maps:get(message, D, <<"(no message)">>) of
+        Msg when is_binary(Msg) -> Msg;
+        Other -> iolist_to_binary(io_lib:format("~p", [Other]))
     end.
 
 -doc "Format Erlang module help via beamtalk_erlang_help (dynamic call).".

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_interface_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_interface_tests.erl
@@ -1,0 +1,149 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_interface_tests).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+EUnit tests for beamtalk_interface module.
+
+Tests log_compiler_diagnostics/2 (BT-2219): verifies that an OTP logger call
+fires at the appropriate level when the compiler port returns {error, Diagnostics}
+in findSendersIn/2 and findReferencesToIn/2, while [] is still returned
+(per-method fault-tolerance contract unchanged).
+""".
+
+%% Logger handler callback for log capture
+-export([log/2]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+%%% ============================================================================
+%%% Logger handler callback
+%%% ============================================================================
+
+%% Capture log events and forward to the test process.
+log(LogEvent, #{config := #{parent := Parent}}) ->
+    Parent ! {captured_log, LogEvent},
+    ok.
+
+%%% ============================================================================
+%%% Helpers
+%%% ============================================================================
+
+install_capture_handler() ->
+    HandlerId = beamtalk_interface_test_capture,
+    ok = logger:add_handler(HandlerId, ?MODULE, #{
+        config => #{parent => self()},
+        level => all
+    }),
+    %% Lower the primary logger level to 'all' so our capture handler receives
+    %% warning/error events. The sys.config for tests sets primary level to 'error'
+    %% to suppress noise; we restore it after the test.
+    #{level := OrigLevel} = logger:get_primary_config(),
+    ok = logger:set_primary_config(level, all),
+    {HandlerId, OrigLevel}.
+
+remove_capture_handler({HandlerId, OrigLevel}) ->
+    logger:remove_handler(HandlerId),
+    logger:set_primary_config(level, OrigLevel).
+
+%% Drain one log event from the mailbox that matches a given level.
+%% Returns {ok, LogEvent} | not_found.
+collect_log(Level, Timeout) ->
+    receive
+        {captured_log, #{level := Level} = E} ->
+            {ok, E};
+        {captured_log, _Other} ->
+            collect_log(Level, Timeout)
+    after Timeout ->
+        not_found
+    end.
+
+%%% ============================================================================
+%%% BT-2219: log_compiler_diagnostics/2 — warning for parse failure
+%%% ============================================================================
+
+log_compiler_diagnostics_warning_test() ->
+    %% Diagnostics that do NOT indicate port unavailability should trigger
+    %% a LOG_WARNING.
+    Handle = install_capture_handler(),
+    try
+        Diagnostics = [#{message => <<"Parse error: unexpected token">>}],
+        beamtalk_interface:log_compiler_diagnostics(Diagnostics, 'findSendersIn:selector:'),
+        Result = collect_log(warning, 500),
+        ?assertMatch({ok, _}, Result),
+        {ok, Event} = Result,
+        %% Verify domain metadata is present
+        #{meta := Meta} = Event,
+        ?assertEqual([beamtalk, stdlib], maps:get(domain, Meta))
+    after
+        remove_capture_handler(Handle)
+    end.
+
+%%% ============================================================================
+%%% BT-2219: log_compiler_diagnostics/2 — error for port unavailability
+%%% ============================================================================
+
+log_compiler_diagnostics_error_on_port_unavailable_test() ->
+    %% Diagnostics that indicate the compiler server is not available should
+    %% trigger a LOG_ERROR (not just a warning).
+    Handle = install_capture_handler(),
+    try
+        Diagnostics = [#{message => <<"Compiler server is not available">>}],
+        beamtalk_interface:log_compiler_diagnostics(Diagnostics, 'findReferencesToIn:class:'),
+        Result = collect_log(error, 500),
+        ?assertMatch({ok, _}, Result),
+        {ok, Event} = Result,
+        #{meta := Meta} = Event,
+        ?assertEqual([beamtalk, stdlib], maps:get(domain, Meta))
+    after
+        remove_capture_handler(Handle)
+    end.
+
+%%% ============================================================================
+%%% BT-2219: log_compiler_diagnostics/2 — error for port timeout
+%%% ============================================================================
+
+log_compiler_diagnostics_error_on_timeout_test() ->
+    %% "timed out" diagnostics also escalate to LOG_ERROR.
+    Handle = install_capture_handler(),
+    try
+        Diagnostics = [#{message => <<"Compiler server timed out">>}],
+        beamtalk_interface:log_compiler_diagnostics(Diagnostics, 'findSendersIn:selector:'),
+        Result = collect_log(error, 500),
+        ?assertMatch({ok, _}, Result),
+        {ok, Event} = Result,
+        #{meta := Meta} = Event,
+        ?assertEqual([beamtalk, stdlib], maps:get(domain, Meta))
+    after
+        remove_capture_handler(Handle)
+    end.
+
+%%% ============================================================================
+%%% BT-2219: findSendersIn/2 — still returns a list (happy path)
+%%% ============================================================================
+
+find_senders_in_returns_list_test() ->
+    %% Even when the compiler returns an error (here we rely on whatever the
+    %% compiler does with invalid source that cannot be parsed), findSendersIn/2
+    %% must return []. The per-method fault-tolerance contract is unchanged.
+    %%
+    %% With a running compiler server, calling with empty binary produces {ok, []}
+    %% (compiler returns empty senders for empty source), not an error. We test
+    %% the error path via log_compiler_diagnostics/2 directly (above).
+    %% This test confirms the happy-path return is still a list.
+    Result = beamtalk_interface:findSendersIn(<<"x + 1">>, <<"ifTrue:">>),
+    ?assert(is_list(Result)).
+
+%%% ============================================================================
+%%% BT-2219: findReferencesToIn/2 — still returns a list (happy path)
+%%% ============================================================================
+
+find_references_to_in_returns_list_test() ->
+    %% As above: the happy path returns a list. The error-path is tested via
+    %% log_compiler_diagnostics/2 directly.
+    Result = beamtalk_interface:findReferencesToIn(<<"x + 1">>, 'Integer'),
+    ?assert(is_list(Result)).

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_interface_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_interface_tests.erl
@@ -52,14 +52,27 @@ remove_capture_handler({HandlerId, OrigLevel}) ->
 
 %% Drain one log event from the mailbox that matches a given level.
 %% Returns {ok, LogEvent} | not_found.
+%% Uses a fixed deadline so non-matching events consume the timeout budget
+%% rather than resetting it on each recursion (avoids waiting far longer than
+%% Timeout under log noise).
 collect_log(Level, Timeout) ->
-    receive
-        {captured_log, #{level := Level} = E} ->
-            {ok, E};
-        {captured_log, _Other} ->
-            collect_log(Level, Timeout)
-    after Timeout ->
-        not_found
+    Deadline = erlang:monotonic_time(millisecond) + Timeout,
+    collect_log_until(Level, Deadline).
+
+collect_log_until(Level, Deadline) ->
+    Remaining = Deadline - erlang:monotonic_time(millisecond),
+    case Remaining =< 0 of
+        true ->
+            not_found;
+        false ->
+            receive
+                {captured_log, #{level := Level} = E} ->
+                    {ok, E};
+                {captured_log, _Other} ->
+                    collect_log_until(Level, Deadline)
+            after Remaining ->
+                not_found
+            end
     end.
 
 %%% ============================================================================
@@ -76,9 +89,11 @@ log_compiler_diagnostics_warning_test() ->
         Result = collect_log(warning, 500),
         ?assertMatch({ok, _}, Result),
         {ok, Event} = Result,
-        %% Verify domain metadata is present
+        %% Verify the log metadata carries domain, selector, and diagnostics payload
         #{meta := Meta} = Event,
-        ?assertEqual([beamtalk, stdlib], maps:get(domain, Meta))
+        ?assertEqual([beamtalk, stdlib], maps:get(domain, Meta)),
+        ?assertEqual('findSendersIn:selector:', maps:get(selector, Meta)),
+        ?assertEqual(Diagnostics, maps:get(diagnostics, Meta))
     after
         remove_capture_handler(Handle)
     end.
@@ -98,7 +113,9 @@ log_compiler_diagnostics_error_on_port_unavailable_test() ->
         ?assertMatch({ok, _}, Result),
         {ok, Event} = Result,
         #{meta := Meta} = Event,
-        ?assertEqual([beamtalk, stdlib], maps:get(domain, Meta))
+        ?assertEqual([beamtalk, stdlib], maps:get(domain, Meta)),
+        ?assertEqual('findReferencesToIn:class:', maps:get(selector, Meta)),
+        ?assertEqual(Diagnostics, maps:get(diagnostics, Meta))
     after
         remove_capture_handler(Handle)
     end.
@@ -117,7 +134,9 @@ log_compiler_diagnostics_error_on_timeout_test() ->
         ?assertMatch({ok, _}, Result),
         {ok, Event} = Result,
         #{meta := Meta} = Event,
-        ?assertEqual([beamtalk, stdlib], maps:get(domain, Meta))
+        ?assertEqual([beamtalk, stdlib], maps:get(domain, Meta)),
+        ?assertEqual('findSendersIn:selector:', maps:get(selector, Meta)),
+        ?assertEqual(Diagnostics, maps:get(diagnostics, Meta))
     after
         remove_capture_handler(Handle)
     end.


### PR DESCRIPTION
## Summary

- When `beamtalk_compiler` returns `{error, Diagnostics}` in `findSendersIn/2` and `findReferencesToIn/2`, the diagnostics payload is now logged via OTP logger before returning `[]`
- Port-unavailability diagnostics (messages containing "not available" or "timed out") escalate to `?LOG_ERROR`; parse errors use `?LOG_WARNING`
- All log calls include `domain => [beamtalk, stdlib]` per project convention
- The per-method fault-tolerance contract (return `[]`) is unchanged with an explanatory comment added

## Test plan

- [ ] `beamtalk_interface_tests` — 5 new EUnit tests verifying:
  - `?LOG_WARNING` fires for parse-error diagnostics with `domain => [beamtalk, stdlib]` metadata
  - `?LOG_ERROR` fires for "not available" diagnostics with correct metadata
  - `?LOG_ERROR` fires for "timed out" diagnostics
  - `findSendersIn/2` still returns a list on the happy path
  - `findReferencesToIn/2` still returns a list on the happy path
- [ ] All 5 tests pass: `rebar3 eunit --module=beamtalk_interface_tests`
- [ ] Erlang format check passes: `rebar3 fmt --check`
- [ ] Dialyzer clean: exit code 0

Fixes BT-2219, follow-up from PR #2239 (Copilot review feedback). Part of BT-2201 (SystemNavigation query API expansion).

https://claude.ai/code/session_01KMXoP8FzzDFgpbRQbEDeVC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compiler diagnostic messages from source analysis are now captured, summarized, and logged with appropriate severity. Logs include selector, diagnostics payload, and domain metadata while preserving existing degrade-on-error behavior.

* **Tests**
  * Added tests verifying diagnostic logging behavior, emitted log levels, included metadata, and normal "happy path" source-analysis results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->