### PR TITLE
refactor(codegen): migrate gen_server/ to document::leaf API (BT-2328)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -498,7 +498,6 @@ impl CoreErlangGenerator {
             let hint_msg = format!(
                 "{owning_class} field '{field_name}' (:: {type_name}) was not initialized",
             );
-            let hint_binary = Self::binary_string_literal(&hint_msg);
 
             body = docvec![
                 "let ",
@@ -530,7 +529,7 @@ impl CoreErlangGenerator {
                                 " = call 'beamtalk_error':'with_hint'(",
                                 leaf::var(err_var0),
                                 ", ",
-                                leaf::var(hint_binary),
+                                leaf::binary_lit(&hint_msg),
                                 ") in",
                                 line(),
                                 "let ",

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -9,7 +9,7 @@
 //! `handle_cast/2`, `handle_call/3`, `handle_info/2`, `code_change/3`,
 //! and `terminate/2`.
 
-use super::super::document::{Document, INDENT, line, nest};
+use super::super::document::{Document, INDENT, leaf, line, nest};
 use super::super::{CoreErlangGenerator, Result};
 use crate::ast::{ClassDefinition, Module, TypeAnnotation};
 use crate::docvec;
@@ -188,9 +188,9 @@ impl CoreErlangGenerator {
                         "let _ParentArgs = call 'maps':'put'('__skip_initialize__', 'true', InitArgs) in",
                         line(),
                         docvec![
-                            "case call '",
-                            Document::String(parent_module.clone()),
-                            "':'init'(_ParentArgs) of"
+                            "case call ",
+                            leaf::atom(parent_module.clone()),
+                            ":'init'(_ParentArgs) of"
                         ],
                         nest(
                             INDENT,
@@ -209,9 +209,8 @@ impl CoreErlangGenerator {
                                             docvec![
                                                 line(),
                                                 docvec![
-                                                    "'__class_mod__' => '",
-                                                    Document::String(module_name.to_string()),
-                                                    "'"
+                                                    "'__class_mod__' => ",
+                                                    leaf::atom(module_name.to_string()),
                                                 ],
                                                 Document::Vec(own_state_fields),
                                             ]
@@ -271,11 +270,7 @@ impl CoreErlangGenerator {
                             INDENT,
                             docvec![
                                 line(),
-                                docvec![
-                                    "'__class_mod__' => '",
-                                    Document::String(module_name.to_string()),
-                                    "'"
-                                ],
+                                docvec!["'__class_mod__' => ", leaf::atom(module_name.to_string()),],
                                 Document::Vec(initial_state_fields),
                             ]
                         ),
@@ -319,9 +314,9 @@ impl CoreErlangGenerator {
                         docvec![
                             line(),
                             docvec![
-                                "call 'erlang':'put'('$beamtalk_actor', '",
-                                Document::String(class_name.to_owned()),
-                                "')",
+                                "call 'erlang':'put'('$beamtalk_actor', ",
+                                leaf::atom(class_name.to_owned()),
+                                ")",
                             ],
                         ]
                     ),
@@ -344,9 +339,9 @@ impl CoreErlangGenerator {
             line(),
             docvec![
                 "let _TelStart = call 'beamtalk_actor':'maybe_execute_telemetry'(",
-                "['beamtalk', 'actor', 'lifecycle', 'start'], ~{}~, ~{'pid' => _TelPid, 'class' => '",
-                Document::String(class_name.to_owned()),
-                "'}~) in",
+                "['beamtalk', 'actor', 'lifecycle', 'start'], ~{}~, ~{'pid' => _TelPid, 'class' => ",
+                leaf::atom(class_name.to_owned()),
+                "}~) in",
             ],
         ]
     }
@@ -507,13 +502,13 @@ impl CoreErlangGenerator {
 
             body = docvec![
                 "let ",
-                Document::String(check_var.clone()),
-                " = call 'maps':'get'('",
-                Document::String(field_name),
-                "', InitNewState) in",
+                leaf::var(check_var.clone()),
+                " = call 'maps':'get'(",
+                leaf::atom(field_name),
+                ", InitNewState) in",
                 line(),
                 "case ",
-                Document::String(check_var),
+                leaf::var(check_var),
                 " of",
                 nest(
                     INDENT,
@@ -525,47 +520,47 @@ impl CoreErlangGenerator {
                             docvec![
                                 line(),
                                 "let ",
-                                Document::String(err_var0.clone()),
-                                " = call 'beamtalk_error':'new'('uninitialized_state_error', '",
-                                Document::String(owning_class.to_string()),
-                                "') in",
+                                leaf::var(err_var0.clone()),
+                                " = call 'beamtalk_error':'new'('uninitialized_state_error', ",
+                                leaf::atom(owning_class.to_string()),
+                                ") in",
                                 line(),
                                 "let ",
-                                Document::String(err_var1.clone()),
+                                leaf::var(err_var1.clone()),
                                 " = call 'beamtalk_error':'with_hint'(",
-                                Document::String(err_var0),
+                                leaf::var(err_var0),
                                 ", ",
-                                Document::String(hint_binary),
+                                leaf::var(hint_binary),
                                 ") in",
                                 line(),
                                 "let ",
-                                Document::String(err_msg_var.clone()),
+                                leaf::var(err_msg_var.clone()),
                                 " = call 'beamtalk_error':'format_safe'(",
-                                Document::String(err_var1.clone()),
+                                leaf::var(err_var1.clone()),
                                 ") in",
                                 line(),
                                 "let ",
-                                Document::String(class_name_var.clone()),
-                                " = call '",
-                                Document::Eco(self.module_name.clone()),
-                                "':'class_name'() in",
+                                leaf::var(class_name_var.clone()),
+                                " = call ",
+                                leaf::atom(self.module_name.clone()),
+                                ":'class_name'() in",
                                 line(),
                                 "let ",
-                                Document::String(fmt_var.clone()),
+                                leaf::var(fmt_var.clone()),
                                 " = call 'beamtalk_error':'format'(",
-                                Document::String(err_var1.clone()),
+                                leaf::var(err_var1.clone()),
                                 ") in",
                                 line(),
                                 "let _ = call 'logger':'error'(",
-                                Document::String(err_msg_var),
+                                leaf::var(err_msg_var),
                                 ", ~{'class' => ",
-                                Document::String(class_name_var),
+                                leaf::var(class_name_var),
                                 ", 'reason' => ",
-                                Document::String(err_var1),
+                                leaf::var(err_var1),
                                 ", 'domain' => ['beamtalk'|['runtime'|[]]]}~) in",
                                 line(),
                                 "{'stop', ",
-                                Document::String(fmt_var),
+                                leaf::var(fmt_var),
                                 ", InitNewState}",
                             ]
                         ),
@@ -926,33 +921,33 @@ impl CoreErlangGenerator {
                     line(),
                     docvec![
                         "let ",
-                        Document::String(old_state_var.clone()),
+                        leaf::var(old_state_var.clone()),
                         " = call 'erlang':'get'('$bt_actor_state') in",
                     ],
                     line(),
                     docvec![
                         "let ",
-                        Document::String(put_ok_var),
+                        leaf::var(put_ok_var),
                         " = call 'erlang':'put'('$bt_actor_state', ",
-                        Document::String(in_state_var.clone()),
+                        leaf::var(in_state_var.clone()),
                         ") in",
                     ],
                     line(),
                     docvec![
                         "let ",
-                        Document::String(result_var.clone()),
-                        " = call '",
-                        Document::String(class.module_name.clone()),
-                        "':'safe_dispatch'('initialize', [], ",
-                        Document::String(in_state_var),
+                        leaf::var(result_var.clone()),
+                        " = call ",
+                        leaf::atom(class.module_name.clone()),
+                        ":'safe_dispatch'('initialize', [], ",
+                        leaf::var(in_state_var),
                         ") in",
                     ],
                     line(),
                     docvec![
                         "let ",
-                        Document::String(restore_ok_var.clone()),
+                        leaf::var(restore_ok_var.clone()),
                         " = case ",
-                        Document::String(old_state_var.clone()),
+                        leaf::var(old_state_var.clone()),
                         " of",
                     ],
                     nest(
@@ -977,12 +972,12 @@ impl CoreErlangGenerator {
                     line(),
                     docvec![
                         "let ",
-                        Document::String(clear_stack_var),
+                        leaf::var(clear_stack_var),
                         " = call 'erlang':'erase'('$bt_call_stack') in",
                     ],
                     line(),
                     "case ",
-                    Document::String(result_var),
+                    leaf::var(result_var),
                     " of",
                     nest(
                         INDENT,
@@ -990,9 +985,9 @@ impl CoreErlangGenerator {
                             line(),
                             docvec![
                                 "<{'reply', ",
-                                Document::String(reply_ret_var),
+                                leaf::var(reply_ret_var),
                                 ", ",
-                                Document::String(next_state_var),
+                                leaf::var(next_state_var),
                                 "}> when 'true' ->",
                             ],
                             nest(INDENT, inner),
@@ -1000,13 +995,13 @@ impl CoreErlangGenerator {
                             // BT-1822: Destructure error triple to capture stacktrace
                             docvec![
                                 "<{'error', {",
-                                Document::String(err_triple_type.clone()),
+                                leaf::var(err_triple_type.clone()),
                                 ", ",
-                                Document::String(err_triple_reason.clone()),
+                                leaf::var(err_triple_reason.clone()),
                                 ", ",
-                                Document::String(err_triple_stack.clone()),
+                                leaf::var(err_triple_stack.clone()),
                                 "}, ",
-                                Document::String(err_state_var.clone()),
+                                leaf::var(err_state_var.clone()),
                                 "}> when 'true' ->",
                             ],
                             nest(
@@ -1015,47 +1010,47 @@ impl CoreErlangGenerator {
                                     line(),
                                     docvec![
                                         "let ",
-                                        Document::String(err_msg.clone()),
+                                        leaf::var(err_msg.clone()),
                                         " = call 'beamtalk_error':'format_safe'({",
-                                        Document::String(err_triple_type.clone()),
+                                        leaf::var(err_triple_type.clone()),
                                         ", ",
-                                        Document::String(err_triple_reason.clone()),
+                                        leaf::var(err_triple_reason.clone()),
                                         "}, ",
-                                        Document::String(err_triple_stack.clone()),
+                                        leaf::var(err_triple_stack.clone()),
                                         ") in",
                                     ],
                                     line(),
                                     docvec![
                                         "let ",
-                                        Document::String(err_class_name_var.clone()),
-                                        " = call '",
-                                        Document::String(class.module_name.clone()),
-                                        "':'class_name'() in",
+                                        leaf::var(err_class_name_var.clone()),
+                                        " = call ",
+                                        leaf::atom(class.module_name.clone()),
+                                        ":'class_name'() in",
                                     ],
                                     line(),
                                     docvec![
                                         "let _ = call 'logger':'error'(",
-                                        Document::String(err_msg),
+                                        leaf::var(err_msg),
                                         ", ~{'class' => ",
-                                        Document::String(err_class_name_var),
+                                        leaf::var(err_class_name_var),
                                         ", 'reason' => {",
-                                        Document::String(err_triple_type.clone()),
+                                        leaf::var(err_triple_type.clone()),
                                         ", ",
-                                        Document::String(err_triple_reason.clone()),
+                                        leaf::var(err_triple_reason.clone()),
                                         "}, 'stacktrace' => ",
-                                        Document::String(err_triple_stack.clone()),
+                                        leaf::var(err_triple_stack.clone()),
                                         ", 'domain' => ['beamtalk'|['runtime'|[]]]}~) in",
                                     ],
                                     line(),
                                     docvec![
                                         "{'stop', {",
-                                        Document::String(err_triple_type),
+                                        leaf::var(err_triple_type),
                                         ", ",
-                                        Document::String(err_triple_reason),
+                                        leaf::var(err_triple_reason),
                                         ", ",
-                                        Document::String(err_triple_stack),
+                                        leaf::var(err_triple_stack),
                                         "}, ",
-                                        Document::String(err_state_var),
+                                        leaf::var(err_state_var),
                                         "}",
                                     ],
                                 ]
@@ -1064,9 +1059,9 @@ impl CoreErlangGenerator {
                             // Fallback: plain {error, Error, State} from dispatch (DNU, #beamtalk_error{}, etc.)
                             docvec![
                                 "<{'error', ",
-                                Document::String(err_plain.clone()),
+                                leaf::var(err_plain.clone()),
                                 ", ",
-                                Document::String(err_state_var2.clone()),
+                                leaf::var(err_state_var2.clone()),
                                 "}> when 'true' ->",
                             ],
                             nest(
@@ -1075,35 +1070,35 @@ impl CoreErlangGenerator {
                                     line(),
                                     docvec![
                                         "let ",
-                                        Document::String(err_msg2.clone()),
+                                        leaf::var(err_msg2.clone()),
                                         " = call 'beamtalk_error':'format_safe'(",
-                                        Document::String(err_plain.clone()),
+                                        leaf::var(err_plain.clone()),
                                         ") in",
                                     ],
                                     line(),
                                     docvec![
                                         "let ",
-                                        Document::String(err_class_name_var2.clone()),
-                                        " = call '",
-                                        Document::String(class.module_name.clone()),
-                                        "':'class_name'() in",
+                                        leaf::var(err_class_name_var2.clone()),
+                                        " = call ",
+                                        leaf::atom(class.module_name.clone()),
+                                        ":'class_name'() in",
                                     ],
                                     line(),
                                     docvec![
                                         "let _ = call 'logger':'error'(",
-                                        Document::String(err_msg2),
+                                        leaf::var(err_msg2),
                                         ", ~{'class' => ",
-                                        Document::String(err_class_name_var2),
+                                        leaf::var(err_class_name_var2),
                                         ", 'reason' => ",
-                                        Document::String(err_plain.clone()),
+                                        leaf::var(err_plain.clone()),
                                         ", 'domain' => ['beamtalk'|['runtime'|[]]]}~) in",
                                     ],
                                     line(),
                                     docvec![
                                         "{'stop', ",
-                                        Document::String(err_plain),
+                                        leaf::var(err_plain),
                                         ", ",
-                                        Document::String(err_state_var2),
+                                        leaf::var(err_state_var2),
                                         "}",
                                     ],
                                 ]
@@ -1206,9 +1201,9 @@ impl CoreErlangGenerator {
             line(),
             // Use safe_dispatch for error isolation; discard result on error
             docvec![
-                "let _CastDispatchResult = call '",
-                Document::Eco(module_name.clone()),
-                "':'safe_dispatch'(CastSelector, CastArgs, State) in"
+                "let _CastDispatchResult = call ",
+                leaf::atom(module_name.clone()),
+                ":'safe_dispatch'(CastSelector, CastArgs, State) in"
             ],
             // BT-1325: Restore pdict
             Self::pdict_restore_epilogue(),
@@ -1363,9 +1358,9 @@ impl CoreErlangGenerator {
             line(),
             // Use safe_dispatch for error isolation per BT-29
             docvec![
-                "let _DispatchResult = call '",
-                Document::Eco(module_name.clone()),
-                "':'safe_dispatch'(Selector, Args, State) in"
+                "let _DispatchResult = call ",
+                leaf::atom(module_name.clone()),
+                ":'safe_dispatch'(Selector, Args, State) in"
             ],
             // BT-1325: Restore pdict
             Self::pdict_restore_epilogue(),
@@ -1438,9 +1433,9 @@ impl CoreErlangGenerator {
                         Self::pdict_stash_preamble(),
                         line(),
                         docvec![
-                            "let _InfoDispatchResult = call '",
-                            Document::Eco(module_name),
-                            "':'safe_dispatch'('handleInfo:', [Msg], State) in",
+                            "let _InfoDispatchResult = call ",
+                            leaf::atom(module_name),
+                            ":'safe_dispatch'('handleInfo:', [Msg], State) in",
                         ],
                         Self::pdict_restore_epilogue(),
                         line(),
@@ -1573,9 +1568,9 @@ impl CoreErlangGenerator {
                     line(),
                     docvec![
                         "let _TelStop = call 'beamtalk_actor':'maybe_execute_telemetry'(",
-                        "['beamtalk', 'actor', 'lifecycle', 'stop'], ~{}~, ~{'pid' => _TelPid, 'class' => '",
-                        Document::String(class_name.to_string()),
-                        "', 'reason' => Reason}~) in",
+                        "['beamtalk', 'actor', 'lifecycle', 'stop'], ~{}~, ~{'pid' => _TelPid, 'class' => ",
+                        leaf::atom(class_name.to_string()),
+                        ", 'reason' => Reason}~) in",
                     ],
                     line(),
                     "%% Call terminate: method if defined — exceptions must not prevent shutdown",
@@ -1583,9 +1578,9 @@ impl CoreErlangGenerator {
                     "let Self = call 'beamtalk_actor':'make_self'(State) in",
                     line(),
                     docvec![
-                        "let _TermDisp = try call '",
-                        Document::String(module_name.to_string()),
-                        "':'dispatch'('terminate:', [Reason], Self, State)"
+                        "let _TermDisp = try call ",
+                        leaf::atom(module_name.to_string()),
+                        ":'dispatch'('terminate:', [Reason], Self, State)"
                     ],
                     nest(
                         INDENT,

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/dispatch.rs
@@ -8,7 +8,7 @@
 //! Generates the method table, `has_method/1`, `safe_dispatch/3`, and
 //! `dispatch/4` functions for runtime message routing.
 
-use super::super::document::{Document, INDENT, line, nest};
+use super::super::document::{Document, INDENT, leaf, line, nest};
 use super::super::{CoreErlangGenerator, Result};
 use crate::ast::{Block, Expression, MethodKind, Module};
 use crate::docvec;
@@ -67,10 +67,9 @@ impl CoreErlangGenerator {
                 entry_docs.push(Document::Str(", "));
             }
             entry_docs.push(docvec![
-                "'",
-                Document::String(name.clone()),
-                "' => ",
-                Document::String(arity.to_string()),
+                leaf::atom(name.clone()),
+                " => ",
+                leaf::int_lit(i64::try_from(*arity).unwrap_or(0)),
             ]);
         }
         let entries_doc = Document::Vec(entry_docs);
@@ -135,7 +134,7 @@ impl CoreErlangGenerator {
             if i > 0 {
                 method_list_docs.push(Document::Str(", "));
             }
-            method_list_docs.push(docvec!["'", Document::String(name.clone()), "'"]);
+            method_list_docs.push(leaf::atom(name.clone()));
         }
         let method_list_doc = Document::Vec(method_list_docs);
 
@@ -173,9 +172,8 @@ impl CoreErlangGenerator {
         _module: &Module,
     ) -> Result<Document<'static>> {
         let doc = docvec![
-            "'class_name'/0 = fun () -> '",
-            Document::String(self.class_name()),
-            "'",
+            "'class_name'/0 = fun () -> ",
+            leaf::atom(self.class_name()),
             "\n\n",
         ];
         Ok(doc)
@@ -217,9 +215,9 @@ impl CoreErlangGenerator {
                     line(),
                     // Core Erlang try uses simple variable patterns in of/catch, not case-style
                     docvec![
-                        "try call '",
-                        Document::Eco(module_name.clone()),
-                        "':'dispatch'(Selector, Args, Self, State)"
+                        "try call ",
+                        leaf::atom(module_name.clone()),
+                        ":'dispatch'(Selector, Args, Self, State)"
                     ],
                     line(),
                     "of Result -> Result",
@@ -364,11 +362,7 @@ impl CoreErlangGenerator {
         param_vars: &[String],
         body_doc: Document<'static>,
     ) -> Document<'static> {
-        let header = docvec![
-            "<'",
-            Document::String(name.to_string()),
-            "'> when 'true' ->",
-        ];
+        let header = docvec!["<", leaf::atom(name.to_string()), "> when 'true' ->",];
 
         if param_vars.is_empty() {
             return docvec![header, nest(INDENT, docvec![line(), body_doc,]), "\n",];
@@ -379,7 +373,7 @@ impl CoreErlangGenerator {
             if i > 0 {
                 param_docs.push(Document::Str(", "));
             }
-            param_docs.push(Document::String(v.clone()));
+            param_docs.push(leaf::var(v.clone()));
         }
         let params_doc = Document::Vec(param_docs);
         let args_case = docvec![
@@ -437,9 +431,9 @@ impl CoreErlangGenerator {
     #[allow(clippy::unused_self)] // method on impl for API consistency
     fn generate_extension_lookup(&self, class_name: &str) -> Document<'static> {
         docvec![
-            "let ExtLookup = try call 'beamtalk_extensions':'lookup'('",
-            Document::String(class_name.to_string()),
-            "', OtherSelector)",
+            "let ExtLookup = try call 'beamtalk_extensions':'lookup'(",
+            leaf::atom(class_name.to_string()),
+            ", OtherSelector)",
             nest(
                 INDENT,
                 docvec![
@@ -499,9 +493,9 @@ impl CoreErlangGenerator {
         docvec![
             "%% ADR 0006: Try hierarchy walk before DNU",
             line(),
-            "case call 'beamtalk_dispatch':'super'(OtherSelector, Args, Self, State, '",
-            Document::String(class_name.to_string()),
-            "') of",
+            "case call 'beamtalk_dispatch':'super'(OtherSelector, Args, Self, State, ",
+            leaf::atom(class_name.to_string()),
+            ") of",
             nest(
                 INDENT,
                 docvec![
@@ -525,27 +519,26 @@ impl CoreErlangGenerator {
     fn generate_dnu_fallback(&self, class_name: &str) -> Document<'static> {
         let module_name = &self.module_name;
         let hint = "Check spelling or use 'respondsTo:' to verify method exists";
-        let hint_binary = Self::binary_string_literal(hint);
 
         let dnu_dispatch = docvec![
-            "call '",
-            Document::Eco(module_name.clone()),
-            "':'dispatch'(DnuSelector, [OtherSelector, Args], Self, State)"
+            "call ",
+            leaf::atom(module_name.clone()),
+            ":'dispatch'(DnuSelector, [OtherSelector, Args], Self, State)"
         ];
 
         let dnu_error = docvec![
             "%% No DNU handler - return #beamtalk_error{} record",
             line(),
-            "let ClassName = '",
-            Document::String(class_name.to_string()),
-            "' in",
+            "let ClassName = ",
+            leaf::atom(class_name.to_string()),
+            " in",
             line(),
             "let Error0 = call 'beamtalk_error':'new'('does_not_understand', ClassName) in",
             line(),
             "let Error1 = call 'beamtalk_error':'with_selector'(Error0, OtherSelector) in",
             line(),
             "let HintMsg = ",
-            Document::String(hint_binary),
+            leaf::binary_lit(hint),
             " in",
             line(),
             "let Error = call 'beamtalk_error':'with_hint'(Error1, HintMsg) in",
@@ -558,9 +551,9 @@ impl CoreErlangGenerator {
             line(),
             "let DnuSelector = 'doesNotUnderstand:args:' in",
             line(),
-            "let Methods = call '",
-            Document::Eco(module_name.clone()),
-            "':'method_table'() in",
+            "let Methods = call ",
+            leaf::atom(module_name.clone()),
+            ":'method_table'() in",
             line(),
             "case call 'maps':'is_key'(DnuSelector, Methods) of",
             nest(

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/extensions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/extensions.rs
@@ -32,7 +32,7 @@
 //! a target known to be an `Actor` subclass gets the 3-arity state-threading
 //! shape.
 
-use super::super::document::{Document, INDENT, line, nest};
+use super::super::document::{Document, INDENT, leaf, line, nest};
 use super::super::{CodeGenContext, CoreErlangGenerator, Result};
 use crate::ast::{MethodKind, Module, StandaloneMethodDefinition};
 use crate::docvec;
@@ -120,16 +120,16 @@ impl CoreErlangGenerator {
         Ok(docvec![
             line(),
             "let _Ext",
-            Document::String(idx.to_string()),
-            " = call 'beamtalk_extensions':'register'('",
-            Document::String(class_tag),
-            "', '",
-            Document::Eco(selector),
-            "', ",
+            leaf::var(idx.to_string()),
+            " = call 'beamtalk_extensions':'register'(",
+            leaf::atom(class_tag),
+            ", ",
+            leaf::atom(selector),
+            ", ",
             fun_doc,
-            ", '",
-            Document::String(owner),
-            "', ",
+            ", ",
+            leaf::atom(owner),
+            ", ",
             source_doc,
             ") in",
         ])
@@ -178,7 +178,7 @@ impl CoreErlangGenerator {
         if source.is_empty() {
             Document::Str("'undefined'")
         } else {
-            Document::String(Self::binary_string_literal(&source))
+            leaf::binary_lit(&source)
         }
     }
 
@@ -387,7 +387,7 @@ impl CoreErlangGenerator {
             }
             parts.push(docvec![
                 "let <",
-                Document::String(var_name),
+                leaf::var(var_name),
                 "> = call 'erlang':'hd'(",
                 access,
                 ") in",

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/extensions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/extensions.rs
@@ -119,8 +119,8 @@ impl CoreErlangGenerator {
 
         Ok(docvec![
             line(),
-            "let _Ext",
-            leaf::var(idx.to_string()),
+            "let ",
+            leaf::var(format!("_Ext{idx}")),
             " = call 'beamtalk_extensions':'register'(",
             leaf::atom(class_tag),
             ", ",

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -9,7 +9,7 @@
 //! and reply tuples, and the `register_class/0` on-load function.
 
 use super::super::document::leaf::fname;
-use super::super::document::{Document, INDENT, line, nest};
+use super::super::document::{Document, INDENT, leaf, line, nest};
 use super::super::selector_mangler::safe_class_method_fn_name;
 use super::super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result, block_analysis};
 use crate::ast::{
@@ -214,9 +214,9 @@ impl CoreErlangGenerator {
         let body_doc: Document = if has_params {
             let params_pattern = param_vars.join(", ");
             docvec![
-                "<'",
-                Document::String(selector_name.to_string()),
-                "'> when 'true' ->",
+                "<",
+                leaf::atom(selector_name.to_string()),
+                "> when 'true' ->",
                 nest(
                     INDENT,
                     docvec![
@@ -227,7 +227,7 @@ impl CoreErlangGenerator {
                             docvec![
                                 line(),
                                 "<[",
-                                Document::String(params_pattern),
+                                leaf::var(params_pattern),
                                 "]> when 'true' ->",
                                 nest(INDENT, docvec![line(), method_body_doc,]),
                                 line(),
@@ -242,9 +242,9 @@ impl CoreErlangGenerator {
             ]
         } else {
             docvec![
-                "<'",
-                Document::String(selector_name.to_string()),
-                "'> when 'true' ->",
+                "<",
+                leaf::atom(selector_name.to_string()),
+                "> when 'true' ->",
                 nest(INDENT, docvec![line(), method_body_doc,]),
                 "\n",
             ]
@@ -474,29 +474,29 @@ impl CoreErlangGenerator {
                                     let field_state = self.next_state_var();
                                     docs.push(docvec![
                                         "let ",
-                                        Document::String(tuple_var.clone()),
+                                        leaf::var(tuple_var.clone()),
                                         " = ",
                                         rhs_str,
                                         " in let ",
-                                        Document::String(val_var.clone()),
+                                        leaf::var(val_var.clone()),
                                         " = call 'erlang':'element'(1, ",
-                                        Document::String(tuple_var.clone()),
+                                        leaf::var(tuple_var.clone()),
                                         ") in let ",
-                                        Document::String(rhs_state.clone()),
+                                        leaf::var(rhs_state.clone()),
                                         " = call 'erlang':'element'(2, ",
-                                        Document::String(tuple_var),
+                                        leaf::var(tuple_var),
                                         ") in let ",
-                                        Document::String(field_state.clone()),
-                                        " = call 'maps':'put'('",
-                                        Document::String(field.name.to_string()),
-                                        "', ",
-                                        Document::String(val_var.clone()),
+                                        leaf::var(field_state.clone()),
+                                        " = call 'maps':'put'(",
+                                        leaf::atom(field.name.to_string()),
                                         ", ",
-                                        Document::String(rhs_state),
+                                        leaf::var(val_var.clone()),
+                                        ", ",
+                                        leaf::var(rhs_state),
                                         ") in {'reply', ",
-                                        Document::String(val_var),
+                                        leaf::var(val_var),
                                         ", ",
-                                        Document::String(field_state),
+                                        leaf::var(field_state),
                                         "}",
                                     ]);
                                 }
@@ -509,7 +509,7 @@ impl CoreErlangGenerator {
                                 "let _ReturnValue = ",
                                 value_str,
                                 " in {'reply', _ReturnValue, ",
-                                Document::String(final_state),
+                                leaf::var(final_state),
                                 "}",
                             ]);
                         }
@@ -526,9 +526,9 @@ impl CoreErlangGenerator {
                         let final_state = self.current_state_var();
                         docs.push(docvec![
                             "{'reply', ",
-                            Document::String(val_var),
+                            leaf::var(val_var),
                             ", ",
-                            Document::String(final_state),
+                            leaf::var(final_state),
                             "}",
                         ]);
                     }
@@ -543,21 +543,21 @@ impl CoreErlangGenerator {
                                 let new_state = self.next_state_var();
                                 docs.push(docvec![
                                     "let ",
-                                    Document::String(val_var.clone()),
+                                    leaf::var(val_var.clone()),
                                     " = ",
                                     value_str,
                                     " in let ",
-                                    Document::String(new_state.clone()),
-                                    " = call 'maps':'put'('",
-                                    Document::String(field.name.to_string()),
-                                    "', ",
-                                    Document::String(val_var.clone()),
+                                    leaf::var(new_state.clone()),
+                                    " = call 'maps':'put'(",
+                                    leaf::atom(field.name.to_string()),
                                     ", ",
-                                    Document::String(current_state),
+                                    leaf::var(val_var.clone()),
+                                    ", ",
+                                    leaf::var(current_state),
                                     ") in {'reply', ",
-                                    Document::String(val_var),
+                                    leaf::var(val_var),
                                     ", ",
-                                    Document::String(new_state),
+                                    leaf::var(new_state),
                                     "}",
                                 ]);
                             }
@@ -580,25 +580,25 @@ impl CoreErlangGenerator {
                             let field_state = self.next_state_var();
                             let mut doc_parts: Vec<Document<'static>> = vec![docvec![
                                 "let ",
-                                Document::String(tuple_var.clone()),
+                                leaf::var(tuple_var.clone()),
                                 " = ",
                                 value_str,
                                 " in let ",
-                                Document::String(val_var.clone()),
+                                leaf::var(val_var.clone()),
                                 " = call 'erlang':'element'(1, ",
-                                Document::String(tuple_var.clone()),
+                                leaf::var(tuple_var.clone()),
                                 ") in let ",
-                                Document::String(rhs_state.clone()),
+                                leaf::var(rhs_state.clone()),
                                 " = call 'erlang':'element'(2, ",
-                                Document::String(tuple_var),
+                                leaf::var(tuple_var),
                                 ") in let ",
-                                Document::String(field_state.clone()),
-                                " = call 'maps':'put'('",
-                                Document::String(field.name.to_string()),
-                                "', ",
-                                Document::String(val_var.clone()),
+                                leaf::var(field_state.clone()),
+                                " = call 'maps':'put'(",
+                                leaf::atom(field.name.to_string()),
                                 ", ",
-                                Document::String(rhs_state),
+                                leaf::var(val_var.clone()),
+                                ", ",
+                                leaf::var(rhs_state),
                                 ") in ",
                             ]];
                             // Extract threaded locals from the control flow state
@@ -612,11 +612,11 @@ impl CoreErlangGenerator {
                                     );
                                     doc_parts.push(docvec![
                                         "let ",
-                                        Document::String(tv_core),
-                                        " = call 'maps':'get'('",
-                                        Document::String(Self::local_state_key(var)),
-                                        "', ",
-                                        Document::String(field_state.clone()),
+                                        leaf::var(tv_core),
+                                        " = call 'maps':'get'(",
+                                        leaf::atom(Self::local_state_key(var)),
+                                        ", ",
+                                        leaf::var(field_state.clone()),
                                         ") in ",
                                     ]);
                                 }
@@ -625,9 +625,9 @@ impl CoreErlangGenerator {
                             if is_last {
                                 docs.push(docvec![
                                     "{'reply', ",
-                                    Document::String(val_var),
+                                    leaf::var(val_var),
                                     ", ",
-                                    Document::String(field_state),
+                                    leaf::var(field_state),
                                     "}",
                                 ]);
                             }
@@ -646,29 +646,29 @@ impl CoreErlangGenerator {
                         let field_state = self.next_state_var();
                         let mut doc_parts: Vec<Document<'static>> = vec![docvec![
                             "let ",
-                            Document::String(name_var.clone()),
+                            leaf::var(name_var.clone()),
                             " = ",
                             name_code,
                             " in let ",
-                            Document::String(tuple_var.clone()),
+                            leaf::var(tuple_var.clone()),
                             " = ",
                             val_code,
                             " in let ",
-                            Document::String(val_var.clone()),
+                            leaf::var(val_var.clone()),
                             " = call 'erlang':'element'(1, ",
-                            Document::String(tuple_var.clone()),
+                            leaf::var(tuple_var.clone()),
                             ") in let ",
-                            Document::String(rhs_state.clone()),
+                            leaf::var(rhs_state.clone()),
                             " = call 'erlang':'element'(2, ",
-                            Document::String(tuple_var),
+                            leaf::var(tuple_var),
                             ") in let ",
-                            Document::String(field_state.clone()),
+                            leaf::var(field_state.clone()),
                             " = call 'maps':'put'(",
-                            Document::String(name_var),
+                            leaf::var(name_var),
                             ", ",
-                            Document::String(val_var.clone()),
+                            leaf::var(val_var.clone()),
                             ", ",
-                            Document::String(rhs_state),
+                            leaf::var(rhs_state),
                             ") in ",
                         ]];
                         if let Some(threaded_vars) =
@@ -680,11 +680,11 @@ impl CoreErlangGenerator {
                                     .map_or_else(|| Self::to_core_erlang_var(var), String::clone);
                                 doc_parts.push(docvec![
                                     "let ",
-                                    Document::String(tv_core),
-                                    " = call 'maps':'get'('",
-                                    Document::String(Self::local_state_key(var)),
-                                    "', ",
-                                    Document::String(field_state.clone()),
+                                    leaf::var(tv_core),
+                                    " = call 'maps':'get'(",
+                                    leaf::atom(Self::local_state_key(var)),
+                                    ", ",
+                                    leaf::var(field_state.clone()),
                                     ") in ",
                                 ]);
                             }
@@ -693,9 +693,9 @@ impl CoreErlangGenerator {
                         if is_last {
                             docs.push(docvec![
                                 "{'reply', ",
-                                Document::String(val_var),
+                                leaf::var(val_var),
                                 ", ",
-                                Document::String(field_state),
+                                leaf::var(field_state),
                                 "}",
                             ]);
                         }
@@ -711,17 +711,17 @@ impl CoreErlangGenerator {
                         let new_state = self.peek_next_state_var();
                         let mut doc_parts: Vec<Document<'static>> = vec![docvec![
                             "let ",
-                            Document::String(tuple_var.clone()),
+                            leaf::var(tuple_var.clone()),
                             " = ",
                             value_str,
                             " in let ",
-                            Document::String(actual_val.clone()),
+                            leaf::var(actual_val.clone()),
                             " = call 'erlang':'element'(1, ",
-                            Document::String(tuple_var.clone()),
+                            leaf::var(tuple_var.clone()),
                             ") in let ",
-                            Document::String(new_state.clone()),
+                            leaf::var(new_state.clone()),
                             " = call 'erlang':'element'(2, ",
-                            Document::String(tuple_var),
+                            leaf::var(tuple_var),
                             ") in ",
                         ]];
                         let _ = self.next_state_var();
@@ -733,11 +733,11 @@ impl CoreErlangGenerator {
                                     .map_or_else(|| Self::to_core_erlang_var(var), String::clone);
                                 doc_parts.push(docvec![
                                     "let ",
-                                    Document::String(tv_core),
-                                    " = call 'maps':'get'('",
-                                    Document::String(Self::local_state_key(var)),
-                                    "', ",
-                                    Document::String(new_state.clone()),
+                                    leaf::var(tv_core),
+                                    " = call 'maps':'get'(",
+                                    leaf::atom(Self::local_state_key(var)),
+                                    ", ",
+                                    leaf::var(new_state.clone()),
                                     ") in ",
                                 ]);
                             }
@@ -752,11 +752,7 @@ impl CoreErlangGenerator {
                     }
                     if is_last {
                         let post_state = self.current_state_var();
-                        docs.push(docvec![
-                            "{'reply', 'nil', ",
-                            Document::String(post_state),
-                            "}",
-                        ]);
+                        docs.push(docvec!["{'reply', 'nil', ", leaf::var(post_state), "}",]);
                     }
                 }
                 BodyExprKind::LocalAssignTier2 => {
@@ -772,17 +768,17 @@ impl CoreErlangGenerator {
                             let new_state = self.next_state_var();
                             docs.push(docvec![
                                 "let ",
-                                Document::String(tuple_var.clone()),
+                                leaf::var(tuple_var.clone()),
                                 " = ",
                                 value_str,
                                 " in let ",
-                                Document::String(core_var),
+                                leaf::var(core_var),
                                 " = call 'erlang':'element'(1, ",
-                                Document::String(tuple_var.clone()),
+                                leaf::var(tuple_var.clone()),
                                 ")\n in let ",
-                                Document::String(new_state),
+                                leaf::var(new_state),
                                 " = call 'erlang':'element'(2, ",
-                                Document::String(tuple_var),
+                                leaf::var(tuple_var),
                                 ") in ",
                             ]);
                         }
@@ -803,17 +799,17 @@ impl CoreErlangGenerator {
                             let value_str = self.expression_doc(value)?;
                             let mut doc_parts: Vec<Document<'static>> = vec![docvec![
                                 "let ",
-                                Document::String(tuple_var.clone()),
+                                leaf::var(tuple_var.clone()),
                                 " = ",
                                 value_str,
                                 " in let ",
-                                Document::String(core_var.clone()),
+                                leaf::var(core_var.clone()),
                                 " = call 'erlang':'element'(1, ",
-                                Document::String(tuple_var.clone()),
+                                leaf::var(tuple_var.clone()),
                                 ") in let ",
-                                Document::String(new_state.clone()),
+                                leaf::var(new_state.clone()),
                                 " = call 'erlang':'element'(2, ",
-                                Document::String(tuple_var),
+                                leaf::var(tuple_var),
                                 ") in ",
                             ]];
                             let _ = self.next_state_var();
@@ -828,11 +824,11 @@ impl CoreErlangGenerator {
                                     );
                                     doc_parts.push(docvec![
                                         "let ",
-                                        Document::String(tv_core),
-                                        " = call 'maps':'get'('",
-                                        Document::String(Self::local_state_key(var)),
-                                        "', ",
-                                        Document::String(new_state.clone()),
+                                        leaf::var(tv_core),
+                                        " = call 'maps':'get'(",
+                                        leaf::atom(Self::local_state_key(var)),
+                                        ", ",
+                                        leaf::var(new_state.clone()),
                                         ") in ",
                                     ]);
                                 }
@@ -859,9 +855,9 @@ impl CoreErlangGenerator {
                             self.bind_var(var_name, &core_var);
                             docs.push(docvec![
                                 "let ",
-                                Document::String(core_var),
+                                leaf::var(core_var),
                                 " = call 'erlang':'element'(1, ",
-                                Document::String(dispatch_var),
+                                leaf::var(dispatch_var),
                                 ") in ",
                             ]);
                         }
@@ -881,7 +877,7 @@ impl CoreErlangGenerator {
                             self.bind_var(var_name, &core_var);
                             docs.push(docvec![
                                 "let ",
-                                Document::String(core_var),
+                                leaf::var(core_var),
                                 " = ",
                                 value_str,
                                 " in ",
@@ -901,11 +897,7 @@ impl CoreErlangGenerator {
                     }
                     if is_last {
                         let post_state = self.current_state_var();
-                        docs.push(docvec![
-                            "{'reply', 'nil', ",
-                            Document::String(post_state),
-                            "}",
-                        ]);
+                        docs.push(docvec!["{'reply', 'nil', ", leaf::var(post_state), "}",]);
                     }
                 }
                 BodyExprKind::SuperSend => {
@@ -930,13 +922,7 @@ impl CoreErlangGenerator {
                     } else {
                         let tmp_var = self.fresh_temp_var("seq");
                         let expr_str = self.expression_doc(expr)?;
-                        docs.push(docvec![
-                            "let ",
-                            Document::String(tmp_var),
-                            " = ",
-                            expr_str,
-                            " in ",
-                        ]);
+                        docs.push(docvec!["let ", leaf::var(tmp_var), " = ", expr_str, " in ",]);
                     }
                 }
                 BodyExprKind::Tier2ValueCall => {
@@ -950,17 +936,17 @@ impl CoreErlangGenerator {
                         let new_state = self.next_state_var();
                         let mut doc_parts: Vec<Document<'static>> = vec![docvec![
                             "let ",
-                            Document::String(tuple_var.clone()),
+                            leaf::var(tuple_var.clone()),
                             " = ",
                             expr_str,
                             " in let ",
-                            Document::String(discard_var),
+                            leaf::var(discard_var),
                             " = call 'erlang':'element'(1, ",
-                            Document::String(tuple_var.clone()),
+                            leaf::var(tuple_var.clone()),
                             ")\n in let ",
-                            Document::String(new_state.clone()),
+                            leaf::var(new_state.clone()),
                             " = call 'erlang':'element'(2, ",
-                            Document::String(tuple_var),
+                            leaf::var(tuple_var),
                             ") in ",
                         ]];
 
@@ -972,11 +958,11 @@ impl CoreErlangGenerator {
                                     .map_or_else(|| Self::to_core_erlang_var(var), String::clone);
                                 doc_parts.push(docvec![
                                     "let ",
-                                    Document::String(core_var),
-                                    " = call 'maps':'get'('",
-                                    Document::String(Self::local_state_key(var)),
-                                    "', ",
-                                    Document::String(new_state.clone()),
+                                    leaf::var(core_var),
+                                    " = call 'maps':'get'(",
+                                    leaf::atom(Self::local_state_key(var)),
+                                    ", ",
+                                    leaf::var(new_state.clone()),
                                     ") in ",
                                 ]);
                             }
@@ -1002,13 +988,13 @@ impl CoreErlangGenerator {
                         let expr_str = self.expression_doc(expr)?;
                         let mut doc_parts: Vec<Document<'static>> = vec![docvec![
                             "let ",
-                            Document::String(tuple_var.clone()),
+                            leaf::var(tuple_var.clone()),
                             " = ",
                             expr_str,
                             " in let ",
-                            Document::String(new_state.clone()),
+                            leaf::var(new_state.clone()),
                             " = call 'erlang':'element'(2, ",
-                            Document::String(tuple_var),
+                            leaf::var(tuple_var),
                             ") in ",
                         ]];
                         let _ = self.next_state_var();
@@ -1021,11 +1007,11 @@ impl CoreErlangGenerator {
                                     .map_or_else(|| Self::to_core_erlang_var(var), String::clone);
                                 doc_parts.push(docvec![
                                     "let ",
-                                    Document::String(core_var),
-                                    " = call 'maps':'get'('",
-                                    Document::String(Self::local_state_key(var)),
-                                    "', ",
-                                    Document::String(new_state.clone()),
+                                    leaf::var(core_var),
+                                    " = call 'maps':'get'(",
+                                    leaf::atom(Self::local_state_key(var)),
+                                    ", ",
+                                    leaf::var(new_state.clone()),
                                     ") in ",
                                 ]);
                             }
@@ -1053,19 +1039,13 @@ impl CoreErlangGenerator {
                             "let _Result = ",
                             expr_str,
                             " in {'reply', _Result, ",
-                            Document::String(post_state),
+                            leaf::var(post_state),
                             "}",
                         ]);
                     } else {
                         let tmp_var = self.fresh_temp_var("seq");
                         let expr_str = self.expression_doc(expr)?;
-                        docs.push(docvec![
-                            "let ",
-                            Document::String(tmp_var),
-                            " = ",
-                            expr_str,
-                            " in ",
-                        ]);
+                        docs.push(docvec!["let ", leaf::var(tmp_var), " = ", expr_str, " in ",]);
                     }
                 }
             }
@@ -1079,11 +1059,7 @@ impl CoreErlangGenerator {
     /// Used by local assignments and other open-chain handlers in last position.
     fn emit_pure_reply(&mut self, docs: &mut Vec<Document<'static>>) {
         let post_state = self.current_state_var();
-        docs.push(docvec![
-            "{'reply', 'nil', ",
-            Document::String(post_state),
-            "}",
-        ]);
+        docs.push(docvec!["{'reply', 'nil', ", leaf::var(post_state), "}",]);
     }
 
     /// Emit the last-position reply for a dispatch open call (Tier 2 self-send
@@ -1092,9 +1068,9 @@ impl CoreErlangGenerator {
         let final_state = self.current_state_var();
         docs.push(docvec![
             "{'reply', call 'erlang':'element'(1, ",
-            Document::String(dispatch_var.to_string()),
+            leaf::var(dispatch_var.to_string()),
             "), ",
-            Document::String(final_state),
+            leaf::var(final_state),
             "}",
         ]);
     }
@@ -1110,13 +1086,13 @@ impl CoreErlangGenerator {
         let tuple_var = self.fresh_temp_var(tuple_label);
         docvec![
             "let ",
-            Document::String(tuple_var.clone()),
+            leaf::var(tuple_var.clone()),
             " = ",
             expr_doc,
             " in let _Result = call 'erlang':'element'(1, ",
-            Document::String(tuple_var.clone()),
+            leaf::var(tuple_var.clone()),
             ") in let _NewState = call 'erlang':'element'(2, ",
-            Document::String(tuple_var),
+            leaf::var(tuple_var),
             ") in {'reply', _Result, _NewState}",
         ]
     }
@@ -1148,24 +1124,24 @@ impl CoreErlangGenerator {
             }
             docs.push(docvec![
                 "let ",
-                Document::String(super_result_var.clone()),
-                " = call 'beamtalk_dispatch':'super'('",
-                Document::String(selector_atom),
-                "', [",
+                leaf::var(super_result_var.clone()),
+                " = call 'beamtalk_dispatch':'super'(",
+                leaf::atom(selector_atom),
+                ", [",
                 Document::Vec(arg_docs),
                 "], Self, ",
-                Document::String(current_state),
-                ", '",
-                Document::String(class_name),
-                "')",
+                leaf::var(current_state),
+                ", ",
+                leaf::atom(class_name),
+                ")",
             ]);
         }
 
         docs.push(docvec![
             " in let ",
-            Document::String(new_state),
+            leaf::var(new_state),
             " = call 'erlang':'element'(3, ",
-            Document::String(super_result_var),
+            leaf::var(super_result_var),
             ") in ",
         ]);
         Ok(())
@@ -1309,13 +1285,13 @@ impl CoreErlangGenerator {
             // BT-101: Method source
             let method_source_doc = Self::build_selector_map(&instance_methods, |m| {
                 let source_str = self.extract_method_source(m);
-                Document::String(Self::binary_string_literal(&source_str))
+                leaf::binary_lit(&source_str)
             });
 
             // BT-988: Method display signatures for :help command
             let method_sigs_doc = Self::build_selector_map(&instance_methods, |m| {
                 let sig_str = unparse_method_display_signature(m);
-                Document::String(Self::binary_string_literal(&sig_str))
+                leaf::binary_lit(&sig_str)
             });
 
             // BT-990: Class-side method display signatures for :help command
@@ -1326,7 +1302,7 @@ impl CoreErlangGenerator {
                 .collect();
             let class_method_sigs_doc = Self::build_selector_map(&class_methods_primary, |m| {
                 let sig_str = unparse_method_display_signature(m);
-                Document::String(Self::binary_string_literal(&sig_str))
+                leaf::binary_lit(&sig_str)
             });
 
             // BT-2195: Class-side method source — mirrors method_source for the
@@ -1334,7 +1310,7 @@ impl CoreErlangGenerator {
             // `referencesTo:` / `methodsMatching:` to scan class-side bodies.
             let class_method_source_doc = Self::build_selector_map(&class_methods_primary, |m| {
                 let source_str = self.extract_method_source(m);
-                Document::String(Self::binary_string_literal(&source_str))
+                leaf::binary_lit(&source_str)
             });
 
             // BT-412: Class variable initial values
@@ -1342,24 +1318,20 @@ impl CoreErlangGenerator {
 
             // BT-771: Class-level doc comment
             let class_doc_value: Document<'static> = if let Some(ref doc) = class.doc_comment {
-                Document::String(Self::binary_string_literal(doc))
+                leaf::binary_lit(doc)
             } else {
                 Document::Str("'none'")
             };
 
             // BT-771: Method-level doc comments
             let method_docs_doc = Self::build_selector_map_filtered(&instance_methods, |m| {
-                m.doc_comment
-                    .as_ref()
-                    .map(|doc| Document::String(Self::binary_string_literal(doc)))
+                m.doc_comment.as_ref().map(|doc| leaf::binary_lit(doc))
             });
 
             // BT-1634: Class method doc comments
             let class_method_docs_doc =
                 Self::build_selector_map_filtered(&class_methods_primary, |m| {
-                    m.doc_comment
-                        .as_ref()
-                        .map(|doc| Document::String(Self::binary_string_literal(doc)))
+                    m.doc_comment.as_ref().map(|doc| leaf::binary_lit(doc))
                 });
 
             // BT-877: Detect non-constructible classes at compile time.
@@ -1486,9 +1458,9 @@ impl CoreErlangGenerator {
                 parts.push(Document::Str(", "));
             }
             parts.push(docvec![
-                "'",
-                Document::Eco(method.selector.name()),
-                "' => ",
+                "",
+                leaf::atom(method.selector.name()),
+                " => ",
                 value_fn(method),
             ]);
         }
@@ -1508,12 +1480,7 @@ impl CoreErlangGenerator {
                 if !parts.is_empty() {
                     parts.push(Document::Str(", "));
                 }
-                parts.push(docvec![
-                    "'",
-                    Document::Eco(method.selector.name()),
-                    "' => ",
-                    val,
-                ]);
+                parts.push(docvec!["", leaf::atom(method.selector.name()), " => ", val,]);
             }
         }
         Document::Vec(parts)
@@ -1539,9 +1506,9 @@ impl CoreErlangGenerator {
                 Document::Str("'nil'")
             };
             parts.push(docvec![
-                "'",
-                Document::String(cv.name.name.to_string()),
-                "' => ",
+                "",
+                leaf::atom(cv.name.name.to_string()),
+                " => ",
                 val,
             ]);
         }
@@ -1589,23 +1556,15 @@ impl CoreErlangGenerator {
                 INDENT,
                 docvec![
                     line(),
-                    docvec![
-                        "'className' => '",
-                        Document::String(class_name.to_string()),
-                        "',"
-                    ],
+                    docvec!["'className' => ", leaf::atom(class_name.to_string()), ","],
                     line(),
                     docvec![
-                        "'superclassRef' => '",
-                        Document::String(superclass_name.to_string()),
-                        "',"
+                        "'superclassRef' => ",
+                        leaf::atom(superclass_name.to_string()),
+                        ","
                     ],
                     line(),
-                    docvec![
-                        "'moduleName' => '",
-                        Document::String(module_name.to_string()),
-                        "',"
-                    ],
+                    docvec!["'moduleName' => ", leaf::atom(module_name.to_string()), ","],
                     line(),
                     "'methodSource' => ~{",
                     method_source_doc,
@@ -1731,10 +1690,10 @@ impl CoreErlangGenerator {
                             let selector = sig.selector.name().to_string();
                             let arity = sig.selector.arity();
                             docvec![
-                                "~{'selector' => '",
-                                Document::String(selector),
-                                "', 'arity' => ",
-                                Document::String(arity.to_string()),
+                                "~{'selector' => ",
+                                leaf::atom(selector),
+                                ", 'arity' => ",
+                                leaf::var(arity.to_string()),
                                 "}~"
                             ]
                         })
@@ -1770,25 +1729,25 @@ impl CoreErlangGenerator {
 
             // Build extending value
             let extending_doc: Document<'static> = if let Some(ref ext) = protocol.extending {
-                docvec!["'", Document::String(ext.name.to_string()), "'"]
+                leaf::atom(ext.name.to_string())
             } else {
                 Document::Str("'undefined'")
             };
 
             // Build doc value — propagate doc comments to runtime for protocol class objects
             let doc_doc: Document<'static> = if let Some(ref doc) = protocol.doc_comment {
-                Document::String(Self::binary_string_literal(doc))
+                leaf::binary_lit(doc)
             } else {
                 Document::Str("'none'")
             };
 
             parts.push(docvec![
                 "\nlet <_ProtoReg_",
-                Document::String(name.clone()),
+                leaf::var(name.clone()),
                 "> = call 'beamtalk_protocol_registry':'register_protocol'(",
-                "~{'name' => '",
-                Document::String(name),
-                "', 'required_methods' => ",
+                "~{'name' => ",
+                leaf::atom(name),
+                ", 'required_methods' => ",
                 methods_doc,
                 ", 'required_class_methods' => ",
                 class_methods_doc,
@@ -2233,7 +2192,7 @@ impl CoreErlangGenerator {
         let mut parts: Vec<Document<'static>> = Vec::new();
         for var in param_vars {
             parts.push(Document::Str(", "));
-            parts.push(Document::String(var.clone()));
+            parts.push(leaf::var(var.clone()));
         }
         Document::Vec(parts)
     }
@@ -2290,7 +2249,7 @@ impl CoreErlangGenerator {
             let result_var = self.fresh_temp_var("Ret");
             let (value_str, open_scope) = self.expression_doc_with_open_scope(value)?;
             let (preamble, value_doc) = if let Some(open_scope_result) = open_scope {
-                (value_str, Document::String(open_scope_result))
+                (value_str, leaf::var(open_scope_result))
             } else {
                 (Document::Nil, value_str)
             };
@@ -2299,31 +2258,31 @@ impl CoreErlangGenerator {
                 Ok(docvec![
                     preamble,
                     "let ",
-                    Document::String(result_var.clone()),
+                    leaf::var(result_var.clone()),
                     " = ",
                     value_doc,
                     " in {'class_var_result', ",
-                    Document::String(result_var),
+                    leaf::var(result_var),
                     ", ",
-                    Document::String(final_cv),
+                    leaf::var(final_cv),
                     "}",
                 ])
             } else {
                 Ok(docvec![
                     preamble,
                     "let ",
-                    Document::String(result_var.clone()),
+                    leaf::var(result_var.clone()),
                     " = ",
                     value_doc,
                     " in ",
-                    Document::String(result_var),
+                    leaf::var(result_var),
                 ])
             }
         } else {
             // BT-1942: Same treatment for the no-class-vars path.
             let (value_str, open_scope) = self.expression_doc_with_open_scope(value)?;
             if let Some(open_scope_result) = open_scope {
-                Ok(docvec![value_str, Document::String(open_scope_result)])
+                Ok(docvec![value_str, leaf::var(open_scope_result)])
             } else {
                 Ok(value_str)
             }
@@ -2355,16 +2314,16 @@ impl CoreErlangGenerator {
                 Ok(docvec![
                     expr_str,
                     "{'class_var_result', ",
-                    Document::String(result_var),
+                    leaf::var(result_var),
                     ", ",
-                    Document::String(final_cv),
+                    leaf::var(final_cv),
                     "}",
                 ])
             } else {
                 Ok(docvec![
                     expr_str,
                     "{'class_var_result', 'nil', ",
-                    Document::String(final_cv),
+                    leaf::var(final_cv),
                     "}",
                 ])
             }
@@ -2379,39 +2338,39 @@ impl CoreErlangGenerator {
                     Ok(docvec![
                         expr_str,
                         "let ",
-                        Document::String(result_var.clone()),
+                        leaf::var(result_var.clone()),
                         " = ",
-                        Document::String(open_scope_result),
+                        leaf::var(open_scope_result),
                         " in {'class_var_result', ",
-                        Document::String(result_var),
+                        leaf::var(result_var),
                         ", ",
-                        Document::String(final_cv),
+                        leaf::var(final_cv),
                         "}",
                     ])
                 } else {
-                    Ok(docvec![expr_str, Document::String(open_scope_result)])
+                    Ok(docvec![expr_str, leaf::var(open_scope_result)])
                 }
             } else if self.class_var_mutated() {
                 let final_cv = self.current_class_var();
                 Ok(docvec![
                     "let ",
-                    Document::String(result_var.clone()),
+                    leaf::var(result_var.clone()),
                     " = ",
                     expr_str,
                     " in {'class_var_result', ",
-                    Document::String(result_var),
+                    leaf::var(result_var),
                     ", ",
-                    Document::String(final_cv),
+                    leaf::var(final_cv),
                     "}",
                 ])
             } else {
                 Ok(docvec![
                     "let ",
-                    Document::String(result_var.clone()),
+                    leaf::var(result_var.clone()),
                     " = ",
                     expr_str,
                     " in ",
-                    Document::String(result_var),
+                    leaf::var(result_var),
                 ])
             }
         }
@@ -2426,7 +2385,7 @@ impl CoreErlangGenerator {
             // BT-891: Class method self-send as last expression with no class vars.
             let (expr_str, open_scope) = self.expression_doc_with_open_scope(expr)?;
             if let Some(result_var) = open_scope {
-                Ok(docvec![expr_str, Document::String(result_var)])
+                Ok(docvec![expr_str, leaf::var(result_var)])
             } else {
                 Ok(expr_str)
             }
@@ -2434,7 +2393,7 @@ impl CoreErlangGenerator {
             // BT-1201: Use expression_doc_with_open_scope to detect open-scope results.
             let (expr_str, open_scope) = self.expression_doc_with_open_scope(expr)?;
             if let Some(open_scope_result) = open_scope {
-                Ok(docvec![expr_str, Document::String(open_scope_result)])
+                Ok(docvec![expr_str, leaf::var(open_scope_result)])
             } else {
                 Ok(expr_str)
             }
@@ -2473,19 +2432,13 @@ impl CoreErlangGenerator {
                 Ok(docvec![
                     expr_str,
                     "let ",
-                    Document::String(tmp_var),
+                    leaf::var(tmp_var),
                     " = ",
-                    Document::String(result_var),
+                    leaf::var(result_var),
                     " in "
                 ])
             } else {
-                Ok(docvec![
-                    "let ",
-                    Document::String(tmp_var),
-                    " = ",
-                    expr_str,
-                    " in "
-                ])
+                Ok(docvec!["let ", leaf::var(tmp_var), " = ", expr_str, " in "])
             }
         }
     }
@@ -2508,19 +2461,13 @@ impl CoreErlangGenerator {
                     return Ok(docvec![
                         val_doc,
                         "let ",
-                        Document::String(core_var),
+                        leaf::var(core_var),
                         " = ",
-                        Document::String(open_scope_result),
+                        leaf::var(open_scope_result),
                         " in "
                     ]);
                 }
-                return Ok(docvec![
-                    "let ",
-                    Document::String(core_var),
-                    " = ",
-                    val_doc,
-                    " in "
-                ]);
+                return Ok(docvec!["let ", leaf::var(core_var), " = ", val_doc, " in "]);
             }
         }
         Ok(Document::Nil)
@@ -2877,7 +2824,7 @@ impl CoreErlangGenerator {
 
         // ADR 0070 Phase 4: Emit package name as compile-time constant
         let package_doc: Document<'static> = match package_name {
-            Some(pkg) => docvec!["'", Document::String(pkg.to_string()), "'"],
+            Some(pkg) => leaf::atom(pkg.to_string()),
             None => Document::Str("'none'"),
         };
 
@@ -2889,11 +2836,11 @@ impl CoreErlangGenerator {
         };
 
         docvec![
-            "~{'class' => '",
-            Document::String(class_name),
-            "',\n      'superclass' => '",
-            Document::String(superclass_name),
-            "',\n      'package' => ",
+            "~{'class' => ",
+            leaf::atom(class_name),
+            ",\n      'superclass' => '",
+            leaf::atom(superclass_name),
+            ",\n      'package' => ",
             package_doc,
             ",\n      'kind' => ",
             kind_doc,
@@ -2942,7 +2889,7 @@ impl CoreErlangGenerator {
             if i > 0 {
                 parts.push(Document::Str(", "));
             }
-            parts.push(docvec!["'", Document::String(name.clone()), "'"]);
+            parts.push(leaf::atom(name.clone()));
         }
         parts.push(Document::Str("]"));
         Document::Vec(parts)
@@ -2980,9 +2927,9 @@ impl CoreErlangGenerator {
                 Document::Str("'false'")
             };
             parts.push(docvec![
-                "'",
-                Document::String(s.name.name.to_string()),
-                "' => ",
+                "",
+                leaf::atom(s.name.name.to_string()),
+                " => ",
                 flag,
             ]);
         }
@@ -3005,13 +2952,13 @@ impl CoreErlangGenerator {
                 parts.push(Document::Str(", "));
             }
             let type_doc = match &s.type_annotation {
-                Some(ta) => docvec!["'", Document::String(ta.type_name().to_string()), "'"],
+                Some(ta) => leaf::atom(ta.type_name().to_string()),
                 None => Document::Str("'none'"),
             };
             parts.push(docvec![
-                "'",
-                Document::String(s.name.name.to_string()),
-                "' => ",
+                "",
+                leaf::atom(s.name.name.to_string()),
+                " => ",
                 type_doc,
             ]);
         }
@@ -3230,12 +3177,12 @@ impl CoreErlangGenerator {
     pub(super) fn meta_type_repr_doc(repr: &MetaTypeRepr) -> Document<'static> {
         match repr {
             MetaTypeRepr::None => Document::Str("'none'"),
-            MetaTypeRepr::Atom(name) => docvec!["'", Document::String(name.clone()), "'"],
+            MetaTypeRepr::Atom(name) => leaf::atom(name.clone()),
             MetaTypeRepr::TypeParam { name, index } => docvec![
-                "{'type_param', '",
-                Document::String(name.clone()),
-                "', ",
-                Document::String(index.to_string()),
+                "{'type_param', ",
+                leaf::atom(name.clone()),
+                ", ",
+                leaf::var(index.to_string()),
                 "}"
             ],
             MetaTypeRepr::Generic { base, parameters } => {
@@ -3249,9 +3196,9 @@ impl CoreErlangGenerator {
                 }
                 params.push(Document::Str("]"));
                 docvec![
-                    "{'generic', '",
-                    Document::String(base.clone()),
-                    "', ",
+                    "{'generic', ",
+                    leaf::atom(base.clone()),
+                    ", ",
                     Document::Vec(params),
                     "}"
                 ]
@@ -3299,10 +3246,10 @@ impl CoreErlangGenerator {
                 Document::Str("'public'")
             };
             parts.push(docvec![
-                "'",
-                Document::String(sel.clone()),
-                "' => ~{'arity' => ",
-                Document::String(arity.to_string()),
+                "",
+                leaf::atom(sel.clone()),
+                " => ~{'arity' => ",
+                leaf::var(arity.to_string()),
                 ", 'param_types' => ",
                 param_types_doc,
                 ", 'return_type' => ",

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -9,7 +9,7 @@
 //! and reply tuples, and the `register_class/0` on-load function.
 
 use super::super::document::leaf::fname;
-use super::super::document::{Document, INDENT, leaf, line, nest};
+use super::super::document::{Document, INDENT, join, leaf, line, nest};
 use super::super::selector_mangler::safe_class_method_fn_name;
 use super::super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result, block_analysis};
 use crate::ast::{
@@ -212,7 +212,6 @@ impl CoreErlangGenerator {
         // Build method clause as Document tree
         let has_params = !param_vars.is_empty();
         let body_doc: Document = if has_params {
-            let params_pattern = param_vars.join(", ");
             docvec![
                 "<",
                 leaf::atom(selector_name.to_string()),
@@ -227,7 +226,10 @@ impl CoreErlangGenerator {
                             docvec![
                                 line(),
                                 "<[",
-                                leaf::var(params_pattern),
+                                join(
+                                    param_vars.iter().map(|p| leaf::var(p.clone())),
+                                    &Document::Str(", ")
+                                ),
                                 "]> when 'true' ->",
                                 nest(INDENT, docvec![line(), method_body_doc,]),
                                 line(),
@@ -1458,7 +1460,6 @@ impl CoreErlangGenerator {
                 parts.push(Document::Str(", "));
             }
             parts.push(docvec![
-                "",
                 leaf::atom(method.selector.name()),
                 " => ",
                 value_fn(method),
@@ -1480,7 +1481,7 @@ impl CoreErlangGenerator {
                 if !parts.is_empty() {
                     parts.push(Document::Str(", "));
                 }
-                parts.push(docvec!["", leaf::atom(method.selector.name()), " => ", val,]);
+                parts.push(docvec![leaf::atom(method.selector.name()), " => ", val,]);
             }
         }
         Document::Vec(parts)
@@ -1505,12 +1506,7 @@ impl CoreErlangGenerator {
             } else {
                 Document::Str("'nil'")
             };
-            parts.push(docvec![
-                "",
-                leaf::atom(cv.name.name.to_string()),
-                " => ",
-                val,
-            ]);
+            parts.push(docvec![leaf::atom(cv.name.name.to_string()), " => ", val,]);
         }
         Ok(Document::Vec(parts))
     }
@@ -2926,12 +2922,7 @@ impl CoreErlangGenerator {
             } else {
                 Document::Str("'false'")
             };
-            parts.push(docvec![
-                "",
-                leaf::atom(s.name.name.to_string()),
-                " => ",
-                flag,
-            ]);
+            parts.push(docvec![leaf::atom(s.name.name.to_string()), " => ", flag,]);
         }
         parts.push(Document::Str("}~"));
         Document::Vec(parts)
@@ -2956,7 +2947,6 @@ impl CoreErlangGenerator {
                 None => Document::Str("'none'"),
             };
             parts.push(docvec![
-                "",
                 leaf::atom(s.name.name.to_string()),
                 " => ",
                 type_doc,
@@ -3246,7 +3236,6 @@ impl CoreErlangGenerator {
                 Document::Str("'public'")
             };
             parts.push(docvec![
-                "",
                 leaf::atom(sel.clone()),
                 " => ~{'arity' => ",
                 leaf::int_lit(i64::try_from(*arity).unwrap_or(0)),

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -1693,7 +1693,7 @@ impl CoreErlangGenerator {
                                 "~{'selector' => ",
                                 leaf::atom(selector),
                                 ", 'arity' => ",
-                                leaf::var(arity.to_string()),
+                                leaf::int_lit(i64::try_from(arity).unwrap_or(0)),
                                 "}~"
                             ]
                         })
@@ -2838,7 +2838,7 @@ impl CoreErlangGenerator {
         docvec![
             "~{'class' => ",
             leaf::atom(class_name),
-            ",\n      'superclass' => '",
+            ",\n      'superclass' => ",
             leaf::atom(superclass_name),
             ",\n      'package' => ",
             package_doc,
@@ -3182,7 +3182,7 @@ impl CoreErlangGenerator {
                 "{'type_param', ",
                 leaf::atom(name.clone()),
                 ", ",
-                leaf::var(index.to_string()),
+                leaf::int_lit(i64::from(*index)),
                 "}"
             ],
             MetaTypeRepr::Generic { base, parameters } => {
@@ -3249,7 +3249,7 @@ impl CoreErlangGenerator {
                 "",
                 leaf::atom(sel.clone()),
                 " => ~{'arity' => ",
-                leaf::var(arity.to_string()),
+                leaf::int_lit(i64::try_from(*arity).unwrap_or(0)),
                 ", 'param_types' => ",
                 param_types_doc,
                 ", 'return_type' => ",

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/native_facade.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/native_facade.rs
@@ -510,11 +510,10 @@ impl CoreErlangGenerator {
                     method_source_docs.push(Document::Str(", "));
                 }
                 let source_str = self.extract_method_source(method);
-                let binary = Self::binary_string_literal(&source_str);
                 method_source_docs.push(docvec![
                     leaf::atom(method.selector.name()),
                     " => ",
-                    leaf::var(binary),
+                    leaf::binary_lit(&source_str),
                 ]);
             }
             let method_source_doc = Document::Vec(method_source_docs);
@@ -526,11 +525,10 @@ impl CoreErlangGenerator {
                     method_sig_docs.push(Document::Str(", "));
                 }
                 let sig_str = unparse_method_display_signature(method);
-                let binary = Self::binary_string_literal(&sig_str);
                 method_sig_docs.push(docvec![
                     leaf::atom(method.selector.name()),
                     " => ",
-                    leaf::var(binary),
+                    leaf::binary_lit(&sig_str),
                 ]);
             }
             let method_sigs_doc = Document::Vec(method_sig_docs);
@@ -547,11 +545,10 @@ impl CoreErlangGenerator {
                     class_method_sig_docs.push(Document::Str(", "));
                 }
                 let sig_str = unparse_method_display_signature(method);
-                let binary = Self::binary_string_literal(&sig_str);
                 class_method_sig_docs.push(docvec![
                     leaf::atom(method.selector.name()),
                     " => ",
-                    leaf::var(binary),
+                    leaf::binary_lit(&sig_str),
                 ]);
             }
             let class_method_sigs_doc = Document::Vec(class_method_sig_docs);
@@ -570,11 +567,10 @@ impl CoreErlangGenerator {
                     class_method_source_docs.push(Document::Str(", "));
                 }
                 let source_str = self.extract_method_source(method);
-                let binary = Self::binary_string_literal(&source_str);
                 class_method_source_docs.push(docvec![
                     leaf::atom(method.selector.name()),
                     " => ",
-                    leaf::var(binary),
+                    leaf::binary_lit(&source_str),
                 ]);
             }
             let class_method_source_doc = Document::Vec(class_method_source_docs);
@@ -608,11 +604,10 @@ impl CoreErlangGenerator {
                     if !method_docs_parts.is_empty() {
                         method_docs_parts.push(Document::Str(", "));
                     }
-                    let binary = Self::binary_string_literal(doc);
                     method_docs_parts.push(docvec![
                         leaf::atom(method.selector.name()),
                         " => ",
-                        leaf::var(binary),
+                        leaf::binary_lit(doc),
                     ]);
                 }
             }

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/native_facade.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/native_facade.rs
@@ -79,10 +79,8 @@ impl CoreErlangGenerator {
                 let selector_name = method.selector.name();
                 let dispatch_arity = method.selector.arity() + 1; // +1 for Self
                 parts.push(docvec![
-                    ", 'dispatch_",
-                    leaf::var(selector_name.to_string()),
-                    "'/",
-                    leaf::int_lit(i64::try_from(dispatch_arity).unwrap_or(0)),
+                    ", ",
+                    leaf::fname(format!("dispatch_{selector_name}"), dispatch_arity),
                 ]);
             }
             Document::Vec(parts)
@@ -815,10 +813,7 @@ impl CoreErlangGenerator {
         };
 
         docvec![
-            "'dispatch_",
-            leaf::var(selector_name.to_string()),
-            "'/",
-            leaf::int_lit(i64::try_from(dispatch_arity).unwrap_or(0)),
+            leaf::fname(format!("dispatch_{selector_name}"), dispatch_arity),
             " = fun (",
             params_doc,
             ") ->",

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/native_facade.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/native_facade.rs
@@ -10,7 +10,7 @@
 //! and provides `has_method/1`, `__beamtalk_meta/0`, `register_class/0`, and
 //! dispatch functions for `self delegate` methods (BT-1210).
 
-use super::super::document::{Document, INDENT, join, line, nest};
+use super::super::document::{Document, INDENT, join, leaf, line, nest};
 use super::super::spec_codegen;
 use super::super::{CodeGenContext, CoreErlangGenerator, Result};
 use crate::ast::{MethodDefinition, MethodKind, Module};
@@ -80,9 +80,9 @@ impl CoreErlangGenerator {
                 let dispatch_arity = method.selector.arity() + 1; // +1 for Self
                 parts.push(docvec![
                     ", 'dispatch_",
-                    Document::String(selector_name.to_string()),
+                    leaf::var(selector_name.to_string()),
                     "'/",
-                    Document::String(dispatch_arity.to_string()),
+                    leaf::int_lit(i64::try_from(dispatch_arity).unwrap_or(0)),
                 ]);
             }
             Document::Vec(parts)
@@ -105,9 +105,9 @@ impl CoreErlangGenerator {
         // Module header
         let module_header = if has_classes {
             docvec![
-                "module '",
-                Document::Eco(self.module_name.clone()),
-                "' [",
+                "module ",
+                leaf::atom(self.module_name.clone()),
+                " [",
                 base_exports,
                 class_method_export_doc,
                 ", 'register_class'/0]",
@@ -121,9 +121,9 @@ impl CoreErlangGenerator {
             ]
         } else {
             docvec![
-                "module '",
-                Document::Eco(self.module_name.clone()),
-                "' [",
+                "module ",
+                leaf::atom(self.module_name.clone()),
+                " [",
                 base_exports,
                 class_method_export_doc,
                 "]",
@@ -212,9 +212,9 @@ impl CoreErlangGenerator {
                 docvec![
                     line(),
                     docvec![
-                        "call '",
-                        Document::Eco(self.module_name.clone()),
-                        "':'spawn'(~{}~)",
+                        "call ",
+                        leaf::atom(self.module_name.clone()),
+                        ":'spawn'(~{}~)",
                     ],
                 ]
             ),
@@ -259,22 +259,21 @@ impl CoreErlangGenerator {
     fn generate_native_spawn_1(&mut self, backing_module: &str) -> Result<Document<'static>> {
         let class_name = self.class_name();
         let module_name = self.module_name.clone();
-        let hint_binary = Self::binary_string_literal("spawnWith: expects a Dictionary argument");
 
         // Helper: build an instantiation_error with reason in details
         let spawn_error_with_reason = |class: &str, reason_var: &str| -> Document<'static> {
             docvec![
                 docvec![
-                    "let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', '",
-                    Document::String(class.to_string()),
-                    "') in",
+                    "let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', ",
+                    leaf::atom(class.to_string()),
+                    ") in",
                 ],
                 line(),
                 "let SpawnErr1 = call 'beamtalk_error':'with_selector'(SpawnErr0, 'spawnWith:') in",
                 line(),
                 docvec![
                     "let SpawnErr2 = call 'beamtalk_error':'with_details'(SpawnErr1, ~{'reason' => ",
-                    Document::String(reason_var.to_string()),
+                    leaf::var(reason_var.to_string()),
                     "}~) in",
                 ],
                 line(),
@@ -299,16 +298,18 @@ impl CoreErlangGenerator {
                                 docvec![
                                     line(),
                                     docvec![
-                                        "let TypeErr0 = call 'beamtalk_error':'new'('type_error', '",
-                                        Document::String(class_name.clone()),
-                                        "') in",
+                                        "let TypeErr0 = call 'beamtalk_error':'new'('type_error', ",
+                                        leaf::atom(class_name.clone()),
+                                        ") in",
                                     ],
                                     line(),
                                     "let TypeErr1 = call 'beamtalk_error':'with_selector'(TypeErr0, 'spawnWith:') in",
                                     line(),
                                     docvec![
                                         "let TypeErr2 = call 'beamtalk_error':'with_hint'(TypeErr1, ",
-                                        Document::String(hint_binary),
+                                        leaf::binary_lit(
+                                            "spawnWith: expects a Dictionary argument"
+                                        ),
                                         ") in",
                                     ],
                                     line(),
@@ -323,9 +324,9 @@ impl CoreErlangGenerator {
                                     line(),
                                     // BT-1337: Wrap start_link in try-catch to handle crashes
                                     docvec![
-                                        "let StartResult = try call '",
-                                        Document::String(backing_module.to_string()),
-                                        "':'start_link'(Config)",
+                                        "let StartResult = try call ",
+                                        leaf::atom(backing_module.to_string()),
+                                        ":'start_link'(Config)",
                                     ],
                                     nest(
                                         INDENT,
@@ -353,11 +354,11 @@ impl CoreErlangGenerator {
                                                     Self::instance_registration_doc(&class_name),
                                                     line(),
                                                     docvec![
-                                                        "{'beamtalk_object', '",
-                                                        Document::String(class_name.clone()),
-                                                        "', '",
-                                                        Document::Eco(module_name.clone()),
-                                                        "', Pid}",
+                                                        "{'beamtalk_object', ",
+                                                        leaf::atom(class_name.clone()),
+                                                        ", ",
+                                                        leaf::atom(module_name.clone()),
+                                                        ", Pid}",
                                                     ],
                                                 ]
                                             ),
@@ -460,9 +461,8 @@ impl CoreErlangGenerator {
     ) -> Document<'static> {
         let native_entries = docvec![
             ",\n      'native' => 'true'",
-            ",\n      'backing_module' => '",
-            Document::String(backing_module.to_string()),
-            "'",
+            ",\n      'backing_module' => ",
+            leaf::atom(backing_module.to_string()),
         ];
 
         Self::build_meta_map_doc_with_extra(
@@ -514,10 +514,9 @@ impl CoreErlangGenerator {
                 let source_str = self.extract_method_source(method);
                 let binary = Self::binary_string_literal(&source_str);
                 method_source_docs.push(docvec![
-                    "'",
-                    Document::Eco(method.selector.name()),
-                    "' => ",
-                    Document::String(binary),
+                    leaf::atom(method.selector.name()),
+                    " => ",
+                    leaf::var(binary),
                 ]);
             }
             let method_source_doc = Document::Vec(method_source_docs);
@@ -531,10 +530,9 @@ impl CoreErlangGenerator {
                 let sig_str = unparse_method_display_signature(method);
                 let binary = Self::binary_string_literal(&sig_str);
                 method_sig_docs.push(docvec![
-                    "'",
-                    Document::Eco(method.selector.name()),
-                    "' => ",
-                    Document::String(binary),
+                    leaf::atom(method.selector.name()),
+                    " => ",
+                    leaf::var(binary),
                 ]);
             }
             let method_sigs_doc = Document::Vec(method_sig_docs);
@@ -553,10 +551,9 @@ impl CoreErlangGenerator {
                 let sig_str = unparse_method_display_signature(method);
                 let binary = Self::binary_string_literal(&sig_str);
                 class_method_sig_docs.push(docvec![
-                    "'",
-                    Document::Eco(method.selector.name()),
-                    "' => ",
-                    Document::String(binary),
+                    leaf::atom(method.selector.name()),
+                    " => ",
+                    leaf::var(binary),
                 ]);
             }
             let class_method_sigs_doc = Document::Vec(class_method_sig_docs);
@@ -577,10 +574,9 @@ impl CoreErlangGenerator {
                 let source_str = self.extract_method_source(method);
                 let binary = Self::binary_string_literal(&source_str);
                 class_method_source_docs.push(docvec![
-                    "'",
-                    Document::Eco(method.selector.name()),
-                    "' => ",
-                    Document::String(binary),
+                    leaf::atom(method.selector.name()),
+                    " => ",
+                    leaf::var(binary),
                 ]);
             }
             let class_method_source_doc = Document::Vec(class_method_source_docs);
@@ -596,18 +592,13 @@ impl CoreErlangGenerator {
                 } else {
                     Document::Str("'nil'")
                 };
-                class_var_parts.push(docvec![
-                    "'",
-                    Document::String(cv.name.name.to_string()),
-                    "' => ",
-                    val,
-                ]);
+                class_var_parts.push(docvec![leaf::atom(cv.name.name.to_string()), " => ", val,]);
             }
             let class_vars_doc = Document::Vec(class_var_parts);
 
             // Class-level doc comment
             let class_doc_value: Document<'static> = if let Some(ref doc) = class.doc_comment {
-                Document::String(Self::binary_string_literal(doc))
+                leaf::binary_lit(doc)
             } else {
                 Document::Str("'none'")
             };
@@ -621,10 +612,9 @@ impl CoreErlangGenerator {
                     }
                     let binary = Self::binary_string_literal(doc);
                     method_docs_parts.push(docvec![
-                        "'",
-                        Document::Eco(method.selector.name()),
-                        "' => ",
-                        Document::String(binary),
+                        leaf::atom(method.selector.name()),
+                        " => ",
+                        leaf::var(binary),
                     ]);
                 }
             }
@@ -641,21 +631,21 @@ impl CoreErlangGenerator {
                     docvec![
                         line(),
                         docvec![
-                            "'className' => '",
-                            Document::String(class.name.name.to_string()),
-                            "',"
+                            "'className' => ",
+                            leaf::atom(class.name.name.to_string()),
+                            ","
                         ],
                         line(),
                         docvec![
-                            "'superclassRef' => '",
-                            Document::String(class.superclass_name().to_string()),
-                            "',"
+                            "'superclassRef' => ",
+                            leaf::atom(class.superclass_name().to_string()),
+                            ","
                         ],
                         line(),
                         docvec![
-                            "'moduleName' => '",
-                            Document::Eco(self.module_name.clone()),
-                            "',"
+                            "'moduleName' => ",
+                            leaf::atom(self.module_name.clone()),
+                            ","
                         ],
                         line(),
                         "'methodSource' => ~{",
@@ -805,7 +795,7 @@ impl CoreErlangGenerator {
         let mut param_docs: Vec<Document<'static>> = method
             .parameters
             .iter()
-            .map(|p| Document::String(Self::to_core_erlang_var(&p.name.name)))
+            .map(|p| leaf::var(Self::to_core_erlang_var(&p.name.name)))
             .collect();
         param_docs.push(Document::Str("Self"));
         let params_doc = join(param_docs, &Document::Str(", "));
@@ -818,7 +808,7 @@ impl CoreErlangGenerator {
                 method
                     .parameters
                     .iter()
-                    .map(|p| Document::String(Self::to_core_erlang_var(&p.name.name))),
+                    .map(|p| leaf::var(Self::to_core_erlang_var(&p.name.name))),
                 &Document::Str(", "),
             );
             docvec!["[", arg_docs, "]"]
@@ -826,9 +816,9 @@ impl CoreErlangGenerator {
 
         docvec![
             "'dispatch_",
-            Document::String(selector_name.to_string()),
+            leaf::var(selector_name.to_string()),
             "'/",
-            Document::String(dispatch_arity.to_string()),
+            leaf::int_lit(i64::try_from(dispatch_arity).unwrap_or(0)),
             " = fun (",
             params_doc,
             ") ->",
@@ -838,9 +828,9 @@ impl CoreErlangGenerator {
                     line(),
                     "let Pid = call 'erlang':'element'(4, Self) in",
                     line(),
-                    "call 'beamtalk_actor':'sync_send'(Pid, '",
-                    Document::String(selector_name.to_string()),
-                    "', ",
+                    "call 'beamtalk_actor':'sync_send'(Pid, ",
+                    leaf::atom(selector_name.to_string()),
+                    ", ",
                     args_list,
                     ")",
                 ]

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/spawn.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/spawn.rs
@@ -8,7 +8,7 @@
 //! Generates `spawn/0`, `spawn/1` class methods and `new/0`, `new/1` error
 //! methods that prevent incorrect actor instantiation.
 
-use super::super::document::{Document, INDENT, line, nest};
+use super::super::document::{Document, INDENT, leaf, line, nest};
 use super::super::{CoreErlangGenerator, Result};
 use crate::ast::Module;
 use crate::docvec;
@@ -20,9 +20,9 @@ impl CoreErlangGenerator {
     pub(super) fn instance_registration_doc(class_name: &str) -> Document<'static> {
         docvec![
             docvec![
-                "let _InstReg = try call 'beamtalk_object_instances':'register'('",
-                Document::String(class_name.to_string()),
-                "', Pid)",
+                "let _InstReg = try call 'beamtalk_object_instances':'register'(",
+                leaf::atom(class_name.to_string()),
+                ", Pid)",
             ],
             nest(
                 INDENT,
@@ -70,11 +70,11 @@ impl CoreErlangGenerator {
         let module_name = self.module_name.clone();
 
         let ok_body = docvec![
-            "{'beamtalk_object', '",
-            Document::String(class_name.clone()),
-            "', '",
-            Document::Eco(module_name.clone()),
-            "', Pid}",
+            "{'beamtalk_object', ",
+            leaf::atom(class_name.clone()),
+            ", ",
+            leaf::atom(module_name.clone()),
+            ", Pid}",
         ];
 
         // BT-1541: Use safe_spawn which handles trap_exit + await_initialize
@@ -85,9 +85,9 @@ impl CoreErlangGenerator {
                 docvec![
                     line(),
                     docvec![
-                        "case call 'beamtalk_actor':'safe_spawn'('",
-                        Document::Eco(module_name.clone()),
-                        "', ~{}~) of",
+                        "case call 'beamtalk_actor':'safe_spawn'(",
+                        leaf::atom(module_name.clone()),
+                        ", ~{}~) of",
                     ],
                     nest(
                         INDENT,
@@ -111,9 +111,9 @@ impl CoreErlangGenerator {
                                 docvec![
                                     line(),
                                     docvec![
-                                        "let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', '",
-                                        Document::String(class_name.clone()),
-                                        "') in",
+                                        "let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', ",
+                                        leaf::atom(class_name.clone()),
+                                        ") in",
                                     ],
                                     line(),
                                     "let SpawnErr1 = call 'beamtalk_error':'with_selector'(SpawnErr0, 'spawn') in",
@@ -174,18 +174,17 @@ impl CoreErlangGenerator {
         let module_name = self.module_name.clone();
 
         let ok_body = docvec![
-            "{'beamtalk_object', '",
-            Document::String(class_name.clone()),
-            "', '",
-            Document::Eco(module_name.clone()),
-            "', Pid}",
+            "{'beamtalk_object', ",
+            leaf::atom(class_name.clone()),
+            ", ",
+            leaf::atom(module_name.clone()),
+            ", Pid}",
         ];
 
         // BT-473: Validate InitArgs is a map before passing to gen_server
         // BT-476: This is the single source of truth for spawnWith: argument validation.
         // The runtime (beamtalk_object_class.erl handle_call({spawn, Args})) delegates
         // validation to this generated code for both static and dynamic dispatch paths.
-        let hint_binary = Self::binary_string_literal("spawnWith: expects a Dictionary argument");
         let doc = docvec![
             "'spawn'/1 = fun (InitArgs) ->",
             nest(
@@ -203,16 +202,18 @@ impl CoreErlangGenerator {
                                 docvec![
                                     line(),
                                     docvec![
-                                        "let TypeErr0 = call 'beamtalk_error':'new'('type_error', '",
-                                        Document::String(class_name.clone()),
-                                        "') in",
+                                        "let TypeErr0 = call 'beamtalk_error':'new'('type_error', ",
+                                        leaf::atom(class_name.clone()),
+                                        ") in",
                                     ],
                                     line(),
                                     "let TypeErr1 = call 'beamtalk_error':'with_selector'(TypeErr0, 'spawnWith:') in",
                                     line(),
                                     docvec![
                                         "let TypeErr2 = call 'beamtalk_error':'with_hint'(TypeErr1, ",
-                                        Document::String(hint_binary.clone()),
+                                        leaf::binary_lit(
+                                            "spawnWith: expects a Dictionary argument"
+                                        ),
                                         ") in",
                                     ],
                                     line(),
@@ -227,9 +228,9 @@ impl CoreErlangGenerator {
                                 docvec![
                                     line(),
                                     docvec![
-                                        "case call 'beamtalk_actor':'safe_spawn'('",
-                                        Document::Eco(module_name.clone()),
-                                        "', InitArgs) of",
+                                        "case call 'beamtalk_actor':'safe_spawn'(",
+                                        leaf::atom(module_name.clone()),
+                                        ", InitArgs) of",
                                     ],
                                     nest(
                                         INDENT,
@@ -253,9 +254,9 @@ impl CoreErlangGenerator {
                                                 docvec![
                                                     line(),
                                                     docvec![
-                                                        "let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', '",
-                                                        Document::String(class_name.clone()),
-                                                        "') in",
+                                                        "let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', ",
+                                                        leaf::atom(class_name.clone()),
+                                                        ") in",
                                                     ],
                                                     line(),
                                                     "let SpawnErr1 = call 'beamtalk_error':'with_selector'(SpawnErr0, 'spawnWith:') in",
@@ -326,7 +327,7 @@ impl CoreErlangGenerator {
         let class_name = self.class_name();
         Ok(Self::instantiation_error_stub(
             "'spawn'/0 = fun () ->",
-            Document::String(class_name),
+            leaf::var(class_name),
             "spawn",
             "Abstract classes cannot be instantiated. Subclass it first.",
         ))
@@ -340,7 +341,7 @@ impl CoreErlangGenerator {
         let class_name = self.class_name();
         Ok(Self::instantiation_error_stub(
             "'spawn'/1 = fun (_InitArgs) ->",
-            Document::String(class_name),
+            leaf::var(class_name),
             "spawnWith:",
             "Abstract classes cannot be instantiated. Subclass it first.",
         ))
@@ -362,7 +363,6 @@ impl CoreErlangGenerator {
         selector: &'static str,
         hint: &str,
     ) -> Document<'static> {
-        let hint_binary = Self::binary_string_literal(hint);
         docvec![
             fun_decl,
             nest(
@@ -383,7 +383,7 @@ impl CoreErlangGenerator {
                     line(),
                     docvec![
                         "let Error2 = call 'beamtalk_error':'with_hint'(Error1, ",
-                        Document::String(hint_binary),
+                        leaf::binary_lit(hint),
                         ") in",
                     ],
                     line(),
@@ -443,9 +443,8 @@ impl CoreErlangGenerator {
 
         let doc = docvec![
             docvec![
-                "'superclass'/0 = fun () -> '",
-                Document::String(superclass_atom.to_string()),
-                "'",
+                "'superclass'/0 = fun () -> ",
+                leaf::atom(superclass_atom.to_string()),
             ],
             "\n",
             "\n",

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/state.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/state.rs
@@ -8,7 +8,7 @@
 //! Generates state field initializers for actor `init/1` callbacks,
 //! including inherited fields from parent classes.
 
-use super::super::document::{Document, line};
+use super::super::document::{Document, leaf, line};
 use super::super::{CoreErlangGenerator, Result};
 use crate::ast::{Expression, Identifier, Module};
 use crate::docvec;
@@ -42,11 +42,7 @@ impl CoreErlangGenerator {
                 };
                 fields.push(docvec![
                     line(),
-                    docvec![
-                        ", '",
-                        Document::String(state.name.name.to_string()),
-                        "' => "
-                    ],
+                    docvec![", ", leaf::atom(state.name.name.to_string()), " => "],
                     value_code,
                 ]);
             }
@@ -78,7 +74,7 @@ impl CoreErlangGenerator {
                         let value_code = self.expression_doc(value)?;
                         fields.push(docvec![
                             line(),
-                            docvec![", '", Document::String(id.name.to_string()), "' => "],
+                            docvec![", ", leaf::atom(id.name.to_string()), " => "],
                             value_code,
                         ]);
                     }
@@ -101,7 +97,7 @@ impl CoreErlangGenerator {
                 let value_code = self.expression_doc(&default_value)?;
                 fields.push(docvec![
                     line(),
-                    docvec![", '", Document::String(field_name.clone()), "' => "],
+                    docvec![", ", leaf::atom(field_name.clone()), " => "],
                     value_code,
                 ]);
             }
@@ -115,11 +111,7 @@ impl CoreErlangGenerator {
                 };
                 fields.push(docvec![
                     line(),
-                    docvec![
-                        ", '",
-                        Document::String(state.name.name.to_string()),
-                        "' => "
-                    ],
+                    docvec![", ", leaf::atom(state.name.name.to_string()), " => "],
                     value_code,
                 ]);
             }
@@ -134,11 +126,7 @@ impl CoreErlangGenerator {
                     };
                     fields.push(docvec![
                         line(),
-                        docvec![
-                            ", '",
-                            Document::String(state.name.name.to_string()),
-                            "' => "
-                        ],
+                        docvec![", ", leaf::atom(state.name.name.to_string()), " => "],
                         value_code,
                     ]);
                 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -3194,6 +3194,26 @@ fn test_native_facade_meta_includes_native_flag() {
 }
 
 #[test]
+fn test_meta_superclass_is_single_quoted_atom() {
+    // BT-2328: the document::leaf migration must emit the meta-map superclass as a
+    // single-quoted atom (`'superclass' => 'Actor'`). A stray leading quote ahead of
+    // leaf::atom produced `''Actor'`, which desyncs Core Erlang atom quoting.
+    let module = make_native_actor_module();
+    let result = generate_module(&module, CodegenOptions::new("bt@test_native"));
+    let code = result.unwrap();
+    let meta_fn =
+        extract_core_fn(&code, "'__beamtalk_meta'/0 = fun").expect("__beamtalk_meta/0 not found");
+    assert!(
+        meta_fn.contains("'superclass' => 'Actor'"),
+        "__beamtalk_meta/0 body should include 'superclass' => 'Actor'. Got:\n{meta_fn}"
+    );
+    assert!(
+        !meta_fn.contains("=> ''"),
+        "__beamtalk_meta/0 must not emit doubled-quote atoms (e.g. ''Actor'). Got:\n{meta_fn}"
+    );
+}
+
+#[test]
 fn test_native_facade_no_gen_server_behaviour() {
     // ADR 0056: Native facade does not declare gen_server behaviour
     let module = make_native_actor_module();


### PR DESCRIPTION
## Summary

ADR 0089 Phase 2 (Epic BT-2319): migrates all `Document::String` / `Document::Eco` leaves across the 8 `gen_server/` codegen files to the typed `document::leaf` API. grep for `Document::(String|Eco)\(` now returns **0** across the entire `gen_server/` tree.

**Files:** `callbacks.rs`, `dispatch.rs`, `extensions.rs`, `methods.rs`, `native_facade.rs`, `spawn.rs`, `state.rs`, plus a regression test in `tests/gen_server.rs`.

**Leaf-helper breakdown:**

| Helper | Count | Notes |
|---|---|---|
| `leaf::var` | 192 | bare variable identifiers (state vars, temps, params, mangled names) |
| `leaf::atom` | 97 | single-quote-wrapped atoms, surrounding `"'"` fragments folded in |
| `leaf::binary_lit` | 14 | error hints / string binaries |
| `leaf::int_lit` | 4 | arities, type-param indexes |
| `leaf::fname` | 2 | `dispatch_<sel>'/arity` export + definition names |

## Leaf-type corrections (review follow-up)

Beyond the mechanical migration, several sites were routed through `leaf::var` for non-variable constructs; these now land on the correct typed helper (output byte-for-byte unchanged):

- `dispatch_<selector>'/arity` export entry and `fun` definition → `leaf::fname` (also escapes the selector name correctly).
- `methodSignatures` arity, `type_param` index, and `meta_method_info` arity → `leaf::int_lit`.
- `_Ext<idx>` register variable → built as one `leaf::var(format!("_Ext{idx}"))`.
- `reason_var` / `dispatch_var` stay on `leaf::var` — they are genuine runtime variables.

## Regression fix

The migration emitted the meta-map superclass as `'superclass' => ''<Super>'` — a stray leading quote ahead of `leaf::atom` (which already quotes). The doubled quote desyncs Core Erlang atom quoting and unbalances the module's map delimiters. No existing test asserted that value, so the suite stayed green while the codegen **validity proptest** went red. Dropping the stray quote restores it, and `test_meta_superclass_is_single_quoted_atom` now locks the quoting.

## Verification

- `cargo build -p beamtalk-core`: clean
- `cargo clippy -p beamtalk-core --lib`: 0 warnings/errors
- `cargo test -p beamtalk-core --lib codegen`: **1172 passed, 0 failed** — `to_pretty_string()` byte-for-byte assertions confirm generated Core Erlang is unchanged, and the validity proptest (balanced delimiters) passes again
- `cargo test -p beamtalk-core --lib`: 4044 passed

Merges cleanly into current `main` (no overlap with the BT-2329 control_flow merge).

https://claude.ai/code/session_011bdwa2ezGVMPmNHpAbzHKW

---
_Generated by [Claude Code](https://claude.ai/code/session_011bdwa2ezGVMPmNHpAbzHKW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal Erlang code generation mechanisms for actor classes to improve consistency and maintainability of generated runtime code across multiple generation paths.

* **Tests**
  * Added regression test for native actor metadata generation to prevent future issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->