### PR TITLE
Tighten loose assertion in perform_locally_test (BT-2353)

### DIFF
--- a/stdlib/test/perform_locally_test.bt
+++ b/stdlib/test/perform_locally_test.bt
@@ -19,7 +19,7 @@ TestCase subclass: PerformLocallyTest
   testUnaryClassMethod =>
     // performLocally: works with zero-argument class methods
     result := LocalCallHelper performLocally: #callerPid withArguments: #()
-    self assert: result notNil
+    self assert: result equals: (Erlang erlang self)
 
   testKeywordClassMethod =>
     // performLocally: works with one-argument keyword methods


### PR DESCRIPTION
## Summary

Replaces a loose `notNil` guard in `testUnaryClassMethod` with an exact value assertion, tightening the regression coverage for `performLocally:withArguments:`.

- `LocalCallHelper>>callerPid` is defined as `Erlang erlang self` (the calling process's PID)
- When invoked via `performLocally:`, it runs in the caller's process, so the result must equal the test process's own PID
- The sibling `testRunsInCallerProcess` in the same file already establishes this invariant; this change makes `testUnaryClassMethod` consistent with it

**Before:**
```
self assert: result notNil
```
**After:**
```
self assert: result equals: (Erlang erlang self)
```

**Diff:** 1 line in 1 file. All 2162 BUnit tests pass.

## Test plan

- [x] `just test-bunit` — 2162 tests, 0 failures
- [x] `just build && just clippy && just fmt-check` — clean

https://linear.app/beamtalk/issue/BT-2353/tighten-loose-assertion-in-perform-locally-testbt

---
_Generated by [Claude Code](https://claude.ai/code/session_01NidVjamcLwb7Vfek9WA82V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertions to verify method return values are properly validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->