### PR TITLE
Tighten loose assertions in compiled_method_test.bt (BT-2274)

### DIFF
--- a/stdlib/test/compiled_method_test.bt
+++ b/stdlib/test/compiled_method_test.bt
@@ -6,7 +6,7 @@
 TestCase subclass: CompiledMethodTest
 
   testMethodLookup =>
-    self assert: (Counter >> #getValue) notNil
+    self assert: (Counter >> #getValue) class equals: CompiledMethod
     self assert: (Counter >> #nonExistent) equals: nil
 
   testMethodLookupOnVariableReceivers =>
@@ -16,7 +16,7 @@ TestCase subclass: CompiledMethodTest
     // resolves class-side via Behaviour instead of producing a DNU hint. At
     // runtime, cls holds the class object and dispatches through the
     // Class→Behaviour chain.
-    self assert: (cls >> #getValue) notNil
+    self assert: (cls >> #getValue) class equals: CompiledMethod
     self assert: (cls >> #getValue) selector equals: #getValue
     self assert: (cls >> #nonExistent) equals: nil
 
@@ -51,7 +51,7 @@ TestCase subclass: CompiledMethodTest
   // receivers through the `{class_method, _}` handler.
   testMetaclassLookupHit =>
     cm := SystemNavigation class >> #default
-    self deny: cm isNil
+    self assert: cm class equals: CompiledMethod
     self assert: cm selector equals: #default
 
   // BT-2195: Class-side source is preserved end-to-end and reachable via


### PR DESCRIPTION
## Summary

Replace 3 loose `notNil`/`deny: isNil` assertions with `class equals: CompiledMethod` in `stdlib/test/compiled_method_test.bt`.

Each replacement is strictly tighter — it catches both a nil return AND a wrong-type return, and produces a more informative failure message. Test intent is unchanged.

### Changes

- `testMethodLookup`: `assert: (Counter >> #getValue) notNil` → `assert: (Counter >> #getValue) class equals: CompiledMethod`
- `testMethodLookupOnVariableReceivers`: `assert: (cls >> #getValue) notNil` → `assert: (cls >> #getValue) class equals: CompiledMethod`
- `testMetaclassLookupHit`: `deny: cm isNil` → `assert: cm class equals: CompiledMethod`

### Test plan

- [x] `just test-bunit` passes (2060/2060 tests, 0 failures)
- [x] Lint clean
- [x] Pattern `class equals: CompiledMethod` already used in same file and `method_resolver_hierarchy_test.bt`

[BT-2274](https://linear.app/beamtalk/issue/BT-2274)

https://claude.ai/code/session_019udqqNwJf4FT3pFG5rivaj

---
_Generated by [Claude Code](https://claude.ai/code/session_019udqqNwJf4FT3pFG5rivaj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tightened method lookup introspection test assertions to validate that resolved method values return their expected runtime class types rather than simply confirming non-nil existence. Enhanced type validation now applies consistently across direct receiver lookups, class and variable receiver lookups, and metaclass hit cases for more robust testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->