### PR TITLE
Reject non-finite f64 when constructing Literal::Float (parser hardening) (BT-2338)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
@@ -826,17 +826,32 @@ impl Parser {
                 }
             }
             TokenKind::Float(s) => {
-                if let Ok(val) = s.parse::<f64>() {
-                    Literal::Float(val)
-                } else {
-                    self.diagnostics.push(Diagnostic::error(
-                        format!("Invalid float literal: {s}"),
-                        span,
-                    ));
-                    return Expression::Error {
-                        message: "Invalid float literal".into(),
-                        span,
-                    };
+                match s.parse::<f64>() {
+                    // Reject values that overflow `f64` to `inf`/`-inf` (e.g. `1e309`)
+                    // or that parse to `NaN`. A non-finite literal would otherwise reach
+                    // codegen and emit `inf.0` / `NaN.0`, which Core Erlang cannot parse,
+                    // surfacing as a confusing `erlc` failure instead of a diagnostic here.
+                    Ok(val) if val.is_finite() => Literal::Float(val),
+                    Ok(_) => {
+                        self.diagnostics.push(Diagnostic::error(
+                            format!("Float literal out of range: {s}"),
+                            span,
+                        ));
+                        return Expression::Error {
+                            message: "Float literal out of range".into(),
+                            span,
+                        };
+                    }
+                    Err(_) => {
+                        self.diagnostics.push(Diagnostic::error(
+                            format!("Invalid float literal: {s}"),
+                            span,
+                        ));
+                        return Expression::Error {
+                            message: "Invalid float literal".into(),
+                            span,
+                        };
+                    }
                 }
             }
             TokenKind::String(s) => Literal::String(s),
@@ -1352,6 +1367,8 @@ impl Parser {
                         let expr = self.parse_literal();
                         let span = start.merge(expr.span());
                         if let Expression::Literal(lit, _) = expr {
+                            // `parse_literal` already rejects non-finite floats, so
+                            // negating `f` here cannot produce `inf`/`NaN`.
                             let neg_lit = match lit {
                                 Literal::Integer(n) => Literal::Integer(-n),
                                 Literal::Float(f) => Literal::Float(-f),
@@ -1565,6 +1582,8 @@ impl Parser {
                         let expr = self.parse_literal();
                         let span = start.merge(expr.span());
                         if let Expression::Literal(lit, _) = expr {
+                            // `parse_literal` already rejects non-finite floats, so
+                            // negating `f` here cannot produce `inf`/`NaN`.
                             let neg_lit = match lit {
                                 Literal::Integer(n) => Literal::Integer(-n),
                                 Literal::Float(f) => Literal::Float(-f),

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/expression_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/expression_tests.rs
@@ -26,6 +26,25 @@ fn parse_float_literal() {
 }
 
 #[test]
+fn parse_float_literal_out_of_range_is_rejected() {
+    // `1e309` overflows f64 to +inf; the parser must surface a diagnostic
+    // rather than constructing a non-finite literal that codegen would emit
+    // as `inf.0` (which Core Erlang cannot parse).
+    use crate::source_analysis::Severity;
+    let diagnostics = parse_err("1e309");
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert_eq!(errors.len(), 1, "expected one error, got: {errors:?}");
+    assert!(
+        errors[0].message.contains("out of range"),
+        "message: {}",
+        errors[0].message
+    );
+}
+
+#[test]
 fn parse_string_literal() {
     let module = parse_ok("\"hello\"");
     assert_eq!(module.expressions.len(), 1);


### PR DESCRIPTION
## Summary

Linear issue: https://linear.app/beamtalk/issue/BT-2338

The parser constructed `Literal::Float` from `TokenKind::Float(s).parse::<f64>()` without an `is_finite()` check. Inputs that overflow `f64` (e.g. `1e309`) parse to `Ok(+inf)` rather than `Err`, so they slipped through. A non-finite literal would then reach codegen and emit `inf.0` / `NaN.0`, which Core Erlang cannot parse — surfacing as a confusing `erlc` failure instead of a user-facing diagnostic at parse time.

This was a pre-existing gap (not introduced by BT-2320 / ADR 0089 Phase 1); it was surfaced by CodeRabbit during review of PR #2366.

## Changes

- **`parser/expressions.rs`** — the float-literal arm in `parse_literal` now matches the parse result three ways: finite `Ok` accepts, non-finite `Ok` emits a `"Float literal out of range"` diagnostic and returns `Expression::Error`, and `Err` keeps the existing `"Invalid float literal"` path.
- The two unary-minus pattern paths (`~1357`, `~1570`) negate floats that already passed `parse_literal`'s finiteness check; negating a finite float cannot produce `inf`/`NaN`, so the invariant is documented with a comment rather than re-checked. These are the only other `Literal::Float` construction sites.
- **`tests/expression_tests.rs`** — adds `parse_float_literal_out_of_range_is_rejected`, asserting `1e309` produces exactly one error containing "out of range".

`document::leaf::float_lit` and the decimal/exponent rendering logic are left unchanged, per the acceptance criteria.

## Acceptance Criteria

- [x] Check `value.is_finite()` at every `Literal::Float` construction site (centralized in `parse_literal`; negation sites covered by that guard).
- [x] Return a user-facing `Diagnostic` for non-finite values rather than relying on a `debug_assert!`.
- [x] Parser test for an overflowing float literal (`1e309`) asserting the diagnostic.
- [x] `document::leaf::float_lit` and the decimal/exponent rendering logic unchanged.

## Testing

- All 449 parser unit tests pass.
- `cargo fmt`, `cargo clippy`, and the full pre-push CI hook (clippy, fmt, ADR-0089 leaf check, Erlang lint, Dialyzer, Biome, Beamtalk format) passed clean.

https://claude.ai/code/session_01MS3v1poc2dks71jJ8LATYw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MS3v1poc2dks71jJ8LATYw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Float literal validation now properly rejects non-finite values (inf, -inf, NaN).
  * Improved error messages to distinguish between out-of-range and invalid float literals.
  * Enhanced parser robustness for edge-case numeric inputs.

* **Tests**
  * Added regression test for out-of-range float literal handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->