### PR TITLE
Migrate leaf utilities + small codegen files to document::leaf (BT-2322)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -301,7 +301,7 @@ clippy:
 lint-no-new-document-string:
     @echo "🔍 Checking for new Document::String / Document::Eco leaves (ADR 0089)..."
     @bash -c ' \
-        baseline=2317; \
+        baseline=2269; \
         files=$(grep -rlE --include="*.rs" "Document::(String|Eco)\(" \
             crates/beamtalk-core/src/codegen/core_erlang/ \
             | grep -vE "document/leaf\.rs|typed_leaves_audit\.rs|cerl_audit\.rs"); \

--- a/crates/beamtalk-core/src/codegen/core_erlang/actor_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/actor_codegen.rs
@@ -9,6 +9,7 @@
 //! `gen_server`-based Erlang modules with async messaging, error isolation,
 //! and hot code reload support.
 
+use super::document::leaf::{atom, fname};
 use super::document::{Document, INDENT, line, nest};
 use super::spec_codegen;
 use super::util::ClassIdentity;
@@ -142,9 +143,9 @@ impl CoreErlangGenerator {
         // the module has classes OR protocols (protocol-only files need it too).
         let module_header = if needs_register_class {
             docvec![
-                "module '",
-                Document::Eco(self.module_name.clone()),
-                "' [",
+                "module ",
+                atom(self.module_name.to_string()),
+                " [",
                 base_exports,
                 sealed_export_doc,
                 class_method_export_doc,
@@ -161,9 +162,9 @@ impl CoreErlangGenerator {
             ]
         } else {
             docvec![
-                "module '",
-                Document::Eco(self.module_name.clone()),
-                "' [",
+                "module ",
+                atom(self.module_name.to_string()),
+                " [",
                 base_exports,
                 sealed_export_doc,
                 class_method_export_doc,
@@ -335,12 +336,7 @@ impl CoreErlangGenerator {
                     .map_or(0, |i| c.methods[i].selector.arity())
             });
             // Standalone function takes Args + Self + State params
-            parts.push(docvec![
-                ", '__sealed_",
-                Document::String(sel),
-                "'/",
-                Document::String((arity + 2).to_string()),
-            ]);
+            parts.push(docvec![", ", fname(format!("__sealed_{sel}"), arity + 2),]);
         }
         Document::Vec(parts)
     }
@@ -360,10 +356,11 @@ impl CoreErlangGenerator {
         {
             // BT-412: Class method takes ClassSelf + ClassVars + user params
             parts.push(docvec![
-                ", 'class_",
-                Document::Eco(m.selector.name()),
-                "'/",
-                Document::String((m.selector.arity() + 2).to_string()),
+                ", ",
+                fname(
+                    format!("class_{}", m.selector.name()),
+                    m.selector.arity() + 2
+                ),
             ]);
         }
         Document::Vec(parts)
@@ -403,9 +400,9 @@ impl CoreErlangGenerator {
                     "let Self = call 'beamtalk_actor':'make_self'(State) in",
                     line(),
                     docvec![
-                        "call '",
-                        Document::Eco(module_name.clone()),
-                        "':'dispatch'(Selector, Args, Self, State)",
+                        "call ",
+                        atom(module_name.to_string()),
+                        ":'dispatch'(Selector, Args, Self, State)",
                     ],
                 ]
             ),
@@ -514,10 +511,7 @@ impl CoreErlangGenerator {
             // Generate: '__sealed_{selector}'/N = fun (Arg1, ..., Self, State) ->
             let method_entry = docvec![
                 "\n",
-                "'__sealed_",
-                Document::String(selector_name.clone()),
-                "'/",
-                Document::String(arity.to_string()),
+                fname(format!("__sealed_{selector_name}"), arity),
                 "  = ",
                 fun_doc,
                 "\n",
@@ -593,37 +587,37 @@ impl CoreErlangGenerator {
     ) -> Document<'static> {
         let spec_mod = self.compiled_module_name("SupervisionSpec");
         let policy_mod: Document<'static> = if has_local_policy_override {
-            Document::Eco(self.module_name.clone())
+            atom(self.module_name.to_string())
         } else {
-            Document::String(self.compiled_module_name("Actor"))
+            atom(self.compiled_module_name("Actor"))
         };
         docvec![
             "'class_supervisionSpec'/2 = fun (ClassSelf, ClassVars) ->\n",
-            "    let CMR = call '",
+            "    let CMR = call ",
             policy_mod,
-            "':'class_supervisionPolicy'(ClassSelf, ClassVars) in\n",
+            ":'class_supervisionPolicy'(ClassSelf, ClassVars) in\n",
             "    case CMR of\n",
             "      <{'class_var_result', Policy, NewClassVars}> when 'true' ->\n",
-            "        let Spec0 = call '",
-            Document::String(spec_mod.clone()),
-            "':'new'() in\n",
-            "        let Spec1 = call '",
-            Document::String(spec_mod.clone()),
-            "':'withActorClass:'(Spec0, ClassSelf) in\n",
-            "        let Spec2 = call '",
-            Document::String(spec_mod.clone()),
-            "':'withRestart:'(Spec1, Policy) in\n",
+            "        let Spec0 = call ",
+            atom(spec_mod.clone()),
+            ":'new'() in\n",
+            "        let Spec1 = call ",
+            atom(spec_mod.clone()),
+            ":'withActorClass:'(Spec0, ClassSelf) in\n",
+            "        let Spec2 = call ",
+            atom(spec_mod.clone()),
+            ":'withRestart:'(Spec1, Policy) in\n",
             "        {'class_var_result', Spec2, NewClassVars}\n",
             "      <Policy> when 'true' ->\n",
-            "        let Spec0 = call '",
-            Document::String(spec_mod.clone()),
-            "':'new'() in\n",
-            "        let Spec1 = call '",
-            Document::String(spec_mod.clone()),
-            "':'withActorClass:'(Spec0, ClassSelf) in\n",
-            "        call '",
-            Document::String(spec_mod),
-            "':'withRestart:'(Spec1, Policy)\n",
+            "        let Spec0 = call ",
+            atom(spec_mod.clone()),
+            ":'new'() in\n",
+            "        let Spec1 = call ",
+            atom(spec_mod.clone()),
+            ":'withActorClass:'(Spec0, ClassSelf) in\n",
+            "        call ",
+            atom(spec_mod),
+            ":'withRestart:'(Spec1, Policy)\n",
             "    end\n",
         ]
     }

--- a/crates/beamtalk-core/src/codegen/core_erlang/operators.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/operators.rs
@@ -6,6 +6,7 @@
 //! **DDD Context:** Compilation — Code Generation
 
 use super::document::Document;
+use super::document::leaf::var;
 use super::{CodeGenError, CoreErlangGenerator, Result};
 use crate::ast::Expression;
 use crate::docvec;
@@ -174,24 +175,24 @@ impl CoreErlangGenerator {
             let right_var = self.fresh_temp_var("ConcatRight");
             docvec![
                 "let ",
-                Document::String(left_var.clone()),
+                var(left_var.clone()),
                 " = ",
                 left_code,
                 " in let ",
-                Document::String(right_var.clone()),
+                var(right_var.clone()),
                 " = ",
                 right_code,
                 " in case call 'erlang':'is_list'(",
-                Document::String(left_var.clone()),
+                var(left_var.clone()),
                 ") of <'true'> when 'true' -> call 'erlang':'++'(",
-                Document::String(left_var.clone()),
+                var(left_var.clone()),
                 ", ",
-                Document::String(right_var.clone()),
+                var(right_var.clone()),
                 ") <'false'> when 'true' -> \
                    call 'erlang':'iolist_to_binary'([call 'erlang':'binary_to_list'(",
-                Document::String(left_var),
+                var(left_var),
                 "), call 'erlang':'binary_to_list'(",
-                Document::String(right_var),
+                var(right_var),
                 ")]) end",
             ]
         };

--- a/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
@@ -50,6 +50,7 @@
 //! | Union | `union(...)` |
 //! | Singleton `#foo` | atom `foo` |
 
+use super::document::leaf::{atom, int_lit};
 use super::document::{Document, join};
 use crate::ast::{ClassDefinition, MethodDefinition, MethodKind, TypeAnnotation};
 use crate::docvec;
@@ -68,7 +69,7 @@ fn type_annotation_to_spec(annotation: &TypeAnnotation) -> Document<'static> {
             ]
         }
         TypeAnnotation::Singleton { name, .. } => {
-            docvec!["{'atom', 0, '", Document::String(name.to_string()), "'}"]
+            docvec!["{'atom', 0, ", atom(name.to_string()), "}"]
         }
         TypeAnnotation::Generic {
             base, parameters, ..
@@ -219,6 +220,8 @@ pub fn generate_method_spec(
     } else {
         method.parameters.len()
     };
+    // Method arities are bounded by the parameter count and always fit in i64.
+    let arity = i64::try_from(arity).unwrap_or(i64::MAX);
 
     let product = if param_types.is_empty() {
         Document::Str("{'type', 0, 'product', []}")
@@ -231,10 +234,10 @@ pub fn generate_method_spec(
     };
 
     Some(docvec![
-        "{'",
-        Document::String(erlang_name),
-        "', ",
-        Document::String(arity.to_string()),
+        "{",
+        atom(erlang_name),
+        ", ",
+        int_lit(arity),
         "}",
         ", [{'type', 0, 'fun', [",
         product,
@@ -284,6 +287,8 @@ fn generate_class_method_spec(method: &MethodDefinition) -> Option<Document<'sta
         });
 
     let arity = method.parameters.len() + 2;
+    // Method arities are bounded by the parameter count and always fit in i64.
+    let arity = i64::try_from(arity).unwrap_or(i64::MAX);
 
     let product = docvec![
         "{'type', 0, 'product', [",
@@ -292,10 +297,10 @@ fn generate_class_method_spec(method: &MethodDefinition) -> Option<Document<'sta
     ];
 
     Some(docvec![
-        "{'",
-        Document::String(erlang_name),
-        "', ",
-        Document::String(arity.to_string()),
+        "{",
+        atom(erlang_name),
+        ", ",
+        int_lit(arity),
         "}",
         ", [{'type', 0, 'fun', [",
         product,
@@ -382,22 +387,22 @@ pub fn generate_type_alias(class: &ClassDefinition, class_name: &str) -> Option<
 
     // '$beamtalk_class' tag field: always present, value = the class atom
     field_types.push(docvec![
-        "{'type', 0, 'map_field_exact', [{'atom', 0, '$beamtalk_class'}, {'atom', 0, '",
-        Document::String(class_name.to_string()),
-        "'}]}"
+        "{'type', 0, 'map_field_exact', [{'atom', 0, '$beamtalk_class'}, {'atom', 0, ",
+        atom(class_name.to_string()),
+        "}]}"
     ]);
 
     // One required field entry per declared state: field
     for field in &class.state {
-        let fname = Document::String(field.name.name.to_string());
+        let fname = atom(field.name.name.to_string());
         let ftype = field.type_annotation.as_ref().map_or(
             Document::Str("{'type', 0, 'any', []}"),
             type_annotation_to_spec,
         );
         field_types.push(docvec![
-            "{'type', 0, 'map_field_exact', [{'atom', 0, '",
+            "{'type', 0, 'map_field_exact', [{'atom', 0, ",
             fname,
-            "'}, ",
+            "}, ",
             ftype,
             "]}"
         ]);

--- a/crates/beamtalk-core/src/codegen/core_erlang/supervisor_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/supervisor_codegen.rs
@@ -22,6 +22,7 @@
 //! - `init/1` — `simple_one_for_one` with `childClass`, `maxRestarts`, `restartWindow`
 
 use super::document::Document;
+use super::document::leaf::{atom, fname};
 use super::util::ClassIdentity;
 use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result, spec_codegen};
 use crate::ast::{MethodKind, Module, SupervisorKind};
@@ -71,10 +72,8 @@ impl CoreErlangGenerator {
             let arity = m.selector.arity() + 2; // +2 for ClassSelf + ClassVars
             class_method_exports = docvec![
                 class_method_exports,
-                ", 'class_",
-                Document::Eco(m.selector.name()),
-                "'/",
-                Document::String(arity.to_string()),
+                ", ",
+                fname(format!("class_{}", m.selector.name()), arity),
             ];
         }
 
@@ -90,9 +89,9 @@ impl CoreErlangGenerator {
 
         // Module header
         docs.push(docvec![
-            "module '",
-            Document::Eco(module_name.clone()),
-            "' ['start_link'/0, 'init'/1",
+            "module ",
+            atom(module_name.to_string()),
+            " ['start_link'/0, 'init'/1",
             class_method_exports,
             ", 'superclass'/0, '__beamtalk_meta'/0, 'register_class'/0]\n",
             "  attributes ['behaviour' = ['supervisor'], 'on_load' = [{'register_class', 0}]",
@@ -146,10 +145,8 @@ impl CoreErlangGenerator {
             let arity = m.selector.arity() + 2;
             class_method_exports = docvec![
                 class_method_exports,
-                ", 'class_",
-                Document::Eco(m.selector.name()),
-                "'/",
-                Document::String(arity.to_string()),
+                ", ",
+                fname(format!("class_{}", m.selector.name()), arity),
             ];
         }
 
@@ -167,9 +164,9 @@ impl CoreErlangGenerator {
         // BT-1220: childClass/0 is called directly by beamtalk_supervisor:startChild/1,2
         // (SupMod:'childClass'() at `beamtalk_supervisor.erl (startChild/1,2)`)
         docs.push(docvec![
-            "module '",
-            Document::Eco(module_name.clone()),
-            "' ['start_link'/0, 'init'/1, 'childClass'/0",
+            "module ",
+            atom(module_name.to_string()),
+            " ['start_link'/0, 'init'/1, 'childClass'/0",
             class_method_exports,
             ", 'superclass'/0, '__beamtalk_meta'/0, 'register_class'/0]\n",
             "  attributes ['behaviour' = ['supervisor'], 'on_load' = [{'register_class', 0}]",
@@ -221,11 +218,11 @@ impl CoreErlangGenerator {
     fn generate_sup_start_link(module_name: &str) -> Document<'static> {
         docvec![
             "'start_link'/0 = fun () ->",
-            "\n    call 'supervisor':'start_link'({'local', '",
-            Document::String(module_name.to_string()),
-            "'}, '",
-            Document::String(module_name.to_string()),
-            "', [])",
+            "\n    call 'supervisor':'start_link'({'local', ",
+            atom(module_name.to_string()),
+            "}, ",
+            atom(module_name.to_string()),
+            ", [])",
         ]
     }
 
@@ -243,11 +240,11 @@ impl CoreErlangGenerator {
     fn generate_static_sup_init(class_name: &str, module_name: &str) -> Document<'static> {
         docvec![
             "'init'/1 = fun (_Args) ->",
-            "\n    call 'beamtalk_supervisor':'static_init'('",
-            Document::String(module_name.to_string()),
-            "', '",
-            Document::String(class_name.to_string()),
-            "')",
+            "\n    call 'beamtalk_supervisor':'static_init'(",
+            atom(module_name.to_string()),
+            ", ",
+            atom(class_name.to_string()),
+            ")",
         ]
     }
 
@@ -264,11 +261,11 @@ impl CoreErlangGenerator {
     fn generate_dynamic_sup_init(class_name: &str, module_name: &str) -> Document<'static> {
         docvec![
             "'init'/1 = fun (_Args) ->",
-            "\n    call 'beamtalk_supervisor':'dynamic_init'('",
-            Document::String(module_name.to_string()),
-            "', '",
-            Document::String(class_name.to_string()),
-            "')",
+            "\n    call 'beamtalk_supervisor':'dynamic_init'(",
+            atom(module_name.to_string()),
+            ", ",
+            atom(class_name.to_string()),
+            ")",
         ]
     }
 
@@ -285,9 +282,9 @@ impl CoreErlangGenerator {
     fn generate_dynamic_child_class(class_name: &str) -> Document<'static> {
         docvec![
             "'childClass'/0 = fun () ->",
-            "\n    let SupCp = call 'beamtalk_class_registry':'whereis_class'('",
-            Document::String(class_name.to_string()),
-            "') in",
+            "\n    let SupCp = call 'beamtalk_class_registry':'whereis_class'(",
+            atom(class_name.to_string()),
+            ") in",
             "\n    call 'beamtalk_object_class':'class_send'(SupCp, 'childClass', [])",
         ]
     }

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -12,6 +12,7 @@
 
 use std::fmt::Write as _;
 
+use super::document::leaf::{atom, string_lit};
 use super::document::{Document, join};
 use super::{CoreErlangGenerator, Result};
 use crate::ast::{ClassDefinition, Expression, ExpressionStatement};
@@ -80,11 +81,11 @@ pub(super) fn beamtalk_class_attribute(classes: &[ClassDefinition]) -> Document<
     }
     let entries = classes.iter().map(|c| {
         docvec![
-            "{'",
-            Document::String(c.name.name.to_string()),
-            "', '",
-            Document::String(c.superclass_name().to_string()),
-            "'}"
+            "{",
+            atom(c.name.name.to_string()),
+            ", ",
+            atom(c.superclass_name().to_string()),
+            "}"
         ]
     });
     docvec![
@@ -115,8 +116,7 @@ impl CoreErlangGenerator {
     pub(super) fn file_attr(&self) -> Document<'static> {
         match &self.source_path {
             Some(path) => {
-                let escaped = escape_core_erlang_string(path);
-                docvec![", 'file' = [{\"", Document::String(escaped), "\", 1}]"]
+                docvec![", 'file' = [{", string_lit(path), ", 1}]"]
             }
             None => Document::Nil,
         }
@@ -296,12 +296,7 @@ impl CoreErlangGenerator {
         }
         match &self.source_path {
             Some(path) => {
-                let escaped = escape_core_erlang_string(path);
-                docvec![
-                    ", 'beamtalk_source' = [\"",
-                    Document::String(escaped),
-                    "\"]"
-                ]
+                docvec![", 'beamtalk_source' = [", string_lit(path), "]"]
             }
             None => Document::Nil,
         }


### PR DESCRIPTION
## Summary

ADR 0089 Phase 2: Migrate 48 `Document::String`/`Document::Eco` sites to typed `document::leaf` helpers across 6 codegen files. This is the first codegen-migration batch, validating the mechanical edit pattern.

- Replace open leaves with `atom()`, `var()`, `string_lit()`, `int_lit()`, and `fname()` in util.rs, operators.rs, spec_codegen.rs, supervisor_codegen.rs, and actor_codegen.rs
- Verified state_codegen.rs, selector_mangler.rs, erlang_types.rs already have 0 sites (audit confirmed)
- Lower lint baseline from 2317 to 2269 (48 sites migrated)
- All existing codegen unit tests pass byte-for-byte (`to_pretty_string()` parity)

## Linear Issue

https://linear.app/beamtalk/issue/BT-2322/migrate-leaf-utilities-small-codegen-files-to-documentleaf-adr-0089

## Key Changes

| File | Sites | Helpers Used |
|------|-------|-------------|
| util.rs | 4 | atom, string_lit |
| operators.rs | 7 | var |
| spec_codegen.rs | 7 | atom, int_lit |
| supervisor_codegen.rs | 13 | atom, fname |
| actor_codegen.rs | 17 | atom, fname |

## Test Plan

- [x] `cargo test -p beamtalk-core --lib` (4032 tests pass)
- [x] `just test` passes (stdlib + BUnit + runtime)
- [x] `just clippy` passes
- [x] `just fmt-check` passes
- [x] `just lint-no-new-document-string` passes at new baseline 2269
- [x] No new `Document::String`/`Document::Eco` in any of the 8 target files

https://claude.ai/code/session_011bdwa2ezGVMPmNHpAbzHKW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code generation infrastructure by standardizing how Erlang identifiers and literals are emitted, enhancing consistency across the codebase.
  * Updated code quality guard baseline to reflect current state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->