### PR TITLE
Extract shared codegen test helper (BT-2247)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/conditionals.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/conditionals.rs
@@ -603,15 +603,7 @@ impl CoreErlangGenerator {
 
 #[cfg(test)]
 mod tests {
-    fn codegen(src: &str) -> String {
-        let tokens = crate::source_analysis::lex_with_eof(src);
-        let (module, _) = crate::source_analysis::parse(tokens);
-        crate::codegen::core_erlang::generate_module(
-            &module,
-            crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
-        )
-        .expect("codegen should succeed")
-    }
+    use crate::codegen::core_erlang::tests::codegen;
 
     #[test]
     fn test_if_true_mutation_bypasses_runtime_dispatch() {

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/counted_loops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/counted_loops.rs
@@ -193,15 +193,7 @@ impl CoreErlangGenerator {
 
 #[cfg(test)]
 mod tests {
-    fn codegen(src: &str) -> String {
-        let tokens = crate::source_analysis::lex_with_eof(src);
-        let (module, _) = crate::source_analysis::parse(tokens);
-        crate::codegen::core_erlang::generate_module(
-            &module,
-            crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
-        )
-        .expect("codegen should succeed")
-    }
+    use crate::codegen::core_erlang::tests::codegen;
 
     #[test]
     fn test_repeat_generates_infinite_letrec_loop() {

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/dict_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/dict_ops.rs
@@ -419,15 +419,7 @@ impl CoreErlangGenerator {
 
 #[cfg(test)]
 mod tests {
-    fn codegen(src: &str) -> String {
-        let tokens = crate::source_analysis::lex_with_eof(src);
-        let (module, _) = crate::source_analysis::parse(tokens);
-        crate::codegen::core_erlang::generate_module(
-            &module,
-            crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
-        )
-        .expect("codegen should succeed")
-    }
+    use crate::codegen::core_erlang::tests::codegen;
 
     #[test]
     fn test_dict_do_with_field_mutation_uses_maps_values_foldl() {

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/exception_handling.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/exception_handling.rs
@@ -786,15 +786,7 @@ impl CoreErlangGenerator {
 
 #[cfg(test)]
 mod tests {
-    fn codegen(src: &str) -> String {
-        let tokens = crate::source_analysis::lex_with_eof(src);
-        let (module, _) = crate::source_analysis::parse(tokens);
-        crate::codegen::core_erlang::generate_module(
-            &module,
-            crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
-        )
-        .expect("codegen should succeed")
-    }
+    use crate::codegen::core_erlang::tests::codegen;
 
     #[test]
     fn test_on_do_generates_try_catch_with_nlr_passthrough() {

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
@@ -1,15 +1,7 @@
 // Copyright 2026 James Casey
 // SPDX-License-Identifier: Apache-2.0
 
-fn codegen(src: &str) -> String {
-    let tokens = crate::source_analysis::lex_with_eof(src);
-    let (module, _) = crate::source_analysis::parse(tokens);
-    crate::codegen::core_erlang::generate_module(
-        &module,
-        crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
-    )
-    .expect("codegen should succeed")
-}
+use crate::codegen::core_erlang::tests::codegen;
 
 #[test]
 fn test_list_do_pure_generates_foreach() {

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
@@ -808,15 +808,7 @@ impl CoreErlangGenerator {
 
 #[cfg(test)]
 mod tests {
-    fn codegen(src: &str) -> String {
-        let tokens = crate::source_analysis::lex_with_eof(src);
-        let (module, _) = crate::source_analysis::parse(tokens);
-        crate::codegen::core_erlang::generate_module(
-            &module,
-            crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
-        )
-        .expect("codegen should succeed")
-    }
+    use crate::codegen::core_erlang::tests::codegen;
 
     #[test]
     fn test_while_true_simple_generates_letrec() {

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -2380,15 +2380,7 @@ fn test_repl_expression_spawn_with_args_uses_class_module_index() {
 
 // --- BT-1321: intrinsic async_send → sync_send migration ---
 
-fn codegen_source(src: &str) -> String {
-    let tokens = crate::source_analysis::lex_with_eof(src);
-    let (module, _) = crate::source_analysis::parse(tokens);
-    crate::codegen::core_erlang::generate_module(
-        &module,
-        crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
-    )
-    .expect("codegen should succeed")
-}
+use super::codegen as codegen_source;
 
 /// Returns `true` if the generated code contains a `beamtalk_actor:sync_send` call
 /// with the given selector atom (e.g. `"'fieldNames'"`) as the second argument.

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/mod.rs
@@ -18,6 +18,20 @@ pub(crate) fn bare(expr: Expression) -> ExpressionStatement {
     ExpressionStatement::bare(expr)
 }
 
+/// Parse `src` as a single-class Beamtalk module and run codegen in workspace mode.
+///
+/// Shared by control-flow and dispatch test modules to avoid copy-pasting this
+/// boilerplate across every sub-module.
+pub(crate) fn codegen(src: &str) -> String {
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _) = crate::source_analysis::parse(tokens);
+    crate::codegen::core_erlang::generate_module(
+        &module,
+        crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
+    )
+    .expect("codegen should succeed")
+}
+
 /// Builds a Module with a `Value subclass: Point` with x and y slots.
 pub(crate) fn make_value_subclass_point() -> Module {
     let class = ClassDefinition {


### PR DESCRIPTION
## Summary

Replace 7 identical copies of `fn codegen(src: &str) -> String` with a single shared helper in `codegen::core_erlang::tests::mod`.

**Linear:** https://linear.app/beamtalk/issue/BT-2247

## Changes

- Added `pub(crate) fn codegen(src: &str) -> String` to `tests/mod.rs`
- Replaced local `fn codegen` in 6 control-flow test modules with `use crate::codegen::core_erlang::tests::codegen`
- Replaced `fn codegen_source` in `tests/dispatch.rs` with `use super::codegen as codegen_source`

Net: -42 lines (21 added, 63 removed). All 3816 tests pass, clippy clean.

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 3816 tests pass
- [x] `just clippy` — clean
- [x] `just fmt` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPg7CM5cWGgSizy6Xq3p86)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated code generation test helpers across multiple test modules into a shared implementation, reducing duplication and improving test maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->