### PR TITLE
LSP infra: runtime-attached navigation query channel + lsp.delegate_to_runtime flag (BT-2239)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ stacker = "0.1"
 # WebSocket (ADR 0020 — REPL protocol transport)
 tungstenite = "0.29"
 tokio-tungstenite = "0.29"
+# Stream/Sink combinators for async WebSocket I/O
+futures-util = "0.3"
 
 # Windows process management (native replacement for sysinfo, BT-1039)
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -50,10 +50,12 @@
 //! ```
 
 mod project_index;
+mod runtime_nav;
 mod value_objects;
 
 // Re-export value objects at the module level
 pub use project_index::ProjectIndex;
+pub use runtime_nav::method_relative_line_span;
 pub use value_objects::{
     ByteOffset, CodeAction, Completion, CompletionKind, Diagnostic, DocumentSymbol,
     DocumentSymbolKind, HoverInfo, Location, ParameterInfo, Position, SignatureHelp, SignatureInfo,
@@ -256,6 +258,72 @@ impl SimpleLanguageService {
     #[must_use]
     pub fn file_source(&self, file: &Utf8PathBuf) -> Option<String> {
         self.files.get(file).map(|data| data.source.clone())
+    }
+
+    /// Resolve a runtime navigation site to a source [`Location`] (BT-2239).
+    ///
+    /// `class` is the class name as reported by `SystemNavigation`; a trailing
+    /// `" class"` marks a class-side (metaclass) method. `selector` is the
+    /// containing method and `relative_line` is 1-based, relative to that
+    /// method's source. Returns `None` when the class/method is not present in
+    /// the indexed files (e.g. a class loaded only at the REPL with no open
+    /// source file) — callers fall back to the AST path or skip the site.
+    ///
+    /// This is the shared translation seam consumed by the runtime-delegated
+    /// navigation children (BT-2240..2244): they obtain `{class, selector,
+    /// line}` sites from the runtime and map each through this method.
+    #[must_use]
+    pub fn locate_nav_site(
+        &self,
+        class: &str,
+        selector: &str,
+        relative_line: u32,
+    ) -> Option<Location> {
+        let (class_name, class_side) = match class.strip_suffix(" class") {
+            Some(base) => (base, true),
+            None => (class, false),
+        };
+        for (path, data) in &self.files {
+            for decl in &data.module.classes {
+                if decl.name.name.as_str() != class_name {
+                    continue;
+                }
+                let methods = if class_side {
+                    &decl.class_methods
+                } else {
+                    &decl.methods
+                };
+                for method in methods {
+                    if method.selector.name() == selector {
+                        let span = runtime_nav::method_relative_line_span(
+                            &data.source,
+                            method.span,
+                            relative_line,
+                        )?;
+                        return Some(Location::new(path.clone(), span));
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Returns the message selector at the given position, if any (BT-2239).
+    ///
+    /// Matches a selector either at a call site (`x bar`, `a + b`,
+    /// `x at: 1 put: 2`) or on a method-definition header (`bar => …`). Returns
+    /// `None` when the cursor is not on a selector.
+    ///
+    /// Used by runtime-delegated navigation to derive the selector argument for
+    /// `sendersOf` / `implementorsOf` queries before delegating to the runtime.
+    #[must_use]
+    pub fn selector_at(&self, file: &Utf8PathBuf, position: Position) -> Option<EcoString> {
+        let file_data = self.get_file(file)?;
+        let offset = position.to_byte_offset(&file_data.source)?;
+        if let Some(lookup) = Self::find_selector_at_offset(&file_data.module, offset.get()) {
+            return Some(lookup.selector_name);
+        }
+        Self::find_method_header_selector_at_offset(&file_data.module, offset.get())
     }
 
     /// If the offset falls inside the header of a method *definition*

--- a/crates/beamtalk-core/src/language_service/runtime_nav.rs
+++ b/crates/beamtalk-core/src/language_service/runtime_nav.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Source-location translation for runtime-delegated navigation (BT-2239).
+//!
+//! **DDD Context:** Language Service
+//!
+//! When the LSP delegates a navigation query to a running runtime (the
+//! static-first, live-augmented model of ADR 0024), `SystemNavigation`
+//! answers with sites shaped as `{class, selector, line}`, where `line` is
+//! 1-based **relative to the containing method's source** — the runtime does
+//! not store absolute file lines. This module turns such a site into a
+//! [`Location`] (file + span) that the LSP can render as `{uri, range}`.
+//!
+//! The relative line is anchored at the method's *header* line, because the
+//! runtime's `method_source` is produced by the unparser starting at the
+//! method signature (see `extract_method_source` in codegen). One known
+//! imprecision: the unparser includes leading doc comments that sit *above*
+//! `method.span.start()`, so a site that lands inside a leading comment can be
+//! off by the number of comment lines. Call sites and references — the common
+//! case — live in the body and resolve correctly. Per-method parity tests in
+//! the BT-2215 children pin this down further.
+
+use crate::source_analysis::Span;
+
+use super::value_objects::{ByteOffset, Position};
+
+/// Compute the [`Span`] of a method-relative line within a file.
+///
+/// `method_span` is the span of the method *definition* (its `start()` is the
+/// header line). `relative_line` is 1-based, relative to the method's source.
+/// The returned span covers the full resolved line (from its first byte to the
+/// end of the line, excluding the trailing newline).
+///
+/// Returns `None` if `method_span.start()` is out of bounds for `source` or the
+/// resolved line lies past the end of `source`.
+#[must_use]
+pub fn method_relative_line_span(
+    source: &str,
+    method_span: Span,
+    relative_line: u32,
+) -> Option<Span> {
+    let header_line =
+        Position::from_byte_offset(source, ByteOffset::new(method_span.start()))?.line;
+    let target_line = header_line + relative_line.saturating_sub(1);
+    line_span(source, target_line)
+}
+
+/// Return the byte span covering the given 0-based line, excluding the trailing
+/// newline. Returns `None` if the line index is beyond the last line.
+fn line_span(source: &str, line: u32) -> Option<Span> {
+    let mut current_line: u32 = 0;
+    let mut line_start: usize = 0;
+
+    for (i, ch) in source.char_indices() {
+        if ch == '\n' {
+            if current_line == line {
+                return Some(Span::new(to_u32(line_start), to_u32(i)));
+            }
+            current_line += 1;
+            line_start = i + 1;
+        }
+    }
+
+    // Last line (no trailing newline).
+    if current_line == line {
+        return Some(Span::new(to_u32(line_start), to_u32(source.len())));
+    }
+    None
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "source files over 4GB are not supported"
+)]
+const fn to_u32(value: usize) -> u32 {
+    value as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Method header on line 2 (0-based line 1). Body sends on lines 3-4.
+    const SRC: &str = "\
+class
+  increment =>
+    self bump
+    self log
+other";
+
+    fn span_at(line_one_based: u32) -> (u32, u32) {
+        // method_span starts at the header `increment =>` which begins at the
+        // 'i' after the two-space indent on line index 1.
+        let header_offset = u32::try_from(SRC.find("increment").unwrap()).unwrap();
+        let method_span = Span::new(header_offset, header_offset + 5);
+        let span = method_relative_line_span(SRC, method_span, line_one_based).unwrap();
+        (span.start(), span.end())
+    }
+
+    #[test]
+    fn relative_line_one_is_method_header() {
+        // Relative line 1 → the header line itself.
+        let (start, end) = span_at(1);
+        let text = &SRC[start as usize..end as usize];
+        assert_eq!(text, "  increment =>");
+    }
+
+    #[test]
+    fn relative_line_two_is_first_body_line() {
+        let (start, end) = span_at(2);
+        let text = &SRC[start as usize..end as usize];
+        assert_eq!(text, "    self bump");
+    }
+
+    #[test]
+    fn relative_line_three_is_second_body_line() {
+        let (start, end) = span_at(3);
+        let text = &SRC[start as usize..end as usize];
+        assert_eq!(text, "    self log");
+    }
+
+    #[test]
+    fn out_of_range_relative_line_returns_none() {
+        let header_offset = u32::try_from(SRC.find("increment").unwrap()).unwrap();
+        let method_span = Span::new(header_offset, header_offset + 5);
+        // Header is on line index 1; +99 overshoots the 5-line source.
+        assert!(method_relative_line_span(SRC, method_span, 99).is_none());
+    }
+
+    #[test]
+    fn last_line_without_trailing_newline() {
+        let src = "a =>\n  b";
+        let method_span = Span::new(0, 1);
+        let span = method_relative_line_span(src, method_span, 2).unwrap();
+        assert_eq!(&src[span.start() as usize..span.end() as usize], "  b");
+    }
+}

--- a/crates/beamtalk-core/src/language_service/runtime_nav.rs
+++ b/crates/beamtalk-core/src/language_service/runtime_nav.rs
@@ -32,17 +32,21 @@ use super::value_objects::{ByteOffset, Position};
 /// The returned span covers the full resolved line (from its first byte to the
 /// end of the line, excluding the trailing newline).
 ///
-/// Returns `None` if `method_span.start()` is out of bounds for `source` or the
-/// resolved line lies past the end of `source`.
+/// Returns `None` if `relative_line` is `0` (the contract is 1-based), if
+/// `method_span.start()` is out of bounds for `source`, or if the resolved line
+/// lies past the end of `source`.
 #[must_use]
 pub fn method_relative_line_span(
     source: &str,
     method_span: Span,
     relative_line: u32,
 ) -> Option<Span> {
+    if relative_line == 0 {
+        return None;
+    }
     let header_line =
         Position::from_byte_offset(source, ByteOffset::new(method_span.start()))?.line;
-    let target_line = header_line + relative_line.saturating_sub(1);
+    let target_line = header_line + (relative_line - 1);
     line_span(source, target_line)
 }
 
@@ -118,6 +122,15 @@ other";
         let (start, end) = span_at(3);
         let text = &SRC[start as usize..end as usize];
         assert_eq!(text, "    self log");
+    }
+
+    #[test]
+    fn zero_relative_line_returns_none() {
+        // The contract is 1-based; 0 is invalid input and is rejected rather
+        // than silently resolving to the method header.
+        let header_offset = u32::try_from(SRC.find("increment").unwrap()).unwrap();
+        let method_span = Span::new(header_offset, header_offset + 5);
+        assert!(method_relative_line_span(SRC, method_span, 0).is_none());
     }
 
     #[test]

--- a/crates/beamtalk-lsp/Cargo.toml
+++ b/crates/beamtalk-lsp/Cargo.toml
@@ -29,7 +29,7 @@ tower-lsp = { workspace = true }
 tokio = { workspace = true }
 # WebSocket client for the runtime query channel (ADR 0020).
 tokio-tungstenite = { workspace = true }
-futures-util = "0.3"
+futures-util = { workspace = true }
 camino = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/beamtalk-lsp/Cargo.toml
+++ b/crates/beamtalk-lsp/Cargo.toml
@@ -20,13 +20,22 @@ path = "src/main.rs"
 
 [dependencies]
 beamtalk-core = { workspace = true }
+# Shared REPL protocol types + workspace discovery for runtime-attached
+# navigation queries (BT-2239). Lets the LSP delegate to SystemNavigation
+# without depending on beamtalk-cli (which the architecture forbids).
+beamtalk-repl-protocol = { workspace = true }
+beamtalk-workspace = { workspace = true }
 tower-lsp = { workspace = true }
 tokio = { workspace = true }
+# WebSocket client for the runtime query channel (ADR 0020).
+tokio-tungstenite = { workspace = true }
+futures-util = "0.3"
 camino = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/beamtalk-lsp/src/main.rs
+++ b/crates/beamtalk-lsp/src/main.rs
@@ -8,6 +8,8 @@
 //! This binary exposes the `SimpleLanguageService` + `ProjectIndex` from
 //! `beamtalk-core` over the Language Server Protocol using `tower-lsp`.
 
+/// Runtime-attached navigation query channel (BT-2239).
+mod runtime;
 /// LSP server backend implementation.
 mod server;
 

--- a/crates/beamtalk-lsp/src/runtime.rs
+++ b/crates/beamtalk-lsp/src/runtime.rs
@@ -73,7 +73,13 @@ impl RuntimeClient {
                 .map_err(|_| format!("timed out connecting to runtime at {url}"))?
                 .map_err(|e| format!("failed to connect to runtime at {url}: {e}"))?;
 
-        perform_auth_handshake(&mut ws, &cookie).await?;
+        // Bound the handshake: a runtime that accepts the TCP connection but
+        // never completes the ADR 0020 handshake must not hang an LSP request.
+        match tokio::time::timeout(CONNECT_TIMEOUT, perform_auth_handshake(&mut ws, &cookie)).await
+        {
+            Ok(result) => result?,
+            Err(_) => return Err("timed out during runtime auth handshake".to_string()),
+        }
         Ok(Some(Self { ws }))
     }
 

--- a/crates/beamtalk-lsp/src/runtime.rs
+++ b/crates/beamtalk-lsp/src/runtime.rs
@@ -1,0 +1,174 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runtime-attached navigation query channel (BT-2239).
+//!
+//! **DDD Context:** Language Service
+//!
+//! When a Beamtalk runtime is attached (a `beamtalk repl` / `beamtalk run`
+//! workspace for the project the editor has open), the LSP can delegate
+//! navigation queries — find-references, go-to-implementation, hierarchy — to
+//! the live `SystemNavigation` facade instead of its in-process AST walker.
+//! This is the static-first, live-augmented tooling model of ADR 0024: the
+//! runtime knows things the AST cannot (extension methods per ADR 0066,
+//! classes loaded only at the REPL), so its answers are richer.
+//!
+//! This module is the transport. It discovers an attached runtime via the
+//! shared workspace files (`~/.beamtalk/workspaces/<id>/{port,cookie}`,
+//! [`beamtalk_workspace`]) and speaks the authenticated JSON-over-WebSocket
+//! REPL protocol (ADR 0020) using the shared request/response types from
+//! [`beamtalk_repl_protocol`]. It mirrors the reference client in
+//! `beamtalk-mcp` but is scoped to the read-only `nav-query` op, so it omits
+//! session resume and keepalive: the LSP connects lazily and reconnects on the
+//! next query if the socket drops.
+//!
+//! The per-method navigation children (BT-2240..2244) consume this via the
+//! dispatch seam on `Backend`; they implement only the per-query mapping, not
+//! the transport.
+
+use std::path::Path;
+use std::time::Duration;
+
+use beamtalk_repl_protocol::{ReplResponse, RequestBuilder};
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::tungstenite::Message;
+
+/// Timeout for establishing the WebSocket connection to a runtime.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Timeout for a single navigation query round-trip.
+const QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// An authenticated connection to an attached runtime's query channel.
+pub struct RuntimeClient {
+    ws: WsStream,
+}
+
+impl RuntimeClient {
+    /// Discover an attached runtime for `project_root` and connect to it.
+    ///
+    /// Returns `Ok(None)` when no runtime is attached (no port file for the
+    /// project's workspace) — the common cold-file case, in which the caller
+    /// falls back to the AST walker. Returns `Err` only when a runtime appears
+    /// to be present but the connection or auth handshake fails.
+    pub async fn discover_and_connect(project_root: &Path) -> Result<Option<Self>, String> {
+        let workspace_id = beamtalk_workspace::generate_workspace_id(project_root)
+            .map_err(|e| format!("workspace id: {e}"))?;
+        let Some((port, _nonce)) = beamtalk_workspace::read_port_file(&workspace_id)
+            .map_err(|e| format!("port file: {e}"))?
+        else {
+            return Ok(None);
+        };
+        let cookie = beamtalk_workspace::read_cookie_file(&workspace_id)
+            .map_err(|e| format!("cookie file: {e}"))?
+            .unwrap_or_default();
+
+        let url = format!("ws://127.0.0.1:{port}/ws");
+        let (mut ws, _response) =
+            tokio::time::timeout(CONNECT_TIMEOUT, tokio_tungstenite::connect_async(&url))
+                .await
+                .map_err(|_| format!("timed out connecting to runtime at {url}"))?
+                .map_err(|e| format!("failed to connect to runtime at {url}: {e}"))?;
+
+        perform_auth_handshake(&mut ws, &cookie).await?;
+        Ok(Some(Self { ws }))
+    }
+
+    /// Run a navigation query and return the parsed response.
+    ///
+    /// `kind` is `"sendersOf"` / `"referencesTo"` / `"implementorsOf"`; `arg` is
+    /// the selector or class name. Callers read `sites` (senders/references) or
+    /// `implementors` from the response and translate via the language service.
+    /// A structured error from the runtime is surfaced as `Err`.
+    pub async fn nav_query(&mut self, kind: &str, arg: &str) -> Result<ReplResponse, String> {
+        let resp = self.send(&RequestBuilder::nav_query(kind, arg)).await?;
+        if let Some(err) = resp.error_message() {
+            return Err(err.to_string());
+        }
+        Ok(resp)
+    }
+
+    /// Send a request and read the final response, skipping any intermediate
+    /// streaming frames (which lack a `status` field).
+    async fn send(&mut self, request: &serde_json::Value) -> Result<ReplResponse, String> {
+        let request_str =
+            serde_json::to_string(request).map_err(|e| format!("serialize request: {e}"))?;
+        let io = async {
+            self.ws
+                .send(Message::Text(request_str.into()))
+                .await
+                .map_err(|e| format!("send: {e}"))?;
+            loop {
+                let text = read_text_message(&mut self.ws).await?;
+                let value: serde_json::Value =
+                    serde_json::from_str(&text).map_err(|e| format!("parse response: {e}"))?;
+                if value.get("status").is_some() {
+                    return serde_json::from_value(value)
+                        .map_err(|e| format!("deserialize response: {e}"));
+                }
+                // Intermediate streaming frame — keep reading.
+            }
+        };
+        tokio::time::timeout(QUERY_TIMEOUT, io)
+            .await
+            .map_err(|_| "runtime query timed out".to_string())?
+    }
+}
+
+/// Perform the ADR 0020 auth handshake: read `auth-required`, send the cookie,
+/// read `auth_ok`, read `session-started`.
+async fn perform_auth_handshake(ws: &mut WsStream, cookie: &str) -> Result<(), String> {
+    let auth_required = read_text_message(ws).await?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(&auth_required).map_err(|e| format!("parse auth-required: {e}"))?;
+    if parsed.get("op").and_then(|v| v.as_str()) != Some("auth-required") {
+        return Err(format!("unexpected pre-auth message: {parsed}"));
+    }
+
+    let auth_msg = serde_json::json!({"type": "auth", "cookie": cookie});
+    let auth_str = serde_json::to_string(&auth_msg).map_err(|e| format!("serialize auth: {e}"))?;
+    ws.send(Message::Text(auth_str.into()))
+        .await
+        .map_err(|e| format!("send auth: {e}"))?;
+
+    let auth_response = read_text_message(ws).await?;
+    let auth_json: serde_json::Value =
+        serde_json::from_str(&auth_response).map_err(|e| format!("parse auth response: {e}"))?;
+    match auth_json.get("type").and_then(|t| t.as_str()) {
+        Some("auth_ok") => {}
+        Some("auth_error") => {
+            let msg = auth_json
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("authentication failed");
+            return Err(format!("runtime authentication failed: {msg}"));
+        }
+        _ => return Err(format!("unexpected auth response: {auth_json}")),
+    }
+
+    let session_started = read_text_message(ws).await?;
+    let session_json: serde_json::Value = serde_json::from_str(&session_started)
+        .map_err(|e| format!("parse session-started: {e}"))?;
+    if session_json.get("op").and_then(|v| v.as_str()) != Some("session-started") {
+        return Err(format!("unexpected post-auth message: {session_json}"));
+    }
+    Ok(())
+}
+
+/// Read the next text frame, skipping ping/pong/binary frames.
+async fn read_text_message(ws: &mut WsStream) -> Result<String, String> {
+    loop {
+        match ws.next().await {
+            Some(Ok(Message::Text(text))) => return Ok(text.to_string()),
+            Some(Ok(Message::Close(_))) => {
+                return Err("runtime closed the connection".to_string());
+            }
+            Some(Ok(_)) => {} // ping/pong/binary — keep reading
+            Some(Err(e)) => return Err(format!("websocket error: {e}")),
+            None => return Err("runtime connection ended".to_string()),
+        }
+    }
+}

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -12,6 +12,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -90,6 +91,12 @@ pub struct Backend {
     workspace_roots: Mutex<Vec<PathBuf>>,
     /// Cached OTP lib directory (e.g., `/usr/lib/erlang/lib`); resolved once at startup.
     otp_lib_dir: Mutex<Option<PathBuf>>,
+    /// BT-2239: feature flag (`lsp.delegate_to_runtime`, default off) gating
+    /// delegation of navigation queries to an attached runtime.
+    delegate_to_runtime: AtomicBool,
+    /// BT-2239: lazily-established connection to the attached runtime's query
+    /// channel. `None` until first use (or after a dropped connection).
+    runtime_client: tokio::sync::Mutex<Option<crate::runtime::RuntimeClient>>,
 }
 
 impl Backend {
@@ -104,7 +111,91 @@ impl Backend {
             stdlib_paths: Mutex::new(HashSet::new()),
             workspace_roots: Mutex::new(Vec::new()),
             otp_lib_dir: Mutex::new(None),
+            delegate_to_runtime: AtomicBool::new(false),
+            runtime_client: tokio::sync::Mutex::new(None),
         }
+    }
+
+    /// BT-2239 dispatch seam: run a navigation query against the attached
+    /// runtime, or return `None` to fall back to the in-process AST walker.
+    ///
+    /// Returns `None` when delegation is disabled (`lsp.delegate_to_runtime`
+    /// off), no runtime is attached, or the query fails. On a transport error
+    /// the cached connection is dropped so the next call reconnects.
+    ///
+    /// This is the reusable transport seam for the BT-2215 navigation children:
+    /// each per-method handler calls this with its `kind`/`arg`, reads `sites`
+    /// or `implementors` from the response, and translates via
+    /// `SimpleLanguageService::locate_nav_site`.
+    async fn delegate_nav_query(
+        &self,
+        kind: &str,
+        arg: &str,
+    ) -> Option<beamtalk_repl_protocol::ReplResponse> {
+        if !self.delegate_to_runtime.load(Ordering::Relaxed) {
+            return None;
+        }
+        let mut guard = self.runtime_client.lock().await;
+        if guard.is_none() {
+            *guard = self.connect_runtime().await;
+        }
+        let client = guard.as_mut()?;
+        match client.nav_query(kind, arg).await {
+            Ok(resp) => Some(resp),
+            Err(e) => {
+                debug!("runtime nav query failed, dropping connection: {e}");
+                *guard = None;
+                None
+            }
+        }
+    }
+
+    /// Connect to the attached runtime for the first workspace root, if any.
+    async fn connect_runtime(&self) -> Option<crate::runtime::RuntimeClient> {
+        let root = {
+            let roots = self
+                .workspace_roots
+                .lock()
+                .expect("workspace_roots lock poisoned");
+            roots.first().cloned()
+        }?;
+        match crate::runtime::RuntimeClient::discover_and_connect(&root).await {
+            Ok(client) => client,
+            Err(e) => {
+                debug!("runtime discovery/connect failed: {e}");
+                None
+            }
+        }
+    }
+
+    /// BT-2239 worked example: answer find-references from the attached runtime.
+    ///
+    /// Resolves the selector under the cursor, runs `sendersOf` against the
+    /// live image, and translates the `{class, selector, line}` sites back to
+    /// LSP locations. Returns `None` (caller falls back to the AST walker) when
+    /// the cursor is not on a selector or the runtime is unavailable. The
+    /// service lock is never held across the network await.
+    ///
+    /// Scope note: this covers selector senders only. Full references parity
+    /// (class references via `referencesTo`, edge cases, snapshot tests) is
+    /// BT-2240; this establishes the seam the children reuse.
+    async fn references_via_runtime(
+        &self,
+        path: &Utf8PathBuf,
+        params: &ReferenceParams,
+    ) -> Option<Vec<tower_lsp::lsp_types::Location>> {
+        let selector = {
+            let svc = self.service.lock().expect("service lock poisoned");
+            let source = svc.file_source(path)?;
+            let pos = to_bt_position(params.text_document_position.position, &source);
+            svc.selector_at(path, pos)?
+        };
+        let resp = self
+            .delegate_nav_query("sendersOf", selector.as_str())
+            .await?;
+        let sites = resp.sites?;
+        let svc = self.service.lock().expect("service lock poisoned");
+        Some(sites_to_lsp_locations(&svc, &sites))
     }
 
     fn file_version_for_uri(&self, uri: &Url) -> Option<i32> {
@@ -538,6 +629,8 @@ impl LanguageServer for Backend {
         let roots = workspace_roots(&params);
         let configured_stdlib = configured_stdlib_source_dir(&params);
         let stdlib_dirs = configured_stdlib_source_dirs(configured_stdlib.as_deref(), &roots);
+        self.delegate_to_runtime
+            .store(runtime_delegation_enabled(&params), Ordering::Relaxed);
         {
             let mut stored_roots = self
                 .workspace_roots
@@ -966,6 +1059,18 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
 
+        // BT-2239: when delegation is enabled and a runtime is attached, answer
+        // from the live image (SystemNavigation) — it sees extension methods and
+        // REPL-loaded classes the AST walker cannot. Falls through to the AST
+        // path when the flag is off, no runtime is attached, or it finds nothing.
+        if self.delegate_to_runtime.load(Ordering::Relaxed) {
+            if let Some(locations) = self.references_via_runtime(&path, &params).await {
+                if !locations.is_empty() {
+                    return Ok(Some(locations));
+                }
+            }
+        }
+
         let svc = self.service.lock().expect("service lock poisoned");
         let Some(source) = svc.file_source(&path) else {
             return Ok(None);
@@ -1215,6 +1320,21 @@ fn configured_stdlib_source_dir(params: &InitializeParams) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
+}
+
+/// Reads the `lsp.delegate_to_runtime` feature flag from initialization options
+/// (`delegateToRuntime`, default `false`) — BT-2239.
+///
+/// When enabled, navigation queries are delegated to an attached runtime's
+/// `SystemNavigation` facade (with the AST walker as fallback). When disabled,
+/// all navigation uses the in-process AST path with no behaviour change.
+fn runtime_delegation_enabled(params: &InitializeParams) -> bool {
+    params
+        .initialization_options
+        .as_ref()
+        .and_then(|value| value.get("delegateToRuntime"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 /// Returns the stdlib source directory auto-discovered from the LSP binary's sysroot.
@@ -1527,6 +1647,30 @@ fn path_to_stdlib_uri(path: &Utf8PathBuf) -> Option<Url> {
     Url::parse(&format!("beamtalk-stdlib:///{filename}")).ok()
 }
 
+/// Translates runtime navigation sites (`{class, selector, line}`) to LSP
+/// locations via the language service (BT-2239).
+///
+/// Each site is resolved to a method-relative source span by
+/// `SimpleLanguageService::locate_nav_site`; sites whose class/method are not
+/// in the indexed files (e.g. a REPL-only class) are skipped.
+fn sites_to_lsp_locations(
+    svc: &SimpleLanguageService,
+    sites: &[beamtalk_repl_protocol::NavSite],
+) -> Vec<tower_lsp::lsp_types::Location> {
+    sites
+        .iter()
+        .filter_map(|site| {
+            let loc = svc.locate_nav_site(&site.class, &site.selector, site.line)?;
+            let source = svc.file_source(&loc.file)?;
+            let range = span_to_range(loc.span, &source);
+            Some(tower_lsp::lsp_types::Location {
+                uri: path_to_uri(&loc.file)?,
+                range,
+            })
+        })
+        .collect()
+}
+
 /// Converts an LSP `Position` (UTF-16 code units) to a beamtalk `Position` (byte offsets).
 ///
 /// LSP positions use UTF-16 code units for the character field.
@@ -1817,6 +1961,61 @@ mod tests {
 
         let configured = configured_stdlib_source_dir(&params);
         assert_eq!(configured.as_deref(), Some("stdlib/src"));
+    }
+
+    #[test]
+    fn runtime_delegation_disabled_by_default() {
+        let params = InitializeParams::default();
+        assert!(!runtime_delegation_enabled(&params));
+    }
+
+    #[test]
+    fn runtime_delegation_reads_initialize_option() {
+        let on = InitializeParams {
+            initialization_options: Some(serde_json::json!({ "delegateToRuntime": true })),
+            ..Default::default()
+        };
+        assert!(runtime_delegation_enabled(&on));
+
+        let off = InitializeParams {
+            initialization_options: Some(serde_json::json!({ "delegateToRuntime": false })),
+            ..Default::default()
+        };
+        assert!(!runtime_delegation_enabled(&off));
+    }
+
+    #[test]
+    fn sites_to_lsp_locations_translates_indexed_sites() {
+        let mut svc = SimpleLanguageService::new();
+        // path_to_uri requires an absolute path (file:// URI).
+        let dir = unique_temp_dir("beamtalk_lsp_nav_sites");
+        let path = Utf8PathBuf::from_path_buf(dir.join("counter.bt")).expect("utf8 temp path");
+        // Method header on line index 1; a send on line index 2 (relative line 2).
+        let source = "Object subclass: Counter\n  bump =>\n    self step\n";
+        svc.update_file(path.clone(), source.to_string());
+
+        let sites = vec![beamtalk_repl_protocol::NavSite {
+            class: "Counter".to_string(),
+            selector: "bump".to_string(),
+            line: 2,
+        }];
+        let locations = sites_to_lsp_locations(&svc, &sites);
+        assert_eq!(locations.len(), 1);
+        // Relative line 2 of `bump` → file line index 2 (the `self step` line).
+        assert_eq!(locations[0].range.start.line, 2);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sites_to_lsp_locations_skips_unknown_class() {
+        let svc = SimpleLanguageService::new();
+        let sites = vec![beamtalk_repl_protocol::NavSite {
+            class: "NotIndexed".to_string(),
+            selector: "whatever".to_string(),
+            line: 1,
+        }];
+        assert!(sites_to_lsp_locations(&svc, &sites).is_empty());
     }
 
     #[test]

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -195,7 +195,11 @@ impl Backend {
             .await?;
         let sites = resp.sites?;
         let svc = self.service.lock().expect("service lock poisoned");
-        Some(sites_to_lsp_locations(&svc, &sites))
+        let stdlib_paths = self
+            .stdlib_paths
+            .lock()
+            .expect("stdlib_paths lock poisoned");
+        Some(sites_to_lsp_locations(&svc, &sites, &stdlib_paths))
     }
 
     fn file_version_for_uri(&self, uri: &Url) -> Option<i32> {
@@ -1652,10 +1656,13 @@ fn path_to_stdlib_uri(path: &Utf8PathBuf) -> Option<Url> {
 ///
 /// Each site is resolved to a method-relative source span by
 /// `SimpleLanguageService::locate_nav_site`; sites whose class/method are not
-/// in the indexed files (e.g. a REPL-only class) are skipped.
+/// in the indexed files (e.g. a REPL-only class) are skipped. Stdlib files are
+/// mapped to `beamtalk-stdlib://` URIs (matching `goto_definition`) so the
+/// editor opens them as virtual documents rather than missing `file://` paths.
 fn sites_to_lsp_locations(
     svc: &SimpleLanguageService,
     sites: &[beamtalk_repl_protocol::NavSite],
+    stdlib_paths: &HashSet<Utf8PathBuf>,
 ) -> Vec<tower_lsp::lsp_types::Location> {
     sites
         .iter()
@@ -1663,10 +1670,12 @@ fn sites_to_lsp_locations(
             let loc = svc.locate_nav_site(&site.class, &site.selector, site.line)?;
             let source = svc.file_source(&loc.file)?;
             let range = span_to_range(loc.span, &source);
-            Some(tower_lsp::lsp_types::Location {
-                uri: path_to_uri(&loc.file)?,
-                range,
-            })
+            let uri = if stdlib_paths.contains(&loc.file) {
+                path_to_stdlib_uri(&loc.file)?
+            } else {
+                path_to_uri(&loc.file)?
+            };
+            Some(tower_lsp::lsp_types::Location { uri, range })
         })
         .collect()
 }
@@ -1999,7 +2008,7 @@ mod tests {
             selector: "bump".to_string(),
             line: 2,
         }];
-        let locations = sites_to_lsp_locations(&svc, &sites);
+        let locations = sites_to_lsp_locations(&svc, &sites, &HashSet::new());
         assert_eq!(locations.len(), 1);
         // Relative line 2 of `bump` → file line index 2 (the `self step` line).
         assert_eq!(locations[0].range.start.line, 2);
@@ -2015,7 +2024,7 @@ mod tests {
             selector: "whatever".to_string(),
             line: 1,
         }];
-        assert!(sites_to_lsp_locations(&svc, &sites).is_empty());
+        assert!(sites_to_lsp_locations(&svc, &sites, &HashSet::new()).is_empty());
     }
 
     #[test]

--- a/crates/beamtalk-mcp/Cargo.toml
+++ b/crates/beamtalk-mcp/Cargo.toml
@@ -51,7 +51,7 @@ tracing-subscriber.workspace = true
 # why: WebSocket client for REPL protocol (ADR 0020)
 tokio-tungstenite.workspace = true
 # why: Stream/Sink combinators for WebSocket I/O
-futures-util = "0.3"
+futures-util = { workspace = true }
 
 # Bundled example corpus and search (ADR 0062)
 beamtalk-examples.workspace = true

--- a/crates/beamtalk-parity-tests/Cargo.toml
+++ b/crates/beamtalk-parity-tests/Cargo.toml
@@ -23,7 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "net", "process", "sync", "time"] }
 tokio-tungstenite.workspace = true
-futures-util = "0.3"
+futures-util.workspace = true
 tracing.workspace = true
 
 [[test]]

--- a/crates/beamtalk-repl-protocol/src/lib.rs
+++ b/crates/beamtalk-repl-protocol/src/lib.rs
@@ -16,4 +16,6 @@ mod request;
 mod response;
 
 pub use request::{RequestBuilder, next_msg_id};
-pub use response::{ActorInfo, ClassInfo, ModuleInfo, ReplResponse, SessionInfo};
+pub use response::{
+    ActorInfo, ClassInfo, ModuleInfo, NavImplementor, NavSite, ReplResponse, SessionInfo,
+};

--- a/crates/beamtalk-repl-protocol/src/request.rs
+++ b/crates/beamtalk-repl-protocol/src/request.rs
@@ -337,6 +337,24 @@ impl RequestBuilder {
         })
     }
 
+    /// Build a `nav-query` request (BT-2239).
+    ///
+    /// Routes a `SystemNavigation` navigation query to the running image so
+    /// the LSP can delegate find-references / go-to-implementation / hierarchy
+    /// queries to the live runtime (the static-first, live-augmented model of
+    /// ADR 0024). `kind` is one of `"implementorsOf"`, `"sendersOf"`, or
+    /// `"referencesTo"`; `arg` is the selector (for implementors/senders) or
+    /// the class name (for references).
+    #[must_use]
+    pub fn nav_query(kind: &str, arg: &str) -> serde_json::Value {
+        serde_json::json!({
+            "op": "nav-query",
+            "id": next_msg_id(),
+            "kind": kind,
+            "arg": arg
+        })
+    }
+
     /// Build a `list-classes` request (BT-1404).
     #[must_use]
     pub fn list_classes(filter: Option<&str>) -> serde_json::Value {
@@ -738,6 +756,15 @@ mod tests {
         let req = RequestBuilder::shutdown("secret-cookie");
         assert_eq!(req["op"], "shutdown");
         assert_eq!(req["cookie"], "secret-cookie");
+    }
+
+    #[test]
+    fn nav_query_request_has_correct_shape() {
+        let req = RequestBuilder::nav_query("sendersOf", "increment");
+        assert_eq!(req["op"], "nav-query");
+        assert_eq!(req["kind"], "sendersOf");
+        assert_eq!(req["arg"], "increment");
+        assert!(req["id"].as_str().unwrap().starts_with("msg-"));
     }
 
     #[test]

--- a/crates/beamtalk-repl-protocol/src/response.rs
+++ b/crates/beamtalk-repl-protocol/src/response.rs
@@ -104,6 +104,18 @@ pub struct ReplResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub info: Option<serde_json::Value>,
 
+    // --- Navigation (nav-query op, BT-2239) ---
+    /// Call/reference sites (`sendersOf` / `referencesTo` nav queries). Each
+    /// entry locates a method by `{class, selector, line}`, where `line` is
+    /// 1-based and relative to the method's source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sites: Option<Vec<NavSite>>,
+
+    /// Implementing classes (`implementorsOf` nav query). `meta` is true when
+    /// the selector is defined on the class side (metaclass).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub implementors: Option<Vec<NavImplementor>>,
+
     /// Actor state (inspect op).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub state: Option<serde_json::Value>,
@@ -223,6 +235,32 @@ impl ReplResponse {
             None => String::new(),
         }
     }
+}
+
+/// A navigation site from a `sendersOf` / `referencesTo` nav query (BT-2239).
+///
+/// Locates a method by class and selector, plus a 1-based line **relative to
+/// that method's source** (the runtime does not store absolute file lines, so
+/// the LSP resolves the method's definition and adds this offset).
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct NavSite {
+    /// Name of the class (or metaclass, e.g. `"Counter class"`) whose method
+    /// contains the site.
+    pub class: String,
+    /// The selector of the containing method.
+    pub selector: String,
+    /// 1-based line of the site, relative to the containing method's source.
+    pub line: u32,
+}
+
+/// An implementing class from an `implementorsOf` nav query (BT-2239).
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct NavImplementor {
+    /// Name of the implementing class.
+    pub class: String,
+    /// Whether the selector is defined on the class side (metaclass).
+    #[serde(default)]
+    pub meta: bool,
 }
 
 /// Information about a running actor, deserialized from REPL JSON.
@@ -355,6 +393,28 @@ mod tests {
         let json = r#"{"id":"msg-007","status":["done"]}"#;
         let resp: ReplResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.value_string(), "");
+    }
+
+    #[test]
+    fn deserialize_nav_sites() {
+        let json = r#"{"id":"msg-008","sites":[{"class":"Counter","selector":"increment","line":3}],"status":["done"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        let sites = resp.sites.unwrap();
+        assert_eq!(sites.len(), 1);
+        assert_eq!(sites[0].class, "Counter");
+        assert_eq!(sites[0].selector, "increment");
+        assert_eq!(sites[0].line, 3);
+    }
+
+    #[test]
+    fn deserialize_nav_implementors() {
+        let json = r#"{"id":"msg-009","implementors":[{"class":"Integer","meta":false},{"class":"Counter class","meta":true}],"status":["done"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        let impls = resp.implementors.unwrap();
+        assert_eq!(impls.len(), 2);
+        assert_eq!(impls[0].class, "Integer");
+        assert!(!impls[0].meta);
+        assert!(impls[1].meta);
     }
 
     #[test]

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -93,7 +93,7 @@ Historically meta-commands like `:bindings`, `:sync`, `:test` existed to bootstr
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
 |---------|---------------|-------------------|----------|----------------|-------|
-| `nav-query` | -- | `via SystemNavigation default` | -- | `references` | System-Browser navigation (implementorsOf / sendersOf / referencesTo) delegated to the live `SystemNavigation` facade (BT-2239). LSP consumes it for find-references when `lsp.delegate_to_runtime` is enabled and a runtime is attached, falling back to the AST walker otherwise (ADR 0024). Per-method coverage (implementation, typeHierarchy, callHierarchy) lands in BT-2240..2244 |
+| `nav-query` | -- | `via SystemNavigation default` | -- | `textDocument/references` | System-Browser navigation (implementorsOf / sendersOf / referencesTo) delegated to the live `SystemNavigation` facade (BT-2239). LSP consumes it for find-references when `lsp.delegate_to_runtime` is enabled and a runtime is attached, falling back to the AST walker otherwise (ADR 0024). Per-method coverage (implementation, typeHierarchy, callHierarchy) lands in BT-2240..2244 |
 
 ## Performance / Tracing Operations
 

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -89,6 +89,12 @@ Historically meta-commands like `:bindings`, `:sync`, `:test` existed to bootstr
 | `erlang-help` | -- | `surface-specific: REPL completion helper` | -- | -- | Erlang module documentation; MCP coverage tracked in BT-1903 |
 | `erlang-complete` | -- | `surface-specific: REPL completion helper` | -- | -- | Erlang module/function completion |
 
+## Navigation Operations
+
+| REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
+|---------|---------------|-------------------|----------|----------------|-------|
+| `nav-query` | -- | `via SystemNavigation default` | -- | `references` | System-Browser navigation (implementorsOf / sendersOf / referencesTo) delegated to the live `SystemNavigation` facade (BT-2239). LSP consumes it for find-references when `lsp.delegate_to_runtime` is enabled and a runtime is attached, falling back to the AST walker otherwise (ADR 0024). Per-method coverage (implementation, typeHierarchy, callHierarchy) lands in BT-2240..2244 |
+
 ## Performance / Tracing Operations
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |

--- a/docs/repl-protocol.md
+++ b/docs/repl-protocol.md
@@ -586,7 +586,7 @@ Returns the list of supported operations with their parameters, protocol version
 }
 ```
 
-The actual response includes all supported operations (e.g., `eval`, `complete`, `info`, `load-source`, `load-project`, `clear`, `bindings`, `sessions`, `clone`, `close`, `actors`, `inspect`, `kill`, `interrupt`, `unload`, `test`, `test-all`, `health`, `describe`, `shutdown`). Each entry lists required `params` and any `optional` parameters. The `versions` map includes the protocol version and the Beamtalk runtime version.
+The actual response includes all supported operations (e.g., `eval`, `complete`, `info`, `load-source`, `load-project`, `clear`, `bindings`, `sessions`, `clone`, `close`, `actors`, `inspect`, `kill`, `interrupt`, `unload`, `test`, `test-all`, `nav-query`, `health`, `describe`, `shutdown`). Each entry lists required `params` and any `optional` parameters. The `versions` map includes the protocol version and the Beamtalk runtime version.
 
 > **BT-2091 (protocol 2.0):** The deprecated ops `docs`, `load-file`, `reload`, and `modules` were removed. Use `Beamtalk help: ClassName`, `Workspace load: "path"`, `ClassName reload`, and `Workspace classes` via the `eval` op instead.
 
@@ -621,6 +621,64 @@ Initiates graceful OTP supervisor tree shutdown. Requires cookie authentication.
 **Response (auth failure):**
 ```json
 {"id": "msg-042", "error": "auth_error: Invalid cookie", "status": ["done", "error"]}
+```
+
+### Navigation Operations
+
+#### `nav-query` — System-Browser Navigation (BT-2239)
+
+Run a System-Browser navigation query against the live image by delegating to
+the `SystemNavigation` facade. This lets editor tooling (the LSP, and a future
+LiveView IDE) answer find-references / go-to-implementation / hierarchy queries
+from the running runtime instead of a static AST walk — the static-first,
+live-augmented model of ADR 0024. The runtime sees facts the AST cannot, such
+as open-class extension methods (ADR 0066) and classes loaded only at the REPL.
+
+**Request:**
+```json
+{"op": "nav-query", "id": "msg-200", "kind": "sendersOf", "arg": "increment"}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `kind` | string | **yes** | One of `implementorsOf`, `sendersOf`, `referencesTo` |
+| `arg` | string | **yes** | Selector (for `implementorsOf` / `sendersOf`) or class name (for `referencesTo`). Restricted to selector / class-name characters |
+
+**Response — `sendersOf` / `referencesTo` (call/reference sites):**
+```json
+{
+  "id": "msg-200",
+  "sites": [
+    {"class": "Counter", "selector": "bump", "line": 2},
+    {"class": "Counter class", "selector": "reset", "line": 1}
+  ],
+  "status": ["done"]
+}
+```
+
+Each site locates a method by `class` and `selector`, plus a 1-based `line`
+**relative to that method's source** (the runtime does not store absolute file
+lines). A `class` ending in `" class"` denotes a class-side method. Clients
+resolve the method definition and add the relative line to obtain an absolute
+position.
+
+**Response — `implementorsOf` (implementing classes):**
+```json
+{
+  "id": "msg-200",
+  "implementors": [
+    {"class": "Integer", "meta": false},
+    {"class": "Counter class", "meta": true}
+  ],
+  "status": ["done"]
+}
+```
+
+`meta` is `true` when the selector is defined on the class side (metaclass).
+
+**Response (invalid request):**
+```json
+{"id": "msg-200", "error": "nav-query 'kind' is not a supported navigation query", "status": ["done", "error"]}
 ```
 
 ## Push Messages

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -1772,6 +1772,7 @@ base_ops() ->
             <<"params">> => [],
             <<"optional">> => [<<"filter">>]
         },
+        <<"nav-query">> => #{<<"params">> => [<<"kind">>, <<"arg">>]},
         <<"show-codegen">> => #{
             <<"params">> => [],
             <<"optional">> => [<<"code">>, <<"class">>, <<"selector">>]

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_nav.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_nav.erl
@@ -114,12 +114,19 @@ encode_result(implementors, Term, Msg) when is_list(Term) ->
     Base = beamtalk_repl_protocol:base_response(Msg),
     Result = Base#{<<"implementors">> => Impls, <<"status">> => [<<"done">>]},
     iolist_to_binary(json:encode(Result));
-encode_result(_Shape, _Term, Msg) ->
+encode_result(Shape, _Term, Msg) ->
     %% Defensive: SystemNavigation always returns a List; a non-list result
-    %% means the query shape changed. Surface an empty result rather than crash.
+    %% means the query shape changed. Surface an empty result in the field that
+    %% matches the requested shape (so the wire contract stays consistent)
+    %% rather than crash.
     ?LOG_WARNING("nav-query: unexpected non-list result", #{domain => [beamtalk, runtime]}),
+    Field =
+        case Shape of
+            implementors -> <<"implementors">>;
+            _ -> <<"sites">>
+        end,
     Base = beamtalk_repl_protocol:base_response(Msg),
-    iolist_to_binary(json:encode(Base#{<<"sites">> => [], <<"status">> => [<<"done">>]})).
+    iolist_to_binary(json:encode(Base#{Field => [], <<"status">> => [<<"done">>]})).
 
 -doc """
 Encode one `{#class, #selector, #line}` record. `#class` is a class or

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_nav.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_nav.erl
@@ -1,0 +1,178 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_repl_ops_nav).
+
+%%% **DDD Context:** REPL Session Context
+
+-moduledoc """
+Op handler for the `nav-query` operation (BT-2239).
+
+Routes System-Browser navigation queries to the live `SystemNavigation`
+facade so editor tooling (the LSP, future LiveView IDE) can delegate
+find-references / go-to-implementation / hierarchy queries to the running
+image instead of duplicating the AST walk in Rust (the static-first,
+live-augmented model of ADR 0024).
+
+This is the runtime side of the BT-2215 epic. Each query is answered by
+evaluating the corresponding `SystemNavigation default <query>` expression in
+the calling session worker (where these sealed-Object value-type methods run
+inline) and serialising the result to a machine-readable JSON shape:
+
+* `implementorsOf` → `{"implementors": [{"class", "meta"}], ...}`
+* `sendersOf` / `referencesTo` → `{"sites": [{"class", "selector", "line"}], ...}`
+
+`line` is 1-based and relative to the containing method's source; the LSP
+resolves the method definition and adds this offset (see
+`beamtalk_core::language_service::method_relative_line_span`).
+""".
+
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+-export([handle/4]).
+
+%% Export internals for white-box testing of validation and serialisation.
+-ifdef(TEST).
+-export([build_query/2, is_safe_arg/1, encode_site/1, encode_implementor/1]).
+-endif.
+
+-doc "Handle the nav-query op. Returns a JSON binary response.".
+-spec handle(binary(), map(), beamtalk_repl_protocol:protocol_msg(), pid()) -> binary().
+handle(<<"nav-query">>, Params, Msg, SessionPid) ->
+    Kind = maps:get(<<"kind">>, Params, undefined),
+    Arg = maps:get(<<"arg">>, Params, undefined),
+    case build_query(Kind, Arg) of
+        {error, Err} ->
+            beamtalk_repl_json:encode_error(Err, Msg);
+        {ok, Expr, ResultShape} ->
+            run_query(Expr, ResultShape, Msg, SessionPid)
+    end.
+
+%%% Internal
+
+-doc """
+Validate the kind/arg pair and build the Beamtalk query expression.
+
+Returns `{ok, Expr, ResultShape}` where `ResultShape` is `sites` or
+`implementors`, or `{error, #beamtalk_error{}}` for an unknown kind or an
+unsafe argument. `arg` is whitelisted to selector/class-name characters so it
+cannot inject arbitrary code into the evaluated expression.
+""".
+-spec build_query(binary() | undefined, binary() | undefined) ->
+    {ok, string(), sites | implementors} | {error, #beamtalk_error{}}.
+build_query(_Kind, Arg) when not is_binary(Arg); Arg =:= <<>> ->
+    {error, arg_error(<<"nav-query requires a non-empty 'arg'">>)};
+build_query(Kind, Arg) ->
+    case query_template(Kind) of
+        unknown ->
+            {error, arg_error(<<"nav-query 'kind' is not a supported navigation query">>)};
+        {Prefix, Shape} ->
+            case is_safe_arg(Arg) of
+                false ->
+                    {error, arg_error(<<"nav-query 'arg' must be a selector or class name">>)};
+                true ->
+                    {ok, Prefix ++ binary_to_list(Arg), Shape}
+            end
+    end.
+
+-doc """
+Map a query kind to its expression prefix and result shape. `implementorsOf`
+and `sendersOf` take a selector (prefixed with `#`); `referencesTo` takes a
+bareword class name.
+""".
+-spec query_template(binary() | undefined) -> {string(), sites | implementors} | unknown.
+query_template(<<"implementorsOf">>) ->
+    {"SystemNavigation default implementorsOf: #", implementors};
+query_template(<<"sendersOf">>) ->
+    {"SystemNavigation default sendersOf: #", sites};
+query_template(<<"referencesTo">>) ->
+    {"SystemNavigation default referencesTo: ", sites};
+query_template(_) ->
+    unknown.
+
+-doc "Evaluate the query expression and encode its result.".
+-spec run_query(string(), sites | implementors, beamtalk_repl_protocol:protocol_msg(), pid()) ->
+    binary().
+run_query(Expr, ResultShape, Msg, SessionPid) ->
+    case beamtalk_repl_shell:eval(SessionPid, Expr) of
+        {ok, Term, _Output, _Warnings} ->
+            encode_result(ResultShape, Term, Msg);
+        {error, Reason, _Output, _Warnings} ->
+            Structured = beamtalk_repl_errors:ensure_structured_error(Reason),
+            beamtalk_repl_json:encode_error(Structured, Msg)
+    end.
+
+-spec encode_result(sites | implementors, term(), beamtalk_repl_protocol:protocol_msg()) ->
+    binary().
+encode_result(sites, Term, Msg) when is_list(Term) ->
+    Sites = [encode_site(S) || S <- Term, is_map(S)],
+    Base = beamtalk_repl_protocol:base_response(Msg),
+    iolist_to_binary(json:encode(Base#{<<"sites">> => Sites, <<"status">> => [<<"done">>]}));
+encode_result(implementors, Term, Msg) when is_list(Term) ->
+    Impls = [encode_implementor(C) || C <- Term],
+    Base = beamtalk_repl_protocol:base_response(Msg),
+    Result = Base#{<<"implementors">> => Impls, <<"status">> => [<<"done">>]},
+    iolist_to_binary(json:encode(Result));
+encode_result(_Shape, _Term, Msg) ->
+    %% Defensive: SystemNavigation always returns a List; a non-list result
+    %% means the query shape changed. Surface an empty result rather than crash.
+    ?LOG_WARNING("nav-query: unexpected non-list result", #{domain => [beamtalk, runtime]}),
+    Base = beamtalk_repl_protocol:base_response(Msg),
+    iolist_to_binary(json:encode(Base#{<<"sites">> => [], <<"status">> => [<<"done">>]})).
+
+-doc """
+Encode one `{#class, #selector, #line}` record. `#class` is a class or
+metaclass object whose display name (`"Counter"` / `"Counter class"`) is
+produced by the shared `term_to_json` class formatter.
+""".
+-spec encode_site(map()) -> map().
+encode_site(#{class := Class, selector := Selector, line := Line}) ->
+    #{
+        <<"class">> => beamtalk_repl_json:term_to_json(Class),
+        <<"selector">> => to_binary(Selector),
+        <<"line">> => Line
+    }.
+
+-doc """
+Encode one implementor (a class or metaclass object). `meta` is derived from
+the `" class"` suffix the formatter appends to metaclass objects, matching the
+class-side display name the LSP translation helper expects.
+""".
+-spec encode_implementor(term()) -> map().
+encode_implementor(Class) ->
+    Name = beamtalk_repl_json:term_to_json(Class),
+    #{<<"class">> => Name, <<"meta">> => has_class_suffix(Name)}.
+
+-spec has_class_suffix(term()) -> boolean().
+has_class_suffix(Name) when is_binary(Name) ->
+    Size = byte_size(Name) - 6,
+    Size >= 0 andalso binary:part(Name, Size, 6) =:= <<" class">>;
+has_class_suffix(_) ->
+    false.
+
+-spec to_binary(term()) -> binary().
+to_binary(V) when is_binary(V) -> V;
+to_binary(V) when is_atom(V) -> atom_to_binary(V, utf8);
+to_binary(V) -> iolist_to_binary(io_lib:format("~tp", [V])).
+
+-doc """
+Whitelist the query argument to characters valid in a selector (keyword,
+unary, or binary) or a package-qualified class name. Rejects anything that
+could break out of the evaluated expression (spaces, quotes, brackets, …).
+""".
+-spec is_safe_arg(binary()) -> boolean().
+is_safe_arg(Arg) ->
+    lists:all(fun is_safe_char/1, binary_to_list(Arg)).
+
+-spec is_safe_char(byte()) -> boolean().
+is_safe_char(C) ->
+    (C >= $a andalso C =< $z) orelse
+        (C >= $A andalso C =< $Z) orelse
+        (C >= $0 andalso C =< $9) orelse
+        lists:member(C, "_:+-*/<>=~%&?,@\\|").
+
+-spec arg_error(binary()) -> #beamtalk_error{}.
+arg_error(Message) ->
+    Err0 = beamtalk_error:new(invalid_argument, 'SystemNavigation'),
+    beamtalk_error:with_message(Err0, Message).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
@@ -430,6 +430,9 @@ handle_op(Op, Params, Msg, SessionPid) when
     Op =:= <<"erlang-complete">>
 ->
     beamtalk_repl_ops_dev:handle(Op, Params, Msg, SessionPid);
+handle_op(<<"nav-query">>, Params, Msg, SessionPid) ->
+    %% BT-2239: System-Browser navigation queries delegated to SystemNavigation.
+    beamtalk_repl_ops_nav:handle(<<"nav-query">>, Params, Msg, SessionPid);
 handle_op(Op, Params, Msg, SessionPid) when Op =:= <<"unload">> ->
     %% BT-1239: Restored — fully removes class from the system (actors, gen_server,
     %% BEAM module, workspace_meta, session tracker). Previously returned a deprecation

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_nav_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_nav_tests.erl
@@ -1,0 +1,111 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_repl_ops_nav_tests).
+
+%%% **DDD Context:** REPL Session Context
+
+-moduledoc """
+EUnit tests for beamtalk_repl_ops_nav (BT-2239).
+
+Covers the pure validation/serialisation surface that does not require a
+running workspace: query construction + injection guard (build_query/2,
+is_safe_arg/1) and the wire-shaping helpers (encode_site/1,
+encode_implementor/1). The end-to-end eval path is exercised by the BT-2240
+references-delegation work.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% build_query/2 — validation + expression construction
+%%====================================================================
+
+build_query_senders_test() ->
+    ?assertEqual(
+        {ok, "SystemNavigation default sendersOf: #increment", sites},
+        beamtalk_repl_ops_nav:build_query(<<"sendersOf">>, <<"increment">>)
+    ).
+
+build_query_implementors_test() ->
+    ?assertEqual(
+        {ok, "SystemNavigation default implementorsOf: #asString", implementors},
+        beamtalk_repl_ops_nav:build_query(<<"implementorsOf">>, <<"asString">>)
+    ).
+
+build_query_references_uses_bareword_class_test() ->
+    ?assertEqual(
+        {ok, "SystemNavigation default referencesTo: Counter", sites},
+        beamtalk_repl_ops_nav:build_query(<<"referencesTo">>, <<"Counter">>)
+    ).
+
+build_query_keyword_selector_test() ->
+    ?assertEqual(
+        {ok, "SystemNavigation default sendersOf: #at:put:", sites},
+        beamtalk_repl_ops_nav:build_query(<<"sendersOf">>, <<"at:put:">>)
+    ).
+
+build_query_binary_selector_test() ->
+    ?assertEqual(
+        {ok, "SystemNavigation default sendersOf: #+", sites},
+        beamtalk_repl_ops_nav:build_query(<<"sendersOf">>, <<"+">>)
+    ).
+
+build_query_unknown_kind_errors_test() ->
+    ?assertMatch(
+        {error, _}, beamtalk_repl_ops_nav:build_query(<<"bogusKind">>, <<"foo">>)
+    ).
+
+build_query_empty_arg_errors_test() ->
+    ?assertMatch({error, _}, beamtalk_repl_ops_nav:build_query(<<"sendersOf">>, <<>>)),
+    ?assertMatch({error, _}, beamtalk_repl_ops_nav:build_query(<<"sendersOf">>, undefined)).
+
+build_query_unsafe_arg_errors_test() ->
+    %% A space, quote, or paren must be rejected so the arg cannot break out of
+    %% the evaluated expression.
+    ?assertMatch({error, _}, beamtalk_repl_ops_nav:build_query(<<"sendersOf">>, <<"a b">>)),
+    ?assertMatch({error, _}, beamtalk_repl_ops_nav:build_query(<<"sendersOf">>, <<"x\"y">>)),
+    ?assertMatch({error, _}, beamtalk_repl_ops_nav:build_query(<<"sendersOf">>, <<"x)">>)).
+
+%%====================================================================
+%% is_safe_arg/1
+%%====================================================================
+
+is_safe_arg_accepts_selectors_and_classes_test() ->
+    ?assert(beamtalk_repl_ops_nav:is_safe_arg(<<"foo">>)),
+    ?assert(beamtalk_repl_ops_nav:is_safe_arg(<<"at:put:">>)),
+    ?assert(beamtalk_repl_ops_nav:is_safe_arg(<<"+">>)),
+    ?assert(beamtalk_repl_ops_nav:is_safe_arg(<<"Counter">>)),
+    %% Package-qualified class name (BT-1659).
+    ?assert(beamtalk_repl_ops_nav:is_safe_arg(<<"json@Parser">>)).
+
+is_safe_arg_rejects_breakout_chars_test() ->
+    ?assertNot(beamtalk_repl_ops_nav:is_safe_arg(<<"a b">>)),
+    ?assertNot(beamtalk_repl_ops_nav:is_safe_arg(<<"x\"y">>)),
+    ?assertNot(beamtalk_repl_ops_nav:is_safe_arg(<<"x.y">>)),
+    ?assertNot(beamtalk_repl_ops_nav:is_safe_arg(<<"(x)">>)).
+
+%%====================================================================
+%% encode_site/1 and encode_implementor/1 — wire shaping
+%%====================================================================
+
+encode_site_shapes_record_test() ->
+    %% term_to_json passes binaries through, so a pre-resolved class name
+    %% binary lets us assert the shape without constructing a class object.
+    Site = #{class => <<"Counter">>, selector => increment, line => 7},
+    ?assertEqual(
+        #{<<"class">> => <<"Counter">>, <<"selector">> => <<"increment">>, <<"line">> => 7},
+        beamtalk_repl_ops_nav:encode_site(Site)
+    ).
+
+encode_implementor_instance_side_test() ->
+    ?assertEqual(
+        #{<<"class">> => <<"Integer">>, <<"meta">> => false},
+        beamtalk_repl_ops_nav:encode_implementor(<<"Integer">>)
+    ).
+
+encode_implementor_class_side_sets_meta_test() ->
+    ?assertEqual(
+        #{<<"class">> => <<"Counter class">>, <<"meta">> => true},
+        beamtalk_repl_ops_nav:encode_implementor(<<"Counter class">>)
+    ).


### PR DESCRIPTION
## Summary

Foundation for delegating LSP navigation queries to a running runtime's `SystemNavigation` facade — the static-first, live-augmented tooling model of ADR 0024. When a runtime is attached, the editor can answer find-references / go-to-implementation / hierarchy queries from the **live image**, which sees open-class extension methods (ADR 0066) and REPL-loaded classes the static AST walker cannot.

This is the foundation issue for the BT-2215 epic: it defines the long-lived wire contract and the reusable dispatch seam the per-method children (BT-2240..2244) build on. **No navigation behaviour changes by default** — the `lsp.delegate_to_runtime` flag is off, so all queries use the existing AST path.

Linear: https://linear.app/beamtalk/issue/BT-2239

## Key changes

- **Protocol** (`beamtalk-repl-protocol`): structured `nav-query` op (`implementorsOf` / `sendersOf` / `referencesTo`) returning machine-readable `{class, selector, line}` sites or `{class, meta}` implementors, with shared `NavSite` / `NavImplementor` response types.
- **Runtime** (`beamtalk_repl_ops_nav.erl`): routes the query to `SystemNavigation` in the calling eval worker (where these sealed-Object value-type methods run inline) and serialises via the shared `term_to_json` class formatter. The argument is whitelisted to selector / class-name characters so it cannot inject into the evaluated expression.
- **Core** (`language_service`): a pure, tested source-location translation helper (`method_relative_line_span` + `locate_nav_site`) mapping the runtime's method-relative `line` to an absolute `Location`, plus a `selector_at` accessor.
- **LSP**: a `tokio-tungstenite` `RuntimeClient` that discovers an attached runtime via `beamtalk-workspace` and speaks the authenticated REPL protocol (ADR 0020); the `delegateToRuntime` flag; and a reusable two-mode dispatch seam wired into find-references as the worked example.
- **Docs**: `repl-protocol.md` (new op) + `surface-parity.md`.

Reuses `beamtalk-repl-protocol` and `beamtalk-workspace` so `beamtalk-lsp` never depends on `beamtalk-cli` (architecture constraint).

## Scope note

find-references is the worked example (selector senders only); full references parity (class references, edge cases, snapshot tests) and the other navigation methods land in the BT-2215 children, which now have a working transport + seam to build on.

## Test plan

- [x] `beamtalk-repl-protocol` unit tests (nav-query request + NavSite/NavImplementor parsing)
- [x] `beamtalk-core` unit tests (method-relative line span + translation, incl. edge cases)
- [x] `beamtalk-lsp` unit tests (flag default-off, flag reader, site→location translation, unknown-class skip)
- [x] `beamtalk_repl_ops_nav_tests` EUnit (13 tests: validation, injection guard, serialisation shaping)
- [x] clippy, rustfmt, erlfmt, dialyzer, dialyzer-specs all clean
- [ ] End-to-end LSP↔runtime↔SystemNavigation exercised by BT-2240 (needs a live runtime harness)

https://claude.ai/code/session_019miSbTZVfEK86ew7JxFw7b

---
_Generated by [Claude Code](https://claude.ai/code/session_019miSbTZVfEK86ew7JxFw7b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime-delegated navigation: LSP can query an attached runtime for references/implementors and return accurate editor locations.
  * WebSocket runtime client with auth, per-query timeouts, and automatic reconnect on failure.
  * Improved on-cursor selector detection and mapping from runtime-relative lines to source locations.

* **Documentation**
  * Added navigation operations and updated REPL/protocol docs describing the new nav-query.

* **Tests**
  * New unit and integration tests for runtime nav requests, protocol shapes, encoding, and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->