### PR TITLE
Add encode_error/2,4,5 wrappers to beamtalk_repl_json

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_json.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_json.erl
@@ -30,7 +30,8 @@ Uses OTP `json` module (OTP 27+) for encoding/decoding.
     term_to_json/1,
     format_error_message/1,
     parse_json/1,
-    encode_reloaded/4, encode_reloaded/5
+    encode_reloaded/4, encode_reloaded/5,
+    encode_error/2, encode_error/4, encode_error/5
 ]).
 
 %%% JSON Parsing
@@ -243,6 +244,28 @@ encode_reloaded(Classes, ActorCount, MigrationFailures, Msg, Warnings) ->
 -spec maybe_add_warnings_reloaded(map(), [binary()]) -> map().
 maybe_add_warnings_reloaded(Map, []) -> Map;
 maybe_add_warnings_reloaded(Map, Warnings) -> Map#{<<"warnings">> => Warnings}.
+
+-doc "Encode an error response using the REPL error formatter.".
+-spec encode_error(term(), beamtalk_repl_protocol:protocol_msg()) -> binary().
+encode_error(Err, Msg) ->
+    beamtalk_repl_protocol:encode_error(Err, Msg, fun format_error_message/1).
+
+-doc "Encode an error response with captured stdout and warnings using the REPL error formatter.".
+-spec encode_error(term(), beamtalk_repl_protocol:protocol_msg(), binary(), [binary()]) -> binary().
+encode_error(Err, Msg, Output, Warnings) ->
+    beamtalk_repl_protocol:encode_error(Err, Msg, fun format_error_message/1, Output, Warnings).
+
+-doc """
+Encode an error response with captured stdout, warnings, and extra metadata fields
+using the REPL error formatter.
+""".
+-spec encode_error(
+    term(), beamtalk_repl_protocol:protocol_msg(), binary(), [binary()], map()
+) -> binary().
+encode_error(Err, Msg, Output, Warnings, Metadata) ->
+    beamtalk_repl_protocol:encode_error(
+        Err, Msg, fun format_error_message/1, Output, Warnings, Metadata
+    ).
 
 %%% Term-to-JSON Conversion
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_actors.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_actors.erl
@@ -27,9 +27,7 @@ encode_invalid_pid_error(Reason, PidStr, Msg) ->
         Err1,
         <<"Use :actors to list valid actor PIDs.">>
     ),
-    beamtalk_repl_protocol:encode_error(
-        Err2, Msg, fun beamtalk_repl_json:format_error_message/1
-    ).
+    beamtalk_repl_json:encode_error(Err2, Msg).
 
 -doc "Handle actors/inspect/kill/interrupt ops.".
 -spec handle(binary(), map(), beamtalk_repl_protocol:protocol_msg(), pid()) -> binary().
@@ -79,9 +77,7 @@ handle(<<"inspect">>, Params, Msg, _SessionPid) ->
                                 Err3,
                                 iolist_to_binary([<<"Failed to inspect actor: ">>, PidBin])
                             ),
-                            beamtalk_repl_protocol:encode_error(
-                                Err4, Msg, fun beamtalk_repl_json:format_error_message/1
-                            )
+                            beamtalk_repl_json:encode_error(Err4, Msg)
                     end;
                 false ->
                     Err3 = beamtalk_error:new(actor_not_alive, 'Actor'),
@@ -89,9 +85,7 @@ handle(<<"inspect">>, Params, Msg, _SessionPid) ->
                         Err3,
                         iolist_to_binary([<<"Actor is not alive: ">>, PidBin])
                     ),
-                    beamtalk_repl_protocol:encode_error(
-                        Err4, Msg, fun beamtalk_repl_json:format_error_message/1
-                    )
+                    beamtalk_repl_json:encode_error(Err4, Msg)
             end
     end;
 handle(<<"kill">>, Params, Msg, _SessionPid) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -171,8 +171,8 @@ handle(<<"erlang-help">>, Params, Msg, _SessionPid) ->
             Err = beamtalk_error:new(invalid_argument, 'REPL'),
             Err1 = beamtalk_error:with_message(Err, <<"Module name required">>),
             Err2 = beamtalk_error:with_hint(Err1, <<"Usage: :help Erlang <module>">>),
-            beamtalk_repl_protocol:encode_error(
-                Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Err2, Msg
             );
         _ ->
             %% Use binary_to_existing_atom to prevent atom table exhaustion
@@ -244,8 +244,8 @@ handle(<<"show-codegen">>, Params, Msg, SessionPid) ->
                 Err1,
                 <<"Provide 'class' along with 'selector' to inspect a specific method.">>
             ),
-            beamtalk_repl_protocol:encode_error(
-                Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Err2, Msg
             );
         _ ->
             case {ClassBin, CodeBin} of
@@ -260,8 +260,8 @@ handle(<<"show-codegen">>, Params, Msg, SessionPid) ->
                             Err2 = beamtalk_error:with_hint(
                                 Err1, <<"Enter an expression to compile.">>
                             ),
-                            beamtalk_repl_protocol:encode_error(
-                                Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+                            beamtalk_repl_json:encode_error(
+                                Err2, Msg
                             );
                         _ ->
                             case beamtalk_repl_shell:show_codegen(SessionPid, Code) of
@@ -271,10 +271,9 @@ handle(<<"show-codegen">>, Params, Msg, SessionPid) ->
                                     WrappedReason = beamtalk_repl_errors:ensure_structured_error(
                                         ErrorReason
                                     ),
-                                    beamtalk_repl_protocol:encode_error(
+                                    beamtalk_repl_json:encode_error(
                                         WrappedReason,
                                         Msg,
-                                        fun beamtalk_repl_json:format_error_message/1,
                                         <<>>,
                                         Warnings
                                     )
@@ -287,8 +286,8 @@ handle(<<"show-codegen">>, Params, Msg, SessionPid) ->
                         Err1,
                         <<"Provide 'code' to compile an expression, or 'class' to inspect a loaded class.">>
                     ),
-                    beamtalk_repl_protocol:encode_error(
-                        Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+                    beamtalk_repl_json:encode_error(
+                        Err2, Msg
                     )
             end
     end;
@@ -326,8 +325,8 @@ handle(<<"list-classes">>, Params, Msg, SessionPid) ->
                 hint = undefined,
                 details = #{}
             },
-            beamtalk_repl_protocol:encode_error(
-                Error, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Error, Msg
             );
         _ ->
             case
@@ -348,8 +347,8 @@ handle(<<"list-classes">>, Params, Msg, SessionPid) ->
                 end
             of
                 {error, Error} ->
-                    beamtalk_repl_protocol:encode_error(
-                        Error, Msg, fun beamtalk_repl_json:format_error_message/1
+                    beamtalk_repl_json:encode_error(
+                        Error, Msg
                     );
                 {ok, ClassPids} ->
                     %% BT-2091: Fetch session-scoped data once for all classes.
@@ -437,16 +436,16 @@ handle(<<"test">>, Params, Msg, _SessionPid) ->
             Err1 = beamtalk_error:with_message(
                 Err0, <<"'class' and 'file' are mutually exclusive">>
             ),
-            beamtalk_repl_protocol:encode_error(
-                Err1, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Err1, Msg
             );
         {undefined, FP} when FP =/= undefined, not is_binary(FP) ->
             Err0 = beamtalk_error:new(invalid_argument, 'TestRunner'),
             Err1 = beamtalk_error:with_message(
                 Err0, <<"'file' must be a binary path">>
             ),
-            beamtalk_repl_protocol:encode_error(
-                Err1, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Err1, Msg
             );
         {undefined, FP} when FP =/= undefined ->
             run_test_op_file(FP, Msg);
@@ -503,18 +502,16 @@ show_codegen_class_method(ClassBin, SelectorBin, Msg) ->
     %% BT-1659: Support package-qualified class names (e.g. "json@Parser")
     case resolve_qualified_class_name(ClassBin) of
         {error, badarg} ->
-            beamtalk_repl_protocol:encode_error(
+            beamtalk_repl_json:encode_error(
                 make_class_not_found_error(ClassBin),
-                Msg,
-                fun beamtalk_repl_json:format_error_message/1
+                Msg
             );
         {ok, ClassAtom} ->
             case beamtalk_runtime_api:whereis_class(ClassAtom) of
                 undefined ->
-                    beamtalk_repl_protocol:encode_error(
+                    beamtalk_repl_json:encode_error(
                         make_class_not_found_error(ClassBin),
-                        Msg,
-                        fun beamtalk_repl_json:format_error_message/1
+                        Msg
                     );
                 ClassPid ->
                     %% Guard all ClassPid gen_server calls against unload/reload races.
@@ -531,10 +528,9 @@ show_codegen_class_method(ClassBin, SelectorBin, Msg) ->
                         end
                     catch
                         exit:{noproc, _} ->
-                            beamtalk_repl_protocol:encode_error(
+                            beamtalk_repl_json:encode_error(
                                 make_class_not_found_error(ClassBin),
-                                Msg,
-                                fun beamtalk_repl_json:format_error_message/1
+                                Msg
                             );
                         exit:{timeout, _} ->
                             Err0 = beamtalk_error:new(runtime_error, ClassAtom),
@@ -546,8 +542,8 @@ show_codegen_class_method(ClassBin, SelectorBin, Msg) ->
                                     <<"' is not responding (may be under heavy load)">>
                                 ])
                             ),
-                            beamtalk_repl_protocol:encode_error(
-                                Err1, Msg, fun beamtalk_repl_json:format_error_message/1
+                            beamtalk_repl_json:encode_error(
+                                Err1, Msg
                             )
                     end
             end
@@ -592,8 +588,8 @@ compile_class_source(ClassBin, ClassAtom, ClassPid, Msg) ->
                     <<". Class may have been defined inline.">>
                 ])
             ),
-            beamtalk_repl_protocol:encode_error(
-                Err1, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Err1, Msg
             );
         {ok, SourceBin} ->
             case beamtalk_repl_compiler:compile_file_for_codegen(SourceBin, CompilePath) of
@@ -601,8 +597,8 @@ compile_class_source(ClassBin, ClassAtom, ClassPid, Msg) ->
                     encode_codegen_response(CoreErlang, Warnings, Msg);
                 {error, ErrorReason} ->
                     WrappedReason = beamtalk_repl_errors:ensure_structured_error(ErrorReason),
-                    beamtalk_repl_protocol:encode_error(
-                        WrappedReason, Msg, fun beamtalk_repl_json:format_error_message/1
+                    beamtalk_repl_json:encode_error(
+                        WrappedReason, Msg
                     )
             end;
         {error, Reason} ->
@@ -613,8 +609,8 @@ compile_class_source(ClassBin, ClassAtom, ClassPid, Msg) ->
                     io_lib:format("Cannot read source file ~s: ~p", [SourcePath, Reason])
                 )
             ),
-            beamtalk_repl_protocol:encode_error(
-                Err1, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Err1, Msg
             )
     end.
 
@@ -655,8 +651,8 @@ validate_selector_if_present(ClassBin, ClassAtom, ClassPid, SelectorBin, Msg) ->
                 ])
             ),
             {error,
-                beamtalk_repl_protocol:encode_error(
-                    Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+                beamtalk_repl_json:encode_error(
+                    Err2, Msg
                 )}
     end.
 
@@ -684,8 +680,8 @@ run_test_op(undefined, Msg) ->
         beamtalk_repl_protocol:encode_test_results(TestResult, Msg)
     catch
         error:#{error := #beamtalk_error{} = Err} ->
-            beamtalk_repl_protocol:encode_error(
-                Err, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Err, Msg
             );
         _Class:Reason ->
             ?LOG_ERROR("test-all op failed: ~p", [Reason], #{domain => [beamtalk, runtime]}),
@@ -693,17 +689,16 @@ run_test_op(undefined, Msg) ->
             Err1 = beamtalk_error:with_message(
                 Err0, iolist_to_binary(io_lib:format("Test run failed: ~p", [Reason]))
             ),
-            beamtalk_repl_protocol:encode_error(
-                Err1, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Err1, Msg
             )
     end;
 run_test_op(ClassName, Msg) when is_binary(ClassName) ->
     case beamtalk_repl_errors:safe_to_existing_atom(ClassName) of
         {error, badarg} ->
-            beamtalk_repl_protocol:encode_error(
+            beamtalk_repl_json:encode_error(
                 make_class_not_found_error(ClassName),
-                Msg,
-                fun beamtalk_repl_json:format_error_message/1
+                Msg
             );
         {ok, ClassAtom} ->
             try
@@ -711,8 +706,8 @@ run_test_op(ClassName, Msg) when is_binary(ClassName) ->
                 beamtalk_repl_protocol:encode_test_results(TestResult, Msg)
             catch
                 error:#{error := #beamtalk_error{} = Err} ->
-                    beamtalk_repl_protocol:encode_error(
-                        Err, Msg, fun beamtalk_repl_json:format_error_message/1
+                    beamtalk_repl_json:encode_error(
+                        Err, Msg
                     );
                 _Class:Reason ->
                     ?LOG_ERROR("test op failed for ~s: ~p", [ClassName, Reason], #{
@@ -725,8 +720,8 @@ run_test_op(ClassName, Msg) when is_binary(ClassName) ->
                             io_lib:format("Test run failed for ~s: ~p", [ClassName, Reason])
                         )
                     ),
-                    beamtalk_repl_protocol:encode_error(
-                        Err1, Msg, fun beamtalk_repl_json:format_error_message/1
+                    beamtalk_repl_json:encode_error(
+                        Err1, Msg
                     )
             end
     end.
@@ -744,8 +739,8 @@ run_test_op_file(FilePath, Msg) ->
         beamtalk_repl_protocol:encode_test_results(TestResult, Msg)
     catch
         error:#{error := #beamtalk_error{} = Err} ->
-            beamtalk_repl_protocol:encode_error(
-                Err, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Err, Msg
             );
         _Class:Reason ->
             ?LOG_ERROR("test file op failed for ~s: ~p", [FilePath, Reason], #{
@@ -758,8 +753,8 @@ run_test_op_file(FilePath, Msg) ->
                     io_lib:format("Test run failed for file ~s: ~p", [FilePath, Reason])
                 )
             ),
-            beamtalk_repl_protocol:encode_error(
-                Err1, Msg, fun beamtalk_repl_json:format_error_message/1
+            beamtalk_repl_json:encode_error(
+                Err1, Msg
             )
     end.
 
@@ -2021,6 +2016,6 @@ format_erlang_not_found_error(What, Hint, Msg) ->
         Err, iolist_to_binary([What, <<" not found">>])
     ),
     Err2 = beamtalk_error:with_hint(Err1, Hint),
-    beamtalk_repl_protocol:encode_error(
-        Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+    beamtalk_repl_json:encode_error(
+        Err2, Msg
     ).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
@@ -23,9 +23,7 @@ handle(<<"eval">>, Params, Msg, SessionPid) ->
             Err = beamtalk_error:new(empty_expression, 'REPL'),
             Err1 = beamtalk_error:with_message(Err, <<"Empty expression">>),
             Err2 = beamtalk_error:with_hint(Err1, <<"Enter an expression to evaluate.">>),
-            beamtalk_repl_protocol:encode_error(
-                Err2, Msg, fun beamtalk_repl_json:format_error_message/1
-            );
+            beamtalk_repl_json:encode_error(Err2, Msg);
         _ when Trace ->
             case beamtalk_repl_shell:eval_trace(SessionPid, Code) of
                 {ok, Steps, Output, Warnings} ->
@@ -34,13 +32,7 @@ handle(<<"eval">>, Params, Msg, SessionPid) ->
                     );
                 {error, ErrorReason, Output, Warnings} ->
                     WrappedReason = beamtalk_repl_errors:ensure_structured_error(ErrorReason),
-                    beamtalk_repl_protocol:encode_error(
-                        WrappedReason,
-                        Msg,
-                        fun beamtalk_repl_json:format_error_message/1,
-                        Output,
-                        Warnings
-                    )
+                    beamtalk_repl_json:encode_error(WrappedReason, Msg, Output, Warnings)
             end;
         _ ->
             case beamtalk_repl_shell:eval(SessionPid, Code) of
@@ -50,13 +42,7 @@ handle(<<"eval">>, Params, Msg, SessionPid) ->
                     );
                 {error, ErrorReason, Output, Warnings} ->
                     WrappedReason = beamtalk_repl_errors:ensure_structured_error(ErrorReason),
-                    beamtalk_repl_protocol:encode_error(
-                        WrappedReason,
-                        Msg,
-                        fun beamtalk_repl_json:format_error_message/1,
-                        Output,
-                        Warnings
-                    )
+                    beamtalk_repl_json:encode_error(WrappedReason, Msg, Output, Warnings)
             end
     end;
 handle(<<"clear">>, _Params, Msg, SessionPid) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
@@ -288,9 +288,7 @@ handle(<<"load-project">>, Params, Msg, SessionPid) ->
     },
     case sync_project(Path, Options) of
         {error, Err} ->
-            beamtalk_repl_protocol:encode_error(
-                Err, Msg, fun beamtalk_repl_json:format_error_message/1
-            );
+            beamtalk_repl_json:encode_error(Err, Msg);
         {ok, Result} ->
             Base = beamtalk_repl_protocol:base_response(Msg),
             DepErrors = maps:get(dep_errors, Result, []),
@@ -318,9 +316,7 @@ handle(<<"load-source">>, Params, Msg, SessionPid) ->
             Err = beamtalk_error:new(empty_expression, 'REPL'),
             Err1 = beamtalk_error:with_message(Err, <<"Empty source">>),
             Err2 = beamtalk_error:with_hint(Err1, <<"Enter Beamtalk source code to compile.">>),
-            beamtalk_repl_protocol:encode_error(
-                Err2, Msg, fun beamtalk_repl_json:format_error_message/1
-            );
+            beamtalk_repl_json:encode_error(Err2, Msg);
         _ ->
             case beamtalk_repl_shell:load_source(SessionPid, Source) of
                 {ok, Classes} ->
@@ -330,9 +326,7 @@ handle(<<"load-source">>, Params, Msg, SessionPid) ->
                     );
                 {error, Reason} ->
                     WrappedReason = beamtalk_repl_errors:ensure_structured_error(Reason),
-                    beamtalk_repl_protocol:encode_error(
-                        WrappedReason, Msg, fun beamtalk_repl_json:format_error_message/1
-                    )
+                    beamtalk_repl_json:encode_error(WrappedReason, Msg)
             end
     end;
 handle(<<"unload">>, Params, Msg, SessionPid) ->
@@ -346,9 +340,7 @@ handle(<<"unload">>, Params, Msg, SessionPid) ->
                 Err0,
                 iolist_to_binary([<<"Class not found: '">>, ClassNameBin, <<"'">>])
             ),
-            beamtalk_repl_protocol:encode_error(
-                Err1, Msg, fun beamtalk_repl_json:format_error_message/1
-            );
+            beamtalk_repl_json:encode_error(Err1, Msg);
         {ok, ClassName} ->
             case beamtalk_runtime_api:remove_class_from_system(ClassName) of
                 {ok, ModuleName} ->
@@ -363,9 +355,7 @@ handle(<<"unload">>, Params, Msg, SessionPid) ->
                         fun beamtalk_repl_json:term_to_json/1
                     );
                 {error, Err} ->
-                    beamtalk_repl_protocol:encode_error(
-                        Err, Msg, fun beamtalk_repl_json:format_error_message/1
-                    )
+                    beamtalk_repl_json:encode_error(Err, Msg)
             end
     end.
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_session.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_session.erl
@@ -52,9 +52,7 @@ handle(<<"clone">>, _Params, Msg, _SessionPid) ->
                     io_lib:format("~p", [Reason])
                 ])
             ),
-            beamtalk_repl_protocol:encode_error(
-                Err1, Msg, fun beamtalk_repl_json:format_error_message/1
-            )
+            beamtalk_repl_json:encode_error(Err1, Msg)
     end;
 handle(<<"close">>, _Params, Msg, _SessionPid) ->
     beamtalk_repl_protocol:encode_status(ok, Msg, fun beamtalk_repl_json:term_to_json/1);
@@ -96,9 +94,5 @@ handle(<<"shutdown">>, Params, Msg, _SessionPid) ->
             Err2 = beamtalk_error:with_hint(
                 Err1, <<"Provide the correct node cookie for shutdown.">>
             ),
-            beamtalk_repl_protocol:encode_error(
-                Err2,
-                Msg,
-                fun beamtalk_repl_json:format_error_message/1
-            )
+            beamtalk_repl_json:encode_error(Err2, Msg)
     end.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
@@ -381,9 +381,7 @@ handle_protocol_request(Msg, SessionPid) ->
                 domain => [beamtalk, runtime]
             }),
             WrappedReason = beamtalk_repl_errors:ensure_structured_error(Reason, Class),
-            beamtalk_repl_protocol:encode_error(
-                WrappedReason, Msg, fun beamtalk_repl_json:format_error_message/1
-            )
+            beamtalk_repl_json:encode_error(WrappedReason, Msg)
     end.
 
 -doc """
@@ -451,9 +449,7 @@ handle_op(Op, _Params, Msg, _SessionPid) ->
         Err0,
         iolist_to_binary([<<"Unknown operation: ">>, Op])
     ),
-    beamtalk_repl_protocol:encode_error(
-        Err1, Msg, fun beamtalk_repl_json:format_error_message/1
-    ).
+    beamtalk_repl_json:encode_error(Err1, Msg).
 
 %%% Protocol Parsing and Formatting
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
@@ -142,10 +142,9 @@ websocket_info(
 ->
     WrappedReason = beamtalk_repl_errors:ensure_structured_error(Reason),
     Location = extract_compile_error_location(Reason),
-    Response = beamtalk_repl_protocol:encode_error(
+    Response = beamtalk_repl_json:encode_error(
         WrappedReason,
         Msg,
-        fun beamtalk_repl_json:format_error_message/1,
         Output,
         Warnings,
         Location
@@ -477,8 +476,8 @@ handle_eval_async(Msg, SessionPid, State = #ws_state{pending_eval = undefined}) 
                     Err = beamtalk_error:new(empty_expression, 'REPL'),
                     Err1 = beamtalk_error:with_message(Err, <<"Empty expression">>),
                     Err2 = beamtalk_error:with_hint(Err1, <<"Enter an expression to evaluate.">>),
-                    Response = beamtalk_repl_protocol:encode_error(
-                        Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+                    Response = beamtalk_repl_json:encode_error(
+                        Err2, Msg
                     ),
                     {[{text, Response}], State};
                 _ ->
@@ -496,8 +495,8 @@ handle_eval_async(Msg, SessionPid, State = #ws_state{pending_eval = undefined}) 
                                 Err1,
                                 <<"Reconnect and retry the evaluation.">>
                             ),
-                            Response = beamtalk_repl_protocol:encode_error(
-                                Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+                            Response = beamtalk_repl_json:encode_error(
+                                Err2, Msg
                             ),
                             {[{text, Response}], State}
                     end
@@ -506,8 +505,8 @@ handle_eval_async(Msg, SessionPid, State = #ws_state{pending_eval = undefined}) 
             Err = beamtalk_error:new(invalid_code, 'REPL'),
             Err1 = beamtalk_error:with_message(Err, <<"Invalid code type">>),
             Err2 = beamtalk_error:with_hint(Err1, <<"Code must be a string.">>),
-            Response = beamtalk_repl_protocol:encode_error(
-                Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+            Response = beamtalk_repl_json:encode_error(
+                Err2, Msg
             ),
             {[{text, Response}], State}
     end;
@@ -516,8 +515,8 @@ handle_eval_async(Msg, _SessionPid, State) ->
     Err = beamtalk_error:new(eval_busy, 'REPL'),
     Err1 = beamtalk_error:with_message(Err, <<"An evaluation is already in progress">>),
     Err2 = beamtalk_error:with_hint(Err1, <<"Use Ctrl-C to interrupt the current evaluation.">>),
-    Response = beamtalk_repl_protocol:encode_error(
-        Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+    Response = beamtalk_repl_json:encode_error(
+        Err2, Msg
     ),
     {[{text, Response}], State}.
 
@@ -550,8 +549,8 @@ handle_stdin(
             Err2 = beamtalk_error:with_hint(
                 Err1, <<"Send {\"op\": \"stdin\", \"value\": \"your input\\n\"}">>
             ),
-            Response = beamtalk_repl_protocol:encode_error(
-                Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+            Response = beamtalk_repl_json:encode_error(
+                Err2, Msg
             ),
             {[{text, Response}], State}
     end;
@@ -560,8 +559,8 @@ handle_stdin(Msg, State) ->
     Err = beamtalk_error:new(no_pending_input, 'REPL'),
     Err1 = beamtalk_error:with_message(Err, <<"No pending input request">>),
     Err2 = beamtalk_error:with_hint(Err1, <<"stdin op is only valid after a need-input status.">>),
-    Response = beamtalk_repl_protocol:encode_error(
-        Err2, Msg, fun beamtalk_repl_json:format_error_message/1
+    Response = beamtalk_repl_json:encode_error(
+        Err2, Msg
     ),
     {[{text, Response}], State}.
 


### PR DESCRIPTION
## Summary

- Adds `encode_error/2`, `encode_error/4`, and `encode_error/5` convenience wrappers to `beamtalk_repl_json`, pre-binding `fun format_error_message/1` — mirroring the existing `encode_reloaded/4,5` pattern
- Updates all 47 call sites across 7 workspace modules that previously repeated the constant formatter argument (extends BT-2235's original 15-site/5-module scope to include the 25 identical-pattern sites in `beamtalk_repl_ops_dev` and 7 in `beamtalk_ws_handler`)
- Net result: 101 insertions, 124 deletions — less code, same behavior

## Files Changed

| File | Change |
|------|--------|
| `beamtalk_repl_json.erl` | +3 exported functions with `-doc`/`-spec` |
| `beamtalk_repl_ops_eval.erl` | 3 substitutions (1× /2, 2× /4) |
| `beamtalk_repl_ops_load.erl` | 5 substitutions (all /2) |
| `beamtalk_repl_ops_session.erl` | 2 substitutions (all /2) |
| `beamtalk_repl_server.erl` | 2 substitutions (all /2) |
| `beamtalk_repl_ops_actors.erl` | 3 substitutions (all /2) |
| `beamtalk_repl_ops_dev.erl` | 25 substitutions (24× /2, 1× /4) |
| `beamtalk_ws_handler.erl` | 7 substitutions (6× /2, 1× /5) |

## Test plan

- [x] `just test` — Rust all green, stdlib 250/250, BUnit 2011/2011, runtime 3823+1289 tests, 0 failures
- [x] `just dialyzer` — clean, no warnings
- [x] `just test-repl-protocol` — 3/3 passed
- [x] `just fmt-check` — clean
- [x] `erlc +strong_validation` on all 8 modified files — exit 0

Closes BT-2235

https://claude.ai/code/session_01W3v17b9qqaEm7VTq8ZdCc4

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3v17b9qqaEm7VTq8ZdCc4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined error message handling across the system for improved consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->