### PR TITLE
Add CI ratchet lint for unreferenced workaround/limitation comments (BT-2347)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -268,7 +268,19 @@ bench:
 # ═══════════════════════════════════════════════════════════════════════════
 
 # Run all linting and formatting checks
-lint: lint-rust lint-erlang lint-js lint-beamtalk
+lint: lint-rust lint-erlang lint-js lint-beamtalk lint-workaround-comments
+
+# Ratchet lint: flag workaround/limitation comments lacking a BT-NNNN tracking
+# reference (BT-2347). Ships with an allowlist snapshot of pre-existing offenders
+# (scripts/ci/workaround-comments-allowlist.txt) so CI is green on introduction;
+# only NEW unreferenced workaround comments fail.
+#
+# To clear a failure: file/find a tracking issue and add its `BT-NNNN` reference
+# to the offending comment line (or an adjacent line). To regenerate the
+# allowlist (e.g. for a genuine false positive), run with `--update`:
+#   scripts/ci/lint-workaround-comments.sh --update
+lint-workaround-comments:
+    @bash scripts/ci/lint-workaround-comments.sh
 
 # Lint Beamtalk: formatting check
 lint-beamtalk: fmt-check-beamtalk

--- a/Justfile
+++ b/Justfile
@@ -279,8 +279,15 @@ lint: lint-rust lint-erlang lint-js lint-beamtalk lint-workaround-comments
 # to the offending comment line (or an adjacent line). To regenerate the
 # allowlist (e.g. for a genuine false positive), run with `--update`:
 #   scripts/ci/lint-workaround-comments.sh --update
+# Unix-only (shells out to bash); Linux CI covers it, so the Windows variant
+# is a no-op, consistent with the `[windows] ci`/`fmt-check` splits.
+[unix]
 lint-workaround-comments:
     @bash scripts/ci/lint-workaround-comments.sh
+
+[windows]
+lint-workaround-comments:
+    @echo "lint-workaround-comments: skipped on Windows (covered by Linux CI)"
 
 # Lint Beamtalk: formatting check
 lint-beamtalk: fmt-check-beamtalk

--- a/scripts/ci/lint-workaround-comments.sh
+++ b/scripts/ci/lint-workaround-comments.sh
@@ -47,7 +47,7 @@ ALLOWLIST="scripts/ci/workaround-comments-allowlist.txt"
 # `nonexistent_type_XXXX` or `does_XXX_understand`):
 WORD_MARKERS='HACK|FIXME|XXX'
 # Phrase markers (matched anywhere, case-insensitive):
-PHRASE_MARKERS='workaround|work around|does ?n.t thread|does not thread|pre-existing limitation|known limitation|language limitation|parser limitation'
+PHRASE_MARKERS='workaround|work around|does not thread|doesn'\''t thread|pre-existing limitation|known limitation|language limitation|parser limitation'
 
 # A combined ERE used to find candidate lines.
 MARKER_RE="(\\b(${WORD_MARKERS})\\b|(${PHRASE_MARKERS}))"

--- a/scripts/ci/lint-workaround-comments.sh
+++ b/scripts/ci/lint-workaround-comments.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ratchet lint: flag workaround / limitation comments that lack a tracking-issue
+# reference (BT-NNNN).
+#
+# Rationale (BT-2347): limitation/workaround comments are unfiled bug reports.
+# A comment like "Uses timesRepeat: to avoid mutable local variables across block
+# boundaries" or "class vars don't thread through to:do: loops — pre-existing
+# limitation" documents a real defect that nobody filed. This lint turns every
+# such comment into a forcing function: either it references a tracking issue
+# (BT-NNNN), or CI fails.
+#
+# This mirrors the existing ratchet lints (ADR 0089). It ships with an allowlist
+# snapshot of the current offenders so CI is green on introduction; only *new*
+# unreferenced workaround comments fail.
+#
+# ── How to clear a failure ──────────────────────────────────────────────────
+# When this lint flags a comment you added, the fix is almost always:
+#   1. File (or find) a tracking issue for the limitation/workaround, then
+#   2. Add its reference (BT-NNNN) to the same comment line or an adjacent line.
+#      e.g.  // Workaround for the to:do: threading gap (BT-2308).
+# That is the intended outcome — make the unfiled bug a filed bug.
+#
+# As a last resort, if the comment genuinely is not a limitation (a false
+# positive), regenerate the allowlist to snapshot it:
+#   scripts/ci/lint-workaround-comments.sh --update
+# Review the diff before committing — only false positives belong there.
+#
+# Usage:
+#   scripts/ci/lint-workaround-comments.sh            # lint (CI mode)
+#   scripts/ci/lint-workaround-comments.sh --update   # regenerate the allowlist
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+ALLOWLIST="scripts/ci/workaround-comments-allowlist.txt"
+
+# Marker phrases that flag a limitation / workaround. Case-insensitive.
+# These were chosen from phrasing actually found in-tree (BT-2347); routine
+# rationale like "to avoid <X>" is intentionally excluded as too noisy.
+#
+# Word-boundary markers (must stand as whole words; excludes test data such as
+# `nonexistent_type_XXXX` or `does_XXX_understand`):
+WORD_MARKERS='HACK|FIXME|XXX'
+# Phrase markers (matched anywhere, case-insensitive):
+PHRASE_MARKERS='workaround|work around|does ?n.t thread|does not thread|pre-existing limitation|known limitation|language limitation|parser limitation'
+
+# A combined ERE used to find candidate lines.
+MARKER_RE="(\\b(${WORD_MARKERS})\\b|(${PHRASE_MARKERS}))"
+
+# Comment-line detector: a line is a comment if it contains a `//` (Rust/BT)
+# or `%` (Erlang) comment introducer.
+COMMENT_RE='(//|%)'
+
+# Lines to ignore even if they match a marker. `elp:fixme` is a structured
+# Erlang LS (ELP) suppression directive that references an ELP warning code
+# (resolved by ELP, not Linear), not a freeform limitation note.
+IGNORE_RE='elp:fixme'
+
+# Tracking-issue reference. BT- followed by at least one digit (excludes the
+# placeholder BT-XXX).
+ISSUE_RE='BT-[0-9]+'
+
+# Compute a stable fingerprint for an offending comment: path + a hash of the
+# normalised comment text, so it survives line-number drift.
+fingerprint() {
+    # args: <path> <text>
+    local path="$1" text="$2"
+    local norm
+    # Collapse whitespace and lowercase so trivial reformatting is stable.
+    norm="$(printf '%s' "$text" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')"
+    printf '%s\t%s\n' "$path" "$(printf '%s' "$norm" | cksum | cut -d' ' -f1)"
+}
+
+# Collect current offenders: comment lines that match a marker but have no
+# BT-NNNN reference on the same or an adjacent (±1) line.
+#   - fd 3 receives a human-readable "path:lineno:text" report line.
+#   - stdout receives the fingerprint.
+collect_offenders() {
+    local files
+    # Tracked files plus untracked-but-not-ignored files, so newly added
+    # offenders are caught before they are committed.
+    files="$( { git ls-files '*.bt' '*.rs' '*.erl' '*.hrl'; \
+                git ls-files --others --exclude-standard '*.bt' '*.rs' '*.erl' '*.hrl'; } \
+              | sort -u )"
+
+    local f
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        local matches
+        matches="$(grep -nIiE "$MARKER_RE" "$f" 2>/dev/null || true)"
+        [ -n "$matches" ] || continue
+
+        local m lineno text
+        while IFS= read -r m; do
+            [ -n "$m" ] || continue
+            lineno="${m%%:*}"
+            text="${m#*:}"
+
+            # Only consider comment lines.
+            printf '%s' "$text" | grep -qE "$COMMENT_RE" || continue
+
+            # Skip structured tool directives that are not limitation notes.
+            printf '%s' "$text" | grep -qiE "$IGNORE_RE" && continue
+
+            # Allowed if BT-NNNN appears on this line or an adjacent line.
+            local lo=$((lineno - 1))
+            local hi=$((lineno + 1))
+            [ "$lo" -lt 1 ] && lo=1
+            if sed -n "${lo},${hi}p" "$f" | grep -qE "$ISSUE_RE"; then
+                continue
+            fi
+
+            printf '%s:%s:%s\n' "$f" "$lineno" "$text" >&3
+            fingerprint "$f" "$text"
+        done <<< "$matches"
+    done <<< "$files"
+}
+
+# ── Update mode: regenerate the allowlist from current offenders ─────────────
+if [ "${1:-}" = "--update" ]; then
+    {
+        echo "# Allowlist for lint-workaround-comments (BT-2347)."
+        echo "# Snapshot of pre-existing workaround/limitation comments lacking a BT-NNNN ref."
+        echo "# Each line: <path><TAB><text-hash>. Regenerate with --update; do NOT hand-edit"
+        echo "# unless adding a genuine false positive. New offenders must add a BT-NNNN ref."
+        collect_offenders 3>/dev/null | sort -u
+    } > "$ALLOWLIST"
+    echo "✅ Wrote allowlist: $ALLOWLIST ($(grep -cvE '^#' "$ALLOWLIST") entries)"
+    exit 0
+fi
+
+# ── Lint mode ────────────────────────────────────────────────────────────────
+echo "🔍 Linting for unreferenced workaround/limitation comments..."
+
+if [ ! -f "$ALLOWLIST" ]; then
+    echo "❌ Allowlist not found: $ALLOWLIST" >&2
+    echo "   Run: scripts/ci/lint-workaround-comments.sh --update" >&2
+    exit 1
+fi
+
+# Human-readable report goes to a temp file via fd 3; fingerprints to stdout.
+REPORT="$(mktemp)"
+trap 'rm -f "$REPORT"' EXIT
+
+CURRENT="$(collect_offenders 3>"$REPORT" | sort -u)"
+ALLOWED="$(grep -vE '^[[:space:]]*#' "$ALLOWLIST" | grep -vE '^[[:space:]]*$' | sort -u || true)"
+
+# New offenders = current fingerprints not present in the allowlist.
+NEW_FINGERPRINTS="$(comm -23 <(printf '%s\n' "$CURRENT") <(printf '%s\n' "$ALLOWED") || true)"
+
+if [ -n "$NEW_FINGERPRINTS" ]; then
+    echo "" >&2
+    echo "❌ New workaround/limitation comment(s) without a BT-NNNN tracking reference:" >&2
+    echo "" >&2
+    # Map each new fingerprint back to its report line(s) for a useful message.
+    while IFS= read -r fp; do
+        [ -n "$fp" ] || continue
+        new_path="${fp%%$'\t'*}"
+        new_hash="${fp##*$'\t'}"
+        while IFS= read -r rline; do
+            rpath="${rline%%:*}"
+            rest="${rline#*:}"
+            rno="${rest%%:*}"
+            rtext="${rest#*:}"
+            [ "$rpath" = "$new_path" ] || continue
+            if [ "$(fingerprint "$rpath" "$rtext" | cut -f2)" = "$new_hash" ]; then
+                printf '  %s:%s:%s\n' "$rpath" "$rno" "$(printf '%s' "$rtext" | sed 's/^[[:space:]]*//')" >&2
+            fi
+        done < "$REPORT"
+    done <<< "$NEW_FINGERPRINTS"
+    echo "" >&2
+    echo "Fix: add a tracking-issue reference (BT-NNNN) on the same or an adjacent line." >&2
+    echo "     File the limitation as a Linear issue first if one does not exist." >&2
+    echo "     See the header of $0 for details." >&2
+    exit 1
+fi
+
+# Stale-entry check: warn if the allowlist references offenders that no longer
+# exist, so the ratchet keeps tightening as comments get fixed.
+STALE="$(comm -13 <(printf '%s\n' "$CURRENT") <(printf '%s\n' "$ALLOWED") || true)"
+if [ -n "$STALE" ] && [ -n "$(printf '%s' "$STALE" | tr -d '[:space:]')" ]; then
+    echo "ℹ️  Allowlist has $(printf '%s\n' "$STALE" | grep -c .) stale entr(y/ies) (offender fixed)." >&2
+    echo "   Tighten the ratchet: scripts/ci/lint-workaround-comments.sh --update" >&2
+fi
+
+echo "✅ No unreferenced workaround/limitation comments."

--- a/scripts/ci/workaround-comments-allowlist.txt
+++ b/scripts/ci/workaround-comments-allowlist.txt
@@ -1,0 +1,12 @@
+# Allowlist for lint-workaround-comments (BT-2347).
+# Snapshot of pre-existing workaround/limitation comments lacking a BT-NNNN ref.
+# Each line: <path><TAB><text-hash>. Regenerate with --update; do NOT hand-edit
+# unless adding a genuine false positive. New offenders must add a BT-NNNN ref.
+crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs	2986145653
+crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_iterable.rs	1945273604
+crates/beamtalk-core/src/source_analysis/parser/tests/expression_tests.rs	1027809464
+fuzz/corpus/parse_arbitrary/011_class_reflection.bt	2213515280
+stdlib/test/class_builder_method_source_test.bt	4143809079
+stdlib/test/class_method_conditional_self_call_test.bt	2205655045
+stdlib/test/object_protocol_test.bt	2532884543
+test-package-compiler/cases/actor_state_mutation/main.bt	4258104962

--- a/stdlib/test/class_var_subexpr_test.bt
+++ b/stdlib/test/class_var_subexpr_test.bt
@@ -190,7 +190,7 @@ TestCase subclass: ClassVarSubExprTest
   // inside `let _Cond = ... in case`); the test runs the method to
   // confirm compilation + execution succeed. The class var mutation
   // observed by the enclosing method is a separate concern (class vars
-  // don't thread through `to:do:` loops — pre-existing limitation).
+  // don't thread through `to:do:` loops — pre-existing limitation, BT-2308).
   testTickInLoopConditionalCompilesAndRuns =>
     result := ClassVarSubExpr tickInLoopConditional
     self assert: result notNil

--- a/stdlib/test/reactive_subprocess_test.bt
+++ b/stdlib/test/reactive_subprocess_test.bt
@@ -179,7 +179,8 @@ TestCase subclass: ReactiveSubprocessTest
     self assert: proc stop equals: #ok
 
   // Helper: poll up to 50 times (10ms each) for delegate exitReceived.
-  // Uses timesRepeat: to avoid mutable local variables across block boundaries.
+  // Uses timesRepeat: to work around mutable locals not threading across block
+  // boundaries (BT-2308).
   waitForExit: delegate from: _proc =>
     50 timesRepeat: [delegate exitReceived ifFalse: [Timer sleep: 10]]
     delegate exitReceived ifFalse: [


### PR DESCRIPTION
## Summary

Limitation/workaround comments in-tree are unfiled bug reports. BT-2308 was literally pre-documented in two test comments before anyone filed it. This adds a **ratchet-style grep lint** (mirroring the ADR 0089 ratchet lints) that flags workaround/limitation comments lacking a `BT-NNNN` tracking reference.

Part of epic **BT-2344** (catch context/position-dependent codegen divergences before they ship).

## What's in it

- **`scripts/ci/lint-workaround-comments.sh`** — fingerprint-based detector. Scans `.bt`/`.rs`/`.erl`/`.hrl` (tracked + untracked) comment lines for marker phrases (`HACK`/`FIXME`/`XXX` as whole words; `workaround`/`does not thread`/`pre-existing limitation`/etc. as phrases) that lack a `BT-NNNN` reference on the same or an adjacent line. Ships with an **allowlist snapshot** so CI is green on introduction — only *new* unreferenced comments fail. Supports `--update` to regenerate the allowlist, and reports stale entries so the ratchet keeps tightening as comments get fixed.
- **`scripts/ci/workaround-comments-allowlist.txt`** — snapshot of the 8 current offenders (path + text-hash, survives line-number drift).
- **`Justfile`** — wires `lint-workaround-comments` into `just lint`.
- Backfilled `BT-2308` references on the two pre-existing workaround comments in `class_var_subexpr_test.bt` and `reactive_subprocess_test.bt` (the exact comments that pre-documented BT-2308).

## Testing

- `bash scripts/ci/lint-workaround-comments.sh` → clean on the repo.
- Negative check: injecting a new `// HACK: workaround …` comment without a `BT-NNNN` ref fails the lint with a path:line report and a fix hint.

## Acceptance criteria

- [x] `just lint` flags new workaround/limitation comments lacking a tracking-issue reference.
- [x] Pre-existing offenders are allowlisted so CI is green on introduction.
- [x] Ratchet tightens (stale-entry warning) as comments get fixed.

https://claude.ai/code/session_01Hu2pvPvwqbTRWGryEPNoCV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI lint that enforces workaround/limitation comments to include BT-NNNN tracking references and integrated it into the lint workflow.
  * Added and committed an allowlist for existing acknowledged workaround comments.
* **Documentation**
  * Clarified and adjusted several inline comment descriptions to include or align with tracking references and rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->