### PR TITLE
Extract duplicate escape_beamtalk_string to beamtalk-core (BT-2351)

### DIFF
--- a/crates/beamtalk-cli/tests/repl_protocol.rs
+++ b/crates/beamtalk-cli/tests/repl_protocol.rs
@@ -36,6 +36,7 @@
 
 use beamtalk_cli::repl_startup;
 use beamtalk_core::source_analysis::is_input_complete;
+use beamtalk_core::unparse::escape_string_literal;
 use beamtalk_repl_protocol::{ReplResponse, RequestBuilder};
 use serial_test::serial;
 use std::env;
@@ -706,8 +707,7 @@ impl ReplClient {
     /// returned value is a Beamtalk list of class objects which renders as a
     /// JSON array of class-name strings.
     fn load_file(&mut self, path: &str) -> Result<Vec<String>, String> {
-        // Escape backslashes and double quotes for embedding in a Beamtalk string literal.
-        let escaped = path.replace('\\', "\\\\").replace('"', "\\\"");
+        let escaped = escape_string_literal(path);
         let expr = format!("Workspace load: \"{escaped}\"");
         self.write_json(&RequestBuilder::eval(&expr))?;
 

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -111,6 +111,24 @@ pub fn format_source(source: &str) -> Option<String> {
     Some(formatted)
 }
 
+/// Escapes an arbitrary string for embedding inside a Beamtalk double-quoted
+/// string literal.
+///
+/// Beamtalk strings share `\\` and `"` escaping with most languages, and also
+/// treat `{` as the start of an interpolation sequence (ADR 0023), so a
+/// literal `{` must be written as `\{`.
+///
+/// The escape order is significant: `\\` must be processed first so a caller-
+/// supplied `\{` is rendered as `\\{` (a literal backslash then a literal
+/// brace) rather than `\\\{` (a literal backslash followed by an
+/// interpolation).
+#[must_use]
+pub fn escape_string_literal(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('{', "\\{")
+}
+
 /// Builds a [`Document`] for a method display signature (no `sealed`, no ` =>`).
 fn unparse_method_display_signature_doc(method: &MethodDefinition) -> Document<'static> {
     let sig = match &method.selector {
@@ -2973,5 +2991,34 @@ mod tests {
             "  asString -> String\n",
         );
         assert_identity(source);
+    }
+
+    // --- escape_string_literal ---
+
+    #[test]
+    fn escape_string_literal_plain_string_unchanged() {
+        assert_eq!(escape_string_literal("hello"), "hello");
+    }
+
+    #[test]
+    fn escape_string_literal_escapes_double_quote() {
+        assert_eq!(escape_string_literal("a\"b"), "a\\\"b");
+    }
+
+    #[test]
+    fn escape_string_literal_escapes_backslash() {
+        assert_eq!(escape_string_literal("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn escape_string_literal_escapes_open_brace() {
+        assert_eq!(escape_string_literal("a{b}"), "a\\{b}");
+    }
+
+    #[test]
+    fn escape_string_literal_backslash_before_brace_both_escaped() {
+        // Backslash must be escaped before brace so "\{x}" → "\\{x}" (literal
+        // backslash + literal brace), not "\\\{x}" (backslash + interpolation).
+        assert_eq!(escape_string_literal("\\{x}"), "\\\\\\{x}");
     }
 }

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -119,9 +119,9 @@ pub fn format_source(source: &str) -> Option<String> {
 /// literal `{` must be written as `\{`.
 ///
 /// The escape order is significant: `\\` must be processed first so a caller-
-/// supplied `\{` is rendered as `\\{` (a literal backslash then a literal
-/// brace) rather than `\\\{` (a literal backslash followed by an
-/// interpolation).
+/// supplied `\{` is rendered as `\\\{` (escaped backslash `\\` then escaped
+/// brace `\{`) rather than `\\{` (escaped backslash followed by an unescaped
+/// `{` that would start interpolation).
 #[must_use]
 pub fn escape_string_literal(s: &str) -> String {
     s.replace('\\', "\\\\")
@@ -3017,8 +3017,16 @@ mod tests {
 
     #[test]
     fn escape_string_literal_backslash_before_brace_both_escaped() {
-        // Backslash must be escaped before brace so "\{x}" → "\\{x}" (literal
-        // backslash + literal brace), not "\\\{x}" (backslash + interpolation).
+        // Backslash must be escaped before brace so "\{x}" → "\\\{x}" (escaped
+        // backslash `\\` + escaped brace `\{`), not "\\{x}" (escaped backslash
+        // followed by an unescaped `{` that would start interpolation).
         assert_eq!(escape_string_literal("\\{x}"), "\\\\\\{x}");
+    }
+
+    #[test]
+    fn escape_string_literal_mixed_backslash_quote_brace() {
+        // Verifies all three escape rules fire correctly in one input and that
+        // replacement order does not corrupt any of them.
+        assert_eq!(escape_string_literal("\\\"\\{"), "\\\\\\\"\\\\\\{");
     }
 }

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -26,7 +26,7 @@ use beamtalk_core::language_service::{
 use beamtalk_core::queries::all_sends_query::{ReceiverKind, find_all_sends_in_source};
 use beamtalk_core::semantic_analysis::ClassHierarchy;
 use beamtalk_core::source_analysis::{Severity, Span};
-use beamtalk_core::unparse::format_source;
+use beamtalk_core::unparse::{escape_string_literal, format_source};
 use camino::Utf8PathBuf;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
@@ -2702,7 +2702,7 @@ pub(crate) fn build_command_expression(
             // dictionary; the path is passed as a String value.
             Ok(format!(
                 "Workspace flush: #{{ #file => \"{}\" }}",
-                escape_beamtalk_string(&file)
+                escape_string_literal(&file)
             ))
         }
         CMD_FLUSH_KIND => {
@@ -2736,8 +2736,8 @@ pub(crate) fn build_command_expression(
             // rather than re-parsed Beamtalk source.
             Ok(format!(
                 "Workspace newClass: \"{}\" at: \"{}\"",
-                escape_beamtalk_string(&source),
-                escape_beamtalk_string(&path)
+                escape_string_literal(&source),
+                escape_string_literal(&path)
             ))
         }
         _ => Err(format!("unknown LSP command: {command}")),
@@ -2800,16 +2800,6 @@ fn validate_class_name(name: &str) -> std::result::Result<(), String> {
         }
     }
     Ok(())
-}
-
-/// Escape an arbitrary Rust string for embedding inside a Beamtalk double-
-/// quoted string literal. Mirrors `beamtalk-mcp::escape_beamtalk_string`:
-/// Beamtalk strings use `\` and `"` like Rust plus `{` triggers
-/// interpolation (ADR 0023), so `\{` is required for a literal `{`.
-fn escape_beamtalk_string(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('{', "\\{")
 }
 
 fn workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {
@@ -4878,8 +4868,8 @@ mod tests {
         )
         .expect("ok");
         // Roundtrip the source through the Beamtalk escaper.
-        let expected_source = escape_beamtalk_string(source);
-        let expected_path = escape_beamtalk_string(path);
+        let expected_source = escape_string_literal(source);
+        let expected_path = escape_string_literal(path);
         assert_eq!(
             expr,
             format!("Workspace newClass: \"{expected_source}\" at: \"{expected_path}\"")
@@ -4930,15 +4920,6 @@ mod tests {
     fn build_unknown_command_returns_error() {
         let err = build_command_expression("not.a.real.command", &[]).expect_err("err");
         assert!(err.contains("unknown LSP command"));
-    }
-
-    #[test]
-    fn escape_beamtalk_string_handles_quotes_backslashes_and_braces() {
-        assert_eq!(escape_beamtalk_string("hello"), "hello");
-        assert_eq!(escape_beamtalk_string("\"q\""), "\\\"q\\\"");
-        assert_eq!(escape_beamtalk_string("a\\b"), "a\\\\b");
-        assert_eq!(escape_beamtalk_string("{x}"), "\\{x}");
-        assert_eq!(escape_beamtalk_string("\\\"{"), "\\\\\\\"\\{");
     }
 
     #[test]

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -13,6 +13,7 @@ use std::fmt::Write;
 use std::sync::Arc;
 
 use beamtalk_core::source_analysis::{Severity, lex_with_eof, parse};
+use beamtalk_core::unparse::escape_string_literal;
 use rmcp::{
     ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -226,19 +227,6 @@ fn pretty_json(value: &serde_json::Value) -> String {
     serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
 }
 
-/// Escape a Rust string so it can be embedded as a Beamtalk String literal.
-///
-/// Beamtalk strings use `\` and `"` like Rust, plus `{` triggers interpolation
-/// (ADR 0023), so `\{` is required to embed a literal `{`. Used by ADR 0082
-/// Phase 3 MCP tools (`save_method`, `try_method`, `save_class`, `flush`)
-/// to forward user-supplied bodies and paths through the `evaluate` op without
-/// the body needing to be valid Beamtalk source on its own.
-fn escape_beamtalk_string(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('{', "\\{")
-}
-
 /// Build the Beamtalk expression for the `save_method` MCP tool — durable
 /// patch path (ADR 0082 Phase 3). Selector is the bare form (no leading `#`).
 fn save_method_expr(class: &str, selector: &str, body: &str) -> String {
@@ -246,7 +234,7 @@ fn save_method_expr(class: &str, selector: &str, body: &str) -> String {
         "{} compile: #{} source: \"{}\"",
         class,
         selector,
-        escape_beamtalk_string(body),
+        escape_string_literal(body),
     )
 }
 
@@ -257,7 +245,7 @@ fn try_method_expr(class: &str, selector: &str, body: &str) -> String {
         "{} tryCompile: #{} source: \"{}\"",
         class,
         selector,
-        escape_beamtalk_string(body),
+        escape_string_literal(body),
     )
 }
 
@@ -266,8 +254,8 @@ fn try_method_expr(class: &str, selector: &str, body: &str) -> String {
 fn save_class_expr(source: &str, path: &str) -> String {
     format!(
         "Workspace newClass: \"{}\" at: \"{}\"",
-        escape_beamtalk_string(source),
-        escape_beamtalk_string(path),
+        escape_string_literal(source),
+        escape_string_literal(path),
     )
 }
 
@@ -292,7 +280,7 @@ fn flush_expr(filter: FlushFilter<'_>) -> String {
         FlushFilter::Class(class) => format!("Workspace flush: {class}"),
         FlushFilter::File(file) => format!(
             "Workspace flush: #{{ #file => \"{}\" }}",
-            escape_beamtalk_string(file)
+            escape_string_literal(file)
         ),
         FlushFilter::Kind(kind) => format!("Workspace flush: #'{kind}'"),
     }
@@ -923,7 +911,7 @@ impl BeamtalkMcp {
         // Use native Beamtalk API: Workspace load: "path"
         let expr = format!(
             "Workspace load: \"{}\"",
-            escape_beamtalk_string(&params.path)
+            escape_string_literal(&params.path)
         );
         let response = self
             .client
@@ -3408,19 +3396,6 @@ mod tests {
     // matching the REPL meta-command tests in
     // crates/beamtalk-cli/src/commands/repl/mod.rs. Surface drift in the
     // expression mapping fails CI through these tests.
-
-    #[test]
-    fn escape_beamtalk_string_handles_backslash_quote_and_brace() {
-        // Brace escaping prevents Beamtalk's '{x}' interpolation (ADR 0023).
-        assert_eq!(escape_beamtalk_string("hello"), "hello");
-        assert_eq!(escape_beamtalk_string("a\"b"), "a\\\"b");
-        assert_eq!(escape_beamtalk_string("a\\b"), "a\\\\b");
-        assert_eq!(escape_beamtalk_string("a{b}"), "a\\{b}");
-        // Order matters: backslash escape must run first so a literal '\{'
-        // arriving from the caller does not become '\\\\{' (which would expand
-        // to a literal backslash followed by an interpolation).
-        assert_eq!(escape_beamtalk_string("\\{x}"), "\\\\\\{x}");
-    }
 
     #[test]
     fn save_method_expr_compiles_durable_patch() {


### PR DESCRIPTION
## Summary

- Move the duplicated `escape_beamtalk_string` function (identical in `beamtalk-mcp` and `beamtalk-lsp`) into `beamtalk_core::unparse::escape_string_literal`
- Consolidate duplicate unit tests from both server modules into `beamtalk-core`
- Fix CLI test's inline escape to also handle `{` (previously missing brace escaping)

No new dependency edges — both MCP and LSP already depend on `beamtalk-core`.

**Linear:** https://linear.app/beamtalk/issue/BT-2351

## Changes

| File | Change |
|------|--------|
| `crates/beamtalk-core/src/unparse/mod.rs` | Add `escape_string_literal` + 5 unit tests |
| `crates/beamtalk-mcp/src/server.rs` | Remove local copy + local test, import from core |
| `crates/beamtalk-lsp/src/server.rs` | Remove local copy + local test, import from core |
| `crates/beamtalk-cli/tests/repl_protocol.rs` | Replace inline escape with shared function |

## Test plan

- [x] `cargo test -p beamtalk-core --lib -- unparse::tests::escape` — 5/5 pass
- [x] `cargo build --workspace` — clean
- [x] `just clippy` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Pre-push hooks (lint, dialyzer, spec validation) — all pass

https://claude.ai/code/session_018U745Hdo5Tc2GxnJXp2T8C

---
_Generated by [Claude Code](https://claude.ai/code/session_018U745Hdo5Tc2GxnJXp2T8C)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized string-escaping behavior across CLI, LSP, and server components to ensure consistent handling when embedding text in expressions.

* **Bug Fixes**
  * Corrected escaping for backslashes, double quotes, and brace characters to avoid malformed expressions for paths and source text.

* **Tests**
  * Added and updated unit and integration tests to validate escaping behavior end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->