### PR TITLE
Fail loud on unmapped quoted @primitive in stdlib codegen (BT-2233)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -150,6 +150,28 @@ pub enum CodeGenError {
         span: Option<Span>,
     },
 
+    /// BT-2233: A quoted `@primitive "selector"` in a stdlib value-type class has
+    /// no inline BIF lowering registered in `generate_primitive_bif`. Without a
+    /// mapping it would silently fall back to runtime dispatch and raise
+    /// `does_not_understand` at runtime (the BT-2232 regression). Only raised in
+    /// stdlib mode; actor classes and a small set of call-site-intercepted
+    /// operations are exempt (see the guard in `generate_primitive`).
+    #[error(
+        "unmapped @primitive \"{selector}\" in class '{class}'{}: no inline BIF lowering registered. \
+         Add a mapping for {class}:{selector} in \
+         crates/beamtalk-core/src/codegen/core_erlang/primitives/, otherwise this method falls back \
+         to runtime dispatch and raises does_not_understand at runtime.",
+        DisplayOptionalSpan(.span)
+    )]
+    UnmappedPrimitive {
+        /// The defining class name.
+        class: String,
+        /// The quoted primitive selector with no inline BIF mapping.
+        selector: String,
+        /// Source span for rich error rendering (Miette / MCP).
+        span: Option<Span>,
+    },
+
     /// Internal code generation error.
     #[error("code generation error: {0}")]
     Internal(String),
@@ -2973,6 +2995,32 @@ impl CoreErlangGenerator {
             let params = self.current_method_params.clone();
             if let Some(code) = primitives::generate_primitive_bif(&class_name, name, &params) {
                 return Ok(code);
+            }
+
+            // BT-2233: An unmapped quoted @primitive in a stdlib value-type class
+            // is a bug — it would silently fall back to the runtime-dispatch path
+            // below and raise does_not_understand at runtime (the BT-2232
+            // regression). Fail the build instead. The check is scoped so it has
+            // no false positives:
+            //  - Stdlib mode only. User/FFI @primitive (via --allow-primitives)
+            //    keeps BT-938's warn-and-fallback behavior for runtime dispatch.
+            //  - Value-type context only. Actor classes legitimately route
+            //    unmapped quoted primitives through their hand-written
+            //    `beamtalk_X:dispatch` module (e.g. Actor's `actorPid`,
+            //    ReactiveSubprocess's `open:args:notify:`).
+            //  - Excluding a small set of call-site-intercepted reflective /
+            //    identity / dynamic operations whose method body is only a
+            //    runtime-dispatch placeholder (see
+            //    `primitives::is_runtime_dispatched_primitive`).
+            if self.stdlib_mode()
+                && self.context == CodeGenContext::ValueType
+                && !primitives::is_runtime_dispatched_primitive(&class_name, name)
+            {
+                return Err(CodeGenError::UnmappedPrimitive {
+                    class: class_name.clone(),
+                    selector: name.to_string(),
+                    span: Some(span),
+                });
             }
         }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -263,7 +263,8 @@ impl CodeGenError {
     /// - MCP: "line N, col C" format
     pub fn span(&self) -> Option<Span> {
         match self {
-            CodeGenError::UnsupportedFeature { span, .. } => *span,
+            CodeGenError::UnsupportedFeature { span, .. }
+            | CodeGenError::UnmappedPrimitive { span, .. } => *span,
             _ => None,
         }
     }

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/actor_types.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/actor_types.rs
@@ -26,6 +26,9 @@ pub(crate) fn generate_opaque_bif(
     match selector {
         "=:=" => binary_bif("=:=", params),
         "/=" => binary_bif("/=", params),
+        // BT-2233: strict-inequality completes the comparison set. For opaque
+        // identity types (Pid/Port/Reference) `=/=` is equivalent to `/=`.
+        "=/=" => binary_bif("=/=", params),
         "asString" => Some(Document::Str(to_string_fn)),
         "hash" => Some(Document::Str("call 'erlang':'phash2'(Self)")),
         _ => extra_selector(selector, params),
@@ -137,6 +140,31 @@ mod tests {
     #[test]
     fn test_no_extra_returns_none() {
         assert_eq!(doc_to_string(no_extra("anything", &[])), None);
+    }
+
+    // generate_opaque_bif comparison tests (BT-2233)
+
+    #[test]
+    fn test_opaque_strict_not_equal() {
+        // BT-2233: `=/=` completes the comparison set for opaque identity types.
+        let result = doc_to_string(generate_opaque_bif(
+            "=/=",
+            &["Other".to_string()],
+            "call 'beamtalk_opaque_ops':'pid_to_string'(Self)",
+            no_extra,
+        ));
+        assert_eq!(result, Some("call 'erlang':'=/='(Self, Other)".to_string()));
+    }
+
+    #[test]
+    fn test_opaque_not_equal() {
+        let result = doc_to_string(generate_opaque_bif(
+            "/=",
+            &["Other".to_string()],
+            "call 'beamtalk_opaque_ops':'pid_to_string'(Self)",
+            no_extra,
+        ));
+        assert_eq!(result, Some("call 'erlang':'/='(Self, Other)".to_string()));
     }
 
     // generate_future_bif tests

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/behaviour.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/behaviour.rs
@@ -30,6 +30,12 @@ const BEHAVIOUR_ZERO_ARG: &[&str] = &[
     "classAllSuperclasses",
     "classMethods",
     "classAllInstVarNames",
+    // BT-2233: `fieldNames`/`allFieldNames` lower through these intrinsics. They
+    // map 1:1 to `beamtalk_behaviour_intrinsics:classFieldNames/1` and
+    // `classAllFieldNames/1`; their omission was the same latent gap as the
+    // BT-2232 `className` bug (silent runtime-dispatch fallback otherwise).
+    "classFieldNames",
+    "classAllFieldNames",
     "classRemoveFromSystem",
     "classSourceFile",
     "classReload",
@@ -171,6 +177,26 @@ mod tests {
         assert_eq!(
             result,
             Some("call 'beamtalk_behaviour_intrinsics':'classInstVarNames'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_class_field_names() {
+        // BT-2233: `fieldNames` lowers via this Behaviour intrinsic.
+        let result = doc_to_string(generate_behaviour_bif("classFieldNames", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_behaviour_intrinsics':'classFieldNames'(Self)".to_string())
+        );
+    }
+
+    #[test]
+    fn test_class_all_field_names() {
+        // BT-2233: `allFieldNames` lowers via this Behaviour intrinsic.
+        let result = doc_to_string(generate_behaviour_bif("classAllFieldNames", &[]));
+        assert_eq!(
+            result,
+            Some("call 'beamtalk_behaviour_intrinsics':'classAllFieldNames'(Self)".to_string())
         );
     }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs
@@ -104,6 +104,38 @@ pub fn generate_primitive_bif(
     }
 }
 
+/// BT-2233: Quoted `@primitive "selector"` declarations that intentionally
+/// route through runtime dispatch instead of an inline BIF, so the fail-loud
+/// cross-check (and `generate_primitive`'s hard error in `mod.rs`) must not
+/// flag them as unmapped.
+///
+/// Each entry is `(defining class, quoted selector)`. These are
+/// call-site-intercepted reflective / identity / dynamic-dispatch operations:
+/// their compiled method body is only a placeholder reached via indirect
+/// dispatch (e.g. `perform:`), so the runtime-dispatch fallback is the correct
+/// lowering for that body. See `dispatch_codegen.rs`
+/// (`beamtalk_object_class:class_send/3`) and `operators.rs` (binary-operator
+/// interception).
+///
+/// Keep this list minimal: a quoted primitive that maps 1:1 to a runtime
+/// function should be added to a per-class BIF table instead, not here.
+const RUNTIME_DISPATCHED_PRIMITIVES: &[(&str, &str)] = &[
+    ("ProtoObject", "=="),
+    ("ProtoObject", "/="),
+    ("ProtoObject", "class"),
+    ("ProtoObject", "perform:withArguments:"),
+    ("ProtoObject", "perform:withArguments:timeout:"),
+    ("ProtoObject", "performLocally:withArguments:"),
+    ("Object", "class"),
+];
+
+/// Returns `true` if `(class_name, selector)` is an intentionally
+/// runtime-dispatched quoted primitive (see `RUNTIME_DISPATCHED_PRIMITIVES`).
+#[must_use]
+pub(crate) fn is_runtime_dispatched_primitive(class_name: &str, selector: &str) -> bool {
+    RUNTIME_DISPATCHED_PRIMITIVES.contains(&(class_name, selector))
+}
+
 // Shared helpers used by per-class modules
 
 /// Generates a comparison BIF call for the standard Erlang comparison operators.
@@ -2037,12 +2069,158 @@ mod tests {
     }
 
     #[test]
+    fn test_is_runtime_dispatched_primitive() {
+        // Allowlisted call-site-intercepted operations.
+        assert!(is_runtime_dispatched_primitive("ProtoObject", "class"));
+        assert!(is_runtime_dispatched_primitive(
+            "ProtoObject",
+            "perform:withArguments:"
+        ));
+        assert!(is_runtime_dispatched_primitive("Object", "class"));
+        // Not allowlisted: mapped primitives and unrelated pairs.
+        assert!(!is_runtime_dispatched_primitive("Integer", "+"));
+        assert!(!is_runtime_dispatched_primitive(
+            "Behaviour",
+            "classFieldNames"
+        ));
+        assert!(!is_runtime_dispatched_primitive(
+            "Object",
+            "perform:withArguments:"
+        ));
+    }
+
+    #[test]
     fn test_core_erlang_binary_string_multi_byte() {
         // "hi" = bytes [104, 105]
         let doc = core_erlang_binary_string("hi");
         assert_eq!(
             doc.to_pretty_string(),
             "#{#<104>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']])}#"
+        );
+    }
+
+    /// BT-2233: Cross-check that every quoted `@primitive "X"` declared in the
+    /// stdlib resolves to a registered inline BIF lowering. An unmapped quoted
+    /// primitive in a value-type class would silently fall back to runtime
+    /// dispatch and raise `does_not_understand` at runtime (the BT-2232
+    /// regression: moving `name` to Behaviour left `className` unmapped). This
+    /// fast `cargo test` catches such gaps before the slower stdlib build does.
+    ///
+    /// Exclusions, to avoid false positives (acceptance criterion 3):
+    /// - Unquoted `@primitive` (structural intrinsics) — handled by the compiler
+    ///   at the call site, never via `generate_primitive_bif`.
+    /// - Actor-backed classes — they legitimately route unmapped quoted
+    ///   primitives through their hand-written `beamtalk_X:dispatch/3` module
+    ///   (e.g. `Actor`'s `actorPid`, `ReactiveSubprocess`'s `open:args:notify:`).
+    #[test]
+    fn test_every_quoted_primitive_resolves_to_a_bif() {
+        use crate::ast::Expression;
+        use std::collections::HashMap;
+
+        let lib_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("stdlib/src");
+
+        if !lib_dir.exists() {
+            // Skip when stdlib sources aren't present (e.g. partial checkouts).
+            return;
+        }
+
+        // Parse every stdlib module once. Parse diagnostics are ignored — class
+        // and method structure (which is all we need) parses fine per-file, the
+        // same approach `primitive_bindings::load_from_directory` relies on.
+        let mut modules = Vec::new();
+        for entry in std::fs::read_dir(&lib_dir)
+            .expect("read stdlib/src")
+            .flatten()
+        {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("bt") {
+                continue;
+            }
+            let source = std::fs::read_to_string(&path).expect("read .bt file");
+            let tokens = crate::source_analysis::lex_with_eof(&source);
+            let (module, _diagnostics) = crate::source_analysis::parse(tokens);
+            modules.push(module);
+        }
+
+        // Build a class -> superclass map across all modules to classify
+        // actor-backed classes (mirrors the spirit of `is_actor_class`).
+        let mut superclass: HashMap<String, String> = HashMap::new();
+        for module in &modules {
+            for class in &module.classes {
+                superclass.insert(
+                    class.name.name.to_string(),
+                    class.superclass_name().to_string(),
+                );
+            }
+        }
+
+        let is_actor_backed = |start: &str| -> bool {
+            if start == "Actor" {
+                return true;
+            }
+            let mut current = start.to_string();
+            // Bounded walk guards against cycles in malformed hierarchies.
+            for _ in 0..64 {
+                match superclass.get(&current) {
+                    Some(parent) if parent == "Actor" => return true,
+                    Some(parent) if parent != "none" => current = parent.clone(),
+                    _ => return false,
+                }
+            }
+            false
+        };
+
+        let mut unmapped: Vec<String> = Vec::new();
+        for module in &modules {
+            for class in &module.classes {
+                let class_name = class.name.name.as_str();
+                if is_actor_backed(class_name) {
+                    continue;
+                }
+                for method in class.methods.iter().chain(class.class_methods.iter()) {
+                    if method.body.len() != 1 {
+                        continue;
+                    }
+                    let Expression::Primitive {
+                        name, is_quoted, ..
+                    } = &method.body[0].expression
+                    else {
+                        continue;
+                    };
+                    if !is_quoted {
+                        continue;
+                    }
+                    if is_runtime_dispatched_primitive(class_name, name.as_str()) {
+                        continue;
+                    }
+                    // Mirror the real codegen path: `current_method_params` holds
+                    // one entry per method parameter (names are irrelevant here).
+                    let params: Vec<String> = (0..method.parameters.len())
+                        .map(|i| format!("Arg{i}"))
+                        .collect();
+                    if generate_primitive_bif(class_name, name.as_str(), &params).is_none() {
+                        unmapped.push(format!(
+                            "{class_name}:{name} (arity {})",
+                            method.parameters.len()
+                        ));
+                    }
+                }
+            }
+        }
+        unmapped.sort();
+
+        assert!(
+            unmapped.is_empty(),
+            "Quoted @primitive selectors with no inline BIF lowering in \
+             generate_primitive_bif. These would silently fall back to runtime \
+             dispatch and raise does_not_understand at runtime (BT-2232/BT-2233). \
+             Add a mapping in the relevant primitives/*.rs table:\n  {}",
+            unmapped.join("\n  ")
         );
     }
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs
@@ -2115,7 +2115,7 @@ mod tests {
     #[test]
     fn test_every_quoted_primitive_resolves_to_a_bif() {
         use crate::ast::Expression;
-        use std::collections::HashMap;
+        use std::collections::{HashMap, HashSet};
 
         let lib_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
@@ -2176,12 +2176,16 @@ mod tests {
         };
 
         let mut unmapped: Vec<String> = Vec::new();
+        // Every quoted (class, primitive) pair seen, for the allowlist-rot check.
+        let mut all_quoted: HashSet<(String, String)> = HashSet::new();
         for module in &modules {
             for class in &module.classes {
                 let class_name = class.name.name.as_str();
-                if is_actor_backed(class_name) {
-                    continue;
-                }
+                // Mirror `is_actor_class`: actor classes (by chain) and concrete
+                // supervisor subclasses compile as actors, so their unmapped
+                // quoted primitives route through hand-written dispatch.
+                let is_concrete_supervisor = class.supervisor_kind.is_some() && !class.is_abstract;
+                let actor_backed = is_concrete_supervisor || is_actor_backed(class_name);
                 for method in class.methods.iter().chain(class.class_methods.iter()) {
                     if method.body.len() != 1 {
                         continue;
@@ -2195,7 +2199,8 @@ mod tests {
                     if !is_quoted {
                         continue;
                     }
-                    if is_runtime_dispatched_primitive(class_name, name.as_str()) {
+                    all_quoted.insert((class_name.to_string(), name.to_string()));
+                    if actor_backed || is_runtime_dispatched_primitive(class_name, name.as_str()) {
                         continue;
                     }
                     // Mirror the real codegen path: `current_method_params` holds
@@ -2221,6 +2226,24 @@ mod tests {
              dispatch and raise does_not_understand at runtime (BT-2232/BT-2233). \
              Add a mapping in the relevant primitives/*.rs table:\n  {}",
             unmapped.join("\n  ")
+        );
+
+        // BT-2233: Keep the allowlist honest — a stale entry (for a quoted
+        // primitive that no longer exists in the stdlib) would silently mask a
+        // future unmapped-primitive bug. Every allowlist entry must still
+        // correspond to a real quoted @primitive declaration.
+        let stale: Vec<String> = RUNTIME_DISPATCHED_PRIMITIVES
+            .iter()
+            .filter(|(class, selector)| {
+                !all_quoted.contains(&((*class).to_string(), (*selector).to_string()))
+            })
+            .map(|(class, selector)| format!("{class}:{selector}"))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "RUNTIME_DISPATCHED_PRIMITIVES has stale entries with no matching \
+             quoted @primitive in the stdlib (remove them):\n  {}",
+            stale.join("\n  ")
         );
     }
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -2259,7 +2259,9 @@ sealed Object subclass: Foo
 fn test_bt2233_unmapped_quoted_primitive_warns_outside_stdlib_mode() {
     // BT-2233: Outside stdlib mode (e.g. user FFI @primitive via
     // --allow-primitives) the BT-938 warn-and-fallback path is preserved — the
-    // strict failure is scoped to the stdlib build it protects.
+    // strict failure is scoped to the stdlib build it protects. The binding
+    // table knows a different class, so `bt@stdlib@foo` is absent and BT-938
+    // emits a warning (not a hard error).
     let src = "
 sealed Object subclass: Foo
   doIt => @primitive \"doIt\"
@@ -2267,11 +2269,26 @@ sealed Object subclass: Foo
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _diags) = crate::source_analysis::parse(tokens);
 
-    let options = CodegenOptions::new("bt@stdlib@foo");
+    let other_src = "
+sealed Object subclass: Bar
+  barOp => @primitive \"barOp\"
+";
+    let other_tokens = crate::source_analysis::lex_with_eof(other_src);
+    let (other_module, _) = crate::source_analysis::parse(other_tokens);
+    let mut table = primitive_bindings::PrimitiveBindingTable::new();
+    table.add_from_module(&other_module); // only Bar is known; Foo is absent
+
+    let options = CodegenOptions::new("bt@stdlib@foo").with_bindings(table);
     let result = generate_module_with_warnings(&module, options);
+    let generated = result
+        .expect("non-stdlib quoted @primitive must not hard-error (BT-938 warn-and-fallback)");
     assert!(
-        result.is_ok(),
-        "non-stdlib quoted @primitive should not hard-error (BT-938 warn-and-fallback)"
+        generated
+            .warnings
+            .iter()
+            .any(|w| w.message.contains("bt@stdlib@foo")),
+        "expected a BT-938 warning about the absent module, got: {:?}",
+        generated.warnings
     );
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -2233,6 +2233,49 @@ sealed Object subclass: Other
 }
 
 #[test]
+fn test_bt2233_unmapped_quoted_primitive_errors_in_stdlib_mode() {
+    // BT-2233: In stdlib mode, a quoted @primitive in a value-type class with no
+    // inline BIF lowering is a hard error (naming class + selector) instead of a
+    // silent runtime-dispatch fallback that DNUs at runtime (the BT-2232 bug).
+    let src = "
+sealed Object subclass: Foo
+  doIt => @primitive \"doIt\"
+";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+
+    let options = CodegenOptions::new("bt@stdlib@foo").with_stdlib_mode(true);
+    let result = generate_module_with_warnings(&module, options);
+    let err = result.expect_err("unmapped quoted @primitive must fail the stdlib build");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("doIt"),
+        "error should name the selector: {msg}"
+    );
+    assert!(msg.contains("Foo"), "error should name the class: {msg}");
+}
+
+#[test]
+fn test_bt2233_unmapped_quoted_primitive_warns_outside_stdlib_mode() {
+    // BT-2233: Outside stdlib mode (e.g. user FFI @primitive via
+    // --allow-primitives) the BT-938 warn-and-fallback path is preserved — the
+    // strict failure is scoped to the stdlib build it protects.
+    let src = "
+sealed Object subclass: Foo
+  doIt => @primitive \"doIt\"
+";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+
+    let options = CodegenOptions::new("bt@stdlib@foo");
+    let result = generate_module_with_warnings(&module, options);
+    assert!(
+        result.is_ok(),
+        "non-stdlib quoted @primitive should not hard-error (BT-938 warn-and-fallback)"
+    );
+}
+
+#[test]
 fn test_repl_expression_spawn_uses_class_module_index() {
     // When a REPL expression like `Counter spawn` is compiled in a workspace
     // with package "getting_started", the class_module_index must be consulted


### PR DESCRIPTION
## Summary

A quoted `@primitive "X"` with no inline BIF lowering used to silently fall back to runtime dispatch and raise `does_not_understand` at runtime — the BT-2232 regression (moving `name` to `Behaviour` left `className` unmapped). This makes the stdlib build **fail loud** instead, plus a fast unit-test cross-check.

Linear: https://linear.app/beamtalk/issue/BT-2233

## Key changes

- **Hard compile error** (`mod.rs`): new `CodeGenError::UnmappedPrimitive` (names class + selector + span), raised from `generate_primitive`. Scoped to avoid false positives:
  - **stdlib mode only** — user/FFI `@primitive` (via `--allow-primitives`) keeps BT-938 warn-and-fallback.
  - **value-type context only** — actor classes legitimately route unmapped quoted primitives through hand-written `beamtalk_X:dispatch` (e.g. `Actor`'s `actorPid`, `ReactiveSubprocess`'s `open:args:notify:`).
  - excludes a small `RUNTIME_DISPATCHED_PRIMITIVES` allowlist of call-site-intercepted reflective/identity/dynamic ops (ProtoObject `==`/`/=`/`class`/`perform:*`, `Object class`) whose method body is only a placeholder.
- **Cross-check unit test** `test_every_quoted_primitive_resolves_to_a_bif`: parses all stdlib `.bt`, asserts every quoted primitive resolves to a registered lowering, excluding actor/supervisor classes and the allowlist. Also guards against allowlist rot (stale entries).
- **Fixed two pre-existing mapping gaps the check surfaced**: `Behaviour fieldNames`/`allFieldNames` now lower to `beamtalk_behaviour_intrinsics` (matching their siblings); opaque-type `=/=` for `Pid`/`Port`/`Reference`.

## Acceptance criteria

- ✅ Build-time + unit-test cross-check that every quoted `@primitive` resolves to a registered lowering.
- ✅ Unmapped quoted `@primitive` produces a clear compile error naming class + selector.
- ✅ Distinguishes legitimately runtime-dispatched / unquoted primitives — no false positives.
- ◻️ (Nice-to-have) Dead-entry detection for `match`-arm per-class tables not implemented (would need those tables to become enumerable data); the allowlist-rot guard covers the practical case.

## Test plan

- [x] `just build` — stdlib compiles with the hard error active
- [x] `just test` — Rust + stdlib (250) + BUnit (1992) + runtime EUnit (3823+1289), 0 failures
- [x] `just clippy`, `just fmt-check`
- [x] New unit tests: hard-error (stdlib vs non-stdlib), allowlist helper, new BIF mappings, stdlib-wide cross-check

https://claude.ai/code/session_01LbbuYpMBnnLbN6Y92caQzB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbbuYpMBnnLbN6Y92caQzB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Code generation now surfaces a clear error (including class and selector) when an unmapped quoted primitive is encountered in stdlib value-type compilation, instead of falling back silently.

* **New Features**
  * Added mapping for strict-inequality in opaque identity operations.
  * Behaviour intrinsics expanded to expose field-name queries for introspection.

* **Tests**
  * New regression and integration-style tests cover stdlib vs non-stdlib codegen behavior and validate the allowlist of intentionally runtime-dispatched primitives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->