### PR TITLE
Metaclass-aware type inference (Slice 2): class-side Self-return precision (BT-2256)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/self_class.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/self_class.rs
@@ -965,3 +965,253 @@ fn class_eq_literal_narrowing_not_regressed() {
          (so `x isEven` resolves) and the guard must not DNU; got {dnu:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// BT-2256 (ADR 0083 Slice 2): class-side `Self`-return precision for *concrete*
+// class-literal / concrete-metatype receivers. A class-side constructor sent to
+// a concrete class literal infers *that* class's instance type (`Set withAll: →
+// Set`, `List withAll: → List`, `Array withAll: → Array`), composing the element
+// type from the argument where statically known (`Set withAll: aList(Integer) →
+// Set(Integer)`). Abstract receivers (`Collection`) keep Slice 1 behaviour.
+// ---------------------------------------------------------------------------
+
+/// Build a `#(...)` array literal of integer elements.
+fn int_array(ns: &[i64]) -> Expression {
+    Expression::ArrayLiteral {
+        elements: ns.iter().map(|n| int_lit(*n)).collect(),
+        span: span(),
+    }
+}
+
+/// Build a keyword send `recv kw: arg`.
+fn kw1_send(receiver: Expression, kw: &str, arg: Expression) -> Expression {
+    msg_send(
+        receiver,
+        MessageSelector::Keyword(vec![KeywordPart::new(kw, span())]),
+        vec![arg],
+    )
+}
+
+/// A `List(elem)`-typed local value (the typed-argument shape for composition).
+fn list_of(elem: &str) -> InferredType {
+    InferredType::Known {
+        class_name: "List".into(),
+        type_args: vec![InferredType::known(elem)],
+        provenance: super::super::TypeProvenance::Inferred(span()),
+    }
+}
+
+#[test]
+fn concrete_collection_withall_infers_concrete_class() {
+    // AC: `Set withAll:` → Set, `List withAll:` → List, `Array withAll:` → Array.
+    // Each concrete collection's class-side `withAll:` constructor, sent to the
+    // bare class literal, infers the *concrete* receiver class — never the
+    // abstract `Collection`.
+    let hierarchy = ClassHierarchy::with_builtins();
+    for cls in ["Set", "List", "Array", "Bag"] {
+        let send = kw1_send(class_ref(cls), "withAll:", int_array(&[1, 2, 3]));
+        let ty = infer_send_on_local("ignored", InferredType::known("Object"), &send, &hierarchy);
+        assert_eq!(
+            ty.as_known().map(EcoString::as_str),
+            Some(cls),
+            "`{cls} withAll: #(1,2,3)` must infer {cls}, not Collection; got {ty:?}"
+        );
+    }
+}
+
+#[test]
+fn concrete_collection_withall_on_metatype_infers_concrete_class() {
+    // AC: same precision when the receiver is a *metatype* of a concrete class
+    // (a class value flowing through a variable), not only a bare literal.
+    // `(Set class)`-typed value `withAll:` → Set.
+    let hierarchy = ClassHierarchy::with_builtins();
+    for cls in ["Set", "List", "Array"] {
+        let send = kw1_send(var("cls"), "withAll:", int_array(&[1, 2]));
+        let ty = infer_send_on_local("cls", InferredType::meta(cls), &send, &hierarchy);
+        assert_eq!(
+            ty.as_known().map(EcoString::as_str),
+            Some(cls),
+            "`(Meta{{{cls}}}) withAll:` must infer {cls}; got {ty:?}"
+        );
+    }
+}
+
+#[test]
+fn abstract_collection_withall_stays_abstract_no_concrete_inference() {
+    // AC: an *abstract* receiver keeps Slice 1 behaviour — `Self` resolves to the
+    // abstract class itself (Collection), NOT some false concrete subclass. The
+    // result must be the abstract class name (so downstream `Self`-typed chaining
+    // type-checks), never a concrete collection.
+    let hierarchy = ClassHierarchy::with_builtins();
+    assert!(hierarchy.is_abstract("Collection"));
+    let send = kw1_send(class_ref("Collection"), "withAll:", int_array(&[1]));
+    let ty = infer_send_on_local("ignored", InferredType::known("Object"), &send, &hierarchy);
+    // Collection>>withAll: is declared `-> Self`; on the abstract Collection
+    // literal it resolves to Collection — never a concrete species.
+    assert_eq!(
+        ty.as_known().map(EcoString::as_str),
+        Some("Collection"),
+        "abstract `Collection withAll:` must stay Collection (Slice 1 behaviour), \
+         not over-resolve to a concrete species; got {ty:?}"
+    );
+    assert!(
+        !matches!(
+            ty.as_known().map(EcoString::as_str),
+            Some("Set" | "List" | "Array" | "Bag")
+        ),
+        "abstract receiver must never infer a concrete collection; got {ty:?}"
+    );
+}
+
+#[test]
+fn concrete_withall_composes_known_element_type() {
+    // AC: composes with ADR 0068 element-type inference — `Set withAll:
+    // aList(Integer)` infers `Set(Integer)` where the element type is statically
+    // known. The element flows from the `List(E)`-shaped parameter, recovered by
+    // class-side nested unification (BT-2256).
+    let hierarchy = ClassHierarchy::with_builtins();
+    for cls in ["Set", "List", "Array"] {
+        let send = kw1_send(class_ref(cls), "withAll:", var("items"));
+        let ty = infer_send_on_local("items", list_of("Integer"), &send, &hierarchy);
+        let known = ty.as_known();
+        assert_eq!(
+            known.map(EcoString::as_str),
+            Some(cls),
+            "`{cls} withAll: items(List(Integer))` must infer {cls}; got {ty:?}"
+        );
+        // The element type composes to Integer (not erased to Dynamic).
+        let elem = match &ty {
+            InferredType::Known { type_args, .. } => type_args.first(),
+            _ => None,
+        };
+        assert_eq!(
+            elem.and_then(InferredType::as_known).map(EcoString::as_str),
+            Some("Integer"),
+            "`{cls} withAll: items(List(Integer))` must compose to {cls}(Integer); got {ty:?}"
+        );
+    }
+}
+
+#[test]
+fn inherited_class_side_self_return_resolves_to_concrete_subclass() {
+    // The genuine Slice 2 `-> Self` mechanism: a concrete subclass that
+    // *inherits* (does not override) a class-side `-> Self` constructor from an
+    // abstract parent. Sent to the concrete class literal, `Self` resolves to the
+    // *concrete* subclass — not the abstract definition site.
+    let source = "
+typed Object subclass: AbstractMaker(E)
+  class make: items :: List(E) -> Self => @primitive \"make:\"
+
+typed AbstractMaker subclass: ConcreteMaker(E)
+";
+    let (_module, hierarchy) = parse_and_build(source);
+    let send = kw1_send(class_ref("ConcreteMaker"), "make:", var("items"));
+    let ty = infer_send_on_local("items", list_of("Integer"), &send, &hierarchy);
+    assert_eq!(
+        ty.as_known().map(EcoString::as_str),
+        Some("ConcreteMaker"),
+        "inherited class-side `-> Self` on a concrete subclass must resolve Self to \
+         the concrete subclass (ConcreteMaker), not the abstract parent; got {ty:?}"
+    );
+    // And it composes the inherited generic element type from the argument.
+    let elem = match &ty {
+        InferredType::Known { type_args, .. } => type_args.first(),
+        _ => None,
+    };
+    assert_eq!(
+        elem.and_then(InferredType::as_known).map(EcoString::as_str),
+        Some("Integer"),
+        "inherited `-> Self` must compose ConcreteMaker(Integer) from List(Integer); got {ty:?}"
+    );
+}
+
+#[test]
+fn abstract_class_side_self_return_stays_abstract_definition_site() {
+    // Slice 1 boundary (no regression): sending the same `-> Self` class-side
+    // method to the *abstract* class literal resolves Self to the abstract class
+    // itself — not a concrete subclass, and not Dynamic.
+    let source = "
+typed Object subclass: AbstractMaker(E)
+  class make: items :: List(E) -> Self => @primitive \"make:\"
+
+typed AbstractMaker subclass: ConcreteMaker(E)
+";
+    let (_module, hierarchy) = parse_and_build(source);
+    // AbstractMaker is not flagged `abstract`, so `-> Self` resolves to itself.
+    let send = kw1_send(class_ref("AbstractMaker"), "make:", var("items"));
+    let ty = infer_send_on_local("items", list_of("Integer"), &send, &hierarchy);
+    assert_eq!(
+        ty.as_known().map(EcoString::as_str),
+        Some("AbstractMaker"),
+        "class-side `-> Self` on the defining class literal resolves to that class; got {ty:?}"
+    );
+}
+
+#[test]
+fn concrete_withall_unknown_element_type_does_not_overclaim() {
+    // Safety: when the element type is NOT statically known (untyped array
+    // literal `#(1, 2)`), composition must not invent a concrete element — the
+    // class is still concrete (`Set`) but the element stays Dynamic. This pins
+    // that the nested-unification fix only fires on a typed, base-matching arg.
+    let hierarchy = ClassHierarchy::with_builtins();
+    let send = kw1_send(class_ref("Set"), "withAll:", int_array(&[1, 2]));
+    let ty = infer_send_on_local("ignored", InferredType::known("Object"), &send, &hierarchy);
+    assert_eq!(
+        ty.as_known().map(EcoString::as_str),
+        Some("Set"),
+        "`Set withAll: #(1,2)` is still a Set; got {ty:?}"
+    );
+    let elem = match &ty {
+        InferredType::Known { type_args, .. } => type_args.first().cloned(),
+        _ => None,
+    };
+    assert!(
+        matches!(elem, Some(InferredType::Dynamic(_))),
+        "untyped `#(1,2)` arg must leave the element type Dynamic, not over-claim; got {elem:?}"
+    );
+}
+
+#[test]
+fn nested_class_param_composition_recurses() {
+    // The nested-unification fix recurses into deeper generic shapes. A
+    // class-side `from: :: List(Pair(K, V)) -> Self` on `Maply(K, V)` must
+    // recover BOTH K and V from a `List(Pair(Symbol, Integer))` argument.
+    let source = "
+typed Object subclass: Pairly(A, B)
+typed Object subclass: Maply(K, V)
+  class from: entries :: List(Pairly(K, V)) -> Self => @primitive \"from:\"
+";
+    let (_module, hierarchy) = parse_and_build(source);
+    let arg_ty = InferredType::Known {
+        class_name: "List".into(),
+        type_args: vec![InferredType::Known {
+            class_name: "Pairly".into(),
+            type_args: vec![
+                InferredType::known("Symbol"),
+                InferredType::known("Integer"),
+            ],
+            provenance: super::super::TypeProvenance::Inferred(span()),
+        }],
+        provenance: super::super::TypeProvenance::Inferred(span()),
+    };
+    let send = kw1_send(class_ref("Maply"), "from:", var("entries"));
+    let ty = infer_send_on_local("entries", arg_ty, &send, &hierarchy);
+    assert_eq!(
+        ty.as_known().map(EcoString::as_str),
+        Some("Maply"),
+        "`Maply from:` must infer Maply; got {ty:?}"
+    );
+    let args = match &ty {
+        InferredType::Known { type_args, .. } => type_args.clone(),
+        _ => vec![],
+    };
+    let names: Vec<Option<&str>> = args
+        .iter()
+        .map(|a| a.as_known().map(EcoString::as_str))
+        .collect();
+    assert_eq!(
+        names,
+        vec![Some("Symbol"), Some("Integer")],
+        "nested unification must recover both K=Symbol and V=Integer; got {ty:?}"
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/self_class.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/self_class.rs
@@ -1126,23 +1126,23 @@ typed AbstractMaker subclass: ConcreteMaker(E)
 }
 
 #[test]
-fn abstract_class_side_self_return_stays_abstract_definition_site() {
-    // Slice 1 boundary (no regression): sending the same `-> Self` class-side
-    // method to the *abstract* class literal resolves Self to the abstract class
-    // itself — not a concrete subclass, and not Dynamic.
+fn class_side_self_return_on_defining_class_literal_resolves_to_itself() {
+    // Slice 1 boundary (no regression): sending a `-> Self` class-side method to
+    // the *defining* class literal resolves Self to that class itself — not a
+    // subclass, and not Dynamic. (The parent here is a plain base class, not
+    // marked `abstract`; this pins the receiver=defining-class case.)
     let source = "
-typed Object subclass: AbstractMaker(E)
+typed Object subclass: BaseMaker(E)
   class make: items :: List(E) -> Self => @primitive \"make:\"
 
-typed AbstractMaker subclass: ConcreteMaker(E)
+typed BaseMaker subclass: ConcreteMaker(E)
 ";
     let (_module, hierarchy) = parse_and_build(source);
-    // AbstractMaker is not flagged `abstract`, so `-> Self` resolves to itself.
-    let send = kw1_send(class_ref("AbstractMaker"), "make:", var("items"));
+    let send = kw1_send(class_ref("BaseMaker"), "make:", var("items"));
     let ty = infer_send_on_local("items", list_of("Integer"), &send, &hierarchy);
     assert_eq!(
         ty.as_known().map(EcoString::as_str),
-        Some("AbstractMaker"),
+        Some("BaseMaker"),
         "class-side `-> Self` on the defining class literal resolves to that class; got {ty:?}"
     );
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -269,8 +269,20 @@ impl TypeChecker {
     /// For non-generic classes (or classes with no class-method type
     /// substitution to do), the returned map is empty.
     ///
+    /// **ADR 0083 Slice 2 (BT-2256): nested element-type composition.** A
+    /// class-side constructor whose parameter mentions a class type param
+    /// *nested* inside a generic — e.g. `class withAll: list :: List(E) -> Self`
+    /// on `Set(E)` — recovers `E` from the matching-base argument:
+    /// `Set withAll: aList(Integer)` binds `E -> Integer`, so the `-> Self`
+    /// return composes to `Set(Integer)` rather than the erased `Set(Dynamic)`.
+    /// This mirrors the instance-side nested unification in
+    /// [`super::TypeChecker::infer_method_local_params`] (which handles only
+    /// *method-local* params); here we resolve *class-level* params on the
+    /// class-side. The exact-match binding still takes precedence (last write
+    /// wins only for unset keys — see the `entry` guard).
+    ///
     /// **References:** BT-2018 (preserve generic return types on class-method
-    /// assignments), ADR 0068 Phase 1c.
+    /// assignments), ADR 0068 Phase 1c, BT-2256 (Slice 2 nested composition).
     fn class_method_substitution(
         class_name: &EcoString,
         hierarchy: &ClassHierarchy,
@@ -285,13 +297,80 @@ impl TypeChecker {
             return subst;
         }
         for (param_ty_opt, arg_ty) in method.param_types.iter().zip(arg_types.iter()) {
-            if let Some(param_ty) = param_ty_opt {
-                if class_info.type_params.contains(param_ty) {
-                    subst.insert(param_ty.clone(), arg_ty.clone());
-                }
+            let Some(param_ty) = param_ty_opt else {
+                continue;
+            };
+            // Exact match: a bare class type param (e.g. `T` in `Box(T)`).
+            if class_info.type_params.contains(param_ty) {
+                subst.insert(param_ty.clone(), arg_ty.clone());
+                continue;
             }
+            // ADR 0083 Slice 2: nested match — a param shaped like `List(E)`
+            // where `E` is a class type param. Recover the binding from a
+            // matching-base `Known` argument (e.g. `List(Integer)` ⇒
+            // `E -> Integer`). Only fills params not already bound by an exact
+            // match, so a direct `T` parameter still wins.
+            Self::unify_nested_class_params(param_ty, arg_ty, class_info, &mut subst);
         }
         subst
+    }
+
+    /// Recover class-level type-param bindings nested inside a generic parameter
+    /// shape (ADR 0083 Slice 2 / BT-2256).
+    ///
+    /// Given a declared parameter type like `List(E)` and an argument type like
+    /// `List(Integer)`, binds `E -> Integer` when `E` is a class type param and
+    /// the argument's base class matches the declared base. Recurses positionally
+    /// so deeper nesting (`Pair(K, List(V))`) composes too. Bindings are merged
+    /// non-destructively: a key already present (e.g. from an exact-match
+    /// parameter) is not overwritten, and a `Dynamic` candidate never replaces a
+    /// `Known`/`Union` binding.
+    fn unify_nested_class_params(
+        declared: &str,
+        arg_ty: &InferredType,
+        class_info: &crate::semantic_analysis::class_hierarchy::ClassInfo,
+        subst: &mut HashMap<EcoString, InferredType>,
+    ) {
+        let (declared_base, declared_args) = super::type_resolver::split_generic_base(declared);
+        let Some(inner) = declared_args else {
+            return;
+        };
+        // Strip a nilable union (`List(String) | Nil`) to its non-nil member so
+        // the optional-collection shape still composes (mirrors BT-2023(A)).
+        let stripped;
+        let effective_arg = if matches!(arg_ty, InferredType::Union { .. }) {
+            stripped = super::TypeChecker::non_nil_type(arg_ty);
+            &stripped
+        } else {
+            arg_ty
+        };
+        let InferredType::Known {
+            class_name: arg_class,
+            type_args,
+            ..
+        } = effective_arg
+        else {
+            return;
+        };
+        if arg_class.as_str() != declared_base || type_args.is_empty() {
+            return;
+        }
+        let declared_params = super::TypeChecker::split_type_params(inner);
+        for (declared_param, actual) in declared_params.iter().zip(type_args.iter()) {
+            let decl_eco: EcoString = (*declared_param).into();
+            if class_info.type_params.contains(&decl_eco) {
+                // Don't clobber an existing binding; don't downgrade to Dynamic.
+                match subst.get(&decl_eco) {
+                    Some(InferredType::Known { .. } | InferredType::Union { .. }) => {}
+                    _ => {
+                        subst.insert(decl_eco, actual.clone());
+                    }
+                }
+            } else {
+                // Recurse into deeper nesting (`Pair(K, List(V))`).
+                Self::unify_nested_class_params(declared_param, actual, class_info, subst);
+            }
+        }
     }
 
     /// Infer the constructor return type for a generic class (ADR 0068 Phase 1c).

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -278,8 +278,9 @@ impl TypeChecker {
     /// This mirrors the instance-side nested unification in
     /// [`super::TypeChecker::infer_method_local_params`] (which handles only
     /// *method-local* params); here we resolve *class-level* params on the
-    /// class-side. The exact-match binding still takes precedence (last write
-    /// wins only for unset keys — see the `entry` guard).
+    /// class-side. Exact-match params are inserted directly and win: the nested
+    /// helper's merge guard refuses to overwrite a `Known`/`Union` binding an
+    /// exact match already set.
     ///
     /// **References:** BT-2018 (preserve generic return types on class-method
     /// assignments), ADR 0068 Phase 1c, BT-2256 (Slice 2 nested composition).
@@ -321,10 +322,10 @@ impl TypeChecker {
     /// Given a declared parameter type like `List(E)` and an argument type like
     /// `List(Integer)`, binds `E -> Integer` when `E` is a class type param and
     /// the argument's base class matches the declared base. Recurses positionally
-    /// so deeper nesting (`Pair(K, List(V))`) composes too. Bindings are merged
-    /// non-destructively: a key already present (e.g. from an exact-match
-    /// parameter) is not overwritten, and a `Dynamic` candidate never replaces a
-    /// `Known`/`Union` binding.
+    /// so deeper nesting (`Pair(K, List(V))`) composes too. Merge precedence: a
+    /// key already bound to a `Known`/`Union` (e.g. from an exact-match parameter)
+    /// is kept and never overwritten; a key that is absent or only bound to
+    /// `Dynamic` is filled in with this candidate.
     fn unify_nested_class_params(
         declared: &str,
         arg_ty: &InferredType,


### PR DESCRIPTION
## Summary

Implements **Slice 2** of ADR 0083 (Metaclass-Aware Type Inference) — the final child of epic BT-2257. Builds on BT-2255 (`Meta` variant + class-side routing) and BT-2260 (class literals → `Meta`).

Concrete class literals already infer `Set withAll: → Set` after BT-2255/BT-2260. This adds the remaining gap: **nested element-type composition** on class-side constructors, so the `-> Self` return carries element types:

```beamtalk
Set withAll: aList(Integer)   // now infers Set(Integer), not Set(Dynamic)
```

- New `unify_nested_class_params` in `validation.rs`: recovers class-level type-param bindings nested inside a generic parameter shape — `List(E)` arg `List(Integer)` ⇒ `E -> Integer` — recursing positionally for deeper nesting (`Pair(K, List(V))`). Non-destructive merge: an exact-match binding (a bare `T` param) still wins.
- Abstract receivers keep their prior behaviour (no false concrete inference).
- Adds metatype/Slice-2 test coverage in `tests/self_class.rs`.

## Test plan
- [x] `cargo test -p beamtalk-core`: 3885 pass, 0 fail
- [x] `build-stdlib` (forced rebuild): 0 stale `@expect`, 0 DNU, 77 modules
- [x] All 221 `stdlib/test/*.bt` compile with `--warnings-as-errors`: 0 stale `@expect`, 0 compile failures
- [x] clippy clean, `cargo fmt --check` clean
- [ ] `just ci` (Erlang runtime) — CI will verify

Linear: BT-2256

https://claude.ai/code/session_01JcL83vPaiRXAhWX7raRYMh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcL83vPaiRXAhWX7raRYMh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests covering class-side constructor/type inference for metaclass-aware scenarios, nested generic composition, concrete collection constructors, and inherited class-side constructors with generic arguments.

* **Bug Fixes**
  * Improved class-side type-parameter inference to recover nested generic bindings so return types (including parameterized `Self`) preserve composed generic shapes in complex type scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->