### PR TITLE
Tighten loose notNil assertion in random_test.bt printString test (BT-2249)

### DIFF
--- a/stdlib/test/random_test.bt
+++ b/stdlib/test/random_test.bt
@@ -28,8 +28,8 @@ TestCase subclass: RandomTest
   testInstanceSideNew =>
     // Random new returns a Random instance
     self assert: (Random new) class equals: Random
-    // Random new printString
-    self assert: ((Random new) printString) notNil
+    // Random new printString returns "a Random" (Object default: "a " ++ class name)
+    self assert: ((Random new) printString) equals: "a Random"
     // Instance next returns a Float
     rng := Random new
     self assert: (rng next) class equals: Float


### PR DESCRIPTION
## Summary

Replaces a loose `notNil` existence check with a concrete `equals:` assertion in `stdlib/test/random_test.bt`.

**Before:**
```bt
// Random new printString
self assert: ((Random new) printString) notNil
```

**After:**
```bt
// Random new printString returns "a Random" (Object default: "a " ++ class name)
self assert: ((Random new) printString) equals: "a Random"
```

`Random` has no custom `printString` override — it inherits `Object.printString` which returns `"a " ++ self class printString`. `Class.printString` returns `self name asString`, so the result is the deterministic string `"a Random"`. The old assertion would pass even if the format changed completely; the new one will catch regressions.

## Changes
- `stdlib/test/random_test.bt`: 1 assertion tightened, comment updated to document the inherited convention

## Test plan
- [x] `just test-bunit` — 2052 tests, 0 failed

Linear: https://linear.app/beamtalk/issue/BT-2249/tighten-loose-notnil-assertion-in-random-testbt-printstring-test

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhRY3CgJq7HcNSn3hsj4BC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions in the random module test suite to validate exact output format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->