### PR TITLE
Tighten isOk assertion in file_stream_test.bt testUnicodeFileContent (BT-2334)

### DIFF
--- a/stdlib/test/file_stream_test.bt
+++ b/stdlib/test/file_stream_test.bt
@@ -114,7 +114,9 @@ TestCase subclass: FileStreamTest
 
   testUnicodeFileContent =>
     // Unicode content (multi-byte UTF-8) reads correctly through streams
-    self assert: (File lines: "test/fixtures/stream_unicode.txt") isOk
+    self assert: (File open: "test/fixtures/stream_unicode.txt" do: [:h |
+      h lines asList
+    ]) unwrap equals: #("Hello 世界", "café", "über")
 
   testOpenDoConcreteReturnValueCheck =>
     // BT-1273: File open:do: returns Result; unwrap gives the block value.


### PR DESCRIPTION
## Summary

`testUnicodeFileContent` claimed "Unicode content (multi-byte UTF-8) reads correctly through streams" but only asserted `isOk` — i.e. that the file could be opened at all. It did not verify a single byte of actual content.

This PR replaces the weak `isOk` check with a concrete content assertion against the three known lines in the fixture:

```diff
-    self assert: (File lines: "test/fixtures/stream_unicode.txt") isOk
+    self assert: (File open: "test/fixtures/stream_unicode.txt" do: [:h |
+      h lines asList
+    ]) unwrap equals: #("Hello 世界", "café", "über")
```

The `unwrap` provides at least as strong a failure mode as `isOk` (raises if the file cannot be opened), while additionally catching any encoding or line-splitting regression that would silently pass the previous test.

## Test plan

- [x] `just test-bunit` passes (2142 tests, 0 failed)
- [x] Follows `File open:do:` content-check pattern established in `testFileOpenDoBlockScopedHandle`
- [x] Pre-push lint hook (including Beamtalk formatter) passes

Linear: https://linear.app/beamtalk/issue/BT-2334/tighten-isok-assertion-in-file-stream-testbt-testunicodefilecontent

https://claude.ai/code/session_01D4YhKsi6m6ifCtuHWL9Gp5

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4YhKsi6m6ifCtuHWL9Gp5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Unicode (UTF-8) file reading validation tests to verify correct content parsing including multibyte characters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->