### PR TITLE
Extract repeated ActorSlotCounter spawn into setUp in actor_slot_test.bt (BT-2312)

### DIFF
--- a/stdlib/test/actor_slot_test.bt
+++ b/stdlib/test/actor_slot_test.bt
@@ -13,20 +13,21 @@
 // and by the E2E @load-error test in tests/repl-protocol/cases/actor_slot.bt
 
 TestCase subclass: ActorSlotTest
+  field: counter = nil
+
+  setUp => self.counter := ActorSlotCounter spawn
 
   testMultipleSlotAssignmentsInOneMethod =>
     // Both count and total are updated and persist correctly
-    c := ActorSlotCounter spawn
-    result := c incrementBoth: 10
+    result := self.counter incrementBoth: 10
     self assert: result equals: #{#count => 1, #total => 10}
-    result2 := c incrementBoth: 5
+    result2 := self.counter incrementBoth: 5
     self assert: result2 equals: #{#count => 2, #total => 15}
 
   testMultipleAssignmentsToSameSlot =>
     // Three sequential assignments to the same slot accumulate correctly
-    c := ActorSlotCounter spawn
-    self assert: (c addThrice: 3) equals: 9
-    self assert: (c addThrice: 1) equals: 12
+    self assert: (self.counter addThrice: 3) equals: 9
+    self assert: (self.counter addThrice: 1) equals: 12
 
   testSlotAssignmentInsideConditional =>
     // Slot assignment inside ifTrue: is applied when condition is true
@@ -45,86 +46,77 @@ TestCase subclass: ActorSlotTest
 
   testSlotAssignmentInsideDoBlock =>
     // do: with self.slot := accumulates correctly
-    c := ActorSlotCounter spawn
-    self assert: (c sumItems: #(1, 2, 3, 4, 5)) equals: 15
+    self assert: (self.counter sumItems: #(1, 2, 3, 4, 5)) equals: 15
     // State persists after the method completes
-    self assert: c getTotal equals: 15
+    self assert: self.counter getTotal equals: 15
 
   testSlotAssignmentInsideDoBlockTwoSlots =>
     // do: with mutations to two different slots both thread correctly
-    c := ActorSlotCounter spawn
-    result := c countAndSum: #(10, 20, 30)
+    result := self.counter countAndSum: #(10, 20, 30)
     self assert: result equals: #{#count => 3, #total => 60}
-    self assert: c getCount equals: 3
-    self assert: c getTotal equals: 60
+    self assert: self.counter getCount equals: 3
+    self assert: self.counter getTotal equals: 60
 
   testSlotAssignmentInsideCollectBlock =>
     // collect: with self.slot := in block: result is correct and state is updated
-    c := ActorSlotCounter spawn
-    result := c collectDoubled: #(1, 2, 3)
+    result := self.counter collectDoubled: #(1, 2, 3)
     self assert: result equals: #(2, 4, 6)
     // count was incremented once per element
-    self assert: c getCount equals: 3
+    self assert: self.counter getCount equals: 3
 
   testSlotAssignmentWithEarlyReturn =>
     // Slot assignment before ifTrue:[^value] preserves the updated state
-    c := ActorSlotCounter spawn
     // count=0+1=1 >= 1, so early return fires
-    result := c addAndCheckLimit: 1
+    result := self.counter addAndCheckLimit: 1
     self assert: result equals: #reached
-    self assert: c getCount equals: 1
+    self assert: self.counter getCount equals: 1
 
   testSlotAssignmentWithEarlyReturnNotFired =>
     // When the limit is not reached, normal path runs and state is still updated
-    c := ActorSlotCounter spawn
     // count=0+1=1 < 5, so early return does NOT fire
-    result := c addAndCheckLimit: 5
+    result := self.counter addAndCheckLimit: 5
     self assert: result equals: #not_yet
-    self assert: c getCount equals: 1
+    self assert: self.counter getCount equals: 1
     // count=1+1=2 < 5, still not reached
-    result2 := c addAndCheckLimit: 5
+    result2 := self.counter addAndCheckLimit: 5
     self assert: result2 equals: #not_yet
-    self assert: c getCount equals: 2
+    self assert: self.counter getCount equals: 2
     // count=2+1=3 < 5, still not reached
-    result3 := c addAndCheckLimit: 5
+    result3 := self.counter addAndCheckLimit: 5
     self assert: result3 equals: #not_yet
-    self assert: c getCount equals: 3
+    self assert: self.counter getCount equals: 3
     // count=3+1=4 < 5, still not reached
-    result4 := c addAndCheckLimit: 5
+    result4 := self.counter addAndCheckLimit: 5
     self assert: result4 equals: #not_yet
-    self assert: c getCount equals: 4
+    self assert: self.counter getCount equals: 4
     // count=4+1=5 >= 5, early return fires
-    result5 := c addAndCheckLimit: 5
+    result5 := self.counter addAndCheckLimit: 5
     self assert: result5 equals: #reached
-    self assert: c getCount equals: 5
+    self assert: self.counter getCount equals: 5
 
   testSlotAssignmentBeforeEarlyReturnValue =>
     // total is incremented before the ^ so the returned value reflects the new state
-    c := ActorSlotCounter spawn
     // total=0+1=1 > 0, so returns total=1
-    result := c addAndReturnIfAbove: 0
+    result := self.counter addAndReturnIfAbove: 0
     self assert: result equals: 1
-    self assert: c getTotal equals: 1
+    self assert: self.counter getTotal equals: 1
 
   testSlotAssignmentBeforeEarlyReturnFallthrough =>
     // When threshold not exceeded, falls through to -1 but state is still updated
-    c := ActorSlotCounter spawn
     // total=0+1=1, 1 > 100? No, returns -1
-    result := c addAndReturnIfAbove: 100
+    result := self.counter addAndReturnIfAbove: 100
     self assert: result equals: -1
-    self assert: c getTotal equals: 1
+    self assert: self.counter getTotal equals: 1
 
   testStatePersistedAcrossMultipleCalls =>
     // State accumulates correctly across independent method calls
-    c := ActorSlotCounter spawn
-    c incrementBoth: 10; incrementBoth: 20; incrementBoth: 30
-    self assert: c getCount equals: 3
-    self assert: c getTotal equals: 60
+    self.counter incrementBoth: 10; incrementBoth: 20; incrementBoth: 30
+    self assert: self.counter getCount equals: 3
+    self assert: self.counter getTotal equals: 60
 
   testResetClearsBothSlots =>
     // reset clears both slots back to 0
-    c := ActorSlotCounter spawn
-    c incrementBoth: 42
-    c reset
-    self assert: c getCount equals: 0
-    self assert: c getTotal equals: 0
+    self.counter incrementBoth: 42
+    self.counter reset
+    self assert: self.counter getCount equals: 0
+    self assert: self.counter getTotal equals: 0


### PR DESCRIPTION
## Summary

- Extract the repeated `c := ActorSlotCounter spawn` line (11 of 13 test methods) into a `field: counter` + `setUp` pattern, following the convention established in `timeout_proxy_test.bt`
- The 2 `ConditionalMutationCounter` tests retain their own local variable unchanged

## Test plan

- [x] `just test-bunit` passes (2136 tests, 0 failures)
- [x] Lint clean on the modified file
- [x] No test assertions changed — only variable source (local → field)

https://linear.app/beamtalk/issue/BT-2312

https://claude.ai/code/session_01U3YntHzX5dQqSKTd33wFn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3YntHzX5dQqSKTd33wFn2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* **Enhanced test coverage** for actor slot assignment scenarios, including multiple assignments, conditional branches, and early-return paths.
* **Improved test structure** with refactored test setup to validate state persistence across method calls and reset functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->