### PR TITLE
Fix value-context super: lower to super_value/4 (no unbound State) (BT-2252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Consolidate three hot class-metadata ETS tables (`beamtalk_class_module_table`, `beamtalk_class_methods_table`, `beamtalk_class_hierarchy_table`) into a single `beamtalk_class_metadata` table with typed field accessors. One atomic insert/delete per class instead of three; `inherits_from/2` reads via `ets:lookup_element/4` for ~10–14% speedup on the per-exception-match hot path (BT-2222).
 - **`beamtalk_extensions:extenders_of/1`** and **`extensions_by/1`** — reverse-index queries for extension methods. `extenders_of(ClassName)` returns unique owner atoms contributing extensions to a target class; `extensions_by(OwnerName)` returns `{TargetClass, Selector}` tuples for every extension an owner contributes (BT-2202).
 - Compiler-port diagnostics in `findSendersIn`/`findReferencesToIn` now logged via OTP logger instead of silently discarded — port-unavailability escalates to `?LOG_ERROR`, parse errors use `?LOG_WARNING`, all with `domain => [beamtalk, stdlib]` metadata (BT-2219).
+- Fix `super` in a value/primitive context (a value-type method or a foreign extension on a value/primitive class) generating invalid Core Erlang. Value-context funs are `fun(Args, Self) -> Result` with no `State` binding, so the old codegen's `beamtalk_dispatch:super(Sel, Args, Self, State, Class)` referenced an unbound `State` and failed to compile. Such `super` sends now route to the new `beamtalk_dispatch:super_value/4`, which walks the same superclass chain without threading state and returns a plain value (BT-2252).
 
 ### Tooling
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -3145,6 +3145,32 @@ mod tests {
         );
     }
 
+    /// BT-2252: in a value/primitive context the generated fun is
+    /// `fun(Args, Self) -> Result` with no `State` binding, so `super` must
+    /// lower to `super_value/4` rather than the state-threading `super/5`.
+    /// Referencing the absent `State` produced invalid Core Erlang
+    /// (variable 'State' is unbound).
+    #[test]
+    fn test_generate_super_send_value_context_uses_super_value() {
+        let mut generator = CoreErlangGenerator::new("test");
+        generator.context = crate::codegen::core_erlang::CodeGenContext::ValueType;
+        let selector = MessageSelector::Unary("printString".into());
+        let doc = generator.generate_super_send(&selector, &[]).unwrap();
+        let output = doc.to_pretty_string();
+        assert!(
+            output.contains("beamtalk_dispatch':'super_value'("),
+            "value-context super should route to super_value/4. Got: {output}"
+        );
+        assert!(
+            !output.contains("State"),
+            "value-context super must not reference an unbound State. Got: {output}"
+        );
+        assert!(
+            output.contains("'printString'"),
+            "should include selector. Got: {output}"
+        );
+    }
+
     #[test]
     fn test_generate_actor_spawn_non_repl() {
         let mut generator = CoreErlangGenerator::new("test");

--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -2059,9 +2059,24 @@ impl CoreErlangGenerator {
     ) -> Result<Document<'static>> {
         let selector_atom = selector.to_erlang_atom();
         let class_name = self.class_name();
-        let current_state = self.current_state_var();
         let args_doc = self.capture_argument_list_doc(arguments)?;
 
+        // BT-2252: value/primitive-context funs (`fun(Args, Self) -> Result`)
+        // have no `State` binding, so `super` must not reference one. Route to
+        // `super_value/4`, which walks the same chain and returns a plain value.
+        if self.context == CodeGenContext::ValueType {
+            return Ok(docvec![
+                "call 'beamtalk_dispatch':'super_value'('",
+                Document::String(selector_atom),
+                "', [",
+                args_doc,
+                "], Self, '",
+                Document::String(class_name),
+                "')",
+            ]);
+        }
+
+        let current_state = self.current_state_var();
         let doc = docvec![
             "call 'beamtalk_dispatch':'super'('",
             Document::String(selector_atom),

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
@@ -62,6 +62,7 @@ super(Selector, Args, Self, State, CurrentClass)
 -export([
     lookup/5,
     super/5,
+    super_value/4,
     responds_to/2,
     invoke_extension/4
 ]).
@@ -183,6 +184,24 @@ super(Selector, Args, Self, State, CurrentClass) ->
                             lookup_in_class_chain(Selector, Args, Self, State, SuperclassName)
                     end
             end
+    end.
+
+-doc """
+Value-context `super` send (BT-2252).
+
+Walks the superclass chain exactly like `super/5`, but for value/primitive
+types whose methods and foreign extensions lower to state-less funs
+(`fun(Args, Self) -> Result`). Such a fun has no `State` binding, so the
+generated code cannot thread one. This wrapper supplies an empty state to the
+shared hierarchy walk (state is meaningless for immutable value types) and
+unwraps the `{reply, Value, _State}` result to a plain value, re-raising any
+structured error.
+""".
+-spec super_value(selector(), args(), bt_self(), class_name()) -> term().
+super_value(Selector, Args, Self, CurrentClass) ->
+    case super(Selector, Args, Self, #{}, CurrentClass) of
+        {reply, Result, _State} -> Result;
+        {error, Error} -> beamtalk_error:raise(Error)
     end.
 
 -doc """

--- a/stdlib/test/value_super_extension_test.bt
+++ b/stdlib/test/value_super_extension_test.bt
@@ -1,0 +1,20 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2252: `super` inside a value/primitive-context method or foreign
+// extension must lower to valid Core Erlang. Value-context funs are
+// `fun(Args, Self) -> Result` with no `State` binding, so `super` routes to
+// `beamtalk_dispatch:super_value/4` (no state threading) instead of
+// `super/5`. Before the fix the generated Core Erlang referenced an unbound
+// `State` and failed to compile.
+
+TestCase subclass: ValueSuperExtensionTest
+
+  // The extension compiles (erlc would reject the unbound `State` that the
+  // pre-fix codegen emitted) and the `super` send dispatches up the value-type
+  // chain to Binary's `printString` via `super_value/4`, returning a String
+  // without raising.
+  testValueContextSuperDispatches =>
+    result := "hi" btSuperPrintProbe
+    self assert: result equals: "hi" printString
+String >> btSuperPrintProbe -> String => super printString


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2252

A `super` send in a **value/primitive context** — a value-type method, or a foreign extension on a value/primitive class — generated **invalid Core Erlang**. Value-context funs are `fun(Args, Self) -> Result` (no `State` parameter; value types are immutable), but `generate_super_send` unconditionally emitted:

```erlang
call 'beamtalk_dispatch':'super'(Sel, Args, Self, State, Class)
```

referencing a `State` binding that doesn't exist in that fun → erlc: *variable 'State' is unbound*. Reachable now that foreign extensions actually lower to funs (BT-2250). Actor-target extensions were fine (3-arity state-threading fun).

## Changes

- **`dispatch_codegen.rs`** — `generate_super_send` now branches on `CodeGenContext::ValueType` and emits `call 'beamtalk_dispatch':'super_value'(Sel, Args, Self, Class)` (no `State`). The actor path is unchanged. The branch covers **both** plain value-type methods and value/primitive foreign extensions, since `generate_value_type_module` and `generate_value_extension_fun` both run under `ValueType` context (AC #3).
- **`beamtalk_dispatch.erl`** — new exported `super_value/4`: walks the same superclass chain as `super/5` with an empty state and unwraps `{reply, Value, _}` to a plain value, re-raising structured errors.
- **`stdlib/test/value_super_extension_test.bt`** — a value-target foreign extension (`String >> btSuperPrintProbe => super printString`) that compiles and dispatches up to `Binary`'s `printString` via `super_value/4`.

## Test plan

- [x] Repro `String >> probe => super printString` now compiles to BEAM (was: unbound `State`); generated `.core` emits `super_value('printString', [], Self, 'String')`
- [x] New BUnit test passes (value-context super compiles + dispatches correctly)
- [x] Full regression: BUnit 2058, REPL-protocol 3, **dialyzer clean** (`super_value/4` typed), `cargo test -p beamtalk-core` 3839 — 0 failures
- [x] clippy + fmt-check clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMXoP8FzzDFgpbRQbEDeVC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a compilation/runtime error when using `super` inside value/primitive-context method extensions; such `super` sends now correctly dispatch through the superclass chain and return plain values.

* **Tests**
  * Added test coverage validating `super` dispatch behavior in value/primitive-context extensions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->