### PR TITLE
ChangeLog gen_server + two-part on-disk persistence (ADR 0082 Phase 1) (BT-2282)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace.app.src
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace.app.src
@@ -2,7 +2,7 @@
     {description, "Beamtalk workspace and interactive development environment"},
     {vsn, {cmd, "escript ../../../scripts/version.escript"}},
     {modules, []},
-    {registered, [beamtalk_workspace_changelog]},
+    {registered, []},
     {applications, [kernel, stdlib, crypto, cowboy, beamtalk_runtime, sasl, beamtalk_stdlib]},
     {mod, {beamtalk_workspace_app, []}},
     {env, [

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace.app.src
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace.app.src
@@ -2,7 +2,7 @@
     {description, "Beamtalk workspace and interactive development environment"},
     {vsn, {cmd, "escript ../../../scripts/version.escript"}},
     {modules, []},
-    {registered, []},
+    {registered, [beamtalk_workspace_changelog]},
     {applications, [kernel, stdlib, crypto, cowboy, beamtalk_runtime, sasl, beamtalk_stdlib]},
     {mod, {beamtalk_workspace_app, []}},
     {env, [

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
@@ -1,0 +1,775 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_workspace_changelog).
+-behaviour(gen_server).
+
+%%% **DDD Context:** Workspace Context
+
+-moduledoc """
+Append-only ChangeLog for live in-memory method mutations (ADR 0082 Phase 1).
+
+The ChangeLog is the workspace-local record of every in-memory class/method
+mutation made via the live-edit path (`Counter >> sel`, `compile:source:`,
+`tryCompile:source:`, `Workspace newClass:at:`). It is both the *dirty-state*
+tracker — "what has the running workspace changed relative to disk?" — and the
+*undo* store. It lives in the **Workspace context** (not the REPL) because it is
+consumed cross-surface by REPL, MCP, LSP, and the browser IDE.
+
+This module owns the gen_server that serialises log appends (and, in a later
+phase, flush-start reads). Live state is held in an ETS table for fast,
+concurrent reads; durable state is a two-part on-disk layout per the ADR:
+
+```
+<workspace>/changes/
+  changes.jsonl              % one compact JSON object per ChangeEntry
+  sources/
+    000142-source.bt        % the patched method body (source_ref)
+    000142-prev.bt          % the prior on-disk body (prev_source_ref), if any
+  archive/
+    changes-<ts>.jsonl.gz    % rotated metadata segment
+    sources-<ts>.tar.gz      % rotated source bodies
+```
+
+The metadata line stays small (well under ~300 chars) regardless of method
+size because the bodies live in `sources/` as plain `.bt` files — `cat`, `less`,
+`bt fmt`, `diff`, and syntax highlighting all work on them without escaping.
+
+### ChangeEntry schema
+
+Each `changes.jsonl` line is a JSON object with these fields (ADR 0082,
+*ChangeLog format*):
+
+| Field                  | Type                                   | Notes |
+|------------------------|----------------------------------------|-------|
+| `ts`                   | integer (ms since epoch)               | append time |
+| `seq`                  | integer                                | monotonic per workspace |
+| `epoch`                | integer                                | bumped each workspace start |
+| `class`                | string                                 | e.g. `"Counter"` |
+| `selector`             | string \| null                         | null for `new-class` |
+| `kind`                 | `"instance"`\|`"class"`\|`"new-class"` | open enum |
+| `source_ref`           | string                                 | filename in `sources/` |
+| `prev_source_ref`      | string \| null                         | null for `new-class` |
+| `sourceFile`           | string \| null                         | null for stdlib/dynamic |
+| `span`                 | `{start,end}` \| null                  | null for `new-class` |
+| `intent`               | `"durable"`\|`"ephemeral"`             | |
+| `flushable`            | boolean                                | true iff in-project source |
+| `not_flushable_reason` | string \| null                         | `"stdlib"`/`"dynamic"`/`"dependency:<path>"` |
+| `author`               | string                                 | session/tool id |
+| `author_kind`          | `"human"`\|`"agent"`                   | audit metadata |
+
+### Restart semantics
+
+The on-disk log survives workspace restart; the in-memory BEAM module state does
+not. On startup the gen_server reads `changes.jsonl`, assigns a **fresh epoch**
+(prior `max(epoch)` + 1), and tags every pre-existing entry as belonging to a
+prior epoch. An entry is additionally tagged `orphan` when its recorded
+`prev_source` no longer matches the current on-disk content of `sourceFile` (the
+disk advanced — via VSCode/git/another flush — while the workspace was down).
+Prior-epoch and orphan entries are excluded from the active dirty view; they
+remain in the log for audit.
+
+### Scope (Phase 1)
+
+This module implements the gen_server, the append API, the two-part persistence,
+restart epoch/orphan tagging, and the bounded ring with archive rotation. The
+install hook that *emits* entries, `Workspace flush`, and the `ChangeLog.bt`
+stdlib facade are later phases (BT-2280 epic). In run mode (no workspace, no
+`workspace_id`) the gen_server keeps state in ETS only and never touches disk —
+release nodes do not start a workspace, so this code is a no-op there.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+%% Public API
+-export([
+    start_link/1,
+    append/1,
+    entries/0,
+    active_entries/0,
+    size/0,
+    epoch/0,
+    clear/0
+]).
+
+%% Accessors on the opaque entry type (used by callers and tests).
+-export([
+    entry_seq/1,
+    entry_class/1,
+    entry_selector/1,
+    entry_kind/1,
+    entry_intent/1,
+    entry_flushable/1,
+    entry_author_kind/1,
+    entry_is_orphan/1,
+    entry_is_prior_epoch/1
+]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+%% Exported for tests only.
+-export([changes_dir/1, entry_to_json/1, entry_from_json/1]).
+
+-define(ETS_TABLE, beamtalk_changelog_entries).
+%% Bounded ring: keep at most this many entries on disk before rotating older
+%% segments into archive/ (ADR 0082, "ChangeLog growth").
+-define(MAX_ENTRIES, 1000).
+
+%%% ----------------------------------------------------------------------------
+%%% Types
+%%% ----------------------------------------------------------------------------
+
+-type kind() :: instance | class | 'new-class'.
+-type intent() :: durable | ephemeral.
+-type author_kind() :: human | agent.
+-type span() :: #{start := non_neg_integer(), 'end' := non_neg_integer()}.
+
+%% A ChangeEntry as stored in memory. Bodies are not kept in the record —
+%% only the `source_ref` / `prev_source_ref` filenames — so the ETS footprint
+%% stays small regardless of method size. The bodies live as files in sources/.
+-record(entry, {
+    seq :: non_neg_integer(),
+    ts :: integer(),
+    epoch :: non_neg_integer(),
+    class :: binary(),
+    selector :: binary() | undefined,
+    kind :: kind(),
+    source_ref :: binary(),
+    prev_source_ref :: binary() | undefined,
+    source_file :: binary() | undefined,
+    span :: span() | undefined,
+    intent :: intent(),
+    flushable :: boolean(),
+    not_flushable_reason :: binary() | undefined,
+    author :: binary(),
+    author_kind :: author_kind(),
+    %% Derived, in-memory only — not persisted (recomputed on restart).
+    prior_epoch = false :: boolean(),
+    orphan = false :: boolean()
+}).
+
+-opaque entry() :: #entry{}.
+
+%% Input map accepted by append/1. Bodies (`source`, `prev_source`) are passed
+%% in full; the gen_server writes them to sources/ and stores only the refs.
+-type append_input() :: #{
+    class := binary(),
+    kind := kind(),
+    source := binary(),
+    intent := intent(),
+    flushable := boolean(),
+    author := binary(),
+    author_kind := author_kind(),
+    selector => binary() | undefined,
+    prev_source => binary() | undefined,
+    source_file => binary() | undefined,
+    span => span() | undefined,
+    not_flushable_reason => binary() | undefined
+}.
+
+-export_type([entry/0, append_input/0, kind/0, intent/0, author_kind/0, span/0]).
+
+-record(state, {
+    %% Absolute path to <workspace>/changes, or undefined in run mode
+    %% (no workspace_id) — in run mode everything stays in ETS only.
+    changes_dir :: string() | undefined,
+    %% Path to changes.jsonl (undefined in run mode).
+    log_path :: string() | undefined,
+    %% Next sequence number to assign (monotonic across restarts).
+    next_seq :: non_neg_integer(),
+    %% Epoch for entries appended in this session (bumped each start).
+    epoch :: non_neg_integer()
+}).
+
+%%% ----------------------------------------------------------------------------
+%%% Public API
+%%% ----------------------------------------------------------------------------
+
+-doc """
+Start the ChangeLog gen_server, registered locally under the module name.
+
+`Config` is a map; the only field consulted in Phase 1 is `workspace_id`
+(binary). When absent or `undefined` the server runs in *memory-only* mode
+(run mode / tests with no workspace): ETS holds the live entries and nothing is
+written to disk. When present, durable state lives under
+`<home>/.beamtalk/workspaces/<workspace_id>/changes/`.
+""".
+-spec start_link(map()) -> {ok, pid()} | {error, term()}.
+start_link(Config) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []).
+
+-doc """
+Append a ChangeEntry to the log.
+
+Writes the source bodies to `sources/` and the metadata line to `changes.jsonl`
+crash-safely (bodies first, then the metadata line that references them, so a
+crash never leaves a metadata line pointing at a missing body), assigns the next
+sequence number, and inserts the entry into ETS. Returns the assigned `seq`.
+
+The append is serialised by the gen_server, so concurrent callers cannot
+interleave sequence numbers or partial writes.
+""".
+-spec append(append_input()) -> {ok, non_neg_integer()} | {error, #beamtalk_error{}}.
+append(Input) when is_map(Input) ->
+    gen_server:call(?MODULE, {append, Input}).
+
+-doc "Return all entries (including prior-epoch and orphan), oldest first.".
+-spec entries() -> [entry()].
+entries() ->
+    Es = [E || {_Seq, E} <- ets:tab2list(?ETS_TABLE)],
+    lists:keysort(#entry.seq, Es).
+
+-doc """
+Return only *active* entries — those from the current epoch that are not
+orphaned. This is the dirty-state view; `Workspace changes` (a later phase) is
+backed by this. Prior-epoch and orphan entries are excluded.
+""".
+-spec active_entries() -> [entry()].
+active_entries() ->
+    [E || E <- entries(), not E#entry.prior_epoch, not E#entry.orphan].
+
+-doc "Total number of entries in the log (all epochs).".
+-spec size() -> non_neg_integer().
+size() ->
+    ets:info(?ETS_TABLE, size).
+
+-doc "The epoch assigned to entries appended in this session.".
+-spec epoch() -> non_neg_integer().
+epoch() ->
+    gen_server:call(?MODULE, epoch).
+
+-doc """
+Discard all entries from the in-memory log and truncate the on-disk metadata
+segment. Source bodies in `sources/` are left in place (they are cheap and a
+later `revert:`/audit flow may still want them; rotation prunes them). Used by
+`Workspace changes clear` (a later phase) and by tests.
+""".
+-spec clear() -> ok.
+clear() ->
+    gen_server:call(?MODULE, clear).
+
+%%% ----------------------------------------------------------------------------
+%%% Entry accessors
+%%% ----------------------------------------------------------------------------
+%%% The entry() type is opaque; these accessors are the supported way to read a
+%%% ChangeEntry's fields (consumed by later phases and by tests).
+
+-spec entry_seq(entry()) -> non_neg_integer().
+entry_seq(#entry{seq = V}) -> V.
+
+-spec entry_class(entry()) -> binary().
+entry_class(#entry{class = V}) -> V.
+
+-spec entry_selector(entry()) -> binary() | undefined.
+entry_selector(#entry{selector = V}) -> V.
+
+-spec entry_kind(entry()) -> kind().
+entry_kind(#entry{kind = V}) -> V.
+
+-spec entry_intent(entry()) -> intent().
+entry_intent(#entry{intent = V}) -> V.
+
+-spec entry_flushable(entry()) -> boolean().
+entry_flushable(#entry{flushable = V}) -> V.
+
+-spec entry_author_kind(entry()) -> author_kind().
+entry_author_kind(#entry{author_kind = V}) -> V.
+
+-spec entry_is_orphan(entry()) -> boolean().
+entry_is_orphan(#entry{orphan = V}) -> V.
+
+-spec entry_is_prior_epoch(entry()) -> boolean().
+entry_is_prior_epoch(#entry{prior_epoch = V}) -> V.
+
+%%% ----------------------------------------------------------------------------
+%%% gen_server callbacks
+%%% ----------------------------------------------------------------------------
+
+init(Config) ->
+    %% Inherit the runtime logging domain for every log call from this process.
+    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    WorkspaceId = maps:get(workspace_id, Config, undefined),
+    ChangesDir = changes_dir(WorkspaceId),
+    ensure_ets(),
+    State0 = #state{
+        changes_dir = ChangesDir,
+        log_path = log_path(ChangesDir),
+        next_seq = 0,
+        epoch = 0
+    },
+    State = load_from_disk(State0),
+    {ok, State}.
+
+handle_call({append, Input}, _From, State) ->
+    case do_append(Input, State) of
+        {ok, Seq, State1} ->
+            {reply, {ok, Seq}, State1};
+        {error, _Reason} = Err ->
+            {reply, Err, State}
+    end;
+handle_call(epoch, _From, State) ->
+    {reply, State#state.epoch, State};
+handle_call(clear, _From, State) ->
+    ets:delete_all_objects(?ETS_TABLE),
+    truncate_log(State),
+    {reply, ok, State};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%% ----------------------------------------------------------------------------
+%%% Append
+%%% ----------------------------------------------------------------------------
+
+-spec do_append(append_input(), #state{}) ->
+    {ok, non_neg_integer(), #state{}} | {error, #beamtalk_error{}}.
+do_append(Input, State) ->
+    Seq = State#state.next_seq,
+    SourceRef = source_ref_filename(Seq, source),
+    PrevSource = maps:get(prev_source, Input, undefined),
+    PrevSourceRef =
+        case PrevSource of
+            undefined -> undefined;
+            _ -> source_ref_filename(Seq, prev)
+        end,
+    Entry = #entry{
+        seq = Seq,
+        ts = erlang:system_time(millisecond),
+        epoch = State#state.epoch,
+        class = maps:get(class, Input),
+        selector = maps:get(selector, Input, undefined),
+        kind = maps:get(kind, Input),
+        source_ref = SourceRef,
+        prev_source_ref = PrevSourceRef,
+        source_file = maps:get(source_file, Input, undefined),
+        span = maps:get(span, Input, undefined),
+        intent = maps:get(intent, Input),
+        flushable = maps:get(flushable, Input),
+        not_flushable_reason = maps:get(not_flushable_reason, Input, undefined),
+        author = maps:get(author, Input),
+        author_kind = maps:get(author_kind, Input)
+    },
+    case persist_append(Entry, maps:get(source, Input), PrevSource, State) of
+        ok ->
+            ets:insert(?ETS_TABLE, {Seq, Entry}),
+            State1 = State#state{next_seq = Seq + 1},
+            State2 = maybe_rotate(State1),
+            {ok, Seq, State2};
+        {error, Reason} ->
+            {error, append_error(Reason)}
+    end.
+
+%% Crash-safe persistence ordering: write the body files first (atomically via
+%% temp+rename), then append the metadata line. A crash between the two leaves
+%% orphaned body files (harmless — pruned on rotation) but never a metadata line
+%% pointing at a missing body. In run mode (no changes_dir) this is a no-op and
+%% the entry lives in ETS only.
+-spec persist_append(#entry{}, binary(), binary() | undefined, #state{}) ->
+    ok | {error, term()}.
+persist_append(_Entry, _Source, _PrevSource, #state{changes_dir = undefined}) ->
+    ok;
+persist_append(Entry, Source, PrevSource, State) ->
+    SourcesDir = filename:join(State#state.changes_dir, "sources"),
+    case filelib:ensure_path(SourcesDir) of
+        ok ->
+            SourcePath = filename:join(SourcesDir, binary_to_list(Entry#entry.source_ref)),
+            case write_file_atomic(SourcePath, Source) of
+                ok ->
+                    case write_prev_source(SourcesDir, Entry, PrevSource) of
+                        ok -> append_metadata_line(Entry, State);
+                        Err -> Err
+                    end;
+                Err ->
+                    Err
+            end;
+        {error, Reason} ->
+            {error, {ensure_path, SourcesDir, Reason}}
+    end.
+
+-spec write_prev_source(string(), #entry{}, binary() | undefined) -> ok | {error, term()}.
+write_prev_source(_SourcesDir, #entry{prev_source_ref = undefined}, _PrevSource) ->
+    ok;
+write_prev_source(SourcesDir, #entry{prev_source_ref = Ref}, PrevSource) ->
+    Path = filename:join(SourcesDir, binary_to_list(Ref)),
+    write_file_atomic(Path, PrevSource).
+
+-spec append_metadata_line(#entry{}, #state{}) -> ok | {error, term()}.
+append_metadata_line(Entry, State) ->
+    Line = [entry_to_json(Entry), $\n],
+    case file:write_file(State#state.log_path, Line, [append]) of
+        ok -> ok;
+        {error, Reason} -> {error, {write_log, Reason}}
+    end.
+
+%%% ----------------------------------------------------------------------------
+%%% Load on startup (restart semantics)
+%%% ----------------------------------------------------------------------------
+
+%% Read changes.jsonl, rebuild ETS, assign a fresh epoch, and tag every
+%% pre-existing entry as prior-epoch + (if prev_source no longer matches disk)
+%% orphan. In run mode (no changes_dir) there is nothing on disk — start clean.
+-spec load_from_disk(#state{}) -> #state{}.
+load_from_disk(#state{changes_dir = undefined} = State) ->
+    State#state{next_seq = 0, epoch = 0};
+load_from_disk(State) ->
+    LogPath = State#state.log_path,
+    case file:read_file(LogPath) of
+        {ok, Bin} ->
+            Entries = parse_log(Bin),
+            PriorEpochMax = max_epoch(Entries),
+            NextSeq = max_seq(Entries) + 1,
+            FreshEpoch = PriorEpochMax + 1,
+            SourcesDir = filename:join(State#state.changes_dir, "sources"),
+            Tagged = [tag_prior(E, SourcesDir) || E <- Entries],
+            lists:foreach(fun(E) -> ets:insert(?ETS_TABLE, {E#entry.seq, E}) end, Tagged),
+            State#state{next_seq = NextSeq, epoch = FreshEpoch};
+        {error, enoent} ->
+            State#state{next_seq = 0, epoch = 1};
+        {error, Reason} ->
+            ?LOG_WARNING("Failed to read ChangeLog at ~ts: ~p", [LogPath, Reason]),
+            State#state{next_seq = 0, epoch = 1}
+    end.
+
+%% Pre-existing entry → prior epoch; orphan iff its recorded prev_source no
+%% longer matches the current on-disk content of its sourceFile.
+-spec tag_prior(#entry{}, string()) -> #entry{}.
+tag_prior(Entry, SourcesDir) ->
+    Entry#entry{prior_epoch = true, orphan = is_orphan(Entry, SourcesDir)}.
+
+-spec is_orphan(#entry{}, string()) -> boolean().
+is_orphan(#entry{source_file = undefined}, _SourcesDir) ->
+    %% Non-flushable (stdlib/dynamic) entries have no disk file to compare —
+    %% their memory state is gone on restart, but they are not "orphaned"
+    %% against disk content. Excluded from the active view via prior_epoch.
+    false;
+is_orphan(#entry{prev_source_ref = undefined}, _SourcesDir) ->
+    %% new-class entries: the file should not have existed at append time. If it
+    %% exists now, the active view excludes it via prior_epoch regardless; we do
+    %% not mark new-class entries orphan here (relocation/conflict is Phase 2).
+    false;
+is_orphan(#entry{source_file = SourceFile, span = Span, prev_source_ref = PrevRef}, SourcesDir) ->
+    PrevPath = filename:join(SourcesDir, binary_to_list(PrevRef)),
+    case {file:read_file(binary_to_list(SourceFile)), file:read_file(PrevPath)} of
+        {{ok, DiskBin}, {ok, PrevBin}} ->
+            not span_matches(DiskBin, Span, PrevBin);
+        _ ->
+            %% Source file or recorded prev body unreadable → treat as orphaned:
+            %% the patch can no longer be safely reconciled against disk.
+            true
+    end.
+
+%% The recorded prev_source must still be byte-identical to the bytes currently
+%% occupying the recorded span in the on-disk file. If the span is out of range
+%% or the bytes differ, the disk advanced under us — orphan.
+-spec span_matches(binary(), span() | undefined, binary()) -> boolean().
+span_matches(_DiskBin, undefined, _PrevBin) ->
+    false;
+span_matches(DiskBin, #{start := Start, 'end' := End}, PrevBin) when
+    is_integer(Start), is_integer(End), End >= Start, End =< byte_size(DiskBin)
+->
+    binary:part(DiskBin, Start, End - Start) =:= PrevBin;
+span_matches(_DiskBin, _Span, _PrevBin) ->
+    false.
+
+-spec parse_log(binary()) -> [#entry{}].
+parse_log(Bin) ->
+    Lines = binary:split(Bin, <<"\n">>, [global, trim_all]),
+    lists:filtermap(
+        fun(Line) ->
+            try
+                {true, entry_from_json(Line)}
+            catch
+                Class:Reason ->
+                    ?LOG_WARNING("Skipping malformed ChangeLog line: ~p:~p", [Class, Reason]),
+                    false
+            end
+        end,
+        Lines
+    ).
+
+-spec max_seq([#entry{}]) -> integer().
+max_seq([]) -> -1;
+max_seq(Entries) -> lists:max([E#entry.seq || E <- Entries]).
+
+-spec max_epoch([#entry{}]) -> integer().
+max_epoch([]) -> 0;
+max_epoch(Entries) -> lists:max([E#entry.epoch || E <- Entries]).
+
+%%% ----------------------------------------------------------------------------
+%%% Bounded ring + archive rotation
+%%% ----------------------------------------------------------------------------
+
+%% When the on-disk log exceeds MAX_ENTRIES, archive the oldest segment
+%% (metadata as a gzipped .jsonl, the referenced source bodies as a gzipped tar)
+%% and drop those entries from the live log + ETS. Human and agent entries are
+%% pruned on equal footing — only the ring bound applies.
+-spec maybe_rotate(#state{}) -> #state{}.
+maybe_rotate(#state{changes_dir = undefined} = State) ->
+    State;
+maybe_rotate(State) ->
+    All = entries(),
+    case length(All) > ?MAX_ENTRIES of
+        false ->
+            State;
+        true ->
+            Overflow = length(All) - ?MAX_ENTRIES,
+            {ToArchive, ToKeep} = lists:split(Overflow, All),
+            archive_segment(ToArchive, State),
+            ets:delete_all_objects(?ETS_TABLE),
+            lists:foreach(fun(E) -> ets:insert(?ETS_TABLE, {E#entry.seq, E}) end, ToKeep),
+            rewrite_log(ToKeep, State),
+            State
+    end.
+
+-spec archive_segment([#entry{}], #state{}) -> ok.
+archive_segment(Entries, State) ->
+    ArchiveDir = filename:join(State#state.changes_dir, "archive"),
+    _ = filelib:ensure_path(ArchiveDir),
+    Ts = integer_to_list(erlang:system_time(second)),
+    archive_metadata(Entries, ArchiveDir, Ts),
+    archive_sources(Entries, ArchiveDir, Ts, State),
+    ok.
+
+-spec archive_metadata([#entry{}], string(), string()) -> ok.
+archive_metadata(Entries, ArchiveDir, Ts) ->
+    Path = filename:join(ArchiveDir, "changes-" ++ Ts ++ ".jsonl.gz"),
+    Lines = [[entry_to_json(E), $\n] || E <- Entries],
+    Gz = zlib:gzip(iolist_to_binary(Lines)),
+    case write_file_atomic(Path, Gz) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            ?LOG_WARNING("Failed to archive ChangeLog metadata to ~ts: ~p", [Path, Reason]),
+            ok
+    end.
+
+-spec archive_sources([#entry{}], string(), string(), #state{}) -> ok.
+archive_sources(Entries, ArchiveDir, Ts, State) ->
+    SourcesDir = filename:join(State#state.changes_dir, "sources"),
+    Refs = source_refs(Entries),
+    Members = collect_source_members(Refs, SourcesDir),
+    Path = filename:join(ArchiveDir, "sources-" ++ Ts ++ ".tar.gz"),
+    case Members of
+        [] ->
+            ok;
+        _ ->
+            case erl_tar:create(Path, Members, [compressed]) of
+                ok ->
+                    %% Tarred safely — remove the now-archived body files.
+                    lists:foreach(
+                        fun({_Name, AbsPath}) -> _ = file:delete(AbsPath) end, Members
+                    ),
+                    ok;
+                {error, Reason} ->
+                    ?LOG_WARNING("Failed to archive ChangeLog sources to ~ts: ~p", [Path, Reason]),
+                    ok
+            end
+    end.
+
+-spec source_refs([#entry{}]) -> [binary()].
+source_refs(Entries) ->
+    lists:flatten([refs_of(E) || E <- Entries]).
+
+-spec refs_of(#entry{}) -> [binary()].
+refs_of(#entry{source_ref = SR, prev_source_ref = undefined}) -> [SR];
+refs_of(#entry{source_ref = SR, prev_source_ref = PR}) -> [SR, PR].
+
+%% Build erl_tar member list {NameInArchive, AbsolutePath} for refs that exist.
+-spec collect_source_members([binary()], string()) -> [{string(), string()}].
+collect_source_members(Refs, SourcesDir) ->
+    lists:filtermap(
+        fun(Ref) ->
+            Name = binary_to_list(Ref),
+            Abs = filename:join(SourcesDir, Name),
+            case filelib:is_regular(Abs) of
+                true -> {true, {Name, Abs}};
+                false -> false
+            end
+        end,
+        Refs
+    ).
+
+%%% ----------------------------------------------------------------------------
+%%% On-disk helpers
+%%% ----------------------------------------------------------------------------
+
+%% Rewrite changes.jsonl from scratch with exactly Entries (used after rotation
+%% and never on the hot append path). Atomic temp+rename so a crash mid-rewrite
+%% cannot truncate the live log.
+-spec rewrite_log([#entry{}], #state{}) -> ok | {error, term()}.
+rewrite_log(_Entries, #state{log_path = undefined}) ->
+    ok;
+rewrite_log(Entries, State) ->
+    Lines = [[entry_to_json(E), $\n] || E <- Entries],
+    write_file_atomic(State#state.log_path, iolist_to_binary(Lines)).
+
+-spec truncate_log(#state{}) -> ok.
+truncate_log(#state{log_path = undefined}) ->
+    ok;
+truncate_log(State) ->
+    _ = write_file_atomic(State#state.log_path, <<>>),
+    ok.
+
+%% Write Data to Path via a sibling temp file + atomic rename so readers never
+%% observe a partially written file.
+-spec write_file_atomic(string(), iodata()) -> ok | {error, term()}.
+write_file_atomic(Path, Data) ->
+    _ = filelib:ensure_dir(Path),
+    Tmp = Path ++ ".tmp",
+    case file:write_file(Tmp, Data) of
+        ok ->
+            case file:rename(Tmp, Path) of
+                ok ->
+                    ok;
+                {error, Reason} ->
+                    _ = file:delete(Tmp),
+                    {error, {rename, Reason}}
+            end;
+        {error, Reason} ->
+            {error, {write, Reason}}
+    end.
+
+%% sources/<seq6>-source.bt / sources/<seq6>-prev.bt
+-spec source_ref_filename(non_neg_integer(), source | prev) -> binary().
+source_ref_filename(Seq, Which) ->
+    Padded = io_lib:format("~6..0b", [Seq]),
+    Suffix =
+        case Which of
+            source -> "-source.bt";
+            prev -> "-prev.bt"
+        end,
+    iolist_to_binary([Padded, Suffix]).
+
+-doc """
+Return the absolute `changes/` directory for a workspace, or `undefined` when
+there is no workspace (run mode). Mirrors `beamtalk_workspace_meta`'s path
+resolution: `<home>/.beamtalk/workspaces/<id>/changes`, falling back to the OS
+user-cache dir when HOME/USERPROFILE is unset. Exported for tests.
+""".
+-spec changes_dir(binary() | undefined) -> string() | undefined.
+changes_dir(undefined) ->
+    undefined;
+changes_dir(WorkspaceId) when is_binary(WorkspaceId) ->
+    Base =
+        case beamtalk_platform:home_dir() of
+            false -> filename:basedir(user_cache, "beamtalk");
+            Home -> filename:join(Home, ".beamtalk")
+        end,
+    filename:join([Base, "workspaces", binary_to_list(WorkspaceId), "changes"]).
+
+-spec log_path(string() | undefined) -> string() | undefined.
+log_path(undefined) -> undefined;
+log_path(ChangesDir) -> filename:join(ChangesDir, "changes.jsonl").
+
+-spec ensure_ets() -> ok.
+ensure_ets() ->
+    case ets:whereis(?ETS_TABLE) of
+        undefined ->
+            ets:new(?ETS_TABLE, [named_table, public, set, {read_concurrency, true}]);
+        _ ->
+            ets:delete_all_objects(?ETS_TABLE)
+    end,
+    ok.
+
+%%% ----------------------------------------------------------------------------
+%%% JSON (de)serialisation
+%%% ----------------------------------------------------------------------------
+
+-doc """
+Encode a ChangeEntry to a compact JSON binary (one `changes.jsonl` line, no
+trailing newline). Exported for tests. The derived in-memory flags
+(`prior_epoch`, `orphan`) are not persisted — they are recomputed on restart.
+""".
+-spec entry_to_json(entry()) -> binary().
+entry_to_json(#entry{} = E) ->
+    Map = #{
+        <<"ts">> => E#entry.ts,
+        <<"seq">> => E#entry.seq,
+        <<"epoch">> => E#entry.epoch,
+        <<"class">> => E#entry.class,
+        <<"selector">> => null_or(E#entry.selector),
+        <<"kind">> => atom_to_binary(E#entry.kind, utf8),
+        <<"source_ref">> => E#entry.source_ref,
+        <<"prev_source_ref">> => null_or(E#entry.prev_source_ref),
+        <<"sourceFile">> => null_or(E#entry.source_file),
+        <<"span">> => span_to_json(E#entry.span),
+        <<"intent">> => atom_to_binary(E#entry.intent, utf8),
+        <<"flushable">> => E#entry.flushable,
+        <<"not_flushable_reason">> => null_or(E#entry.not_flushable_reason),
+        <<"author">> => E#entry.author,
+        <<"author_kind">> => atom_to_binary(E#entry.author_kind, utf8)
+    },
+    iolist_to_binary(json:encode(Map)).
+
+-doc "Decode a `changes.jsonl` line into a ChangeEntry record. Exported for tests.".
+-spec entry_from_json(binary()) -> entry().
+entry_from_json(Line) ->
+    Map = json:decode(Line),
+    #entry{
+        ts = maps:get(<<"ts">>, Map),
+        seq = maps:get(<<"seq">>, Map),
+        epoch = maps:get(<<"epoch">>, Map),
+        class = maps:get(<<"class">>, Map),
+        selector = from_null(maps:get(<<"selector">>, Map, null)),
+        kind = binary_to_existing_atom(maps:get(<<"kind">>, Map), utf8),
+        source_ref = maps:get(<<"source_ref">>, Map),
+        prev_source_ref = from_null(maps:get(<<"prev_source_ref">>, Map, null)),
+        source_file = from_null(maps:get(<<"sourceFile">>, Map, null)),
+        span = span_from_json(maps:get(<<"span">>, Map, null)),
+        intent = binary_to_existing_atom(maps:get(<<"intent">>, Map), utf8),
+        flushable = maps:get(<<"flushable">>, Map),
+        not_flushable_reason = from_null(maps:get(<<"not_flushable_reason">>, Map, null)),
+        author = maps:get(<<"author">>, Map),
+        author_kind = binary_to_existing_atom(maps:get(<<"author_kind">>, Map), utf8)
+    }.
+
+-spec span_to_json(span() | undefined) -> map() | null.
+span_to_json(undefined) -> null;
+span_to_json(#{start := Start, 'end' := End}) -> #{<<"start">> => Start, <<"end">> => End}.
+
+-spec span_from_json(map() | null) -> span() | undefined.
+span_from_json(null) -> undefined;
+span_from_json(#{<<"start">> := Start, <<"end">> := End}) -> #{start => Start, 'end' => End}.
+
+-spec null_or(binary() | undefined) -> binary() | null.
+null_or(undefined) -> null;
+null_or(V) -> V.
+
+-spec from_null(term()) -> term().
+from_null(null) -> undefined;
+from_null(V) -> V.
+
+%%% ----------------------------------------------------------------------------
+%%% Errors
+%%% ----------------------------------------------------------------------------
+
+-spec append_error(term()) -> #beamtalk_error{}.
+append_error(Reason) ->
+    #beamtalk_error{
+        kind = changelog_write_error,
+        class = 'ChangeLog',
+        selector = 'append:',
+        message = <<"Failed to persist ChangeLog entry to disk">>,
+        hint = <<"Check that the workspace changes/ directory is writable">>,
+        details = #{reason => Reason}
+    }.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
@@ -128,9 +128,12 @@ release nodes do not start a workspace, so this code is a no-op there.
 %%% Types
 %%% ----------------------------------------------------------------------------
 
--type kind() :: instance | class | 'new-class'.
--type intent() :: durable | ephemeral.
--type author_kind() :: human | agent.
+%% `kind` is an open enum (ADR 0082): newer writers may add values this beam does
+%% not know. Decoding maps any unrecognised value to `unknown` so history is
+%% preserved across versions rather than dropped.
+-type kind() :: instance | class | 'new-class' | unknown.
+-type intent() :: durable | ephemeral | unknown.
+-type author_kind() :: human | agent | unknown.
 -type span() :: #{start := non_neg_integer(), 'end' := non_neg_integer()}.
 
 %% A ChangeEntry as stored in memory. Bodies are not kept in the record —
@@ -222,11 +225,21 @@ interleave sequence numbers or partial writes.
 append(Input) when is_map(Input) ->
     gen_server:call(?MODULE, {append, Input}).
 
--doc "Return all entries (including prior-epoch and orphan), oldest first.".
+-doc """
+Return all entries (including prior-epoch and orphan), oldest first.
+
+Returns `[]` when the ChangeLog server has not been started (the ETS table is
+absent), so callers on a node without a workspace do not crash.
+""".
 -spec entries() -> [entry()].
 entries() ->
-    Es = [E || {_Seq, E} <- ets:tab2list(?ETS_TABLE)],
-    lists:keysort(#entry.seq, Es).
+    case ets:info(?ETS_TABLE, id) of
+        undefined ->
+            [];
+        _ ->
+            Es = [E || {_Seq, E} <- ets:tab2list(?ETS_TABLE)],
+            lists:keysort(#entry.seq, Es)
+    end.
 
 -doc """
 Return only *active* entries — those from the current epoch that are not
@@ -237,10 +250,18 @@ backed by this. Prior-epoch and orphan entries are excluded.
 active_entries() ->
     [E || E <- entries(), not E#entry.prior_epoch, not E#entry.orphan].
 
--doc "Total number of entries in the log (all epochs).".
+-doc """
+Total number of entries in the log (all epochs).
+
+Returns `0` when the ChangeLog server has not been started (the ETS table is
+absent).
+""".
 -spec size() -> non_neg_integer().
 size() ->
-    ets:info(?ETS_TABLE, size).
+    case ets:info(?ETS_TABLE, size) of
+        undefined -> 0;
+        N -> N
+    end.
 
 -doc "The epoch assigned to entries appended in this session.".
 -spec epoch() -> non_neg_integer().
@@ -306,7 +327,12 @@ init(Config) ->
         next_seq = 0,
         epoch = 0
     },
-    State = load_from_disk(State0),
+    State1 = load_from_disk(State0),
+    %% A persisted log may already exceed MAX_ENTRIES (it was written by an older
+    %% build, hand-edited, or restored from backup). The ring bound is otherwise
+    %% only enforced on append, so trim the overflow now rather than letting a
+    %% large log linger until the next mutation.
+    State = maybe_rotate(State1),
     {ok, State}.
 
 handle_call({append, Input}, _From, State) ->
@@ -523,6 +549,12 @@ max_epoch(Entries) -> lists:max([E#entry.epoch || E <- Entries]).
 %% (metadata as a gzipped .jsonl, the referenced source bodies as a gzipped tar)
 %% and drop those entries from the live log + ETS. Human and agent entries are
 %% pruned on equal footing — only the ring bound applies.
+%%
+%% Rotation is transactional: the live ETS and changes.jsonl are mutated ONLY
+%% after the archive segment is written AND the trimmed log is rewritten, both
+%% successfully. If archiving or the rewrite fails (disk full, permissions,
+%% tar/gzip error) the existing ETS + log are left untouched and the error is
+%% logged — a failed rotation must never lose history or leave disk inconsistent.
 -spec maybe_rotate(#state{}) -> #state{}.
 maybe_rotate(#state{changes_dir = undefined} = State) ->
     State;
@@ -534,23 +566,79 @@ maybe_rotate(State) ->
         true ->
             Overflow = length(All) - ?MAX_ENTRIES,
             {ToArchive, ToKeep} = lists:split(Overflow, All),
-            archive_segment(ToArchive, State),
-            ets:delete_all_objects(?ETS_TABLE),
-            lists:foreach(fun(E) -> ets:insert(?ETS_TABLE, {E#entry.seq, E}) end, ToKeep),
-            rewrite_log(ToKeep, State),
+            rotate_transactional(ToArchive, ToKeep, State)
+    end.
+
+%% Perform the rotation only if every disk step succeeds. Order:
+%%   1. archive the overflow segment (metadata + sources) to archive/
+%%   2. rewrite changes.jsonl with exactly the retained entries
+%% Both are crash-safe (atomic temp+rename). Only once both succeed do we prune
+%% the archived source bodies and swap ETS to the retained set. On any failure we
+%% return State unchanged (ETS and the live log keep all entries) and log it.
+-spec rotate_transactional([#entry{}], [#entry{}], #state{}) -> #state{}.
+rotate_transactional(ToArchive, ToKeep, State) ->
+    case archive_segment(ToArchive, State) of
+        {ok, ArchivedMembers} ->
+            case rewrite_log(ToKeep, State) of
+                ok ->
+                    %% Both disk steps committed — now it is safe to drop the
+                    %% archived body files and swap ETS to the retained set.
+                    prune_source_members(ArchivedMembers),
+                    ets:delete_all_objects(?ETS_TABLE),
+                    lists:foreach(
+                        fun(E) -> ets:insert(?ETS_TABLE, {E#entry.seq, E}) end, ToKeep
+                    ),
+                    State;
+                {error, Reason} ->
+                    %% Archive succeeded but the live-log rewrite failed. Leave
+                    %% ETS + log untouched; the (harmless) extra archive segment
+                    %% will be superseded on the next successful rotation.
+                    ?LOG_ERROR(
+                        "ChangeLog rotation aborted: failed to rewrite live log",
+                        #{reason => Reason, domain => [beamtalk, runtime]}
+                    ),
+                    State
+            end;
+        {error, Reason} ->
+            ?LOG_ERROR(
+                "ChangeLog rotation aborted: failed to archive overflow segment",
+                #{reason => Reason, domain => [beamtalk, runtime]}
+            ),
             State
     end.
 
--spec archive_segment([#entry{}], #state{}) -> ok.
+%% Archive the overflow segment. Returns `{ok, Members}` (the source-body files
+%% that were tarred, so the caller can delete them after the whole rotation
+%% commits) or `{error, Reason}` if any disk step fails. Source bodies are NOT
+%% deleted here — deletion is deferred until rewrite_log/2 also succeeds.
+-spec archive_segment([#entry{}], #state{}) ->
+    {ok, [{string(), string()}]} | {error, term()}.
 archive_segment(Entries, State) ->
     ArchiveDir = filename:join(State#state.changes_dir, "archive"),
-    _ = filelib:ensure_path(ArchiveDir),
-    Ts = integer_to_list(erlang:system_time(second)),
-    archive_metadata(Entries, ArchiveDir, Ts),
-    archive_sources(Entries, ArchiveDir, Ts, State),
-    ok.
+    Ts = archive_suffix(),
+    case filelib:ensure_path(ArchiveDir) of
+        ok ->
+            case archive_metadata(Entries, ArchiveDir, Ts) of
+                ok ->
+                    archive_sources(Entries, ArchiveDir, Ts, State);
+                {error, _} = Err ->
+                    Err
+            end;
+        {error, Reason} ->
+            {error, {ensure_path, ArchiveDir, Reason}}
+    end.
 
--spec archive_metadata([#entry{}], string(), string()) -> ok.
+%% Unique, monotonic, collision-free archive filename suffix. A millisecond
+%% timestamp can still collide when two rotations land in the same millisecond
+%% (e.g. a single overflowing batch), so we append a strictly-increasing unique
+%% integer. Format: "<ms>-<unique>".
+-spec archive_suffix() -> string().
+archive_suffix() ->
+    Ms = integer_to_list(erlang:system_time(millisecond)),
+    Unique = integer_to_list(erlang:unique_integer([positive, monotonic])),
+    Ms ++ "-" ++ Unique.
+
+-spec archive_metadata([#entry{}], string(), string()) -> ok | {error, term()}.
 archive_metadata(Entries, ArchiveDir, Ts) ->
     Path = filename:join(ArchiveDir, "changes-" ++ Ts ++ ".jsonl.gz"),
     Lines = [[entry_to_json(E), $\n] || E <- Entries],
@@ -559,11 +647,14 @@ archive_metadata(Entries, ArchiveDir, Ts) ->
         ok ->
             ok;
         {error, Reason} ->
-            ?LOG_WARNING("Failed to archive ChangeLog metadata to ~ts: ~p", [Path, Reason]),
-            ok
+            {error, {archive_metadata, Path, Reason}}
     end.
 
--spec archive_sources([#entry{}], string(), string(), #state{}) -> ok.
+%% Tar the referenced source bodies into archive/. Returns `{ok, Members}` with
+%% the body files that were archived (deleted later, once the rotation commits)
+%% or `{error, Reason}`. An empty member set is a successful no-op.
+-spec archive_sources([#entry{}], string(), string(), #state{}) ->
+    {ok, [{string(), string()}]} | {error, term()}.
 archive_sources(Entries, ArchiveDir, Ts, State) ->
     SourcesDir = filename:join(State#state.changes_dir, "sources"),
     Refs = source_refs(Entries),
@@ -571,20 +662,22 @@ archive_sources(Entries, ArchiveDir, Ts, State) ->
     Path = filename:join(ArchiveDir, "sources-" ++ Ts ++ ".tar.gz"),
     case Members of
         [] ->
-            ok;
+            {ok, []};
         _ ->
             case erl_tar:create(Path, Members, [compressed]) of
                 ok ->
-                    %% Tarred safely — remove the now-archived body files.
-                    lists:foreach(
-                        fun({_Name, AbsPath}) -> _ = file:delete(AbsPath) end, Members
-                    ),
-                    ok;
+                    {ok, Members};
                 {error, Reason} ->
-                    ?LOG_WARNING("Failed to archive ChangeLog sources to ~ts: ~p", [Path, Reason]),
-                    ok
+                    {error, {archive_sources, Path, Reason}}
             end
     end.
+
+%% Delete the source-body files that were safely archived. Called only after the
+%% whole rotation has committed (archive + log rewrite both succeeded).
+-spec prune_source_members([{string(), string()}]) -> ok.
+prune_source_members(Members) ->
+    lists:foreach(fun({_Name, AbsPath}) -> _ = file:delete(AbsPath) end, Members),
+    ok.
 
 -spec source_refs([#entry{}]) -> [binary()].
 source_refs(Entries) ->
@@ -731,17 +824,59 @@ entry_from_json(Line) ->
         epoch = maps:get(<<"epoch">>, Map),
         class = maps:get(<<"class">>, Map),
         selector = from_null(maps:get(<<"selector">>, Map, null)),
-        kind = binary_to_existing_atom(maps:get(<<"kind">>, Map), utf8),
+        kind = decode_kind(maps:get(<<"kind">>, Map)),
         source_ref = maps:get(<<"source_ref">>, Map),
         prev_source_ref = from_null(maps:get(<<"prev_source_ref">>, Map, null)),
         source_file = from_null(maps:get(<<"sourceFile">>, Map, null)),
         span = span_from_json(maps:get(<<"span">>, Map, null)),
-        intent = binary_to_existing_atom(maps:get(<<"intent">>, Map), utf8),
+        intent = decode_intent(maps:get(<<"intent">>, Map)),
         flushable = maps:get(<<"flushable">>, Map),
         not_flushable_reason = from_null(maps:get(<<"not_flushable_reason">>, Map, null)),
         author = maps:get(<<"author">>, Map),
-        author_kind = binary_to_existing_atom(maps:get(<<"author_kind">>, Map), utf8)
+        author_kind = decode_author_kind(maps:get(<<"author_kind">>, Map))
     }.
+
+%% Enum decoders use an explicit allowlist with a safe `unknown` fallback rather
+%% than binary_to_existing_atom/2. A value written by a newer build (kind is an
+%% open enum) — or a corrupt closed-enum field — would otherwise throw and cause
+%% parse_log/1 to silently drop the whole line, losing history. Mapping to
+%% `unknown` keeps the entry; it is excluded from the active view via prior_epoch
+%% on restart regardless.
+-spec decode_kind(binary()) -> kind().
+decode_kind(<<"instance">>) ->
+    instance;
+decode_kind(<<"class">>) ->
+    class;
+decode_kind(<<"new-class">>) ->
+    'new-class';
+decode_kind(Other) ->
+    log_unknown_enum(kind, Other),
+    unknown.
+
+-spec decode_intent(binary()) -> intent().
+decode_intent(<<"durable">>) ->
+    durable;
+decode_intent(<<"ephemeral">>) ->
+    ephemeral;
+decode_intent(Other) ->
+    log_unknown_enum(intent, Other),
+    unknown.
+
+-spec decode_author_kind(binary()) -> author_kind().
+decode_author_kind(<<"human">>) ->
+    human;
+decode_author_kind(<<"agent">>) ->
+    agent;
+decode_author_kind(Other) ->
+    log_unknown_enum(author_kind, Other),
+    unknown.
+
+-spec log_unknown_enum(atom(), term()) -> ok.
+log_unknown_enum(Field, Value) ->
+    ?LOG_WARNING(
+        "Unknown ChangeLog enum value; preserving entry as 'unknown'",
+        #{field => Field, value => Value, domain => [beamtalk, runtime]}
+    ).
 
 -spec span_to_json(span() | undefined) -> map() | null.
 span_to_json(undefined) -> null;

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_sup.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_sup.erl
@@ -21,6 +21,7 @@ Architecture (from ADR 0004, implemented in BT-262):
 ```
 beamtalk_workspace_sup
   ├─ beamtalk_workspace_meta      % Metadata (project path, created_at)
+  ├─ beamtalk_workspace_changelog % Append-only ChangeLog (ADR 0082, BT-2282)
   ├─ beamtalk_transcript_stream    % Transcript singleton (ADR 0010, Actor)
   ├─ beamtalk_actor_registry       % Workspace-wide actor registry
   ├─ beamtalk_workspace_bootstrap % Class var bootstrap (ADR 0019)
@@ -120,6 +121,25 @@ init(Config) ->
                 shutdown => 5000,
                 type => worker,
                 modules => [beamtalk_workspace_meta]
+            },
+
+            %% ChangeLog gen_server (ADR 0082 Phase 1, BT-2282).
+            %% Append-only log of live in-memory method mutations; dirty-state +
+            %% undo store, consumed cross-surface (REPL/MCP/LSP/browser). Owns the
+            %% two-part on-disk persistence under <workspace>/changes/. Depends only
+            %% on workspace_id, so it can start right after meta. In run mode
+            %% (repl=false) the id is dropped to undefined so the log stays
+            %% memory-only — no workspace artifacts on disk, matching workspace_meta.
+            #{
+                id => beamtalk_workspace_changelog,
+                start =>
+                    {beamtalk_workspace_changelog, start_link, [
+                        #{workspace_id => changelog_workspace_id(Repl, WorkspaceId)}
+                    ]},
+                restart => permanent,
+                shutdown => 5000,
+                type => worker,
+                modules => [beamtalk_workspace_changelog]
             }
 
             %% Actor singleton — workspace singletons (ADR 0010 Phase 2, ADR 0019 Phase 4)
@@ -238,6 +258,17 @@ repl_child_specs(true, TcpPort, WorkspaceId, BindAddr, WebPort, AutoCleanup, Max
             modules => [beamtalk_session_sup]
         }
     ].
+
+%%% ChangeLog workspace id
+
+-doc """
+Resolve the workspace id passed to the ChangeLog gen_server.
+Run mode (repl=false) returns `undefined` so the log stays memory-only and
+writes no artifacts to disk; REPL mode passes the real id through.
+""".
+-spec changelog_workspace_id(boolean(), binary()) -> binary() | undefined.
+changelog_workspace_id(false, _WorkspaceId) -> undefined;
+changelog_workspace_id(true, WorkspaceId) -> WorkspaceId.
 
 %%% Singleton Child Specs
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
@@ -1,0 +1,412 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_workspace_changelog_tests).
+
+-moduledoc """
+Unit tests for beamtalk_workspace_changelog (ADR 0082 Phase 1, BT-2282).
+
+Covers:
+- append + sequence assignment + ETS state
+- two-part on-disk layout (changes.jsonl metadata + sources/*.bt bodies)
+- crash-safety (no .tmp leftovers; metadata references existing bodies)
+- JSON round-trip of the ChangeEntry schema
+- restart semantics: fresh epoch, prior-epoch tagging, orphan tagging
+- bounded ring rotation with archive segments
+- run-mode (no workspace_id): memory-only, no disk artifacts
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+%%====================================================================
+%% Fixtures
+%%====================================================================
+
+%% Each test runs against a fresh temp workspace dir so disk state is isolated.
+%% We drive the gen_server with a synthetic workspace_id and point HOME at the
+%% temp dir, mirroring how a real workspace resolves <home>/.beamtalk/...
+changelog_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun append_assigns_sequential_seqs/1,
+        fun append_writes_two_part_layout/1,
+        fun append_metadata_line_bounded_regardless_of_body_size/1,
+        fun append_no_tmp_leftovers/1,
+        fun append_new_class_has_no_prev_or_span/1,
+        fun json_round_trip/1,
+        fun active_excludes_nothing_in_fresh_session/1,
+        fun append_returns_error_on_unwritable_dir/1,
+        fun clear_empties_log/1
+    ]}.
+
+setup() ->
+    {WorkspaceId, TmpHome, OldHome} = fresh_workspace(),
+    {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WorkspaceId}),
+    #{pid => Pid, workspace_id => WorkspaceId, tmp_home => TmpHome, old_home => OldHome}.
+
+cleanup(#{pid := Pid, tmp_home := TmpHome, old_home := OldHome}) ->
+    stop(Pid),
+    restore_home(OldHome),
+    del_tree(TmpHome),
+    ok.
+
+%%====================================================================
+%% append
+%%====================================================================
+
+append_assigns_sequential_seqs(_Ctx) ->
+    {ok, S0} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+    {ok, S1} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"dec">>)),
+    {ok, S2} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"reset">>)),
+    [
+        ?_assertEqual(0, S0),
+        ?_assertEqual(1, S1),
+        ?_assertEqual(2, S2),
+        ?_assertEqual(3, beamtalk_workspace_changelog:size())
+    ].
+
+append_writes_two_part_layout(#{workspace_id := WsId}) ->
+    {ok, Seq} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+    Dir = beamtalk_workspace_changelog:changes_dir(WsId),
+    LogPath = filename:join(Dir, "changes.jsonl"),
+    SourcePath = filename:join([Dir, "sources", seq_file(Seq, "-source.bt")]),
+    PrevPath = filename:join([Dir, "sources", seq_file(Seq, "-prev.bt")]),
+    {ok, LogBin} = file:read_file(LogPath),
+    [Line | _] = binary:split(LogBin, <<"\n">>, [global, trim_all]),
+    Decoded = json:decode(Line),
+    [
+        ?_assert(filelib:is_regular(SourcePath)),
+        ?_assert(filelib:is_regular(PrevPath)),
+        ?_assertEqual({ok, <<"^ self value + 1">>}, file:read_file(SourcePath)),
+        ?_assertEqual({ok, <<"^ self value">>}, file:read_file(PrevPath)),
+        ?_assertEqual(<<"Counter">>, maps:get(<<"class">>, Decoded)),
+        ?_assertEqual(<<"inc">>, maps:get(<<"selector">>, Decoded)),
+        ?_assertEqual(<<"instance">>, maps:get(<<"kind">>, Decoded)),
+        ?_assertEqual(<<"durable">>, maps:get(<<"intent">>, Decoded)),
+        ?_assertEqual(true, maps:get(<<"flushable">>, Decoded)),
+        ?_assertEqual(<<"human">>, maps:get(<<"author_kind">>, Decoded))
+    ].
+
+%% The two-part layout's core invariant: the metadata line size is independent
+%% of the method body size (bodies live in sources/, not in the JSON line). A
+%% 50 KB body must not bloat the metadata line.
+append_metadata_line_bounded_regardless_of_body_size(#{workspace_id := WsId}) ->
+    HugeBody = binary:copy(<<"x">>, 50000),
+    Input = (durable_input(<<"Counter">>, <<"inc">>))#{source => HugeBody},
+    {ok, _} = beamtalk_workspace_changelog:append(Input),
+    Dir = beamtalk_workspace_changelog:changes_dir(WsId),
+    {ok, LogBin} = file:read_file(filename:join(Dir, "changes.jsonl")),
+    [Line | _] = binary:split(LogBin, <<"\n">>, [global, trim_all]),
+    SourcePath = filename:join([Dir, "sources", seq_file(0, "-source.bt")]),
+    [
+        %% Metadata line stays small even with a 50 KB method body.
+        ?_assert(byte_size(Line) < 500),
+        %% ...and the full body is preserved in sources/.
+        ?_assertEqual({ok, HugeBody}, file:read_file(SourcePath))
+    ].
+
+append_no_tmp_leftovers(#{workspace_id := WsId}) ->
+    {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+    Dir = beamtalk_workspace_changelog:changes_dir(WsId),
+    {ok, SourceFiles} = file:list_dir(filename:join(Dir, "sources")),
+    Tmps = [F || F <- SourceFiles, lists:suffix(".tmp", F)],
+    [?_assertEqual([], Tmps)].
+
+append_new_class_has_no_prev_or_span(#{workspace_id := WsId}) ->
+    Input = #{
+        class => <<"NewThing">>,
+        kind => 'new-class',
+        source => <<"class NewThing\nend">>,
+        intent => durable,
+        flushable => true,
+        author => <<"sess-1">>,
+        author_kind => human,
+        source_file => <<"/proj/src/new_thing.bt">>
+    },
+    {ok, Seq} = beamtalk_workspace_changelog:append(Input),
+    Dir = beamtalk_workspace_changelog:changes_dir(WsId),
+    PrevPath = filename:join([Dir, "sources", seq_file(Seq, "-prev.bt")]),
+    {ok, LogBin} = file:read_file(filename:join(Dir, "changes.jsonl")),
+    [Line | _] = binary:split(LogBin, <<"\n">>, [global, trim_all]),
+    Decoded = json:decode(Line),
+    [
+        ?_assertNot(filelib:is_regular(PrevPath)),
+        ?_assertEqual(null, maps:get(<<"prev_source_ref">>, Decoded)),
+        ?_assertEqual(null, maps:get(<<"span">>, Decoded)),
+        ?_assertEqual(null, maps:get(<<"selector">>, Decoded)),
+        ?_assertEqual(<<"new-class">>, maps:get(<<"kind">>, Decoded))
+    ].
+
+%%====================================================================
+%% JSON round-trip
+%%====================================================================
+
+json_round_trip(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    Json = beamtalk_workspace_changelog:entry_to_json(Entry),
+    Decoded = beamtalk_workspace_changelog:entry_from_json(Json),
+    Reencoded = beamtalk_workspace_changelog:entry_to_json(Decoded),
+    [?_assertEqual(Json, Reencoded)].
+
+%%====================================================================
+%% active vs all
+%%====================================================================
+
+active_excludes_nothing_in_fresh_session(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+    {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"dec">>)),
+    [
+        ?_assertEqual(2, length(beamtalk_workspace_changelog:active_entries())),
+        ?_assertEqual(2, length(beamtalk_workspace_changelog:entries()))
+    ].
+
+%%====================================================================
+%% error path
+%%====================================================================
+
+append_returns_error_on_unwritable_dir(#{pid := Pid, workspace_id := WsId}) ->
+    %% Make the sources dir a regular file so ensure_path fails.
+    Dir = beamtalk_workspace_changelog:changes_dir(WsId),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+    SourcesPath = filename:join(Dir, "sources"),
+    ok = file:write_file(SourcesPath, <<"not a dir">>),
+    Result = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+    %% Server survives the error.
+    Alive = is_process_alive(Pid),
+    [
+        ?_assertMatch({error, #beamtalk_error{kind = changelog_write_error}}, Result),
+        ?_assert(Alive)
+    ].
+
+clear_empties_log(#{workspace_id := WsId}) ->
+    {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+    {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"dec">>)),
+    ok = beamtalk_workspace_changelog:clear(),
+    Dir = beamtalk_workspace_changelog:changes_dir(WsId),
+    {ok, LogBin} = file:read_file(filename:join(Dir, "changes.jsonl")),
+    [
+        ?_assertEqual(0, beamtalk_workspace_changelog:size()),
+        ?_assertEqual(<<>>, LogBin)
+    ].
+
+%%====================================================================
+%% Restart semantics (separate fixture: stop + restart same workspace)
+%%====================================================================
+
+restart_test_() ->
+    {setup, fun() -> ok end, fun(_) -> ok end, [
+        fun restart_bumps_epoch_and_tags_prior/0,
+        fun restart_tags_orphan_when_disk_advanced/0,
+        fun restart_keeps_prior_when_disk_matches/0
+    ]}.
+
+restart_bumps_epoch_and_tags_prior() ->
+    {WsId, TmpHome, OldHome} = fresh_workspace(),
+    try
+        {ok, P1} = beamtalk_workspace_changelog:start_link(#{workspace_id => WsId}),
+        ?assertEqual(1, beamtalk_workspace_changelog:epoch()),
+        {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+        stop(P1),
+
+        %% Restart: epoch must advance, the pre-existing entry must be prior-epoch
+        %% and therefore excluded from the active view, but still present overall.
+        {ok, P2} = beamtalk_workspace_changelog:start_link(#{workspace_id => WsId}),
+        ?assertEqual(2, beamtalk_workspace_changelog:epoch()),
+        ?assertEqual(1, beamtalk_workspace_changelog:size()),
+        ?assertEqual([], beamtalk_workspace_changelog:active_entries()),
+        %% A new append in the fresh epoch is active.
+        {ok, Seq} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"dec">>)),
+        ?assertEqual(1, Seq),
+        ?assertEqual(1, length(beamtalk_workspace_changelog:active_entries())),
+        stop(P2)
+    after
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+restart_tags_orphan_when_disk_advanced() ->
+    {WsId, TmpHome, OldHome} = fresh_workspace(),
+    try
+        %% A real on-disk source file whose method body the entry recorded.
+        SrcFile = filename:join(TmpHome, "counter.bt"),
+        ok = file:write_file(SrcFile, <<"class Counter\n  inc => ^ self value\nend\n">>),
+        %% span covers "^ self value" within the file
+        Span = span_of(<<"class Counter\n  inc => ^ self value\nend\n">>, <<"^ self value">>),
+        {ok, P1} = beamtalk_workspace_changelog:start_link(#{workspace_id => WsId}),
+        Input = (durable_input(<<"Counter">>, <<"inc">>))#{
+            source_file => list_to_binary(SrcFile),
+            span => Span,
+            prev_source => <<"^ self value">>
+        },
+        {ok, _} = beamtalk_workspace_changelog:append(Input),
+        stop(P1),
+
+        %% Disk advances under us (someone edited the file).
+        ok = file:write_file(SrcFile, <<"class Counter\n  inc => ^ 999\nend\n">>),
+
+        {ok, P2} = beamtalk_workspace_changelog:start_link(#{workspace_id => WsId}),
+        [Entry] = beamtalk_workspace_changelog:entries(),
+        ?assert(is_orphan_flag(Entry)),
+        ?assertEqual([], beamtalk_workspace_changelog:active_entries()),
+        stop(P2)
+    after
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+restart_keeps_prior_when_disk_matches() ->
+    {WsId, TmpHome, OldHome} = fresh_workspace(),
+    try
+        Content = <<"class Counter\n  inc => ^ self value\nend\n">>,
+        SrcFile = filename:join(TmpHome, "counter.bt"),
+        ok = file:write_file(SrcFile, Content),
+        Span = span_of(Content, <<"^ self value">>),
+        {ok, P1} = beamtalk_workspace_changelog:start_link(#{workspace_id => WsId}),
+        Input = (durable_input(<<"Counter">>, <<"inc">>))#{
+            source_file => list_to_binary(SrcFile),
+            span => Span,
+            prev_source => <<"^ self value">>
+        },
+        {ok, _} = beamtalk_workspace_changelog:append(Input),
+        stop(P1),
+
+        %% Disk unchanged → entry is prior-epoch but NOT orphan.
+        {ok, P2} = beamtalk_workspace_changelog:start_link(#{workspace_id => WsId}),
+        [Entry] = beamtalk_workspace_changelog:entries(),
+        ?assertNot(is_orphan_flag(Entry)),
+        stop(P2)
+    after
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+%%====================================================================
+%% Bounded ring rotation
+%%====================================================================
+
+rotation_test_() ->
+    {setup, fun() -> ok end, fun(_) -> ok end, [
+        fun rotation_archives_overflow/0
+    ]}.
+
+rotation_archives_overflow() ->
+    {WsId, TmpHome, OldHome} = fresh_workspace(),
+    try
+        {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WsId}),
+        %% Append MAX_ENTRIES + 3 entries; the 3 oldest must be archived.
+        Total = 1003,
+        lists:foreach(
+            fun(N) ->
+                Sel = list_to_binary("m" ++ integer_to_list(N)),
+                {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, Sel))
+            end,
+            lists:seq(1, Total)
+        ),
+        Dir = beamtalk_workspace_changelog:changes_dir(WsId),
+        ArchiveDir = filename:join(Dir, "archive"),
+        {ok, ArchiveFiles} = file:list_dir(ArchiveDir),
+        MetaArchives = [F || F <- ArchiveFiles, lists:suffix(".jsonl.gz", F)],
+        SrcArchives = [F || F <- ArchiveFiles, lists:suffix(".tar.gz", F)],
+        ?assertEqual(1000, beamtalk_workspace_changelog:size()),
+        ?assert(length(MetaArchives) >= 1),
+        ?assert(length(SrcArchives) >= 1),
+        %% The live log on disk holds exactly the retained 1000 entries.
+        {ok, LogBin} = file:read_file(filename:join(Dir, "changes.jsonl")),
+        Lines = binary:split(LogBin, <<"\n">>, [global, trim_all]),
+        ?assertEqual(1000, length(Lines)),
+        stop(Pid)
+    after
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+%%====================================================================
+%% Run mode (no workspace_id): memory-only
+%%====================================================================
+
+run_mode_test_() ->
+    {setup, fun() -> ok end, fun(_) -> ok end, [
+        fun run_mode_is_memory_only/0
+    ]}.
+
+run_mode_is_memory_only() ->
+    {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => undefined}),
+    try
+        {ok, Seq} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+        ?assertEqual(0, Seq),
+        ?assertEqual(1, beamtalk_workspace_changelog:size()),
+        ?assertEqual(undefined, beamtalk_workspace_changelog:changes_dir(undefined))
+    after
+        stop(Pid)
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+durable_input(Class, Selector) ->
+    #{
+        class => Class,
+        selector => Selector,
+        kind => instance,
+        source => <<"^ self value + 1">>,
+        prev_source => <<"^ self value">>,
+        intent => durable,
+        flushable => true,
+        author => <<"sess-1">>,
+        author_kind => human,
+        source_file => <<"/proj/src/counter.bt">>,
+        span => #{start => 0, 'end' => 10}
+    }.
+
+%% Create an isolated workspace: a unique id + a temp HOME so the changelog
+%% resolves its changes/ dir under our temp tree. Returns the prior HOME so it
+%% can be restored.
+fresh_workspace() ->
+    Unique = integer_to_list(erlang:unique_integer([positive])),
+    WorkspaceId = list_to_binary("test-ws-" ++ Unique),
+    Tmp = filename:join(temp_dir(), "bt-changelog-" ++ Unique),
+    ok = filelib:ensure_path(Tmp),
+    OldHome = os:getenv("HOME"),
+    true = os:putenv("HOME", Tmp),
+    {WorkspaceId, Tmp, OldHome}.
+
+restore_home(false) -> os:unsetenv("HOME");
+restore_home(OldHome) -> os:putenv("HOME", OldHome).
+
+%% Cross-platform absolute temp dir (CLAUDE.md: never hardcode /tmp in tests).
+temp_dir() ->
+    unicode:characters_to_list(beamtalk_file:'tempDirectory'()).
+
+stop(Pid) ->
+    case is_process_alive(Pid) of
+        true ->
+            Ref = monitor(process, Pid),
+            unlink(Pid),
+            exit(Pid, shutdown),
+            receive
+                {'DOWN', Ref, process, Pid, _} -> ok
+            after 5000 -> ok
+            end;
+        false ->
+            ok
+    end.
+
+del_tree(Path) ->
+    case filelib:is_dir(Path) of
+        true -> _ = file:del_dir_r(Path);
+        false -> _ = file:delete(Path)
+    end,
+    ok.
+
+seq_file(Seq, Suffix) ->
+    lists:flatten(io_lib:format("~6..0b~s", [Seq, Suffix])).
+
+%% Find the byte span of Needle within Haystack (0-based start, exclusive end).
+span_of(Haystack, Needle) ->
+    {Start, Len} = binary:match(Haystack, Needle),
+    #{start => Start, 'end' => Start + Len}.
+
+is_orphan_flag(Entry) ->
+    beamtalk_workspace_changelog:entry_is_orphan(Entry).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
@@ -39,6 +39,13 @@ changelog_test_() ->
         fun clear_empties_log/1
     ]}.
 
+%% These run with no gen_server started so they exercise the table-absent guards.
+no_server_test_() ->
+    [
+        fun entries_returns_empty_when_table_absent/0,
+        fun size_returns_zero_when_table_absent/0
+    ].
+
 setup() ->
     {WorkspaceId, TmpHome, OldHome} = fresh_workspace(),
     {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WorkspaceId}),
@@ -287,7 +294,10 @@ restart_keeps_prior_when_disk_matches() ->
 
 rotation_test_() ->
     {setup, fun() -> ok end, fun(_) -> ok end, [
-        fun rotation_archives_overflow/0
+        fun rotation_archives_overflow/0,
+        fun rotation_keeps_state_when_archive_fails/0,
+        fun archive_filenames_unique_within_same_second/0,
+        fun load_enforces_ring_bound_when_disk_exceeds_max/0
     ]}.
 
 rotation_archives_overflow() ->
@@ -320,6 +330,159 @@ rotation_archives_overflow() ->
         restore_home(OldHome),
         del_tree(TmpHome)
     end.
+
+rotation_keeps_state_when_archive_fails() ->
+    %% Transactional rotation: if archiving the overflow segment fails, the live
+    %% ETS and on-disk log must be left untouched (no history loss).
+    {WsId, TmpHome, OldHome} = fresh_workspace(),
+    try
+        {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WsId}),
+        Total = 1003,
+        lists:foreach(
+            fun(N) ->
+                Sel = list_to_binary("m" ++ integer_to_list(N)),
+                {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, Sel))
+            end,
+            lists:seq(1, Total)
+        ),
+        Dir = beamtalk_workspace_changelog:changes_dir(WsId),
+        %% After a healthy rotation the ring is bounded and an archive exists.
+        ?assertEqual(1000, beamtalk_workspace_changelog:size()),
+        %% Now sabotage the archive dir: make it a regular file so the next
+        %% rotation's archive write fails. Append enough to trigger a rotation.
+        ArchiveDir = filename:join(Dir, "archive"),
+        ok = file:del_dir_r(ArchiveDir),
+        ok = file:write_file(ArchiveDir, <<"not a dir">>),
+        SizeBefore = beamtalk_workspace_changelog:size(),
+        {ok, LogBefore} = file:read_file(filename:join(Dir, "changes.jsonl")),
+        %% This append overflows the ring and attempts a rotation that must fail.
+        {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"boom">>)),
+        SizeAfter = beamtalk_workspace_changelog:size(),
+        {ok, LogAfter} = file:read_file(filename:join(Dir, "changes.jsonl")),
+        %% The new entry was appended (persist_append succeeded); rotation was
+        %% attempted, failed, and left the ring intact rather than dropping
+        %% the oldest 1 entry. So size grew by exactly the one append.
+        ?assertEqual(SizeBefore + 1, SizeAfter),
+        %% The on-disk log was NOT rewritten/truncated by the failed rotation —
+        %% it still contains everything it had before (plus the new line).
+        ?assert(byte_size(LogAfter) >= byte_size(LogBefore)),
+        ?assert(is_process_alive(Pid)),
+        stop(Pid)
+    after
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+archive_filenames_unique_within_same_second() ->
+    %% Two rotations in the same wall-clock second must not collide.
+    {WsId, TmpHome, OldHome} = fresh_workspace(),
+    try
+        {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WsId}),
+        %% Drive enough appends to force at least two separate rotations quickly.
+        lists:foreach(
+            fun(N) ->
+                Sel = list_to_binary("m" ++ integer_to_list(N)),
+                {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, Sel))
+            end,
+            lists:seq(1, 1002)
+        ),
+        %% First rotation done. Append more to trigger a second rotation in the
+        %% (very likely) same second.
+        lists:foreach(
+            fun(N) ->
+                Sel = list_to_binary("n" ++ integer_to_list(N)),
+                {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, Sel))
+            end,
+            lists:seq(1, 5)
+        ),
+        Dir = beamtalk_workspace_changelog:changes_dir(WsId),
+        ArchiveDir = filename:join(Dir, "archive"),
+        {ok, ArchiveFiles} = file:list_dir(ArchiveDir),
+        MetaArchives = [F || F <- ArchiveFiles, lists:suffix(".jsonl.gz", F)],
+        %% Both rotations produced distinct archive files (no overwrite).
+        ?assert(length(MetaArchives) >= 2),
+        ?assertEqual(length(MetaArchives), length(lists:usort(MetaArchives))),
+        stop(Pid)
+    after
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+load_enforces_ring_bound_when_disk_exceeds_max() ->
+    %% A changes.jsonl persisted with > MAX_ENTRIES must be trimmed to the ring
+    %% bound on startup, not left unbounded until the next append.
+    {WsId, TmpHome, OldHome} = fresh_workspace(),
+    try
+        Dir = beamtalk_workspace_changelog:changes_dir(WsId),
+        ok = filelib:ensure_path(Dir),
+        %% Hand-write 1005 metadata lines straight to disk (no source bodies
+        %% needed for this test — entries with source_file=null are non-orphan).
+        Lines = [
+            begin
+                Entry = beamtalk_workspace_changelog:entry_from_json(
+                    line_json(N)
+                ),
+                [beamtalk_workspace_changelog:entry_to_json(Entry), $\n]
+            end
+         || N <- lists:seq(0, 1004)
+        ],
+        ok = file:write_file(
+            filename:join(Dir, "changes.jsonl"), iolist_to_binary(Lines)
+        ),
+        {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WsId}),
+        Size = beamtalk_workspace_changelog:size(),
+        {ok, LogBin} = file:read_file(filename:join(Dir, "changes.jsonl")),
+        LogLines = binary:split(LogBin, <<"\n">>, [global, trim_all]),
+        ?assertEqual(1000, Size),
+        ?assertEqual(1000, length(LogLines)),
+        stop(Pid)
+    after
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+%%====================================================================
+%% Forward-compatibility: unknown enum values must not drop the line
+%%====================================================================
+
+forward_compat_test_() ->
+    [
+        fun unknown_kind_preserved_not_dropped/0,
+        fun known_kinds_decode_to_atoms/0
+    ].
+
+unknown_kind_preserved_not_dropped() ->
+    %% A newer writer may emit a kind this beam doesn't know. Decoding must keep
+    %% the line (map unknown to 'unknown') rather than throw and drop history.
+    Json = line_json_with(#{<<"kind">> => <<"future-kind">>}),
+    Entry = beamtalk_workspace_changelog:entry_from_json(Json),
+    ?assertEqual(unknown, beamtalk_workspace_changelog:entry_kind(Entry)).
+
+known_kinds_decode_to_atoms() ->
+    Instance = beamtalk_workspace_changelog:entry_from_json(
+        line_json_with(#{<<"kind">> => <<"instance">>})
+    ),
+    Class = beamtalk_workspace_changelog:entry_from_json(
+        line_json_with(#{<<"kind">> => <<"class">>})
+    ),
+    NewClass = beamtalk_workspace_changelog:entry_from_json(
+        line_json_with(#{<<"kind">> => <<"new-class">>})
+    ),
+    ?assertEqual(instance, beamtalk_workspace_changelog:entry_kind(Instance)),
+    ?assertEqual(class, beamtalk_workspace_changelog:entry_kind(Class)),
+    ?assertEqual('new-class', beamtalk_workspace_changelog:entry_kind(NewClass)).
+
+%%====================================================================
+%% Table-absent guards (no gen_server started)
+%%====================================================================
+
+entries_returns_empty_when_table_absent() ->
+    ok = ensure_no_changelog_table(),
+    ?assertEqual([], beamtalk_workspace_changelog:entries()).
+
+size_returns_zero_when_table_absent() ->
+    ok = ensure_no_changelog_table(),
+    ?assertEqual(0, beamtalk_workspace_changelog:size()).
 
 %%====================================================================
 %% Run mode (no workspace_id): memory-only
@@ -410,3 +573,39 @@ span_of(Haystack, Needle) ->
 
 is_orphan_flag(Entry) ->
     beamtalk_workspace_changelog:entry_is_orphan(Entry).
+
+%% A minimal, valid changes.jsonl line (non-orphan: sourceFile=null) for tests
+%% that hand-write the log. Seq/ts derived from N so lines are distinct.
+line_json(N) ->
+    line_json_with(#{<<"seq">> => N, <<"ts">> => N}).
+
+%% Build a changes.jsonl line from a base map merged with Overrides.
+line_json_with(Overrides) ->
+    Base = #{
+        <<"ts">> => 0,
+        <<"seq">> => 0,
+        <<"epoch">> => 1,
+        <<"class">> => <<"Counter">>,
+        <<"selector">> => <<"inc">>,
+        <<"kind">> => <<"instance">>,
+        <<"source_ref">> => <<"000000-source.bt">>,
+        <<"prev_source_ref">> => null,
+        <<"sourceFile">> => null,
+        <<"span">> => null,
+        <<"intent">> => <<"durable">>,
+        <<"flushable">> => true,
+        <<"not_flushable_reason">> => null,
+        <<"author">> => <<"sess-1">>,
+        <<"author_kind">> => <<"human">>
+    },
+    iolist_to_binary(json:encode(maps:merge(Base, Overrides))).
+
+%% Ensure the changelog ETS table does not exist (table-absent guard tests).
+ensure_no_changelog_table() ->
+    case ets:whereis(beamtalk_changelog_entries) of
+        undefined ->
+            ok;
+        Tid ->
+            ets:delete(Tid),
+            ok
+    end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_sup_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_sup_tests.erl
@@ -49,11 +49,11 @@ supervisor_intensity_test() ->
 children_count_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(test_config()),
 
-    %% Should have 10 children: workspace_meta, transcript_stream, actor_registry,
-    %% class_events, bindings_events, workspace_bootstrap, repl_server, idle_monitor,
-    %% actor_sup, session_sup.
+    %% Should have 11 children: workspace_meta, workspace_changelog,
+    %% transcript_stream, actor_registry, class_events, bindings_events,
+    %% workspace_bootstrap, repl_server, idle_monitor, actor_sup, session_sup.
     %% BeamtalkInterface and WorkspaceInterface are value singletons (no gen_server).
-    ?assertEqual(10, length(ChildSpecs)).
+    ?assertEqual(11, length(ChildSpecs)).
 
 children_ids_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(test_config()),
@@ -63,6 +63,7 @@ children_ids_test() ->
     %% they are NOT gen_server children of this supervisor.
     Ids = [maps:get(id, Spec) || Spec <- ChildSpecs],
     ?assert(lists:member(beamtalk_workspace_meta, Ids)),
+    ?assert(lists:member(beamtalk_workspace_changelog, Ids)),
     ?assert(lists:member(beamtalk_transcript_stream, Ids)),
     ?assertNot(lists:member('bt@stdlib@beamtalk_interface', Ids)),
     ?assertNot(lists:member('bt@stdlib@workspace_interface', Ids)),
@@ -258,6 +259,7 @@ all_children_alive_test() ->
         %% BeamtalkInterface and WorkspaceInterface are value singletons — not children.
         ExpectedIds = [
             beamtalk_workspace_meta,
+            beamtalk_workspace_changelog,
             beamtalk_transcript_stream,
             beamtalk_actor_registry,
             beamtalk_class_events,
@@ -472,10 +474,10 @@ run_mode_config() ->
 run_mode_children_count_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(run_mode_config()),
 
-    %% Run mode: 7 children (no repl_server, idle_monitor, session_sup).
-    %% workspace_meta, transcript_stream, actor_registry, class_events,
-    %% bindings_events, workspace_bootstrap, actor_sup.
-    ?assertEqual(7, length(ChildSpecs)).
+    %% Run mode: 8 children (no repl_server, idle_monitor, session_sup).
+    %% workspace_meta, workspace_changelog, transcript_stream, actor_registry,
+    %% class_events, bindings_events, workspace_bootstrap, actor_sup.
+    ?assertEqual(8, length(ChildSpecs)).
 
 run_mode_no_repl_server_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(run_mode_config()),


### PR DESCRIPTION
## Summary

Phase 1 of epic BT-2280 (ADR 0082): a workspace-local **ChangeLog** gen_server that records every live method patch as a ChangeEntry, with two-part on-disk persistence. This is the foundation later phases build on (`Workspace changes`, `flush`, and the `compile:source:` install-hook).

Linear: https://linear.app/beamtalk/issue/BT-2282

## Key changes

- `beamtalk_workspace_changelog.erl` (new) — registered gen_server owning the ChangeLog state and its two-part on-disk persistence.
- `beamtalk_workspace_sup.erl` — supervises the new gen_server.
- `beamtalk_workspace.app.src` — registers `beamtalk_workspace_changelog`.
- EUnit coverage in `beamtalk_workspace_changelog_tests.erl` + updated supervisor tests.

## Test plan

- [x] `just build-erlang` — clean compile
- [x] `just test-runtime` — 3983 + 1329 tests, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added crash-safe changelog system to track method and code mutations with automatic recovery capability
  * Implemented session-aware change history that separates current edits from prior session records
  * Added automatic archival of change history to manage growth and prevent unbounded data accumulation

* **Tests**
  * Added comprehensive changelog test suite covering crash-safety and persistence validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->