### PR TITLE
Migrate mod.rs + primitives to document::leaf (ADR 0089 Phase 2) (BT-2330)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -301,7 +301,7 @@ clippy:
 lint-no-new-document-string:
     @echo "🔍 Checking for new Document::String / Document::Eco leaves (ADR 0089)..."
     @bash -c ' \
-        baseline=2103; \
+        baseline=2039; \
         files=$(grep -rlE --include="*.rs" "Document::(String|Eco)\(" \
             crates/beamtalk-core/src/codegen/core_erlang/ \
             | grep -vE "document/leaf\.rs|typed_leaves_audit\.rs|cerl_audit\.rs"); \

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -119,6 +119,7 @@ pub use util::to_module_name;
 use crate::ast::{Block, Expression, MessageSelector, Module, WellKnownSelector};
 use crate::docvec;
 use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
+use document::leaf;
 use document::{Document, INDENT, line, nest};
 use ecow::EcoString;
 use primitive_bindings::PrimitiveBindingTable;
@@ -1784,15 +1785,14 @@ impl CoreErlangGenerator {
     ) -> Document<'static> {
         match &self.source_path {
             Some(path) => {
-                let escaped = util::escape_core_erlang_string(path);
                 docvec![
                     "( ",
                     doc,
                     " -| [{",
-                    Document::String(line_num.to_string()),
-                    ", 1}, {'file', \"",
-                    Document::String(escaped),
-                    "\"}] )"
+                    leaf::int_lit(i64::from(line_num)),
+                    ", 1}, {'file', ",
+                    leaf::string_lit(path),
+                    "}] )"
                 ]
             }
             None => {
@@ -1801,7 +1801,7 @@ impl CoreErlangGenerator {
                     "( ",
                     doc,
                     " -| [",
-                    Document::String(line_num.to_string()),
+                    leaf::int_lit(i64::from(line_num)),
                     "] )"
                 ]
             }
@@ -2022,13 +2022,13 @@ impl CoreErlangGenerator {
         let nlr_arm_result: Document<'static> = if has_class_vars {
             docvec![
                 "{'class_var_result', ",
-                Document::String(val_var.clone()),
+                leaf::var(val_var.clone()),
                 ", ",
-                Document::String(state_var.clone()),
+                leaf::var(state_var.clone()),
                 "}",
             ]
         } else {
-            Document::String(val_var.clone())
+            leaf::var(val_var.clone())
         };
 
         docvec![
@@ -2058,9 +2058,9 @@ impl CoreErlangGenerator {
             "    <{'throw', {'$bt_nlr', ",
             ctk_var.clone(),
             ", ",
-            Document::String(val_var),
+            leaf::var(val_var),
             ", ",
-            Document::String(state_var),
+            leaf::var(state_var),
             "}}> ",
             "when call 'erlang':'=:='(",
             ctk_var,
@@ -2278,9 +2278,9 @@ impl CoreErlangGenerator {
                 docvec![
                     line(),
                     docvec![
-                        "call 'gen_server':'start_link'('",
-                        Document::Eco(self.module_name.clone()),
-                        "', InitArgs, [])",
+                        "call 'gen_server':'start_link'(",
+                        leaf::atom(self.module_name.to_string()),
+                        ", InitArgs, [])",
                     ],
                 ]
             ),
@@ -2308,9 +2308,9 @@ impl CoreErlangGenerator {
                 docvec![
                     line(),
                     docvec![
-                        "call 'gen_server':'start_link'(ServerName, '",
-                        Document::Eco(self.module_name.clone()),
-                        "', InitArgs, [])",
+                        "call 'gen_server':'start_link'(ServerName, ",
+                        leaf::atom(self.module_name.to_string()),
+                        ", InitArgs, [])",
                     ],
                 ]
             ),
@@ -2338,10 +2338,10 @@ impl CoreErlangGenerator {
         // If `to_module_name` already emits a `beamtalk_` prefix (e.g.
         // `BeamtalkInterface` → `beamtalk_interface`), use it as-is.
         let snake_name = to_module_name(&self.class_name());
-        let actor_module: Document<'static> = if snake_name.starts_with("beamtalk_") {
-            Document::String(snake_name)
+        let actor_module_name = if snake_name.starts_with("beamtalk_") {
+            snake_name
         } else {
-            docvec!["beamtalk_", Document::String(snake_name)]
+            format!("beamtalk_{snake_name}")
         };
         docvec![
             "'dispatch'/3 = fun (Selector, Args, Self) ->",
@@ -2349,7 +2349,11 @@ impl CoreErlangGenerator {
                 INDENT,
                 docvec![
                     line(),
-                    docvec!["call '", actor_module, "':'dispatch'(Selector, Args, Self)",],
+                    docvec![
+                        "call ",
+                        leaf::atom(actor_module_name),
+                        ":'dispatch'(Selector, Args, Self)",
+                    ],
                 ]
             ),
             "\n\n",
@@ -2559,31 +2563,31 @@ impl CoreErlangGenerator {
             let error_doc = self.class_not_found_error_doc(class_name);
 
             Ok(docvec![
-                "case call 'maps':'find'('",
-                Document::String(class_name.to_string()),
-                "', ",
-                Document::String(state_var),
+                "case call 'maps':'find'(",
+                leaf::atom(class_name.to_string()),
+                ", ",
+                leaf::var(state_var),
                 ") of ",
                 "<{'ok', _BindingVal}> when 'true' -> _BindingVal ",
                 "<'error'> when 'true' -> ",
-                "case call 'beamtalk_class_registry':'whereis_class'('",
-                Document::String(class_name.to_string()),
-                "') of ",
+                "case call 'beamtalk_class_registry':'whereis_class'(",
+                leaf::atom(class_name.to_string()),
+                ") of ",
                 error_doc,
                 "<",
-                Document::String(class_pid_var.clone()),
+                leaf::var(class_pid_var.clone()),
                 "> when 'true' -> ",
                 "let ",
-                Document::String(class_mod_var.clone()),
+                leaf::var(class_mod_var.clone()),
                 " = call 'beamtalk_object_class':'module_name'(",
-                Document::String(class_pid_var.clone()),
+                leaf::var(class_pid_var.clone()),
                 ") in ",
-                "{'beamtalk_object', '",
-                Document::String(display_name),
-                " class', ",
-                Document::String(class_mod_var),
+                "{'beamtalk_object', ",
+                leaf::atom(format!("{display_name} class")),
                 ", ",
-                Document::String(class_pid_var),
+                leaf::var(class_mod_var),
+                ", ",
+                leaf::var(class_pid_var),
                 "} ",
                 "end end",
             ])
@@ -2595,24 +2599,24 @@ impl CoreErlangGenerator {
             let error_doc = self.class_not_found_error_doc(class_name);
 
             Ok(docvec![
-                "case call 'beamtalk_class_registry':'whereis_class'('",
-                Document::String(class_name.to_string()),
-                "') of ",
+                "case call 'beamtalk_class_registry':'whereis_class'(",
+                leaf::atom(class_name.to_string()),
+                ") of ",
                 error_doc,
                 "<",
-                Document::String(class_pid_var.clone()),
+                leaf::var(class_pid_var.clone()),
                 "> when 'true' -> ",
                 "let ",
-                Document::String(class_mod_var.clone()),
+                leaf::var(class_mod_var.clone()),
                 " = call 'beamtalk_object_class':'module_name'(",
-                Document::String(class_pid_var.clone()),
+                leaf::var(class_pid_var.clone()),
                 ") in ",
-                "{'beamtalk_object', '",
-                Document::String(display_name),
-                " class', ",
-                Document::String(class_mod_var),
+                "{'beamtalk_object', ",
+                leaf::atom(format!("{display_name} class")),
                 ", ",
-                Document::String(class_pid_var),
+                leaf::var(class_mod_var),
+                ", ",
+                leaf::var(class_pid_var),
                 "} ",
                 "end",
             ])
@@ -2626,23 +2630,22 @@ impl CoreErlangGenerator {
         let err0_var = self.fresh_var("CnfErr");
         let err1_var = self.fresh_var("CnfErr");
         let hint = format!("Define {class_name} with: Object subclass: {class_name}");
-        let hint_binary = Self::binary_string_literal(&hint);
 
         docvec![
             "<'undefined'> when 'true' -> let ",
-            Document::String(err0_var.clone()),
-            " = call 'beamtalk_error':'new'('class_not_found', '",
-            Document::String(class_name.to_string()),
-            "') in ",
+            leaf::var(err0_var.clone()),
+            " = call 'beamtalk_error':'new'('class_not_found', ",
+            leaf::atom(class_name.to_string()),
+            ") in ",
             "let ",
-            Document::String(err1_var.clone()),
+            leaf::var(err1_var.clone()),
             " = call 'beamtalk_error':'with_hint'(",
-            Document::String(err0_var),
+            leaf::var(err0_var),
             ", ",
-            Document::String(hint_binary),
+            leaf::binary_lit(hint),
             ") in ",
             "call 'beamtalk_error':'raise'(",
-            Document::String(err1_var),
+            leaf::var(err1_var),
             ") ",
         ]
     }
@@ -3007,7 +3010,7 @@ impl CoreErlangGenerator {
                         "call 'beamtalk_class_instantiation':'class_self_new'(",
                         "call 'erlang':'get'('beamtalk_class_name'), ",
                         "call 'erlang':'get'('beamtalk_class_module'), [",
-                        Document::String(param),
+                        leaf::var(param),
                         "])",
                     ]);
                 }
@@ -3033,9 +3036,9 @@ impl CoreErlangGenerator {
                         .unwrap_or_else(|| "Arguments".to_string());
                     return Ok(docvec![
                         "call 'beamtalk_erlang_proxy':'dispatch'(",
-                        Document::String(selector_param),
+                        leaf::var(selector_param),
                         ", ",
-                        Document::String(args_param),
+                        leaf::var(args_param),
                         ", Self)"
                     ]);
                 }
@@ -3051,9 +3054,9 @@ impl CoreErlangGenerator {
                         .unwrap_or_else(|| "Arguments".to_string());
                     return Ok(docvec![
                         "call 'beamtalk_erlang_class':'dispatch'(",
-                        Document::String(selector_param),
+                        leaf::var(selector_param),
                         ", ",
-                        Document::String(args_param),
+                        leaf::var(args_param),
                         ", Self)"
                     ]);
                 }
@@ -3134,7 +3137,12 @@ impl CoreErlangGenerator {
             }
         }
 
-        let params_str = self.current_method_params.join(", ");
+        let params_doc = document::join(
+            self.current_method_params
+                .iter()
+                .map(|p| leaf::var(p.clone())),
+            &Document::Str(", "),
+        );
         // BT-677: In class methods, self is bound to ClassSelf, not Self
         let self_var = if self.in_class_method() {
             "ClassSelf"
@@ -3142,12 +3150,12 @@ impl CoreErlangGenerator {
             "Self"
         };
         Ok(docvec![
-            "call '",
-            Document::String(runtime_module),
-            "':'dispatch'('",
-            Document::String(name.to_string()),
-            "', [",
-            Document::String(params_str),
+            "call ",
+            leaf::atom(runtime_module),
+            ":'dispatch'(",
+            leaf::atom(name.to_string()),
+            ", [",
+            params_doc,
             "], ",
             Document::Str(self_var),
             ")"
@@ -3191,12 +3199,11 @@ impl CoreErlangGenerator {
         let metadata_map_doc = docvec![
             "~{",
             "'domain' => ['beamtalk' | ['user']], ",
-            "'beamtalk_class' => '",
-            Document::String(ctx_class),
-            "', ",
-            "'beamtalk_selector' => '",
-            Document::String(ctx_selector),
-            "'",
+            "'beamtalk_class' => ",
+            leaf::atom(ctx_class),
+            ", ",
+            "'beamtalk_selector' => ",
+            leaf::atom(ctx_selector),
             "}~",
         ];
 
@@ -3207,25 +3214,25 @@ impl CoreErlangGenerator {
             let merge_var = self.fresh_temp_var("LogMeta");
             docvec![
                 "let ",
-                Document::String(merge_var.clone()),
+                leaf::var(merge_var.clone()),
                 " = call 'maps':'merge'(",
-                Document::String(meta_param),
+                leaf::var(meta_param),
                 ", ",
                 metadata_map_doc,
-                ") in call 'logger':'log'('",
-                Document::String(level.to_string()),
-                "', ",
-                Document::String(msg_param),
+                ") in call 'logger':'log'(",
+                leaf::atom(level.to_string()),
                 ", ",
-                Document::String(merge_var),
+                leaf::var(msg_param),
+                ", ",
+                leaf::var(merge_var),
                 ")"
             ]
         } else {
             docvec![
-                "call 'logger':'log'('",
-                Document::String(level.to_string()),
-                "', ",
-                Document::String(msg_param),
+                "call 'logger':'log'(",
+                leaf::atom(level.to_string()),
+                ", ",
+                leaf::var(msg_param),
                 ", ",
                 metadata_map_doc,
                 ")"
@@ -3234,7 +3241,7 @@ impl CoreErlangGenerator {
 
         let doc = docvec![
             "let ",
-            Document::String(discard_var),
+            leaf::var(discard_var),
             " = ",
             log_call_doc,
             " in 'nil'"
@@ -3277,33 +3284,33 @@ impl CoreErlangGenerator {
 
         docvec![
             "let ",
-            Document::String(pid_var.clone()),
+            leaf::var(pid_var.clone()),
             " = call 'erlang':'self'() in ",
             "let ",
-            Document::String(state_var.clone()),
+            leaf::var(state_var.clone()),
             " = call 'maps':'put'('builderPid', ",
-            Document::String(pid_var),
+            leaf::var(pid_var),
             ", ",
-            Document::String(current_state),
+            leaf::var(current_state),
             ") in ",
             "case call 'beamtalk_class_builder':'register'(",
-            Document::String(state_var),
+            leaf::var(state_var),
             ") of ",
             "<{'ok', ",
-            Document::String(class_pid_var.clone()),
+            leaf::var(class_pid_var.clone()),
             "}> when 'true' -> ",
             // BT-2258: return the canonical class-object shape
             // {'beamtalk_object', <Name> ++ " class", ModuleName, ClassPid}
             // built by the runtime helper, instead of an unusable hardcoded
             // {'beamtalk_object', 'Class', 'beamtalk_class_bt', ClassPid} wrapper.
             "call 'beamtalk_class_registry':'class_object_from_pid'(",
-            Document::String(class_pid_var),
+            leaf::var(class_pid_var),
             ") ",
             "<{'error', ",
-            Document::String(error_var.clone()),
+            leaf::var(error_var.clone()),
             "}> when 'true' -> ",
             "call 'beamtalk_error':'raise'(",
-            Document::String(error_var),
+            leaf::var(error_var),
             ") ",
             "end"
         ]

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/error_handling.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/error_handling.rs
@@ -8,6 +8,7 @@
 //! Contains BIF generators for error-related classes: `Exception`, `StackFrame`.
 
 use super::super::document::Document;
+use super::super::document::leaf;
 use super::param;
 use crate::docvec;
 
@@ -79,9 +80,9 @@ pub(crate) fn generate_stack_frame_bif(
     match selector {
         "method" | "receiverClass" | "arguments" | "sourceLocation" | "moduleName" | "line"
         | "file" | "printString" => Some(docvec![
-            "call 'beamtalk_stack_frame':'dispatch'('",
-            Document::String(selector.to_owned()),
-            "', [], Self)",
+            "call 'beamtalk_stack_frame':'dispatch'(",
+            leaf::atom(selector.to_owned()),
+            ", [], Self)",
         ]),
         _ => None,
     }

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/list.rs
@@ -9,6 +9,7 @@
 //! Complex operations delegate to `beamtalk_list` helper module.
 
 use super::super::document::Document;
+use super::super::document::leaf;
 use super::{build_dnu_error_doc, call_p0_self, call_self_p0, param};
 use crate::docvec;
 
@@ -192,7 +193,7 @@ fn generate_list_misc_bif(selector: &str, params: &[String]) -> Option<Document<
         // Class-side factory: List class withAll: list is identity (list is already a List)
         "withAll:" => {
             let p0 = param(params, 0, "_List");
-            Some(Document::String(p0.to_string()))
+            Some(leaf::var(p0.to_string()))
         }
         _ => None,
     }

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/mod.rs
@@ -31,6 +31,7 @@ mod string;
 mod value_types;
 
 use super::document::Document;
+use super::document::leaf;
 use crate::docvec;
 
 /// Core Erlang expression for `printString` — delegates to the runtime's
@@ -276,7 +277,7 @@ pub(crate) fn core_erlang_binary_string(s: &str) -> Document<'static> {
             parts.push(Document::Str(","));
         }
         parts.push(Document::Str("#<"));
-        parts.push(Document::String(b.to_string()));
+        parts.push(leaf::int_lit(i64::from(b)));
         parts.push(Document::Str(">(8,1,'integer',['unsigned'|['big']])"));
     }
     parts.push(Document::Str("}#"));


### PR DESCRIPTION
## Summary

ADR 0089 Phase 2 (BT-2330). Replaces 64 open-leaf `Document::String(...)` / `Document::Eco(...)` call sites with the typed `document::leaf` helpers (`atom` / `var` / `string_lit` / `int_lit` / `binary_lit`) introduced in BT-2320. This closes the BT-875 recurrence vector in these files: the Core Erlang atom-quote, variable, integer, and string-literal punctuation now lives inside the helper instead of being re-typed at every call site.

## Scope

Per BT-2330: `codegen/core_erlang/mod.rs` (59 `String` + 2 `Eco`) and the remaining primitives sites — `primitives/mod.rs`, `primitives/list.rs`, `primitives/error_handling.rs` (1 each).

Out of scope and untouched: `expressions.rs` (BT-2324), `intrinsics.rs`, `control_flow/`, `dispatch_codegen.rs`, `value_type_codegen.rs`, `gen_server/`, and the throwaway audit modules.

## Notable conversions

- Module-name `Document::Eco` atoms in `start_link`/`start_link_named` → `leaf::atom`.
- The `'<Name> class'` class-object atom in `generate_class_reference` → `leaf::atom(format!("{display_name} class"))` (atom-quote escaping now owned by the helper).
- The joined method-param list in the `@primitive` dispatch call → `document::join` of `leaf::var` over the params (was a `Vec::join(", ")` string).
- Binary-literal byte emission in `core_erlang_binary_string` → `leaf::int_lit(i64::from(b))`.
- The `{'file', "<path>"}` line annotation in `annotate_with_line` → `leaf::string_lit(path)` (drops the manual `escape_core_erlang_string` + `\"…\"` wrapping, which `string_lit` does internally).

## Verification

- All 1137 `codegen::core_erlang` unit tests pass — these assert on `to_pretty_string()` output, giving byte-for-byte parity.
- The `core_erlang_validity` proptests (generated text parses as Core Erlang, no `format!` artifacts) pass.
- Full `beamtalk-core` lib suite: 4032 passed.
- `cargo clippy --all-targets --all-features` clean; `cargo fmt --all --check` clean.
- Lowered the `lint-no-new-document-string` baseline 2103 → 2039 to lock in the 64 migrated sites (live count matches the new baseline). The parent epic reconciles the final value at merge.

> Note: Erlang/OTP and `just` are not installed in the authoring environment, so the Erlang-dependent behavioural suites (`test-stdlib` / `test-bunit` / `test-repl-protocol`) and `dialyzer` were not run locally — CI covers them. The Document-level byte-for-byte unit-test parity is the guarantee the ADR relies on for these mechanical migrations.

https://claude.ai/code/session_011bdwa2ezGVMPmNHpAbzHKW

---
_Generated by [Claude Code](https://claude.ai/code/session_011bdwa2ezGVMPmNHpAbzHKW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Core Erlang code generation to emit typed literals and variable/atom helpers instead of building raw string fragments, across class handling, error paths, list operations, logging, and runtime dispatch.
* **Chores**
  * Lowered the lint migration baseline for the relevant check to reflect the refactoring, adjusting its pass/fail cutoff.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamesc/beamtalk/pull/2372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->