### PR TITLE
Add unparse::leaf API and migrate unparse/mod.rs to typed leaves (BT-2321)

### DIFF
--- a/crates/beamtalk-core/src/unparse/leaf.rs
+++ b/crates/beamtalk-core/src/unparse/leaf.rs
@@ -1,0 +1,256 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Typed leaf constructors for the Beamtalk *source* unparser (ADR 0089).
+//!
+//! **DDD Context:** Language Service — Formatting / Unparse
+//!
+//! The unparser in [`super`] turns AST nodes back into Beamtalk source text.
+//! Every text-shaped [`Document`] leaf it emits used to be built with the open
+//! [`Document::String`] escape hatch, which accepts arbitrary text and carries
+//! no intent. ADR 0089 replaces those open leaves with this small parallel API
+//! so each call site declares *what kind* of leaf it produces.
+//!
+//! # Why this is separate from `document::leaf`
+//!
+//! These helpers produce **Beamtalk syntax**, not Core Erlang. The escaping
+//! rules differ entirely:
+//!
+//! - No atom-quote ceremony (`'...'`) — that's a Core Erlang concept.
+//! - No Core Erlang string escaping — Beamtalk string literals use the
+//!   doubled-delimiter convention (`"` → `""`) and escape `{` to avoid
+//!   triggering interpolation.
+//!
+//! Sharing the Core Erlang leaf API here would be incorrect, so this module is
+//! intentionally a sibling rather than a reuse of `document::leaf`.
+//!
+//! # The single chokepoint
+//!
+//! Every helper wraps [`Document::String`] internally. When Phase 3 of ADR 0089
+//! removes the `Document::String` variant, this module is the *only* place in
+//! the unparser that needs to switch to the replacement owned-string
+//! constructor.
+
+use crate::codegen::core_erlang::document::Document;
+
+/// A Beamtalk identifier, operator, keyword part, or other syntactic name.
+///
+/// Identifiers are emitted verbatim — Beamtalk source identifiers, binary
+/// operators (`+`, `++`), keyword selectors (`at:`), type names, field names,
+/// and class names need no escaping.
+#[must_use]
+pub(super) fn ident(name: impl AsRef<str>) -> Document<'static> {
+    Document::String(name.as_ref().to_string())
+}
+
+/// An integer literal (`42`, `-7`).
+#[must_use]
+pub(super) fn int_lit(value: i64) -> Document<'static> {
+    Document::String(value.to_string())
+}
+
+/// A non-negative integer rendered in decimal — e.g. a binary-segment unit size
+/// (`:8`). Distinct from [`int_lit`] only in the source type it accepts.
+#[must_use]
+pub(super) fn nat_lit(value: usize) -> Document<'static> {
+    Document::String(value.to_string())
+}
+
+/// A float literal, rendered so it always reads back as a float (`2.0`, not `2`).
+///
+/// Integral floats gain a `.0` suffix; values already containing `.` or `e`
+/// are emitted as Rust's default `f64` formatting produces them.
+#[must_use]
+pub(super) fn float_lit(value: f64) -> Document<'static> {
+    let s = format!("{value}");
+    let rendered = if s.contains('.') || s.contains('e') {
+        s
+    } else {
+        format!("{value}.0")
+    };
+    Document::String(rendered)
+}
+
+/// A character literal (`$a`, `$\n`).
+///
+/// Control characters and the backslash are re-escaped; all other characters
+/// are emitted directly after the `$` sigil.
+#[must_use]
+pub(super) fn char_lit(c: char) -> Document<'static> {
+    let repr = match c {
+        '\n' => "\\n".to_string(),
+        '\t' => "\\t".to_string(),
+        '\r' => "\\r".to_string(),
+        '\\' => "\\\\".to_string(),
+        _ => c.to_string(),
+    };
+    Document::String(format!("${repr}"))
+}
+
+/// The *inner* content of a Beamtalk string literal, with delimiters escaped.
+///
+/// The caller is responsible for emitting the surrounding `"` delimiters; this
+/// helper escapes only the content so the same routine works for both plain
+/// string literals and the literal segments of an interpolated string.
+///
+/// Escaping rules (Beamtalk source, not Core Erlang):
+///
+/// - `"` is doubled (`""`) — the doubled-delimiter convention.
+/// - `{` becomes `\{` — otherwise it would start an interpolation.
+#[must_use]
+pub(super) fn string_content(s: impl AsRef<str>) -> Document<'static> {
+    let s = s.as_ref();
+    let mut result = String::with_capacity(s.len() + 4);
+    for c in s.chars() {
+        match c {
+            '"' => {
+                result.push('"');
+                result.push('"');
+            }
+            '{' => {
+                result.push('\\');
+                result.push('{');
+            }
+            _ => result.push(c),
+        }
+    }
+    Document::String(result)
+}
+
+/// The *inner* content of a symbol literal (`#name`, `#'with spaces'`).
+///
+/// The caller emits the `#` sigil and any surrounding quotes; the symbol name
+/// itself is emitted verbatim (no escaping).
+#[must_use]
+pub(super) fn symbol_content(s: impl AsRef<str>) -> Document<'static> {
+    Document::String(s.as_ref().to_string())
+}
+
+/// A class reference, optionally package-qualified (`Foo` or `pkg@Foo`).
+#[must_use]
+pub(super) fn class_ref(package: Option<&str>, name: &str) -> Document<'static> {
+    match package {
+        Some(pkg) => Document::String(format!("{pkg}@{name}")),
+        None => Document::String(name.to_string()),
+    }
+}
+
+/// Raw, unescaped text such as comment bodies, doc-comment lines, and error
+/// messages.
+///
+/// The caller is responsible for any surrounding syntax (e.g. `// `, `/* */`)
+/// and for any content sanitisation it requires (such as neutralising `*/`
+/// inside a block comment).
+#[must_use]
+pub(super) fn raw_text(s: impl AsRef<str>) -> Document<'static> {
+    Document::String(s.as_ref().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(doc: &Document<'static>) -> String {
+        doc.to_pretty_string()
+    }
+
+    #[test]
+    fn ident_is_verbatim() {
+        assert_eq!(render(&ident("fooBar")), "fooBar");
+        assert_eq!(render(&ident("++")), "++");
+        assert_eq!(render(&ident("at:")), "at:");
+        assert_eq!(render(&ident("")), "");
+    }
+
+    #[test]
+    fn int_lit_renders_decimal() {
+        assert_eq!(render(&int_lit(0)), "0");
+        assert_eq!(render(&int_lit(42)), "42");
+        assert_eq!(render(&int_lit(-7)), "-7");
+        assert_eq!(render(&int_lit(i64::MAX)), i64::MAX.to_string());
+        assert_eq!(render(&int_lit(i64::MIN)), i64::MIN.to_string());
+    }
+
+    #[test]
+    fn nat_lit_renders_decimal() {
+        assert_eq!(render(&nat_lit(0)), "0");
+        assert_eq!(render(&nat_lit(8)), "8");
+        assert_eq!(render(&nat_lit(usize::MAX)), usize::MAX.to_string());
+    }
+
+    #[test]
+    fn float_lit_adds_point_zero_for_integral_values() {
+        assert_eq!(render(&float_lit(2.0)), "2.0");
+        assert_eq!(render(&float_lit(0.0)), "0.0");
+        assert_eq!(render(&float_lit(-5.0)), "-5.0");
+    }
+
+    #[test]
+    fn float_lit_preserves_fractional_and_exponent_forms() {
+        assert_eq!(render(&float_lit(2.5)), "2.5");
+        assert_eq!(render(&float_lit(3.15)), "3.15");
+        // Very large magnitudes render in exponent form; the `.0` branch must
+        // not fire for those.
+        let big = render(&float_lit(1e300));
+        assert!(big.contains('e') || big.contains('.'), "got {big}");
+    }
+
+    #[test]
+    fn char_lit_escapes_control_chars() {
+        assert_eq!(render(&char_lit('a')), "$a");
+        assert_eq!(render(&char_lit('\n')), "$\\n");
+        assert_eq!(render(&char_lit('\t')), "$\\t");
+        assert_eq!(render(&char_lit('\r')), "$\\r");
+        assert_eq!(render(&char_lit('\\')), "$\\\\");
+        assert_eq!(render(&char_lit('$')), "$$");
+    }
+
+    #[test]
+    fn string_content_doubles_quotes() {
+        assert_eq!(render(&string_content("plain")), "plain");
+        assert_eq!(render(&string_content("say \"hi\"")), "say \"\"hi\"\"");
+    }
+
+    #[test]
+    fn string_content_escapes_interpolation_brace() {
+        assert_eq!(render(&string_content("a{b")), "a\\{b");
+        assert_eq!(render(&string_content("{")), "\\{");
+    }
+
+    #[test]
+    fn string_content_leaves_other_chars_untouched() {
+        // Closing brace and backslash are not special to the unparser's
+        // string-content escaping.
+        assert_eq!(render(&string_content("a}b")), "a}b");
+        assert_eq!(render(&string_content("a\\b")), "a\\b");
+    }
+
+    #[test]
+    fn symbol_content_is_verbatim() {
+        assert_eq!(render(&symbol_content("foo")), "foo");
+        assert_eq!(render(&symbol_content("with spaces")), "with spaces");
+    }
+
+    #[test]
+    fn class_ref_qualifies_with_package() {
+        assert_eq!(render(&class_ref(None, "Foo")), "Foo");
+        assert_eq!(render(&class_ref(Some("pkg"), "Foo")), "pkg@Foo");
+    }
+
+    #[test]
+    fn text_helpers_accept_any_str_like_source() {
+        // The unparser passes `&str`, `&String`, and `&EcoString` AST fields;
+        // `AsRef<str>` must accept all of them.
+        let owned = String::from("x");
+        let eco = ecow::EcoString::from("y");
+        assert_eq!(render(&ident("x")), "x");
+        assert_eq!(render(&ident(&owned)), "x");
+        assert_eq!(render(&ident(&eco)), "y");
+    }
+
+    #[test]
+    fn raw_text_is_verbatim() {
+        assert_eq!(render(&raw_text("a comment")), "a comment");
+        assert_eq!(render(&raw_text("has \" and { chars")), "has \" and { chars");
+    }
+}

--- a/crates/beamtalk-core/src/unparse/leaf.rs
+++ b/crates/beamtalk-core/src/unparse/leaf.rs
@@ -251,6 +251,9 @@ mod tests {
     #[test]
     fn raw_text_is_verbatim() {
         assert_eq!(render(&raw_text("a comment")), "a comment");
-        assert_eq!(render(&raw_text("has \" and { chars")), "has \" and { chars");
+        assert_eq!(
+            render(&raw_text("has \" and { chars")),
+            "has \" and { chars"
+        );
     }
 }

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -25,8 +25,13 @@
 //!
 //! - All output goes through the [`Document`] API — **never** `format!()` or
 //!   string concatenation (CLAUDE.md / ADR 0018).
-//! - Functions return `Document<'static>` using `Document::String` for all
-//!   content derived from AST data (identifiers, literal values, etc.).
+//! - Text leaves derived from AST data (identifiers, literal values, comments,
+//!   etc.) are constructed through the intent-carrying [`leaf`] helpers rather
+//!   than the open `Document::String` escape hatch (ADR 0089). When Phase 3 of
+//!   ADR 0089 removes `Document::String`, [`leaf`] is the single place that
+//!   needs updating.
+
+mod leaf;
 
 use crate::ast::{
     BinaryEndianness, BinarySegment, BinarySegmentType, BinarySignedness, Block, BlockParameter,
@@ -110,13 +115,13 @@ pub fn format_source(source: &str) -> Option<String> {
 /// Builds a [`Document`] for a method display signature (no `sealed`, no ` =>`).
 fn unparse_method_display_signature_doc(method: &MethodDefinition) -> Document<'static> {
     let sig = match &method.selector {
-        MessageSelector::Unary(name) => Document::String(name.to_string()),
+        MessageSelector::Unary(name) => leaf::ident(name),
         MessageSelector::Binary(op) => {
             let param = &method.parameters[0];
             docvec![
-                Document::String(op.to_string()),
+                leaf::ident(op),
                 " ",
-                Document::String(param.name.name.to_string()),
+                leaf::ident(&param.name.name),
                 unparse_type_annotation_opt(param.type_annotation.as_ref()),
             ]
         }
@@ -130,7 +135,7 @@ fn unparse_method_display_signature_doc(method: &MethodDefinition) -> Document<'
                 if i < method.parameters.len() {
                     sig_docs.push(Document::Str(" "));
                     let param = &method.parameters[i];
-                    sig_docs.push(Document::String(param.name.name.to_string()));
+                    sig_docs.push(leaf::ident(&param.name.name));
                     sig_docs.push(unparse_type_annotation_opt(param.type_annotation.as_ref()));
                 }
             }
@@ -225,7 +230,7 @@ pub(crate) fn unparse_class_definition(class: &ClassDefinition) -> Document<'sta
             if line_text.is_empty() {
                 docs.push(Document::Str("///"));
             } else {
-                docs.push(docvec!["/// ", Document::String(line_text.to_string())]);
+                docs.push(docvec!["/// ", leaf::raw_text(line_text)]);
             }
             docs.push(line());
         }
@@ -252,7 +257,7 @@ pub(crate) fn unparse_class_definition(class: &ClassDefinition) -> Document<'sta
     }
 
     let class_name_doc = if class.type_params.is_empty() {
-        Document::String(class.name.name.to_string())
+        leaf::ident(&class.name.name)
     } else {
         let params: Vec<Document<'static>> = class
             .type_params
@@ -260,13 +265,9 @@ pub(crate) fn unparse_class_definition(class: &ClassDefinition) -> Document<'sta
             .enumerate()
             .map(|(i, p)| {
                 let param_doc = if let Some(ref bound) = p.bound {
-                    docvec![
-                        Document::String(p.name.name.to_string()),
-                        " :: ",
-                        Document::String(bound.name.to_string())
-                    ]
+                    docvec![leaf::ident(&p.name.name), " :: ", leaf::ident(&bound.name)]
                 } else {
-                    Document::String(p.name.name.to_string())
+                    leaf::ident(&p.name.name)
                 };
                 if i == 0 {
                     param_doc
@@ -275,24 +276,19 @@ pub(crate) fn unparse_class_definition(class: &ClassDefinition) -> Document<'sta
                 }
             })
             .collect();
-        docvec![
-            Document::String(class.name.name.to_string()),
-            "(",
-            concat(params),
-            ")"
-        ]
+        docvec![leaf::ident(&class.name.name), "(", concat(params), ")"]
     };
 
     // Emit superclass type args: `Collection(E)` or `Collection(Integer)`
     let superclass_with_type_args = if class.superclass_type_args.is_empty() {
-        Document::String(superclass)
+        leaf::ident(&superclass)
     } else {
-        let mut parts = vec![Document::String(superclass), Document::Str("(")];
+        let mut parts = vec![leaf::ident(&superclass), Document::Str("(")];
         for (i, ta) in class.superclass_type_args.iter().enumerate() {
             if i > 0 {
                 parts.push(Document::Str(", "));
             }
-            parts.push(Document::String(ta.type_name().to_string()));
+            parts.push(leaf::ident(ta.type_name()));
         }
         parts.push(Document::Str(")"));
         concat(parts)
@@ -306,11 +302,7 @@ pub(crate) fn unparse_class_definition(class: &ClassDefinition) -> Document<'sta
     ];
 
     let header = if let Some(module) = &class.backing_module {
-        docvec![
-            class_header,
-            " native: ",
-            Document::String(module.name.to_string())
-        ]
+        docvec![class_header, " native: ", leaf::ident(&module.name)]
     } else {
         class_header
     };
@@ -385,7 +377,7 @@ pub(crate) fn unparse_class_definition(class: &ClassDefinition) -> Document<'sta
 pub(crate) fn unparse_standalone_method_definition(
     smd: &StandaloneMethodDefinition,
 ) -> Document<'static> {
-    let class = Document::String(smd.class_name.name.to_string());
+    let class = leaf::ident(&smd.class_name.name);
     let separator = if smd.is_class_method {
         Document::Str(" class >> ")
     } else {
@@ -411,7 +403,7 @@ fn unparse_protocol_definition(protocol: &ProtocolDefinition) -> Document<'stati
             if line_text.is_empty() {
                 docs.push(Document::Str("///"));
             } else {
-                docs.push(docvec!["/// ", Document::String(line_text.to_string())]);
+                docs.push(docvec!["/// ", leaf::raw_text(line_text)]);
             }
             docs.push(line());
         }
@@ -420,7 +412,7 @@ fn unparse_protocol_definition(protocol: &ProtocolDefinition) -> Document<'stati
     // Protocol header: `Protocol define: Name`
     let mut header: Vec<Document<'static>> = vec![
         Document::Str("Protocol define: "),
-        Document::String(protocol.name.name.to_string()),
+        leaf::ident(&protocol.name.name),
     ];
 
     // Type parameters: `(E)`, `(K, V)`
@@ -430,7 +422,7 @@ fn unparse_protocol_definition(protocol: &ProtocolDefinition) -> Document<'stati
             if i > 0 {
                 header.push(Document::Str(", "));
             }
-            header.push(Document::String(tp.name.name.to_string()));
+            header.push(leaf::ident(&tp.name.name));
         }
         header.push(Document::Str(")"));
     }
@@ -440,10 +432,7 @@ fn unparse_protocol_definition(protocol: &ProtocolDefinition) -> Document<'stati
     // `extending: ParentProtocol`
     if let Some(ext) = &protocol.extending {
         docs.push(line());
-        docs.push(docvec![
-            "  extending: ",
-            Document::String(ext.name.to_string())
-        ]);
+        docs.push(docvec!["  extending: ", leaf::ident(&ext.name)]);
     }
 
     // Instance method signatures (indented by 2 spaces)
@@ -487,7 +476,7 @@ fn unparse_protocol_method_signature(
             if line_text.is_empty() {
                 docs.push(Document::Str("///"));
             } else {
-                docs.push(docvec!["/// ", Document::String(line_text.to_string())]);
+                docs.push(docvec!["/// ", leaf::raw_text(line_text)]);
             }
             docs.push(line());
         }
@@ -501,13 +490,13 @@ fn unparse_protocol_method_signature(
     // Selector and parameters
     match &sig.selector {
         MessageSelector::Unary(name) => {
-            docs.push(Document::String(name.to_string()));
+            docs.push(leaf::ident(name));
         }
         MessageSelector::Binary(op) => {
-            docs.push(Document::String(op.to_string()));
+            docs.push(leaf::ident(op));
             if let Some(param) = sig.parameters.first() {
                 docs.push(Document::Str(" "));
-                docs.push(Document::String(param.name.name.to_string()));
+                docs.push(leaf::ident(&param.name.name));
                 docs.push(unparse_type_annotation_opt(param.type_annotation.as_ref()));
             }
         }
@@ -516,10 +505,10 @@ fn unparse_protocol_method_signature(
                 if i > 0 {
                     docs.push(Document::Str(" "));
                 }
-                docs.push(Document::String(part.keyword.to_string()));
+                docs.push(leaf::ident(&part.keyword));
                 if let Some(param) = sig.parameters.get(i) {
                     docs.push(Document::Str(" "));
-                    docs.push(Document::String(param.name.name.to_string()));
+                    docs.push(leaf::ident(&param.name.name));
                     docs.push(unparse_type_annotation_opt(param.type_annotation.as_ref()));
                 }
             }
@@ -571,7 +560,7 @@ fn unparse_method_definition_with_prefix(
             if line_text.is_empty() {
                 docs.push(Document::Str("///"));
             } else {
-                docs.push(docvec!["/// ", Document::String(line_text.to_string())]);
+                docs.push(docvec!["/// ", leaf::raw_text(line_text)]);
             }
             docs.push(line());
         }
@@ -581,12 +570,7 @@ fn unparse_method_definition_with_prefix(
     if let Some((cat, ref reason, _)) = method.expect {
         let base = docvec!["@expect ", unparse_expect_category(cat)];
         if let Some(reason) = reason {
-            docs.push(docvec![
-                base,
-                " \"",
-                Document::String(escape_string_literal(reason)),
-                "\""
-            ]);
+            docs.push(docvec![base, " \"", leaf::string_content(reason), "\""]);
         } else {
             docs.push(base);
         }
@@ -660,13 +644,13 @@ fn unparse_method_definition_with_prefix(
 /// Builds the method signature (selector + parameters + return type + arrow).
 fn unparse_method_signature(method: &MethodDefinition) -> Document<'static> {
     let sig = match &method.selector {
-        MessageSelector::Unary(name) => Document::String(name.to_string()),
+        MessageSelector::Unary(name) => leaf::ident(name),
         MessageSelector::Binary(op) => {
             let param = &method.parameters[0];
             docvec![
-                Document::String(op.to_string()),
+                leaf::ident(op),
                 " ",
-                Document::String(param.name.name.to_string()),
+                leaf::ident(&param.name.name),
                 unparse_type_annotation_opt(param.type_annotation.as_ref()),
             ]
         }
@@ -680,7 +664,7 @@ fn unparse_method_signature(method: &MethodDefinition) -> Document<'static> {
                 if i < method.parameters.len() {
                     sig_docs.push(Document::Str(" "));
                     let param = &method.parameters[i];
-                    sig_docs.push(Document::String(param.name.name.to_string()));
+                    sig_docs.push(leaf::ident(&param.name.name));
                     sig_docs.push(unparse_type_annotation_opt(param.type_annotation.as_ref()));
                 }
             }
@@ -710,7 +694,7 @@ fn unparse_method_signature(method: &MethodDefinition) -> Document<'static> {
 }
 
 fn unparse_keyword_part(part: &KeywordPart) -> Document<'static> {
-    Document::String(part.keyword.to_string())
+    leaf::ident(&part.keyword)
 }
 
 /// Builds a [`Document`] for a [`StateDeclaration`].
@@ -738,7 +722,7 @@ fn unparse_state_declaration_inner(state: &StateDeclaration, is_class: bool) -> 
             if line_text.is_empty() {
                 docs.push(Document::Str("///"));
             } else {
-                docs.push(docvec!["/// ", Document::String(line_text.to_string())]);
+                docs.push(docvec!["/// ", leaf::raw_text(line_text)]);
             }
             docs.push(line());
         }
@@ -751,7 +735,7 @@ fn unparse_state_declaration_inner(state: &StateDeclaration, is_class: bool) -> 
                 "@expect ",
                 unparse_expect_category(cat),
                 " \"",
-                Document::String(escape_string_literal(reason)),
+                leaf::string_content(reason),
                 "\""
             ]);
         } else {
@@ -765,10 +749,8 @@ fn unparse_state_declaration_inner(state: &StateDeclaration, is_class: bool) -> 
     } else {
         state.declared_keyword.as_str()
     };
-    let mut decl: Vec<Document<'static>> = vec![
-        Document::Str(keyword),
-        Document::String(state.name.name.to_string()),
-    ];
+    let mut decl: Vec<Document<'static>> =
+        vec![Document::Str(keyword), leaf::ident(&state.name.name)];
 
     if let Some(ty) = &state.type_annotation {
         decl.push(Document::Str(" :: "));
@@ -821,21 +803,13 @@ pub(crate) fn unparse_expression(expr: &Expression) -> Document<'static> {
         Expression::Literal(lit, _) => unparse_literal(lit),
         Expression::Identifier(id) => unparse_identifier(id),
         Expression::ClassReference { name, package, .. } => {
-            if let Some(pkg) = package {
-                Document::String(format!("{}@{}", pkg.name, name.name))
-            } else {
-                Document::String(name.name.to_string())
-            }
+            leaf::class_ref(package.as_ref().map(|pkg| pkg.name.as_str()), &name.name)
         }
         Expression::Super(_) => Document::Str("super"),
         Expression::FieldAccess {
             receiver, field, ..
         } => {
-            docvec![
-                unparse_expression(receiver),
-                ".",
-                Document::String(field.name.to_string()),
-            ]
+            docvec![unparse_expression(receiver), ".", leaf::ident(&field.name),]
         }
         Expression::MessageSend {
             receiver,
@@ -899,9 +873,9 @@ pub(crate) fn unparse_expression(expr: &Expression) -> Document<'static> {
                 "@primitive"
             };
             if *is_quoted {
-                docvec![directive, " \"", Document::String(name.to_string()), "\""]
+                docvec![directive, " \"", leaf::ident(name), "\""]
             } else {
-                docvec![directive, " ", Document::String(name.to_string())]
+                docvec![directive, " ", leaf::ident(name)]
             }
         }
         Expression::StringInterpolation { segments, .. } => unparse_string_interpolation(segments),
@@ -910,12 +884,7 @@ pub(crate) fn unparse_expression(expr: &Expression) -> Document<'static> {
         } => {
             let base = docvec!["@expect ", unparse_expect_category(*category)];
             if let Some(reason) = reason {
-                docvec![
-                    base,
-                    " \"",
-                    Document::String(escape_string_literal(reason)),
-                    "\""
-                ]
+                docvec![base, " \"", leaf::string_content(reason), "\""]
             } else {
                 base
             }
@@ -924,13 +893,13 @@ pub(crate) fn unparse_expression(expr: &Expression) -> Document<'static> {
             // Emit a comment indicating the error rather than nothing.
             // Escape `*/` in the message to prevent breaking the block comment.
             let safe_msg = message.as_str().replace("*/", "* /");
-            docvec!["/* error: ", Document::String(safe_msg), " */"]
+            docvec!["/* error: ", leaf::raw_text(&safe_msg), " */"]
         }
         Expression::DestructureAssignment { pattern, value, .. } => {
             docvec![unparse_pattern(pattern), " := ", unparse_expression(value)]
         }
         Expression::Spread { name, .. } => {
-            docvec!["...", Document::String(name.name.to_string())]
+            docvec!["...", leaf::ident(&name.name)]
         }
     }
 }
@@ -939,19 +908,19 @@ pub(crate) fn unparse_expression(expr: &Expression) -> Document<'static> {
 
 fn unparse_literal(lit: &Literal) -> Document<'static> {
     match lit {
-        Literal::Integer(n) => Document::String(n.to_string()),
-        Literal::Float(f) => Document::String(format_float(*f)),
+        Literal::Integer(n) => leaf::int_lit(*n),
+        Literal::Float(f) => leaf::float_lit(*f),
         Literal::String(s) => {
             // The lexer unescapes doubled delimiters ("" → ") in the AST.
             // We re-escape any bare " using the Beamtalk convention: double it ("").
-            docvec!["\"", Document::String(escape_string_literal(s)), "\""]
+            docvec!["\"", leaf::string_content(s), "\""]
         }
         Literal::Symbol(s) => {
             // Symbols: #name or #'name with spaces'
             if needs_symbol_quoting(s) {
-                docvec!["#'", Document::String(s.to_string()), "'"]
+                docvec!["#'", leaf::symbol_content(s), "'"]
             } else {
-                docvec!["#", Document::String(s.to_string())]
+                docvec!["#", leaf::symbol_content(s)]
             }
         }
         Literal::List(items) => {
@@ -964,50 +933,9 @@ fn unparse_literal(lit: &Literal) -> Document<'static> {
                 docvec!["#(", joined, ")"]
             }
         }
-        Literal::Character(c) => {
-            // $a, $\n, $\t etc. — re-escape control characters
-            let repr = match c {
-                '\n' => "\\n".to_string(),
-                '\t' => "\\t".to_string(),
-                '\r' => "\\r".to_string(),
-                '\\' => "\\\\".to_string(),
-                _ => c.to_string(),
-            };
-            Document::String(format!("${repr}"))
-        }
+        // $a, $\n, $\t etc. — re-escape control characters (see `leaf::char_lit`)
+        Literal::Character(c) => leaf::char_lit(*c),
     }
-}
-
-/// Format a float, preserving a decimal point.
-fn format_float(f: f64) -> String {
-    let s = format!("{f}");
-    if s.contains('.') || s.contains('e') {
-        s
-    } else {
-        format!("{f}.0")
-    }
-}
-
-/// Escape string contents for output as a Beamtalk string literal.
-///
-/// - `"` is doubled (`""`) — the Beamtalk doubled-delimiter convention.
-/// - `{` is escaped as `\{` — otherwise it would start interpolation.
-fn escape_string_literal(s: &str) -> String {
-    let mut result = String::with_capacity(s.len() + 4);
-    for c in s.chars() {
-        match c {
-            '"' => {
-                result.push('"');
-                result.push('"');
-            }
-            '{' => {
-                result.push('\\');
-                result.push('{');
-            }
-            _ => result.push(c),
-        }
-    }
-    result
 }
 
 /// Returns true if a symbol name needs quoting.
@@ -1024,7 +952,7 @@ fn needs_symbol_quoting(s: &str) -> bool {
 // --- Identifier unparsing ---
 
 fn unparse_identifier(id: &Identifier) -> Document<'static> {
-    Document::String(id.name.to_string())
+    leaf::ident(&id.name)
 }
 
 // --- Message send unparsing ---
@@ -1077,11 +1005,11 @@ fn unparse_message_send(
 
     let msg = match selector {
         MessageSelector::Unary(name) => {
-            docvec![recv_doc, " ", Document::String(name.to_string())]
+            docvec![recv_doc, " ", leaf::ident(name)]
         }
         MessageSelector::Binary(op) => {
             let arg = unparse_expression(&arguments[0]);
-            docvec![recv_doc, " ", Document::String(op.to_string()), " ", arg]
+            docvec![recv_doc, " ", leaf::ident(op), " ", arg]
         }
         MessageSelector::Keyword(parts) => {
             // Break all keywords to their own indented lines when:
@@ -1277,17 +1205,17 @@ fn unparse_block(block: &Block) -> Document<'static> {
 }
 
 fn unparse_block_parameter(param: &BlockParameter) -> Document<'static> {
-    docvec![":", Document::String(param.name.to_string())]
+    docvec![":", leaf::ident(&param.name)]
 }
 
 // --- Cascade unparsing ---
 
 fn unparse_cascade_message(msg: &CascadeMessage) -> Document<'static> {
     match &msg.selector {
-        MessageSelector::Unary(name) => Document::String(name.to_string()),
+        MessageSelector::Unary(name) => leaf::ident(name),
         MessageSelector::Binary(op) => {
             let arg = unparse_expression(&msg.arguments[0]);
-            docvec![Document::String(op.to_string()), " ", arg]
+            docvec![leaf::ident(op), " ", arg]
         }
         MessageSelector::Keyword(parts) => {
             let mut kw_docs: Vec<Document<'static>> = Vec::new();
@@ -1460,10 +1388,10 @@ fn unparse_pattern(pattern: &Pattern) -> Document<'static> {
         Pattern::Constructor {
             class, keywords, ..
         } => {
-            let mut parts: Vec<Document<'static>> = vec![Document::String(class.name.to_string())];
+            let mut parts: Vec<Document<'static>> = vec![leaf::ident(&class.name)];
             for (kw, binding) in keywords {
                 parts.push(Document::Str(" "));
-                parts.push(Document::String(kw.name.to_string()));
+                parts.push(leaf::ident(&kw.name));
                 parts.push(Document::Str(" "));
                 parts.push(unparse_pattern(binding));
             }
@@ -1507,7 +1435,7 @@ fn unparse_binary_segment(seg: &BinarySegment) -> Document<'static> {
     }
     if let Some(unit) = seg.unit {
         docs.push(Document::Str(":"));
-        docs.push(Document::String(unit.to_string()));
+        docs.push(leaf::nat_lit(unit));
     }
     concat(docs)
 }
@@ -1575,7 +1503,7 @@ fn unparse_string_interpolation(segments: &[StringSegment]) -> Document<'static>
         match seg {
             StringSegment::Literal(s) => {
                 // Literal segments may contain bare " from doubled-delimiter unescaping.
-                inner.push(Document::String(escape_string_literal(s)));
+                inner.push(leaf::string_content(s));
             }
             StringSegment::Interpolation(expr) => {
                 inner.push(Document::Str("{"));
@@ -1591,9 +1519,9 @@ fn unparse_string_interpolation(segments: &[StringSegment]) -> Document<'static>
 
 fn unparse_type_annotation(ty: &TypeAnnotation) -> Document<'static> {
     match ty {
-        TypeAnnotation::Simple(id) => Document::String(id.name.to_string()),
+        TypeAnnotation::Simple(id) => leaf::ident(&id.name),
         TypeAnnotation::Singleton { name, .. } => {
-            docvec!["#", Document::String(name.to_string())]
+            docvec!["#", leaf::ident(name)]
         }
         TypeAnnotation::Union { types, .. } => {
             let type_docs: Vec<Document<'static>> =
@@ -1606,7 +1534,7 @@ fn unparse_type_annotation(ty: &TypeAnnotation) -> Document<'static> {
             let param_docs: Vec<Document<'static>> =
                 parameters.iter().map(unparse_type_annotation).collect();
             let joined = join_docs(param_docs, ", ");
-            docvec![Document::String(base.name.to_string()), "(", joined, ")"]
+            docvec![leaf::ident(&base.name), "(", joined, ")"]
         }
         TypeAnnotation::FalseOr { inner, .. } => {
             docvec![unparse_type_annotation(inner), " | False"]
@@ -1614,7 +1542,7 @@ fn unparse_type_annotation(ty: &TypeAnnotation) -> Document<'static> {
         TypeAnnotation::SelfType { .. } => Document::Str("Self"),
         TypeAnnotation::SelfClass { .. } => Document::Str("Self class"),
         TypeAnnotation::ClassOf { class_name, .. } => {
-            docvec![Document::String(class_name.name.to_string()), " class"]
+            docvec![leaf::ident(&class_name.name), " class"]
         }
     }
 }
@@ -1644,11 +1572,11 @@ fn unparse_comment(comment: &Comment) -> Document<'static> {
             if comment.content.is_empty() {
                 Document::Str("//")
             } else {
-                docvec!["// ", Document::String(comment.content.to_string())]
+                docvec!["// ", leaf::raw_text(&comment.content)]
             }
         }
         CommentKind::Block => {
-            docvec!["/* ", Document::String(comment.content.to_string()), " */"]
+            docvec!["/* ", leaf::raw_text(&comment.content), " */"]
         }
     }
 }

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -873,7 +873,7 @@ pub(crate) fn unparse_expression(expr: &Expression) -> Document<'static> {
                 "@primitive"
             };
             if *is_quoted {
-                docvec![directive, " \"", leaf::ident(name), "\""]
+                docvec![directive, " \"", leaf::string_content(name), "\""]
             } else {
                 docvec![directive, " ", leaf::ident(name)]
             }


### PR DESCRIPTION
## Summary

ADR 0089 Phase 1 — introduces `unparse::leaf`, a typed leaf API for the Beamtalk source unparser, and migrates all ~66 `Document::String` sites in `unparse/mod.rs` to use it.

- **New file**: `crates/beamtalk-core/src/unparse/leaf.rs` — 9 intent-carrying helpers (`ident`, `int_lit`, `nat_lit`, `float_lit`, `char_lit`, `string_content`, `symbol_content`, `class_ref`, `raw_text`) that wrap `Document::String` as a single Phase-3 chokepoint
- **Migrated**: all 66 production `Document::String(...)` sites in `unparse/mod.rs` to the new helpers
- **Removed**: `escape_string_literal` and `format_float` (logic moved into leaf helpers)
- **Tests**: 12 unit tests covering each helper's escaping/rendering, plus `AsRef<str>` acceptance test. All 4018 core lib tests, 250 stdlib tests, and 2140 BUnit tests pass byte-for-byte.

## Linear Issue

https://linear.app/beamtalk/issue/BT-2321/add-unparseleaf-api-and-migrate-unparsemodrs-to-typed-leaves-adr-0089

## Test plan

- [x] All 129 existing unparse tests pass (including property tests)
- [x] All 12 new leaf unit tests pass
- [x] 250 stdlib tests pass
- [x] 2140 BUnit tests pass
- [x] Clippy clean, fmt clean
- [x] No `Document::String` sites remain in `unparse/mod.rs` (only in docstring)

https://claude.ai/code/session_011bdwa2ezGVMPmNHpAbzHKW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized formatting helpers for source unparsing, consolidating identifier, literal, comment, and class/type rendering to produce more consistent output (including string/char/number formatting and escaping).
* **Tests**
  * Added unit tests that verify rendering and escaping behavior for literals and text segments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->