### PR TITLE
Add EUnit tests for shutdown handler in beamtalk_repl_ops_session (BT-2336)

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_session_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_session_tests.erl
@@ -1,0 +1,140 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_repl_ops_session_tests).
+
+%%% **DDD Context:** REPL Session Context
+
+-moduledoc """
+EUnit tests for beamtalk_repl_ops_session module.
+
+Covers the shutdown handler (lines 75-97), which was 0% covered prior to
+this test file. The sessions, close, health, and clone (success) handlers
+are already exercised by integration tests and are not duplicated here.
+
+The shutdown handler validates the Erlang node cookie via constant-time
+comparison (crypto:hash_equals/2) before scheduling a graceful shutdown.
+All tests run without any live services:
+- erlang:get_cookie/0 is always available in any Erlang node.
+- erlang:send_after/3 called with an unregistered atom destination
+  silently discards the message when the timer fires — no crash.
+- beamtalk_workspace_meta and beamtalk_repl_server are not involved
+  in this handler's cookie-validation branches.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+make_msg(Op, Id, Session, Legacy) ->
+    {protocol_msg, Op, Id, Session, #{}, Legacy}.
+
+%%====================================================================
+%% shutdown op — invalid cookie (false branch)
+%%====================================================================
+
+shutdown_missing_cookie_returns_auth_error_test() ->
+    %% No <<"cookie">> key → maps:get defaults to <<>> → size mismatch → false.
+    Msg = make_msg(<<"shutdown">>, <<"sd-1">>, undefined, false),
+    Result = beamtalk_repl_ops_session:handle(<<"shutdown">>, #{}, Msg, self()),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ?assert(binary:match(maps:get(<<"error">>, Decoded), <<"Invalid cookie">>) =/= nomatch).
+
+shutdown_empty_cookie_returns_auth_error_test() ->
+    %% Explicit empty binary → byte_size(<<>>) =/= byte_size(NodeCookie) → false.
+    Msg = make_msg(<<"shutdown">>, <<"sd-2">>, undefined, false),
+    Result = beamtalk_repl_ops_session:handle(
+        <<"shutdown">>, #{<<"cookie">> => <<>>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ?assert(binary:match(maps:get(<<"error">>, Decoded), <<"Invalid cookie">>) =/= nomatch).
+
+shutdown_wrong_length_cookie_returns_auth_error_test() ->
+    %% Cookie one byte longer than the real cookie → byte_size check short-circuits
+    %% before crypto:hash_equals/2 is ever called.
+    NodeCookieBin = atom_to_binary(erlang:get_cookie(), utf8),
+    WrongLen = byte_size(NodeCookieBin) + 1,
+    WrongCookie = binary:copy(<<$X>>, WrongLen),
+    Msg = make_msg(<<"shutdown">>, <<"sd-3">>, undefined, false),
+    Result = beamtalk_repl_ops_session:handle(
+        <<"shutdown">>, #{<<"cookie">> => WrongCookie}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ?assert(binary:match(maps:get(<<"error">>, Decoded), <<"Invalid cookie">>) =/= nomatch).
+
+shutdown_same_length_wrong_cookie_exercises_hash_equals_test() ->
+    %% Same byte-length as the real cookie but different content → exercises the
+    %% crypto:hash_equals/2 false branch (constant-time comparison returns false).
+    NodeCookieBin = atom_to_binary(erlang:get_cookie(), utf8),
+    Len = byte_size(NodeCookieBin),
+    %% XOR the first byte to guarantee the binary differs from the real cookie.
+    <<First, Rest/binary>> = NodeCookieBin,
+    WrongCookie =
+        case <<(First bxor 16#FF), Rest/binary>> of
+            NodeCookieBin -> binary:copy(<<$X>>, Len);
+            Flipped -> Flipped
+        end,
+    Msg = make_msg(<<"shutdown">>, <<"sd-4">>, undefined, false),
+    Result = beamtalk_repl_ops_session:handle(
+        <<"shutdown">>, #{<<"cookie">> => WrongCookie}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ?assert(binary:match(maps:get(<<"error">>, Decoded), <<"Invalid cookie">>) =/= nomatch).
+
+shutdown_error_response_includes_status_done_error_test() ->
+    %% The non-legacy error response must include status: [done, error].
+    Msg = make_msg(<<"shutdown">>, <<"sd-5">>, undefined, false),
+    Result = beamtalk_repl_ops_session:handle(<<"shutdown">>, #{}, Msg, self()),
+    Decoded = json:decode(Result),
+    ?assertEqual([<<"done">>, <<"error">>], maps:get(<<"status">>, Decoded)).
+
+%%====================================================================
+%% shutdown op — valid cookie (true branch)
+%%====================================================================
+
+shutdown_valid_cookie_returns_ok_status_test() ->
+    %% Correct node cookie → ValidCookie = true → encode_status(ok) → done JSON.
+    %% erlang:send_after/3 targets the atom beamtalk_repl_server which is not
+    %% registered in unit tests; the timer message is silently discarded on fire.
+    NodeCookieBin = atom_to_binary(erlang:get_cookie(), utf8),
+    Msg = make_msg(<<"shutdown">>, <<"sd-6">>, undefined, false),
+    Result = beamtalk_repl_ops_session:handle(
+        <<"shutdown">>, #{<<"cookie">> => NodeCookieBin}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assertEqual(false, maps:is_key(<<"error">>, Decoded)),
+    ?assertEqual([<<"done">>], maps:get(<<"status">>, Decoded)).
+
+%%====================================================================
+%% shutdown op — legacy protocol format
+%%====================================================================
+
+shutdown_valid_cookie_legacy_returns_result_type_test() ->
+    %% Legacy protocol: response uses <<"type">> = <<"result">> + <<"value">> = <<"ok">>.
+    NodeCookieBin = atom_to_binary(erlang:get_cookie(), utf8),
+    Msg = make_msg(<<"shutdown">>, undefined, undefined, true),
+    Result = beamtalk_repl_ops_session:handle(
+        <<"shutdown">>, #{<<"cookie">> => NodeCookieBin}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assertEqual(<<"result">>, maps:get(<<"type">>, Decoded)),
+    ?assertEqual(<<"ok">>, maps:get(<<"value">>, Decoded)).
+
+shutdown_wrong_cookie_legacy_returns_error_type_test() ->
+    %% Legacy protocol error: <<"type">> = <<"error">>, <<"message">> key (not <<"error">>).
+    Msg = make_msg(<<"shutdown">>, undefined, undefined, true),
+    Result = beamtalk_repl_ops_session:handle(
+        <<"shutdown">>, #{<<"cookie">> => <<"definitely-wrong-cookie">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assertEqual(<<"error">>, maps:get(<<"type">>, Decoded)),
+    ?assert(maps:is_key(<<"message">>, Decoded)),
+    ?assert(
+        binary:match(maps:get(<<"message">>, Decoded), <<"Invalid cookie">>) =/= nomatch
+    ).


### PR DESCRIPTION
## Summary

The `shutdown` handler in `beamtalk_repl_ops_session.erl` was **0% covered** (lines 75–97) despite being security-relevant — it gates graceful node shutdown behind constant-time cookie comparison via `crypto:hash_equals/2`. Module coverage was 42% overall.

This PR adds `beamtalk_repl_ops_session_tests.erl` with **8 EUnit tests** covering all shutdown branches without requiring any live services:

- **Invalid cookie paths (5 tests):** missing cookie key, empty binary, wrong-length (byte_size short-circuit), same-length wrong content (exercises `hash_equals` false branch), status shape verification (`[done, error]`)
- **Valid cookie path (1 test):** correct node cookie → ok status JSON. The `send_after` side-effect targets `beamtalk_repl_server` which is not registered in unit tests — timer fires silently.
- **Legacy protocol format (2 tests):** valid cookie → `type: result` / `value: ok`; wrong cookie → `type: error` / `message` key

**No production code changes.** Test-only.

## Test plan

- [x] `rebar3 eunit --module=beamtalk_repl_ops_session_tests` — 8/8 pass
- [x] `rebar3 eunit --app=beamtalk_workspace` — 1770 tests (was 1762), no new failures
- [x] `rebar3 fmt --check` — clean
- [x] Pre-push hooks (clippy, dialyzer, erlfmt, biome) — all pass

## Linear

https://linear.app/beamtalk/issue/BT-2336/add-eunit-tests-for-shutdown-handler-in-beamtalk-repl-ops-session

https://claude.ai/code/session_01DVA5tHcLEY1f2isRBEWhsq

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVA5tHcLEY1f2isRBEWhsq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authentication and protocol handling in shutdown operations, verifying both modern and legacy protocol behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->