### PR TITLE
DRY up repeated setUp in erlang_object_inheritance_test.bt (BT-2296)

### DIFF
--- a/stdlib/test/erlang_object_inheritance_test.bt
+++ b/stdlib/test/erlang_object_inheritance_test.bt
@@ -22,11 +22,9 @@ TestCase subclass: ErlangObjectInheritanceTest
   testErlangModuleDisplayString =>
     self assert: (self.proxy displayString isKindOf: String)
 
-  testErlangModuleInspect =>
-    self assert: (self.proxy inspect isKindOf: String)
+  testErlangModuleInspect => self assert: (self.proxy inspect isKindOf: String)
 
-  testErlangModuleIsNilReturnsFalse =>
-    self deny: self.proxy isNil
+  testErlangModuleIsNilReturnsFalse => self deny: self.proxy isNil
 
   testErlangModuleRespondsToDisplayString =>
     self assert: (self.proxy respondsTo: #displayString)
@@ -34,15 +32,13 @@ TestCase subclass: ErlangObjectInheritanceTest
   testErlangModuleRespondsToIsNil =>
     self assert: (self.proxy respondsTo: #isNil)
 
-  testErlangModuleHash =>
-    self assert: (self.proxy hash isKindOf: Integer)
+  testErlangModuleHash => self assert: (self.proxy hash isKindOf: Integer)
 
   // === ErlangModule: FFI dispatch still works ===
   testErlangModuleKeywordDispatch =>
     self assert: (self.proxy reverse: #(3, 2, 1)) equals: #(1, 2, 3)
 
-  testErlangModuleUnaryDispatch =>
-    self assert: (Erlang erlang) node notNil
+  testErlangModuleUnaryDispatch => self assert: (Erlang erlang) node notNil
 
   // === Erlang: Object-inherited methods ===
   // Note: Must use dynamic dispatch (via variable or perform:) because
@@ -51,20 +47,16 @@ TestCase subclass: ErlangObjectInheritanceTest
   testErlangDisplayString =>
     self assert: (self.e displayString isKindOf: String)
 
-  testErlangInspect =>
-    self assert: (self.e inspect isKindOf: String)
+  testErlangInspect => self assert: (self.e inspect isKindOf: String)
 
-  testErlangIsNilReturnsFalse =>
-    self deny: self.e isNil
+  testErlangIsNilReturnsFalse => self deny: self.e isNil
 
   testErlangRespondsToDisplayString =>
     self assert: (self.e respondsTo: #displayString)
 
-  testErlangRespondsToIsNil =>
-    self assert: (self.e respondsTo: #isNil)
+  testErlangRespondsToIsNil => self assert: (self.e respondsTo: #isNil)
 
-  testErlangHash =>
-    self assert: (self.e hash isKindOf: Integer)
+  testErlangHash => self assert: (self.e hash isKindOf: Integer)
 
   // === Erlang: module lookup still works ===
   testErlangModuleLookup =>

--- a/stdlib/test/erlang_object_inheritance_test.bt
+++ b/stdlib/test/erlang_object_inheritance_test.bt
@@ -9,67 +9,62 @@
 // and that Erlang FFI dispatch is preserved.
 
 TestCase subclass: ErlangObjectInheritanceTest
+  field: proxy
+  field: e
+
+  // proxy = ErlangModule for `lists`; e = the Erlang class object itself.
+  // `e` is stored in a field (not used bare as `Erlang <selector>`) so that
+  // dispatch goes through dynamic lookup instead of the compile-time static
+  // path that always creates an ErlangModule proxy.
+  setUp => (self withProxy: Erlang lists) withE: Erlang
 
   // === ErlangModule: Object-inherited methods ===
   testErlangModuleDisplayString =>
-    proxy := Erlang lists
-    self assert: (proxy displayString isKindOf: String)
+    self assert: (self.proxy displayString isKindOf: String)
 
   testErlangModuleInspect =>
-    proxy := Erlang lists
-    self assert: (proxy inspect isKindOf: String)
+    self assert: (self.proxy inspect isKindOf: String)
 
   testErlangModuleIsNilReturnsFalse =>
-    proxy := Erlang lists
-    self deny: proxy isNil
+    self deny: self.proxy isNil
 
   testErlangModuleRespondsToDisplayString =>
-    proxy := Erlang lists
-    self assert: (proxy respondsTo: #displayString)
+    self assert: (self.proxy respondsTo: #displayString)
 
   testErlangModuleRespondsToIsNil =>
-    proxy := Erlang lists
-    self assert: (proxy respondsTo: #isNil)
+    self assert: (self.proxy respondsTo: #isNil)
 
   testErlangModuleHash =>
-    proxy := Erlang lists
-    self assert: (proxy hash isKindOf: Integer)
+    self assert: (self.proxy hash isKindOf: Integer)
 
   // === ErlangModule: FFI dispatch still works ===
   testErlangModuleKeywordDispatch =>
-    proxy := Erlang lists
-    self assert: (proxy reverse: #(3, 2, 1)) equals: #(1, 2, 3)
+    self assert: (self.proxy reverse: #(3, 2, 1)) equals: #(1, 2, 3)
 
   testErlangModuleUnaryDispatch =>
-    proxy := Erlang erlang
-    self assert: proxy node notNil
+    self assert: (Erlang erlang) node notNil
 
   // === Erlang: Object-inherited methods ===
   // Note: Must use dynamic dispatch (via variable or perform:) because
   // compile-time `Erlang <selector>` always creates an ErlangModule proxy.
+  // self.e holds the Erlang class object and provides the needed indirection.
   testErlangDisplayString =>
-    e := Erlang
-    self assert: (e displayString isKindOf: String)
+    self assert: (self.e displayString isKindOf: String)
 
   testErlangInspect =>
-    e := Erlang
-    self assert: (e inspect isKindOf: String)
+    self assert: (self.e inspect isKindOf: String)
 
   testErlangIsNilReturnsFalse =>
-    e := Erlang
-    self deny: e isNil
+    self deny: self.e isNil
 
   testErlangRespondsToDisplayString =>
-    e := Erlang
-    self assert: (e respondsTo: #displayString)
+    self assert: (self.e respondsTo: #displayString)
 
   testErlangRespondsToIsNil =>
-    e := Erlang
-    self assert: (e respondsTo: #isNil)
+    self assert: (self.e respondsTo: #isNil)
 
   testErlangHash =>
-    e := Erlang
-    self assert: (e hash isKindOf: Integer)
+    self assert: (self.e hash isKindOf: Integer)
 
   // === Erlang: module lookup still works ===
   testErlangModuleLookup =>


### PR DESCRIPTION
## Summary

Removes 13 duplicated local variable assignments from `stdlib/test/erlang_object_inheritance_test.bt` by introducing a proper `setUp` method.

**Linear issue:** https://linear.app/beamtalk/issue/BT-2296

## Problem

Every test method in `ErlangObjectInheritanceTest` independently re-established the same precondition before its assertion:

- 7 methods started with `proxy := Erlang lists`
- 6 methods started with `e := Erlang`

No `setUp` existed to consolidate this, so the boilerplate was copy-pasted across all 13 tests.

## Changes

- Add `field: proxy` and `field: e` declarations
- Add `setUp => (self withProxy: Erlang lists) withE: Erlang` using the established functional-setUp pattern (same as `os_test.bt`, `functional_setup_test.bt`)
- Remove the 13 duplicated local variable assignments
- Inline `testErlangModuleUnaryDispatch` (which needed `Erlang erlang`, not `Erlang lists`) to `(Erlang erlang) node notNil`
- Apply `beamtalk fmt` (single-statement methods inlined to one-liner form)

## Why it's safe

- TestCase is a Value subclass; each test method receives a fresh `setUp`-initialized instance — tests remain isolated
- `Erlang lists` and `Erlang` are stateless; no side effects in setUp
- `self.e` provides the same dynamic-dispatch indirection as the original local `e := Erlang` — the compiler does not treat field access as a static `Erlang <selector>` proxy-creation
- No assertions changed; only the receiver expression was updated

## Test results

```
228 file(s), 2128 tests, 2126 passed, 0 failed
```

https://claude.ai/code/session_01SQwxVw6ZRC3vB1Lpht9MA6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQwxVw6ZRC3vB1Lpht9MA6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure to improve maintainability of object inheritance test suite. Test behavior and coverage remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->