### PR TITLE
docs: ADR 0087 Accepted + implementation tracking (BT-2228)

### DIFF
--- a/docs/ADR/0087-maintained-xref-index-for-system-navigation.md
+++ b/docs/ADR/0087-maintained-xref-index-for-system-navigation.md
@@ -1,7 +1,40 @@
 # ADR 0087: Maintained Selector→Sites Cross-Reference Index for SystemNavigation
 
 ## Status
-Proposed (2026-05-26)
+Accepted (2026-05-26)
+
+## Implementation Tracking
+
+**Epic:** [BT-2228](https://linear.app/beamtalk/issue/BT-2228) — Runtime: maintained selector→sites xref index for SystemNavigation queries
+
+**Phases / child issues:**
+
+| Phase | Issue | Title | Size | Blocked by |
+|---|---|---|---|---|
+| 1 | [BT-2297](https://linear.app/beamtalk/issue/BT-2297) | Runtime: `beamtalk_xref` gen_server + supervisor wiring | M | – |
+| 2 | [BT-2298](https://linear.app/beamtalk/issue/BT-2298) | Codegen + runtime: bake `method_xref` into `register_class/0`; sync-forward in `start/2` | M | BT-2297 |
+| 3 | [BT-2299](https://linear.app/beamtalk/issue/BT-2299) | Stdlib: migrate `sendersOf:` to xref + miss-policy fallback + benchmark (napkin wire-check) | M | BT-2298 |
+| 4 | [BT-2300](https://linear.app/beamtalk/issue/BT-2300) | Runtime: hot-reload purge + new-gen install with atomicity | M | BT-2299 |
+| 4 | [BT-2301](https://linear.app/beamtalk/issue/BT-2301) | Runtime: `put_method/4`, extension, and ClassBuilder lifecycle hooks | M | BT-2298 |
+| 5 | [BT-2302](https://linear.app/beamtalk/issue/BT-2302) | Stdlib: migrate `referencesTo:` + `implementorsOf:` + `selectorsMatching:` to xref | M | BT-2299 |
+| 5 | [BT-2303](https://linear.app/beamtalk/issue/BT-2303) | Stdlib: migrate `unimplementedSelectors` + `unusedSelectors` to xref | M | BT-2299 |
+| 6 | [BT-2304](https://linear.app/beamtalk/issue/BT-2304) | Codegen: synthetic-method xref emission + parity tests + ADR Accepted→Implemented | M | BT-2298 |
+
+**Wave plan:**
+
+```
+Wave 1 (1 issue):    BT-2297
+Wave 2 (1 issue):    BT-2298
+Wave 3 (1 issue):    BT-2299   ← napkin wire-check
+Wave 4 (3 parallel): BT-2300   BT-2302   BT-2304
+Wave 5 (2 parallel): BT-2301   BT-2303
+```
+
+File-overlap constraints:
+- BT-2302 and BT-2303 both touch `stdlib/src/SystemNavigation.bt` — serialized across waves 4 and 5.
+- BT-2300 and BT-2301 both touch `runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl` API surface — serialized across waves 4 and 5.
+
+**Status will move to `Implemented` when BT-2304 (Phase 6) merges** — that issue's acceptance criteria include updating this header.
 
 ## Context
 


### PR DESCRIPTION
## Summary

Companion docs PR to the [BT-2228 ADR](https://github.com/jamesc/beamtalk/pull/2324) (merged):

- Flip ADR 0087 status `Proposed` → `Accepted (2026-05-26)`.
- Add an **Implementation Tracking** section listing the 8 child issues created via `/plan-adr` and the wave plan for executing them.

## Epic structure

[BT-2228](https://linear.app/beamtalk/issue/BT-2228) is now labelled `Epic` and parents 8 implementation issues:

| Phase | Issue | Title | Blocked by |
|---|---|---|---|
| 1 | [BT-2297](https://linear.app/beamtalk/issue/BT-2297) | Runtime: `beamtalk_xref` gen_server + supervisor wiring | – |
| 2 | [BT-2298](https://linear.app/beamtalk/issue/BT-2298) | Codegen + runtime: bake `method_xref` into `register_class/0` | BT-2297 |
| 3 | [BT-2299](https://linear.app/beamtalk/issue/BT-2299) | Stdlib: migrate `sendersOf:` + miss-policy + benchmark (napkin wire-check) | BT-2298 |
| 4 | [BT-2300](https://linear.app/beamtalk/issue/BT-2300) | Runtime: hot-reload purge + new-gen install (atomicity) | BT-2299 |
| 4 | [BT-2301](https://linear.app/beamtalk/issue/BT-2301) | Runtime: `put_method/4` + extension + ClassBuilder hooks | BT-2298 |
| 5 | [BT-2302](https://linear.app/beamtalk/issue/BT-2302) | Stdlib: migrate `referencesTo:` + `implementorsOf:` + `selectorsMatching:` | BT-2299 |
| 5 | [BT-2303](https://linear.app/beamtalk/issue/BT-2303) | Stdlib: migrate `unimplementedSelectors` + `unusedSelectors` | BT-2299 |
| 6 | [BT-2304](https://linear.app/beamtalk/issue/BT-2304) | Codegen: synthetic-method xref emission + ADR Accepted→Implemented | BT-2298 |

Wave plan:

```
Wave 1 (1):  BT-2297
Wave 2 (1):  BT-2298
Wave 3 (1):  BT-2299  ← napkin wire-check
Wave 4 (3):  BT-2300   BT-2302   BT-2304   (parallel)
Wave 5 (2):  BT-2301   BT-2303              (parallel)
```

File-overlap constraints noted (SystemNavigation.bt and beamtalk_xref.erl each touched by two issues, serialized across waves).

Final status flip Accepted→Implemented is folded into BT-2304's acceptance criteria.

## Test plan

- [x] Docs-only diff; no build/CI gate applies.
- [x] All 8 child issues exist in Linear with `agent-ready` labels, full ACs, file lists, and blocking relationships.
- [x] BT-2228 reopened to `In Progress` (auto-closed when its ADR PR squash-merged).
- [ ] BT-2297 subagent (Wave 1) is in flight — separate PR will appear when it completes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ik9CtvPqsnmZpBFfYReX2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated architectural documentation reflecting current implementation status and phased rollout plan.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->