### PR TITLE
Add async FuturePid path tests for beamtalk_transcript_stream (BT-2306)

### DIFF
--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_transcript_stream_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_transcript_stream_tests.erl
@@ -434,3 +434,176 @@ sync_show_then_clear_test() ->
     Result = gen_server:call(Pid, recent),
     ?assertEqual([], Result),
     gen_server:stop(Pid).
+
+%%% ============================================================================
+%%% Async FuturePid path tests — handle_cast/2 actor-protocol clauses (BT-2306)
+%%%
+%%% These cover the {Selector, Args, FuturePid} 3-tuple form that compiled
+%%% Beamtalk actors use when sending async messages to TranscriptStream.
+%%% Pattern: create a future, cast the message, await the resolved value.
+%%% ============================================================================
+
+%% --- async show: resolves future with self-ref ---
+
+async_show_resolves_future_test() ->
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    Future = beamtalk_future:new(),
+    FuturePid = beamtalk_future:pid(Future),
+    gen_server:cast(Pid, {'show:', [<<"async_hello">>], FuturePid}),
+    SelfRef = beamtalk_future:await(Future, 1000),
+    ?assertMatch({beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, Pid}, SelfRef),
+    %% Text must also appear in the buffer
+    Result = gen_server:call(Pid, recent),
+    ?assertEqual([<<"async_hello">>], Result),
+    gen_server:stop(Pid).
+
+async_show_converts_integer_async_test() ->
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    Future = beamtalk_future:new(),
+    FuturePid = beamtalk_future:pid(Future),
+    gen_server:cast(Pid, {'show:', [99], FuturePid}),
+    _ = beamtalk_future:await(Future, 1000),
+    Result = gen_server:call(Pid, recent),
+    ?assertEqual([<<"99">>], Result),
+    gen_server:stop(Pid).
+
+%% --- async show: notifies subscribers ---
+
+async_show_notifies_subscriber_test() ->
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    %% Subscribe via direct cast so self() is the subscriber
+    gen_server:cast(Pid, {subscribe, self()}),
+    _ = gen_server:call(Pid, recent),  %% sync barrier — ensure subscribe processed
+    Future = beamtalk_future:new(),
+    FuturePid = beamtalk_future:pid(Future),
+    gen_server:cast(Pid, {'show:', [<<"async_msg">>], FuturePid}),
+    _ = beamtalk_future:await(Future, 1000),
+    receive
+        {transcript_output, <<"async_msg">>} -> ok
+    after 500 ->
+        ?assert(false)
+    end,
+    flush_transcript(),
+    gen_server:stop(Pid).
+
+%% --- async cr resolves future with self-ref ---
+
+async_cr_resolves_future_test() ->
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    Future = beamtalk_future:new(),
+    FuturePid = beamtalk_future:pid(Future),
+    gen_server:cast(Pid, {cr, [], FuturePid}),
+    SelfRef = beamtalk_future:await(Future, 1000),
+    ?assertMatch({beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, Pid}, SelfRef),
+    Result = gen_server:call(Pid, recent),
+    ?assertEqual([<<"\n">>], Result),
+    gen_server:stop(Pid).
+
+%% --- async recent resolves future with buffer list ---
+
+async_recent_resolves_future_test() ->
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    _ = gen_server:call(Pid, {'show:', [<<"a">>]}),
+    _ = gen_server:call(Pid, {'show:', [<<"b">>]}),
+    Future = beamtalk_future:new(),
+    FuturePid = beamtalk_future:pid(Future),
+    gen_server:cast(Pid, {recent, [], FuturePid}),
+    Result = beamtalk_future:await(Future, 1000),
+    ?assertEqual([<<"a">>, <<"b">>], Result),
+    gen_server:stop(Pid).
+
+%% --- async clear resolves future with self-ref and empties buffer ---
+
+async_clear_resolves_future_test() ->
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    _ = gen_server:call(Pid, {'show:', [<<"data">>]}),
+    Future = beamtalk_future:new(),
+    FuturePid = beamtalk_future:pid(Future),
+    gen_server:cast(Pid, {clear, [], FuturePid}),
+    SelfRef = beamtalk_future:await(Future, 1000),
+    ?assertMatch({beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, Pid}, SelfRef),
+    Result = gen_server:call(Pid, recent),
+    ?assertEqual([], Result),
+    gen_server:stop(Pid).
+
+%% --- async subscribe resolves future with self-ref ---
+
+async_subscribe_resolves_future_test() ->
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    Future = beamtalk_future:new(),
+    FuturePid = beamtalk_future:pid(Future),
+    gen_server:cast(Pid, {subscribe, [], FuturePid}),
+    SelfRef = beamtalk_future:await(Future, 1000),
+    ?assertMatch({beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, Pid}, SelfRef),
+    gen_server:stop(Pid).
+
+%% --- async unsubscribe resolves future with self-ref ---
+
+async_unsubscribe_resolves_future_test() ->
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    SubFuture = beamtalk_future:new(),
+    SubFuturePid = beamtalk_future:pid(SubFuture),
+    gen_server:cast(Pid, {subscribe, [], SubFuturePid}),
+    _ = beamtalk_future:await(SubFuture, 1000),
+    UnsubFuture = beamtalk_future:new(),
+    UnsubFuturePid = beamtalk_future:pid(UnsubFuture),
+    gen_server:cast(Pid, {unsubscribe, [], UnsubFuturePid}),
+    SelfRef = beamtalk_future:await(UnsubFuture, 1000),
+    ?assertMatch({beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, Pid}, SelfRef),
+    gen_server:stop(Pid).
+
+%%% ============================================================================
+%%% Context-propagation strip — 4-tuple {Selector, Args, FuturePid, PropCtx}
+%%% (ADR 0069 Phase 2b) BT-2306
+%%% ============================================================================
+
+async_context_strip_delegates_test() ->
+    %% A 4-tuple with a PropCtx map should strip the context and fall through
+    %% to the matching 3-tuple clause. Use show: so we can verify buffering.
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    Future = beamtalk_future:new(),
+    FuturePid = beamtalk_future:pid(Future),
+    PropCtx = #{},
+    gen_server:cast(Pid, {'show:', [<<"ctx_stripped">>], FuturePid, PropCtx}),
+    SelfRef = beamtalk_future:await(Future, 1000),
+    ?assertMatch({beamtalk_object, 'TranscriptStream', beamtalk_transcript_stream, Pid}, SelfRef),
+    Result = gen_server:call(Pid, recent),
+    ?assertEqual([<<"ctx_stripped">>], Result),
+    gen_server:stop(Pid).
+
+%%% ============================================================================
+%%% Catch-all paths — BT-2306
+%%% ============================================================================
+
+%% --- handle_cast(_Msg, State) — unknown cast is a silent no-op ---
+
+async_unknown_cast_noop_test() ->
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    gen_server:cast(Pid, totally_unknown_garbage),
+    %% Sync barrier: if the server crashed, this call would fail/timeout
+    Result = gen_server:call(Pid, recent),
+    ?assertEqual([], Result),
+    gen_server:stop(Pid).
+
+%% --- handle_call(Request, ...) DNU catch-all — bare non-tuple request ---
+
+sync_dnu_bare_request_test() ->
+    {ok, Pid} = beamtalk_transcript_stream:start_link(),
+    %% A bare atom that matches no known handle_call clause triggers the DNU fallback
+    Reply = gen_server:call(Pid, definitely_not_a_known_selector),
+    ?assertMatch({error, _}, Reply),
+    gen_server:stop(Pid).
+
+%%% ============================================================================
+%%% start_link/2 — named variant — BT-2306
+%%% ============================================================================
+
+start_link_named_variant_test() ->
+    Name = bt_ts_named_test_BT_2306,
+    {ok, Pid} = beamtalk_transcript_stream:start_link({local, Name}, 500),
+    ?assert(is_pid(Pid)),
+    ?assertEqual(Pid, whereis(Name)),
+    _ = gen_server:call(Name, {'show:', [<<"named_test">>]}),
+    Result = gen_server:call(Name, recent),
+    ?assertEqual([<<"named_test">>], Result),
+    gen_server:stop(Name).

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_transcript_stream_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_transcript_stream_tests.erl
@@ -473,7 +473,8 @@ async_show_notifies_subscriber_test() ->
     {ok, Pid} = beamtalk_transcript_stream:start_link(),
     %% Subscribe via direct cast so self() is the subscriber
     gen_server:cast(Pid, {subscribe, self()}),
-    _ = gen_server:call(Pid, recent),  %% sync barrier — ensure subscribe processed
+    %% sync barrier — ensure subscribe processed
+    _ = gen_server:call(Pid, recent),
     Future = beamtalk_future:new(),
     FuturePid = beamtalk_future:pid(Future),
     gen_server:cast(Pid, {'show:', [<<"async_msg">>], FuturePid}),


### PR DESCRIPTION
## Summary

Adds 12 EUnit tests covering the async `handle_cast` actor-protocol paths in `beamtalk_transcript_stream.erl` that had 0% coverage. These are the code paths used by compiled Beamtalk actors in production (via `beamtalk_actor:async_send/4`).\n\nLinear: https://linear.app/beamtalk/issue/BT-2306\n\n## Key changes\n\n- **Async show:** resolves future with self-ref, converts integers, notifies subscribers\n- **Async cr/recent/clear:** each resolves future correctly and updates buffer state\n- **Async subscribe/unsubscribe:** exercises `caller_from_future/1` path\n- **Context propagation strip:** 4-tuple `{Selector, Args, FuturePid, PropCtx}` delegates to 3-tuple (ADR 0069 Phase 2b)\n- **Catch-all paths:** unknown cast no-op, DNU bare request fallback\n- **`start_link/2` named variant:** registered name + message dispatch via name\n\nAll tests use `beamtalk_future:pid(Future)` to extract the bare pid for `gen_server:cast` (required by the `is_pid(FuturePid)` guards), while keeping the tagged tuple for `beamtalk_future:await/2`.\n\n## Test plan\n\n- [x] All 12 new tests pass (`rebar3 eunit --module=beamtalk_transcript_stream_tests` — 1391 tests, 0 failures)\n- [x] Full `just test` passes (5296 Rust + 250 stdlib + 2134 BUnit + 4173 runtime)\n- [x] Pre-push hooks pass (clippy, dialyzer, erlfmt, spec validation)"

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLjSmCGhUEPV4VCxKwAUHq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for async protocol handling, including async operations (`show`, `clear`, `subscribe`, `unsubscribe`) and context propagation scenarios.
  * Added tests for error handling of unknown async requests and unrecognized commands.
  * Added tests for named instance registration and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->