### PR TITLE
Add EUnit tests for beamtalk_class_bt and beamtalk_class_builder_bt (both 0%) (BT-2262)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_bt_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_bt_tests.erl
@@ -1,0 +1,126 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_class_bt_tests).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+EUnit tests for beamtalk_class_bt module (BT-2262).
+
+Tests Class bootstrap stub dispatch error handling, has_method/1 queries,
+and class registration. Models beamtalk_metaclass_bt_tests.erl.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include("beamtalk.hrl").
+
+%%% ============================================================================
+%%% dispatch/4 — classBuilder selector (ADR 0038 Phase 1)
+%%% ============================================================================
+
+dispatch_classbuilder_returns_dnu_test() ->
+    State = #{},
+    {error, Error, RetState} = beamtalk_class_bt:dispatch('classBuilder', [], self(), State),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind),
+    ?assertEqual('Class', Error#beamtalk_error.class),
+    ?assertEqual('classBuilder', Error#beamtalk_error.selector),
+    ?assertEqual(State, RetState).
+
+dispatch_classbuilder_preserves_state_test() ->
+    State = #{value => 99, name => <<"test">>},
+    {error, _, RetState} = beamtalk_class_bt:dispatch('classBuilder', [], self(), State),
+    ?assertEqual(State, RetState).
+
+%%% ============================================================================
+%%% dispatch/4 — generic unknown selectors
+%%% ============================================================================
+
+dispatch_unknown_selector_test() ->
+    State = #{},
+    {error, Error, RetState} = beamtalk_class_bt:dispatch('unknownMethod', [], self(), State),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind),
+    ?assertEqual('Class', Error#beamtalk_error.class),
+    ?assertEqual('unknownMethod', Error#beamtalk_error.selector),
+    ?assertEqual(State, RetState).
+
+dispatch_unknown_with_args_test() ->
+    State = #{},
+    {error, Error, _} = beamtalk_class_bt:dispatch('foo:', [42], self(), State),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind),
+    ?assertEqual('Class', Error#beamtalk_error.class).
+
+dispatch_name_selector_returns_dnu_test() ->
+    %% 'name' is not handled in Phase 1; Phase 2 (Class.bt) provides it
+    State = #{},
+    {error, Error, _} = beamtalk_class_bt:dispatch('name', [], self(), State),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind).
+
+dispatch_superclass_selector_returns_dnu_test() ->
+    %% 'superclass' is a class method, not an instance method in this stub
+    State = #{},
+    {error, Error, _} = beamtalk_class_bt:dispatch('superclass', [], self(), State),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind).
+
+dispatch_preserves_nonempty_state_test() ->
+    %% State map should pass through unchanged for any selector
+    State = #{foo => bar, count => 42},
+    {error, _, RetState} = beamtalk_class_bt:dispatch('anySelector', [], self(), State),
+    ?assertEqual(State, RetState).
+
+%%% ============================================================================
+%%% has_method/1
+%%% ============================================================================
+
+has_method_classbuilder_true_test() ->
+    %% ADR 0038 Phase 1: classBuilder must return true so Class respondsTo: #classBuilder
+    ?assert(beamtalk_class_bt:has_method('classBuilder')).
+
+has_method_unknown_selectors_test() ->
+    ?assertNot(beamtalk_class_bt:has_method('unknownMethod')),
+    ?assertNot(beamtalk_class_bt:has_method('new')),
+    ?assertNot(beamtalk_class_bt:has_method('name')),
+    ?assertNot(beamtalk_class_bt:has_method('superclass')),
+    ?assertNot(beamtalk_class_bt:has_method('printString')).
+
+%%% ============================================================================
+%%% register_class/0 (requires bootstrap)
+%%% ============================================================================
+
+register_class_test_() ->
+    {setup, fun setup_bootstrap/0, fun teardown_bootstrap/1, [
+        {"register_class creates Class", fun register_class_creates_test/0},
+        {"register_class is idempotent", fun register_class_idempotent_test/0},
+        {"registered Class has correct superclass", fun register_class_superclass_test/0}
+    ]}.
+
+setup_bootstrap() ->
+    case whereis(pg) of
+        undefined -> pg:start_link();
+        _ -> ok
+    end,
+    beamtalk_extensions:init(),
+    case beamtalk_bootstrap:start_link() of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    ok.
+
+teardown_bootstrap(_) ->
+    ok.
+
+register_class_creates_test() ->
+    %% Bootstrap already registered Class; verify it's there
+    Pid = beamtalk_class_registry:whereis_class('Class'),
+    ?assertNotEqual(undefined, Pid),
+    ?assertEqual('Class', beamtalk_object_class:class_name(Pid)).
+
+register_class_idempotent_test() ->
+    %% Calling register_class again must not crash and Class must still be there
+    ok = beamtalk_class_bt:register_class(),
+    Pid = beamtalk_class_registry:whereis_class('Class'),
+    ?assertNotEqual(undefined, Pid).
+
+register_class_superclass_test() ->
+    Pid = beamtalk_class_registry:whereis_class('Class'),
+    ?assertEqual('Object', beamtalk_object_class:superclass(Pid)).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_bt_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_bt_tests.erl
@@ -20,6 +20,9 @@ and class registration. Models beamtalk_metaclass_bt_tests.erl.
 %%% ============================================================================
 
 dispatch_classbuilder_returns_dnu_test() ->
+    %% ADR 0038 Phase 1: dispatch still returns DNU even though has_method/1 returns true.
+    %% has_method/1 returning true makes Class respondsTo: #classBuilder answer true, but
+    %% the actual implementation is deferred to Phase 2 (ClassBuilder.bt stdlib module).
     State = #{},
     {error, Error, RetState} = beamtalk_class_bt:dispatch('classBuilder', [], self(), State),
     ?assertEqual(does_not_understand, Error#beamtalk_error.kind),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_builder_bt_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_builder_bt_tests.erl
@@ -1,0 +1,116 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_class_builder_bt_tests).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+EUnit tests for beamtalk_class_builder_bt module (BT-2262).
+
+Tests ClassBuilder bootstrap stub dispatch error handling (always DNU),
+has_method/1 queries (always false), and class registration.
+Models beamtalk_metaclass_bt_tests.erl and beamtalk_class_bt_tests.erl.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include("beamtalk.hrl").
+
+%%% ============================================================================
+%%% dispatch/4 — always returns does_not_understand (Phase 1 stub)
+%%% ============================================================================
+
+dispatch_any_selector_returns_dnu_test() ->
+    State = #{},
+    {error, Error, RetState} = beamtalk_class_builder_bt:dispatch('anyMethod', [], self(), State),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind),
+    ?assertEqual('ClassBuilder', Error#beamtalk_error.class),
+    ?assertEqual('anyMethod', Error#beamtalk_error.selector),
+    ?assertEqual(State, RetState).
+
+dispatch_name_colon_returns_dnu_test() ->
+    %% name: is a Phase 2 ClassBuilder protocol method; Phase 1 stub returns DNU
+    State = #{},
+    {error, Error, RetState} = beamtalk_class_builder_bt:dispatch(
+        'name:', [<<"MyClass">>], self(), State
+    ),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind),
+    ?assertEqual('ClassBuilder', Error#beamtalk_error.class),
+    ?assertEqual('name:', Error#beamtalk_error.selector),
+    ?assertEqual(State, RetState).
+
+dispatch_superclass_colon_returns_dnu_test() ->
+    %% superclass: is a Phase 2 ClassBuilder protocol method; Phase 1 stub returns DNU
+    State = #{},
+    {error, Error, _} = beamtalk_class_builder_bt:dispatch(
+        'superclass:', [self()], self(), State
+    ),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind),
+    ?assertEqual('ClassBuilder', Error#beamtalk_error.class).
+
+dispatch_register_returns_dnu_test() ->
+    %% register is a Phase 2 ClassBuilder protocol method
+    State = #{},
+    {error, Error, _} = beamtalk_class_builder_bt:dispatch('register', [], self(), State),
+    ?assertEqual(does_not_understand, Error#beamtalk_error.kind).
+
+dispatch_preserves_nonempty_state_test() ->
+    %% State map must pass through unchanged for every selector
+    State = #{value => 100, tag => <<"cb">>},
+    {error, _, RetState} = beamtalk_class_builder_bt:dispatch('anything', [], self(), State),
+    ?assertEqual(State, RetState).
+
+%%% ============================================================================
+%%% has_method/1 — always false in Phase 1 stub
+%%% ============================================================================
+
+has_method_returns_false_for_any_selector_test() ->
+    ?assertNot(beamtalk_class_builder_bt:has_method('name:')),
+    ?assertNot(beamtalk_class_builder_bt:has_method('superclass:')),
+    ?assertNot(beamtalk_class_builder_bt:has_method('fields:')),
+    ?assertNot(beamtalk_class_builder_bt:has_method('methods:')),
+    ?assertNot(beamtalk_class_builder_bt:has_method('register')),
+    ?assertNot(beamtalk_class_builder_bt:has_method('new')),
+    ?assertNot(beamtalk_class_builder_bt:has_method('unknownSelector')).
+
+%%% ============================================================================
+%%% register_class/0 (requires bootstrap)
+%%% ============================================================================
+
+register_class_test_() ->
+    {setup, fun setup_bootstrap/0, fun teardown_bootstrap/1, [
+        {"register_class creates ClassBuilder", fun register_class_creates_test/0},
+        {"register_class is idempotent", fun register_class_idempotent_test/0},
+        {"registered ClassBuilder has correct superclass", fun register_class_superclass_test/0}
+    ]}.
+
+setup_bootstrap() ->
+    case whereis(pg) of
+        undefined -> pg:start_link();
+        _ -> ok
+    end,
+    beamtalk_extensions:init(),
+    case beamtalk_bootstrap:start_link() of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    ok.
+
+teardown_bootstrap(_) ->
+    ok.
+
+register_class_creates_test() ->
+    %% Bootstrap already registered ClassBuilder; verify it is present
+    Pid = beamtalk_class_registry:whereis_class('ClassBuilder'),
+    ?assertNotEqual(undefined, Pid),
+    ?assertEqual('ClassBuilder', beamtalk_object_class:class_name(Pid)).
+
+register_class_idempotent_test() ->
+    %% Calling register_class again must not crash and ClassBuilder must still be there
+    ok = beamtalk_class_builder_bt:register_class(),
+    Pid = beamtalk_class_registry:whereis_class('ClassBuilder'),
+    ?assertNotEqual(undefined, Pid).
+
+register_class_superclass_test() ->
+    Pid = beamtalk_class_registry:whereis_class('ClassBuilder'),
+    ?assertEqual('Actor', beamtalk_object_class:superclass(Pid)).


### PR DESCRIPTION
## Summary

Nightly test-improvement pass. Both `beamtalk_class_bt` and `beamtalk_class_builder_bt` had **0% isolated line coverage** and no dedicated EUnit test files. These are the ADR 0032/0038 bootstrap stubs for the `Class` and `ClassBuilder` classes in the object system.

Linear issue: https://linear.app/beamtalk/issue/BT-2262

## Coverage improvement

| Module | Before | After |
|--------|--------|-------|
| `beamtalk_class_bt` | 0% | 82% |
| `beamtalk_class_builder_bt` | 0% | 78% |

The 3 remaining uncovered lines in each module are the `{error, Reason}` fallback branch of `register_class/0` — identical to the gap in the model `beamtalk_metaclass_bt` (85%). Triggering that branch requires gen_server to fail with a non-`already_started` error, which is not achievable without mocking infrastructure (meck is not in the dependency tree).

## What's in this PR

**`beamtalk_class_bt_tests.erl`** (15 tests):
- `dispatch/4`: classBuilder DNU (with ADR 0038 Phase 1 comment explaining why dispatch still returns DNU even though `has_method` returns true), generic unknown selectors, state preservation
- `has_method/1`: `classBuilder` → true, all others → false
- `register_class/0`: creates Class in registry, idempotent, superclass = Object

**`beamtalk_class_builder_bt_tests.erl`** (12 tests):
- `dispatch/4`: name:, superclass:, register, and any-selector all return DNU
- `has_method/1`: always false for all selectors (Phase 1 stub)
- `register_class/0`: creates ClassBuilder in registry, idempotent, superclass = Actor

Both files follow the pattern established by `beamtalk_metaclass_bt_tests.erl`.

## Verification

```
27 tests, 0 failures
✅ Clippy passed
✅ Erlang formatting check passed
✅ All lint checks passed
```

https://claude.ai/code/session_01Dzt6RwPVrSKze6RRJYVcdm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dzt6RwPVrSKze6RRJYVcdm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for bootstrap class and class builder registration, ensuring proper error handling and protocol behavior.
  * Validates class hierarchy relationships and idempotent registration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->