### PR TITLE
Remove misplaced // => _ annotations from os_test.bt (BT-2341)

### DIFF
--- a/stdlib/test/os_test.bt
+++ b/stdlib/test/os_test.bt
@@ -13,12 +13,10 @@ TestCase subclass: OSTest
     result := OS run: "echo hello"
     self assert: result class equals: String
 
-  // => _
   testRunTrimsTrailingWhitespace =>
     result := OS run: "echo hello"
     self assert: result equals: "hello"
 
-  // => _
   testRunWithNonStringRaisesTypeError =>
     @expect type
     self should: [OS run: 42] raise: #type_error
@@ -27,7 +25,6 @@ TestCase subclass: OSTest
     result := OS run: "echo hello" timeout: 5000
     self assert: result equals: "hello"
 
-  // => _
   testRunTimeoutWithNonStringRaisesTypeError =>
     @expect type
     self should: [OS run: 42 timeout: 5000] raise: #type_error
@@ -35,4 +32,3 @@ TestCase subclass: OSTest
   testRunTimeoutExpiryRaisesTimeout =>
     cmd := self.isUnix ifTrue: ["sleep 60"] ifFalse: ["ping -n 100 127.0.0.1"]
     self should: [OS run: cmd timeout: 100] raise: #timeout
-// => _


### PR DESCRIPTION
## Summary

- Removes 4 stray `// => _` annotations from `stdlib/test/os_test.bt`
- The `// =>` annotation mechanism belongs only in expression-style test files (`.btscript` / bootstrap-test); it has no effect in BUnit `TestCase` files, which auto-discover `test*` methods and use `self assert:` / `self should:` for assertions
- Every other BUnit test file in `stdlib/test/*.bt` has zero such annotations — `os_test.bt` was the sole outlier

## Test plan

- [x] `just test-bunit` passes — all 2142 tests pass, 0 failures
- [x] All 6 test methods in `OSTest` still discovered and run (BUnit auto-discovery by `test` prefix is unaffected by removing `// =>` annotations)

Linear: https://linear.app/beamtalk/issue/BT-2341/remove-misplaced-annotations-from-stdlibtestos-testbt

https://claude.ai/code/session_01J7sJ7e1e6yD38yS5sQgjkv

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7sJ7e1e6yD38yS5sQgjkv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up test file formatting and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->