### PR TITLE
ADR 0088 Phase 0c — typed-Document-leaves shrinkage comparison (BT-2316)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs
@@ -461,7 +461,7 @@ pub struct PackPrefixInputs {
 }
 
 impl PackPrefixInputs {
-    fn fresh_temp(&self) -> String {
+    pub(super) fn fresh_temp(&self) -> String {
         self.fresh_temps
             .borrow_mut()
             .pop_front()

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -106,6 +106,8 @@ pub mod selector_mangler;
 mod spec_codegen;
 mod state_codegen;
 mod supervisor_codegen;
+#[cfg(test)]
+mod typed_leaves_audit;
 mod util;
 mod value_type_codegen;
 mod variable_context;

--- a/crates/beamtalk-core/src/codegen/core_erlang/typed_leaves_audit.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/typed_leaves_audit.rs
@@ -1,0 +1,428 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! **THROWAWAY** — ADR 0088 Phase 0c audit only.  Delete with the memo
+//! (BT-2316) once the Phase 0 decision is recorded.
+//!
+//! This file is the experimental rig for the ADR 0088 Phase 0c
+//! typed-Document-leaves shrinkage comparison (BT-2316 / epic BT-2313).
+//! It mirrors the structure of [`super::cerl_audit`] but measures a
+//! different alternative — the **typed-Document-leaves** refactor that
+//! Phase 0a's memo flagged as the strongest counter-argument to a full
+//! cerl-direct migration.
+//!
+//! # The thesis
+//!
+//! The original `Document::String(arbitrary_string)` leaf is the BT-875
+//! recurrence vector: any author can stuff an unquoted atom, a misformatted
+//! variable name, or a hand-rendered `format!()` fragment into a leaf and
+//! the compiler will accept it.  Typed-Document-leaves replaces the open
+//! `String` leaf with a tiny "what kind of leaf is this?" API — `atom()`
+//! and `var()` — that does the punctuation for you.
+//!
+//! It captures most of cerl-direct's atom-quote-ceremony savings without
+//! changing the wire format and without building a full Core Erlang AST.
+//! Phase 0c measures how much of that savings the typed-leaves alternative
+//! actually delivers, so the Phase 0 verdict can choose between the two
+//! refactors on data rather than rhetoric.
+//!
+//! # What this file contains
+//!
+//! 1. A **minimal** `leaf::*` API — two helpers (`atom`, `var`) that
+//!    return `Document<'static>` with the appropriate punctuation.  Not a
+//!    full Phase-1 typed-leaves mirror; just the leaves the three audit
+//!    subjects exercise.  In a production typed-leaves refactor these
+//!    would replace `Document::String(...)` at call sites across the
+//!    codegen; here they sit alongside it.
+//!
+//! 2. Three rewrites of the same functions as [`super::cerl_audit`]:
+//!    - leaf utility — `beamtalk_class_attribute_typed_leaves`
+//!    - medium expression — `logger_log_call_typed_leaves`
+//!    - high-complexity construct — `generate_pack_prefix_typed_leaves`
+//!
+//! 3. Text-equivalence tests: each rewrite renders byte-for-byte identical
+//!    to the existing `*_original` functions in [`super::cerl_audit`] —
+//!    same fixtures, same `to_pretty_string()` comparison, same sanity
+//!    substring assertions.
+//!
+//! 4. The originals are NOT modified.  They continue to drive production
+//!    codegen.  This file reuses the `*_original` functions and the
+//!    `PackPrefixInputs` struct from [`super::cerl_audit`] so the three
+//!    audits compare the same code against the same fixtures.
+//!
+//! # Methodology
+//!
+//! Same conventions as the BT-2314 memo:
+//! - LOC counts the *body* of each function (signature + braces excluded).
+//! - Branching uses cyclomatic count (1 + decision points).
+//! - "Helper-call count" is the number of `docvec!` / `Document::*` calls
+//!   in the original vs. typed-leaves-helper calls in the rewrite.
+//! - Char count uses non-whitespace bytes (the more honest of the two
+//!   metrics — LOC fluctuates with rustfmt collapse choices).
+
+#![allow(dead_code)] // entire module is throwaway scaffolding
+
+use super::cerl_audit::{
+    PackPrefixInputs, beamtalk_class_attribute_original, generate_pack_prefix_original,
+    logger_log_call_original,
+};
+use super::document::{Document, join};
+use crate::docvec;
+
+// ════════════════════════════════════════════════════════════════════════════
+// Minimal leaf::* API
+// ════════════════════════════════════════════════════════════════════════════
+//
+// What this audits: whether replacing `Document::String(arbitrary_string)`
+// with a tiny typed-leaf API (`atom`, `var`) — leaving the rest of the
+// `Document` pretty-printer untouched — captures the same atom-quote
+// ceremony savings that cerl-direct does.
+//
+// What this is NOT: a full sum-type replacement of `Document::String`.
+// In a real typed-leaves refactor, `Document::String` would be removed
+// from the enum and `Document::Leaf(Leaf)` (or a set of leaf variants)
+// would replace it.  For the audit, the helpers coexist with the open
+// `Document::String` leaf so the rewrites can be measured in isolation.
+//
+// Design choice: helpers return `Document<'static>` directly rather than
+// going through an intermediate AST.  This is the entire pitch — typed
+// leaves stay inside the existing Document API.  No new render layer.
+// ════════════════════════════════════════════════════════════════════════════
+
+pub mod leaf {
+    use super::{Document, docvec};
+
+    /// `'atom_name'` — quoted Core Erlang atom.  The atom-quote punctuation
+    /// is the entire BT-875 recurrence vector this audit closes.
+    #[must_use]
+    pub fn atom(name: impl Into<String>) -> Document<'static> {
+        docvec!["'", Document::String(name.into()), "'"]
+    }
+
+    /// `VarName` — bare Core Erlang variable name.  Authors no longer
+    /// reach for `Document::String(...)` directly; the typed `var()`
+    /// call sites the intent.
+    #[must_use]
+    pub fn var(name: impl Into<String>) -> Document<'static> {
+        Document::String(name.into())
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Rewrite #1 (leaf): util.rs::beamtalk_class_attribute
+// ════════════════════════════════════════════════════════════════════════════
+//
+// Compare against:
+// - cerl_audit::beamtalk_class_attribute_original (the production shape)
+// - cerl_audit::beamtalk_class_attribute_cerl (the cerl-direct rewrite)
+//
+// Per-class entry in the original: 5 `Document::String`/`Document::Str`
+// parts wrapping atom-quote punctuation.  Typed-leaves collapses each
+// atom to a single `atom(...)` call:
+//
+//     // Original
+//     docvec!["{'", Document::String(name), "', '", Document::String(superclass), "'}"]
+//
+//     // Typed-leaves
+//     docvec!["{", atom(name), ", ", atom(superclass), "}"]
+//
+// The structural template (`{`, `, `, `}`) stays as inline strings — they
+// are not atoms or variables, they're punctuation.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Audit version of `beamtalk_class_attribute` built on the typed-leaves API.
+///
+/// Same input shape as [`super::cerl_audit::beamtalk_class_attribute_original`].
+#[must_use]
+pub fn beamtalk_class_attribute_typed_leaves(classes: &[(String, String)]) -> Document<'static> {
+    use leaf::*;
+    if classes.is_empty() {
+        return Document::Nil;
+    }
+    let entries = classes.iter().map(|(name, superclass)| {
+        docvec!["{", atom(name.clone()), ", ", atom(superclass.clone()), "}"]
+    });
+    docvec![
+        ",\n     'beamtalk_class' = [",
+        join(entries, &Document::Str(", ")),
+        "]",
+    ]
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Rewrite #2 (medium): Logger metadata-map + log-call from intrinsics.rs
+// ════════════════════════════════════════════════════════════════════════════
+//
+// The metadata-map is the worst case for the original: each dynamic atom
+// value requires six `Document` parts (open quote, value, close quote,
+// comma…).  Typed-leaves collapses each dynamic atom to a single `atom()`.
+//
+//     // Original
+//     "'beamtalk_class' => '", Document::String(ctx_class), "', "
+//
+//     // Typed-leaves
+//     "'beamtalk_class' => ", atom(ctx_class), ", "
+//
+// The keys (`'domain'`, `'beamtalk_class'`, `'beamtalk_selector'`) and
+// the static `call 'logger':'log'(` template stay as inline string
+// literals — these are constant atoms hard-coded by the template author,
+// not dynamic values where the BT-875 hole exists.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Audit version of the metadata-map + log-call fragments on typed leaves.
+#[must_use]
+pub fn logger_log_call_typed_leaves(
+    level: &str,
+    msg_doc_text: &str,
+    ctx_class: &str,
+    ctx_selector: &str,
+) -> Document<'static> {
+    use leaf::*;
+    let metadata_map_doc = docvec![
+        "~{",
+        "'domain' => ['beamtalk' | ['user']], ",
+        "'beamtalk_class' => ",
+        atom(ctx_class),
+        ", ",
+        "'beamtalk_selector' => ",
+        atom(ctx_selector),
+        "}~",
+    ];
+    docvec![
+        "call 'logger':'log'(",
+        atom(level),
+        ", ",
+        Document::String(msg_doc_text.to_string()),
+        ", ",
+        metadata_map_doc,
+        ")",
+    ]
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Rewrite #3 (high-complexity): generate_pack_prefix from control_flow/mod.rs
+// ════════════════════════════════════════════════════════════════════════════
+//
+// Each `maps:put` let in the original costs **8** `Document::String`
+// punctuation parts.  Typed-leaves collapses to one `var(...)` per
+// variable and one `atom(...)` per atom key — same algorithm, smaller
+// per-line cost.
+//
+//     // Original
+//     docvec![
+//         "let ", Document::String(packed_var), " = call 'maps':'put'('",
+//         Document::String(key), "', ", Document::String(core_var), ", ",
+//         Document::String(current), ") in ",
+//     ]
+//
+//     // Typed-leaves
+//     docvec![
+//         "let ", var(packed_var), " = call 'maps':'put'(",
+//         atom(key), ", ", var(core_var), ", ", var(current), ") in ",
+//     ]
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Audit version of `ThreadingPlan::generate_pack_prefix` on typed leaves.
+#[must_use]
+pub fn generate_pack_prefix_typed_leaves(inputs: &PackPrefixInputs) -> (Document<'static>, String) {
+    use leaf::*;
+    if inputs.threaded_locals.is_empty() || inputs.use_direct_params || inputs.use_hybrid_params {
+        return (Document::Nil, inputs.initial_state_var.clone());
+    }
+    let mut pack_docs: Vec<Document<'static>> = Vec::new();
+    let mut current = if inputs.is_value_type {
+        let init_map_var = inputs.fresh_temp();
+        pack_docs.push(docvec![
+            "let ",
+            var(init_map_var.clone()),
+            " = call 'maps':'new'() in ",
+        ]);
+        init_map_var
+    } else {
+        inputs.initial_state_var.clone()
+    };
+    for var_name in &inputs.threaded_locals {
+        let packed_var = inputs.fresh_temp();
+        let core_var = inputs.core_var_for_local[var_name].clone();
+        let key = inputs.key_for_local[var_name].clone();
+        pack_docs.push(docvec![
+            "let ",
+            var(packed_var.clone()),
+            " = call 'maps':'put'(",
+            atom(key),
+            ", ",
+            var(core_var),
+            ", ",
+            var(current),
+            ") in ",
+        ]);
+        current = packed_var;
+    }
+    (Document::Vec(pack_docs), current)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Text-equivalence tests — same fixtures and assertions as cerl_audit.rs
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pack_inputs(
+        threaded_locals: &[&str],
+        is_value_type: bool,
+        fresh_temps: &[&str],
+    ) -> PackPrefixInputs {
+        let mut core_var = std::collections::HashMap::new();
+        let mut key = std::collections::HashMap::new();
+        for v in threaded_locals {
+            // mimic to_core_erlang_var: capitalize first letter
+            let mut chars = v.chars();
+            let core = match chars.next() {
+                None => String::new(),
+                Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+            };
+            core_var.insert((*v).to_string(), core);
+            key.insert((*v).to_string(), format!("__local__{v}"));
+        }
+        PackPrefixInputs {
+            threaded_locals: threaded_locals.iter().map(|s| (*s).to_string()).collect(),
+            use_direct_params: false,
+            use_hybrid_params: false,
+            is_value_type,
+            initial_state_var: "State".to_string(),
+            core_var_for_local: core_var,
+            key_for_local: key,
+            fresh_temps: std::cell::RefCell::new(
+                fresh_temps.iter().map(|s| (*s).to_string()).collect(),
+            ),
+        }
+    }
+
+    // ─── Rewrite #1: leaf ───────────────────────────────────────────────────
+
+    #[test]
+    fn beamtalk_class_attribute_empty_matches() {
+        let original = beamtalk_class_attribute_original(&[]);
+        let rewrite = beamtalk_class_attribute_typed_leaves(&[]);
+        assert_eq!(original.to_pretty_string(), rewrite.to_pretty_string());
+        assert_eq!(original.to_pretty_string(), "");
+    }
+
+    #[test]
+    fn beamtalk_class_attribute_single_class_matches() {
+        let classes = vec![("Counter".to_string(), "Object".to_string())];
+        let original = beamtalk_class_attribute_original(&classes);
+        let rewrite = beamtalk_class_attribute_typed_leaves(&classes);
+        assert_eq!(original.to_pretty_string(), rewrite.to_pretty_string());
+        assert_eq!(
+            original.to_pretty_string(),
+            ",\n     'beamtalk_class' = [{'Counter', 'Object'}]"
+        );
+    }
+
+    #[test]
+    fn beamtalk_class_attribute_multi_class_matches() {
+        let classes = vec![
+            ("Counter".to_string(), "Object".to_string()),
+            ("Account".to_string(), "Counter".to_string()),
+            ("BankAccount".to_string(), "Account".to_string()),
+        ];
+        let original = beamtalk_class_attribute_original(&classes);
+        let rewrite = beamtalk_class_attribute_typed_leaves(&classes);
+        assert_eq!(original.to_pretty_string(), rewrite.to_pretty_string());
+    }
+
+    // ─── Rewrite #2: medium ─────────────────────────────────────────────────
+
+    #[test]
+    fn logger_log_call_matches() {
+        let level = "info";
+        let msg = r#"{"~ts", [_LogArg1]}"#;
+        let ctx_class = "Counter";
+        let ctx_selector = "tick";
+        let original = logger_log_call_original(level, msg, ctx_class, ctx_selector);
+        let rewrite = logger_log_call_typed_leaves(level, msg, ctx_class, ctx_selector);
+        assert_eq!(original.to_pretty_string(), rewrite.to_pretty_string());
+        let text = original.to_pretty_string();
+        assert!(text.contains("call 'logger':'log'("));
+        assert!(text.contains("'beamtalk_class' => 'Counter'"));
+        assert!(text.contains("'beamtalk_selector' => 'tick'"));
+        assert!(text.contains("['beamtalk' | ['user']]"));
+    }
+
+    #[test]
+    fn logger_log_call_various_levels_match() {
+        for level in &["debug", "info", "warning", "error"] {
+            let original =
+                logger_log_call_original(level, r#"{"~ts", [_LogArg1]}"#, "Account", "deposit:");
+            let rewrite = logger_log_call_typed_leaves(
+                level,
+                r#"{"~ts", [_LogArg1]}"#,
+                "Account",
+                "deposit:",
+            );
+            assert_eq!(
+                original.to_pretty_string(),
+                rewrite.to_pretty_string(),
+                "level={level}",
+            );
+        }
+    }
+
+    // ─── Rewrite #3: high-complexity ────────────────────────────────────────
+
+    #[test]
+    fn pack_prefix_empty_locals_matches() {
+        let inputs = make_pack_inputs(&[], false, &[]);
+        let (orig_doc, orig_var) = generate_pack_prefix_original(&inputs);
+        let inputs2 = make_pack_inputs(&[], false, &[]);
+        let (rewrite_doc, rewrite_var) = generate_pack_prefix_typed_leaves(&inputs2);
+        assert_eq!(orig_doc.to_pretty_string(), rewrite_doc.to_pretty_string());
+        assert_eq!(orig_var, rewrite_var);
+        assert_eq!(orig_var, "State");
+    }
+
+    #[test]
+    fn pack_prefix_actor_context_matches() {
+        let temps = ["Packed1", "Packed2"];
+        let inputs_a = make_pack_inputs(&["counter", "total"], false, &temps);
+        let inputs_b = make_pack_inputs(&["counter", "total"], false, &temps);
+        let (orig_doc, orig_var) = generate_pack_prefix_original(&inputs_a);
+        let (rewrite_doc, rewrite_var) = generate_pack_prefix_typed_leaves(&inputs_b);
+        assert_eq!(orig_doc.to_pretty_string(), rewrite_doc.to_pretty_string());
+        assert_eq!(orig_var, rewrite_var);
+        let text = orig_doc.to_pretty_string();
+        assert!(text.contains("call 'maps':'put'('__local__counter', Counter, State)"));
+        assert!(text.contains("call 'maps':'put'('__local__total', Total, Packed1)"));
+    }
+
+    #[test]
+    fn pack_prefix_value_type_context_matches() {
+        let temps = ["InitMap1", "Packed2", "Packed3"];
+        let inputs_a = make_pack_inputs(&["x", "y"], true, &temps);
+        let inputs_b = make_pack_inputs(&["x", "y"], true, &temps);
+        let (orig_doc, orig_var) = generate_pack_prefix_original(&inputs_a);
+        let (rewrite_doc, rewrite_var) = generate_pack_prefix_typed_leaves(&inputs_b);
+        assert_eq!(orig_doc.to_pretty_string(), rewrite_doc.to_pretty_string());
+        assert_eq!(orig_var, rewrite_var);
+        let text = orig_doc.to_pretty_string();
+        assert!(text.contains("call 'maps':'new'()"));
+        assert!(text.contains("call 'maps':'put'('__local__x', X, InitMap1)"));
+        assert!(text.contains("call 'maps':'put'('__local__y', Y, Packed2)"));
+    }
+
+    #[test]
+    fn pack_prefix_direct_params_returns_nil() {
+        let mut inputs_a = make_pack_inputs(&["counter"], false, &[]);
+        inputs_a.use_direct_params = true;
+        let mut inputs_b = make_pack_inputs(&["counter"], false, &[]);
+        inputs_b.use_direct_params = true;
+        let (orig_doc, orig_var) = generate_pack_prefix_original(&inputs_a);
+        let (rewrite_doc, rewrite_var) = generate_pack_prefix_typed_leaves(&inputs_b);
+        assert_eq!(orig_doc.to_pretty_string(), rewrite_doc.to_pretty_string());
+        assert_eq!(orig_var, rewrite_var);
+        assert_eq!(orig_doc.to_pretty_string(), "");
+    }
+}

--- a/docs/ADR/0088-direct-cerl-emission.md
+++ b/docs/ADR/0088-direct-cerl-emission.md
@@ -1,7 +1,66 @@
 # ADR 0088: Direct Core Erlang AST Emission via ETF
 
 ## Status
-Proposed (2026-05-26) — **Phase 0a + 0b only**. Phases 1–4 are explicitly contingent on two decision gates:
+
+**Phases 1–4: Rejected (2026-05-28).** Phase 0c measured the
+typed-Document-leaves alternative against the cerl-direct rewrite on the
+same three functions used in Phase 0a — typed-leaves came in at −8.7%
+aggregate char shrinkage vs cerl's −9.5% (within 0.8% on the aggregate;
+typed-leaves wins on 2 of 3 function tiers). With typed-leaves capturing
+essentially the same shrinkage at ~30× the migration cost ratio, the
+58K-LOC cerl-direct migration does not pay back. The recommendation in
+[Phase 0c memo](0088-phase-0c-typed-leaves.md) is **withdraw ADR 0088
+in favour of the typed-leaves refactor** as the long-term fix for the
+BT-875 recurrence vector.
+
+**The wire-as-ETF question is Deferred, not rejected.** Phase 0b
+([memo](0088-phase-0b-napkin.md)) found ETF encode+decode is only
+~2.4–3.4% of per-compile cost — small enough that ETF is viable — and
+the cerl wire beat the text wire end-to-end by ~7.7–10% on the same
+fixtures because `core_scan` + `core_parse` cost ~4–4.5× more than
+`binary_to_term`. If compile time becomes a real bottleneck on
+larger projects, this win can be reclaimed by a much smaller
+*independent* ADR (wire-only, no codegen restructure) — by then the
+codegen will already be typed-leaves clean and only the wire question
+remains. **Do not re-open ADR 0088 itself**; the bundled scope (typed
+codegen + wire change + 58K LOC migration) is what's rejected.
+
+**Phase 0 audit history (all merged):**
+
+| Phase | Memo | PR | Finding |
+|---|---|---|---|
+| 0a — Codegen shrinkage audit | [`0088-phase-0a-audit.md`](0088-phase-0a-audit.md) | [#2348](https://github.com/jamesc/beamtalk/pull/2348) | ~9.5% projected shrinkage by char count — in-between the 5% / 15% gates; qualified |
+| 0b — Wire-mechanism napkin | [`0088-phase-0b-napkin.md`](0088-phase-0b-napkin.md) | [#2350](https://github.com/jamesc/beamtalk/pull/2350) | ETF cost = 2.4–3.4% of per-compile time; pivot-to-Alternative-7 gate does not fire |
+| 0c — Typed-leaves comparison | [`0088-phase-0c-typed-leaves.md`](0088-phase-0c-typed-leaves.md) | [#2352](https://github.com/jamesc/beamtalk/pull/2352) | Typed-leaves shrinkage within 0.8% of cerl on the aggregate; decisive against Phase 1 |
+
+**Decision criteria that fired and why:**
+
+- The ADR's Phase 0a "≥15% shrinkage proceeds unconditionally" gate did
+  not fire (~9.5% < 15%).
+- The ADR's Phase 0a "≤5% shrinkage withdraw" gate did not fire either
+  (~9.5% > 5%); Phase 0a's verdict was qualified.
+- Phase 0b's "pivot to Alternative 7" gate did not fire (ETF cost is
+  small).
+- Phase 0c's BT-2316 criterion *did* fire: "if typed-Document-leaves
+  comes in within ~3% of cerl's shrinkage, ADR 0088 should be
+  withdrawn in favour of the typed-leaves refactor." The measured
+  delta is 0.8%, well inside that threshold.
+
+**What is left intact for downstream work:**
+
+- The Phase 0a + 0b throwaway audit modules (`cerl_audit.rs`, `cerl.rs`,
+  the EUnit wire tests, the timing harnesses) live on as references
+  but are explicitly marked throwaway. They can be deleted once
+  typed-leaves is shipped.
+- BT-aware stack traces (one of the original Phase 1+ motivators) are
+  still a committed downstream consumer, but they do not require cerl
+  on the wire — annotations can be carried in the typed-leaves
+  approach via per-leaf metadata or a separate side-band channel.
+  Plan as part of the typed-leaves rollout ADR.
+
+---
+
+**Original Status (now superseded — Proposed, 2026-05-26):** Phase 0a + 0b only. Phases 1–4 are explicitly contingent on two decision gates:
 
 - **Phase 0a (Codegen Shrinkage Audit)** — 3 representative codegen functions rewritten cerl-direct, projected LOC delta across the codebase. If the projection is ≥15% shrinkage, the migration pays back its own LOC cost and is justified on simplification grounds alone. If ≤5%, the typed-Document-leaves alternative (see *Why not just constrain `Document` leaves?* below) likely wins for the BT-875 vector, and the remaining justification rests on annotation-consumer roadmap.
 - **Phase 0b (Napkin)** — ETF encode/decode timing on representative-sized modules. If ETF cost dominates, pivot to Alternative 7 (Port + NIF-for-conversion) before Phase 1.

--- a/docs/ADR/0088-phase-0c-typed-leaves.md
+++ b/docs/ADR/0088-phase-0c-typed-leaves.md
@@ -1,0 +1,294 @@
+# ADR 0088 Phase 0c Audit: Typed-Document-Leaves Comparison
+
+**Date:** 2026-05-28
+**Issue:** BT-2316 (epic [BT-2313](https://linear.app/beamtalk/issue/BT-2313))
+**Compares:** the cerl-direct rewrite measured in [Phase 0a](0088-phase-0a-audit.md) against a typed-Document-leaves rewrite of the same three functions.
+**Status:** Recommendation — **Withdraw ADR 0088** in favour of the typed-Document-leaves refactor.
+
+## Executive Summary
+
+Phase 0a measured cerl-direct's projected codegen shrinkage at ~6-9% by
+character count and qualified its recommendation pending a comparison
+against the typed-Document-leaves alternative. This memo runs that
+comparison: three rewrites of the same three functions, same fixtures,
+same byte-for-byte equivalence tests.
+
+| Tier | Function | Char shrinkage (cerl) | Char shrinkage (typed-leaves) |
+|---|---|---|---|
+| Leaf | `beamtalk_class_attribute` | **+1.5%** (slightly worse) | **−4.0%** |
+| Medium | Logger metadata-map + log-call | **−13.2%** | **−18.4%** |
+| High | `generate_pack_prefix` | **−11.4%** | **−6.2%** |
+| **Aggregate (sum across 3 fns)** | | **−9.5%** | **−8.7%** |
+
+**Typed-Document-leaves captures essentially the same shrinkage as
+cerl-direct** — within ~0.8% on the aggregate, and ahead on two
+of the three function tiers. The leaf tier in particular swings from
+"cerl is *slightly worse* than the original (+1.5%)" to "typed-leaves
+delivers a clean −4.0%", because typed-leaves doesn't pay cerl's
+AST-construction tax on small functions.
+
+This satisfies the decision criterion in [BT-2316](https://linear.app/beamtalk/issue/BT-2316):
+
+> If typed-Document-leaves comes in **within ~3% of cerl's shrinkage**:
+> cerl's marginal benefit is too small to justify a 30× migration cost.
+> ADR 0088 should be withdrawn in favour of the typed-leaves refactor.
+
+**Recommendation:** **Withdraw ADR 0088 (Phases 1–4 of the cerl
+migration) and pursue typed-Document-leaves as a smaller refactor** that
+closes the same [BT-875](https://linear.app/beamtalk/issue/BT-875)
+recurrence vector at a fraction of the cost. The Phase 0b wire-cost
+data (~10% compile-speed bonus from skipping `core_scan`+`core_parse`)
+is the *only* meaningful thing typed-leaves leaves on the table; if
+that win matters later, it can be revisited as an independent ADR
+without bundling it with the 58K-LOC AST restructure ADR 0088 proposed.
+
+## Methodology
+
+Same as the BT-2314 audit, with one addition: a third "typed-leaves"
+column. The three audit functions are unchanged (`beamtalk_class_attribute`,
+the Logger metadata-map + log-call fragments, `generate_pack_prefix`).
+The originals and the cerl rewrites live in
+`crates/beamtalk-core/src/codegen/core_erlang/cerl_audit.rs`; the
+typed-leaves rewrites live in the sibling
+`crates/beamtalk-core/src/codegen/core_erlang/typed_leaves_audit.rs`.
+
+* LOC counts the *body* of each function (signature + braces excluded).
+* Char count uses non-whitespace bytes per line, summed — the more
+  honest metric (LOC is sensitive to rustfmt's multi-arg-call
+  collapse choices, char count isn't).
+* Helper-call count is the number of `docvec!`, `Document::*`,
+  `atom(...)`, `var(...)`, `cons(...)`, `map(...)`, `tuple(...)`,
+  `call(...)`, etc. calls in the body — a rough proxy for "ceremony
+  per emitted Core Erlang fragment".
+* Text-equivalence is asserted by `to_pretty_string()` byte-for-byte
+  match against the original — same fixtures as the cerl audit. All
+  9 tests pass (`cargo test -p beamtalk-core typed_leaves_audit`).
+
+### The typed-leaves API in this audit
+
+Two helpers, both returning `Document<'static>`:
+
+```rust
+pub fn atom(name: impl Into<String>) -> Document<'static> {
+    docvec!["'", Document::String(name.into()), "'"]
+}
+pub fn var(name: impl Into<String>) -> Document<'static> {
+    Document::String(name.into())
+}
+```
+
+That's it. Ten lines including doc comments. In a production
+typed-leaves refactor these would replace direct `Document::String(...)`
+call sites and `Document::String` itself would be removed (or made
+private), closing the BT-875 vector for good. For Phase 0c the helpers
+sit alongside `Document::String` so the audit can be measured without
+disturbing production code.
+
+Note the asymmetry vs. cerl's ~250-LOC support module: cerl needs an
+`Expr` sum type with 12 variants and a `to_doc()` renderer.
+Typed-leaves needs nothing beyond what `Document` already provides.
+
+## Per-function results
+
+### Rewrite #1 (leaf): `beamtalk_class_attribute`
+
+| Variant | Body LOC | Char count | Helper calls |
+|---|---|---|---|
+| Original | 17 | 275 | 8 |
+| cerl-direct | 15 (−12%) | 279 (**+1.5%**) | 9 |
+| **typed-leaves** | **12 (−29%)** | **264 (−4.0%)** | **8** |
+
+**Cerl is actually slightly worse than the original by char count.** The
+atom-quote ceremony savings are real but get eaten by the verbosity of
+`tuple(vec![atom(name), atom(superclass)]).to_doc()`. Typed-leaves
+avoids the AST round-trip entirely — `atom(name)` is just three
+characters — so it banks the savings without paying for them.
+
+```rust
+// Original
+docvec![
+    "{'", Document::String(name), "', '", Document::String(superclass), "'}"
+]
+
+// cerl
+tuple(vec![atom(name), atom(superclass)]).to_doc()
+
+// typed-leaves
+docvec!["{", atom(name), ", ", atom(superclass), "}"]
+```
+
+### Rewrite #2 (medium): Logger metadata-map + log-call
+
+| Variant | Body LOC | Char count | Helper calls |
+|---|---|---|---|
+| Original | 20 | 370 | 6 |
+| cerl-direct | 15 (−25%) | 321 (−13%) | 14 |
+| **typed-leaves** | **20 (0%)** | **302 (−18%)** | **6** |
+
+Char count is the headline result here — typed-leaves wins (−18% vs
+cerl's −13%) because it can mix static template strings with dynamic
+typed leaves. Cerl forces the whole structure into AST construction,
+which inflates the helper-call count from 6 to 14.
+
+LOC numerically favours cerl (−25% vs 0%), but inspection shows rustfmt
+collapses the multi-arg `map(vec![...])` constructor onto fewer lines
+while the typed-leaves `docvec![..., atom(x), ", ", ...]` shape keeps
+one element per line. The char count is the apples-to-apples measure.
+
+```rust
+// Original
+"'beamtalk_class' => '", Document::String(ctx_class), "', "
+
+// cerl (inside a map(vec![...]) constructor)
+(atom("beamtalk_class"), atom(ctx_class))
+
+// typed-leaves
+"'beamtalk_class' => ", atom(ctx_class), ", "
+```
+
+### Rewrite #3 (high-complexity): `generate_pack_prefix`
+
+| Variant | Body LOC | Char count | Helper calls |
+|---|---|---|---|
+| Original | 33 | 876 | 9 |
+| **cerl-direct** | **23 (−30%)** | **776 (−11%)** | 10 |
+| typed-leaves | 34 (+3%) | 822 (−6%) | 9 |
+
+This is the one tier where cerl decisively wins on char count (−11% vs
+typed-leaves' −6%). The function has many `Document::String(var_name)`
+sites and cerl's `var(x)` is a touch shorter than the typed-leaves
+`var(x.clone())` because cerl's `var(impl Into<String>)` swallows the
+clone. A more carefully designed typed-leaves API that takes `&str`
+might claw some of that back, but for this audit the rules were the
+same as cerl's API.
+
+```rust
+// Original (per maps:put let)
+docvec![
+    "let ", Document::String(packed_var), " = call 'maps':'put'('",
+    Document::String(key), "', ", Document::String(core_var), ", ",
+    Document::String(current), ") in ",
+]
+
+// cerl
+pack_exprs.push(let_open(
+    packed_var.clone(),
+    call("maps", "put", vec![atom(key), var(core_var), var(current)]),
+));
+
+// typed-leaves
+docvec![
+    "let ", var(packed_var), " = call 'maps':'put'(",
+    atom(key), ", ", var(core_var), ", ", var(current), ") in ",
+]
+```
+
+## Aggregate
+
+Summed across the three functions:
+
+| Variant | Total chars (3 fns) | Shrinkage vs original |
+|---|---|---|
+| Original | 1,521 | — |
+| cerl-direct | 1,376 | **−9.5%** |
+| typed-leaves | 1,388 | **−8.7%** |
+
+**Within 0.8% of each other on the aggregate.** This is well inside the
+BT-2316 decision criterion's "within ~3%" threshold.
+
+## What typed-leaves doesn't give that cerl does
+
+Two things, both small:
+
+1. **The ~10% compile-speed win** Phase 0b measured (cerl wire
+   eliminates `core_scan`+`core_parse`). Typed-leaves changes nothing
+   on the wire; the BEAM side still scans and parses text. For a build
+   of N modules where each module averages a few-ms `compile:forms/2`
+   cost, this is the order of hundreds of µs per module — noticeable
+   for huge projects, not transformative.
+
+2. **Structural type safety inside the codegen tree.** A `Document::Vec`
+   says nothing about what its contents mean; a `cerl::Expr::Call`
+   does. This matters when refactoring across the tree, which is rare
+   in practice — codegen rewrites tend to be additive (new selectors,
+   new lowerings) rather than structural.
+
+Both are real, neither justifies a 58K-LOC migration when ~9% of the
+shrinkage benefit can be had for the cost of a `Document::String`
+audit.
+
+## What typed-leaves gives that cerl doesn't
+
+1. **~30× cheaper migration.** The typed-leaves refactor replaces
+   `Document::String(...)` call sites with `atom(...)` / `var(...)` /
+   `string_lit(...)` / `int_lit(...)` calls — same number of call
+   sites as cerl would touch, but each is a one-token edit, not a
+   structural rewrite. A rough upper bound: a few hundred call sites
+   across the ~55 codegen files, mechanically transformable with
+   targeted greps. Versus cerl's full reshape of every function's
+   return type and every helper signature.
+
+2. **No wire format change.** No Erlang-side modifications. No new
+   ETF encoder. No `binary_to_term` safety review. No Port handler
+   variant. The Phase 0b napkin found ETF was cheap, but cheap is not
+   free — there's still real work to ship Phase 0b's prototype as a
+   production wire (cross-platform OTP behaviour, error handling on
+   the BEAM side, atom-table safety in production payloads). All of
+   that goes away.
+
+3. **Tiny support code.** Ten lines of helpers vs cerl's ~250-LOC
+   AST + renderer. Easier to review, easier to extend, fewer moving
+   parts when something breaks.
+
+4. **Same BT-875 closure.** Once `Document::String` is removed from
+   the public Document API and the typed helpers are the only way to
+   produce a Core Erlang fragment, the recurrence vector is sealed.
+   This is the entire original motivation for ADR 0088; typed-leaves
+   delivers it at 1/30th the cost.
+
+## Recommendation
+
+**Withdraw ADR 0088 (Phases 1–4 of the cerl-direct migration).**
+
+The empirical case for cerl-direct rested on two pillars:
+
+1. **Shrinkage justifies the migration cost.** Phase 0a found this
+   pillar wobbly (~6-9%); Phase 0c finds it broken — typed-leaves
+   captures essentially the same shrinkage at a fraction of the cost.
+
+2. **The wire cost doesn't disqualify ETF.** Phase 0b found ETF cheap.
+   But this is a *necessary, not sufficient* finding; it removes a
+   blocker on cerl-direct without arguing for it.
+
+With both pillars examined, the case to spend 58K LOC on a wire
+restructure to get ~1% more shrinkage and ~10% compile-speed
+improvement does not hold up. **The typed-Document-leaves refactor is
+the better path** — same simplification, same BT-875 closure, no wire
+change, no Erlang-side risk, ~30× cheaper to ship.
+
+Open a follow-up issue (or a fresh ADR if the scope warrants) to plan
+the typed-leaves rollout. Keep [BT-875](https://linear.app/beamtalk/issue/BT-875)
+as the umbrella — typed-leaves is its long-term fix.
+
+If the ~10% compile-speed bonus from Phase 0b becomes important later
+(e.g. for very large projects where build time dominates), revisit
+cerl-as-wire as an *independent* ADR — a much smaller scope than
+ADR 0088 proposed, because by then the codegen will already be
+typed-leaves clean and only the wire question remains.
+
+## Files
+
+* New: `crates/beamtalk-core/src/codegen/core_erlang/typed_leaves_audit.rs`
+  (throwaway, `#[cfg(test)]`-only; 9 text-equivalence tests)
+* New: `docs/ADR/0088-phase-0c-typed-leaves.md` (this memo)
+* Reuses: `cerl_audit::{beamtalk_class_attribute_original,
+  logger_log_call_original, generate_pack_prefix_original,
+  PackPrefixInputs}` for the comparison fixtures.
+
+## References
+
+* Phase 0a memo: [`docs/ADR/0088-phase-0a-audit.md`](0088-phase-0a-audit.md)
+* Phase 0b memo: [`docs/ADR/0088-phase-0b-napkin.md`](0088-phase-0b-napkin.md)
+* The ADR being evaluated: [`docs/ADR/0088-direct-cerl-emission.md`](0088-direct-cerl-emission.md)
+* The recurrence vector at stake: [BT-875](https://linear.app/beamtalk/issue/BT-875)
+* Decision criterion source: [BT-2316](https://linear.app/beamtalk/issue/BT-2316)


### PR DESCRIPTION
## Summary

Empirical Phase 0c audit: rewrites the same three functions from Phase 0a (`beamtalk_class_attribute`, Logger metadata-map + log-call, `generate_pack_prefix`) using a minimal typed-Document-leaves API (10 LOC of `atom()`/`var()` helpers), and compares LOC + char count against both the originals and the cerl-direct rewrites already living in `cerl_audit.rs`.

## Aggregate result (sum across 3 fns, char count)

| Variant | Total chars | Shrinkage vs original |
|---|---|---|
| Original | 1,521 | — |
| cerl-direct (Phase 0a) | 1,376 | **−9.5%** |
| typed-leaves (this PR) | 1,388 | **−8.7%** |

**Within 0.8% of each other** — well inside [BT-2316](https://linear.app/beamtalk/issue/BT-2316)'s "within ~3%" decision criterion. Typed-leaves wins on 2 of 3 tiers (leaf and medium) and trails on high-complexity; cerl needs ~250 LOC of AST + renderer support code vs typed-leaves' 10 LOC.

## Per-function

| Tier | Function | cerl Δ chars | typed-leaves Δ chars |
|---|---|---|---|
| Leaf | `beamtalk_class_attribute` | **+1.5%** (slightly worse) | **−4.0%** |
| Medium | Logger metadata-map + log-call | −13.2% | **−18.4%** |
| High | `generate_pack_prefix` | **−11.4%** | −6.2% |

## Recommendation (in memo)

**Withdraw ADR 0088** (Phases 1–4 of the cerl-direct migration). Typed-Document-leaves captures essentially the same shrinkage at:
- ~30× cheaper migration (one-token edits vs structural reshape)
- No wire format change, no Erlang-side risk
- 10 LOC of support code vs cerl's ~250 LOC AST+renderer
- Same [BT-875](https://linear.app/beamtalk/issue/BT-875) recurrence closure

Phase 0b's ~10% compile-speed bonus (from skipping `core_scan`/`core_parse`) is the only thing typed-leaves leaves on the table; if needed later it can be revisited as an independent ADR.

## Changes

- **New:** `crates/beamtalk-core/src/codegen/core_erlang/typed_leaves_audit.rs` — throwaway `#[cfg(test)]`-only audit module with the `leaf::*` API + 3 rewrites + 9 text-equivalence tests. Reuses `*_original` functions and `PackPrefixInputs` from `cerl_audit.rs`.
- **New:** `docs/ADR/0088-phase-0c-typed-leaves.md` — memo with per-function side-by-sides, aggregate table, qualitative analysis, and explicit recommendation against the BT-2316 decision criterion.
- **Modified:** `cerl_audit.rs` — `PackPrefixInputs::fresh_temp` visibility raised from `fn` to `pub(super) fn` so the sibling typed-leaves audit can reuse the same fixtures.
- **Modified:** `mod.rs` — `#[cfg(test)] mod typed_leaves_audit;`

## Safety

- All code is `#[cfg(test)]`-gated and never reachable from production codegen.
- The originals (`*_original` functions in `cerl_audit.rs`) are unchanged and continue to drive production codegen.
- No wire format changes, no Erlang-side modifications.

## Test plan

- [x] 9 typed-leaves text-equivalence tests pass (`cargo test -p beamtalk-core --lib typed_leaves_audit`) — byte-for-byte match against the same originals the Phase 0a audit uses
- [x] 9 cerl-direct tests still pass (`cargo test -p beamtalk-core --lib cerl_audit`) — no regression from raising `fresh_temp` visibility
- [x] `just test` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Resolves [BT-2316](https://linear.app/beamtalk/issue/BT-2316). Closes the Phase 0 decision loop opened by epic [BT-2313](https://linear.app/beamtalk/issue/BT-2313) (already Done).

---
_Generated by [Claude Code](https://claude.ai/code/session_013gmP7cmvmLEKYNeB5pHair)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal visibility for testing infrastructure.

* **Tests**
  * Added a throwaway audit benchmarking alternative rewrite candidates against originals to ensure output equivalence.

* **Documentation**
  * Added ADR summarizing the audit, results, and an updated decision status for the prior proposal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->