### PR TITLE
Add EUnit tests for beamtalk_repl_ops_nav, 2% → 89% coverage (BT-2311)

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_nav_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_nav_tests.erl
@@ -1,0 +1,356 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_repl_ops_nav_tests).
+
+%%% **DDD Context:** REPL Session Context (Navigation bridge)
+
+-moduledoc """
+EUnit tests for beamtalk_repl_ops_nav (BT-2311).
+
+Covers: describe_ops/0 map shape, all validate_params/1 error branches,
+and success paths via handle/4 for senders, implementors, and references
+queries against a live beamtalk_xref server seeded with a minimal fixture.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% Construct a minimal non-legacy protocol_msg record.
+%% The tuple form mirrors #protocol_msg{op, id, session, params, legacy}.
+make_msg() ->
+    {protocol_msg, <<"nav-query">>, <<"t1">>, <<"s1">>, #{}, false}.
+
+%% Decode a JSON binary and assert it represents an error response.
+assert_error_response(Response) ->
+    Decoded = json:decode(Response),
+    ?assertMatch(#{<<"status">> := [<<"done">>, <<"error">>]}, Decoded),
+    ?assert(is_binary(maps:get(<<"error">>, Decoded))),
+    Decoded.
+
+%%====================================================================
+%% describe_ops/0
+%%====================================================================
+
+describe_ops_returns_map_with_nav_query_key_test() ->
+    Ops = beamtalk_repl_ops_nav:describe_ops(),
+    ?assertMatch(#{<<"nav-query">> := _}, Ops).
+
+describe_ops_nav_query_requires_kind_param_test() ->
+    #{<<"nav-query">> := Info} = beamtalk_repl_ops_nav:describe_ops(),
+    ?assertEqual([<<"kind">>], maps:get(<<"params">>, Info)).
+
+describe_ops_nav_query_optional_includes_selector_and_class_test() ->
+    #{<<"nav-query">> := Info} = beamtalk_repl_ops_nav:describe_ops(),
+    Optional = maps:get(<<"optional">>, Info),
+    ?assert(lists:member(<<"selector">>, Optional)),
+    ?assert(lists:member(<<"class">>, Optional)).
+
+%%====================================================================
+%% handle/4 — validation error paths (no xref dependency)
+%%====================================================================
+
+handle_missing_kind_returns_error_mentioning_kind_test() ->
+    Msg = make_msg(),
+    Response = beamtalk_repl_ops_nav:handle(<<"nav-query">>, #{}, Msg, self()),
+    Decoded = assert_error_response(Response),
+    ErrBin = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrBin, <<"kind">>)).
+
+handle_unknown_kind_returns_error_mentioning_the_value_test() ->
+    Msg = make_msg(),
+    Response = beamtalk_repl_ops_nav:handle(
+        <<"nav-query">>, #{<<"kind">> => <<"bogus">>}, Msg, self()
+    ),
+    Decoded = assert_error_response(Response),
+    ErrBin = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrBin, <<"bogus">>)).
+
+handle_kind_not_a_string_returns_error_test() ->
+    Msg = make_msg(),
+    Response = beamtalk_repl_ops_nav:handle(
+        <<"nav-query">>, #{<<"kind">> => 42}, Msg, self()
+    ),
+    assert_error_response(Response).
+
+handle_senders_missing_selector_returns_error_mentioning_selector_test() ->
+    Msg = make_msg(),
+    Response = beamtalk_repl_ops_nav:handle(
+        <<"nav-query">>, #{<<"kind">> => <<"senders">>}, Msg, self()
+    ),
+    Decoded = assert_error_response(Response),
+    ErrBin = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrBin, <<"selector">>)).
+
+handle_senders_empty_selector_returns_error_test() ->
+    Msg = make_msg(),
+    Response = beamtalk_repl_ops_nav:handle(
+        <<"nav-query">>,
+        #{<<"kind">> => <<"senders">>, <<"selector">> => <<>>},
+        Msg,
+        self()
+    ),
+    assert_error_response(Response).
+
+handle_implementors_missing_selector_returns_error_mentioning_selector_test() ->
+    Msg = make_msg(),
+    Response = beamtalk_repl_ops_nav:handle(
+        <<"nav-query">>, #{<<"kind">> => <<"implementors">>}, Msg, self()
+    ),
+    Decoded = assert_error_response(Response),
+    ErrBin = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrBin, <<"selector">>)).
+
+handle_implementors_empty_selector_returns_error_test() ->
+    Msg = make_msg(),
+    Response = beamtalk_repl_ops_nav:handle(
+        <<"nav-query">>,
+        #{<<"kind">> => <<"implementors">>, <<"selector">> => <<>>},
+        Msg,
+        self()
+    ),
+    assert_error_response(Response).
+
+handle_references_missing_class_returns_error_mentioning_class_test() ->
+    Msg = make_msg(),
+    Response = beamtalk_repl_ops_nav:handle(
+        <<"nav-query">>, #{<<"kind">> => <<"references">>}, Msg, self()
+    ),
+    Decoded = assert_error_response(Response),
+    ErrBin = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrBin, <<"class">>)).
+
+handle_references_empty_class_returns_error_test() ->
+    Msg = make_msg(),
+    Response = beamtalk_repl_ops_nav:handle(
+        <<"nav-query">>,
+        #{<<"kind">> => <<"references">>, <<"class">> => <<>>},
+        Msg,
+        self()
+    ),
+    assert_error_response(Response).
+
+%%====================================================================
+%% handle/4 — success paths (require a live beamtalk_xref)
+%%====================================================================
+
+xref_setup() ->
+    Pid =
+        case whereis(beamtalk_xref) of
+            undefined ->
+                {ok, P} = beamtalk_xref:start_link(),
+                P;
+            P ->
+                P
+        end,
+    %% Start each test from a clean slate to avoid bleed from other suites.
+    clear_xref_tables(),
+    Pid.
+
+xref_cleanup(_Pid) ->
+    clear_xref_tables(),
+    ok.
+
+clear_xref_tables() ->
+    try
+        sys:replace_state(beamtalk_xref, fun(S) ->
+            ets:delete_all_objects(beamtalk_xref_methods),
+            ets:delete_all_objects(beamtalk_xref_senders),
+            ets:delete_all_objects(beamtalk_xref_references),
+            ets:delete_all_objects(xref_class_gen),
+            S
+        end)
+    catch
+        _:_ -> ok
+    end.
+
+nav_query_test_() ->
+    {setup, fun xref_setup/0, fun xref_cleanup/1, fun nav_tests/1}.
+
+nav_tests(_Pid) ->
+    [
+        {"senders of non-existent atom returns empty sites list", fun() ->
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            %% Atom does not exist in VM → binary_to_existing_atom catches badarg
+            %% → uses '__nav_query_unknown__' sentinel → senders returns []
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"senders">>, <<"selector">> => <<"__does_not_exist_nav__">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            ?assertMatch(#{<<"status">> := [<<"done">>]}, Decoded),
+            ?assertMatch(#{<<"value">> := #{<<"sites">> := []}}, Decoded)
+        end},
+        {"senders of known selector returns non-empty sites list", fun() ->
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            %% 'increment' sends '+', so senders_of('+') should return a site
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"senders">>, <<"selector">> => <<"+">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            ?assertMatch(#{<<"status">> := [<<"done">>]}, Decoded),
+            #{<<"value">> := #{<<"sites">> := Sites}} = Decoded,
+            ?assertNotEqual([], Sites)
+        end},
+        {"site row has all required fields", fun() ->
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"senders">>, <<"selector">> => <<"+">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            #{<<"value">> := #{<<"sites">> := [Row | _]}} = Decoded,
+            ?assert(maps:is_key(<<"class">>, Row)),
+            ?assert(maps:is_key(<<"class_side">>, Row)),
+            ?assert(maps:is_key(<<"method">>, Row)),
+            ?assert(maps:is_key(<<"line">>, Row)),
+            ?assert(maps:is_key(<<"source_file">>, Row))
+        end},
+        {"site row class field matches registered class name", fun() ->
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"senders">>, <<"selector">> => <<"+">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            #{<<"value">> := #{<<"sites">> := [Row | _]}} = Decoded,
+            ?assertEqual(<<"NavTestClass">>, maps:get(<<"class">>, Row))
+        end},
+        {"implementors of known selector returns non-empty list", fun() ->
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"implementors">>, <<"selector">> => <<"increment">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            ?assertMatch(#{<<"status">> := [<<"done">>]}, Decoded),
+            #{<<"value">> := #{<<"sites">> := Sites}} = Decoded,
+            ?assertNotEqual([], Sites)
+        end},
+        {"implementors of unknown selector returns empty list", fun() ->
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"implementors">>, <<"selector">> => <<"__no_such_method__">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            ?assertMatch(#{<<"value">> := #{<<"sites">> := []}}, Decoded)
+        end},
+        {"implementor row has all required fields", fun() ->
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"implementors">>, <<"selector">> => <<"increment">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            #{<<"value">> := #{<<"sites">> := [Row | _]}} = Decoded,
+            ?assert(maps:is_key(<<"class">>, Row)),
+            ?assert(maps:is_key(<<"class_side">>, Row)),
+            ?assert(maps:is_key(<<"method">>, Row)),
+            ?assert(maps:is_key(<<"line">>, Row)),
+            ?assert(maps:is_key(<<"source_file">>, Row))
+        end},
+        {"implementor row method field matches queried selector", fun() ->
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"implementors">>, <<"selector">> => <<"increment">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            #{<<"value">> := #{<<"sites">> := [Row | _]}} = Decoded,
+            ?assertEqual(<<"increment">>, maps:get(<<"method">>, Row))
+        end},
+        {"references to known class returns non-empty sites list", fun() ->
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            %% nav_test_xref references 'Integer' in increment method
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"references">>, <<"class">> => <<"Integer">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            ?assertMatch(#{<<"status">> := [<<"done">>]}, Decoded),
+            #{<<"value">> := #{<<"sites">> := Sites}} = Decoded,
+            ?assertNotEqual([], Sites)
+        end},
+        {"references to non-existent class returns empty sites list", fun() ->
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"references">>, <<"class">> => <<"__no_such_class__">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            ?assertMatch(#{<<"value">> := #{<<"sites">> := []}}, Decoded)
+        end},
+        {"source_file field is null when class has no backing process", fun() ->
+            %% NavTestClass is registered in xref only, not in the class registry,
+            %% so source_file_of/1 returns null for it.
+            ok = beamtalk_xref:register_class('NavTestClass', nav_test_xref()),
+            Msg = make_msg(),
+            Response = beamtalk_repl_ops_nav:handle(
+                <<"nav-query">>,
+                #{<<"kind">> => <<"senders">>, <<"selector">> => <<"+">>},
+                Msg,
+                self()
+            ),
+            Decoded = json:decode(Response),
+            #{<<"value">> := #{<<"sites">> := [Row | _]}} = Decoded,
+            ?assertEqual(null, maps:get(<<"source_file">>, Row))
+        end}
+    ].
+
+%%====================================================================
+%% Fixtures
+%%====================================================================
+
+%% Minimal xref payload: one instance-side method 'increment' that sends '+'
+%% and references 'Integer'. Mirrors the shape codegen will emit (BT-2239).
+nav_test_xref() ->
+    [
+        #{
+            class_side => false,
+            selector => 'increment',
+            line => 7,
+            sends => [
+                #{selector => '+', line => 8, recv_kind => self_recv}
+            ],
+            references => [
+                #{class => 'Integer', line => 7}
+            ],
+            source_status => indexed,
+            provenance => class_body
+        }
+    ].


### PR DESCRIPTION
## Summary

- New EUnit test file for `beamtalk_repl_ops_nav` — the nav-query REPL op used by LSP for `textDocument/references`, `textDocument/implementation`, and `callHierarchy`
- Module coverage moves from **2% → 89%** (measured via local `rebar3 eunit --cover`)
- 23 tests covering all validation error paths and success paths against a live `beamtalk_xref` fixture

## Details

**Error path tests (12 tests):** All `validate_params/1` branches — missing kind, unknown kind, non-string kind, senders/implementors with missing or empty selector, references with missing or empty class. Each test asserts the JSON error response shape and that the error message mentions the relevant parameter name.

**Success path tests (11 tests via setup/teardown fixture):** Seeds `beamtalk_xref` with a minimal `NavTestClass` fixture, then exercises:
- `senders` query — known selector returns sites, unknown atom returns empty
- `implementors` query — known selector returns pairs, unknown returns empty
- `references` query — known class returns sites, unknown returns empty
- Row field shapes — both `site_to_row` and `implementor_to_row` produce all expected fields
- `source_file` field is `null` when class has no backing process in the class registry

**Remaining 11%:** The `source_file_of/1` "class exists" branch (lines 207-212) and `method_line_of/1` "line found" branch (line 220) require a running class registry with a registered class — deeper integration work for a follow-up.

## Test plan

- [x] `rebar3 eunit --module=beamtalk_repl_ops_nav_tests` — 23 tests, 0 failures
- [x] `just test` — all Rust, stdlib, BUnit, and runtime tests pass
- [x] `rebar3 eunit --app=beamtalk_workspace` — 1759 tests, 0 failures
- [x] Pre-push hooks (clippy, fmt, dialyzer, erlfmt, biome) all pass

Closes BT-2311
https://linear.app/beamtalk/issue/BT-2311

https://claude.ai/code/session_01VFu9wdVhY82jaTQN1Kg1mT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFu9wdVhY82jaTQN1Kg1mT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Added comprehensive test coverage for navigation query functionality, validating parameter requirements and error handling across multiple scenarios, with integration-level success tests that verify response structure, required fields in results, and expected behavior across different query types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->