### PR TITLE
Fix E0283 test-profile build break on main (from #2302)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/parser/tests/expression_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/expression_tests.rs
@@ -800,7 +800,7 @@ fn parse_intrinsic_bare_identifier() {
         Expression::Primitive {
             name, is_quoted, ..
         } => {
-            assert_eq!(name.as_ref(), "blockValue");
+            assert_eq!(name.as_str(), "blockValue");
             assert!(!is_quoted, "bare @intrinsic should not be quoted");
         }
         other => panic!("Expected Primitive, got: {other:?}"),
@@ -818,7 +818,7 @@ fn parse_intrinsic_quoted_selector() {
         Expression::Primitive {
             name, is_quoted, ..
         } => {
-            assert_eq!(name.as_ref(), "size");
+            assert_eq!(name.as_str(), "size");
             assert!(*is_quoted, "quoted @intrinsic should be quoted");
         }
         other => panic!("Expected Primitive, got: {other:?}"),


### PR DESCRIPTION
## Summary

`main` is red: `cargo test` fails to compile `beamtalk-core` (lib test) with four `error[E0283]: type annotations needed`. The regular (non-test) build passes, which is why #2302 (BT-2266/BT-2267) slipped through and broke `main` after merge.

Root cause: the two `@intrinsic` parser tests added in #2302 assert with `name.as_ref()` on the `Primitive.name` field, which is an `EcoString`. `EcoString` implements `AsRef` for multiple targets (`str`, `[u8]`, …), so `name.as_ref()` is ambiguous under the test profile. Every other assertion in this file already uses `.as_str()`.

## Fix

`crates/beamtalk-core/src/source_analysis/parser/tests/expression_tests.rs:803,821` — `name.as_ref()` → `name.as_str()`.

## Test plan

- [x] `cargo test -p beamtalk-core --no-run` compiles cleanly (was failing on `main`)
- [x] No other `name.as_ref()` call sites remain in the file

https://claude.ai/code/session_01Ue7R7kqXU8ZDxcYqh8Lw39

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ue7R7kqXU8ZDxcYqh8Lw39)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test assertions to improve code consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->