### PR TITLE
Fix Windows nightly: append .exe to compiler-port path in port tests

### DIFF
--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
@@ -10,7 +10,13 @@
 compiler_binary() ->
     %% Look in target/debug from project root
     ProjectRoot = find_project_root(filename:absname("")),
-    Path = filename:join([ProjectRoot, "target", "debug", "beamtalk-compiler-port"]),
+    %% On Windows, executables have a .exe extension.
+    ExeName =
+        case os:type() of
+            {win32, _} -> "beamtalk-compiler-port.exe";
+            _ -> "beamtalk-compiler-port"
+        end,
+    Path = filename:join([ProjectRoot, "target", "debug", ExeName]),
     case filelib:is_regular(Path) of
         true -> Path;
         false -> error({compiler_not_found, Path})


### PR DESCRIPTION
The beamtalk_compiler_port_tests helper compiler_binary/0 built the dev
binary path as "beamtalk-compiler-port" with no extension, so on Windows
filelib:is_regular/1 missed the actual "beamtalk-compiler-port.exe" and
every test that opens a real port failed with {compiler_not_found, _}.

These tests were newly wired into CI (BT-2184, #2220), which is why the
nightly Windows run started failing on 2026-05-18. Mirror the .exe
handling already present in the production find_compiler_binary_dev/0.

https://claude.ai/code/session_01LWMq8urEE449K1dx6P7HZS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved compiler test suite with enhanced cross-platform compatibility to properly support Windows and other operating systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->