### PR TITLE
docs: daily refresh 2026-05-22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 - **`SystemNavigation unimplementedSelectors`** — returns selectors that are *sent* somewhere in the loaded registry but *defined* nowhere — a typo-finder lint. Each result is a `#{#selector, #sites}` record where each site has `#{#class, #selector, #line}` for IDE jump-to-source. Excludes Erlang FFI sends, `doesNotUnderstand:args:` DNU dispatchers, and parse-recovery phantoms to minimize false positives (BT-2206).
 - **`SystemNavigation unusedSelectors`** — returns selectors *defined* on some class but *sent* nowhere — dead-method candidates. Each result is a `#{#class, #selector}` record (class object for instance-side, metaclass for class-side). Conservatively excludes runtime-called overrides (`initialize`, `printString`, `hash`, etc.), TestCase lifecycle methods (`setUp`/`tearDown`/`test*`), and `@primitive`/`@intrinsic` methods (BT-2207).
 - **`Behaviour >> superclassChain`** — returns the chain from self up to and including `Object` as a list. Self is at the head; `Object` is at the tail. For metaclass receivers, walks the parallel metaclass hierarchy: `Counter class superclassChain` returns `[Counter class, Actor class, Object class]` (BT-2189).
+- **`Behaviour >> name` promoted from `Class`** — `name` now lives on `Behaviour` (the abstract superclass of `Class` and `Metaclass`) so registry walks holding the `Behaviour` type can read it without `@expect dnu`. `Metaclass >> name` now returns a `Symbol` (e.g. `#'Integer class'`) instead of a `String`, matching `Class >> name` (BT-2232).
+- **`SystemNavigation actorClasses`** — returns every class whose superclass chain includes `Actor`, sorted alphabetically. Includes `Actor` itself; returns `[]` if `Actor` is not loaded (BT-2209).
+- **`SystemNavigation dnuHandlers`** — returns every class that locally overrides `doesNotUnderstand:args:` (the DNU handler), sorted alphabetically. Useful for identifying proxy/builder/DSL classes that absorb arbitrary sends (BT-2210).
+- **`SystemNavigation extendersOf:`** / **`extensionsBy:`** — reverse extension-method navigation. `extendersOf: aClass` returns the packages contributing extension methods to `aClass`; `extensionsBy: aPackage` returns `#{#class, #selector}` records for each extension method a package contributes (BT-2212).
+- **`SystemNavigation selectorsMatching:` performance** — accumulator changed from O(n²) left-append to O(n) right-append. No behavior change (BT-2218).
 
 ### Runtime
 
@@ -29,6 +34,7 @@
 - Fix `findClass:` not resolving metaclass display tags — `findClass: #'Integer class'` now returns the metaclass object instead of `nil`, so stdlib code no longer needs string surgery to resolve metaclass names (BT-2223).
 - Consolidate three hot class-metadata ETS tables (`beamtalk_class_module_table`, `beamtalk_class_methods_table`, `beamtalk_class_hierarchy_table`) into a single `beamtalk_class_metadata` table with typed field accessors. One atomic insert/delete per class instead of three; `inherits_from/2` reads via `ets:lookup_element/4` for ~10–14% speedup on the per-exception-match hot path (BT-2222).
 - **`beamtalk_extensions:extenders_of/1`** and **`extensions_by/1`** — reverse-index queries for extension methods. `extenders_of(ClassName)` returns unique owner atoms contributing extensions to a target class; `extensions_by(OwnerName)` returns `{TargetClass, Selector}` tuples for every extension an owner contributes (BT-2202).
+- Compiler-port diagnostics in `findSendersIn`/`findReferencesToIn` now logged via OTP logger instead of silently discarded — port-unavailability escalates to `?LOG_ERROR`, parse errors use `?LOG_WARNING`, all with `domain => [beamtalk, stdlib]` metadata (BT-2219).
 
 ### Tooling
 
@@ -61,6 +67,8 @@
 - Replace `format!()` violations with `Document`/`docvec!` API in `value_type_codegen.rs` module header — continues the BT-875 cleanup (BT-2181).
 - Resolve type references into preloaded modules — `resolve_remote_type` for `:erlang` and other preloaded modules now reads type specs from the BEAM binary via `code:get_object_code/1` instead of returning `Dynamic` (BT-2185).
 - Remove three duplicate Erlang string escape implementations in beamtalk-cli — consolidated onto `escape_for_erlang_string` from `erlang_eval.rs` (BT-2224).
+- Unmapped quoted `@primitive` in stdlib value-type codegen now fails the build with a clear error naming class + selector, instead of silently falling back to runtime dispatch (BT-2233).
+- Shared `beamtalk_error:raise_type_error/3` extracted from five stdlib modules — zero behavior change (BT-2229).
 
 ## 0.4.0 — 2026-04-27
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -2590,7 +2590,7 @@ nav dnuHandlers
 // => [ErlangModule, ProtoObject, TimeoutProxy, ...]
 
 nav extendersOf: String
-// => [(Package named: "my_lib"), ...]
+// => [Package(my_lib v1.0.0), ...]
 
 nav extensionsBy: (Package named: "my_lib")
 // => [#{#class => String, #selector => #asJson}, ...]

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -2541,6 +2541,10 @@ class registry. Reach the singleton via `SystemNavigation default`.
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `allClasses` | `List(Behaviour)` | All registered classes (class objects) |
+| `actorClasses` | `List(Behaviour)` | Classes whose superclass chain includes `Actor`, sorted alphabetically |
+| `dnuHandlers` | `List(Behaviour)` | Classes that locally override `doesNotUnderstand:args:`, sorted alphabetically |
+| `extendersOf: aClass` | `List(Package)` | Packages contributing extension methods to `aClass` |
+| `extensionsBy: aPackage` | `List(Dictionary)` | `#{#class, #selector}` for each extension method `aPackage` contributes |
 | `implementorsOf: #sel` | `List(Behaviour)` | Classes that define the given selector |
 | `sendersOf: #sel` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method body that sends `#sel` |
 | `referencesTo: aClass` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method body that references the class name |
@@ -2578,6 +2582,18 @@ nav unimplementedSelectors
 
 nav unusedSelectors
 // => [#{#class => MyLib, #selector => #helperNoOneCalls}, ...]
+
+nav actorClasses
+// => [Actor, ClassBuilder, MyActor, ...]
+
+nav dnuHandlers
+// => [ErlangModule, ProtoObject, TimeoutProxy, ...]
+
+nav extendersOf: String
+// => [(Package named: "my_lib"), ...]
+
+nav extensionsBy: (Package named: "my_lib")
+// => [#{#class => String, #selector => #asJson}, ...]
 ```
 
 ### REPL shortcuts (`:` commands) are thin wrappers


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 12 commits merged to `main` since the last refresh (2026-05-21).

### Commits reviewed and doc changes

| Commit | Title | Doc change |
|--------|-------|------------|
| `5a027f0` | Stdlib: SystemNavigation extendersOf: / extensionsBy: (BT-2212) | CHANGELOG "Standard Library" + language features table + examples |
| `cacfeef` | Stdlib: SystemNavigation dnuHandlers (BT-2210) | CHANGELOG "Standard Library" + language features table + examples |
| `fedb12c` | Stdlib: SystemNavigation actorClasses (BT-2209) | CHANGELOG "Standard Library" + language features table + examples |
| `bbf0237` | Refactor: promote Behaviour name (BT-2232) | CHANGELOG "Standard Library" (Behaviour>>name promotion, Metaclass>>name returns Symbol) |
| `53e7c69` | Stdlib: optimise selectorsMatching: accumulator (BT-2218) | CHANGELOG "Standard Library" (performance note) |
| `ed61550` | Runtime: log compiler-port diagnostics (BT-2219) | CHANGELOG "Runtime" |
| `849bc75` | Fail loud on unmapped quoted @primitive (BT-2233) | CHANGELOG "Internal" |
| `f125365` | Extract shared raise_type_error/3 (BT-2229) | CHANGELOG "Internal" |

### Skipped (test-only / internal-only, no doc impact)

| Commit | Title | Reason |
|--------|-------|--------|
| `7026a00` | Fix Windows nightly: append .exe to compiler-port path | Test-only (`runtime/apps/*/test/`) |
| `dc15602` | Tests: stabilise SystemNavigation E2E tests (BT-2220) | Test-only (`tests/repl-protocol/`) |
| `9904e77` | Replace placeholder assertions in tracing.btscript (BT-2231) | Test-only (`tests/repl-protocol/`) |
| `249f3d5` | Add unit tests for TestResult accessors (BT-2230) | Test-only (`runtime/apps/*/test/`) |

### Files updated

- **CHANGELOG.md** — 8 new entries under Unreleased (6 Standard Library, 1 Runtime, 2 Internal)
- **docs/beamtalk-language-features.md** — 4 new rows in SystemNavigation method table + 4 new examples

### Needs human judgment

None — all commits had clear diffs with unambiguous user-visible semantics.

https://claude.ai/code/session_01KxuYwPDHAicnxeeRw4z5zN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxuYwPDHAicnxeeRw4z5zN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SystemNavigation adds new query methods for system introspection.

* **Improvements**
  * Selector-matching algorithm documented as now linear-time for better performance.
  * Compiler diagnostics and logging coverage expanded to surface previously ignored issues.
  * Build-time checks strengthened to fail clearly on certain malformed primitives.

* **Documentation**
  * Language features docs updated with new API entries and REPL-style examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->