### PR TITLE
Extract duplicate make_actor_class test helper into test_helpers::test_support (BT-2310)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -3324,11 +3324,12 @@ impl CoreErlangGenerator {
 mod tests {
     use super::{MetaTypeRepr, extract_package_from_module_name};
     use crate::ast::{
-        ClassDefinition, ClassKind, Expression, ExpressionStatement, Identifier, Literal,
-        MessageSelector, MethodDefinition, Module, TypeParamDecl,
+        ClassKind, Expression, ExpressionStatement, Identifier, Literal, MessageSelector,
+        MethodDefinition, Module, TypeParamDecl,
     };
     use crate::codegen::core_erlang::CoreErlangGenerator;
     use crate::source_analysis::Span;
+    use crate::test_helpers::test_support::make_actor_class;
 
     fn s() -> Span {
         Span::new(0, 0)
@@ -3343,16 +3344,6 @@ mod tests {
             MessageSelector::Unary(selector.into()),
             vec![],
             vec![bare(Expression::Literal(Literal::Integer(42), s()))],
-            s(),
-        )
-    }
-
-    fn empty_actor_class(name: &str) -> ClassDefinition {
-        ClassDefinition::new(
-            Identifier::new(name, s()),
-            Identifier::new("Actor", s()),
-            vec![],
-            vec![],
             s(),
         )
     }
@@ -3381,7 +3372,7 @@ mod tests {
     fn test_generate_register_class_includes_class_name() {
         let mut generator = CoreErlangGenerator::new("test");
         let module = Module {
-            classes: vec![empty_actor_class("Counter")],
+            classes: vec![make_actor_class("Counter")],
             method_definitions: Vec::new(),
             protocols: Vec::new(),
             expressions: Vec::new(),
@@ -3416,7 +3407,7 @@ mod tests {
     #[test]
     fn test_generate_class_method_dispatches_empty_class() {
         let mut generator = CoreErlangGenerator::new("test");
-        let class = empty_actor_class("Counter");
+        let class = make_actor_class("Counter");
         let doc = generator
             .generate_class_method_dispatches(&class, 2)
             .unwrap();
@@ -3430,7 +3421,7 @@ mod tests {
     #[test]
     fn test_generate_class_method_functions_empty_class() {
         let mut generator = CoreErlangGenerator::new("test");
-        let class = empty_actor_class("Counter");
+        let class = make_actor_class("Counter");
         let doc = generator.generate_class_method_functions(&class).unwrap();
         assert_eq!(
             doc.to_pretty_string(),
@@ -3593,7 +3584,7 @@ mod tests {
     #[test]
     fn test_meta_type_params_in_meta_map() {
         // Build a generic class and verify type_params appears in meta map
-        let mut class = empty_actor_class("Container");
+        let mut class = make_actor_class("Container");
         class.type_params = vec![
             TypeParamDecl::unbounded(Identifier::new("T", s())),
             TypeParamDecl::unbounded(Identifier::new("E", s())),
@@ -3623,7 +3614,7 @@ mod tests {
 
     #[test]
     fn test_meta_type_params_empty_for_non_generic() {
-        let class = empty_actor_class("Counter");
+        let class = make_actor_class("Counter");
         let module = Module {
             classes: vec![class],
             method_definitions: Vec::new(),
@@ -3649,7 +3640,7 @@ mod tests {
 
     #[test]
     fn test_meta_map_includes_package_name() {
-        let class = empty_actor_class("Counter");
+        let class = make_actor_class("Counter");
         let module = Module {
             classes: vec![class],
             method_definitions: Vec::new(),
@@ -3675,7 +3666,7 @@ mod tests {
 
     #[test]
     fn test_meta_map_package_none_without_package() {
-        let class = empty_actor_class("Counter");
+        let class = make_actor_class("Counter");
         let module = Module {
             classes: vec![class],
             method_definitions: Vec::new(),
@@ -3701,7 +3692,7 @@ mod tests {
 
     #[test]
     fn test_meta_map_includes_kind_actor() {
-        let class = empty_actor_class("Counter");
+        let class = make_actor_class("Counter");
         let module = Module {
             classes: vec![class],
             method_definitions: Vec::new(),
@@ -3727,7 +3718,7 @@ mod tests {
 
     #[test]
     fn test_meta_map_includes_kind_value() {
-        let mut class = empty_actor_class("Point");
+        let mut class = make_actor_class("Point");
         class.class_kind = ClassKind::Value;
         let module = Module {
             classes: vec![class],
@@ -3772,7 +3763,7 @@ mod tests {
 
     #[test]
     fn test_meta_map_visibility_public_by_default() {
-        let class = empty_actor_class("Counter");
+        let class = make_actor_class("Counter");
         let module = Module {
             classes: vec![class],
             method_definitions: Vec::new(),
@@ -3798,7 +3789,7 @@ mod tests {
 
     #[test]
     fn test_meta_map_visibility_internal() {
-        let mut class = empty_actor_class("Helper");
+        let mut class = make_actor_class("Helper");
         class.is_internal = true;
         let module = Module {
             classes: vec![class],

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -2943,6 +2943,7 @@ mod tests {
         AutoSlotMethods, compute_auto_slot_methods,
     };
     use crate::source_analysis::Span;
+    use crate::test_helpers::test_support::make_actor_class;
 
     fn s() -> Span {
         Span::new(0, 0)
@@ -2972,16 +2973,6 @@ mod tests {
         // Explicitly set class_kind to avoid relying on constructor inference
         class.class_kind = ClassKind::Value;
         class
-    }
-
-    fn make_actor_class(name: &str) -> ClassDefinition {
-        ClassDefinition::new(
-            Identifier::new(name, s()),
-            Identifier::new("Actor", s()),
-            vec![],
-            vec![],
-            s(),
-        )
     }
 
     #[test]

--- a/crates/beamtalk-core/src/test_helpers.rs
+++ b/crates/beamtalk-core/src/test_helpers.rs
@@ -228,6 +228,19 @@ pub mod test_support {
         }
 
         #[test]
+        fn make_actor_class_builds_minimal_actor_class() {
+            let class = make_actor_class("CounterActor");
+            assert_eq!(class.name.name.as_str(), "CounterActor");
+            assert_eq!(
+                class.superclass.as_ref().map(|superclass| superclass.name.as_str()),
+                Some("Actor")
+            );
+            assert_eq!(class.class_kind, crate::ast::ClassKind::Actor);
+            assert!(class.methods.is_empty());
+            assert!(class.state.is_empty());
+        }
+
+        #[test]
         fn make_method_builds_unary_method() {
             let method = make_method("increment");
             assert_eq!(method.selector, MessageSelector::Unary("increment".into()));

--- a/crates/beamtalk-core/src/test_helpers.rs
+++ b/crates/beamtalk-core/src/test_helpers.rs
@@ -232,7 +232,10 @@ pub mod test_support {
             let class = make_actor_class("CounterActor");
             assert_eq!(class.name.name.as_str(), "CounterActor");
             assert_eq!(
-                class.superclass.as_ref().map(|superclass| superclass.name.as_str()),
+                class
+                    .superclass
+                    .as_ref()
+                    .map(|superclass| superclass.name.as_str()),
                 Some("Actor")
             );
             assert_eq!(class.class_kind, crate::ast::ClassKind::Actor);

--- a/crates/beamtalk-core/src/test_helpers.rs
+++ b/crates/beamtalk-core/src/test_helpers.rs
@@ -141,6 +141,22 @@ pub mod test_support {
         )
     }
 
+    /// Builds a minimal Actor [`ClassDefinition`] with the given name, no state, and no methods.
+    ///
+    /// Equivalent to `Actor subclass: <name>` with no declarations — the standard fixture for
+    /// codegen tests that need an actor class but don't care about its shape.
+    #[must_use]
+    pub fn make_actor_class(name: &str) -> ClassDefinition {
+        let span = test_span();
+        ClassDefinition::new(
+            Identifier::new(name, span),
+            Identifier::new("Actor", span),
+            Vec::new(),
+            Vec::new(),
+            span,
+        )
+    }
+
     /// Builds a minimal [`MethodDefinition`] with a unary selector and empty body.
     #[must_use]
     pub fn make_method(selector: &str) -> MethodDefinition {


### PR DESCRIPTION
## Summary

Consolidates two identical `ClassDefinition` test-fixture builders into the shared `test_helpers::test_support` module that already holds `make_class`, `make_method`, and other AST builders.

**Linear:** https://linear.app/beamtalk/issue/BT-2310

## Problem

Two `#[cfg(test)]` modules defined the same helper independently:

- `gen_server/methods.rs:3350` — `fn empty_actor_class(name: &str)` (11 call sites)
- `value_type_codegen.rs:2977` — `fn make_actor_class(name: &str)` (1 call site)

Both had identical bodies:
```rust
ClassDefinition::new(
    Identifier::new(name, s()),
    Identifier::new("Actor", s()),
    vec[], vec[], s(),
)
```

## Changes

- **`test_helpers.rs`** — add `pub fn make_actor_class(name: &str) -> ClassDefinition` to `test_support` with doc comment and `#[must_use]`
- **`gen_server/methods.rs`** — remove local `empty_actor_class`, import from `test_support`, rename 11 call sites
- **`value_type_codegen.rs`** — remove local `make_actor_class`, import from `test_support`
- Drop now-unused `ClassDefinition` from `gen_server/methods.rs` test imports

## Test plan

- [x] `just build && just clippy && just fmt-check` — all pass
- [x] `cargo test -p beamtalk-core` — all tests pass, no regressions
- [x] Test-only change: zero production behavior impact

---
_Generated by [Claude Code](https://claude.ai/code/session_011BnKepfAhtYsDPEmLgxz1Z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a reusable test helper and accompanying unit test to build minimal actor-class fixtures for testing.
  * Updated multiple test suites to use the new helper, removing legacy fixtures, consolidating imports, and reducing duplication for improved maintainability and clearer test setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->