### PR TITLE
docs: document remaining SystemNavigation query methods

### DIFF
--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -2548,13 +2548,19 @@ class registry. Reach the singleton via `SystemNavigation default`.
 | `implementorsOf: #sel` | `List(Behaviour)` | Classes that define the given selector |
 | `sendersOf: #sel` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method body that sends `#sel` |
 | `referencesTo: aClass` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method body that references the class name |
+| `ffiSitesFor: aSpec` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method body that calls Erlang `module:function` (optionally arity-qualified, e.g. `"lists:reverse/1"`) |
+| `fieldReadersOf: #slot in: aClass` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method that reads instance field `#slot` (scopes `aClass` + subclasses) |
+| `fieldWritersOf: #slot in: aClass` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method that writes (assigns) instance field `#slot` |
 | `methodsMatching: aRegex` | `List(Dictionary)` | `#{#class, #selector}` for every method whose source matches the regex |
 | `selectorsMatching: pattern` | `List(Symbol)` | Selectors matching a case-insensitive substring (e.g., `"print"`) |
 | `selectorsForClass: aClass` | `List(Symbol)` | All selectors defined on a class (instance + class + extension) |
+| `classesInPackage: aPackage` | `List(Behaviour)` | Class objects belonging to package `aPackage` (Symbol or String; ADR 0070) |
+| `subclassesOf: aClass in: aPackage` | `List(Behaviour)` | Subclasses of `aClass` that live in package `aPackage` (`allSubclasses` filtered by package) |
 | `unimplementedSelectors` | `List(Dictionary)` | Selectors sent but defined nowhere — a typo-finder lint |
 | `unusedSelectors` | `List(Dictionary)` | Selectors defined but sent nowhere — dead-method candidates |
 
-Body-based queries (`sendersOf:`, `referencesTo:`, `methodsMatching:`, and the
+Body-based queries (`sendersOf:`, `referencesTo:`, `ffiSitesFor:`,
+`fieldReadersOf:in:`, `fieldWritersOf:in:`, `methodsMatching:`, and the
 selector-lint queries) scan instance-side, class-side, and extension method
 bodies. Each result's `#class` field is the class object for an instance-side
 hit and the metaclass object (`Counter class`) for a class-side hit.
@@ -2594,6 +2600,21 @@ nav extendersOf: String
 
 nav extensionsBy: (Package named: "my_lib")
 // => [#{#class => String, #selector => #asJson}, ...]
+
+nav classesInPackage: #stdlib
+// => [Actor, Array, ...]
+
+nav subclassesOf: Number in: #stdlib
+// => [Float, Integer]
+
+nav fieldReadersOf: #value in: Counter
+// => [#{#class => Counter, #selector => #getValue, #line => 5}, ...]
+
+nav fieldWritersOf: #value in: Counter
+// => [#{#class => Counter, #selector => #increment, #line => 3}, ...]
+
+nav ffiSitesFor: "lists:reverse"
+// => [#{#class => MyList, #selector => #reversed, #line => 7}, ...]
 ```
 
 ### REPL shortcuts (`:` commands) are thin wrappers

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -2549,8 +2549,8 @@ class registry. Reach the singleton via `SystemNavigation default`.
 | `sendersOf: #sel` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method body that sends `#sel` |
 | `referencesTo: aClass` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method body that references the class name |
 | `ffiSitesFor: aSpec` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method body that calls Erlang `module:function` (optionally arity-qualified, e.g. `"lists:reverse/1"`) |
-| `fieldReadersOf: #slot in: aClass` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method that reads instance field `#slot` (scopes `aClass` + subclasses) |
-| `fieldWritersOf: #slot in: aClass` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method that writes (assigns) instance field `#slot` |
+| `fieldReadersOf: #slot in: aClass` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method that reads field/class var `#slot` while scanning `aClass` + subclasses on instance and class sides |
+| `fieldWritersOf: #slot in: aClass` | `List(Dictionary)` | `#{#class, #selector, #line}` for every method that writes field/class var `#slot` while scanning `aClass` + subclasses on instance and class sides |
 | `methodsMatching: aRegex` | `List(Dictionary)` | `#{#class, #selector}` for every method whose source matches the regex |
 | `selectorsMatching: pattern` | `List(Symbol)` | Selectors matching a case-insensitive substring (e.g., `"print"`) |
 | `selectorsForClass: aClass` | `List(Symbol)` | All selectors defined on a class (instance + class + extension) |
@@ -2560,10 +2560,12 @@ class registry. Reach the singleton via `SystemNavigation default`.
 | `unusedSelectors` | `List(Dictionary)` | Selectors defined but sent nowhere — dead-method candidates |
 
 Body-based queries (`sendersOf:`, `referencesTo:`, `ffiSitesFor:`,
-`fieldReadersOf:in:`, `fieldWritersOf:in:`, `methodsMatching:`, and the
-selector-lint queries) scan instance-side, class-side, and extension method
-bodies. Each result's `#class` field is the class object for an instance-side
-hit and the metaclass object (`Counter class`) for a class-side hit.
+`methodsMatching:`, and the selector-lint queries) scan instance-side,
+class-side, and extension method bodies. `fieldReadersOf:in:` and
+`fieldWritersOf:in:` scan `aClass` + subclasses on instance/class sides (not
+extension methods). Each result's `#class` field is the class object for an
+instance-side hit and the metaclass object (`Counter class`) for a class-side
+hit.
 
 ```beamtalk
 nav := SystemNavigation default


### PR DESCRIPTION
## Summary

The `SystemNavigation` reference table in `docs/beamtalk-language-features.md` had drifted behind the implementation — five shipped query methods were missing. This adds them with accurate return shapes, examples, and updates the body-based-queries note.

Methods added to the table:
- `ffiSitesFor: aSpec` → `List(Dictionary)` (`#{#class, #selector, #line}`)
- `fieldReadersOf: #slot in: aClass` → `List(Dictionary)`
- `fieldWritersOf: #slot in: aClass` → `List(Dictionary)`
- `classesInPackage: aPackage` → `List(Behaviour)`
- `subclassesOf: aClass in: aPackage` → `List(Behaviour)`

Also extended the "body-based queries" note to list `ffiSitesFor:`, `fieldReadersOf:in:`, and `fieldWritersOf:in:`, and added matching examples to the code block.

Docs-only change; no code or behaviour affected.

## Test plan

- [ ] Confirm the new table rows match the signatures in `stdlib/src/SystemNavigation.bt` (`classesInPackage:` L219, `subclassesOf:in:` L242, `fieldReadersOf:in:` L562, `fieldWritersOf:in:` L594, `ffiSitesFor:` L750)
- [ ] Render `docs/beamtalk-language-features.md` and verify the table and example block format correctly

https://claude.ai/code/session_013EStTm1zVeiqqLNJJCLcZ9

---
_Generated by [Claude Code](https://claude.ai/code/session_013EStTm1zVeiqqLNJJCLcZ9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for three new cross-class query APIs in the SystemNavigation section.
  * Clarified how body-based queries scan classes, subclasses, and instance/class sides (excluding extension method bodies).
  * Expanded examples showing usage patterns and example result shapes to aid codebase inspection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->