### PR TITLE
docs(ADR-0006): remove stray merge conflict marker

### DIFF
--- a/docs/ADR/0006-unified-method-dispatch.md
+++ b/docs/ADR/0006-unified-method-dispatch.md
@@ -417,11 +417,7 @@ handle_call(methods, _From, #class_state{flattened_methods = Flattened} = State)
 ### Phase 1b: Runtime Dispatch Service
 
 1. Create `beamtalk_dispatch` module (hierarchy walking, method invocation, method combinations)
-<<<<<<< HEAD
-2. Bootstrap Object with hand-written `beamtalk_object.erl` runtime module (reflection methods: `class`, `respondsTo:`, `instVarNames`, `perform:`, `instVarAt:`, `instVarAt:put:` — later renamed per ADR 0035)
-=======
 2. Bootstrap Object with hand-written `beamtalk_object.erl` runtime module (reflection methods: `class`, `respondsTo:`, `instVarNames`, `perform:`, `instVarAt:`, `instVarAt:put:`) — note: `instVarNames`/`instVarAt:`/`instVarAt:put:` renamed to `fieldNames`/`fieldAt:`/`fieldAt:put:` in [ADR 0035](0035-field-based-reflection-api.md)
->>>>>>> origin/main
 3. Modify codegen: local fast path + `beamtalk_dispatch:lookup/5` fallback before DNU
 4. Update `beamtalk_object_class:methods/1` to walk hierarchy
 5. Remove duplicated reflection methods from per-class codegen


### PR DESCRIPTION
## Summary

A literal `<<<<<<< HEAD` / `>>>>>>> origin/main` conflict marker landed in `docs/ADR/0006-unified-method-dispatch.md` (Phase 1b bullet list) via PR #2281 — the uuid-bump dependabot PR that apparently merged with the markers still in place. Spotted while merging BT-2243 (PR #2349) into main.

## Resolution

The two variants conveyed the same information; kept the more informative one. The version retained:

- Names the renamed APIs explicitly (`fieldNames` / `fieldAt:` / `fieldAt:put:`) rather than just referencing the ADR
- Links directly to [ADR 0035](docs/ADR/0035-field-based-reflection-api.md)

This is purely documentation cleanup — no code, no tests, no behaviour change.

## Test plan

- [x] `grep -rn '^<<<<<<<\|^>>>>>>>' docs/` returns no matches anywhere in the repo
- [x] Surrounding Phase 1b bullets render as a clean ordered list
- N/A — markdown-only change, nothing to test

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPZNKDaiMRnPvXk4esT1RJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified method naming conventions in architecture documentation and resolved documentation inconsistencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->