### PR TITLE
Extract shared instantiation_error_stub helper in gen_server/spawn.rs (BT-2335)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/spawn.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/spawn.rs
@@ -287,132 +287,49 @@ impl CoreErlangGenerator {
     /// Generates the `new/0` error method for actors (BT-217).
     ///
     /// Actors cannot be instantiated with `new` - they must use `spawn`.
-    /// This function generates a method that throws a structured `#beamtalk_error{}`
-    /// record with `kind=instantiation_error`.
-    ///
-    /// # Generated Code
-    ///
-    /// ```erlang
-    /// 'new'/0 = fun () ->
-    ///     let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in
-    ///     let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new') in
-    ///     let Error2 = call 'beamtalk_error':'with_hint'(Error1, <<"Use spawn instead">>) in
-    ///     call 'beamtalk_error':'raise'(Error2)
-    /// ```
     #[allow(clippy::unused_self)] // method on impl for API consistency
     #[allow(clippy::unnecessary_wraps)] // uniform Result<Document> codegen interface
     pub(in crate::codegen::core_erlang) fn generate_actor_new_error_method(
         &self,
     ) -> Result<Document<'static>> {
-        let hint_binary = Self::binary_string_literal("Use spawn instead");
-        let doc = docvec![
+        Ok(Self::instantiation_error_stub(
             "'new'/0 = fun () ->",
-            nest(
-                INDENT,
-                docvec![
-                    line(),
-                    "let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in",
-                    line(),
-                    "let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new') in",
-                    line(),
-                    docvec![
-                        "let Error2 = call 'beamtalk_error':'with_hint'(Error1, ",
-                        Document::String(hint_binary.clone()),
-                        ") in",
-                    ],
-                    line(),
-                    "call 'beamtalk_error':'raise'(Error2)",
-                ]
-            ),
-            "\n",
-        ];
-        Ok(doc)
+            Document::Str("Actor"),
+            "new",
+            "Use spawn instead",
+        ))
     }
 
     /// Generates the `new/1` error method for actors (BT-217).
     ///
     /// Actors cannot be instantiated with `new:` - they must use `spawnWith:`.
-    /// This function generates a method that throws a structured `#beamtalk_error{}`
-    /// record with `kind=instantiation_error`.
-    ///
-    /// # Generated Code
-    ///
-    /// ```erlang
-    /// 'new'/1 = fun (_InitArgs) ->
-    ///     let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in
-    ///     let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new:') in
-    ///     let Error2 = call 'beamtalk_error':'with_hint'(Error1, <<"Use spawnWith: instead">>) in
-    ///     call 'beamtalk_error':'raise'(Error2)
-    /// ```
     #[allow(clippy::unused_self)] // method on impl for API consistency
     #[allow(clippy::unnecessary_wraps)] // uniform Result<Document> codegen interface
     pub(in crate::codegen::core_erlang) fn generate_actor_new_with_args_error_method(
         &self,
     ) -> Result<Document<'static>> {
-        let hint_binary = Self::binary_string_literal("Use spawnWith: instead");
-        let doc = docvec![
+        Ok(Self::instantiation_error_stub(
             "'new'/1 = fun (_InitArgs) ->",
-            nest(
-                INDENT,
-                docvec![
-                    line(),
-                    "let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in",
-                    line(),
-                    "let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new:') in",
-                    line(),
-                    docvec![
-                        "let Error2 = call 'beamtalk_error':'with_hint'(Error1, ",
-                        Document::String(hint_binary.clone()),
-                        ") in",
-                    ],
-                    line(),
-                    "call 'beamtalk_error':'raise'(Error2)",
-                ]
-            ),
-            "\n",
-        ];
-        Ok(doc)
+            Document::Str("Actor"),
+            "new:",
+            "Use spawnWith: instead",
+        ))
     }
 
     /// Generates the `spawn/0` error method for abstract classes (BT-105).
     ///
     /// Abstract classes cannot be instantiated — they must be subclassed first.
-    /// This function generates a method that throws a structured `#beamtalk_error{}`
-    /// record with `kind=instantiation_error`.
     #[allow(clippy::unnecessary_wraps)] // uniform Result<Document> codegen interface
     pub(in crate::codegen::core_erlang) fn generate_abstract_spawn_error_method(
         &mut self,
     ) -> Result<Document<'static>> {
         let class_name = self.class_name();
-        let hint_binary = Self::binary_string_literal(
-            "Abstract classes cannot be instantiated. Subclass it first.",
-        );
-        let doc = docvec![
+        Ok(Self::instantiation_error_stub(
             "'spawn'/0 = fun () ->",
-            nest(
-                INDENT,
-                docvec![
-                    line(),
-                    docvec![
-                        "let Error0 = call 'beamtalk_error':'new'('instantiation_error', '",
-                        Document::String(class_name.clone()),
-                        "') in",
-                    ],
-                    line(),
-                    "let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'spawn') in",
-                    line(),
-                    docvec![
-                        "let Error2 = call 'beamtalk_error':'with_hint'(Error1, ",
-                        Document::String(hint_binary.clone()),
-                        ") in",
-                    ],
-                    line(),
-                    "call 'beamtalk_error':'raise'(Error2)",
-                ]
-            ),
-            "\n",
-        ];
-        Ok(doc)
+            Document::String(class_name),
+            "spawn",
+            "Abstract classes cannot be instantiated. Subclass it first.",
+        ))
     }
 
     /// Generates the `spawn/1` error method for abstract classes (BT-105).
@@ -421,26 +338,52 @@ impl CoreErlangGenerator {
         &mut self,
     ) -> Result<Document<'static>> {
         let class_name = self.class_name();
-        let hint_binary = Self::binary_string_literal(
-            "Abstract classes cannot be instantiated. Subclass it first.",
-        );
-        let doc = docvec![
+        Ok(Self::instantiation_error_stub(
             "'spawn'/1 = fun (_InitArgs) ->",
+            Document::String(class_name),
+            "spawnWith:",
+            "Abstract classes cannot be instantiated. Subclass it first.",
+        ))
+    }
+
+    /// Builds the 4-step `instantiation_error` let-chain for a stub method that always raises.
+    ///
+    /// Shared by all four actor/abstract instantiation guard methods. Generates:
+    /// ```text
+    /// '<method>'/N = fun (...) ->
+    ///     let Error0 = call 'beamtalk_error':'new'('instantiation_error', '<class>') in
+    ///     let Error1 = call 'beamtalk_error':'with_selector'(Error0, '<selector>') in
+    ///     let Error2 = call 'beamtalk_error':'with_hint'(Error1, <<"hint">>) in
+    ///     call 'beamtalk_error':'raise'(Error2)
+    /// ```
+    fn instantiation_error_stub(
+        fun_decl: &'static str,
+        class_name_doc: Document<'static>,
+        selector: &'static str,
+        hint: &str,
+    ) -> Document<'static> {
+        let hint_binary = Self::binary_string_literal(hint);
+        docvec![
+            fun_decl,
             nest(
                 INDENT,
                 docvec![
                     line(),
                     docvec![
                         "let Error0 = call 'beamtalk_error':'new'('instantiation_error', '",
-                        Document::String(class_name.clone()),
+                        class_name_doc,
                         "') in",
                     ],
                     line(),
-                    "let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'spawnWith:') in",
+                    docvec![
+                        "let Error1 = call 'beamtalk_error':'with_selector'(Error0, '",
+                        selector,
+                        "') in",
+                    ],
                     line(),
                     docvec![
                         "let Error2 = call 'beamtalk_error':'with_hint'(Error1, ",
-                        Document::String(hint_binary.clone()),
+                        Document::String(hint_binary),
                         ") in",
                     ],
                     line(),
@@ -448,8 +391,7 @@ impl CoreErlangGenerator {
                 ]
             ),
             "\n",
-        ];
-        Ok(doc)
+        ]
     }
 
     /// Returns a Core Erlang binary string literal for the given string.


### PR DESCRIPTION
## Summary

Extracts a shared private helper to eliminate four near-identical Core Erlang error-chain methods in `gen_server/spawn.rs`.

- `generate_actor_new_error_method` (line 304)
- `generate_actor_new_with_args_error_method` (line 349)
- `generate_abstract_spawn_error_method` (line 383)
- `generate_abstract_spawn_with_args_error_method` (line 420)

Each generated the same 4-step `instantiation_error → with_selector → with_hint → raise` let-chain, varying only in function declaration, class name atom, selector, and hint. A single private `fn instantiation_error_stub(fun_decl, class_name_doc, selector, hint)` replaces all four bodies. Net change: −58 lines, zero behaviour change.

Mirrors the existing `generate_primitive_new_error` pattern already present in `value_type_codegen.rs:676`.

## Key changes

- Added `fn instantiation_error_stub` — private, built entirely with `docvec!`/Document API (no `format!` for Core Erlang fragments)
- Four public methods reduced to single-line `Ok(Self::instantiation_error_stub(...))` delegates
- Removed unnecessary `.clone()` on `class_name` in the two abstract-class callers (String now consumed directly by `Document::String`)

## Test plan

- [x] Existing `test_generate_actor_new_error_methods` passes (asserts exact Core Erlang substrings)
- [x] Existing instantiation_error tests pass (2 additional tests)
- [x] 4005 `beamtalk-core` unit tests pass
- [x] `just build && just clippy && just fmt-check` all green
- [x] Dialyzer clean

Linear: https://linear.app/beamtalk/issue/BT-2335/extract-shared-helper-for-four-near-identical-instantiation-error-stub

https://claude.ai/code/session_016RiKW8pKCUbY8bJS5Q5TWW

---
_Generated by [Claude Code](https://claude.ai/code/session_016RiKW8pKCUbY8bJS5Q5TWW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Consolidated internal error handling code for actor instantiation logic, improving code maintainability and reducing duplication across shared error generation routines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->