### PR TITLE
Fix LSP type-hierarchy to honour BT-1933 protocol/class shadowing

### DIFF
--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -590,23 +590,22 @@ impl SimpleLanguageService {
     /// the language service hasn't indexed (the editor still shows the
     /// item via the name returned from
     /// [`Self::type_hierarchy_prepare_at`]; navigation just doesn't have a
-    /// jump target). Protocol declarations are also resolved here so
-    /// `prepareTypeHierarchy` on a protocol name lands on the protocol
-    /// header.
+    /// jump target).
+    ///
+    /// BT-2317: resolution delegates to
+    /// [`definition_provider::find_class_or_protocol_declaration`], the same
+    /// helper goto-definition uses, so the BT-1933 protocol/class shadowing
+    /// rule applies on this path too. When a name is defined as both a real
+    /// class and a synthetic protocol (across separate files), the real class
+    /// wins; a protocol declaration is only returned when the hierarchy marks
+    /// the name as a protocol class — so `prepareTypeHierarchy` on a protocol
+    /// name still lands on the protocol header.
     fn find_class_declaration_location(&self, class_name: &str) -> Option<Location> {
-        for (file_path, data) in &self.files {
-            for class in &data.module.classes {
-                if class.name.name.as_str() == class_name {
-                    return Some(Location::new(file_path.clone(), class.name.span));
-                }
-            }
-            for protocol in &data.module.protocols {
-                if protocol.name.name.as_str() == class_name {
-                    return Some(Location::new(file_path.clone(), protocol.name.span));
-                }
-            }
-        }
-        None
+        crate::queries::definition_provider::find_class_or_protocol_declaration(
+            class_name,
+            &self.project_index,
+            self.files.iter().map(|(path, data)| (path, &data.module)),
+        )
     }
 
     /// BT-2242: Resolve the supertype chain of `class_name` to declaration
@@ -3467,5 +3466,42 @@ mod tests {
         service.update_file(file.clone(), "Object subclass: Foo\n".to_string());
         let subs = service.subtypes_of("Foo");
         assert!(subs.is_empty());
+    }
+
+    // ---------- BT-2317: protocol/class shadowing on the type-hierarchy path ----------
+
+    #[test]
+    fn type_hierarchy_prepare_at_prefers_class_over_same_named_protocol() {
+        // BT-2317: a name defined as both a real class and a synthetic
+        // protocol (BT-1933) across separate files must resolve to the class
+        // on the type-hierarchy path, mirroring goto-definition. Before the
+        // fix this depended on `HashMap` iteration order and could land on the
+        // protocol header.
+        let mut service = SimpleLanguageService::new();
+        let class_file = Utf8PathBuf::from("real_class.bt");
+        let protocol_file = Utf8PathBuf::from("protocol_foo.bt");
+        let ref_file = Utf8PathBuf::from("uses_foo.bt");
+
+        service.update_file(
+            class_file.clone(),
+            "Object subclass: Foo\n  bar => 1\n".to_string(),
+        );
+        service.update_file(
+            protocol_file.clone(),
+            "Protocol define: Foo\n  baz -> Integer\n".to_string(),
+        );
+        // `Foo subclass: Sub` gives us a `Foo` reference token to put the
+        // cursor on (col 1 lands inside the `Foo` identifier).
+        service.update_file(ref_file.clone(), "Foo subclass: Sub\n".to_string());
+
+        let (name, loc) = service
+            .type_hierarchy_prepare_at(&ref_file, Position::new(0, 1))
+            .expect("Some for cursor on the Foo class reference");
+        assert_eq!(name.as_str(), "Foo");
+        let loc = loc.expect("Foo's real class declaration is indexed");
+        assert_eq!(
+            loc.file, class_file,
+            "type hierarchy must resolve to the real class, not the protocol header"
+        );
     }
 }

--- a/crates/beamtalk-core/src/queries/definition_provider.rs
+++ b/crates/beamtalk-core/src/queries/definition_provider.rs
@@ -73,46 +73,65 @@ pub fn find_definition_cross_file<'a>(
         return Some(Location::new(current_file.clone(), span));
     }
 
-    // 2. Class or protocol definition in the project index.
-    //
-    // BT-1933 registers protocol names as synthetic class entries, so
-    // `has_class` returns true for both. We walk the indexed files once
-    // looking for a real class declaration — that wins unconditionally.
-    // Otherwise, fall back to a protocol match only when the hierarchy
-    // explicitly marks the name as a protocol class (`is_protocol_class`).
-    //
-    // Built-in/stdlib classes can still have source files (e.g. stdlib/src/*.bt),
-    // so we always search indexed files for a concrete declaration span.
-    if project_index.hierarchy().has_class(name) {
-        let mut protocol_match: Option<Location> = None;
-        for (file_path, module) in files {
-            for class in &module.classes {
-                if class.name.name.as_str() == name {
-                    return Some(Location::new(file_path.clone(), class.name.span));
-                }
-            }
-            if protocol_match.is_none() {
-                for protocol in &module.protocols {
-                    if protocol.name.name.as_str() == name {
-                        protocol_match = Some(Location::new(file_path.clone(), protocol.name.span));
-                        break;
-                    }
-                }
+    // 2. Class or protocol definition in the project index, honouring the
+    //    BT-1933 protocol/class shadowing rule.
+    find_class_or_protocol_declaration(name, project_index, files)
+}
+
+/// Resolve the declaration site of a class or protocol `name`, applying the
+/// BT-1933 protocol/class shadowing rule.
+///
+/// BT-1933 registers protocol names as synthetic class entries, so
+/// [`ClassHierarchy::has_class`] returns true for both real classes and
+/// protocols. We walk the indexed files once looking for a real class
+/// declaration — that wins unconditionally. Otherwise, fall back to a protocol
+/// match only when the hierarchy explicitly marks the name as a protocol class
+/// ([`ClassHierarchy::is_protocol_class`], BT-1936).
+///
+/// Built-in/stdlib classes can still have source files (e.g. `stdlib/src/*.bt`),
+/// so we always search indexed files for a concrete declaration span.
+///
+/// Returns `None` when the name isn't known to the hierarchy, or when it *is*
+/// known but no source span is available (a real class whose source file isn't
+/// open — consistent with stdlib classes that have no indexed source).
+///
+/// This is the single source of truth for class/protocol declaration
+/// resolution, shared by [`find_definition_cross_file`] (goto-definition) and
+/// the language-service type-hierarchy path (BT-2242 / BT-2317), so the two
+/// agree on which declaration a name resolves to.
+#[must_use]
+pub fn find_class_or_protocol_declaration<'a>(
+    name: &str,
+    project_index: &ProjectIndex,
+    files: impl IntoIterator<Item = (&'a Utf8PathBuf, &'a Module)>,
+) -> Option<Location> {
+    if !project_index.hierarchy().has_class(name) {
+        return None;
+    }
+
+    let mut protocol_match: Option<Location> = None;
+    for (file_path, module) in files {
+        for class in &module.classes {
+            if class.name.name.as_str() == name {
+                return Some(Location::new(file_path.clone(), class.name.span));
             }
         }
-        // Only return the protocol fallback when the hierarchy definitively
-        // knows this name as a protocol. Otherwise, the hierarchy entry refers
-        // to a real class whose source isn't open; returning None keeps the
-        // behaviour consistent with class-only lookup (stdlib classes with no
-        // open source file already return None).
-        if let Some(location) = protocol_match {
-            if project_index.hierarchy().is_protocol_class(name) {
-                return Some(location);
+        if protocol_match.is_none() {
+            for protocol in &module.protocols {
+                if protocol.name.name.as_str() == name {
+                    protocol_match = Some(Location::new(file_path.clone(), protocol.name.span));
+                    break;
+                }
             }
         }
     }
 
-    None
+    // Only return the protocol fallback when the hierarchy definitively knows
+    // this name as a protocol. Otherwise, the hierarchy entry refers to a real
+    // class whose source isn't open; returning None keeps the behaviour
+    // consistent with class-only lookup (stdlib classes with no open source
+    // file already return None).
+    protocol_match.filter(|_| project_index.hierarchy().is_protocol_class(name))
 }
 
 /// Find the definition of a method selector, searching across all indexed files.


### PR DESCRIPTION
## Summary

Fixes **BT-2317** — the LSP type-hierarchy path bypassed the BT-1933 protocol/class shadowing rule.

`find_class_declaration_location` in `language_service/mod.rs` (used by `prepareTypeHierarchy`, `supertypes_of`, and `subtypes_of`) iterated indexed files and returned the first matching class *or* protocol header. When a name was defined as both a real class and a synthetic protocol (BT-1933) across separate files, resolution depended on `HashMap` iteration order and could land on the protocol header instead of the real class — diverging from goto-definition, which already applied the rule.

This was latent (no corpus/test exercised the collision) but would surface in any project defining protocols alongside same-named classes.

## Changes

- Extracted the class/protocol resolution out of `find_definition_cross_file` into a new shared, public helper `find_class_or_protocol_declaration` in `definition_provider.rs`. It applies the BT-1933 rule: a real class wins unconditionally; a protocol declaration is returned only when `ClassHierarchy::is_protocol_class` is true.
- `find_definition_cross_file` (goto-definition) and `find_class_declaration_location` (type-hierarchy) now both delegate to the helper — single source of truth, so the two paths agree on resolution.
- Added regression test `type_hierarchy_prepare_at_prefers_class_over_same_named_protocol`: class `Foo` in one file, protocol `Foo` in another; `prepareTypeHierarchy` on a `Foo` cursor resolves to the class.

## Acceptance criteria

- [x] `find_class_declaration_location` consults the BT-1933 shadowing rule (prefer real class; protocol only when `is_protocol_class`).
- [x] Resolution order mirrors `definition_provider.rs`, so goto-definition and type-hierarchy agree.
- [x] Regression test for the class/protocol name collision.
- [x] Existing 3 LSP + 2 language-service type-hierarchy tests still green.
- [x] Shared resolution factored into a helper both paths delegate to (rather than duplicating the rule).

## Testing

- `cargo test -p beamtalk-core --lib` (type-hierarchy, supertypes/subtypes, goto-definition/shadowing suites) — green
- `cargo test -p beamtalk-lsp -- type_hierarchy` — 3 tests green
- `cargo fmt` / `cargo clippy` — clean
- Pre-push CI hook (clippy, fmt, dialyzer, build, stdlib) — passed

Closes BT-2317.

https://claude.ai/code/session_017c9TgSTrUxuNnDSwk8Covw

---
_Generated by [Claude Code](https://claude.ai/code/session_017c9TgSTrUxuNnDSwk8Covw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type hierarchy resolution to correctly prioritize real class declarations over synthetic protocol definitions when both exist with the same name.

* **Tests**
  * Added test coverage for class-over-protocol resolution behavior across multiple files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->