### PR TITLE
Class literals infer as Meta{C} so class values flow class-side (BT-2260)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -347,8 +347,20 @@ impl TypeChecker {
                 }
             }
 
-            // Class references are the class itself (class-side receiver)
-            Expression::ClassReference { name, .. } => InferredType::known(name.name.clone()),
+            // A bare class literal `Foo` is the class *object*, whose type is the
+            // metatype `Meta{Foo}` (ADR 0083 / BT-2260) — *not* an instance of
+            // `Foo`. Typing it `Meta{C}` makes a class value route class-side
+            // wherever it flows (through a variable, collection, or FFI return),
+            // not just when used syntactically as a direct receiver (`Foo new`).
+            //
+            // The syntactic class-side path (`Expression::ClassReference`
+            // receiver in `infer_message_send`) still fires for direct sends, and
+            // the type-driven `Meta{C}` path covers receivers reached through a
+            // binding. `Meta{C} <: Class <: Behaviour` subtyping (validation.rs)
+            // keeps `:: Class` / `:: Behaviour` parameter checks and `isKindOf:`
+            // satisfied; `x class = Foo` narrowing is AST-driven (class_eq.rs) and
+            // unaffected by this inference change.
+            Expression::ClassReference { name, .. } => InferredType::meta(name.name.clone()),
 
             // Field access — infer type from declared state type for self.field
             // BT-2048: Check env first for narrowed type (e.g. inside isNil ifFalse: block)
@@ -4703,11 +4715,13 @@ mod tests {
 
     #[test]
     fn infer_expr_class_reference() {
+        // BT-2260: a bare class literal `Integer` is the class *object*, whose
+        // type is the metatype `Meta{Integer}` — not an instance of `Integer`.
         let hierarchy = ClassHierarchy::with_builtins();
         let mut checker = TypeChecker::new();
         let mut env = TypeEnv::new();
         let ty = checker.infer_expr(&class_ref("Integer"), &hierarchy, &mut env, false);
-        assert_eq!(ty, InferredType::known("Integer"));
+        assert_eq!(ty, InferredType::meta("Integer"));
     }
 
     #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -79,7 +79,9 @@ impl TypeChecker {
                         .any(|s| matches!(s.expression, Expression::Primitive { .. }))
                 {
                     match &body_type {
-                        InferredType::Known { .. } | InferredType::Never => {
+                        InferredType::Known { .. }
+                        | InferredType::Meta { .. }
+                        | InferredType::Never => {
                             self.method_return_types.insert(
                                 (class.name.name.clone(), method.selector.name(), false),
                                 body_type.clone(),
@@ -112,7 +114,9 @@ impl TypeChecker {
                         .any(|s| matches!(s.expression, Expression::Primitive { .. }))
                 {
                     match &body_type {
-                        InferredType::Known { .. } | InferredType::Never => {
+                        InferredType::Known { .. }
+                        | InferredType::Meta { .. }
+                        | InferredType::Never => {
                             self.method_return_types.insert(
                                 (class.name.name.clone(), method.selector.name(), true),
                                 body_type.clone(),
@@ -167,7 +171,9 @@ impl TypeChecker {
                     .any(|s| matches!(s.expression, Expression::Primitive { .. }))
             {
                 match &body_type {
-                    InferredType::Known { .. } | InferredType::Never => {
+                    InferredType::Known { .. }
+                    | InferredType::Meta { .. }
+                    | InferredType::Never => {
                         self.method_return_types.insert(
                             (
                                 class_name.clone(),

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/self_class.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/self_class.rs
@@ -962,6 +962,6 @@ fn class_eq_literal_narrowing_not_regressed() {
     assert!(
         dnu.is_empty(),
         "`x class = Integer` literal-eq narrowing must still narrow x to Integer \
-         (so `x even` resolves) and the guard must not DNU; got {dnu:?}"
+         (so `x isEven` resolves) and the guard must not DNU; got {dnu:?}"
     );
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/self_class.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/self_class.rs
@@ -762,3 +762,206 @@ typed Object subclass: Beta
          not Known(\"Integer class\"); got {ty:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// BT-2260: a *bare class literal* `Foo` infers `Meta{Foo}` so an unannotated
+// class value routes class-side wherever it flows — through a variable, a
+// collection, or as a class/behaviour argument — not just when used
+// syntactically as a direct receiver (`Foo new`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_class_literal_infers_metatype() {
+    // The core flip: `Expression::ClassReference` is the class *object*, typed
+    // `Meta{C}` — NOT an instance of `C` (`Known(C)`).
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    let ty = checker.infer_expr(&class_ref("Integer"), &hierarchy, &mut env, false);
+    assert_eq!(
+        ty.as_meta().map(EcoString::as_str),
+        Some("Integer"),
+        "a bare class literal `Integer` must infer Meta{{Integer}}; got {ty:?}"
+    );
+    assert!(
+        ty.as_known().is_none(),
+        "a class literal is the class object, not an instance — `as_known` must be None; got {ty:?}"
+    );
+}
+
+#[test]
+fn class_literal_through_variable_then_new_infers_instance() {
+    // AC: `klass := Foo. klass new` → an instance of `Foo`. The literal `Foo` is
+    // now Meta{Foo}; storing it in a local keeps the metatype, so `klass new`
+    // routes through the type-driven class-side path and yields a `Foo` instance.
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    // klass := Integer
+    let assign_expr = assign("klass", class_ref("Integer"));
+    let assigned_ty = checker.infer_expr(&assign_expr, &hierarchy, &mut env, false);
+    assert_eq!(
+        assigned_ty.as_meta().map(EcoString::as_str),
+        Some("Integer"),
+        "`klass := Integer` must bind klass to Meta{{Integer}}; got {assigned_ty:?}"
+    );
+    // klass new
+    let new_send = msg_send(var("klass"), MessageSelector::Unary("new".into()), vec![]);
+    let new_ty = checker.infer_expr(&new_send, &hierarchy, &mut env, false);
+    assert_eq!(
+        new_ty.as_known().map(EcoString::as_str),
+        Some("Integer"),
+        "`klass new` (klass = a class literal) must infer an Integer instance; got {new_ty:?}"
+    );
+}
+
+#[test]
+fn class_literal_through_variable_resolves_class_selector() {
+    // AC: `klass <classSelector>` resolves class-side when `klass` came from a
+    // bare class literal. `name` lives on Behaviour (class-side) -> Symbol.
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    let assign_expr = assign("klass", class_ref("Integer"));
+    checker.infer_expr(&assign_expr, &hierarchy, &mut env, false);
+    let name_send = msg_send(var("klass"), MessageSelector::Unary("name".into()), vec![]);
+    let ty = checker.infer_expr(&name_send, &hierarchy, &mut env, false);
+    assert_eq!(
+        ty.as_known().map(EcoString::as_str),
+        Some("Symbol"),
+        "`klass name` (klass = a class literal) resolves Behaviour>>name -> Symbol; got {ty:?}"
+    );
+}
+
+#[test]
+fn class_literal_in_collection_routes_class_side_no_false_dnu() {
+    // AC: class values in a collection route class-side. `#(Integer, String)` is
+    // an untyped Array, so each element is still type-checked as Meta{C}; sending
+    // a class-side selector to a class value pulled from the collection must not
+    // produce a false DNU.
+    let source = "
+typed Object subclass: Registry
+  describe -> Object =>
+    #(Integer, String) do: [:c | c new]
+";
+    let diags = dnu_diags(source);
+    assert!(
+        diags.is_empty(),
+        "class values in a collection (`#(Integer, String) do: [:c | c new]`) must not \
+         produce a false DNU; got {diags:?}"
+    );
+}
+
+#[test]
+fn bare_class_literal_satisfies_class_and_behaviour_parameters() {
+    // AC: a class literal passed to a `:: Class` / `:: Behaviour` parameter is
+    // accepted. The bare literal is Meta{C}, and Meta{C} <: Class <: Behaviour.
+    let source = "
+typed Object subclass: Registry
+  register: cls :: Behaviour -> Object => cls
+  registerClass: cls :: Class -> Object => cls
+  use -> Object =>
+    self register: Integer
+    self registerClass: String
+";
+    let diags = dnu_diags(source);
+    assert!(
+        diags.is_empty(),
+        "passing bare class literals to `:: Behaviour` / `:: Class` params must not DNU; got {diags:?}"
+    );
+    let (module, hierarchy) = parse_and_build(source);
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let arg_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("expects Behaviour") || d.message.contains("expects Class"))
+        .map(|d| d.message.clone())
+        .collect();
+    assert!(
+        arg_warnings.is_empty(),
+        "bare class literals must satisfy `:: Behaviour` / `:: Class` params; got {arg_warnings:?}"
+    );
+}
+
+#[test]
+fn syntactic_class_literal_new_still_works() {
+    // REGRESSION: the syntactic `Foo new` direct-literal path must keep working
+    // (it dispatches via the `Expression::ClassReference` receiver arm, not the
+    // type-driven Meta path). `Integer new` infers an Integer instance.
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    let new_send = msg_send(
+        class_ref("Integer"),
+        MessageSelector::Unary("new".into()),
+        vec![],
+    );
+    let ty = checker.infer_expr(&new_send, &hierarchy, &mut env, false);
+    assert_eq!(
+        ty.as_known().map(EcoString::as_str),
+        Some("Integer"),
+        "syntactic `Integer new` must still infer an Integer instance; got {ty:?}"
+    );
+}
+
+#[test]
+fn class_eq_literal_narrowing_not_regressed() {
+    // REGRESSION (critical): `x class = Foo` narrowing must still narrow `x` to a
+    // `Foo` instance in the true branch, even though `Foo` is now Meta{Foo} and
+    // the `= Foo` comparison receiver `x class` is Meta{X}. The narrowing rule is
+    // AST-driven (class_eq.rs), so it builds Known(Foo) from the literal node —
+    // and the `Meta{X} = ...` comparison must stay Boolean (no DNU on the guard).
+    //
+    // Built as AST (mirrors the pinned narrowing tests) so the guard
+    // `x class = Integer` is exercised — the parser does not accept the inline
+    // `(x class = Integer)` paren-spelling, so source-level isn't an option here.
+    let hierarchy = ClassHierarchy::with_builtins();
+    // process: x :: Object =>
+    //   (x class = Integer) ifTrue: [x isEven] ifFalse: [x printString]
+    // `isEven` is an Integer-only selector — it must resolve in the true branch
+    // (x narrowed to Integer), confirming the literal-eq narrowing still fires.
+    let guard = msg_send(
+        msg_send(var("x"), MessageSelector::Unary("class".into()), vec![]),
+        MessageSelector::Binary("=".into()),
+        vec![class_ref("Integer")],
+    );
+    let process_method = make_keyword_method(
+        &["process:"],
+        vec![("x", Some("Object"))],
+        vec![if_true_if_false(
+            guard,
+            block_expr(vec![msg_send(
+                var("x"),
+                MessageSelector::Unary("isEven".into()),
+                vec![],
+            )]),
+            block_expr(vec![msg_send(
+                var("x"),
+                MessageSelector::Unary("printString".into()),
+                vec![],
+            )]),
+        )],
+    );
+    let class = ClassDefinition::new(
+        ident("Probe"),
+        ident("Object"),
+        vec![],
+        vec![process_method],
+        span(),
+    );
+    let module = make_module_with_classes(vec![], vec![class]);
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let dnu: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .map(|d| d.message.clone())
+        .collect();
+    assert!(
+        dnu.is_empty(),
+        "`x class = Integer` literal-eq narrowing must still narrow x to Integer \
+         (so `x even` resolves) and the guard must not DNU; got {dnu:?}"
+    );
+}

--- a/stdlib/test/compiled_method_test.bt
+++ b/stdlib/test/compiled_method_test.bt
@@ -12,14 +12,12 @@ TestCase subclass: CompiledMethodTest
   testMethodLookupOnVariableReceivers =>
     cls := Counter
     self assert: cls equals: Counter
-    // Type checker infers cls as Counter instance, not Counter class object,
-    // so >> is not found via instance-side lookup. At runtime, cls holds the
-    // class object and dispatches through Class→Behaviour chain.
-    @expect dnu
+    // Bare class literals infer as Meta{Counter} (BT-2260), so `cls >> #sel`
+    // resolves class-side via Behaviour instead of producing a DNU hint. At
+    // runtime, cls holds the class object and dispatches through the
+    // Class→Behaviour chain.
     self assert: (cls >> #getValue) notNil
-    @expect dnu
     self assert: (cls >> #getValue) selector equals: #getValue
-    @expect dnu
     self assert: (cls >> #nonExistent) equals: nil
 
   testClass => self assert: (Counter >> #getValue) class equals: CompiledMethod


### PR DESCRIPTION
## Summary

Makes a bare class literal `Foo` infer as the metatype `Meta{Foo}` (the class *object*) instead of `Known(Foo)` (as if it were an instance). This is the deferred "heavy lift" from BT-2255 / ADR 0083: it lets an **unannotated** class value route class-side wherever it flows — through a variable, a collection, or an FFI return — not just when used syntactically as a direct receiver (`Foo new`).

Builds directly on BT-2255 (#2288), which already added `InferredType::Meta` plus the type-driven class-side routing, `new`/`basicNew`, and `-> Self` machinery for metatype receivers. With the literal now typed `Meta{C}`:

- `klass := Foo. klass new` → an instance of `Foo`
- `klass <classSelector>` → resolves class-side
- class values passed to a `:: Class` / `:: Behaviour` parameter are accepted

Link: https://linear.app/beamtalk/issue/BT-2260

## Key changes

- `type_checker/inference.rs` — `Expression::ClassReference` arm now returns `InferredType::meta(name)` (one line + explanatory doc comment).
- Updated the one unit test (`infer_expr_class_reference`) that pinned the old `Known` behaviour.
- Added 7 tests in `tests/self_class.rs` covering the new flow and the critical regressions.

## Fallout handled

- **Syntactic `Foo new` direct path** is unchanged — it dispatches via the `ClassReference` *receiver* arm in `infer_message_send`, not the type-driven `Meta` path, so both paths coexist without double-handling.
- **`x class = Foo` and `isKindOf:` narrowing** read the class name straight from the AST `ClassReference` node (`class_eq.rs` / `is_kind_of.rs`), so they are unaffected by the inference-result change.
- **`:: Class` / `:: Behaviour` parameter checks** already accept a metatype via the `Meta{C} <: Class <: Behaviour` subtyping added in BT-2255 (`validation.rs`).
- `on:do:` also extracts its exception class name from the AST node, not the inferred type — unaffected.

## New tests

- `bare_class_literal_infers_metatype`
- `class_literal_through_variable_then_new_infers_instance`
- `class_literal_through_variable_resolves_class_selector`
- `class_literal_in_collection_routes_class_side_no_false_dnu`
- `bare_class_literal_satisfies_class_and_behaviour_parameters`
- `syntactic_class_literal_new_still_works`
- `class_eq_literal_narrowing_not_regressed`

## Test plan

- [x] `cargo test -p beamtalk-core` fully green (3876 lib + integration), including all 73 narrowing tests and all 47 `self_class` tests
- [x] Full workspace tests green (only the offline-runtime-dependent `cli_doc` doctest fails, identically on clean `main`)
- [x] `cargo run --bin beamtalk -- build-stdlib`: builds 77 modules, 0 DNU, no net-new warnings (warning counts identical to `main`: 13 + 99 + 162 untyped/FFI Dynamic)
- [x] clippy clean, `cargo fmt --check` clean

> Note: the Erlang runtime build (`build-erlang`, `fmt-check-erlang`) cannot run offline (hex mirror unavailable); stdlib `@expect`/DNU status verified via `build-stdlib` directly per the change being Rust-only.

https://claude.ai/code/session_01JcL83vPaiRXAhWX7raRYMh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcL83vPaiRXAhWX7raRYMh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Class literals now infer as metatypes, preserving metatype return info and enabling correct class-side method resolution.
  * Metatype propagation fixed for variables, collections, and parameter passing to avoid incorrect fall-through or diagnostics.

* **Tests**
  * Added and updated tests to cover metatype inference, class-side message handling, collection/variable receivers, and removed false “does not understand” expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->