### PR TITLE
ClassBuilder programmatic register returns a usable class object (BT-2258)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -3257,7 +3257,12 @@ impl CoreErlangGenerator {
     /// Emits a call to `beamtalk_class_builder:register/1` with the builder's
     /// `gen_server` state augmented with the builder's own PID (for cleanup).
     ///
-    /// On success: returns a `#beamtalk_object{class = 'Class', class_mod = beamtalk_class_bt, pid = Pid}`
+    /// On success: returns the canonical class-object record built by
+    /// `beamtalk_class_registry:class_object_from_pid/1`, i.e.
+    /// `#beamtalk_object{class = '<Name> class', class_mod = ModuleName, pid = Pid}`
+    /// — the same shape produced by `generate_class_reference` and
+    /// `beamtalk_interface:handle_class_named/1`, so the value is dispatchable
+    /// and `==` to the registry reference (BT-2258).
     /// On error: raises the structured error via `beamtalk_error:raise/1`
     ///
     /// # Generated Code
@@ -3267,7 +3272,7 @@ impl CoreErlangGenerator {
     /// let _BS = call 'maps':'put'('builderPid', _Pid, State) in
     /// case call 'beamtalk_class_builder':'register'(_BS) of
     ///   <{'ok', _CP}> when 'true' ->
-    ///     {'beamtalk_object', 'Class', 'beamtalk_class_bt', _CP}
+    ///     call 'beamtalk_class_registry':'class_object_from_pid'(_CP)
     ///   <{'error', _Err}> when 'true' ->
     ///     call 'beamtalk_error':'raise'(_Err)
     /// end
@@ -3296,9 +3301,13 @@ impl CoreErlangGenerator {
             "<{'ok', ",
             Document::String(class_pid_var.clone()),
             "}> when 'true' -> ",
-            "{'beamtalk_object', 'Class', 'beamtalk_class_bt', ",
+            // BT-2258: return the canonical class-object shape
+            // {'beamtalk_object', <Name> ++ " class", ModuleName, ClassPid}
+            // built by the runtime helper, instead of an unusable hardcoded
+            // {'beamtalk_object', 'Class', 'beamtalk_class_bt', ClassPid} wrapper.
+            "call 'beamtalk_class_registry':'class_object_from_pid'(",
             Document::String(class_pid_var),
-            "} ",
+            ") ",
             "<{'error', ",
             Document::String(error_var.clone()),
             "}> when 'true' -> ",

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/expression_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/expression_tests.rs
@@ -800,7 +800,7 @@ fn parse_intrinsic_bare_identifier() {
         Expression::Primitive {
             name, is_quoted, ..
         } => {
-            assert_eq!(name.as_ref(), "blockValue");
+            assert_eq!(name.as_str(), "blockValue");
             assert!(!is_quoted, "bare @intrinsic should not be quoted");
         }
         other => panic!("Expected Primitive, got: {other:?}"),
@@ -818,7 +818,7 @@ fn parse_intrinsic_quoted_selector() {
         Expression::Primitive {
             name, is_quoted, ..
         } => {
-            assert_eq!(name.as_ref(), "size");
+            assert_eq!(name.as_str(), "size");
             assert!(*is_quoted, "quoted @intrinsic should be quoted");
         }
         other => panic!("Expected Primitive, got: {other:?}"),

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_registry.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_registry.erl
@@ -32,6 +32,7 @@ Extracted from `beamtalk_object_class` (BT-576) for single-responsibility.
     all_classes/0,
     live_class_entries/0,
     user_classes/0,
+    class_object_from_pid/1,
     registry_name/1,
     ensure_pg_started/0,
     ensure_hierarchy_table/0,
@@ -155,6 +156,22 @@ user_classes() ->
         exit:{noproc, _} ->
             []
     end.
+
+-doc """
+Build a canonical class object record from a class gen_server pid (BT-2258).
+
+Mirrors the inline `{beamtalk_object, ClassTag, ModuleName, Pid}` construction
+in user_classes/0. Used by the programmatic ClassBuilder `register` intrinsic
+so its return value matches the shape produced by codegen class references and
+beamtalk_interface:handle_class_named/1 (i.e. is_class_object/1 is true and it
+is `==` to the registry reference).
+""".
+-spec class_object_from_pid(pid()) -> #beamtalk_object{}.
+class_object_from_pid(Pid) when is_pid(Pid) ->
+    ClassName = beamtalk_object_class:class_name(Pid),
+    ModuleName = beamtalk_object_class:module_name(Pid),
+    ClassTag = class_object_tag(ClassName),
+    #beamtalk_object{class = ClassTag, class_mod = ModuleName, pid = Pid}.
 
 -doc "Compute the Erlang registry name for a class.".
 -spec registry_name(class_name()) -> atom().

--- a/stdlib/test/class_builder_class_method_test.bt
+++ b/stdlib/test/class_builder_class_method_test.bt
@@ -8,8 +8,9 @@
 // these blocks as class-method bodies so `self`/`super` resolve and the
 // receiver `self` parameter does not warn about shadowing.
 //
-// The class is dispatched by its registered name via findClass: (register's
-// return is an unusable wrapper today, BT-2258, fixed separately).
+// The class is dispatched by its registered name via findClass:. (Since
+// BT-2258, register also returns the canonical, dispatchable class object;
+// these tests keep the registry lookup, which exercises the same class.)
 
 TestCase subclass: ClassBuilderClassMethodTest
   field: cls = nil

--- a/stdlib/test/class_builder_method_source_test.bt
+++ b/stdlib/test/class_builder_method_source_test.bt
@@ -10,10 +10,9 @@
 // via `String >> #matchesRegex:`), so it is exercisable in BUnit without the
 // compiler port that `sendersOf:` requires.
 //
-// The class is looked up via the registry (`findClass:`) rather than the value
-// returned by `register`: the programmatic-builder cascade currently returns an
-// unusable wrapper around the (live, registered) class — a pre-existing bug
-// tracked separately. The registry entry is the genuine, dispatchable class.
+// BT-2258: the programmatic-builder cascade now returns the canonical class
+// object, so these tests use `register`'s return value directly (the earlier
+// `findClass:` registry lookup was a workaround for the now-fixed wrapper bug).
 
 TestCase subclass: ClassBuilderMethodSourceTest
   field: cls = nil
@@ -24,11 +23,10 @@ TestCase subclass: ClassBuilderMethodSourceTest
   // indexable. Before BT-2246 the method installed as a bare fun with empty
   // source and never matched a source-text query.
   testBuilderBlockMethodBodyIsIndexable =>
-    Object classBuilder name: #BTBuilderSourceProbe;
+    self.cls := Object classBuilder name: #BTBuilderSourceProbe;
       superclass: Object;
       methods: #{#greetLoudly => [:_self | "hi" uppercase]};
       register
-    self.cls := (Erlang beamtalk_interface) findClass: #BTBuilderSourceProbe
     nav := SystemNavigation default
     results := nav
       collectMethodsMatching: (Regex from: "uppercase") unwrap
@@ -41,11 +39,10 @@ TestCase subclass: ClassBuilderMethodSourceTest
   // The reconstructed source carries the keyword selector and its parameter,
   // so a query against the body matches and the record names the selector.
   testKeywordBuilderMethodIsIndexable =>
-    Object classBuilder name: #BTBuilderKeywordProbe;
+    self.cls := Object classBuilder name: #BTBuilderKeywordProbe;
       superclass: Object;
       methods: #{#scaleBy: => [:_self :factor | factor * factor]};
       register
-    self.cls := (Erlang beamtalk_interface) findClass: #BTBuilderKeywordProbe
     nav := SystemNavigation default
     results := nav
       collectMethodsMatching: (Regex from: "factor") unwrap
@@ -59,11 +56,10 @@ TestCase subclass: ClassBuilderMethodSourceTest
   // unindexable — the source query degrades to "no match", never a crash.
   testComputedMethodIsKnownButUnindexable =>
     blk := [:obj | obj size]
-    Object classBuilder name: #BTBuilderComputedProbe;
+    self.cls := Object classBuilder name: #BTBuilderComputedProbe;
       superclass: Object;
       methods: #{#computedSize => blk};
       register
-    self.cls := (Erlang beamtalk_interface) findClass: #BTBuilderComputedProbe
     self assert: (self.cls includesSelector: #computedSize)
     nav := SystemNavigation default
     results := nav

--- a/stdlib/test/class_builder_test.bt
+++ b/stdlib/test/class_builder_test.bt
@@ -5,6 +5,13 @@
 //
 // Tests ClassBuilder error cases: validation failures caught before class
 // registration. Exercises the validate/2 logic in beamtalk_class_builder.erl
+//
+// BT-2258: also covers a successful programmatic register-then-use. Before the
+// fix, the programmatic cascade returned an unusable wrapper
+// ({beamtalk_object, 'Class', beamtalk_class_bt, Pid}) that failed every
+// message with a spurious "actor process has terminated" error and was not
+// `==` to the registry reference. register now returns the canonical class
+// object, so the cascade result is directly usable.
 
 TestCase subclass: ClassBuilderTest
   field: cls = nil
@@ -18,3 +25,23 @@ TestCase subclass: ClassBuilderTest
 
   testMissingSuperclassRejected =>
     self should: [Object classBuilder register] raise: #missing_parameter
+
+  // BT-2258: register returns a usable class object that answers reflection
+  // messages without the "terminated" error the wrapper used to produce.
+  testRegisterReturnsUsableClassObject =>
+    self.cls := Object classBuilder name: #BTBuilderUsable;
+      superclass: Object;
+      methods: #{#greet => [:_self | "hi"]};
+      register
+    self assert: self.cls isClass
+    self assert: self.cls name equals: #BTBuilderUsable
+    self assert: self.cls printString equals: "BTBuilderUsable"
+    self assert: (self.cls methods includes: #greet)
+    self deny: (self.cls >> #greet) isNil
+
+  // BT-2258: the returned object is the canonical class object, so it is `==`
+  // to the registry reference for the same name.
+  testRegisterReturnEqualsRegistryReference =>
+    self.cls := Object classBuilder name: #BTBuilderIdentity; superclass: Object; register
+    registryRef := (Erlang beamtalk_interface) findClass: #BTBuilderIdentity
+    self assert: self.cls == registryRef

--- a/tests/repl-protocol/cases/class_builder_class_methods.btscript
+++ b/tests/repl-protocol/cases/class_builder_class_methods.btscript
@@ -8,8 +8,8 @@
 // `self` class-method sends — without the BT-873 Path-2 failures.
 //
 // The class is dispatched by its registered name (a registry-resolved class
-// reference), not via register's return value (an unusable wrapper today,
-// BT-2258, fixed separately).
+// reference). Since BT-2258, register also returns the canonical class object
+// (the class name renders directly), so the cascade result is usable too.
 //
 // NOTE: `self new` on a module-less dynamic builder class is a pre-existing
 // limitation (handle_new requires a compiled new/0 export — even external
@@ -21,7 +21,7 @@
 // ---------------------------------------------------------------------------
 
 Object classBuilder name: #BT2267Tally; superclass: Object; classVars: #{ #total => 0 }; classMethods: #{ #bump => [:self | self.total := self.total + 1. self.total] }; register
-// => #Actor<Class,_>
+// => BT2267Tally
 
 BT2267Tally bump
 // => 1
@@ -37,7 +37,7 @@ BT2267Tally bump
 // ---------------------------------------------------------------------------
 
 Object classBuilder name: #BT2267Plain; superclass: Object; classMethods: #{ #answer => [:self | 42] }; register
-// => #Actor<Class,_>
+// => BT2267Plain
 
 BT2267Plain answer
 // => 42
@@ -47,7 +47,7 @@ BT2267Plain answer
 // ---------------------------------------------------------------------------
 
 Object classBuilder name: #BT2267Kw; superclass: Object; classMethods: #{ #scale: => [:self :n | n * 3] }; register
-// => #Actor<Class,_>
+// => BT2267Kw
 
 BT2267Kw scale: 4
 // => 12
@@ -58,7 +58,7 @@ BT2267Kw scale: 4
 // ---------------------------------------------------------------------------
 
 Object classBuilder name: #BT2267Self; superclass: Object; classMethods: #{ #base => [:self | 10], #doubled => [:self | self base * 2] }; register
-// => #Actor<Class,_>
+// => BT2267Self
 
 BT2267Self doubled
 // => 20
@@ -69,10 +69,10 @@ BT2267Self doubled
 // ---------------------------------------------------------------------------
 
 Object classBuilder name: #BT2267SuperBase; superclass: Object; classMethods: #{ #greeting => [:self | "base"] }; register
-// => #Actor<Class,_>
+// => BT2267SuperBase
 
 Object classBuilder name: #BT2267SuperChild; superclass: #BT2267SuperBase; classMethods: #{ #greeting => [:self | super greeting] }; register
-// => #Actor<Class,_>
+// => BT2267SuperChild
 
 BT2267SuperChild greeting
 // => base


### PR DESCRIPTION
## Summary

The programmatic `ClassBuilder` cascade `register` intrinsic returned an unusable wrapper `{beamtalk_object, 'Class', beamtalk_class_bt, ClassPid}` instead of the canonical class-object shape. As a result, every message sent to `register`'s return value failed with a spurious `Cannot send '<sel>' to unknown (actor process has terminated)` error, `is_class_object/1` was `false`, and the value was not `==` to the registry reference (even though the underlying class was live and usable by name).

This fix makes `register` return the canonical class-object record `{beamtalk_object, <Name> ++ " class", ModuleName, ClassPid}` — the same shape produced by `generate_class_reference` and `beamtalk_interface:handle_class_named/1` — fulfilling the behaviour already documented on `ClassBuilder >> register` ("return the new class object").

Link: https://linear.app/beamtalk/issue/BT-2258

## Key changes

- **Runtime** (`beamtalk_class_registry.erl`): add `class_object_from_pid/1`, mirroring the inline construction in `user_classes/0`, building the canonical `#beamtalk_object{class = ClassTag, class_mod = ModuleName, pid = Pid}` record. Exported with `-spec`/`-doc` and an `is_pid` guard.
- **Codegen** (`core_erlang/mod.rs`): `generate_class_builder_register` now emits `call 'beamtalk_class_registry':'class_object_from_pid'(ClassPid)` via the `Document`/`docvec!` API (no `format!`) instead of the hardcoded wrapper tuple.
- **Tests**:
  - `class_builder_test.bt`: new register-then-use coverage (`isClass`, `name`, `printString`, `methods`, `>>`, and `==` to the registry reference).
  - `class_builder_method_source_test.bt`: drops the `findClass:` workaround and uses `register`'s return value directly.
  - `class_builder_class_methods.btscript` / `class_builder_class_method_test.bt`: updated assertions/comments to the corrected output (the class name now renders directly).
- **Build unblock**: disambiguate two pre-existing `EcoString` comparisons (`name.as_ref()` → `name.as_str()`) in `expression_tests.rs` that fail to compile on `main` (E0283) and blocked all builds/tests.

## Test plan

- [x] `just build` (Rust + runtime + stdlib)
- [x] `just clippy` — passed
- [x] `just fmt-check` — passed
- [x] Full Rust test suite (`cargo test --all-targets`) — all pass
- [x] BUnit: `class_builder_test.bt`, `class_builder_method_source_test.bt`, `class_builder_class_method_test.bt` — pass
- [x] Runtime EUnit (`just test-runtime`) — 0 failures
- [x] `just dialyzer` — no warnings
- [x] REPL e2e (`e2e_language_tests`, covers `class_builder_class_methods.btscript`, `class_builder_compiled.btscript`, `inline_class_hot_reload.btscript`) — pass

## Acceptance criteria

- [x] `register` returns a class object that responds to `name`, `methods`, `>>`, `printString` without "terminated" errors
- [x] The returned object equals the registry reference (`is_class_object/1` is `true`)
- [x] BUnit register-then-use coverage added; BT-2246 test drops its `findClass:` workaround
- [x] No regression in the file-defined class load path
- [ ] Sending a defined method to a freshly-spawned instance of a builder-defined class — `new`/`spawn` on a module-less dynamic builder class is a separate pre-existing limitation (tracked under BT-2275), out of scope here

https://claude.ai/code/session_01Ue7R7kqXU8ZDxcYqh8Lw39

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ue7R7kqXU8ZDxcYqh8Lw39)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `register` to return a usable, canonical class object instead of an unusable wrapper, resolving errors related to terminated actor processes and identity check failures.

* **Tests**
  * Added comprehensive test coverage to verify the canonical class object behavior and compatibility with registry lookups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->