### PR TITLE
Add edge-path tests for codegen/operators.rs (BT-2333)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/expressions.rs
@@ -245,7 +245,7 @@ fn test_generate_loose_equality_operator() {
     assert_eq!(output, "call 'erlang':'=='(5, 5)");
 }
 
-// ── Binary-operator error paths (operators.rs lines 38–40, 68–72) ─────────
+// ── Binary-operator error paths ────────────────────────────────────────────
 
 #[test]
 fn test_binary_op_wrong_argument_count_returns_error() {
@@ -270,7 +270,7 @@ fn test_binary_op_unsupported_operator_returns_error() {
     );
 }
 
-// ── Concat-op branches (operators.rs lines 158–197) ───────────────────────
+// ── Concat-op dispatch branches ────────────────────────────────────────────
 
 #[test]
 fn test_concat_op_list_literal_uses_list_append() {

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/expressions.rs
@@ -245,6 +245,87 @@ fn test_generate_loose_equality_operator() {
     assert_eq!(output, "call 'erlang':'=='(5, 5)");
 }
 
+// ── Binary-operator error paths (operators.rs lines 38–40, 68–72) ─────────
+
+#[test]
+fn test_binary_op_wrong_argument_count_returns_error() {
+    let mut generator = CoreErlangGenerator::new("test");
+    let left = Expression::Literal(Literal::Integer(1), Span::new(0, 1));
+    let result = generator.generate_binary_op("+", &left, &[]);
+    assert!(
+        result.is_err(),
+        "generate_binary_op with 0 arguments must return an error"
+    );
+}
+
+#[test]
+fn test_binary_op_unsupported_operator_returns_error() {
+    let mut generator = CoreErlangGenerator::new("test");
+    let left = Expression::Literal(Literal::Integer(1), Span::new(0, 1));
+    let right = vec![Expression::Literal(Literal::Integer(2), Span::new(4, 5))];
+    let result = generator.generate_binary_op("@", &left, &right);
+    assert!(
+        result.is_err(),
+        "generate_binary_op with unsupported operator '@' must return an error"
+    );
+}
+
+// ── Concat-op branches (operators.rs lines 158–197) ───────────────────────
+
+#[test]
+fn test_concat_op_list_literal_uses_list_append() {
+    // Left operand is a list literal → is_list = true → should emit erlang:'++'.
+    let mut generator = CoreErlangGenerator::new("test");
+    let left = Expression::Literal(
+        Literal::List(vec![Literal::Integer(1), Literal::Integer(2)]),
+        Span::new(0, 6),
+    );
+    let right = vec![Expression::Literal(
+        Literal::List(vec![Literal::Integer(3)]),
+        Span::new(10, 13),
+    )];
+    let doc = generator.generate_binary_op("++", &left, &right).unwrap();
+    let output = doc.to_pretty_string();
+    assert!(
+        output.contains("'erlang':'++'"),
+        "List ++ should use 'erlang':'++', got: {output}"
+    );
+    assert!(
+        !output.contains("iolist_to_binary"),
+        "List ++ must not use iolist_to_binary, got: {output}"
+    );
+}
+
+#[test]
+fn test_concat_op_identifier_left_uses_runtime_dispatch() {
+    // Left operand is an identifier (type unknown at compile time) →
+    // should emit a runtime is_list check that dispatches to either
+    // erlang:'++' or iolist_to_binary depending on the runtime value.
+    let mut generator = CoreErlangGenerator::new("test");
+    let left = Expression::Identifier(Identifier {
+        name: "xs".into(),
+        span: Span::new(0, 2),
+    });
+    let right = vec![Expression::Identifier(Identifier {
+        name: "ys".into(),
+        span: Span::new(6, 8),
+    })];
+    let doc = generator.generate_binary_op("++", &left, &right).unwrap();
+    let output = doc.to_pretty_string();
+    assert!(
+        output.contains("is_list"),
+        "Non-literal ++ should emit a runtime is_list type check, got: {output}"
+    );
+    assert!(
+        output.contains("'erlang':'++'"),
+        "Runtime dispatch must include the list path 'erlang':'++', got: {output}"
+    );
+    assert!(
+        output.contains("iolist_to_binary"),
+        "Runtime dispatch must include the binary path iolist_to_binary, got: {output}"
+    );
+}
+
 #[test]
 fn test_fresh_var_generation() {
     let mut generator = CoreErlangGenerator::new("test");


### PR DESCRIPTION
## Summary\n\nAdds 4 unit tests covering previously-untested error and dispatch branches in `codegen/core_erlang/operators.rs`, improving line coverage from 69.57% to ~95%.\n\nhttps://linear.app/beamtalk/issue/BT-2333\n\n## Changes\n\n- `test_binary_op_wrong_argument_count_returns_error` — exercises the `arguments.len() != 1` error branch (lines 38–40)\n- `test_binary_op_unsupported_operator_returns_error` — exercises the unsupported operator `_` match arm (lines 68–72)\n- `test_concat_op_list_literal_uses_list_append` — exercises the `is_list` branch in `generate_concat_op` that emits `erlang:'++'` for list literals (lines 158–167)\n- `test_concat_op_identifier_left_uses_runtime_dispatch` — exercises the runtime dispatch `else` branch that emits an `is_list` type check with both list-append and iolist_to_binary paths (lines 170–197)\n\n## Test plan\n\n- [x] All 4 new tests pass (`cargo test -p beamtalk-core`)\n- [x] Full CI passes (`just ci`)\n- [x] Test-only change — zero production code modified\n\nhttps://claude.ai/code/session_01GBLKM9SmVFHe2WaB7SpWz5"

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBLKM9SmVFHe2WaB7SpWz5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Core Erlang codegen test coverage for binary-operator error paths and concatenation behavior.
  * Added tests validating error handling for incorrect argument counts and unsupported operators.
  * Added tests confirming concat semantics: list-literal append path vs binary path, and runtime checks when operand types are dynamic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->