### PR TITLE
Add error-path tests for beamtalk_json_formatter (BT-2273)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_json_formatter_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_json_formatter_tests.erl
@@ -534,7 +534,10 @@ format_gen_server_terminate_with_bt_error_reason_test() ->
     },
     Decoded = decode_event(Event),
     Msg = maps:get(<<"msg">>, Decoded),
-    ?assertNotEqual(nomatch, binary:match(Msg, <<"Counter does not understand">>)).
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"Counter does not understand">>)),
+    %% If the BtError branch was NOT taken, the raw ~tp of WrappedError would
+    %% include the '$beamtalk_class' atom key. Its absence confirms extraction.
+    ?assertEqual(nomatch, binary:match(Msg, <<"$beamtalk_class">>)).
 
 %% Exercises format_reason_with_bt_error/2 AND format_reason_concise/1 BtError
 %% branches (top-level key form): when a supervisor child_terminated report has
@@ -557,9 +560,13 @@ format_supervisor_child_terminated_with_bt_error_reason_test() ->
     Decoded = decode_event(Event),
     Msg = maps:get(<<"msg">>, Decoded),
     ?assertNotEqual(nomatch, binary:match(Msg, <<"Worker does not understand">>)),
+    %% If the BtError branch was NOT taken, the raw ~tp of WrappedError would
+    %% include the '$beamtalk_class' atom key. Its absence confirms extraction.
+    ?assertEqual(nomatch, binary:match(Msg, <<"$beamtalk_class">>)),
     %% format_reason_concise/1 BtError branch: the reason field also uses the BT error message
     Reason = maps:get(<<"reason">>, Decoded),
-    ?assertNotEqual(nomatch, binary:match(Reason, <<"Worker does not understand">>)).
+    ?assertNotEqual(nomatch, binary:match(Reason, <<"Worker does not understand">>)),
+    ?assertEqual(nomatch, binary:match(Reason, <<"$beamtalk_class">>)).
 
 %% Exercises format_reason_with_bt_error/2 BtError branch in the proplist-form
 %% supervisor child_terminated handler (data nested under `report` key).
@@ -581,7 +588,14 @@ format_supervisor_child_terminated_proplist_with_bt_error_test() ->
     },
     Decoded = decode_event(Event),
     Msg = maps:get(<<"msg">>, Decoded),
-    ?assertNotEqual(nomatch, binary:match(Msg, <<"Service does not understand">>)).
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"Service does not understand">>)),
+    %% If the BtError branch was NOT taken, the raw ~tp of WrappedError would
+    %% include the '$beamtalk_class' atom key. Its absence confirms extraction.
+    ?assertEqual(nomatch, binary:match(Msg, <<"$beamtalk_class">>)),
+    %% format_reason_concise/1 BtError branch: the reason field also uses the BT error message
+    Reason = maps:get(<<"reason">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(Reason, <<"Service does not understand">>)),
+    ?assertEqual(nomatch, binary:match(Reason, <<"$beamtalk_class">>)).
 
 %% Exercises format_extra_value/2 non-list stacktrace BtError branch: when the
 %% stacktrace metadata value is not a list but contains an embedded beamtalk
@@ -599,7 +613,11 @@ format_non_list_stacktrace_with_bt_error_test() ->
     },
     Decoded = decode_event(Event),
     StackBin = maps:get(<<"stacktrace">>, Decoded),
-    ?assertNotEqual(nomatch, binary:match(StackBin, <<"MyClass does not understand">>)).
+    ?assertNotEqual(nomatch, binary:match(StackBin, <<"MyClass does not understand">>)),
+    %% The BtError branch in format_extra_value/2 appends "\n  raw: <term>" after
+    %% the error message. Asserting the "raw:" marker proves this branch was taken
+    %% rather than the undefined-branch ~tp fallback (which does not append it).
+    ?assertNotEqual(nomatch, binary:match(StackBin, <<"raw:">>)).
 
 %% Exercises the inner catch in format_msg_fallback/1: when the outer formatter
 %% path crashes (here via a binary domain element) and the log msg is a

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_json_formatter_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_json_formatter_tests.erl
@@ -513,6 +513,136 @@ format_handles_format_args_with_binary_test() ->
     ?assertEqual(<<"http server started">>, maps:get(<<"msg">>, Decoded)).
 
 %%====================================================================
+%% Error-path Tests (BT-2273)
+%%====================================================================
+
+%% Exercises format_reason_with_bt_error/2 BtError branch: when the crash
+%% reason in a gen_server terminate report contains a beamtalk error, the
+%% formatted BT error message is used in the msg field instead of the raw term.
+format_gen_server_terminate_with_bt_error_reason_test() ->
+    BtError = beamtalk_error:new(does_not_understand, 'Counter', 'increment'),
+    WrappedError = #{'$beamtalk_class' => 'NoSuchMethodError', error => BtError},
+    Event = #{
+        level => error,
+        msg =>
+            {report, #{
+                label => {gen_server, terminate},
+                name => my_counter_server,
+                reason => WrappedError
+            }},
+        meta => #{time => erlang:system_time(microsecond)}
+    },
+    Decoded = decode_event(Event),
+    Msg = maps:get(<<"msg">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"Counter does not understand">>)).
+
+%% Exercises format_reason_with_bt_error/2 AND format_reason_concise/1 BtError
+%% branches (top-level key form): when a supervisor child_terminated report has
+%% a beamtalk error as the termination reason both the msg field and the
+%% structured reason field use the BT error message.
+format_supervisor_child_terminated_with_bt_error_reason_test() ->
+    BtError = beamtalk_error:new(does_not_understand, 'Worker', 'process'),
+    WrappedError = #{'$beamtalk_class' => 'NoSuchMethodError', error => BtError},
+    Event = #{
+        level => error,
+        msg =>
+            {report, #{
+                label => {supervisor, child_terminated},
+                supervisor => test_sup,
+                reason => WrappedError,
+                offender => [{id, worker_child}, {pid, self()}]
+            }},
+        meta => #{time => erlang:system_time(microsecond)}
+    },
+    Decoded = decode_event(Event),
+    Msg = maps:get(<<"msg">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"Worker does not understand">>)),
+    %% format_reason_concise/1 BtError branch: the reason field also uses the BT error message
+    Reason = maps:get(<<"reason">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(Reason, <<"Worker does not understand">>)).
+
+%% Exercises format_reason_with_bt_error/2 BtError branch in the proplist-form
+%% supervisor child_terminated handler (data nested under `report` key).
+format_supervisor_child_terminated_proplist_with_bt_error_test() ->
+    BtError = beamtalk_error:new(does_not_understand, 'Service', 'call'),
+    WrappedError = #{'$beamtalk_class' => 'NoSuchMethodError', error => BtError},
+    Event = #{
+        level => error,
+        msg =>
+            {report, #{
+                label => {supervisor, child_terminated},
+                report => [
+                    {supervisor, {local, svc_sup}},
+                    {reason, WrappedError},
+                    {offender, [{id, svc_worker}]}
+                ]
+            }},
+        meta => #{time => erlang:system_time(microsecond)}
+    },
+    Decoded = decode_event(Event),
+    Msg = maps:get(<<"msg">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"Service does not understand">>)).
+
+%% Exercises format_extra_value/2 non-list stacktrace BtError branch: when the
+%% stacktrace metadata value is not a list but contains an embedded beamtalk
+%% error, the BT error message is extracted and used in the output.
+format_non_list_stacktrace_with_bt_error_test() ->
+    BtError = beamtalk_error:new(does_not_understand, 'MyClass', 'myMethod'),
+    WrappedError = #{'$beamtalk_class' => 'NoSuchMethodError', error => BtError},
+    Event = #{
+        level => error,
+        msg => {string, "error occurred"},
+        meta => #{
+            time => erlang:system_time(microsecond),
+            stacktrace => WrappedError
+        }
+    },
+    Decoded = decode_event(Event),
+    StackBin = maps:get(<<"stacktrace">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(StackBin, <<"MyClass does not understand">>)).
+
+%% Exercises the inner catch in format_msg_fallback/1: when the outer formatter
+%% path crashes (here via a binary domain element) and the log msg is a
+%% {Format, Args} pair whose io_lib:format call also fails (mismatched arity),
+%% the inner catch renders the {Format, Args} pair as a raw term.
+format_msg_fallback_inner_catch_test() ->
+    %% A binary in the domain list crashes atom_to_list inside format_domain,
+    %% triggering the outer catch in format/2 which calls format_msg_fallback/1.
+    %% The msg has 2 format directives but only 1 arg, so io_lib:format raises
+    %% inside format_msg_fallback, exercising the inner catch.
+    Event = #{
+        level => info,
+        msg => {"~p ~p", [only_one_arg]},
+        meta => #{
+            time => erlang:system_time(microsecond),
+            domain => [<<"not-an-atom">>]
+        }
+    },
+    Result = beamtalk_json_formatter:format(Event, #{}),
+    Bin = iolist_to_binary(Result),
+    %% Outer catch emits a "formatter error:" marker
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"formatter error:">>)),
+    %% Inner catch in format_msg_fallback formats {Format,Args} as a term;
+    %% the atom only_one_arg must appear in that rendered tuple.
+    ?assertNotEqual(nomatch, binary:match(Bin, <<"only_one_arg">>)).
+
+%% Exercises key_to_binary/1 fallback clause: when an extra metadata key is
+%% neither an atom nor a binary (e.g., a tuple), it is formatted via ~tp and
+%% used as the JSON key.
+format_extra_meta_non_atom_key_test() ->
+    Event = #{
+        level => info,
+        msg => {string, "test"},
+        meta => #{
+            time => erlang:system_time(microsecond),
+            {custom, meta_key} => <<"meta_value">>
+        }
+    },
+    Decoded = decode_event(Event),
+    %% Tuple key {custom,meta_key} becomes the string "{custom,meta_key}" in JSON
+    ?assertEqual(<<"meta_value">>, maps:get(<<"{custom,meta_key}">>, Decoded)).
+
+%%====================================================================
 %% Helpers
 %%====================================================================
 


### PR DESCRIPTION
Closes https://linear.app/beamtalk/issue/BT-2273

## Summary

Adds 6 EUnit tests to `beamtalk_json_formatter_tests` targeting code paths that were not exercised despite the module having 36 existing tests (measured at 39% line coverage).

## Paths now covered

| Test | Path exercised |
|---|---|
| `format_gen_server_terminate_with_bt_error_reason_test` | `format_reason_with_bt_error/2` — BtError branch when gen_server terminate reason contains a `#beamtalk_error{}` |
| `format_supervisor_child_terminated_with_bt_error_reason_test` | `format_reason_with_bt_error/2` + `format_reason_concise/1` BtError branches (top-level keys form) |
| `format_supervisor_child_terminated_proplist_with_bt_error_test` | Same two branches via the proplist `report` key form of the supervisor report |
| `format_non_list_stacktrace_with_bt_error_test` | `format_extra_value/2` non-list stacktrace BtError branch — when `stacktrace` metadata wraps a beamtalk error |
| `format_msg_fallback_inner_catch_test` | Inner `catch` in `format_msg_fallback/1` — `io_lib:format` raises on arity mismatch in `{Format, Args}` fallback |
| `format_extra_meta_non_atom_key_test` | `key_to_binary/1` fallback clause — tuple metadata key formatted via `~tp` |

## Test count: 36 → 42

All 42 tests pass. `just test` (3911 + 1329 Erlang runtime tests, 2060 BUnit, 250 stdlib) green with zero failures.

https://claude.ai/code/session_01Yai5nu9Nf47a2a5gsHvVVF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yai5nu9Nf47a2a5gsHvVVF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added six tests enhancing JSON formatter error-path coverage: gen_server terminate reports and supervisor child-termination (including proplist-style reports) when embedded errors appear; non-list stacktrace handling with embedded errors; fallback formatting when primary formatter fails; and metadata key conversion fallback for non-atom/non-binary keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->