### PR TITLE
refactor(codegen): migrate repl/codegen.rs to document::leaf API (BT-2323)

### DIFF
--- a/crates/beamtalk-core/src/repl/codegen.rs
+++ b/crates/beamtalk-core/src/repl/codegen.rs
@@ -18,6 +18,7 @@
 
 use crate::ast::{Expression, Pattern};
 use crate::codegen::core_erlang::document::Document;
+use crate::codegen::core_erlang::document::leaf::{atom, var};
 use crate::codegen::core_erlang::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result};
 use crate::docvec;
 
@@ -258,16 +259,12 @@ impl<'a> ReplAssembler<'a> {
                 Document::Str("    let State = Bindings in\n"),
             ];
             parts.extend(binding_docs);
-            parts.push(docvec![
-                "    let Result = ",
-                Document::String(rhs_var),
-                " in\n",
-            ]);
+            parts.push(docvec!["    let Result = ", var(rhs_var), " in\n",]);
             parts.push(docvec![
                 "    {[{",
                 src_bin,
                 ", Result}], ",
-                Document::String(final_state),
+                var(final_state),
                 "}\n",
             ]);
             parts.push(Document::Str("end\n"));
@@ -346,7 +343,7 @@ impl<'a> ReplAssembler<'a> {
             let step_val: Document<'static> = if repl_mutated {
                 docvec!["call 'erlang':'element'(1, ", result_var, ")",]
             } else {
-                Document::String(result_var)
+                var(result_var)
             };
             step_pairs.push((source_texts[i].clone(), step_val));
         }
@@ -388,8 +385,8 @@ impl<'a> ReplAssembler<'a> {
             let mut all_steps = prev_steps;
             all_steps.push((source_text.to_string(), Document::Str("Result")));
             let steps_doc = Self::build_steps_list_doc(all_steps);
-            let trace_return = docvec!["{", steps_doc, ", ", Document::String(final_state), "}"];
-            return Ok((binding_docs, Document::String(rhs_var), trace_return));
+            let trace_return = docvec!["{", steps_doc, ", ", var(final_state), "}"];
+            return Ok((binding_docs, var(rhs_var), trace_return));
         }
 
         if let Expression::Assignment { target, value, .. } = expr {
@@ -543,16 +540,8 @@ impl<'a> ReplAssembler<'a> {
                 Document::Str("    let State = Bindings in\n"),
             ];
             parts.extend(binding_docs);
-            parts.push(docvec![
-                "    let Result = ",
-                Document::String(rhs_var),
-                " in\n",
-            ]);
-            parts.push(docvec![
-                "    {Result, ",
-                Document::String(final_state),
-                "}\n",
-            ]);
+            parts.push(docvec!["    let Result = ", var(rhs_var), " in\n",]);
+            parts.push(docvec!["    {Result, ", var(final_state), "}\n",]);
             parts.push(Document::Str("end\n"));
             return Ok(Document::Vec(parts));
         }
@@ -670,7 +659,7 @@ impl<'a> ReplAssembler<'a> {
                 "    let ",
                 result_var.to_string(),
                 " = ",
-                Document::String(rhs_var),
+                var(rhs_var),
                 " in\n",
             ]);
             return Ok((Document::Vec(result), false));
@@ -743,8 +732,8 @@ impl<'a> ReplAssembler<'a> {
         if let Expression::DestructureAssignment { pattern, value, .. } = expr {
             let (binding_docs, rhs_var) = self.generate_repl_destructure(pattern, value)?;
             let final_state = self.generator.current_state_var();
-            let return_tuple = docvec!["{Result, ", Document::String(final_state), "}"];
-            return Ok((binding_docs, Document::String(rhs_var), return_tuple));
+            let return_tuple = docvec!["{Result, ", var(final_state), "}"];
+            return Ok((binding_docs, var(rhs_var), return_tuple));
         }
 
         if let Expression::Assignment { target, value, .. } = expr {
@@ -807,7 +796,7 @@ impl<'a> ReplAssembler<'a> {
             .expression_doc_with_repl_mutation_tracking(value)?;
         docs.push(docvec![
             "    let ",
-            Document::String(raw_var.clone()),
+            var(raw_var.clone()),
             " = ",
             val_doc,
             " in\n",
@@ -820,16 +809,16 @@ impl<'a> ReplAssembler<'a> {
             let new_state = self.generator.next_state_var();
             docs.push(docvec![
                 "    let ",
-                Document::String(value_var.clone()),
+                var(value_var.clone()),
                 " = call 'erlang':'element'(1, ",
-                Document::String(raw_var.clone()),
+                var(raw_var.clone()),
                 ") in\n",
             ]);
             docs.push(docvec![
                 "    let ",
-                Document::String(new_state),
+                var(new_state),
                 " = call 'erlang':'element'(2, ",
-                Document::String(raw_var),
+                var(raw_var),
                 ") in\n",
             ]);
             value_var
@@ -856,13 +845,13 @@ impl<'a> ReplAssembler<'a> {
             let new_state = self.generator.next_state_var();
             docs.push(docvec![
                 "    let ",
-                Document::String(new_state),
-                " = call 'maps':'put'('",
-                Document::String(name),
-                "', ",
-                Document::String(core_var),
+                var(new_state),
+                " = call 'maps':'put'(",
+                atom(name),
                 ", ",
-                Document::String(current_state),
+                var(core_var),
+                ", ",
+                var(current_state),
                 ") in\n",
             ]);
         }


### PR DESCRIPTION
## Summary

Migrates all 19 `Document::String(...)` sites in `crates/beamtalk-core/src/repl/codegen.rs` to the typed-leaf helpers from `document::leaf` (ADR 0089, added in BT-2320). This is the Phase 2 migration step for the REPL Core Erlang codegen tracked in the [ADR 0089 epic (BT-2319)](docs/ADR/0089-typed-document-leaves.md).

## Changes

- **18 variable-name sites** → `leaf::var(...)` (let-bound temporaries, threaded state vars, RHS/result vars).
- **1 `maps:put` key site** → `leaf::atom(...)`. This site previously hand-rolled the atom-quote punctuation (`'` + raw name + `'`); `atom()` now owns the quoting and escaping, closing the BT-875 recurrence vector for this file.
- Added `use crate::codegen::core_erlang::document::leaf::{atom, var};`.

## Equivalence

Generated Core Erlang output is byte-for-byte identical:
- `var(x)` is defined as `Document::String(x.into())` — pure rename.
- The migrated `atom(name)` site renders `'name'`; binding names are Beamtalk identifiers with no chars requiring escaping, so output matches the prior hand-quoted form exactly (and is strictly safer for any future edge case).

## Verification

- `cargo build -p beamtalk-core` — clean.
- `cargo fmt --all --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test -p beamtalk-core --lib` — 4032 passed, 0 failed (including the 23 `repl::codegen` unit tests that assert on generated module structure, and the Core Erlang validity proptests).
- Behavioural suites (`test-stdlib` / `test-repl-protocol`) require the Erlang toolchain (`erlc`), which is unavailable in the dev environment — left to CI.

Part of the ADR 0089 Phase 2 typed-Document-leaves migration.

https://claude.ai/code/session_011bdwa2ezGVMPmNHpAbzHKW

---
_Generated by [Claude Code](https://claude.ai/code/session_011bdwa2ezGVMPmNHpAbzHKW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved REPL implementation with more consistent code generation across all execution modes for enhanced reliability and predictability of evaluation results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->