### PR TITLE
Byte-span resolver + corpus round-trip validation spike (BT-2281)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/method_span.rs
+++ b/crates/beamtalk-core/src/source_analysis/method_span.rs
@@ -42,7 +42,7 @@
 //! no-op: `source[..start] ++ source[span] ++ source[end..] == source`.
 
 use crate::ast::{ClassDefinition, MessageSelector, Module};
-use crate::source_analysis::{Span, lex, parse};
+use crate::source_analysis::{Diagnostic, Span, lex_with_eof, parse};
 
 /// Which side of a class a method lives on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -140,24 +140,31 @@ impl std::error::Error for SpanResolveError {}
 /// newline; see the module docs for exact boundary semantics. Splicing the
 /// span's own bytes back is a guaranteed no-op.
 ///
-/// # Errors
+/// Parser [`Diagnostic`]s produced while parsing `source` are returned alongside
+/// the result so callers can surface parse problems (per the project convention
+/// that user-facing operations return `(Result, Vec<Diagnostic>)`). The span
+/// `Result` is the resolver's own outcome; an empty diagnostics vector means the
+/// source parsed cleanly.
 ///
-/// Returns [`SpanResolveError`] if the class is absent, the selector is absent
-/// on the requested side, or the match is ambiguous. Never panics.
+/// The `Result` is [`SpanResolveError`] if the class is absent, the selector is
+/// absent on the requested side, or the match is ambiguous. Never panics.
 pub fn resolve_method_span(
     source: &str,
     class: &str,
     selector: &str,
     side: MethodSide,
-) -> Result<Span, SpanResolveError> {
-    let tokens = lex(source);
-    let (module, _diagnostics) = parse(tokens);
-    resolve_in_module(&module, source, class, selector, side)
+) -> (Result<Span, SpanResolveError>, Vec<Diagnostic>) {
+    let tokens = lex_with_eof(source);
+    let (module, diagnostics) = parse(tokens);
+    let result = resolve_in_module(&module, source, class, selector, side);
+    (result, diagnostics)
 }
 
-/// Resolves against an already-parsed module. Exposed for tests that parse once
-/// and resolve many methods (the corpus round-trip), avoiding repeated lexing.
-fn resolve_in_module(
+/// Resolves against an already-parsed module, avoiding repeated lexing/parsing.
+///
+/// `pub(crate)` so the corpus round-trip test can parse each file once and
+/// resolve many methods against the same [`Module`].
+pub(crate) fn resolve_in_module(
     module: &Module,
     source: &str,
     class: &str,
@@ -282,11 +289,52 @@ impl SelectorMatch for MessageSelector {
 mod tests {
     use super::*;
 
-    const ATOMIC: &str = include_str!("../../../../stdlib/src/AtomicCounter.bt");
+    /// In-crate fixture mirroring the shapes the resolver must handle: a
+    /// class-side keyword method, an instance method, a keyword method with a
+    /// multi-line body, and an instance method preceded by a doc comment.
+    ///
+    /// An inline string (rather than `include_str!` of `stdlib/src/*.bt`) keeps
+    /// these unit tests self-contained so the crate still compiles from a source
+    /// distribution that omits the workspace `stdlib/` directory. The full
+    /// stdlib + `examples/` corpus is exercised by the corpus round-trip tests,
+    /// which read those files at runtime and skip when absent.
+    const ATOMIC: &str = "\
+typed Object subclass: AtomicCounter
+
+  /// Create a new named counter starting at 0 (class method).
+  class sealed new: name :: Symbol -> AtomicCounter =>
+    (Erlang beamtalk_atomic_counter) new: name
+
+  /// Atomically add 1. Returns the new value.
+  increment -> Integer => (Erlang beamtalk_atomic_counter) increment: self
+
+  /// Atomically add N. Returns the new value.
+  incrementBy: n :: Integer -> Integer =>
+    (Erlang beamtalk_atomic_counter) incrementBy: self by: n
+
+  /// Read the current value.
+  value -> Integer => (Erlang beamtalk_atomic_counter) readValue: self
+";
+
+    /// Test helper: resolve and assert there were no parse diagnostics, then
+    /// return the span result.
+    fn resolve(
+        source: &str,
+        class: &str,
+        selector: &str,
+        side: MethodSide,
+    ) -> Result<Span, SpanResolveError> {
+        let (result, diagnostics) = resolve_method_span(source, class, selector, side);
+        assert!(
+            diagnostics.is_empty(),
+            "fixture should parse cleanly, got diagnostics: {diagnostics:?}"
+        );
+        result
+    }
 
     #[test]
     fn resolves_instance_method() {
-        let span = resolve_method_span(ATOMIC, "AtomicCounter", "increment", MethodSide::Instance)
+        let span = resolve(ATOMIC, "AtomicCounter", "increment", MethodSide::Instance)
             .expect("increment should resolve");
         let text = &ATOMIC[span.as_range()];
         assert!(text.starts_with("increment -> Integer =>"), "got: {text:?}");
@@ -300,7 +348,7 @@ mod tests {
 
     #[test]
     fn resolves_keyword_method() {
-        let span = resolve_method_span(
+        let span = resolve(
             ATOMIC,
             "AtomicCounter",
             "incrementBy:",
@@ -322,7 +370,7 @@ mod tests {
 
     #[test]
     fn resolves_class_method() {
-        let span = resolve_method_span(ATOMIC, "AtomicCounter", "new:", MethodSide::Class)
+        let span = resolve(ATOMIC, "AtomicCounter", "new:", MethodSide::Class)
             .expect("class new: should resolve");
         let text = &ATOMIC[span.as_range()];
         assert!(text.starts_with("class sealed new: name"), "got: {text:?}");
@@ -333,14 +381,14 @@ mod tests {
     fn instance_and_class_sides_are_distinct() {
         // `new:` only exists on the class side; asking for it as an instance
         // method must miss.
-        let err = resolve_method_span(ATOMIC, "AtomicCounter", "new:", MethodSide::Instance)
+        let err = resolve(ATOMIC, "AtomicCounter", "new:", MethodSide::Instance)
             .expect_err("new: is class-side only");
         assert!(matches!(err, SpanResolveError::SelectorNotFound { .. }));
     }
 
     #[test]
     fn class_not_found_is_structured_error() {
-        let err = resolve_method_span(ATOMIC, "NoSuchClass", "increment", MethodSide::Instance)
+        let err = resolve(ATOMIC, "NoSuchClass", "increment", MethodSide::Instance)
             .expect_err("missing class");
         assert_eq!(
             err,
@@ -352,7 +400,7 @@ mod tests {
 
     #[test]
     fn selector_not_found_is_structured_error() {
-        let err = resolve_method_span(
+        let err = resolve(
             ATOMIC,
             "AtomicCounter",
             "noSuchSelector",
@@ -373,8 +421,7 @@ mod tests {
     fn ambiguous_duplicate_method_is_structured_error() {
         // Two methods with the same selector on the same side.
         let src = "Object subclass: Dup\n  foo => 1\n  foo => 2\n";
-        let err = resolve_method_span(src, "Dup", "foo", MethodSide::Instance)
-            .expect_err("duplicate foo");
+        let err = resolve(src, "Dup", "foo", MethodSide::Instance).expect_err("duplicate foo");
         assert_eq!(
             err,
             SpanResolveError::Ambiguous {
@@ -389,8 +436,7 @@ mod tests {
     #[test]
     fn binary_selector_method() {
         let src = "Object subclass: Vec\n  + other => self\n";
-        let span =
-            resolve_method_span(src, "Vec", "+", MethodSide::Instance).expect("+ should resolve");
+        let span = resolve(src, "Vec", "+", MethodSide::Instance).expect("+ should resolve");
         let text = &src[span.as_range()];
         assert!(text.starts_with("+ other =>"), "got: {text:?}");
         assert_eq!(splice(src, span, text), src);
@@ -399,8 +445,7 @@ mod tests {
     #[test]
     fn last_method_without_trailing_newline_clamps_to_eof() {
         let src = "Object subclass: Tail\n  done => 42";
-        let span =
-            resolve_method_span(src, "Tail", "done", MethodSide::Instance).expect("done resolves");
+        let span = resolve(src, "Tail", "done", MethodSide::Instance).expect("done resolves");
         assert_eq!(span.end() as usize, src.len());
         let text = &src[span.as_range()];
         assert_eq!(splice(src, span, text), src);
@@ -409,7 +454,7 @@ mod tests {
     #[test]
     fn doc_comment_is_excluded_from_span() {
         // The doc comment precedes the method but is not part of the span.
-        let span = resolve_method_span(ATOMIC, "AtomicCounter", "value", MethodSide::Instance)
+        let span = resolve(ATOMIC, "AtomicCounter", "value", MethodSide::Instance)
             .expect("value resolves");
         let text = &ATOMIC[span.as_range()];
         assert!(
@@ -417,6 +462,19 @@ mod tests {
             "doc comment must be excluded: {text:?}"
         );
         assert!(text.starts_with("value -> Integer =>"));
+    }
+
+    #[test]
+    fn returns_parser_diagnostics_alongside_result() {
+        // A user-facing operation surfaces parse problems rather than swallowing
+        // them. The class still resolves; the diagnostics carry the parse issue.
+        let src = "Object subclass: Broken\n  ok => 1\n  bad => @@@\n";
+        let (result, diagnostics) = resolve_method_span(src, "Broken", "ok", MethodSide::Instance);
+        assert!(result.is_ok(), "ok method should still resolve: {result:?}");
+        assert!(
+            !diagnostics.is_empty(),
+            "malformed body should produce parse diagnostics"
+        );
     }
 
     /// Test helper: replace `span` in `source` with `replacement`.

--- a/crates/beamtalk-core/src/source_analysis/method_span.rs
+++ b/crates/beamtalk-core/src/source_analysis/method_span.rs
@@ -1,0 +1,430 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Byte-span resolver for method definitions (ADR 0082, Phase 0).
+//!
+//! **DDD Context:** Source Analysis (Compilation context per ADR 0082).
+//!
+//! Given the source text of a `.bt` file and a target `(class, selector, kind)`,
+//! [`resolve_method_span`] returns the exact byte span of that method's
+//! definition — from the first significant token of the definition through the
+//! trailing newline that terminates its last body line.
+//!
+//! # Why this exists
+//!
+//! ADR 0082 ("Method-Level Edit and Save in the Live Workspace") chose
+//! **byte-span replacement**, not AST round-trip, as its flush splice strategy.
+//! At flush time a new file body is produced by copying bytes verbatim outside
+//! the target span and substituting the patched method source inside it. No
+//! reformat, no AST reprint of unchanged content. The load-bearing assumption
+//! is that the parser can resolve *any* method's exact byte span against
+//! arbitrary `.bt` files. This module — and its corpus round-trip test — exist
+//! to validate that assumption before any flush code is written (Phase 0).
+//!
+//! This is internal scaffolding, not a user-facing feature: the resolver is the
+//! proof of concept that the splice approach is sound.
+//!
+//! # Span boundaries
+//!
+//! The returned span covers:
+//! - **start**: the first significant token of the definition. For a class-body
+//!   method that is the first modifier or the selector (whichever comes first);
+//!   leading doc comments and indentation are *excluded* (they are not part of
+//!   the method body the patcher replaces). For a standalone `Class >> selector`
+//!   extension the start is the class-name token.
+//! - **end**: the byte immediately after the trailing newline that terminates
+//!   the last source line of the body (so the span includes the body and its
+//!   trailing newline, per ADR 0082's "start..end including body and trailing
+//!   newline"). If the body's last line is the final line of the file with no
+//!   trailing newline, the end is clamped to the file length.
+//!
+//! Splicing `source[span]` back into `source` at `span` is therefore an exact
+//! no-op: `source[..start] ++ source[span] ++ source[end..] == source`.
+
+use crate::ast::{ClassDefinition, MessageSelector, Module};
+use crate::source_analysis::{Span, lex, parse};
+
+/// Which side of a class a method lives on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MethodSide {
+    /// An instance method (the default; e.g. `increment => ...`).
+    Instance,
+    /// A class-side method (`class new: name => ...` or `Class class >> ...`).
+    Class,
+}
+
+impl MethodSide {
+    /// Human-readable name for diagnostics.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            MethodSide::Instance => "instance",
+            MethodSide::Class => "class",
+        }
+    }
+}
+
+/// Why a method span could not be resolved.
+///
+/// Resolution never panics on well-formed *or* malformed input — every failure
+/// is one of these structured variants (ADR 0082 acceptance criterion: "Failures
+/// (selector not found, ambiguous) return a structured error, never a panic").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpanResolveError {
+    /// No class with the requested name was found in the source.
+    ClassNotFound {
+        /// The class name that was searched for.
+        class: String,
+    },
+    /// The class exists but has no method matching `(selector, side)`.
+    SelectorNotFound {
+        /// The class that was searched.
+        class: String,
+        /// The selector that was searched for.
+        selector: String,
+        /// Which side (instance/class) was searched.
+        side: MethodSide,
+    },
+    /// More than one definition matched `(class, selector, side)` — the source
+    /// is malformed (duplicate methods) or the resolver cannot disambiguate.
+    Ambiguous {
+        /// The class that was searched.
+        class: String,
+        /// The selector that matched more than once.
+        selector: String,
+        /// Which side (instance/class) was searched.
+        side: MethodSide,
+        /// How many definitions matched.
+        count: usize,
+    },
+}
+
+impl std::fmt::Display for SpanResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpanResolveError::ClassNotFound { class } => {
+                write!(f, "class `{class}` not found in source")
+            }
+            SpanResolveError::SelectorNotFound {
+                class,
+                selector,
+                side,
+            } => write!(
+                f,
+                "{side} method `{selector}` not found in class `{class}`",
+                side = side.as_str()
+            ),
+            SpanResolveError::Ambiguous {
+                class,
+                selector,
+                side,
+                count,
+            } => write!(
+                f,
+                "{side} method `{selector}` in class `{class}` is ambiguous ({count} definitions)",
+                side = side.as_str()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SpanResolveError {}
+
+/// Resolves the byte span of a method definition in `source`.
+///
+/// `class` is the class name (e.g. `"AtomicCounter"`), `selector` is the
+/// canonical selector string (e.g. `"increment"`, `"incrementBy:"`, `"at:put:"`,
+/// `"+"`), and `side` selects the instance vs class side.
+///
+/// The returned [`Span`] covers the method definition including its trailing
+/// newline; see the module docs for exact boundary semantics. Splicing the
+/// span's own bytes back is a guaranteed no-op.
+///
+/// # Errors
+///
+/// Returns [`SpanResolveError`] if the class is absent, the selector is absent
+/// on the requested side, or the match is ambiguous. Never panics.
+pub fn resolve_method_span(
+    source: &str,
+    class: &str,
+    selector: &str,
+    side: MethodSide,
+) -> Result<Span, SpanResolveError> {
+    let tokens = lex(source);
+    let (module, _diagnostics) = parse(tokens);
+    resolve_in_module(&module, source, class, selector, side)
+}
+
+/// Resolves against an already-parsed module. Exposed for tests that parse once
+/// and resolve many methods (the corpus round-trip), avoiding repeated lexing.
+fn resolve_in_module(
+    module: &Module,
+    source: &str,
+    class: &str,
+    selector: &str,
+    side: MethodSide,
+) -> Result<Span, SpanResolveError> {
+    // Each match contributes the *AST span* of its definition (whose end is the
+    // last body token; the trailing newline is added later by `definition_span`).
+    let mut matches: Vec<Span> = Vec::new();
+    let mut class_seen = false;
+
+    for class_def in &module.classes {
+        if class_def.name.name.as_str() != class {
+            continue;
+        }
+        class_seen = true;
+        collect_matches(class_def, selector, side, &mut matches);
+    }
+
+    // Standalone `Class >> selector` extension definitions (ADR 0066). These
+    // live at module level rather than inside a class body. They count as the
+    // same class for span-resolution purposes. Their span starts at the
+    // class-name token (not the selector), so use `standalone.span`.
+    for standalone in &module.method_definitions {
+        if standalone.class_name.name.as_str() != class {
+            continue;
+        }
+        class_seen = true;
+        let standalone_side = if standalone.is_class_method {
+            MethodSide::Class
+        } else {
+            MethodSide::Instance
+        };
+        if standalone_side == side && standalone.method.selector.matches(selector) {
+            matches.push(standalone.span);
+        }
+    }
+
+    match matches.len() {
+        0 if !class_seen => Err(SpanResolveError::ClassNotFound {
+            class: class.to_string(),
+        }),
+        0 => Err(SpanResolveError::SelectorNotFound {
+            class: class.to_string(),
+            selector: selector.to_string(),
+            side,
+        }),
+        1 => Ok(definition_span(source, matches[0])),
+        count => Err(SpanResolveError::Ambiguous {
+            class: class.to_string(),
+            selector: selector.to_string(),
+            side,
+            count,
+        }),
+    }
+}
+
+/// Collects the spans of instance/class method definitions in `class_def`
+/// matching the selector and side.
+fn collect_matches(
+    class_def: &ClassDefinition,
+    selector: &str,
+    side: MethodSide,
+    out: &mut Vec<Span>,
+) {
+    let methods = match side {
+        MethodSide::Instance => &class_def.methods,
+        MethodSide::Class => &class_def.class_methods,
+    };
+    for method in methods {
+        if method.selector.matches(selector) {
+            out.push(method.span);
+        }
+    }
+}
+
+/// Computes the definition span for a method whose AST span is `method_span`.
+///
+/// The AST span ends at the last body expression's last token. The definition
+/// span extends that end forward across the remainder of the body's final line,
+/// up to and including the terminating newline, so the splice covers the body
+/// and its trailing newline (ADR 0082). The start is unchanged.
+fn definition_span(source: &str, method_span: Span) -> Span {
+    let start = method_span.start();
+    let end = extend_to_line_end(source, method_span.end());
+    Span::new(start, end)
+}
+
+/// Returns the byte offset just past the next newline at or after `offset`,
+/// clamped to the source length. If there is no newline before EOF (the final
+/// line lacks a trailing newline), returns the source length.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "source files over 4GB are not supported (Span uses u32)"
+)]
+fn extend_to_line_end(source: &str, offset: u32) -> u32 {
+    let bytes = source.as_bytes();
+    let len = bytes.len();
+    let mut i = (offset as usize).min(len);
+    while i < len {
+        let b = bytes[i];
+        i += 1;
+        if b == b'\n' {
+            break;
+        }
+    }
+    i as u32
+}
+
+/// Selector matching helper. Compares the canonical selector string.
+trait SelectorMatch {
+    fn matches(&self, selector: &str) -> bool;
+}
+
+impl SelectorMatch for MessageSelector {
+    fn matches(&self, selector: &str) -> bool {
+        self.name().as_str() == selector
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ATOMIC: &str = include_str!("../../../../stdlib/src/AtomicCounter.bt");
+
+    #[test]
+    fn resolves_instance_method() {
+        let span = resolve_method_span(ATOMIC, "AtomicCounter", "increment", MethodSide::Instance)
+            .expect("increment should resolve");
+        let text = &ATOMIC[span.as_range()];
+        assert!(text.starts_with("increment -> Integer =>"), "got: {text:?}");
+        assert!(
+            text.ends_with('\n'),
+            "span should include trailing newline: {text:?}"
+        );
+        // No-op splice is identity.
+        assert_eq!(splice(ATOMIC, span, text), ATOMIC);
+    }
+
+    #[test]
+    fn resolves_keyword_method() {
+        let span = resolve_method_span(
+            ATOMIC,
+            "AtomicCounter",
+            "incrementBy:",
+            MethodSide::Instance,
+        )
+        .expect("incrementBy: should resolve");
+        let text = &ATOMIC[span.as_range()];
+        assert!(
+            text.starts_with("incrementBy: n :: Integer"),
+            "got: {text:?}"
+        );
+        // Multi-line body: the `=>` is on one line, the call on the next.
+        assert!(
+            text.contains("by: n"),
+            "should cover full multi-line body: {text:?}"
+        );
+        assert!(text.ends_with('\n'));
+    }
+
+    #[test]
+    fn resolves_class_method() {
+        let span = resolve_method_span(ATOMIC, "AtomicCounter", "new:", MethodSide::Class)
+            .expect("class new: should resolve");
+        let text = &ATOMIC[span.as_range()];
+        assert!(text.starts_with("class sealed new: name"), "got: {text:?}");
+        assert!(text.ends_with('\n'));
+    }
+
+    #[test]
+    fn instance_and_class_sides_are_distinct() {
+        // `new:` only exists on the class side; asking for it as an instance
+        // method must miss.
+        let err = resolve_method_span(ATOMIC, "AtomicCounter", "new:", MethodSide::Instance)
+            .expect_err("new: is class-side only");
+        assert!(matches!(err, SpanResolveError::SelectorNotFound { .. }));
+    }
+
+    #[test]
+    fn class_not_found_is_structured_error() {
+        let err = resolve_method_span(ATOMIC, "NoSuchClass", "increment", MethodSide::Instance)
+            .expect_err("missing class");
+        assert_eq!(
+            err,
+            SpanResolveError::ClassNotFound {
+                class: "NoSuchClass".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn selector_not_found_is_structured_error() {
+        let err = resolve_method_span(
+            ATOMIC,
+            "AtomicCounter",
+            "noSuchSelector",
+            MethodSide::Instance,
+        )
+        .expect_err("missing selector");
+        assert_eq!(
+            err,
+            SpanResolveError::SelectorNotFound {
+                class: "AtomicCounter".to_string(),
+                selector: "noSuchSelector".to_string(),
+                side: MethodSide::Instance,
+            }
+        );
+    }
+
+    #[test]
+    fn ambiguous_duplicate_method_is_structured_error() {
+        // Two methods with the same selector on the same side.
+        let src = "Object subclass: Dup\n  foo => 1\n  foo => 2\n";
+        let err = resolve_method_span(src, "Dup", "foo", MethodSide::Instance)
+            .expect_err("duplicate foo");
+        assert_eq!(
+            err,
+            SpanResolveError::Ambiguous {
+                class: "Dup".to_string(),
+                selector: "foo".to_string(),
+                side: MethodSide::Instance,
+                count: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn binary_selector_method() {
+        let src = "Object subclass: Vec\n  + other => self\n";
+        let span =
+            resolve_method_span(src, "Vec", "+", MethodSide::Instance).expect("+ should resolve");
+        let text = &src[span.as_range()];
+        assert!(text.starts_with("+ other =>"), "got: {text:?}");
+        assert_eq!(splice(src, span, text), src);
+    }
+
+    #[test]
+    fn last_method_without_trailing_newline_clamps_to_eof() {
+        let src = "Object subclass: Tail\n  done => 42";
+        let span =
+            resolve_method_span(src, "Tail", "done", MethodSide::Instance).expect("done resolves");
+        assert_eq!(span.end() as usize, src.len());
+        let text = &src[span.as_range()];
+        assert_eq!(splice(src, span, text), src);
+    }
+
+    #[test]
+    fn doc_comment_is_excluded_from_span() {
+        // The doc comment precedes the method but is not part of the span.
+        let span = resolve_method_span(ATOMIC, "AtomicCounter", "value", MethodSide::Instance)
+            .expect("value resolves");
+        let text = &ATOMIC[span.as_range()];
+        assert!(
+            !text.contains("///"),
+            "doc comment must be excluded: {text:?}"
+        );
+        assert!(text.starts_with("value -> Integer =>"));
+    }
+
+    /// Test helper: replace `span` in `source` with `replacement`.
+    fn splice(source: &str, span: Span, replacement: &str) -> String {
+        let mut out = String::with_capacity(source.len());
+        out.push_str(&source[..span.start() as usize]);
+        out.push_str(replacement);
+        out.push_str(&source[span.end() as usize..]);
+        out
+    }
+}

--- a/crates/beamtalk-core/src/source_analysis/method_span_corpus_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/method_span_corpus_tests.rs
@@ -1,0 +1,335 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Corpus round-trip validation for the byte-span resolver (ADR 0082, Phase 0).
+//!
+//! This is the **load-bearing validation spike** for ADR 0082. The entire
+//! method-level edit-and-save design rests on one assumption: that the parser
+//! can resolve *any* method's exact byte span against arbitrary `.bt` files, so
+//! that flush can splice a patched method body in by byte replacement (no AST
+//! reprint).
+//!
+//! The proof: for **every method in the stdlib + `examples/` corpus**, resolve
+//! its span, splice the span's own verbatim bytes back in (a no-op edit), and
+//! assert the resulting file is **byte-identical** to the original. If this
+//! holds across the whole corpus — doc comments, multi-line bodies, cascades,
+//! class-side methods, binary selectors, trailing-comment lines — the splice
+//! strategy is sound and the rest of ADR 0082 can be built on it.
+//!
+//! In addition to the no-op identity check (which is tautological for a correct
+//! slice), this suite asserts the *structural* properties that make the span
+//! meaningful: every method resolves to exactly one span, spans are non-empty,
+//! cover the method's selector text, lie within the class definition, are
+//! ordered, and never overlap a sibling. Those properties are what would break
+//! if the resolver returned a wrong or sloppy span.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use crate::ast::Module;
+use crate::source_analysis::method_span::{MethodSide, resolve_method_span};
+use crate::source_analysis::{Span, lex, parse};
+
+/// Returns the repository root (`CARGO_MANIFEST_DIR/../..`).
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/")
+        .parent()
+        .expect("repo root")
+        .to_path_buf()
+}
+
+/// Recursively collects every `.bt` file under `dir`.
+fn collect_bt_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).map(|e| e.path()).collect();
+    // Deterministic order for stable test output.
+    entries.sort();
+    for path in entries {
+        if path.is_dir() {
+            collect_bt_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "bt") {
+            out.push(path);
+        }
+    }
+}
+
+/// Gathers the whole corpus: every `.bt` file under `stdlib/src` and `examples`.
+fn corpus_files() -> Vec<PathBuf> {
+    let root = repo_root();
+    let mut files = Vec::new();
+    collect_bt_files(&root.join("stdlib/src"), &mut files);
+    collect_bt_files(&root.join("examples"), &mut files);
+    files
+}
+
+/// One method to resolve, identified the way a caller would: by class name,
+/// canonical selector string, and side.
+#[derive(Debug, Clone)]
+struct MethodTarget {
+    class: String,
+    selector: String,
+    side: MethodSide,
+    /// AST span of the definition, for the structural overlap/ordering checks.
+    ast_span: Span,
+}
+
+/// Enumerates every resolvable method definition in `module`.
+///
+/// This mirrors what the resolver searches: instance and class methods in class
+/// bodies, plus standalone `Class >> selector` extension definitions.
+fn enumerate_methods(module: &Module) -> Vec<MethodTarget> {
+    let mut targets = Vec::new();
+    for class_def in &module.classes {
+        for m in &class_def.methods {
+            targets.push(MethodTarget {
+                class: class_def.name.name.to_string(),
+                selector: m.selector.name().to_string(),
+                side: MethodSide::Instance,
+                ast_span: m.span,
+            });
+        }
+        for m in &class_def.class_methods {
+            targets.push(MethodTarget {
+                class: class_def.name.name.to_string(),
+                selector: m.selector.name().to_string(),
+                side: MethodSide::Class,
+                ast_span: m.span,
+            });
+        }
+    }
+    for standalone in &module.method_definitions {
+        targets.push(MethodTarget {
+            class: standalone.class_name.name.to_string(),
+            selector: standalone.method.selector.name().to_string(),
+            side: if standalone.is_class_method {
+                MethodSide::Class
+            } else {
+                MethodSide::Instance
+            },
+            ast_span: standalone.span,
+        });
+    }
+    targets
+}
+
+/// Splices `replacement` into `source` over `span`.
+fn splice(source: &str, span: Span, replacement: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    out.push_str(&source[..span.start() as usize]);
+    out.push_str(replacement);
+    out.push_str(&source[span.end() as usize..]);
+    out
+}
+
+/// The headline Phase 0 proof: no-op byte-span splice is byte-identical across
+/// the entire corpus.
+#[test]
+fn corpus_round_trip_is_byte_identical() {
+    let files = corpus_files();
+    assert!(
+        !files.is_empty(),
+        "corpus walk found no .bt files — check repo layout"
+    );
+
+    let mut total_methods = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for path in &files {
+        let source = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) => {
+                failures.push(format!("{}: could not read: {e}", path.display()));
+                continue;
+            }
+        };
+        let tokens = lex(&source);
+        let (module, _diags) = parse(tokens);
+
+        for target in enumerate_methods(&module) {
+            total_methods += 1;
+            let span =
+                match resolve_method_span(&source, &target.class, &target.selector, target.side) {
+                    Ok(span) => span,
+                    Err(e) => {
+                        failures.push(format!(
+                            "{}: {}.{} ({}): resolve failed: {e}",
+                            path.display(),
+                            target.class,
+                            target.selector,
+                            target.side.as_str()
+                        ));
+                        continue;
+                    }
+                };
+
+            // The core no-op identity: splicing the span's own bytes back is a
+            // byte-for-byte no-op.
+            let own_bytes = &source[span.as_range()];
+            let round_tripped = splice(&source, span, own_bytes);
+            if round_tripped != source {
+                failures.push(format!(
+                    "{}: {}.{} ({}): no-op splice changed the file",
+                    path.display(),
+                    target.class,
+                    target.selector,
+                    target.side.as_str()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "corpus round-trip failed for {} method(s) (of {} across {} files):\n{}",
+        failures.len(),
+        total_methods,
+        files.len(),
+        failures.join("\n")
+    );
+
+    // Sanity: the corpus is non-trivial (>1300 methods across the stdlib +
+    // examples at time of writing). If this ever drops to a handful, the walk
+    // silently broke.
+    assert!(
+        total_methods > 100,
+        "expected the corpus to contain >100 methods, found {total_methods} — \
+         the walk may have silently failed"
+    );
+}
+
+/// Structural invariants that make the no-op identity meaningful: every method
+/// resolves to exactly one non-empty span that covers its selector, lies within
+/// its class, and never overlaps a sibling in the same file.
+#[test]
+fn corpus_spans_are_well_formed_and_non_overlapping() {
+    let files = corpus_files();
+    let mut failures: Vec<String> = Vec::new();
+
+    for path in &files {
+        let Ok(source) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let tokens = lex(&source);
+        let (module, _diags) = parse(tokens);
+
+        let mut resolved: Vec<(MethodTarget, Span)> = Vec::new();
+        for target in enumerate_methods(&module) {
+            let Ok(span) =
+                resolve_method_span(&source, &target.class, &target.selector, target.side)
+            else {
+                // Resolution failures are reported by the round-trip test; skip
+                // here to keep this test focused on geometry.
+                continue;
+            };
+
+            // Span must be non-empty and within the file.
+            if span.is_empty() {
+                failures.push(format!(
+                    "{}: {}.{} ({}): empty span",
+                    path.display(),
+                    target.class,
+                    target.selector,
+                    target.side.as_str()
+                ));
+            }
+            if span.end() as usize > source.len() {
+                failures.push(format!(
+                    "{}: {}.{} ({}): span end {} exceeds file length {}",
+                    path.display(),
+                    target.class,
+                    target.selector,
+                    target.side.as_str(),
+                    span.end(),
+                    source.len()
+                ));
+            }
+
+            // The span must contain the selector's textual start (the AST span's
+            // start lies inside the resolved span — the resolver only extends
+            // the end, never moves the start).
+            if !(span.start() <= target.ast_span.start() && target.ast_span.start() < span.end()) {
+                failures.push(format!(
+                    "{}: {}.{} ({}): span {:?} does not contain selector start {}",
+                    path.display(),
+                    target.class,
+                    target.selector,
+                    target.side.as_str(),
+                    span.as_range(),
+                    target.ast_span.start()
+                ));
+            }
+
+            resolved.push((target, span));
+        }
+
+        // No two distinct method spans in the same file may overlap.
+        resolved.sort_by_key(|(_, span)| (span.start(), span.end()));
+        for window in resolved.windows(2) {
+            let (a_t, a) = &window[0];
+            let (b_t, b) = &window[1];
+            if a.end() > b.start() {
+                failures.push(format!(
+                    "{}: spans overlap: {}.{} ({}) {:?} vs {}.{} ({}) {:?}",
+                    path.display(),
+                    a_t.class,
+                    a_t.selector,
+                    a_t.side.as_str(),
+                    a.as_range(),
+                    b_t.class,
+                    b_t.selector,
+                    b_t.side.as_str(),
+                    b.as_range()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "span geometry violations:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// Every method in the corpus must resolve — none may report a structured
+/// error. This is the "no false negatives" half of the proof: the resolver
+/// finds a span for *every* method the parser knows about.
+#[test]
+fn corpus_every_method_resolves() {
+    let files = corpus_files();
+    let mut unresolved: BTreeSet<String> = BTreeSet::new();
+    let mut total = 0usize;
+
+    for path in &files {
+        let Ok(source) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let tokens = lex(&source);
+        let (module, _diags) = parse(tokens);
+
+        for target in enumerate_methods(&module) {
+            total += 1;
+            if resolve_method_span(&source, &target.class, &target.selector, target.side).is_err() {
+                unresolved.insert(format!(
+                    "{}: {}.{} ({})",
+                    path.display(),
+                    target.class,
+                    target.selector,
+                    target.side.as_str()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        unresolved.is_empty(),
+        "{} of {} methods did not resolve:\n{}",
+        unresolved.len(),
+        total,
+        unresolved.iter().cloned().collect::<Vec<_>>().join("\n")
+    );
+}

--- a/crates/beamtalk-core/src/source_analysis/method_span_corpus_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/method_span_corpus_tests.rs
@@ -27,8 +27,8 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use crate::ast::Module;
-use crate::source_analysis::method_span::{MethodSide, resolve_method_span};
-use crate::source_analysis::{Span, lex, parse};
+use crate::source_analysis::method_span::{MethodSide, resolve_in_module};
+use crate::source_analysis::{Span, lex_with_eof, parse};
 
 /// Returns the repository root (`CARGO_MANIFEST_DIR/../..`).
 fn repo_root() -> PathBuf {
@@ -57,13 +57,38 @@ fn collect_bt_files(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
+/// The corpus directories: every `.bt` file lives under one of these.
+fn corpus_dirs() -> [PathBuf; 2] {
+    let root = repo_root();
+    [root.join("stdlib/src"), root.join("examples")]
+}
+
+/// Whether the corpus directories are present in this checkout.
+///
+/// They are absent when the crate is built from a source distribution or a
+/// partial checkout that omits the workspace `stdlib/` and `examples/` trees. In
+/// that case the corpus tests skip rather than hard-fail (a present-but-
+/// unreadable *file*, by contrast, is always a hard failure).
+fn corpus_present() -> bool {
+    corpus_dirs().iter().any(|dir| dir.is_dir())
+}
+
 /// Gathers the whole corpus: every `.bt` file under `stdlib/src` and `examples`.
 fn corpus_files() -> Vec<PathBuf> {
-    let root = repo_root();
     let mut files = Vec::new();
-    collect_bt_files(&root.join("stdlib/src"), &mut files);
-    collect_bt_files(&root.join("examples"), &mut files);
+    for dir in corpus_dirs() {
+        collect_bt_files(&dir, &mut files);
+    }
     files
+}
+
+/// Reads a corpus file, hard-failing (with the path + error) if it is present
+/// but cannot be read. Unlike skipping an absent *directory*, an unreadable file
+/// that the walk already discovered must never be silently ignored — that would
+/// let the round-trip proof go false-green.
+fn read_corpus_file(path: &Path) -> String {
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("could not read corpus file {}: {e}", path.display()))
 }
 
 /// One method to resolve, identified the way a caller would: by class name,
@@ -129,6 +154,11 @@ fn splice(source: &str, span: Span, replacement: &str) -> String {
 /// the entire corpus.
 #[test]
 fn corpus_round_trip_is_byte_identical() {
+    if !corpus_present() {
+        // Partial checkout / source distribution without the workspace corpus
+        // dirs: nothing to validate here.
+        return;
+    }
     let files = corpus_files();
     assert!(
         !files.is_empty(),
@@ -139,32 +169,31 @@ fn corpus_round_trip_is_byte_identical() {
     let mut failures: Vec<String> = Vec::new();
 
     for path in &files {
-        let source = match std::fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(e) => {
-                failures.push(format!("{}: could not read: {e}", path.display()));
-                continue;
-            }
-        };
-        let tokens = lex(&source);
+        let source = read_corpus_file(path);
+        let tokens = lex_with_eof(&source);
         let (module, _diags) = parse(tokens);
 
         for target in enumerate_methods(&module) {
             total_methods += 1;
-            let span =
-                match resolve_method_span(&source, &target.class, &target.selector, target.side) {
-                    Ok(span) => span,
-                    Err(e) => {
-                        failures.push(format!(
-                            "{}: {}.{} ({}): resolve failed: {e}",
-                            path.display(),
-                            target.class,
-                            target.selector,
-                            target.side.as_str()
-                        ));
-                        continue;
-                    }
-                };
+            let span = match resolve_in_module(
+                &module,
+                &source,
+                &target.class,
+                &target.selector,
+                target.side,
+            ) {
+                Ok(span) => span,
+                Err(e) => {
+                    failures.push(format!(
+                        "{}: {}.{} ({}): resolve failed: {e}",
+                        path.display(),
+                        target.class,
+                        target.selector,
+                        target.side.as_str()
+                    ));
+                    continue;
+                }
+            };
 
             // The core no-op identity: splicing the span's own bytes back is a
             // byte-for-byte no-op.
@@ -206,21 +235,26 @@ fn corpus_round_trip_is_byte_identical() {
 /// its class, and never overlaps a sibling in the same file.
 #[test]
 fn corpus_spans_are_well_formed_and_non_overlapping() {
+    if !corpus_present() {
+        return;
+    }
     let files = corpus_files();
     let mut failures: Vec<String> = Vec::new();
 
     for path in &files {
-        let Ok(source) = std::fs::read_to_string(path) else {
-            continue;
-        };
-        let tokens = lex(&source);
+        let source = read_corpus_file(path);
+        let tokens = lex_with_eof(&source);
         let (module, _diags) = parse(tokens);
 
         let mut resolved: Vec<(MethodTarget, Span)> = Vec::new();
         for target in enumerate_methods(&module) {
-            let Ok(span) =
-                resolve_method_span(&source, &target.class, &target.selector, target.side)
-            else {
+            let Ok(span) = resolve_in_module(
+                &module,
+                &source,
+                &target.class,
+                &target.selector,
+                target.side,
+            ) else {
                 // Resolution failures are reported by the round-trip test; skip
                 // here to keep this test focused on geometry.
                 continue;
@@ -300,20 +334,29 @@ fn corpus_spans_are_well_formed_and_non_overlapping() {
 /// finds a span for *every* method the parser knows about.
 #[test]
 fn corpus_every_method_resolves() {
+    if !corpus_present() {
+        return;
+    }
     let files = corpus_files();
     let mut unresolved: BTreeSet<String> = BTreeSet::new();
     let mut total = 0usize;
 
     for path in &files {
-        let Ok(source) = std::fs::read_to_string(path) else {
-            continue;
-        };
-        let tokens = lex(&source);
+        let source = read_corpus_file(path);
+        let tokens = lex_with_eof(&source);
         let (module, _diags) = parse(tokens);
 
         for target in enumerate_methods(&module) {
             total += 1;
-            if resolve_method_span(&source, &target.class, &target.selector, target.side).is_err() {
+            if resolve_in_module(
+                &module,
+                &source,
+                &target.class,
+                &target.selector,
+                target.side,
+            )
+            .is_err()
+            {
                 unresolved.insert(format!(
                     "{}: {}.{} ({})",
                     path.display(),

--- a/crates/beamtalk-core/src/source_analysis/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/mod.rs
@@ -39,6 +39,7 @@
 
 mod error;
 mod lexer;
+pub mod method_span;
 mod parser;
 mod span;
 pub mod summary;
@@ -48,8 +49,13 @@ mod token;
 #[cfg(test)]
 mod lexer_property_tests;
 
+// Corpus round-trip validation for the byte-span resolver (ADR 0082, Phase 0).
+#[cfg(test)]
+mod method_span_corpus_tests;
+
 pub use error::{LexError, LexErrorKind};
 pub use lexer::{Lexer, lex, lex_with_eof};
+pub use method_span::{MethodSide, SpanResolveError, resolve_method_span};
 pub use parser::{
     Diagnostic, DiagnosticCategory, DiagnosticNote, Severity, is_input_complete,
     needs_blank_line_to_complete, parse,


### PR DESCRIPTION
## Summary

ADR 0082 Phase 0 validation spike: proves the load-bearing assumption that the parser can resolve any method's exact byte span for flush-time splice replacement.

- Adds `source_analysis::method_span` module with `resolve_method_span(source, class, selector, side) -> Result<Span, SpanResolveError>`
- Corpus round-trip test validates 1347 methods across 161 files (stdlib + examples) all pass the no-op splice identity check
- Spans are non-overlapping, non-empty, ordered, and cover the selector text
- Structured errors (ClassNotFound, SelectorNotFound, Ambiguous) — never panics

## Key changes

- `crates/beamtalk-core/src/source_analysis/method_span.rs` — the resolver (public API + unit tests)
- `crates/beamtalk-core/src/source_analysis/method_span_corpus_tests.rs` — corpus round-trip proof
- `crates/beamtalk-core/src/source_analysis/mod.rs` — module registration + re-exports

## Test plan

- [x] 10 unit tests covering instance/class/keyword/binary methods, error cases, edge cases
- [x] 3 corpus tests: byte-identical round-trip, non-overlapping geometry, every-method-resolves
- [x] `cargo clippy` clean, `cargo fmt --check` clean
- [x] Full source_analysis test suite (607 tests) passes

## References

- Linear: https://linear.app/beamtalk/issue/BT-2281
- ADR: `docs/ADR/0082-method-level-edit-save-and-changelog.md` (Phase 0)

https://claude.ai/code/session_01Sp9oYSjVcdx7FDeuKDdVwU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added method byte-span resolution capability to support precise, byte-based editing operations in source files.

* **Tests**
  * Comprehensive test suite added to validate method span resolution across the entire codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->