### PR TITLE
Tighten placeholder assertions in repl_inline_class_superclass_index.btscript (BT-2263)

### DIFF
--- a/tests/repl-protocol/cases/repl_inline_class_superclass_index.btscript
+++ b/tests/repl-protocol/cases/repl_inline_class_superclass_index.btscript
@@ -25,7 +25,7 @@
 Shape subclass: Triangle
   field: base = 1.0
   class withBase: b => self new: #{#base => b}
-// => _
+// => Triangle
 
 Triangle >> base => self.base
 // => _
@@ -48,7 +48,7 @@ t class name
 
 // Field access works on the value object
 t base
-// => _
+// => 6.0
 
 // ===========================================================================
 // CHAINED INLINE SUBCLASS (inline class as parent of another inline class)
@@ -59,7 +59,7 @@ t base
 // so that the next inline compile can resolve Triangle→Shape→Object as value-object.
 Triangle subclass: RightTriangle
   field: hypotenuse = 0.0
-// => _
+// => RightTriangle
 
 rt := RightTriangle new: #{#base => 3.0, #hypotenuse => 5.0}
 // => _
@@ -68,4 +68,4 @@ rt class name
 // => RightTriangle
 
 rt base
-// => _
+// => 3.0


### PR DESCRIPTION
## Summary

- Replace 4 of 8 `// => _` placeholder assertions with real expected values where the result is fully deterministic
- Value subclass definitions (`Shape subclass: Triangle`, `Triangle subclass: RightTriangle`) now assert the class name is returned — confirmed by `extension_type_annotations.btscript` pattern
- Field access assertions (`t base`, `rt base`) now check actual values (`6.0`, `3.0`) — confirmed by `cross_file_value_object_inheritance.btscript` pattern
- Remaining 4 wildcards are correctly preserved (method extensions + constructor calls)

Resolves https://linear.app/beamtalk/issue/BT-2263

## Test plan

- [x] `just test-repl-protocol` passes (3/3 tests, including `e2e_language_tests` which runs this `.btscript`)
- [x] No other files touched
- [x] Verified assertion patterns match comparable tests in `extension_type_annotations.btscript` and `cross_file_value_object_inheritance.btscript`

https://claude.ai/code/session_01To8eKxw7gLpxvMmBgMMxfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01To8eKxw7gLpxvMmBgMMxfs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations to validate inline subclass definitions and inheritance patterns with concrete expected values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->