### PR TITLE
docs: daily refresh 2026-05-28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 - **`ChangeLog` and `ChangeEntry`** — new stdlib classes exposing the workspace ChangeLog as a navigable Beamtalk object (ADR 0082 Phase 1). `Workspace changes` returns a `ChangeLog` with collection protocol: `size`, `isEmpty`, `notEmpty`, `do:`, `select:`, `dirtyMethods`, `activeEntries`, `allEntries`. Each `ChangeEntry` wraps one logged patch with predicates (`isOrphan`, `isActive`, `isDurable`, `isEphemeral`, `isAgent`, `isHuman`, `isFlushable`, `isNewClass`) and accessors (`className`, `selector`, `kind`, `intent`, `authorKind`, `sourceFile`, `seq`). Default views reflect only active entries (current epoch, not orphaned); `select:` ranges over the full set (BT-2284).
 - **`ClassBuilder >> register` returns canonical class object** — previously returned an unusable wrapper that failed all dispatch; now returns the same shape as `classNamed:` (dispatchable, `isClass: true`, `==` to the registry reference) (BT-2258).
 - **`ClassBuilder` metadata parity setters** — `methodSignatures:`, `classMethodSignatures:`, `methodDocs:`, `classMethodDocs:`, `methodReturnTypes:`, `classMethodReturnTypes:`, `classDoc:`, `meta:`, and `isConstructible:` bring programmatically built classes to `:help` parity with file-defined ones (BT-2268).
+- **`Workspace newClass:at:`** — compiles and installs a brand-new class in memory from a source String and target path, logging a durable `new-class` ChangeEntry for later `Workspace flush`. Validates that the target does not already exist on disk, lies within the project source tree, matches the declared class name, and is not already loaded (BT-2285).
+- **`ChangeLog revert:` / `clear` / `flushKinds:` and `Workspace autoflush`** — `revert:` re-installs a ChangeEntry's previous method body via durable `compile:source:`, `clear` discards all pending entries without touching disk, and `flushKinds:` selectively flushes entries filtered by kind (`#instance`, `#class`, `#'new-class'`) and/or author kind (`#human`, `#agent`). `Workspace autoflush` / `autoflush:` is a persistent workspace setting that, when enabled, immediately flushes every successful durable in-memory patch to disk (BT-2290).
 
 ### Runtime
 
@@ -59,6 +61,8 @@
 - Harden module-less `ClassBuilder` instantiation — depth-guard logging on ancestor chain walks, deadlock-free self-dispatch for fun-backed instance methods inside the class gen_server, and robust ancestor exit handling (BT-2277).
 - Fix `selector_arity` for malformed selectors — interior-colon atoms (e.g. `'at:put'`) are now treated as unary instead of keyword, avoiding spurious `arity_mismatch` diagnostics (BT-2278).
 - **`beamtalk_workspace_changelog`** gen_server — workspace-local ChangeLog that records every live method patch as a crash-safe, session-aware change entry with two-part on-disk persistence (ADR 0082 Phase 1) (BT-2282).
+- **`Workspace flush` / `flush:`** — writes pending ChangeLog entries to disk via trivia-preserving byte-span splice (no AST reprint) with atomic rename, multi-file two-phase commit, and external-edit conflict detection. Method patches splice the new body into the exact byte span of the old one; new-class entries write the full source to the target path. Conflicts are reported per-file rather than raised as exceptions (BT-2286).
+- **`beamtalk_xref` gen_server** — maintained selector-to-sites cross-reference index for `SystemNavigation` queries (ADR 0087). Four ETS tables track method definitions, senders, references, and per-class generation counters. Reads hit ETS directly without serializing through the gen_server; writes serialize for atomic per-class publish (BT-2297).
 
 ### Tooling
 
@@ -70,6 +74,9 @@
 - Fix false-positive `Unresolved class` warnings in the LSP for classes defined in fetched dependencies — the LSP now preloads `.bt` files from `_build/deps/*/src/` (BT-2137).
 - Fix LSP `is_protocol_type` always returning `false` for registered protocols, causing false-positive type warnings on protocol-typed parameters (BT-2135).
 - **Redundant type annotation lint** — `name :: T := <expr>` is flagged when the inferred type of `<expr>` exactly matches `T`, since the annotation adds no information the type checker doesn't already have. Suppressible with `@expect type_annotation`. Skips unions and widening annotations where the annotation does real work (BT-2140).
+- **REPL `:flush` / `:changes` / `:dirty` meta-commands** — `:flush` desugars to `Workspace flush`, `:flush <arg>` to `Workspace flush: <arg>` (accepting a class name, symbol kind, or dictionary filter), `:changes` to `Workspace changes`, and `:dirty` to `Workspace changes dirtyMethods` (BT-2287).
+- **MCP `save_method` / `try_method` / `save_class` / `flush` / `list_changes` / `dirty_methods` tools** — six new MCP tools exposing the ADR 0082 ChangeLog and flush operations to IDE and agent clients. `save_method` and `try_method` install durable and ephemeral method patches respectively, `save_class` creates a new class via `Workspace newClass:at:`, `flush` writes pending changes to disk, and `list_changes` / `dirty_methods` query the ChangeLog (BT-2288).
+- **LSP `executeCommand` handlers and `workspace/applyEdit` on flush** — `beamtalk.flush`, `beamtalk.flush.class`, `beamtalk.flush.file`, `beamtalk.flush.kind`, and `beamtalk.saveClass` editor commands dispatch through the attached workspace. After flush the LSP emits `workspace/applyEdit` with a whole-document `TextEdit` for every flushed file currently open in the editor, so buffers refresh automatically (BT-2289).
 
 ### Internal
 
@@ -97,6 +104,7 @@
 - Unify Behaviour/Class/Metaclass primitive-lowering into a single `REGISTRY` table — tower classes share one function pointer so any tower selector resolves regardless of which class declares it, preventing the BT-2232 regression pattern where moving a method up the tower silently dropped its inline BIF (BT-2234).
 - Byte-span resolver validates that the parser can resolve exact method byte spans for flush-time splice replacement — 1347 methods across 161 files pass no-op round-trip (ADR 0082 Phase 0) (BT-2281).
 - Extract `kill_and_wait/1` and `delegate_error/1` helpers in `beamtalk_actor.erl` — zero behavior change (BT-2272).
+- Replace 7 `format!()` calls with `versioned_var` helper in Core Erlang variable-name generators — continues the BT-875 cleanup (BT-2305).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 21 commits merged since the last refresh (cad6b928, 2026-05-24).

### What changed

**CHANGELOG.md** — 8 new entries for ADR 0082 Phase 2–5 features and tooling surface that were missing:

- **Standard Library:** `Workspace newClass:at:` (BT-2285), `ChangeLog revert:/clear/flushKinds:` + `Workspace autoflush` (BT-2290)
- **Runtime:** `Workspace flush` byte-span splice + conflict detection (BT-2286), `beamtalk_xref` maintained index gen_server (BT-2297)
- **Tooling:** REPL `:flush`/`:changes`/`:dirty` meta-commands (BT-2287), MCP `save_method`/`try_method`/`save_class`/`flush`/`list_changes`/`dirty_methods` tools (BT-2288), LSP `executeCommand` handlers + `workspace/applyEdit` on flush (BT-2289)
- **Internal:** format!() cleanup continuation (BT-2305)

### Already up to date (no changes needed)

- `docs/beamtalk-language-features.md` — ClassBuilder section, class-side live patching, compile:source:/tryCompile:source:, ChangeLog/ChangeEntry/flush/autoflush all updated by feature PRs and the ADR 0082 Phase 5 docs audit (63bf27f)
- `docs/beamtalk-tooling.md` — ChangeLog REPL section, MCP tools table, LSP executeCommand pointers all updated by 63bf27f
- `docs/development/surface-parity.md` — define-class, live-edit-method, nav-query rows all present
- `docs/repl-protocol.md` — nav-query op documented by 4c40ce1

### Commits reviewed

| SHA | Title | Doc change |
|-----|-------|------------|
| `0fb87e1` | Behaviour compile:source:/tryCompile:source: + install-hook ChangeEntry (BT-2283) | Already documented (May 27 refresh) |
| `a61ffb7` | Workspace changes + ChangeLog.bt collection protocol (BT-2284) | Already documented (May 27 refresh) |
| `649628d` | Byte-span resolver + corpus round-trip validation spike (BT-2281) | Internal — already in CHANGELOG |
| `36dc0e3` | ChangeLog gen_server + two-part on-disk persistence (BT-2282) | Already in CHANGELOG |
| `14451d1` | Gate addClassMethod:body: super on literal-symbol selector (BT-2279) | Already in CHANGELOG |
| `8bdf00f` | Capstone: first-class ClassBuilder + live class-edit e2e, docs (BT-2271) | Docs-only commit (already applied) |
| `12720d8` | Harden module-less ClassBuilder instantiation (BT-2277) | Already in CHANGELOG |
| `252eb8a` | docs: correct ADR index statuses and add missing entries | Docs-only — skipped |
| `a9d13a7` | Fix selector_arity for malformed selectors (BT-2278) | Already in CHANGELOG |
| `61b8afc` | ClassBuilder incremental class-piece API (BT-2269) | Already in CHANGELOG |
| `b3d50f8` | Validate ClassBuilder classMethods: block arity (BT-2276) | Already in CHANGELOG |
| `999671c` | Runtime: instantiate module-less dynamic ClassBuilder classes (BT-2275) | Already in CHANGELOG |
| `53bc9d2` | Compiler: auto-derive class-side classMethodSource (BT-2270) | Covered by BT-2246 update |
| `2bc6515` | ClassBuilder programmatic register returns usable class object (BT-2258) | Already in CHANGELOG |
| `f3f8fae` | ClassBuilder metadata parity setters (BT-2268) | Already in CHANGELOG |
| `0fd45aa` | Fix E0283 test-profile build break | Internal build fix — skipped |
| `f61d388` | Class-side runtime method dispatch (BT-2266, BT-2267) | Already in CHANGELOG |
| `75033d7` | Tighten loose assertions in compiled_method_test.bt (BT-2274) | Test-only — skipped |
| `abe63bd` | Add error-path tests for beamtalk_json_formatter (BT-2273) | Test-only — skipped |
| `c6e3cea` | Extract kill_and_wait/1 helpers in beamtalk_actor (BT-2272) | Already in CHANGELOG |
| `5d0b6e4` | docs: ADR 0085 — Editor Live-Image Representation | ADR — skipped |
| `166eb0e` | Add ADR 0084: class-side runtime method fun dispatch | ADR — skipped |

Plus 20 branch-only commits (ADR 0082 Phases 2–5, LSP nav dispatch, xref, tests, internal cleanup) — 8 new CHANGELOG entries added.

### Skipped (test/docs/ADR only): 7 commits

`252eb8a`, `0fd45aa`, `75033d7`, `abe63bd`, `5d0b6e4`, `166eb0e`, plus test/refactor branch commits.

### Needs human judgment: None

https://claude.ai/code/session_01NSBAQnmdT4R8EgZd7YV5RB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSBAQnmdT4R8EgZd7YV5RB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to document upcoming workspace improvements: enhanced change tracking with durable logging and persistence management, new REPL meta-commands for change inspection and flushing, MCP tools for workspace operations, and improved LSP integration enabling coordinated updates across open editors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->