### PR TITLE
ADR 0088 Phase 0a — codegen shrinkage audit (BT-2314)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs
@@ -1,0 +1,757 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! **THROWAWAY** — ADR 0088 Phase 0a audit only.  Delete with the memo (BT-2314)
+//! once the gate decision has been made.
+//!
+//! This file is the experimental rig for the ADR 0088 Phase 0a shrinkage audit
+//! (BT-2314 / epic BT-2313).  It contains:
+//!
+//! 1. A **minimal** `cerl::*` Rust mirror of the Core Erlang AST — only the
+//!    node kinds the three audit subjects need.  Not the full Phase 1 mirror;
+//!    not production-ready; intentionally lossy on syntactic concerns the audit
+//!    does not exercise (e.g. annotations, line numbers).
+//!
+//! 2. Three rewritten codegen functions, one each from the size tiers required
+//!    by the ADR:
+//!    - leaf utility — `beamtalk_class_attribute` (util.rs)
+//!    - medium expression — Logger metadata-map fragment (intrinsics.rs)
+//!    - high-complexity construct — `generate_pack_prefix` (`control_flow/mod.rs`,
+//!      the 4.2K-LOC hot spot)
+//!
+//! 3. Text-equivalence tests: each rewrite renders to the same string the
+//!    `Document` original produces on representative inputs.
+//!
+//! The originals are NOT modified — they continue to drive production codegen.
+//! Comparison is byte-for-byte against `to_pretty_string()`.
+//!
+//! Methodology notes for the memo:
+//! - LOC counts use `cargo run --quiet -p tokei` style hand counts of the
+//!   *body* of each function (signature + braces excluded), so a 3-line wrapper
+//!   doesn't artificially inflate the original's count.
+//! - Branching is cyclomatic count (1 + decision points).
+//! - "Helper-call count" is the number of `docvec!` / `Document::*` calls in
+//!   the original vs. the number of `cerl::*` constructor calls in the rewrite.
+
+#![allow(dead_code)] // entire module is throwaway scaffolding
+
+use super::document::{Document, join};
+use crate::docvec;
+
+// ════════════════════════════════════════════════════════════════════════════
+// Minimal cerl::* mirror
+// ════════════════════════════════════════════════════════════════════════════
+//
+// What this audits: whether expressing Core Erlang as a typed Rust tree
+// (instead of a sea of `Document::String("'") + atom + Document::String("'")`
+// ceremony) materially shrinks codegen.
+//
+// What this is NOT: a full Core Erlang AST.  Notably absent: function defs,
+// case/clause, receive, try/catch, primops, binary syntax, fun expressions,
+// annotations, source locations.  Phase 1 of ADR 0088 (if it proceeds) would
+// build the full thing.
+//
+// Design choice: `Expr` is a single sum type, like OTP's own `cerl` module.
+// `Atom`/`Var`/`Int`/`Lit` are leaves; everything else is a composite.
+//
+// All `cerl::Expr` values know how to render themselves to a `Document` via
+// `to_doc()`.  This is what production cerl-direct codegen would NOT need
+// (it would ETF-encode and ship to BEAM as a term).  In the audit, however,
+// rendering to text is the cheapest way to prove semantic equivalence with
+// the existing text-based pipeline.
+// ════════════════════════════════════════════════════════════════════════════
+
+pub mod cerl {
+    use super::{Document, docvec, join};
+
+    /// A single Core Erlang expression node.  Phase 0a subset.
+    #[derive(Debug, Clone)]
+    pub enum Expr {
+        /// `'atom_name'` — Core Erlang atom (always quoted).
+        Atom(String),
+        /// `VarName` — Core Erlang variable.
+        Var(String),
+        /// Integer literal — printed as decimal.
+        Int(i64),
+        /// `~{ k1 => v1, k2 => v2 }~` — map literal.  Order-preserving.
+        Map(Vec<(Expr, Expr)>),
+        /// `{ e1, e2, ... }` — tuple literal.
+        Tuple(Vec<Expr>),
+        /// `[e1, e2, ... ]` — proper list literal (no improper-tail support).
+        List(Vec<Expr>),
+        /// `[h | t]` — cons cell (improper list head/tail).
+        Cons(Box<Expr>, Box<Expr>),
+        /// `call Mod:Fun(Args...)` — remote call.  `module`/`fun` are atoms.
+        Call {
+            /// The module atom (e.g. `"maps"`).
+            module: String,
+            /// The function atom (e.g. `"put"`).
+            fun: String,
+            /// Argument expressions in left-to-right order.
+            args: Vec<Expr>,
+        },
+        /// `let Var = Bound in Body`.
+        Let {
+            /// The variable name bound by this let.
+            var: String,
+            /// The expression bound to `var`.
+            bound: Box<Expr>,
+            /// The expression where `var` is in scope.
+            body: Box<Expr>,
+        },
+        /// `let Var = Bound in ` (no body — caller will splice the rest).
+        ///
+        /// This models the "open let-chain" pattern that appears throughout the
+        /// current codegen, where a function returns a `Document` ending in
+        /// `" in "` to be concatenated with sibling output.  In a fully-typed
+        /// world this wouldn't exist — every `Let` would carry its `body` —
+        /// but the audit must produce identical text, so we permit it for
+        /// fidelity with the originals.
+        LetOpen {
+            /// The variable name bound by this open let.
+            var: String,
+            /// The expression bound to `var`.
+            bound: Box<Expr>,
+        },
+        /// `~{ ... }~` continuation — composes several open-lets in sequence.
+        Seq(Vec<Expr>),
+        /// A raw escape hatch for fragments we don't need to model in Phase 0a
+        /// (e.g. the binary-string `#{ #<104>... }#` body).  Keeping this small
+        /// is part of the audit — the more `Raw` we need, the worse cerl-direct
+        /// looks.
+        Raw(String),
+    }
+
+    impl Expr {
+        /// Render this expression to a `Document` for text-equivalence checks.
+        ///
+        /// **Note for the audit:** production cerl-direct codegen would NOT do
+        /// this — it would ETF-encode the tree and pipe it to BEAM.  This
+        /// renderer exists only so the audit's rewrites can be byte-for-byte
+        /// compared with the originals' `Document` output.
+        #[must_use]
+        pub fn to_doc(&self) -> Document<'static> {
+            match self {
+                Self::Atom(name) => docvec!["'", Document::String(name.clone()), "'"],
+                Self::Var(name) => Document::String(name.clone()),
+                Self::Int(n) => Document::String(n.to_string()),
+                Self::Map(pairs) => {
+                    let entries = pairs
+                        .iter()
+                        .map(|(k, v)| docvec![k.to_doc(), " => ", v.to_doc()]);
+                    docvec!["~{", join(entries, &Document::Str(", ")), "}~"]
+                }
+                Self::Tuple(elems) => {
+                    let parts = elems.iter().map(Self::to_doc);
+                    docvec!["{", join(parts, &Document::Str(", ")), "}"]
+                }
+                Self::List(elems) => {
+                    let parts = elems.iter().map(Self::to_doc);
+                    docvec!["[", join(parts, &Document::Str(", ")), "]"]
+                }
+                Self::Cons(h, t) => docvec!["[", h.to_doc(), " | ", t.to_doc(), "]"],
+                Self::Call { module, fun, args } => {
+                    let arg_parts = args.iter().map(Self::to_doc);
+                    docvec![
+                        "call '",
+                        Document::String(module.clone()),
+                        "':'",
+                        Document::String(fun.clone()),
+                        "'(",
+                        join(arg_parts, &Document::Str(", ")),
+                        ")",
+                    ]
+                }
+                Self::Let { var, bound, body } => docvec![
+                    "let ",
+                    Document::String(var.clone()),
+                    " = ",
+                    bound.to_doc(),
+                    " in ",
+                    body.to_doc(),
+                ],
+                Self::LetOpen { var, bound } => docvec![
+                    "let ",
+                    Document::String(var.clone()),
+                    " = ",
+                    bound.to_doc(),
+                    " in ",
+                ],
+                Self::Seq(parts) => Document::Vec(parts.iter().map(Self::to_doc).collect()),
+                Self::Raw(s) => Document::String(s.clone()),
+            }
+        }
+    }
+
+    // ─── tiny constructors — the user-facing API ────────────────────────────
+    //
+    // These are the surface area cerl-direct codegen would actually use.
+    // Their brevity vs. `docvec![Document::String("'"), name, Document::String("'")]`
+    // is the entire point of the experiment.
+
+    /// `'atom'`
+    #[must_use]
+    pub fn atom(name: impl Into<String>) -> Expr {
+        Expr::Atom(name.into())
+    }
+    /// `Var`
+    #[must_use]
+    pub fn var(name: impl Into<String>) -> Expr {
+        Expr::Var(name.into())
+    }
+    /// `call 'mod':'fun'(args...)`
+    #[must_use]
+    pub fn call(module: impl Into<String>, fun: impl Into<String>, args: Vec<Expr>) -> Expr {
+        Expr::Call {
+            module: module.into(),
+            fun: fun.into(),
+            args,
+        }
+    }
+    /// `{e1, e2, ...}`
+    #[must_use]
+    pub fn tuple(elems: Vec<Expr>) -> Expr {
+        Expr::Tuple(elems)
+    }
+    /// `~{ k => v, ... }~`
+    #[must_use]
+    pub fn map(pairs: Vec<(Expr, Expr)>) -> Expr {
+        Expr::Map(pairs)
+    }
+    /// `let var = bound in body`
+    #[must_use]
+    pub fn let_(var: impl Into<String>, bound: Expr, body: Expr) -> Expr {
+        Expr::Let {
+            var: var.into(),
+            bound: Box::new(bound),
+            body: Box::new(body),
+        }
+    }
+    /// `let var = bound in `  (no body, caller splices)
+    #[must_use]
+    pub fn let_open(var: impl Into<String>, bound: Expr) -> Expr {
+        Expr::LetOpen {
+            var: var.into(),
+            bound: Box::new(bound),
+        }
+    }
+    /// Sequence several `LetOpen` exprs followed by a final value.
+    #[must_use]
+    pub fn seq(parts: Vec<Expr>) -> Expr {
+        Expr::Seq(parts)
+    }
+    /// Cons cell: `[h | t]`.
+    #[must_use]
+    pub fn cons(h: Expr, t: Expr) -> Expr {
+        Expr::Cons(Box::new(h), Box::new(t))
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Rewrite #1 (leaf): util.rs::beamtalk_class_attribute
+// ════════════════════════════════════════════════════════════════════════════
+//
+// Original (util.rs lines 77-95, ~19 source lines incl. signature):
+//
+//     pub(super) fn beamtalk_class_attribute(classes: &[ClassDefinition]) -> Document<'static> {
+//         if classes.is_empty() { return Document::Nil; }
+//         let entries = classes.iter().map(|c| {
+//             docvec![
+//                 "{'",
+//                 Document::String(c.name.name.to_string()),
+//                 "', '",
+//                 Document::String(c.superclass_name().to_string()),
+//                 "'}"
+//             ]
+//         });
+//         docvec![
+//             ",\n     'beamtalk_class' = [",
+//             join(entries, &Document::Str(", ")),
+//             "]"
+//         ]
+//     }
+//
+// Observations:
+// - 5 `Document::String`/`Document::Str` calls per class entry (mostly delimiters).
+// - The atom-quote dance (`"{'"`, `"', '"`, `"'}"`) is exactly the kind of
+//   ceremony cerl-direct removes.
+// - The leading `",\n     "` and trailing `"]"` are *not* Core Erlang — they're
+//   attribute-list glue.  cerl-direct cannot eliminate them entirely; they
+//   become attribute-key/value composition at a higher level.  For the audit,
+//   we keep them as `Raw` to be honest about what cerl-direct can and can't do.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Audit version of [`beamtalk_class_attribute`] built on `cerl::Expr`.
+///
+/// `classes` are `(class_name, superclass_name)` pairs — kept as plain strings
+/// so the audit doesn't depend on `ClassDefinition` and the file stays trivial
+/// to delete.
+#[must_use]
+pub fn beamtalk_class_attribute_cerl(classes: &[(String, String)]) -> Document<'static> {
+    use cerl::*;
+    if classes.is_empty() {
+        return Document::Nil;
+    }
+    let entries: Vec<_> = classes
+        .iter()
+        .map(|(name, superclass)| {
+            tuple(vec![atom(name.clone()), atom(superclass.clone())]).to_doc()
+        })
+        .collect();
+    docvec![
+        ",\n     'beamtalk_class' = [",
+        join(entries, &Document::Str(", ")),
+        "]",
+    ]
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Rewrite #2 (medium): the metadata-map fragment from
+// intrinsics.rs::try_generate_logger_intrinsic
+// ════════════════════════════════════════════════════════════════════════════
+//
+// We pull only the metadata-map and log-call fragments here, not the entire
+// 115-LOC dispatch function — the *interesting* shape work is in those two
+// fragments.  The selector parsing, arg hoisting, and ProtoObject fallthrough
+// are independent of the Document/cerl decision and would look identical in
+// both implementations.
+//
+// Original metadata-map fragment (intrinsics.rs lines 2087-2097, ~11 lines):
+//
+//     let metadata_map_doc = docvec![
+//         "~{",
+//         "'domain' => ['beamtalk' | ['user']], ",
+//         "'beamtalk_class' => '",
+//         Document::String(ctx_class),
+//         "', ",
+//         "'beamtalk_selector' => '",
+//         Document::String(ctx_selector),
+//         "'",
+//         "}~",
+//     ];
+//
+// Original log-call (no-metadata branch, intrinsics.rs lines 2123-2133, ~11 lines):
+//
+//     docvec![
+//         "call 'logger':'log'('",
+//         Document::String(level.to_string()),
+//         "', ",
+//         msg_doc,
+//         ", ",
+//         metadata_map_doc,
+//         ")"
+//     ]
+//
+// Observations:
+// - The map fragment is the worst case: every key and string value requires
+//   six `Document` parts (open quote, value, close quote, comma…), and the
+//   author has to manually keep the punctuation in sync.
+// - cerl-direct collapses to a `Map(vec![(atom, value), …])` constructor.
+// - The cons cell `['beamtalk' | ['user']]` is currently a raw string — with
+//   cerl-direct it's a tiny `cons(atom("beamtalk"), list(vec![atom("user")]))`.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Audit version of the metadata-map + log-call fragments.
+///
+/// `msg_doc_text` is the rendered `{"~ts", [<arg>]}` fragment from upstream;
+/// the audit substitutes a fixed placeholder string instead of re-running the
+/// whole arg-hoisting machinery.  This isolates the *shape* work from the
+/// orthogonal sub-expression-capture work.
+#[must_use]
+pub fn logger_log_call_cerl(
+    level: &str,
+    msg_doc_text: &str,
+    ctx_class: &str,
+    ctx_selector: &str,
+) -> Document<'static> {
+    use cerl::*;
+    let metadata = map(vec![
+        (
+            atom("domain"),
+            cons(atom("beamtalk"), Expr::List(vec![atom("user")])),
+        ),
+        (atom("beamtalk_class"), atom(ctx_class)),
+        (atom("beamtalk_selector"), atom(ctx_selector)),
+    ]);
+    let log_call = call(
+        "logger",
+        "log",
+        vec![atom(level), Expr::Raw(msg_doc_text.to_string()), metadata],
+    );
+    log_call.to_doc()
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Rewrite #3 (high-complexity): control_flow/mod.rs::generate_pack_prefix
+// ════════════════════════════════════════════════════════════════════════════
+//
+// Original lines 577-618, body ~38 lines.
+//
+//     pub fn generate_pack_prefix(...) -> (Document<'static>, String) {
+//         if self.threaded_locals.is_empty() || self.use_direct_params || self.use_hybrid_params {
+//             return (Document::Nil, self.initial_state_var.clone());
+//         }
+//         let mut pack_docs: Vec<Document<'static>> = Vec::new();
+//         let mut current = if matches!(self.context, CodeGenContext::ValueType) {
+//             let init_map_var = generator.fresh_temp_var("InitMap");
+//             pack_docs.push(docvec![
+//                 "let ",
+//                 Document::String(init_map_var.clone()),
+//                 " = call 'maps':'new'() in ",
+//             ]);
+//             init_map_var
+//         } else {
+//             self.initial_state_var.clone()
+//         };
+//         for var_name in &self.threaded_locals {
+//             let packed_var = generator.fresh_temp_var("Packed");
+//             let core_var = generator.lookup_var(var_name).cloned()
+//                 .unwrap_or_else(|| CoreErlangGenerator::to_core_erlang_var(var_name));
+//             let key = self.state_key(var_name);
+//             pack_docs.push(docvec![
+//                 "let ",
+//                 Document::String(packed_var.clone()),
+//                 " = call 'maps':'put'('",
+//                 Document::String(key),
+//                 "', ",
+//                 Document::String(core_var),
+//                 ", ",
+//                 Document::String(current),
+//                 ") in ",
+//             ]);
+//             current = packed_var;
+//         }
+//         (Document::Vec(pack_docs), current)
+//     }
+//
+// Observations (the heavy-hitter of the audit):
+// - Each `maps:put` let costs **8** `Document::String` punctuation parts.
+//   cerl-direct collapses to: `let_open(packed_var, call("maps", "put",
+//   vec![atom(key), var(core_var), var(current)]))` — one constructor each.
+// - The control flow (early return, ValueType branch, for-loop) is unchanged.
+//   This is the audit's most honest answer: cerl-direct doesn't change the
+//   *algorithm*, just the per-line cost of each emitted expression.
+// - `pack_docs.push(docvec![…])` becomes `pack_exprs.push(let_open(…))` —
+//   same shape, smaller payload.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Stripped-down inputs for the audit — no `CoreErlangGenerator` dependency.
+pub struct PackPrefixInputs {
+    /// Variables to pack into the state map.
+    pub threaded_locals: Vec<String>,
+    /// Whether this is a direct-params loop (skips packing).
+    pub use_direct_params: bool,
+    /// Whether this is a hybrid-params loop (skips packing).
+    pub use_hybrid_params: bool,
+    /// Whether this is a `ValueType` context (fresh `maps:new()` instead of State).
+    pub is_value_type: bool,
+    /// Name of the variable holding the initial state map.
+    pub initial_state_var: String,
+    /// Pre-resolved per-local Core Erlang variable names (production code
+    /// calls `generator.lookup_var(...)`; the audit substitutes a fixed map).
+    pub core_var_for_local: std::collections::HashMap<String, String>,
+    /// Pre-resolved per-local state-map keys.
+    pub key_for_local: std::collections::HashMap<String, String>,
+    /// Pre-generated fresh temp names — the audit replaces the live generator's
+    /// counter with a deterministic vec, but the *shape* of the resulting code
+    /// is identical.
+    pub fresh_temps: std::cell::RefCell<std::collections::VecDeque<String>>,
+}
+
+impl PackPrefixInputs {
+    fn fresh_temp(&self) -> String {
+        self.fresh_temps
+            .borrow_mut()
+            .pop_front()
+            .expect("audit harness ran out of fresh temp names")
+    }
+}
+
+/// Audit version of [`ThreadingPlan::generate_pack_prefix`] built on `cerl::Expr`.
+#[must_use]
+pub fn generate_pack_prefix_cerl(inputs: &PackPrefixInputs) -> (Document<'static>, String) {
+    use cerl::*;
+    if inputs.threaded_locals.is_empty() || inputs.use_direct_params || inputs.use_hybrid_params {
+        return (Document::Nil, inputs.initial_state_var.clone());
+    }
+    let mut pack_exprs: Vec<Expr> = Vec::new();
+    let mut current = if inputs.is_value_type {
+        let init_map_var = inputs.fresh_temp();
+        pack_exprs.push(let_open(init_map_var.clone(), call("maps", "new", vec![])));
+        init_map_var
+    } else {
+        inputs.initial_state_var.clone()
+    };
+    for var_name in &inputs.threaded_locals {
+        let packed_var = inputs.fresh_temp();
+        let core_var = inputs.core_var_for_local[var_name].clone();
+        let key = inputs.key_for_local[var_name].clone();
+        pack_exprs.push(let_open(
+            packed_var.clone(),
+            call("maps", "put", vec![atom(key), var(core_var), var(current)]),
+        ));
+        current = packed_var;
+    }
+    (seq(pack_exprs).to_doc(), current)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Originals — verbatim copies, isolated from the live generator so the audit
+// can compare bytes without a compiler instance.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Original `beamtalk_class_attribute`, retargeted to `(String, String)` pairs
+/// to match the rewrite's input shape.
+#[must_use]
+pub fn beamtalk_class_attribute_original(classes: &[(String, String)]) -> Document<'static> {
+    if classes.is_empty() {
+        return Document::Nil;
+    }
+    let entries = classes.iter().map(|(name, superclass)| {
+        docvec![
+            "{'",
+            Document::String(name.clone()),
+            "', '",
+            Document::String(superclass.clone()),
+            "'}"
+        ]
+    });
+    docvec![
+        ",\n     'beamtalk_class' = [",
+        join(entries, &Document::Str(", ")),
+        "]"
+    ]
+}
+
+/// Original Logger metadata-map + log-call (no-metadata branch), inlined.
+#[must_use]
+pub fn logger_log_call_original(
+    level: &str,
+    msg_doc_text: &str,
+    ctx_class: &str,
+    ctx_selector: &str,
+) -> Document<'static> {
+    let metadata_map_doc = docvec![
+        "~{",
+        "'domain' => ['beamtalk' | ['user']], ",
+        "'beamtalk_class' => '",
+        Document::String(ctx_class.to_string()),
+        "', ",
+        "'beamtalk_selector' => '",
+        Document::String(ctx_selector.to_string()),
+        "'",
+        "}~",
+    ];
+    docvec![
+        "call 'logger':'log'('",
+        Document::String(level.to_string()),
+        "', ",
+        Document::String(msg_doc_text.to_string()),
+        ", ",
+        metadata_map_doc,
+        ")"
+    ]
+}
+
+/// Original `generate_pack_prefix`, retargeted to `PackPrefixInputs`.
+#[must_use]
+pub fn generate_pack_prefix_original(inputs: &PackPrefixInputs) -> (Document<'static>, String) {
+    if inputs.threaded_locals.is_empty() || inputs.use_direct_params || inputs.use_hybrid_params {
+        return (Document::Nil, inputs.initial_state_var.clone());
+    }
+    let mut pack_docs: Vec<Document<'static>> = Vec::new();
+    let mut current = if inputs.is_value_type {
+        let init_map_var = inputs.fresh_temp();
+        pack_docs.push(docvec![
+            "let ",
+            Document::String(init_map_var.clone()),
+            " = call 'maps':'new'() in ",
+        ]);
+        init_map_var
+    } else {
+        inputs.initial_state_var.clone()
+    };
+    for var_name in &inputs.threaded_locals {
+        let packed_var = inputs.fresh_temp();
+        let core_var = inputs.core_var_for_local[var_name].clone();
+        let key = inputs.key_for_local[var_name].clone();
+        pack_docs.push(docvec![
+            "let ",
+            Document::String(packed_var.clone()),
+            " = call 'maps':'put'('",
+            Document::String(key),
+            "', ",
+            Document::String(core_var),
+            ", ",
+            Document::String(current),
+            ") in ",
+        ]);
+        current = packed_var;
+    }
+    (Document::Vec(pack_docs), current)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Text-equivalence tests
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pack_inputs(
+        threaded_locals: &[&str],
+        is_value_type: bool,
+        fresh_temps: &[&str],
+    ) -> PackPrefixInputs {
+        let mut core_var = std::collections::HashMap::new();
+        let mut key = std::collections::HashMap::new();
+        for v in threaded_locals {
+            // mimic to_core_erlang_var: capitalize first letter
+            let mut chars = v.chars();
+            let core = match chars.next() {
+                None => String::new(),
+                Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+            };
+            core_var.insert((*v).to_string(), core);
+            key.insert((*v).to_string(), format!("__local__{v}"));
+        }
+        PackPrefixInputs {
+            threaded_locals: threaded_locals.iter().map(|s| (*s).to_string()).collect(),
+            use_direct_params: false,
+            use_hybrid_params: false,
+            is_value_type,
+            initial_state_var: "State".to_string(),
+            core_var_for_local: core_var,
+            key_for_local: key,
+            fresh_temps: std::cell::RefCell::new(
+                fresh_temps.iter().map(|s| (*s).to_string()).collect(),
+            ),
+        }
+    }
+
+    // ─── Rewrite #1: leaf ───────────────────────────────────────────────────
+
+    #[test]
+    fn beamtalk_class_attribute_empty_matches() {
+        let original = beamtalk_class_attribute_original(&[]);
+        let rewrite = beamtalk_class_attribute_cerl(&[]);
+        assert_eq!(original.to_pretty_string(), rewrite.to_pretty_string());
+        assert_eq!(original.to_pretty_string(), "");
+    }
+
+    #[test]
+    fn beamtalk_class_attribute_single_class_matches() {
+        let classes = vec![("Counter".to_string(), "Object".to_string())];
+        let original = beamtalk_class_attribute_original(&classes);
+        let rewrite = beamtalk_class_attribute_cerl(&classes);
+        assert_eq!(original.to_pretty_string(), rewrite.to_pretty_string());
+        // Sanity-check the literal output
+        assert_eq!(
+            original.to_pretty_string(),
+            ",\n     'beamtalk_class' = [{'Counter', 'Object'}]"
+        );
+    }
+
+    #[test]
+    fn beamtalk_class_attribute_multi_class_matches() {
+        let classes = vec![
+            ("Counter".to_string(), "Object".to_string()),
+            ("Account".to_string(), "Counter".to_string()),
+            ("BankAccount".to_string(), "Account".to_string()),
+        ];
+        let original = beamtalk_class_attribute_original(&classes);
+        let rewrite = beamtalk_class_attribute_cerl(&classes);
+        assert_eq!(original.to_pretty_string(), rewrite.to_pretty_string());
+    }
+
+    // ─── Rewrite #2: medium ─────────────────────────────────────────────────
+
+    #[test]
+    fn logger_log_call_matches() {
+        let level = "info";
+        let msg = r#"{"~ts", [_LogArg1]}"#;
+        let ctx_class = "Counter";
+        let ctx_selector = "tick";
+        let original = logger_log_call_original(level, msg, ctx_class, ctx_selector);
+        let rewrite = logger_log_call_cerl(level, msg, ctx_class, ctx_selector);
+        assert_eq!(original.to_pretty_string(), rewrite.to_pretty_string());
+        // Sanity check: ensure the generated text contains the expected shape
+        let text = original.to_pretty_string();
+        assert!(text.contains("call 'logger':'log'("));
+        assert!(text.contains("'beamtalk_class' => 'Counter'"));
+        assert!(text.contains("'beamtalk_selector' => 'tick'"));
+        assert!(text.contains("['beamtalk' | ['user']]"));
+    }
+
+    #[test]
+    fn logger_log_call_various_levels_match() {
+        for level in &["debug", "info", "warning", "error"] {
+            let original =
+                logger_log_call_original(level, r#"{"~ts", [_LogArg1]}"#, "Account", "deposit:");
+            let rewrite =
+                logger_log_call_cerl(level, r#"{"~ts", [_LogArg1]}"#, "Account", "deposit:");
+            assert_eq!(
+                original.to_pretty_string(),
+                rewrite.to_pretty_string(),
+                "level={level}",
+            );
+        }
+    }
+
+    // ─── Rewrite #3: high-complexity ────────────────────────────────────────
+
+    #[test]
+    fn pack_prefix_empty_locals_matches() {
+        let inputs = make_pack_inputs(&[], false, &[]);
+        let (orig_doc, orig_var) = generate_pack_prefix_original(&inputs);
+        // Re-create inputs because fresh_temps is consumed by interior mutability.
+        let inputs2 = make_pack_inputs(&[], false, &[]);
+        let (rewrite_doc, rewrite_var) = generate_pack_prefix_cerl(&inputs2);
+        assert_eq!(orig_doc.to_pretty_string(), rewrite_doc.to_pretty_string());
+        assert_eq!(orig_var, rewrite_var);
+        assert_eq!(orig_var, "State");
+    }
+
+    #[test]
+    fn pack_prefix_actor_context_matches() {
+        let temps = ["Packed1", "Packed2"];
+        let inputs_a = make_pack_inputs(&["counter", "total"], false, &temps);
+        let inputs_b = make_pack_inputs(&["counter", "total"], false, &temps);
+        let (orig_doc, orig_var) = generate_pack_prefix_original(&inputs_a);
+        let (rewrite_doc, rewrite_var) = generate_pack_prefix_cerl(&inputs_b);
+        assert_eq!(orig_doc.to_pretty_string(), rewrite_doc.to_pretty_string());
+        assert_eq!(orig_var, rewrite_var);
+        let text = orig_doc.to_pretty_string();
+        assert!(text.contains("call 'maps':'put'('__local__counter', Counter, State)"));
+        assert!(text.contains("call 'maps':'put'('__local__total', Total, Packed1)"));
+    }
+
+    #[test]
+    fn pack_prefix_value_type_context_matches() {
+        let temps = ["InitMap1", "Packed2", "Packed3"];
+        let inputs_a = make_pack_inputs(&["x", "y"], true, &temps);
+        let inputs_b = make_pack_inputs(&["x", "y"], true, &temps);
+        let (orig_doc, orig_var) = generate_pack_prefix_original(&inputs_a);
+        let (rewrite_doc, rewrite_var) = generate_pack_prefix_cerl(&inputs_b);
+        assert_eq!(orig_doc.to_pretty_string(), rewrite_doc.to_pretty_string());
+        assert_eq!(orig_var, rewrite_var);
+        let text = orig_doc.to_pretty_string();
+        assert!(text.contains("call 'maps':'new'()"));
+        assert!(text.contains("call 'maps':'put'('__local__x', X, InitMap1)"));
+        assert!(text.contains("call 'maps':'put'('__local__y', Y, Packed2)"));
+    }
+
+    #[test]
+    fn pack_prefix_direct_params_returns_nil() {
+        let mut inputs_a = make_pack_inputs(&["counter"], false, &[]);
+        inputs_a.use_direct_params = true;
+        let mut inputs_b = make_pack_inputs(&["counter"], false, &[]);
+        inputs_b.use_direct_params = true;
+        let (orig_doc, orig_var) = generate_pack_prefix_original(&inputs_a);
+        let (rewrite_doc, rewrite_var) = generate_pack_prefix_cerl(&inputs_b);
+        assert_eq!(orig_doc.to_pretty_string(), rewrite_doc.to_pretty_string());
+        assert_eq!(orig_var, rewrite_var);
+        assert_eq!(orig_doc.to_pretty_string(), "");
+    }
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs
@@ -52,7 +52,7 @@ use crate::docvec;
 // build the full thing.
 //
 // Design choice: `Expr` is a single sum type, like OTP's own `cerl` module.
-// `Atom`/`Var`/`Int`/`Lit` are leaves; everything else is a composite.
+// `Atom`/`Var`/`Int` are leaves; everything else is a composite.
 //
 // All `cerl::Expr` values know how to render themselves to a `Document` via
 // `to_doc()`.  This is what production cerl-direct codegen would NOT need
@@ -113,7 +113,8 @@ pub mod cerl {
             /// The expression bound to `var`.
             bound: Box<Expr>,
         },
-        /// `~{ ... }~` continuation — composes several open-lets in sequence.
+        /// Concatenation of fragments — composes several `LetOpen` chains
+        /// (and optionally a terminal value) into a single expression.
         Seq(Vec<Expr>),
         /// A raw escape hatch for fragments we don't need to model in Phase 0a
         /// (e.g. the binary-string `#{ #<104>... }#` body).  Keeping this small
@@ -235,7 +236,8 @@ pub mod cerl {
             bound: Box::new(bound),
         }
     }
-    /// Sequence several `LetOpen` exprs followed by a final value.
+    /// Concatenate several fragments (typically `LetOpen` chains, optionally
+    /// followed by a terminal value).
     #[must_use]
     pub fn seq(parts: Vec<Expr>) -> Expr {
         Expr::Seq(parts)

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -88,6 +88,8 @@
 
 mod actor_codegen;
 mod block_analysis;
+#[cfg(test)]
+mod cerl_audit;
 mod class_builder_source;
 mod control_flow;
 mod dispatch_codegen;

--- a/docs/ADR/0088-phase-0a-audit.md
+++ b/docs/ADR/0088-phase-0a-audit.md
@@ -33,9 +33,9 @@ the 5% "withdraw" gate**.
 
 **Recommendation:** This is the **qualified middle**. The audit does *not*
 support proceeding with Phase 1 on simplification grounds alone; the per-line
-savings exist but are modest and trend smaller as function complexity
-increases — exactly the opposite of what the ADR's most optimistic scenario
-predicts. Before committing to Phase 1, gather **Phase 0b** data (ETF
+savings exist but are modest and converge to ~11% regardless of function
+complexity — not the "bigger functions benefit more" curve the ADR's most
+optimistic scenario predicts. Before committing to Phase 1, gather **Phase 0b** data (ETF
 encode/decode cost) and explicitly compare against the **typed-Document-leaves**
 alternative on the same three functions. See §"What would shift the
 recommendation" below.
@@ -71,7 +71,7 @@ All rewrites + a minimal `cerl::*` mirror + the original functions (verbatim
 copies, isolated from `CoreErlangGenerator` so they need no compiler instance)
 live in `crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs`. The file
 is `#[cfg(test)]`-gated so it ships no production code, and is to be deleted
-when the gate decision lands. The minimal `cerl::*` mirror has 10 node kinds
+when the gate decision lands. The minimal `cerl::*` mirror has 12 node kinds
 (Atom, Var, Int, Map, Tuple, List, Cons, Call, Let, LetOpen, Seq, Raw) — a
 small fraction of the 20–30 the real ADR-0088 Phase 1 would need.
 
@@ -88,7 +88,7 @@ matrix:
 
 All 9 tests pass:
 
-```
+```text
 test codegen::core_erlang::cerl_audit::tests::beamtalk_class_attribute_empty_matches ... ok
 test codegen::core_erlang::cerl_audit::tests::beamtalk_class_attribute_single_class_matches ... ok
 test codegen::core_erlang::cerl_audit::tests::beamtalk_class_attribute_multi_class_matches ... ok
@@ -417,10 +417,12 @@ here is too small to justify the migration on its own.
 3. Decide Phase 1 *only* after both Phase 0b and Phase 0c data are in.
 
 The audit specifically does **not** support the ADR's Phase 1 plan on the
-simplification dimension alone. Shrinkage is real but below the gate, and the
-high-complexity hot-spot (`control_flow/mod.rs`) shrinks the *least* — exactly
-inverse to where the migration cost is highest. The cheaper typed-leaves
-alternative is now a serious contender and must be measured before commitment.
+simplification dimension alone. Shrinkage is real but plateaus at ~11% by
+characters regardless of function complexity — it does not grow proportionally
+with the emission-heaviness of the file, so the largest files (where migration
+cost is highest) gain proportionally no more than small leaf utilities. The
+cheaper typed-leaves alternative is now a serious contender and must be
+measured before commitment.
 
 ## No regressions
 
@@ -435,7 +437,7 @@ alternative is now a serious contender and must be measured before commitment.
 ## Files added/modified
 
 * **New:** `crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs`
-  (throwaway, ~600 LOC including doc comments + 9 tests)
+  (throwaway, ~760 LOC including doc comments + 9 tests)
 * **New:** `docs/ADR/0088-phase-0a-audit.md` (this memo)
 * **Modified:** `crates/beamtalk-core/src/codegen/core_erlang/mod.rs` — added
   `#[cfg(test)] mod cerl_audit;` declaration

--- a/docs/ADR/0088-phase-0a-audit.md
+++ b/docs/ADR/0088-phase-0a-audit.md
@@ -1,0 +1,452 @@
+# ADR 0088 Phase 0a Audit: Codegen Shrinkage Measurement
+
+**Date:** 2026-05-28
+**Issue:** BT-2314 (part of epic BT-2313)
+**Evaluator:** 3-function rewrite + projection across 58 codegen files (49,351 non-test LOC)
+**Status:** Recommendation — **Qualified**: in-between zone (≈10–12% projected shrinkage), neither clear-proceed nor clear-withdraw.
+
+## Executive Summary
+
+The audit rewrote 3 representative `Document`-based codegen functions on a
+throwaway `cerl::*` Rust AST mirror and measured the size delta. Aggregate
+shrinkage lands at **~11% by non-whitespace character count** and **12–30%
+by non-blank LOC** (LOC has higher variance because rustfmt collapses
+multi-line constructor calls):
+
+| Tier            | Function                              | Body LOC               | Char count        |
+| --------------- | ------------------------------------- | ---------------------- | ----------------- |
+| Leaf utility    | `beamtalk_class_attribute`            | 17 → 15 (**−12%**)     | 275 → 279 (+1.5%) |
+| Medium          | Logger metadata-map + log-call        | 25 → 20 (**−20%**)     | 460 → 411 (−11%)  |
+| High-complexity | `ThreadingPlan::generate_pack_prefix` | 33 → 23 (**−30%**)     | 876 → 776 (−11%)  |
+
+By **character count** (the more honest of the two metrics — see Methodology),
+all three rewrites cluster near **11%**. The leaf utility is a wash (the
+ceremony shifts from atom-quote punctuation to `tuple(vec![atom(...), ...])`
+Rust verbosity); the medium and high-complexity rewrites both deliver ~11%
+shrinkage. The high-complexity LOC win of 30% reflects rustfmt's ability to
+collapse short `cerl::*` constructor chains onto single lines that the
+original's multi-element `docvec!` calls could not — real but partly
+cosmetic.
+
+This sits **below the ADR's 15% "proceed unconditionally" gate** but **above
+the 5% "withdraw" gate**.
+
+**Recommendation:** This is the **qualified middle**. The audit does *not*
+support proceeding with Phase 1 on simplification grounds alone; the per-line
+savings exist but are modest and trend smaller as function complexity
+increases — exactly the opposite of what the ADR's most optimistic scenario
+predicts. Before committing to Phase 1, gather **Phase 0b** data (ETF
+encode/decode cost) and explicitly compare against the **typed-Document-leaves**
+alternative on the same three functions. See §"What would shift the
+recommendation" below.
+
+## Methodology
+
+### What was rewritten
+
+Three functions, one per size tier mandated by the ADR's "real audit"
+requirement (Appendix A used a biased 2-file sample of `util.rs`-like code; the
+audit had to include the 4.2K-LOC `control_flow/mod.rs` hot spot):
+
+1. **Leaf utility (`util.rs`)**: `beamtalk_class_attribute` — builds the
+   `'beamtalk_class' = [{Name, Super}, ...]` module attribute fragment.
+   Pure leaf, no generator state, almost all atom-quote ceremony.
+
+2. **Medium (`intrinsics.rs`)**: the metadata-map + `logger:log/3` call
+   fragments inside `try_generate_logger_intrinsic`. Pulled the two map/call
+   fragments out of the 115-LOC parent function — the rest of that function
+   (selector parsing, arg hoisting, dispatch fall-through) is orthogonal to
+   the Document/cerl choice and would look identical in both designs.
+
+3. **High-complexity (`control_flow/mod.rs`)**: `ThreadingPlan::generate_pack_prefix`,
+   the function that emits the `maps:put`-chain prefix that loads a `StateAcc`
+   map for stateful loops. Body has 3 control-flow branches (early-return,
+   ValueType vs. actor context, threaded-locals loop), each emitting `let`-chains.
+   Pulled out of `control_flow/mod.rs` (4,237 LOC, the hot spot Appendix A
+   explicitly flagged as missing).
+
+### Rewrite location
+
+All rewrites + a minimal `cerl::*` mirror + the original functions (verbatim
+copies, isolated from `CoreErlangGenerator` so they need no compiler instance)
+live in `crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs`. The file
+is `#[cfg(test)]`-gated so it ships no production code, and is to be deleted
+when the gate decision lands. The minimal `cerl::*` mirror has 10 node kinds
+(Atom, Var, Int, Map, Tuple, List, Cons, Call, Let, LetOpen, Seq, Raw) — a
+small fraction of the 20–30 the real ADR-0088 Phase 1 would need.
+
+### Semantic equivalence check
+
+Each rewrite is paired with the verbatim original; tests render both to text
+via `to_pretty_string()` and assert byte-equality on a representative input
+matrix:
+
+* `beamtalk_class_attribute`: empty, single class, three classes
+* Logger fragment: four log levels (debug/info/warning/error)
+* `generate_pack_prefix`: empty locals, actor context with two locals,
+  ValueType context with two locals, direct-params early-return
+
+All 9 tests pass:
+
+```
+test codegen::core_erlang::cerl_audit::tests::beamtalk_class_attribute_empty_matches ... ok
+test codegen::core_erlang::cerl_audit::tests::beamtalk_class_attribute_single_class_matches ... ok
+test codegen::core_erlang::cerl_audit::tests::beamtalk_class_attribute_multi_class_matches ... ok
+test codegen::core_erlang::cerl_audit::tests::logger_log_call_matches ... ok
+test codegen::core_erlang::cerl_audit::tests::logger_log_call_various_levels_match ... ok
+test codegen::core_erlang::cerl_audit::tests::pack_prefix_empty_locals_matches ... ok
+test codegen::core_erlang::cerl_audit::tests::pack_prefix_actor_context_matches ... ok
+test codegen::core_erlang::cerl_audit::tests::pack_prefix_value_type_context_matches ... ok
+test codegen::core_erlang::cerl_audit::tests::pack_prefix_direct_params_returns_nil ... ok
+```
+
+### Measurement rules
+
+* **LOC** counts non-blank, non-comment body lines (signature + closing brace
+  excluded; doc-comments excluded).
+* **Char count** counts non-whitespace characters in the body (comments
+  stripped). This is a more honest proxy than line count when one style has a
+  habit of wrapping single expressions across many lines (Document does, cerl
+  does too — but cerl does it less).
+* **Branching (cyclomatic)** is `1 + (number of decision points)`. Counted by
+  hand — the rewrites preserve the original control flow exactly, so this is
+  unchanged across rewrites (a key audit finding: cerl-direct does not change
+  *algorithmic* complexity).
+* **Helper-call count** is the number of constructor invocations
+  (`Document::String`, `docvec!`, `Document::Nil`, … on the original side;
+  `atom`, `var`, `call`, `let_open`, `tuple`, `map`, `cons`, `seq`, on the
+  rewrite side).
+
+## Per-function comparisons
+
+### Rewrite 1: Leaf utility — `beamtalk_class_attribute`
+
+**Original** (verbatim, in `cerl_audit.rs` as `beamtalk_class_attribute_original`):
+
+```rust
+pub fn beamtalk_class_attribute_original(classes: &[(String, String)]) -> Document<'static> {
+    if classes.is_empty() {
+        return Document::Nil;
+    }
+    let entries = classes.iter().map(|(name, superclass)| {
+        docvec![
+            "{'",
+            Document::String(name.clone()),
+            "', '",
+            Document::String(superclass.clone()),
+            "'}"
+        ]
+    });
+    docvec![
+        ",\n     'beamtalk_class' = [",
+        join(entries, &Document::Str(", ")),
+        "]"
+    ]
+}
+```
+
+**Rewrite** (`beamtalk_class_attribute_cerl`):
+
+```rust
+pub fn beamtalk_class_attribute_cerl(classes: &[(String, String)]) -> Document<'static> {
+    use cerl::*;
+    if classes.is_empty() {
+        return Document::Nil;
+    }
+    let entries: Vec<_> = classes
+        .iter()
+        .map(|(name, superclass)| tuple(vec![atom(name.clone()), atom(superclass.clone())]).to_doc())
+        .collect();
+    docvec![
+        ",\n     'beamtalk_class' = [",
+        join(entries, &Document::Str(", ")),
+        "]",
+    ]
+}
+```
+
+| Metric                     | Original | Rewrite        | Δ      |
+| -------------------------- | -------- | -------------- | ------ |
+| Body LOC (non-blank)       | 17       | 15             | −12%   |
+| Char count (no whitespace) | 275      | 279            | +1.5%  |
+| Branching (cyclomatic)     | 2        | 2              | 0      |
+| Helper calls               | 5        | 6 (+1 `tuple`) | +1     |
+
+**Reading:** The LOC win is real (the `"{'", name, "', '", superclass, "'}"`
+five-part atom dance collapses to `tuple(vec![atom(name), atom(superclass)])`).
+But the character count is **slightly worse** — the Rust verbosity (`tuple`,
+`vec!`, `.iter().map().collect::<Vec<_>>()` plus `.to_doc()` because the
+surrounding attribute glue is still text) eats the savings. The leading
+`",\n     "` and `"'beamtalk_class' = [..."` glue is *not* Core Erlang — it's
+attribute-list plumbing one level up — so cerl-direct cannot remove it.
+**In a function this small, ceremony shifts; it doesn't shrink.**
+
+### Rewrite 2: Medium — Logger metadata-map + log-call fragments
+
+**Original** (verbatim, no-metadata branch of `try_generate_logger_intrinsic`):
+
+```rust
+let metadata_map_doc = docvec![
+    "~{",
+    "'domain' => ['beamtalk' | ['user']], ",
+    "'beamtalk_class' => '",
+    Document::String(ctx_class.to_string()),
+    "', ",
+    "'beamtalk_selector' => '",
+    Document::String(ctx_selector.to_string()),
+    "'",
+    "}~",
+];
+docvec![
+    "call 'logger':'log'('",
+    Document::String(level.to_string()),
+    "', ",
+    Document::String(msg_doc_text.to_string()),
+    ", ",
+    metadata_map_doc,
+    ")"
+]
+```
+
+**Rewrite** (`logger_log_call_cerl`):
+
+```rust
+pub fn logger_log_call_cerl(level: &str, msg_doc_text: &str, ctx_class: &str, ctx_selector: &str)
+    -> Document<'static>
+{
+    use cerl::*;
+    let metadata = map(vec![
+        (atom("domain"), cons(atom("beamtalk"), Expr::List(vec![atom("user")]))),
+        (atom("beamtalk_class"), atom(ctx_class)),
+        (atom("beamtalk_selector"), atom(ctx_selector)),
+    ]);
+    let log_call = call(
+        "logger", "log",
+        vec![atom(level), Expr::Raw(msg_doc_text.to_string()), metadata],
+    );
+    log_call.to_doc()
+}
+```
+
+| Metric                  | Original | Rewrite | Δ      |
+| ----------------------- | -------- | ------- | ------ |
+| Body LOC (non-blank)    | 25       | 20      | −20%   |
+| Char count (no whitespace) | 460  | 411     | −10.7% |
+| Branching (cyclomatic)  | 1        | 1       | 0      |
+| Helper calls            | 6        | 14      | +8     |
+
+**Reading:** This is closer to the ADR's optimistic prediction. The metadata
+map (a 9-element punctuation tower in the original) collapses to a 4-element
+`Vec<(Expr, Expr)>`. The `call 'logger':'log'('debug', ..., ...)` ceremony
+collapses to `call("logger", "log", vec![atom("debug"), ..., ...])`. Char
+count drops ~11% even after accounting for `cerl::*` import boilerplate. The
+helper-call count *increases* because cerl-direct expresses structure with
+many small constructors — but those constructors carry zero punctuation, so
+the net per-character density is much lower.
+
+### Rewrite 3: High-complexity — `ThreadingPlan::generate_pack_prefix`
+
+**Original** (excerpt — the per-iteration `maps:put` let):
+
+```rust
+pack_docs.push(docvec![
+    "let ",
+    Document::String(packed_var.clone()),
+    " = call 'maps':'put'('",
+    Document::String(key),
+    "', ",
+    Document::String(core_var),
+    ", ",
+    Document::String(current),
+    ") in ",
+]);
+```
+
+**Rewrite** (`generate_pack_prefix_cerl` — same iteration):
+
+```rust
+pack_exprs.push(let_open(
+    packed_var.clone(),
+    call("maps", "put", vec![atom(key), var(core_var), var(current)]),
+));
+```
+
+Full-function metrics:
+
+| Metric                     | Original                                    | Rewrite | Δ      |
+| -------------------------- | ------------------------------------------- | ------- | ------ |
+| Body LOC (non-blank)       | 33                                          | 23      | −30%   |
+| Char count (no whitespace) | 876                                         | 776     | −11.4% |
+| Branching (cyclomatic)     | 4 (if/match/for + early-return)             | 4       | 0      |
+| Helper calls               | 17 (2 docvec + 14 Doc::String + 1 Doc::Vec) | 9       | −8     |
+
+**Reading — the most important data point of the audit:** Per `maps:put`
+emission, cerl-direct saves **6 of 9 lines** (the punctuation lines) *inside
+the loop body* — a 67% per-call shrinkage. But that loop is only 9 of the 33
+original-function lines; the surrounding control flow (early-return,
+ValueType branch, fresh-temp generation, vector building, threading state
+through `current`) is **unchanged**.
+
+The 30% LOC headline overstates the picture because rustfmt collapses the
+`call("maps", "put", vec![atom(key), var(core_var), var(current)])` chain
+onto a single line where the original `docvec![ "let ", Document::String(...),
+" = call 'maps':'put'('", Document::String(key), ..., ") in ", ]` ran 9
+multi-line lines. **The honest measurement is the −11% character count**,
+which is consistent across the medium and high-complexity rewrites.
+
+The audit's key finding: **per-line savings are real but ceiling-bound by the
+proportion of a function that is pure-emission vs. control-flow.**
+`generate_pack_prefix` is roughly 50/50, and it shrinks ~11% by chars.
+Functions dominated by emission (logger fragment) shrink in the same
+ballpark. Functions dominated by control flow (most of `control_flow/mod.rs`,
+which is largely analysis + threading-plan construction, not emission) will
+shrink less.
+
+## Projection across the codegen
+
+The codegen layer is 49,351 non-test LOC across 58 files. Projection uses the
+**character-count basis** (~11% per emission-heavy fragment) rather than the
+LOC basis, because raw LOC mixes real shrinkage with rustfmt-collapse noise.
+Naive per-file shrinkage by `Document::*` / `docvec!` ref density:
+
+| File                                                | LOC   | Doc refs | Refs/LOC | Est. tier      |
+| --------------------------------------------------- | ----- | -------- | -------- | -------------- |
+| `control_flow/mod.rs`                               | 4,237 | 314      | 7.4%     | high-complex   |
+| `gen_server/methods.rs`                             | 3,861 | 355      | 9.2%     | medium-high    |
+| `dispatch_codegen.rs`                               | 3,326 | 264      | 7.9%     | medium-high    |
+| `expressions.rs`                                    | 3,097 | 348      | 11.2%    | medium         |
+| `value_type_codegen.rs`                             | 3,063 | 290      | 9.5%     | medium-high    |
+| `intrinsics.rs`                                     | 2,365 | 181      | 7.7%     | medium         |
+| `control_flow/list_ops/transform_ops.rs`            | 2,205 | 510      | 23.1%    | emission-heavy |
+| `gen_server/callbacks.rs`                           | 1,608 | 168      | 10.4%    | medium         |
+| Other 50 files                                      | 25,589 | ~1,559   | ~6.1%    | mostly low-medium |
+| **Total non-test**                                  | **49,351** | **3,989** | **8.1%** | — |
+
+Linking these density buckets to the per-function shrinkage tiers measured
+above:
+
+* **Emission-heavy** (>15% Doc-refs/LOC, e.g. `transform_ops.rs` at 23%):
+  expect ~12–15% shrinkage by chars. ~2,200 LOC. Estimated savings:
+  **260–330 LOC** of equivalent character density.
+* **Medium-high emission** (8–12% Doc-refs/LOC): ~13,500 LOC. Expect ~11%
+  shrinkage (matches the logger and pack-prefix data points). Estimated
+  savings: **~1,500 LOC.**
+* **Low-medium emission** (<8% Doc-refs/LOC, e.g. `control_flow/mod.rs` body
+  outside its emission hot spots): ~33,500 LOC. Expect 4–8% shrinkage —
+  `generate_pack_prefix` was 11% in this bucket, but it's a relatively
+  emission-heavy function within that file; the file's average is much
+  lower. Estimated savings: **1,340–2,680 LOC.**
+
+**Projected total codegen shrinkage: ~3,100–4,500 LOC, or 6–9% of 49K LOC.**
+
+This is **below the 15% "proceed unconditionally" threshold** the ADR sets.
+It is **above the 5% "withdraw" threshold**.
+
+### Caveats and bias correction
+
+* **Selection bias:** all three rewrites are *known-emission-heavy* functions
+  within their tier (we picked the metadata-map fragment, not the
+  selector-parsing portion of `try_generate_logger_intrinsic`). The projection
+  uses Doc-ref density to correct for this, but the rewrites themselves
+  understate average-case complexity.
+
+* **Renderer overhead unaccounted for:** the audit's `cerl::Expr::to_doc()`
+  is ~35 LOC and would not exist in production Phase 1 — it's audit-only
+  scaffolding. Production would ETF-encode directly. This means the audit
+  *understates* shrinkage by about a function-renderer's worth (~30–50 LOC
+  globally, negligible).
+
+* **Cerl mirror itself adds LOC:** Phase 1 of ADR 0088 would need 20–30 node
+  kinds with full annotation, line-number, and pattern support, plus
+  constructors and ETF encoders. Estimate ~800–1,500 LOC of new infrastructure
+  not present today. Net savings shrink to **2,000–4,300 LOC, or 4–9%.**
+
+* **`format!()`-violation surface:** the audit does *not* directly measure the
+  BT-875 vector (one of the ADR's strongest non-shrinkage benefits). Both
+  cerl-direct and typed-Document-leaves close it equally well — this is a
+  wash for the gate decision but matters for the typed-leaves alternative.
+
+## Recommendation against the ADR's gates
+
+The ADR 0088 (proposed) Status section sets three gates:
+
+> * Phase 0a ≥15% projected shrinkage → migration justified on simplification grounds alone
+> * Phase 0a ≤5% shrinkage → typed-Document-leaves alternative likely wins; ADR may be withdrawn
+> * Between 5% and 15% → qualified recommendation explaining what additional data would decide
+
+The audit lands in the **between zone**:
+
+* Raw projected shrinkage: ~6–9% of codegen LOC (character-count basis).
+* After deducting Phase 1 cerl infrastructure cost (estimated 800–1,500 LOC
+  of new node-type, builder, and ETF-encoder code): ~4–7% net shrinkage.
+
+### What would shift the recommendation
+
+**Toward proceed (Phase 0b critical):**
+The ADR's *strongest* remaining argument after this audit is the wire-cost
+argument (Phase 0b). If ETF encode/decode is a small fraction of per-compile
+cost (the ADR's hopeful case), cerl-direct unlocks compile-time wins
+*independent* of LOC shrinkage. If Phase 0b lands favourably, the modest
+codegen shrinkage measured here is sufficient justification to proceed —
+because the simplification is a side benefit, not the primary motivation.
+
+**Toward withdraw (typed-Document-leaves alternative):**
+The same three rewrites should be done with typed-Document-leaves
+(`Atom | VarName | StringLit | …` replacing `Document::String` for known
+kinds, keeping the rest of `Document` intact). If typed-leaves achieves ≥60%
+of the cerl-direct shrinkage measured here at ~1/30th the LOC cost (the ADR's
+own counter-argument estimate), withdrawal in favour of the cheaper refactor
+is justified — modest codegen shrinkage does not buy the 58K-LOC migration
+the ADR proposes. **This is the single highest-value follow-up experiment.**
+
+**Toward pivot (Alternative 7, Port+NIF):**
+If Phase 0b shows ETF dominates per-compile cost, the ADR should pivot to
+NIF-for-conversion before any Phase 1 work — the codegen shrinkage measured
+here is too small to justify the migration on its own.
+
+### Net recommendation
+
+**Qualified: do not proceed with Phase 1 yet.**
+
+1. Run Phase 0b (wire-cost napkin) — this remains in the epic and is now
+   load-bearing for the decision.
+2. **Add a Phase 0c**: typed-Document-leaves rewrite of the same three audit
+   subjects. The ADR's own typed-leaves counter-argument is untested — this
+   audit's data makes it *more* important, not less, to know how the
+   alternative measures up against cerl-direct at the same three functions.
+3. Decide Phase 1 *only* after both Phase 0b and Phase 0c data are in.
+
+The audit specifically does **not** support the ADR's Phase 1 plan on the
+simplification dimension alone. Shrinkage is real but below the gate, and the
+high-complexity hot-spot (`control_flow/mod.rs`) shrinks the *least* — exactly
+inverse to where the migration cost is highest. The cheaper typed-leaves
+alternative is now a serious contender and must be measured before commitment.
+
+## No regressions
+
+* Rewritten functions live in `cerl_audit.rs`, gated `#[cfg(test)]`. Zero
+  production code is touched. Originals in `util.rs`, `intrinsics.rs`, and
+  `control_flow/mod.rs` are unchanged.
+* `just test` passes: 9 new cerl_audit tests + all existing tests.
+* The throwaway `cerl::*` types and rewrites will be deleted in a follow-up
+  cleanup once the gate decision is made. The file is clearly marked as
+  throwaway at the top.
+
+## Files added/modified
+
+* **New:** `crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs`
+  (throwaway, ~600 LOC including doc comments + 9 tests)
+* **New:** `docs/ADR/0088-phase-0a-audit.md` (this memo)
+* **Modified:** `crates/beamtalk-core/src/codegen/core_erlang/mod.rs` — added
+  `#[cfg(test)] mod cerl_audit;` declaration
+
+## References
+
+* ADR (proposed): `docs/ADR/0088-direct-cerl-emission.md` (Phase 0a, Appendix A)
+* Epic: BT-2313 (ADR 0088 Phase 0 decision gates)
+* Audit rig: `crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs`
+* Hot-spot file: `crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs`
+  (4,237 LOC, the one Appendix A explicitly flagged as the missing sample)
+* Original `Document` API: `crates/beamtalk-core/src/codegen/core_erlang/document.rs`
+* Related: BT-875 (eliminate `format!()` violations in Core Erlang codegen) —
+  closed by typed-Document-leaves at far lower cost


### PR DESCRIPTION
## Summary

- ADR 0088 Phase 0a empirical audit: rewrites 3 representative codegen functions on a throwaway `cerl::*` Rust AST mirror and measures size delta
- Projected shrinkage: ~6–9% by character count (below 15% proceed gate, above 5% withdraw gate)
- Qualified recommendation: do not proceed with Phase 1 yet; gather Phase 0b (wire-cost) and Phase 0c (typed-Document-leaves comparison) data first

## Changes

- **New:** `crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs` — throwaway `cerl::*` types + 3 rewritten functions + 9 text-equivalence tests (`#[cfg(test)]` only)
- **New:** `docs/ADR/0088-phase-0a-audit.md` — audit memo with per-function measurements, weighted projection, and recommendation
- **Modified:** `crates/beamtalk-core/src/codegen/core_erlang/mod.rs` — added `#[cfg(test)] mod cerl_audit;`

## Key findings

| Tier | Function | Body LOC | Char count |
|------|----------|----------|------------|
| Leaf | `beamtalk_class_attribute` | 17 → 15 (−12%) | 275 → 279 (+1.5%) |
| Medium | Logger metadata-map + log-call | 25 → 20 (−20%) | 460 → 411 (−11%) |
| High | `generate_pack_prefix` | 33 → 23 (−30%) | 876 → 776 (−11%) |

Character count (the more honest metric) clusters at ~11% regardless of complexity tier. LOC varies 12–30% due to rustfmt collapse effects.

## Test plan

- [x] 9 text-equivalence tests pass (`cargo test -p beamtalk-core --lib cerl_audit`)
- [x] All 3947 beamtalk-core tests pass
- [x] Clippy clean, fmt clean
- [x] No production code modified — audit module is `#[cfg(test)]` gated

Resolves [BT-2314](https://linear.app/beamtalk/issue/BT-2314)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added audit test harness that verifies rewritten code-generation outputs match existing outputs across multiple scenarios.

* **Documentation**
  * Added an ADR documenting the audit, measured size reductions, caveats, and recommendations for next phases.

Note: No user-facing functionality changed; additions are test and documentation-only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->