### PR TITLE
Runtime: beamtalk_xref gen_server + supervisor wiring (BT-2297)

### DIFF
--- a/docs/ADR/0087-maintained-xref-index-for-system-navigation.md
+++ b/docs/ADR/0087-maintained-xref-index-for-system-navigation.md
@@ -14,11 +14,13 @@ Accepted (2026-05-26)
 | 1 | [BT-2297](https://linear.app/beamtalk/issue/BT-2297) | Runtime: `beamtalk_xref` gen_server + supervisor wiring | M | – |
 | 2 | [BT-2298](https://linear.app/beamtalk/issue/BT-2298) | Codegen + runtime: bake `method_xref` into `register_class/0`; sync-forward in `start/2` | M | BT-2297 |
 | 3 | [BT-2299](https://linear.app/beamtalk/issue/BT-2299) | Stdlib: migrate `sendersOf:` to xref + miss-policy fallback + benchmark (napkin wire-check) | M | BT-2298 |
-| 4 | [BT-2300](https://linear.app/beamtalk/issue/BT-2300) | Runtime: hot-reload purge + new-gen install with atomicity | M | BT-2299 |
-| 4 | [BT-2301](https://linear.app/beamtalk/issue/BT-2301) | Runtime: `put_method/4`, extension, and ClassBuilder lifecycle hooks | M | BT-2298 |
-| 5 | [BT-2302](https://linear.app/beamtalk/issue/BT-2302) | Stdlib: migrate `referencesTo:` + `implementorsOf:` + `selectorsMatching:` to xref | M | BT-2299 |
-| 5 | [BT-2303](https://linear.app/beamtalk/issue/BT-2303) | Stdlib: migrate `unimplementedSelectors` + `unusedSelectors` to xref | M | BT-2299 |
+| 4a | [BT-2300](https://linear.app/beamtalk/issue/BT-2300) | Runtime: hot-reload purge + new-gen install with atomicity | M | BT-2299 |
+| 4b | [BT-2301](https://linear.app/beamtalk/issue/BT-2301) | Runtime: `put_method/4`, extension, and ClassBuilder lifecycle hooks | M | BT-2298 |
+| 5a | [BT-2302](https://linear.app/beamtalk/issue/BT-2302) | Stdlib: migrate `referencesTo:` + `implementorsOf:` + `selectorsMatching:` to xref | M | BT-2299 |
+| 5b | [BT-2303](https://linear.app/beamtalk/issue/BT-2303) | Stdlib: migrate `unimplementedSelectors` + `unusedSelectors` to xref | M | BT-2299 |
 | 6 | [BT-2304](https://linear.app/beamtalk/issue/BT-2304) | Codegen: synthetic-method xref emission + parity tests + ADR Accepted→Implemented | M | BT-2298 |
+
+Phases 4 and 5 each split into two sibling issues (4a/4b, 5a/5b) — they touch overlapping files and serialize across waves, but conceptually live in the same phase of the migration.
 
 **Wave plan:**
 

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_runtime_sup.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_runtime_sup.erl
@@ -33,6 +33,17 @@ init([]) ->
     },
 
     ChildSpecs = [
+        %% Cross-reference index for SystemNavigation queries (ADR 0087).
+        %% MUST be the first non-pg child so its tables exist before any
+        %% `register_class/0` runs in beamtalk_bootstrap / beamtalk_stdlib.
+        #{
+            id => beamtalk_xref,
+            start => {beamtalk_xref, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [beamtalk_xref]
+        },
         %% Bootstrap the class hierarchy first
         #{
             id => beamtalk_bootstrap,

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
@@ -1,0 +1,430 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_xref).
+-behaviour(gen_server).
+
+%%% **DDD Context:** Runtime Context
+
+-moduledoc """
+Cross-reference index gen_server for SystemNavigation queries (ADR 0087).
+
+Owns four ETS tables that maintain a runtime-resident `selector → sites` /
+`class → references` index, populated at class-load time via
+`register_class/2`. Reads (`senders_of/1`, `references_to/1`,
+`implementors_of/1`, `defined_selectors/2`) hit ETS directly and do not
+serialize through the gen_server. Writes serialize through the gen_server
+so per-class generation bumps stay atomic.
+
+Phase 1 (BT-2297) provides the skeleton: tables, API contract, supervisor
+wiring. Subsequent phases land producers (codegen → `register_class/0`,
+lifecycle hooks) and read-path migration in `SystemNavigation`. The
+multi-generation reload sweep lands in Phase 4 (BT-2300).
+
+Storage layout (all `protected, named_table, {read_concurrency, true}`):
+- `beamtalk_xref_methods` (bag): per-method definitions
+- `beamtalk_xref_senders` (bag): selector → call sites
+- `beamtalk_xref_references` (bag): class → reference sites
+- `xref_class_gen` (set): class → current generation
+
+See also: docs/ADR/0087-maintained-xref-index-for-system-navigation.md
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+%% API — write path
+-export([
+    start_link/0,
+    register_class/2,
+    purge_class/1,
+    put_method/4
+]).
+
+%% API — read path
+-export([
+    senders_of/1,
+    references_to/1,
+    implementors_of/1,
+    defined_selectors/2
+]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+%% Table names
+-define(METHODS_TABLE, beamtalk_xref_methods).
+-define(SENDERS_TABLE, beamtalk_xref_senders).
+-define(REFERENCES_TABLE, beamtalk_xref_references).
+-define(CLASS_GEN_TABLE, xref_class_gen).
+
+%%====================================================================
+%% Types
+%%====================================================================
+
+-type class_name() :: atom().
+-type selector() :: atom().
+-type class_side() :: boolean().
+-type gen() :: pos_integer().
+-type source_status() :: indexed | unindexed_runtime_fun | synthetic.
+-type provenance() :: class_body | extension | class_builder | put_method.
+-type recv_kind() :: self_recv | super_recv | erlang_ffi | other.
+
+-type send_entry() :: #{
+    selector := selector(),
+    line := pos_integer(),
+    recv_kind => recv_kind()
+}.
+
+-type reference_entry() :: #{
+    class := class_name(),
+    line := pos_integer()
+}.
+
+-type method_xref_entry() :: #{
+    class_side := class_side(),
+    selector := selector(),
+    line := pos_integer(),
+    sends => [send_entry()],
+    references => [reference_entry()],
+    source_status => source_status(),
+    provenance => provenance(),
+    synthetic_origin => pos_integer() | undefined
+}.
+
+-type method_info() :: #{
+    owner := class_name(),
+    line := pos_integer(),
+    source_status := source_status(),
+    provenance := provenance(),
+    gen := gen()
+}.
+
+-type site() :: #{
+    owner := class_name(),
+    class_side := class_side(),
+    method := selector(),
+    line := pos_integer(),
+    recv_kind => recv_kind(),
+    gen := gen()
+}.
+
+-export_type([
+    method_xref_entry/0,
+    method_info/0,
+    site/0,
+    source_status/0,
+    provenance/0,
+    recv_kind/0
+]).
+
+-record(state, {}).
+
+%%====================================================================
+%% API — write path
+%%====================================================================
+
+-doc "Start the xref gen_server.".
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-doc """
+Register all per-method xref rows for a class. Synchronous.
+
+Bumps the class's generation counter, inserts new rows under the new
+generation, then atomically publishes the new generation in
+`xref_class_gen`. Readers observing during the call see either the
+pre- or post-write state (the gen-bump is the atomic publish).
+
+Phase 1 (BT-2297): the multi-gen reload sweep (old-gen `select_delete`)
+is out of scope and lands in Phase 4 / BT-2300. For now `purge_class/1`
+is the primary way to drop old rows before re-registering.
+""".
+-spec register_class(class_name(), [method_xref_entry()]) -> ok.
+register_class(Class, MethodXref) when is_atom(Class), is_list(MethodXref) ->
+    gen_server:call(?MODULE, {register_class, Class, MethodXref}).
+
+-doc """
+Remove all rows belonging to a class from every xref table.
+Synchronous. Idempotent — purging an unknown class is a no-op.
+""".
+-spec purge_class(class_name()) -> ok.
+purge_class(Class) when is_atom(Class) ->
+    gen_server:call(?MODULE, {purge_class, Class}).
+
+-doc """
+Replace the xref rows for a single method without touching siblings.
+
+Used for method-level edits (`put_method/4` source patches, ADR 0082;
+extension registers, ADR 0066) where only one method's data changes.
+Synchronous. Bumps the owning class's generation so the new rows are
+visible atomically.
+""".
+-spec put_method(class_name(), class_side(), selector(), method_xref_entry()) -> ok.
+put_method(Class, ClassSide, Selector, MethodXref) when
+    is_atom(Class), is_boolean(ClassSide), is_atom(Selector), is_map(MethodXref)
+->
+    gen_server:call(?MODULE, {put_method, Class, ClassSide, Selector, MethodXref}).
+
+%%====================================================================
+%% API — read path
+%%====================================================================
+
+-doc """
+Return all sites that send `Selector`. Direct ETS lookup — does not
+go through the gen_server.
+
+Phase 1 (BT-2297): no miss-policy fallback. Callers should treat an
+empty result as "no known senders"; the source-scan fallback for
+unloaded / unindexed classes lands with Phase 3 (BT-2299).
+""".
+-spec senders_of(selector()) -> [site()].
+senders_of(Selector) when is_atom(Selector) ->
+    case ets:whereis(?SENDERS_TABLE) of
+        undefined -> [];
+        _ -> [Site || {_Sel, Site} <- ets:lookup(?SENDERS_TABLE, Selector)]
+    end.
+
+-doc """
+Return all sites that reference `Class` (type annotations, class
+literals, etc.). Direct ETS lookup.
+""".
+-spec references_to(class_name()) -> [site()].
+references_to(Class) when is_atom(Class) ->
+    case ets:whereis(?REFERENCES_TABLE) of
+        undefined -> [];
+        _ -> [Site || {_Cls, Site} <- ets:lookup(?REFERENCES_TABLE, Class)]
+    end.
+
+-doc """
+Return all `{Class, ClassSide}` pairs that implement `Selector`.
+Direct ETS lookup via `match_object` on the methods bag.
+""".
+-spec implementors_of(selector()) -> [{class_name(), class_side()}].
+implementors_of(Selector) when is_atom(Selector) ->
+    case ets:whereis(?METHODS_TABLE) of
+        undefined ->
+            [];
+        _ ->
+            %% Match keys of shape {Class, ClassSide, Selector} where Selector matches.
+            %% Use ets:match/2 with key wildcard on Class and ClassSide.
+            Matches = ets:match(?METHODS_TABLE, {{'$1', '$2', Selector}, '_'}),
+            lists:usort([{Cls, CS} || [Cls, CS] <- Matches])
+    end.
+
+-doc """
+Return the selectors defined on `Class` for the given side
+(`ClassSide = true` for class-side methods, `false` for instance-side).
+""".
+-spec defined_selectors(class_name(), class_side()) -> [selector()].
+defined_selectors(Class, ClassSide) when is_atom(Class), is_boolean(ClassSide) ->
+    case ets:whereis(?METHODS_TABLE) of
+        undefined ->
+            [];
+        _ ->
+            Matches = ets:match(?METHODS_TABLE, {{Class, ClassSide, '$1'}, '_'}),
+            lists:usort([Sel || [Sel] <- Matches])
+    end.
+
+%%====================================================================
+%% gen_server callbacks
+%%====================================================================
+
+init([]) ->
+    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+
+    %% Create the four ETS tables, owned by this process. Heir is undefined
+    %% per the acceptance criteria — tables die with the process, supervisor
+    %% restart triggers re-population from the next round of register_class/0
+    %% calls (or from miss-policy fallback once Phase 3 lands).
+    BagOpts = [bag, protected, named_table, {read_concurrency, true}],
+    SetOpts = [set, protected, named_table, {read_concurrency, true}],
+    ?METHODS_TABLE = ets:new(?METHODS_TABLE, BagOpts),
+    ?SENDERS_TABLE = ets:new(?SENDERS_TABLE, BagOpts),
+    ?REFERENCES_TABLE = ets:new(?REFERENCES_TABLE, BagOpts),
+    ?CLASS_GEN_TABLE = ets:new(?CLASS_GEN_TABLE, SetOpts),
+
+    ?LOG_INFO("xref started", #{
+        tables => [?METHODS_TABLE, ?SENDERS_TABLE, ?REFERENCES_TABLE, ?CLASS_GEN_TABLE]
+    }),
+    {ok, #state{}}.
+
+handle_call({register_class, Class, MethodXref}, _From, State) ->
+    Gen = bump_gen(Class),
+    insert_method_xref_rows(Class, MethodXref, Gen),
+    {reply, ok, State};
+handle_call({purge_class, Class}, _From, State) ->
+    do_purge_class(Class),
+    {reply, ok, State};
+handle_call({put_method, Class, ClassSide, Selector, MethodXref}, _From, State) ->
+    Gen = bump_gen(Class),
+    delete_method_rows(Class, ClassSide, Selector),
+    %% Force the entry's class_side/selector to match the addressed slot —
+    %% protects against accidental drift between the call args and the map.
+    Normalised = MethodXref#{class_side => ClassSide, selector => Selector},
+    insert_method_xref_rows(Class, [Normalised], Gen),
+    {reply, ok, State};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    %% ETS tables are owned by this process; they die automatically. The
+    %% supervisor restart brings up fresh empty tables — Phase 4's
+    %% miss-policy fallback / re-register hook will repopulate from the
+    %% class registry as classes are reloaded.
+    ok.
+
+code_change(OldVsn, State, Extra) ->
+    beamtalk_hot_reload:code_change(OldVsn, State, Extra).
+
+%%====================================================================
+%% Internal: generation management
+%%====================================================================
+
+-doc """
+Increment the per-class generation counter and return the new generation.
+On first registration the counter starts at 1.
+
+The increment + new-gen-row insert is the atomic publish step described
+in ADR 0087 §Atomicity. Phase 1 only writes the new-gen rows; the
+async sweep of old-gen rows lands in Phase 4 (BT-2300).
+""".
+-spec bump_gen(class_name()) -> gen().
+bump_gen(Class) ->
+    NewGen =
+        case ets:lookup(?CLASS_GEN_TABLE, Class) of
+            [] -> 1;
+            [{_, Current}] -> Current + 1
+        end,
+    true = ets:insert(?CLASS_GEN_TABLE, {Class, NewGen}),
+    NewGen.
+
+%%====================================================================
+%% Internal: write helpers
+%%====================================================================
+
+-doc """
+Insert all rows for a class's method_xref list under the given generation.
+Each entry contributes one row to `methods`, plus one row per send to
+`senders`, plus one row per reference to `references`.
+""".
+-spec insert_method_xref_rows(class_name(), [method_xref_entry()], gen()) -> ok.
+insert_method_xref_rows(Class, MethodXref, Gen) ->
+    lists:foreach(
+        fun(Entry) -> insert_one_method(Class, Entry, Gen) end,
+        MethodXref
+    ),
+    ok.
+
+-spec insert_one_method(class_name(), method_xref_entry(), gen()) -> ok.
+insert_one_method(Class, Entry, Gen) ->
+    ClassSide = maps:get(class_side, Entry, false),
+    Selector = maps:get(selector, Entry),
+    Line = maps:get(line, Entry, 0),
+    SourceStatus = maps:get(source_status, Entry, indexed),
+    Provenance = maps:get(provenance, Entry, class_body),
+
+    MethodInfo = #{
+        owner => Class,
+        line => Line,
+        source_status => SourceStatus,
+        provenance => Provenance,
+        gen => Gen
+    },
+    true = ets:insert(?METHODS_TABLE, {{Class, ClassSide, Selector}, MethodInfo}),
+
+    Sends = maps:get(sends, Entry, []),
+    lists:foreach(
+        fun(Send) ->
+            SendSelector = maps:get(selector, Send),
+            Site = #{
+                owner => Class,
+                class_side => ClassSide,
+                method => Selector,
+                line => maps:get(line, Send, Line),
+                recv_kind => maps:get(recv_kind, Send, other),
+                gen => Gen
+            },
+            true = ets:insert(?SENDERS_TABLE, {SendSelector, Site})
+        end,
+        Sends
+    ),
+
+    References = maps:get(references, Entry, []),
+    lists:foreach(
+        fun(Ref) ->
+            RefClass = maps:get(class, Ref),
+            Site = #{
+                owner => Class,
+                class_side => ClassSide,
+                method => Selector,
+                line => maps:get(line, Ref, Line),
+                gen => Gen
+            },
+            true = ets:insert(?REFERENCES_TABLE, {RefClass, Site})
+        end,
+        References
+    ),
+    ok.
+
+-doc """
+Delete all rows belonging to a class from every table, including the
+class's generation counter. Idempotent.
+
+`senders` and `references` are keyed by selector / referenced class, so
+the class-owner predicate lives inside the value map. ETS match_spec
+maps support partial-key pattern matching (`#{owner := '$1'}`), so we
+use `select_delete` with a guard on the owner field rather than the
+non-existent literal-map `match_delete` form.
+""".
+-spec do_purge_class(class_name()) -> ok.
+do_purge_class(Class) ->
+    %% Methods are keyed by {Class, ClassSide, Selector} — direct key match.
+    true = ets:match_delete(?METHODS_TABLE, {{Class, '_', '_'}, '_'}),
+    %% Senders / references — match on the value map's owner field.
+    _ = ets:select_delete(
+        ?SENDERS_TABLE,
+        [{{'_', #{owner => '$1'}}, [{'=:=', '$1', {const, Class}}], [true]}]
+    ),
+    _ = ets:select_delete(
+        ?REFERENCES_TABLE,
+        [{{'_', #{owner => '$1'}}, [{'=:=', '$1', {const, Class}}], [true]}]
+    ),
+    true = ets:delete(?CLASS_GEN_TABLE, Class),
+    ok.
+
+-doc """
+Delete rows for one specific method (Class, ClassSide, Selector).
+Senders / references entries for the method are scrubbed by matching
+the value map's owner + class_side + method fields via `select_delete`.
+""".
+-spec delete_method_rows(class_name(), class_side(), selector()) -> ok.
+delete_method_rows(Class, ClassSide, Selector) ->
+    true = ets:match_delete(?METHODS_TABLE, {{Class, ClassSide, Selector}, '_'}),
+    MatchSpec = [
+        {
+            {'_', #{owner => '$1', class_side => '$2', method => '$3'}},
+            [
+                {'=:=', '$1', {const, Class}},
+                {'=:=', '$2', {const, ClassSide}},
+                {'=:=', '$3', {const, Selector}}
+            ],
+            [true]
+        }
+    ],
+    _ = ets:select_delete(?SENDERS_TABLE, MatchSpec),
+    _ = ets:select_delete(?REFERENCES_TABLE, MatchSpec),
+    ok.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
@@ -333,7 +333,7 @@ insert_method_xref_rows(Class, MethodXref, Gen) ->
 insert_one_method(Class, Entry, Gen) ->
     ClassSide = maps:get(class_side, Entry, false),
     Selector = maps:get(selector, Entry),
-    Line = maps:get(line, Entry, 0),
+    Line = maps:get(line, Entry),
     SourceStatus = maps:get(source_status, Entry, indexed),
     Provenance = maps:get(provenance, Entry, class_body),
 
@@ -386,7 +386,7 @@ class's generation counter. Idempotent.
 
 `senders` and `references` are keyed by selector / referenced class, so
 the class-owner predicate lives inside the value map. ETS match_spec
-maps support partial-key pattern matching (`#{owner := '$1'}`), so we
+maps support partial-key pattern matching (`#{owner => '$1'}`), so we
 use `select_delete` with a guard on the owner field rather than the
 non-existent literal-map `match_delete` form.
 """.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_runtime_sup_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_runtime_sup_tests.erl
@@ -34,14 +34,17 @@ supervisor_intensity_test() ->
 children_count_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    %% Should have exactly 6 children: bootstrap, stdlib, object_instances, subprocess_sup, reactive_subprocess_sup, trace_store
-    ?assertEqual(6, length(ChildSpecs)).
+    %% Should have exactly 7 children: xref, bootstrap, stdlib, object_instances,
+    %% subprocess_sup, reactive_subprocess_sup, trace_store
+    ?assertEqual(7, length(ChildSpecs)).
 
 children_ids_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    %% Children should be bootstrap, stdlib, object_instances, subprocess_sup, and reactive_subprocess_sup
+    %% Children should include xref (first non-pg child, ADR 0087), bootstrap,
+    %% stdlib, object_instances, subprocess_sup, reactive_subprocess_sup, trace_store
     Ids = [maps:get(id, Spec) || Spec <- ChildSpecs],
+    ?assert(lists:member(beamtalk_xref, Ids)),
     ?assert(lists:member(beamtalk_bootstrap, Ids)),
     ?assert(lists:member(beamtalk_stdlib, Ids)),
     ?assert(lists:member(beamtalk_object_instances, Ids)),
@@ -53,28 +56,38 @@ children_ids_test() ->
 children_are_workers_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    %% First three children are workers; subprocess_sup and reactive_subprocess_sup are supervisors; trace_store is worker
+    %% xref (worker), bootstrap, stdlib, object_instances are workers; subprocess_sup
+    %% and reactive_subprocess_sup are supervisors; trace_store is worker.
     Types = [maps:get(type, Spec) || Spec <- ChildSpecs],
-    ?assertEqual([worker, worker, worker, supervisor, supervisor, worker], Types).
+    ?assertEqual(
+        [worker, worker, worker, worker, supervisor, supervisor, worker],
+        Types
+    ).
 
 children_are_permanent_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
     %% All children should have permanent restart
     RestartTypes = [maps:get(restart, Spec) || Spec <- ChildSpecs],
-    ?assertEqual([permanent, permanent, permanent, permanent, permanent, permanent], RestartTypes).
+    ?assertEqual(
+        lists:duplicate(7, permanent),
+        RestartTypes
+    ).
 
 %%% Child ordering tests
-%%% Order matters: bootstrap must start before stdlib (which registers classes),
-%%% and stdlib must complete before instances tracking starts.
+%%% Order matters per ADR 0087: xref MUST be the first non-pg child so its
+%%% ETS tables exist before any register_class/0 runs in bootstrap or stdlib.
+%%% Then bootstrap → stdlib → object_instances → ...
 
 children_ordered_correctly_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    %% Verify ordering: bootstrap -> stdlib -> instances -> subprocess_sup -> reactive_subprocess_sup -> trace_store
+    %% Verify ordering: xref -> bootstrap -> stdlib -> instances -> subprocess_sup
+    %% -> reactive_subprocess_sup -> trace_store
     Ids = [maps:get(id, Spec) || Spec <- ChildSpecs],
     ?assertEqual(
         [
+            beamtalk_xref,
             beamtalk_bootstrap,
             beamtalk_stdlib,
             beamtalk_object_instances,
@@ -87,10 +100,23 @@ children_ordered_correctly_test() ->
 
 %%% Child specifications tests
 
+xref_child_spec_test() ->
+    %% ADR 0087: beamtalk_xref MUST be the first non-pg child.
+    {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
+
+    [XrefSpec | _] = ChildSpecs,
+    ?assertEqual(beamtalk_xref, maps:get(id, XrefSpec)),
+    ?assertEqual({beamtalk_xref, start_link, []}, maps:get(start, XrefSpec)),
+    ?assertEqual(permanent, maps:get(restart, XrefSpec)),
+    ?assertEqual(5000, maps:get(shutdown, XrefSpec)),
+    ?assertEqual(worker, maps:get(type, XrefSpec)),
+    ?assertEqual([beamtalk_xref], maps:get(modules, XrefSpec)).
+
 bootstrap_child_spec_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
     [
+        _XrefSpec,
         BootstrapSpec,
         _StdlibSpec,
         _InstancesSpec,
@@ -109,6 +135,7 @@ instances_child_spec_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
     [
+        _XrefSpec,
         _BootstrapSpec,
         _StdlibSpec,
         InstancesSpec,
@@ -127,6 +154,7 @@ stdlib_child_spec_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
     [
+        _XrefSpec,
         _BootstrapSpec,
         StdlibSpec,
         _InstancesSpec,
@@ -145,6 +173,7 @@ subprocess_sup_child_spec_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
     [
+        _XrefSpec,
         _BootstrapSpec,
         _StdlibSpec,
         _InstancesSpec,
@@ -163,6 +192,7 @@ reactive_subprocess_sup_child_spec_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
     [
+        _XrefSpec,
         _BootstrapSpec,
         _StdlibSpec,
         _InstancesSpec,
@@ -183,7 +213,7 @@ reactive_subprocess_sup_child_spec_test() ->
 
 init_returns_proper_format_test() ->
     Result = beamtalk_runtime_sup:init([]),
-    ?assertMatch({ok, {#{strategy := one_for_one}, [_, _, _, _, _, _]}}, Result).
+    ?assertMatch({ok, {#{strategy := one_for_one}, [_, _, _, _, _, _, _]}}, Result).
 
 %%% Behavioral tests
 
@@ -215,6 +245,7 @@ all_children_alive_test() ->
 
         %% Verify each child has correct ID and is alive
         ExpectedIds = [
+            beamtalk_xref,
             beamtalk_bootstrap,
             beamtalk_stdlib,
             beamtalk_object_instances,

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_xref_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_xref_tests.erl
@@ -1,0 +1,489 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_xref_tests).
+
+-moduledoc """
+EUnit tests for `beamtalk_xref` (BT-2297 / ADR 0087 Phase 1).
+
+Covers: insert via register_class/2, query via the four read APIs,
+purge via purge_class/1, per-class generation increments, put_method/4
+isolation, and concurrent reader during a write.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Setup / teardown
+%%====================================================================
+
+setup() ->
+    %% Use an already-running supervised server when one exists (the runtime
+    %% app starts xref under the supervisor); otherwise stand a fresh one up
+    %% for tests that run outside the application.
+    Pid =
+        case whereis(beamtalk_xref) of
+            undefined ->
+                {ok, P} = beamtalk_xref:start_link(),
+                P;
+            P ->
+                P
+        end,
+    %% Start each test from a clean slate. This protects against bleed-through
+    %% when EUnit groups multiple test_ generators under one fixture and from
+    %% a stale supervised process surviving an earlier failure.
+    clear_all_tables(),
+    Pid.
+
+cleanup(_Pid) ->
+    %% Don't stop the server — supervised in the runtime app. Clear all rows
+    %% so the next test starts empty even if it picks up the same gen_server.
+    clear_all_tables(),
+    ok.
+
+clear_all_tables() ->
+    %% The tables are `protected` (owned by the gen_server, only the owner can
+    %% write), so route the clears through the owning process. Phase 1 doesn't
+    %% expose a public clear API yet (lands with the Phase 4 sweep); for tests
+    %% we ride sys:replace_state to mutate from inside the gen_server.
+    try
+        sys:replace_state(beamtalk_xref, fun(S) ->
+            ets:delete_all_objects(beamtalk_xref_methods),
+            ets:delete_all_objects(beamtalk_xref_senders),
+            ets:delete_all_objects(beamtalk_xref_references),
+            ets:delete_all_objects(xref_class_gen),
+            S
+        end)
+    catch
+        _:_ -> ok
+    end,
+    ok.
+
+%%====================================================================
+%% Fixtures
+%%====================================================================
+
+counter_xref() ->
+    %% Hand-rolled method_xref payload mimicking what codegen will emit in
+    %% Phase 2 — gives the read APIs something to match against.
+    [
+        #{
+            class_side => false,
+            selector => 'increment',
+            line => 14,
+            sends => [
+                #{selector => '+', line => 17, recv_kind => self_recv}
+            ],
+            references => [
+                #{class => 'Integer', line => 16}
+            ],
+            source_status => indexed,
+            provenance => class_body
+        },
+        #{
+            class_side => false,
+            selector => 'value',
+            line => 22,
+            sends => [],
+            references => [],
+            source_status => indexed,
+            provenance => class_body
+        },
+        #{
+            class_side => true,
+            selector => 'new',
+            line => 8,
+            sends => [
+                #{selector => 'basicNew', line => 9, recv_kind => super_recv}
+            ],
+            references => [],
+            source_status => indexed,
+            provenance => class_body
+        }
+    ].
+
+point_xref() ->
+    [
+        #{
+            class_side => false,
+            selector => 'distanceTo:',
+            line => 30,
+            sends => [
+                #{selector => '+', line => 32, recv_kind => self_recv},
+                #{selector => 'sqrt', line => 33, recv_kind => other}
+            ],
+            references => [
+                #{class => 'Integer', line => 31}
+            ]
+        }
+    ].
+
+%%====================================================================
+%% register_class / read APIs
+%%====================================================================
+
+register_and_read_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+
+                %% defined_selectors
+                Instance = lists:sort(beamtalk_xref:defined_selectors('Counter', false)),
+                ?assertEqual(['increment', 'value'], Instance),
+                ?assertEqual(['new'], beamtalk_xref:defined_selectors('Counter', true)),
+                ?assertEqual([], beamtalk_xref:defined_selectors('NoSuchClass', false)),
+
+                %% implementors_of
+                ?assertEqual([{'Counter', false}], beamtalk_xref:implementors_of('increment')),
+                ?assertEqual([{'Counter', true}], beamtalk_xref:implementors_of('new')),
+                ?assertEqual([], beamtalk_xref:implementors_of('noSuchSelector')),
+
+                %% senders_of
+                PlusSites = beamtalk_xref:senders_of('+'),
+                ?assertEqual(1, length(PlusSites)),
+                [PlusSite] = PlusSites,
+                ?assertEqual('Counter', maps:get(owner, PlusSite)),
+                ?assertEqual('increment', maps:get(method, PlusSite)),
+                ?assertEqual(false, maps:get(class_side, PlusSite)),
+                ?assertEqual(self_recv, maps:get(recv_kind, PlusSite)),
+                ?assertEqual(17, maps:get(line, PlusSite)),
+                ?assertEqual(1, maps:get(gen, PlusSite)),
+
+                BasicNewSites = beamtalk_xref:senders_of('basicNew'),
+                ?assertEqual(1, length(BasicNewSites)),
+                [BasicNewSite] = BasicNewSites,
+                ?assertEqual(true, maps:get(class_side, BasicNewSite)),
+                ?assertEqual(super_recv, maps:get(recv_kind, BasicNewSite)),
+
+                %% references_to
+                IntRefs = beamtalk_xref:references_to('Integer'),
+                ?assertEqual(1, length(IntRefs)),
+                [IntRef] = IntRefs,
+                ?assertEqual('Counter', maps:get(owner, IntRef)),
+                ?assertEqual('increment', maps:get(method, IntRef)),
+                ?assertEqual([], beamtalk_xref:references_to('NoSuchClass'))
+            end)
+        ]
+    end}.
+
+multi_class_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+                ok = beamtalk_xref:register_class('Point', point_xref()),
+
+                %% Both classes contribute to senders_of('+').
+                PlusSites = beamtalk_xref:senders_of('+'),
+                ?assertEqual(2, length(PlusSites)),
+                Owners = lists:sort([maps:get(owner, S) || S <- PlusSites]),
+                ?assertEqual(['Counter', 'Point'], Owners),
+
+                %% Both classes reference Integer.
+                IntRefs = beamtalk_xref:references_to('Integer'),
+                ?assertEqual(2, length(IntRefs)),
+
+                %% implementors_of is class-specific.
+                ?assertEqual([{'Point', false}], beamtalk_xref:implementors_of('distanceTo:'))
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% purge_class
+%%====================================================================
+
+purge_class_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+                ok = beamtalk_xref:register_class('Point', point_xref()),
+
+                ?assertEqual(2, length(beamtalk_xref:senders_of('+'))),
+
+                ok = beamtalk_xref:purge_class('Counter'),
+
+                %% Counter rows are gone, Point rows remain.
+                ?assertEqual([], beamtalk_xref:defined_selectors('Counter', false)),
+                ?assertEqual([], beamtalk_xref:defined_selectors('Counter', true)),
+                ?assertEqual([], beamtalk_xref:implementors_of('increment')),
+                ?assertEqual([], beamtalk_xref:implementors_of('new')),
+
+                PlusSites = beamtalk_xref:senders_of('+'),
+                ?assertEqual(1, length(PlusSites)),
+                [Site] = PlusSites,
+                ?assertEqual('Point', maps:get(owner, Site)),
+
+                IntRefs = beamtalk_xref:references_to('Integer'),
+                ?assertEqual(1, length(IntRefs)),
+                [IntRef] = IntRefs,
+                ?assertEqual('Point', maps:get(owner, IntRef)),
+
+                %% Purging an unknown class is a no-op.
+                ok = beamtalk_xref:purge_class('NoSuchClass')
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Generation counter
+%%====================================================================
+
+generation_increments_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+                Gen1 = current_gen('Counter'),
+                ?assertEqual(1, Gen1),
+
+                %% Inspect the gen embedded in a senders row.
+                [Site1] = beamtalk_xref:senders_of('basicNew'),
+                ?assertEqual(1, maps:get(gen, Site1)),
+
+                %% Re-register bumps the gen.
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+                ?assertEqual(2, current_gen('Counter')),
+
+                %% put_method also bumps the gen.
+                NewEntry = #{
+                    class_side => false,
+                    selector => 'increment',
+                    line => 14,
+                    sends => [],
+                    references => [],
+                    source_status => indexed,
+                    provenance => put_method
+                },
+                ok = beamtalk_xref:put_method('Counter', false, 'increment', NewEntry),
+                ?assertEqual(3, current_gen('Counter')),
+
+                %% A fresh class starts at gen 1.
+                ok = beamtalk_xref:register_class('Point', point_xref()),
+                ?assertEqual(1, current_gen('Point'))
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% put_method isolation
+%%====================================================================
+
+put_method_replaces_one_method_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+
+                %% Sanity: the sibling 'value' method is present and 'increment'
+                %% sends '+'.
+                ?assert(lists:member('value', beamtalk_xref:defined_selectors('Counter', false))),
+                ?assertEqual(1, length(beamtalk_xref:senders_of('+'))),
+
+                %% Replace `increment` with a version that sends `-` instead.
+                NewEntry = #{
+                    class_side => false,
+                    selector => 'increment',
+                    line => 14,
+                    sends => [
+                        #{selector => '-', line => 17, recv_kind => self_recv}
+                    ],
+                    references => [
+                        #{class => 'Float', line => 16}
+                    ],
+                    source_status => indexed,
+                    provenance => put_method
+                },
+                ok = beamtalk_xref:put_method('Counter', false, 'increment', NewEntry),
+
+                %% Sibling `value` untouched.
+                ?assert(lists:member('value', beamtalk_xref:defined_selectors('Counter', false))),
+                %% Class-side `new` untouched.
+                ?assertEqual(['new'], beamtalk_xref:defined_selectors('Counter', true)),
+                %% Class-side `basicNew` site preserved (was on `new`, not `increment`).
+                ?assertEqual(1, length(beamtalk_xref:senders_of('basicNew'))),
+
+                %% Old `+` send from `increment` is gone, new `-` send is present.
+                ?assertEqual([], beamtalk_xref:senders_of('+')),
+                MinusSites = beamtalk_xref:senders_of('-'),
+                ?assertEqual(1, length(MinusSites)),
+                [MinusSite] = MinusSites,
+                ?assertEqual('increment', maps:get(method, MinusSite)),
+
+                %% References updated: Integer dropped, Float added.
+                ?assertEqual([], beamtalk_xref:references_to('Integer')),
+                FloatRefs = beamtalk_xref:references_to('Float'),
+                ?assertEqual(1, length(FloatRefs))
+            end)
+        ]
+    end}.
+
+put_method_normalises_selector_and_side_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+
+                %% Even if the entry omits class_side/selector or has stale
+                %% values, the call args win — the entry is addressed by
+                %% {Class, ClassSide, Selector}.
+                BareEntry = #{
+                    line => 20,
+                    sends => [#{selector => 'foo', line => 21}],
+                    references => [],
+                    source_status => indexed,
+                    provenance => put_method
+                },
+                ok = beamtalk_xref:put_method('Counter', false, 'value', BareEntry),
+
+                %% The row lands under 'value', not under whatever was in the map.
+                ?assert(lists:member('value', beamtalk_xref:defined_selectors('Counter', false))),
+                FooSites = beamtalk_xref:senders_of('foo'),
+                ?assertEqual(1, length(FooSites)),
+                [FooSite] = FooSites,
+                ?assertEqual('value', maps:get(method, FooSite)),
+                ?assertEqual(false, maps:get(class_side, FooSite))
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Concurrent reader during write
+%%====================================================================
+
+concurrent_reader_during_write_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            {timeout, 30,
+                ?_test(begin
+                    %% Seed the table so the reader always has something to
+                    %% observe — even before any writer's first call lands.
+                    ok = beamtalk_xref:register_class('Counter', counter_xref()),
+
+                    Parent = self(),
+                    Writers = 4,
+                    Iterations = 50,
+
+                    %% Spawn writers that repeatedly register_class — each call
+                    %% bumps the per-class gen and re-inserts rows.
+                    WriterPids = [
+                        spawn_link(fun() ->
+                            lists:foreach(
+                                fun(_) ->
+                                    ok = beamtalk_xref:register_class('Counter', counter_xref())
+                                end,
+                                lists:seq(1, Iterations)
+                            ),
+                            Parent ! {writer_done, self()}
+                        end)
+                     || _ <- lists:seq(1, Writers)
+                    ],
+
+                    %% Reader runs concurrently and must see a non-empty,
+                    %% well-formed view at every observation. Phase 1
+                    %% guarantees `register_class` always leaves rows in the
+                    %% table (delete-then-reinsert under a single gen_server
+                    %% call would expose a gap; we instead just insert under
+                    %% a new gen — old rows stay until purge), so the reader
+                    %% never sees an empty Counter view between writes.
+                    ReaderPid = spawn_link(fun() -> reader_loop(Parent) end),
+
+                    lists:foreach(
+                        fun(_) ->
+                            receive
+                                {writer_done, _} -> ok
+                            after 10000 ->
+                                ?assert(false)
+                            end
+                        end,
+                        WriterPids
+                    ),
+
+                    %% Tell the reader the writers are done; it should also
+                    %% finish soon after.
+                    ReaderPid ! stop,
+                    receive
+                        {reader_done, Count, Errors} ->
+                            ?assert(Count > 0),
+                            ?assertEqual([], Errors)
+                    after 10000 ->
+                        ?assert(false)
+                    end,
+
+                    %% Final consistency check: the table is non-empty and gen
+                    %% is at least 1 (in fact >= Writers*Iterations + 1, but
+                    %% we don't assume that to keep the test robust).
+                    ?assert(current_gen('Counter') >= 1),
+                    ?assertNotEqual([], beamtalk_xref:defined_selectors('Counter', false))
+                end)}
+        ]
+    end}.
+
+reader_loop(Parent) ->
+    reader_loop(Parent, 0, []).
+
+reader_loop(Parent, Count, Errors) ->
+    receive
+        stop ->
+            Parent ! {reader_done, Count, lists:reverse(Errors)}
+    after 0 ->
+        NewErrors =
+            case check_counter_view() of
+                ok -> Errors;
+                {error, Reason} -> [Reason | Errors]
+            end,
+        reader_loop(Parent, Count + 1, NewErrors)
+    end.
+
+check_counter_view() ->
+    %% Snapshot the four read APIs and assert they agree internally.
+    %% The Phase 1 invariant: once a class is registered, subsequent
+    %% writers under that class never observe an empty view because each
+    %% register_class call appends new rows under a higher gen before
+    %% the supervisor sweep (Phase 4) runs.
+    InstSels = beamtalk_xref:defined_selectors('Counter', false),
+    ClassSels = beamtalk_xref:defined_selectors('Counter', true),
+    Impl = beamtalk_xref:implementors_of('increment'),
+    PlusSites = beamtalk_xref:senders_of('+'),
+    IntRefs = beamtalk_xref:references_to('Integer'),
+
+    HasIncrement = lists:member('increment', InstSels),
+    HasValue = lists:member('value', InstSels),
+    HasNew = lists:member('new', ClassSels),
+    HasImpl = lists:member({'Counter', false}, Impl),
+    HasPlusSite = lists:any(
+        fun(S) -> maps:get(owner, S, undefined) =:= 'Counter' end,
+        PlusSites
+    ),
+    HasIntRef = lists:any(
+        fun(S) -> maps:get(owner, S, undefined) =:= 'Counter' end,
+        IntRefs
+    ),
+
+    case
+        HasIncrement andalso HasValue andalso HasNew andalso
+            HasImpl andalso HasPlusSite andalso HasIntRef
+    of
+        true ->
+            ok;
+        false ->
+            {error, #{
+                instance_selectors => InstSels,
+                class_selectors => ClassSels,
+                implementors => Impl,
+                plus_sites_count => length(PlusSites),
+                int_refs_count => length(IntRefs)
+            }}
+    end.
+
+%%====================================================================
+%% Internal helpers
+%%====================================================================
+
+current_gen(Class) ->
+    case ets:lookup(xref_class_gen, Class) of
+        [] -> 0;
+        [{_, Gen}] -> Gen
+    end.


### PR DESCRIPTION
## Summary

Phase 1 of ADR 0087 — the maintained selector→sites xref index for SystemNavigation queries.

- New `beamtalk_xref` gen_server with four ETS tables (`beamtalk_xref_methods`, `beamtalk_xref_senders`, `beamtalk_xref_references`, `xref_class_gen`) — all `protected, named_table, {read_concurrency, true}`
- **Write API**: `register_class/2`, `purge_class/1`, `put_method/4` with per-class generation counter for atomic publish (ADR 0087 §Atomicity)
- **Read API**: `senders_of/1`, `references_to/1`, `implementors_of/1`, `defined_selectors/2` — direct ETS lookups bypassing the gen_server
- **Supervisor wiring**: `beamtalk_xref` is the first non-pg child of `beamtalk_runtime_sup`, ahead of `beamtalk_bootstrap` and `beamtalk_stdlib` (ADR 0087 bootstrap ordering invariant)
- EUnit tests covering all acceptance criteria: register/read, multi-class, purge, generation increments, put_method isolation, concurrent reader during write
- Updated `beamtalk_runtime_sup_tests` for new 7-child ordering

## Test plan

- [x] `rebar3 eunit --module=beamtalk_xref_tests` — 7 tests, 0 failures
- [x] `rebar3 eunit --module=beamtalk_runtime_sup_tests` — 17 tests, 0 failures
- [x] Full runtime eunit suite — no new failures vs baseline (340 pre-existing)
- [x] `just build` — clean
- [x] `just clippy` — clean
- [x] `just fmt-check` — clean
- [x] `rebar3 fmt --check` — clean

**Linear:** https://linear.app/beamtalk/issue/BT-2297
**ADR:** docs/ADR/0087-maintained-xref-index-for-system-navigation.md
**Epic:** BT-2228

https://claude.ai/code/session_017ik9CtvPqsnmZpBFfYReX2