### PR TITLE
Extract setUp/tearDown in actor_monitor_test.bt (BT-2237)

### DIFF
--- a/stdlib/test/actor_monitor_test.bt
+++ b/stdlib/test/actor_monitor_test.bt
@@ -4,33 +4,31 @@
 // BT-1442: Tests for Actor monitor/pid/onExit: process monitoring API
 
 TestCase subclass: ActorMonitorTest
+  field: counter = nil
+
+  setUp => self withCounter: Counter spawn
+
+  tearDown => self.counter isNil ifFalse: [self.counter isAlive ifTrue: [self.counter stop]]
 
   testPidReturnsAPid =>
-    counter := Counter spawn
-    rawPid := counter pid
+    rawPid := self.counter pid
     self assert: rawPid class equals: Pid
     self assert: rawPid isAlive
-    counter stop
 
   testMonitorReturnsReference =>
-    counter := Counter spawn
-    ref := counter monitor
+    ref := self.counter monitor
     self assert: ref class equals: Reference
     ref demonitor
-    counter stop
 
   testDemonitorCancelsMonitor =>
-    counter := Counter spawn
-    ref := counter monitor
+    ref := self.counter monitor
     result := ref demonitor
     self assert: result
-    counter stop
 
   testOnExitCallsBlockOnActorDeath =>
-    counter := Counter spawn
     exitCounter := AtomicCounter new: #actorMonitorTestExit
-    counter onExit: [:_reason | exitCounter increment]
-    counter stop
+    self.counter onExit: [:_reason | exitCounter increment]
+    self.counter stop
     // Poll with bounded wait instead of fixed sleep (avoids timing flakiness)
     50 timesRepeat: [exitCounter value < 1 ifTrue: [Timer sleep: 10]]
     self assert: exitCounter value equals: 1
@@ -38,27 +36,22 @@ TestCase subclass: ActorMonitorTest
 
   testMultipleOnExitCallbacks =>
     // Multiple onExit: callbacks can be registered on the same actor
-    counter := Counter spawn
     exitCounter := AtomicCounter new: #actorMonitorTestMulti
-    counter onExit: [:_reason | exitCounter increment]
-    counter onExit: [:_reason | exitCounter increment]
-    counter stop
+    self.counter onExit: [:_reason | exitCounter increment]
+    self.counter onExit: [:_reason | exitCounter increment]
+    self.counter stop
     // Poll with bounded wait instead of fixed sleep
     50 timesRepeat: [exitCounter value < 2 ifTrue: [Timer sleep: 10]]
     self assert: exitCounter value equals: 2
     exitCounter delete
 
   testRespondsToMonitorMethods =>
-    counter := Counter spawn
-    self assert: (counter respondsTo: #pid)
-    self assert: (counter respondsTo: #monitor)
-    self assert: (counter respondsTo: #onExit:)
-    counter stop
+    self assert: (self.counter respondsTo: #pid)
+    self assert: (self.counter respondsTo: #monitor)
+    self assert: (self.counter respondsTo: #onExit:)
 
   testErlangMonitorWithActorProxy =>
     // Direct Erlang FFI monitor should work with actor proxy (auto-coercion)
-    counter := Counter spawn
-    ref := Erlang erlang monitor: #process arg: counter
+    ref := Erlang erlang monitor: #process arg: self.counter
     self assert: ref class equals: Reference
     Erlang erlang demonitor: ref
-    counter stop

--- a/stdlib/test/actor_monitor_test.bt
+++ b/stdlib/test/actor_monitor_test.bt
@@ -8,10 +8,7 @@ TestCase subclass: ActorMonitorTest
 
   setUp => self withCounter: Counter spawn
 
-  tearDown =>
-    self.counter isNil ifFalse: [
-      self.counter isAlive ifTrue: [self.counter stop]
-    ]
+  tearDown => self.counter isNil ifFalse: [self.counter stop]
 
   testPidReturnsAPid =>
     rawPid := self.counter pid

--- a/stdlib/test/actor_monitor_test.bt
+++ b/stdlib/test/actor_monitor_test.bt
@@ -8,7 +8,10 @@ TestCase subclass: ActorMonitorTest
 
   setUp => self withCounter: Counter spawn
 
-  tearDown => self.counter isNil ifFalse: [self.counter isAlive ifTrue: [self.counter stop]]
+  tearDown =>
+    self.counter isNil ifFalse: [
+      self.counter isAlive ifTrue: [self.counter stop]
+    ]
 
   testPidReturnsAPid =>
     rawPid := self.counter pid


### PR DESCRIPTION
## Summary

- Extract repeated `counter := Counter spawn` (7 occurrences) and `counter stop` (5 cleanup occurrences) into `setUp`/`tearDown` lifecycle methods
- Follows the established BUnit pattern used by `atomic_counter_test.bt` and `do_accumulator_test.bt`
- `tearDown` guards with `isNil`/`isAlive` so tests that stop the counter internally (onExit callback tests) don't double-stop

## Test plan

- [x] `just test-bunit` passes (2013 tests, 0 failures)
- [x] All 7 test methods in ActorMonitorTest still exercise the same assertions
- [x] Beamtalk formatter check passes

https://linear.app/beamtalk/issue/BT-2237/extract-setupteardown-in-actor-monitor-testbt

https://claude.ai/code/session_016wuU8AcE2A2oTDEagdWaLn

---
_Generated by [Claude Code](https://claude.ai/code/session_016wuU8AcE2A2oTDEagdWaLn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored actor monitor tests to share a single actor instance initialized in test setup and cleaned up in teardown, centralizing lifecycle management.
  * Updated monitor/demonitor and exit-callback tests to use the shared actor; exit-triggering tests still explicitly stop the actor.
  * Adjusted foreign-interface monitor test to target the shared actor.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->