### PR TITLE
Remove 7 format!() violations in CE variable-name generators (BT-2305)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -1549,11 +1549,7 @@ impl CoreErlangGenerator {
             self.state_threading.current_var()
         } else if self.in_loop_body {
             // Normal loop body: use StateAcc* nomenclature
-            if self.state_threading.version() == 0 {
-                "StateAcc".to_string()
-            } else {
-                format!("StateAcc{}", self.state_threading.version())
-            }
+            util::versioned_var("StateAcc", self.state_threading.version())
         } else {
             // Normal context - use State nomenclature
             self.state_threading.current_var()
@@ -1637,12 +1633,7 @@ impl CoreErlangGenerator {
 
     /// BT-412: Returns the current class variable state variable name.
     fn current_class_var(&self) -> String {
-        let version = self.class_var_version();
-        if version == 0 {
-            "ClassVars".to_string()
-        } else {
-            format!("ClassVars{version}")
-        }
+        util::versioned_var("ClassVars", self.class_var_version())
     }
 
     /// BT-412: Increments class var version and returns the new variable name.
@@ -1650,7 +1641,7 @@ impl CoreErlangGenerator {
         let new_version = self.class_var_version() + 1;
         self.set_class_var_version(new_version);
         self.set_class_var_mutated(true);
-        format!("ClassVars{new_version}")
+        util::versioned_var("ClassVars", new_version)
     }
 
     /// BT-833: Returns the current Self variable name for value type Self-threading.
@@ -1658,19 +1649,14 @@ impl CoreErlangGenerator {
     /// Version 0 → `"Self"` (the original method parameter).
     /// Version N → `"Self{N}"` (after N field assignments have threaded a new snapshot).
     pub(super) fn current_self_var(&self) -> String {
-        let version = self.self_version();
-        if version == 0 {
-            "Self".to_string()
-        } else {
-            format!("Self{version}")
-        }
+        util::versioned_var("Self", self.self_version())
     }
 
     /// BT-833: Increments the Self version and returns the new variable name.
     pub(super) fn next_self_var(&mut self) -> String {
         let new_version = self.self_version() + 1;
         self.set_self_version(new_version);
-        format!("Self{new_version}")
+        util::versioned_var("Self", new_version)
     }
 
     /// BT-855: Records a structured diagnostic warning for the current module.

--- a/crates/beamtalk-core/src/codegen/core_erlang/state_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/state_codegen.rs
@@ -63,11 +63,7 @@ impl StateThreading {
     /// - Version 2 → `"State2"`
     /// - etc.
     pub(super) fn current_var(&self) -> String {
-        if self.version == 0 {
-            "State".to_string()
-        } else {
-            format!("State{}", self.version)
-        }
+        super::util::versioned_var("State", self.version)
     }
 
     /// Increments the state version and returns the new state variable name.
@@ -92,8 +88,7 @@ impl StateThreading {
     /// version counter.  Used when the caller needs to know the name before
     /// calling `expression_doc` (which may itself advance state).
     pub(super) fn peek_next_var(&self) -> String {
-        let next = self.version + 1;
-        format!("State{next}")
+        super::util::versioned_var("State", self.version + 1)
     }
 
     /// Resets the state version to 0.

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -10,10 +10,42 @@
 //! - Name conversions (class names, module names)
 //! - Class identity (DDD Value Object bundling module + class names)
 
+use std::fmt::Write as _;
+
 use super::document::{Document, join};
 use super::{CoreErlangGenerator, Result};
 use crate::ast::{ClassDefinition, Expression, ExpressionStatement};
 use crate::docvec;
+
+/// Builds a versioned Core Erlang variable name.
+///
+/// Returns `prefix` when `version == 0`, otherwise `prefix{version}`
+/// (e.g. `"State"`, `"State1"`, `"StateAcc2"`, `"ClassVars1"`, `"Self3"`).
+///
+/// Uses [`std::fmt::Write`] on a pre-allocated buffer rather than `format!()`
+/// to comply with CLAUDE.md: "NEVER use `format!()` to produce Core Erlang
+/// fragments."  See also: `variable_context::VariableContext::fresh_var` which
+/// uses the same `write!` pattern (introduced in BT-875).
+///
+/// # Examples
+///
+/// ```ignore
+/// assert_eq!(versioned_var("State", 0), "State");
+/// assert_eq!(versioned_var("State", 1), "State1");
+/// assert_eq!(versioned_var("StateAcc", 2), "StateAcc2");
+/// ```
+pub(super) fn versioned_var(prefix: &str, version: usize) -> String {
+    if version == 0 {
+        prefix.to_string()
+    } else {
+        // Pre-allocate: prefix length + up to 4 digits (handles version ≤ 9999).
+        let mut s = String::with_capacity(prefix.len() + 4);
+        s.push_str(prefix);
+        // Write the counter directly instead of using format!.
+        let _ = write!(s, "{version}");
+        s
+    }
+}
 
 /// Escapes a string for use inside a Core Erlang double-quoted string literal.
 ///
@@ -445,5 +477,29 @@ mod tests {
             escape_core_erlang_string("C:\\Users\\foo\\bar.bt"),
             "C:\\\\Users\\\\foo\\\\bar.bt"
         );
+    }
+
+    #[test]
+    fn test_versioned_var_version_zero_returns_prefix() {
+        assert_eq!(versioned_var("State", 0), "State");
+        assert_eq!(versioned_var("StateAcc", 0), "StateAcc");
+        assert_eq!(versioned_var("ClassVars", 0), "ClassVars");
+        assert_eq!(versioned_var("Self", 0), "Self");
+    }
+
+    #[test]
+    fn test_versioned_var_appends_version_number() {
+        assert_eq!(versioned_var("State", 1), "State1");
+        assert_eq!(versioned_var("State", 2), "State2");
+        assert_eq!(versioned_var("StateAcc", 1), "StateAcc1");
+        assert_eq!(versioned_var("ClassVars", 3), "ClassVars3");
+        assert_eq!(versioned_var("Self", 5), "Self5");
+    }
+
+    #[test]
+    fn test_versioned_var_large_version() {
+        // Verify capacity pre-allocation does not truncate for larger versions.
+        assert_eq!(versioned_var("State", 100), "State100");
+        assert_eq!(versioned_var("State", 9999), "State9999");
     }
 }


### PR DESCRIPTION
## Summary

- Add `versioned_var(prefix, version)` helper to `util.rs` using `write!` instead of `format!()`, matching the pattern established in `variable_context.rs` during BT-875
- Replace all 7 `format!()` call sites that build Core Erlang variable names (`State1`, `StateAcc2`, `ClassVars1`, `Self1`) across `state_codegen.rs` and `mod.rs`
- Generated `.core` output is byte-for-byte identical — only the string-construction mechanism changes

## Context

BT-875 cleaned up `format!()` usage in Core Erlang codegen but missed 7 violations in `state_codegen.rs` and `mod.rs`. These all build CE variable-name strings and embed them as `Document::String(...)` in `docvec!` output, violating CLAUDE.md:

> "NEVER use `format!()` or string concatenation to produce Core Erlang fragments"

## Files Changed

| File | Changes |
|------|---------|
| `util.rs` | Added `versioned_var` helper + 3 unit tests |
| `state_codegen.rs` | Replaced 2 `format!()` calls with `versioned_var` delegation |
| `mod.rs` | Replaced 5 `format!()` calls with `versioned_var` |

## Test plan

- [x] `cargo test` — all unit tests pass including new `versioned_var` tests
- [x] `just build` — Rust + Erlang + stdlib build clean
- [x] `just clippy` — no warnings
- [x] `just fmt-check` — formatting clean
- [x] `just ci` — full CI passes (pre-push hook verified)
- [x] No `format!()` remains in state variable name generators

https://linear.app/beamtalk/issue/BT-2305

https://claude.ai/code/session_018GvtYJaG35z6LZ21mdNxwn

---
_Generated by [Claude Code](https://claude.ai/code/session_018GvtYJaG35z6LZ21mdNxwn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated variable naming logic in Core Erlang code generation to improve maintainability and consistency across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->