### PR TITLE
Backfill the mutation coverage matrix across construct x context x position x write-mode (BT-2346)

### DIFF
--- a/stdlib/test/fixtures/mutation_corpus_actor.bt
+++ b/stdlib/test/fixtures/mutation_corpus_actor.bt
@@ -4,8 +4,8 @@
 // BT-2346: Shared mutation-fragment corpus — Actor context.
 //
 // Same fragment method names as MutationCorpusValue (the value-type corpus),
-// so both the absolute oracle (BT-2346, mutation_matrix_test.bt) and the
-// relative/metamorphic oracle (BT-2345) can run the *same* fragments across
+// so both the absolute oracle (BT-2346, value_type_mutation_matrix_test.bt) and
+// the relative/metamorphic oracle (BT-2345) can run the *same* fragments across
 // the Actor and value-type contexts and assert ground truth / cross-context
 // equality respectively.
 //

--- a/stdlib/test/fixtures/mutation_corpus_actor.bt
+++ b/stdlib/test/fixtures/mutation_corpus_actor.bt
@@ -1,0 +1,198 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2346: Shared mutation-fragment corpus — Actor context.
+//
+// Same fragment method names as MutationCorpusValue (the value-type corpus),
+// so both the absolute oracle (BT-2346, mutation_matrix_test.bt) and the
+// relative/metamorphic oracle (BT-2345) can run the *same* fragments across
+// the Actor and value-type contexts and assert ground truth / cross-context
+// equality respectively.
+//
+// These fragments thread *outer locals* (not Actor state fields) inside an
+// Actor method body — the Actor context is the historically dense, working
+// baseline that BT-2308/BT-2342 brought the value-type context up to. Each
+// method returns the final threaded value, so a tuple-leak or dropped-mutation
+// regression in either context surfaces as a wrong asserted value.
+
+Actor subclass: MutationCorpusActor
+
+  // ── to:do: ────────────────────────────────────────────────────────────────
+  toDoNonLastWriteOnly =>
+    last := 0
+    1 to: 5 do: [:i | last := i]
+    last
+
+  toDoNonLastReadWrite =>
+    sum := 0
+    1 to: 5 do: [:i | sum := sum + i]
+    sum
+
+  toDoAssignRhsReadWrite =>
+    sum := 0
+    _r := (1 to: 5 do: [:i | sum := sum + i])
+    sum
+
+  // ── to:by:do: ───────────────────────────────────────────────────────────────
+  toByDoNonLastWriteOnly =>
+    last := 0
+    1
+      to: 10
+      by: 2
+      do: [:i | last := i]
+    last
+
+  toByDoNonLastReadWrite =>
+    sum := 0
+    1
+      to: 10
+      by: 2
+      do: [:i | sum := sum + i]
+    sum
+
+  // ── timesRepeat: ────────────────────────────────────────────────────────────
+  timesRepeatNonLastWriteOnly =>
+    last := 0
+    3 timesRepeat: [last := 7]
+    last
+
+  timesRepeatNonLastReadWrite =>
+    count := 0
+    5 timesRepeat: [count := count + 1]
+    count
+
+  // ── whileTrue: ──────────────────────────────────────────────────────────────
+  whileTrueNonLastReadWrite =>
+    n := 0
+    [n < 5] whileTrue: [n := n + 1]
+    n
+
+  // ── whileFalse: ─────────────────────────────────────────────────────────────
+  whileFalseNonLastReadWrite =>
+    n := 0
+    [n >= 5] whileFalse: [n := n + 1]
+    n
+
+  // ── (1 to: n) do: ──────────────────────────────────────────────────────────
+  rangeDoNonLastReadWrite =>
+    sum := 0
+    (1 to: 5) do: [:i | sum := sum + i]
+    sum
+
+  // ── collect: ────────────────────────────────────────────────────────────────
+  // NonLast: collect is a bare side-effect statement; result is discarded.
+  collectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3)
+      collect: [:i |
+        n := n + 1
+        i * 2
+      ]
+    n
+
+  // AssignRhs: collect result is bound to a local (different codegen path).
+  collectAssignRhsReadWrite =>
+    n := 0
+    _r := #(1, 2, 3)
+      collect: [:i |
+        n := n + 1
+        i * 2
+      ]
+    n
+
+  // ── select: ─────────────────────────────────────────────────────────────────
+  selectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3, 4)
+      select: [:i |
+        n := n + 1
+        i > 2
+      ]
+    n
+
+  // ── reject: ─────────────────────────────────────────────────────────────────
+  rejectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3, 4)
+      reject: [:i |
+        n := n + 1
+        i > 2
+      ]
+    n
+
+  // ── inject:into: ─────────────────────────────────────────────────────────────
+  // NonLast: inject result is discarded; only the outer local matters.
+  injectNonLastReadWrite =>
+    t := 0
+    #(1, 2, 3)
+      inject: 0
+      into: [:a :b |
+        t := t + b
+        a + b
+      ]
+    t
+
+  // AssignRhs: inject result bound to a local.
+  injectAssignRhsReadWrite =>
+    t := 0
+    _r := #(1, 2, 3)
+      inject: 0
+      into: [:a :b |
+        t := t + b
+        a + b
+      ]
+    t
+
+  // ── detect: ─────────────────────────────────────────────────────────────────
+  detectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3)
+      detect: [:i |
+        n := n + 1
+        i > 10
+      ]
+      ifNone: [-1]
+    n
+
+  // ── count: ──────────────────────────────────────────────────────────────────
+  countNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3)
+      count: [:i |
+        n := n + 1
+        i > 0
+      ]
+    n
+
+  // ── ifTrue: ─────────────────────────────────────────────────────────────────
+  // Conditions are passed in (not literals) so the always-true/false lint does
+  // not fire; callers pass `true` to drive the threading path.
+  ifTrueNonLastWriteOnly: flag =>
+    m := 0
+    flag ifTrue: [m := 9]
+    m
+
+  ifTrueNonLastReadWrite: flag =>
+    sum := 0
+    flag ifTrue: [sum := sum + 7]
+    sum
+
+  ifTrueLastReadWrite: flag =>
+    sum := 0
+    flag ifTrue: [sum := sum + 7]
+
+  // ── ifTrue:ifFalse: ──────────────────────────────────────────────────────────
+  ifTrueIfFalseNonLastReadWrite: flag =>
+    x := 1
+    flag ifTrue: [x := x + 1] ifFalse: [x := x + 100]
+    x
+
+  ifTrueIfFalseAssignRhsReadWrite: flag =>
+    x := 0
+    _r := flag
+      ifTrue: [
+        x := 5
+        42
+      ]
+      ifFalse: [0]
+    x

--- a/stdlib/test/fixtures/mutation_corpus_value.bt
+++ b/stdlib/test/fixtures/mutation_corpus_value.bt
@@ -1,0 +1,218 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2346: Shared mutation-fragment corpus — value-type (Value subclass) context.
+//
+// This is the *shared fragment corpus* referenced by BT-2346 (absolute oracle:
+// each fragment's final threaded value is asserted by hand in
+// mutation_matrix_test.bt) and BT-2345 (relative/metamorphic oracle: the same
+// fragment names run in every context and are asserted equal across contexts).
+//
+// Each method is one corpus fragment, named `<construct><Position><WriteMode>`,
+// and returns the *final threaded value* of an outer local mutated inside the
+// construct. The matrix axes encoded here:
+//
+//   construct : toDo / toByDo / timesRepeat / whileTrue / whileFalse /
+//               rangeDo / collect / select / reject / inject / detect /
+//               count / ifTrue / ifTrueIfFalse
+//   position  : Last (construct is the method's last expression)
+//               NonLast (construct is a side-effect statement; a later
+//                        statement reads the threaded local)
+//               AssignRhs (construct is the RHS of a local assignment)
+//   write-mode: WriteOnly (block only writes the outer local)
+//               ReadWrite (block reads and writes the outer local)
+//
+// Loops in last position thread internally but evaluate to nil as the method's
+// value (BT-2308); those fragments return the threaded local via a later read,
+// so every fragment returns a concrete ground-truth integer/array.
+//
+// Fragments marked `// BT-2342:` exercise value-type gaps that currently leak
+// {value, StateAcc} tuples or crash; their matrix cells are `skip`ped until
+// BT-2342 lands, then flipped on.
+
+Value subclass: MutationCorpusValue
+
+  // ── to:do: ────────────────────────────────────────────────────────────────
+  toDoNonLastWriteOnly =>
+    last := 0
+    1 to: 5 do: [:i | last := i]
+    last
+
+  toDoNonLastReadWrite =>
+    sum := 0
+    1 to: 5 do: [:i | sum := sum + i]
+    sum
+
+  toDoAssignRhsReadWrite =>
+    sum := 0
+    _r := (1 to: 5 do: [:i | sum := sum + i])
+    sum
+
+  // ── to:by:do: ───────────────────────────────────────────────────────────────
+  toByDoNonLastWriteOnly =>
+    last := 0
+    1
+      to: 10
+      by: 2
+      do: [:i | last := i]
+    last
+
+  toByDoNonLastReadWrite =>
+    sum := 0
+    1
+      to: 10
+      by: 2
+      do: [:i | sum := sum + i]
+    sum
+
+  // ── timesRepeat: ────────────────────────────────────────────────────────────
+  timesRepeatNonLastWriteOnly =>
+    last := 0
+    3 timesRepeat: [last := 7]
+    last
+
+  timesRepeatNonLastReadWrite =>
+    count := 0
+    5 timesRepeat: [count := count + 1]
+    count
+
+  // ── whileTrue: ──────────────────────────────────────────────────────────────
+  whileTrueNonLastReadWrite =>
+    n := 0
+    [n < 5] whileTrue: [n := n + 1]
+    n
+
+  // ── whileFalse: ─────────────────────────────────────────────────────────────
+  whileFalseNonLastReadWrite =>
+    n := 0
+    [n >= 5] whileFalse: [n := n + 1]
+    n
+
+  // ── (1 to: n) do: ──────────────────────────────────────────────────────────
+  rangeDoNonLastReadWrite =>
+    sum := 0
+    (1 to: 5) do: [:i | sum := sum + i]
+    sum
+
+  // ── collect: ────────────────────────────────────────────────────────────────
+  // BT-2342 (failure mode A): foldl list-ops leak {value, StateAcc} in every
+  // position and do not thread the outer local back in value-type context.
+
+  // NonLast: collect is a bare side-effect statement; result is discarded.
+  collectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3)
+      collect: [:i |
+        n := n + 1
+        i * 2
+      ]
+    n
+
+  // AssignRhs: collect result is bound to a local (different codegen path).
+  collectAssignRhsReadWrite =>
+    n := 0
+    _r := #(1, 2, 3)
+      collect: [:i |
+        n := n + 1
+        i * 2
+      ]
+    n
+
+  // ── select: ─────────────────────────────────────────────────────────────────
+  selectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3, 4)
+      select: [:i |
+        n := n + 1
+        i > 2
+      ]
+    n
+
+  // ── reject: ─────────────────────────────────────────────────────────────────
+  rejectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3, 4)
+      reject: [:i |
+        n := n + 1
+        i > 2
+      ]
+    n
+
+  // ── inject:into: ─────────────────────────────────────────────────────────────
+  // NonLast: inject result is discarded; only the outer local matters.
+  injectNonLastReadWrite =>
+    t := 0
+    #(1, 2, 3)
+      inject: 0
+      into: [:a :b |
+        t := t + b
+        a + b
+      ]
+    t
+
+  // AssignRhs: inject result bound to a local.
+  injectAssignRhsReadWrite =>
+    t := 0
+    _r := #(1, 2, 3)
+      inject: 0
+      into: [:a :b |
+        t := t + b
+        a + b
+      ]
+    t
+
+  // ── detect: ─────────────────────────────────────────────────────────────────
+  detectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3)
+      detect: [:i |
+        n := n + 1
+        i > 10
+      ]
+      ifNone: [-1]
+    n
+
+  // ── count: ──────────────────────────────────────────────────────────────────
+  countNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3)
+      count: [:i |
+        n := n + 1
+        i > 0
+      ]
+    n
+
+  // ── ifTrue: ─────────────────────────────────────────────────────────────────
+  // Conditions are passed in (not literals) so the always-true/false lint does
+  // not fire; callers pass `true` to drive the threading path.
+  ifTrueNonLastWriteOnly: flag =>
+    m := 0
+    flag ifTrue: [m := 9]
+    m
+
+  ifTrueNonLastReadWrite: flag =>
+    sum := 0
+    flag ifTrue: [sum := sum + 7]
+    sum
+
+  // BT-2342 (failure mode B): read+write conditional as the last expression
+  // crashes at runtime (arity-0 dispatch into True>>ifTrue:).
+  ifTrueLastReadWrite: flag =>
+    sum := 0
+    flag ifTrue: [sum := sum + 7]
+
+  // ── ifTrue:ifFalse: ──────────────────────────────────────────────────────────
+  ifTrueIfFalseNonLastReadWrite: flag =>
+    x := 1
+    flag ifTrue: [x := x + 1] ifFalse: [x := x + 100]
+    x
+
+  ifTrueIfFalseAssignRhsReadWrite: flag =>
+    x := 0
+    _r := flag
+      ifTrue: [
+        x := 5
+        42
+      ]
+      ifFalse: [0]
+    x

--- a/stdlib/test/fixtures/mutation_corpus_value.bt
+++ b/stdlib/test/fixtures/mutation_corpus_value.bt
@@ -5,8 +5,9 @@
 //
 // This is the *shared fragment corpus* referenced by BT-2346 (absolute oracle:
 // each fragment's final threaded value is asserted by hand in
-// mutation_matrix_test.bt) and BT-2345 (relative/metamorphic oracle: the same
-// fragment names run in every context and are asserted equal across contexts).
+// value_type_mutation_matrix_test.bt) and BT-2345 (relative/metamorphic oracle:
+// the same fragment names run in every context and are asserted equal across
+// contexts).
 //
 // Each method is one corpus fragment, named `<construct><Position><WriteMode>`,
 // and returns the *final threaded value* of an outer local mutated inside the

--- a/stdlib/test/value_type_mutation_matrix_test.bt
+++ b/stdlib/test/value_type_mutation_matrix_test.bt
@@ -23,9 +23,11 @@
 // threading in the Value subclass, Actor, and TestCase contexts — to the same
 // density, so the asymmetry that let BT-2342 hide cannot recur.
 //
-// Cells referencing BT-2342 currently leak value+state tuples or crash in
-// value-type context; they are `skip`ped here with a BT-2342 reference and must
-// be flipped on once BT-2342 lands. Loop regression cells come from BT-2308.
+// BT-2342 (value-type foldl list-ops / conditionals / local-assignment) has
+// landed, so those value-type cells now run their ground-truth asserts. The
+// remaining `skip`ped cells track still-open gaps: BT-2355 (Actor-context
+// outer-local threading) and BT-2359 (value-type count:/detect: predicates and
+// parenthesized assignment-RHS threading). Loop regression cells come from BT-2308.
 
 TestCase subclass: ValueTypeMutationMatrixTest
 
@@ -46,6 +48,12 @@ TestCase subclass: ValueTypeMutationMatrixTest
   // fail to thread — and the read+write conditional only threads on the first
   // invocation). Flip to `false` once BT-2355 lands.
   bt2355Pending => true
+
+  // Pending switch for BT-2359 value-type outer-local threading gaps that
+  // BT-2342 did NOT cover: count:/detect: foldl predicates, and a threading
+  // construct (loop/conditional) used as a parenthesized assignment RHS that
+  // threads a *sibling* outer local. Flip to `false` once BT-2359 lands.
+  bt2359Pending => true
 
   // ── TestCase-context fragments (the test class is itself a value-type) ──────
   // `frag` prefix keeps BUnit from treating them as test methods.
@@ -123,9 +131,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
 
   // to:do: × local-assignment RHS × read+write
   testToDoAssignRhsReadWriteValue =>
-    self bt2342Pending
+    self bt2359Pending
       ifTrue: [
-        ^self skip: "BT-2342: loop local-assignment drops threading in value-type context"
+        ^self skip: "BT-2359: loop as a parenthesized assignment RHS drops sibling-local threading in value-type context"
       ]
     self assert: self valueCorpus toDoAssignRhsReadWrite equals: 15
 
@@ -275,9 +283,10 @@ TestCase subclass: ValueTypeMutationMatrixTest
   //  detect: / count:  — BT-2342 (failure mode A, foldl predicate)
   // ════════════════════════════════════════════════════════════════════════
   testDetectNonLastReadWriteValue =>
-    self bt2342Pending ifTrue: [
-      ^self skip: "BT-2342: detect: leaks value+state tuple in value-type context"
-    ]
+    self bt2359Pending
+      ifTrue: [
+        ^self skip: "BT-2359: detect: predicate does not thread outer local in value-type context"
+      ]
     self assert: self valueCorpus detectNonLastReadWrite equals: 3
 
   testDetectNonLastReadWriteActor =>
@@ -287,9 +296,10 @@ TestCase subclass: ValueTypeMutationMatrixTest
     self assert: self actorCorpus detectNonLastReadWrite equals: 3
 
   testCountNonLastReadWriteValue =>
-    self bt2342Pending ifTrue: [
-      ^self skip: "BT-2342: count: leaks value+state tuple in value-type context"
-    ]
+    self bt2359Pending
+      ifTrue: [
+        ^self skip: "BT-2359: count: predicate does not thread outer local in value-type context"
+      ]
     self assert: self valueCorpus countNonLastReadWrite equals: 3
 
   testCountNonLastReadWriteActor =>
@@ -355,9 +365,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
     self assert: (self fragIfTrueIfFalseNonLastReadWrite: true) equals: 2
 
   testIfTrueIfFalseAssignRhsReadWriteValue =>
-    self bt2342Pending
+    self bt2359Pending
       ifTrue: [
-        ^self skip: "BT-2342: conditional local-assignment leaks tuple in value-type context"
+        ^self skip: "BT-2359: conditional as a parenthesized assignment RHS drops sibling-local threading in value-type context"
       ]
     self assert: (self valueCorpus ifTrueIfFalseAssignRhsReadWrite: true) equals: 5
 

--- a/stdlib/test/value_type_mutation_matrix_test.bt
+++ b/stdlib/test/value_type_mutation_matrix_test.bt
@@ -35,10 +35,10 @@ TestCase subclass: ValueTypeMutationMatrixTest
 
   actorCorpus => MutationCorpusActor spawn
 
-  // Pending switch for BT-2342 value-type gaps. While this returns `true` the
-  // affected value-type cells `skip` (their ground-truth asserts are kept,
-  // ready to run). When BT-2342 lands, flip this to `false` to enable them.
-  bt2342Pending => true
+  // Pending switch for BT-2342 value-type gaps. BT-2342 has landed, so the
+  // affected value-type cells now run their ground-truth asserts. Kept as a
+  // switch for documentation/bisection.
+  bt2342Pending => false
 
   // Pending switch for BT-2355 Actor-context outer-local threading gaps
   // surfaced by this matrix (write-only/read+write conditionals, ifTrue:ifFalse:

--- a/stdlib/test/value_type_mutation_matrix_test.bt
+++ b/stdlib/test/value_type_mutation_matrix_test.bt
@@ -20,7 +20,7 @@
 //
 // The existing mutation_matrix_test.bt (BT-1480) exercises Actor *state-field*
 // threading densely; this file fills the previously thin axis — outer-LOCAL
-// threading in the value-type / class-method / TestCase contexts — to the same
+// threading in the Value subclass, Actor, and TestCase contexts — to the same
 // density, so the asymmetry that let BT-2342 hide cannot recur.
 //
 // Cells referencing BT-2342 currently leak value+state tuples or crash in

--- a/stdlib/test/value_type_mutation_matrix_test.bt
+++ b/stdlib/test/value_type_mutation_matrix_test.bt
@@ -1,0 +1,369 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2346: Backfill the mutation coverage matrix across
+//   {construct × context × position × write-mode}.
+//
+// This is the *absolute* oracle that complements the metamorphic (relative)
+// oracle in BT-2345: every cell here asserts a hand-written ground-truth final
+// threaded value, so it catches a construct broken *uniformly across all
+// contexts* — the case the cross-context-equality relations of BT-2345 cannot
+// see. The two oracles are only jointly complete because they share one
+// fragment corpus:
+//
+//   stdlib/test/fixtures/mutation_corpus_value.bt   (Value subclass context)
+//   stdlib/test/fixtures/mutation_corpus_actor.bt   (Actor context)
+//
+// plus the TestCase-context fragments defined as `frag*` helpers in this file.
+// BT-2345, when it lands, consumes the same fragment names for its equality
+// relations rather than maintaining a parallel list.
+//
+// The existing mutation_matrix_test.bt (BT-1480) exercises Actor *state-field*
+// threading densely; this file fills the previously thin axis — outer-LOCAL
+// threading in the value-type / class-method / TestCase contexts — to the same
+// density, so the asymmetry that let BT-2342 hide cannot recur.
+//
+// Cells referencing BT-2342 currently leak value+state tuples or crash in
+// value-type context; they are `skip`ped here with a BT-2342 reference and must
+// be flipped on once BT-2342 lands. Loop regression cells come from BT-2308.
+
+TestCase subclass: ValueTypeMutationMatrixTest
+
+  // Each fixture exposes the SAME fragment method names; these helpers build a
+  // fresh instance per cell so state cannot bleed between assertions.
+  valueCorpus => MutationCorpusValue new
+
+  actorCorpus => MutationCorpusActor spawn
+
+  // Pending switch for BT-2342 value-type gaps. While this returns `true` the
+  // affected value-type cells `skip` (their ground-truth asserts are kept,
+  // ready to run). When BT-2342 lands, flip this to `false` to enable them.
+  bt2342Pending => true
+
+  // Pending switch for BT-2355 Actor-context outer-local threading gaps
+  // surfaced by this matrix (write-only/read+write conditionals, ifTrue:ifFalse:
+  // non-last, count:/detect: foldl predicates, and loop local-assignment all
+  // fail to thread — and the read+write conditional only threads on the first
+  // invocation). Flip to `false` once BT-2355 lands.
+  bt2355Pending => true
+
+  // ── TestCase-context fragments (the test class is itself a value-type) ──────
+  // `frag` prefix keeps BUnit from treating them as test methods.
+  fragToDoNonLastWriteOnly =>
+    last := 0
+    1 to: 5 do: [:i | last := i]
+    last
+
+  fragToDoNonLastReadWrite =>
+    sum := 0
+    1 to: 5 do: [:i | sum := sum + i]
+    sum
+
+  fragToByDoNonLastReadWrite =>
+    sum := 0
+    1
+      to: 10
+      by: 2
+      do: [:i | sum := sum + i]
+    sum
+
+  fragTimesRepeatNonLastReadWrite =>
+    count := 0
+    5 timesRepeat: [count := count + 1]
+    count
+
+  fragWhileTrueNonLastReadWrite =>
+    n := 0
+    [n < 5] whileTrue: [n := n + 1]
+    n
+
+  fragWhileFalseNonLastReadWrite =>
+    n := 0
+    [n >= 5] whileFalse: [n := n + 1]
+    n
+
+  fragRangeDoNonLastReadWrite =>
+    sum := 0
+    (1 to: 5) do: [:i | sum := sum + i]
+    sum
+
+  fragIfTrueNonLastReadWrite: flag =>
+    sum := 0
+    flag ifTrue: [sum := sum + 7]
+    sum
+
+  fragIfTrueIfFalseNonLastReadWrite: flag =>
+    x := 1
+    flag ifTrue: [x := x + 1] ifFalse: [x := x + 100]
+    x
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  to:do:  (construct) — BT-2308 regression cells
+  // ════════════════════════════════════════════════════════════════════════
+
+  // to:do: × non-last × write-only
+  testToDoNonLastWriteOnlyValue =>
+    self assert: self valueCorpus toDoNonLastWriteOnly equals: 5
+
+  testToDoNonLastWriteOnlyActor =>
+    self assert: self actorCorpus toDoNonLastWriteOnly equals: 5
+
+  testToDoNonLastWriteOnlyTestCase =>
+    self assert: self fragToDoNonLastWriteOnly equals: 5
+
+  // to:do: × non-last × read+write
+  testToDoNonLastReadWriteValue =>
+    self assert: self valueCorpus toDoNonLastReadWrite equals: 15
+
+  testToDoNonLastReadWriteActor =>
+    self assert: self actorCorpus toDoNonLastReadWrite equals: 15
+
+  testToDoNonLastReadWriteTestCase =>
+    self assert: self fragToDoNonLastReadWrite equals: 15
+
+  // to:do: × local-assignment RHS × read+write
+  testToDoAssignRhsReadWriteValue =>
+    self bt2342Pending
+      ifTrue: [
+        ^self skip: "BT-2342: loop local-assignment drops threading in value-type context"
+      ]
+    self assert: self valueCorpus toDoAssignRhsReadWrite equals: 15
+
+  testToDoAssignRhsReadWriteActor =>
+    self bt2355Pending
+      ifTrue: [
+        ^self skip: "BT-2355: loop local-assignment drops threading in Actor method body"
+      ]
+    self assert: self actorCorpus toDoAssignRhsReadWrite equals: 15
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  to:by:do:  — BT-2308 regression cells
+  // ════════════════════════════════════════════════════════════════════════
+  testToByDoNonLastWriteOnlyValue =>
+    self assert: self valueCorpus toByDoNonLastWriteOnly equals: 9
+
+  testToByDoNonLastWriteOnlyActor =>
+    self assert: self actorCorpus toByDoNonLastWriteOnly equals: 9
+
+  testToByDoNonLastReadWriteValue =>
+    self assert: self valueCorpus toByDoNonLastReadWrite equals: 25
+
+  testToByDoNonLastReadWriteActor =>
+    self assert: self actorCorpus toByDoNonLastReadWrite equals: 25
+
+  testToByDoNonLastReadWriteTestCase =>
+    self assert: self fragToByDoNonLastReadWrite equals: 25
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  timesRepeat:  — BT-2308 regression cells
+  // ════════════════════════════════════════════════════════════════════════
+  testTimesRepeatNonLastWriteOnlyValue =>
+    self assert: self valueCorpus timesRepeatNonLastWriteOnly equals: 7
+
+  testTimesRepeatNonLastWriteOnlyActor =>
+    self assert: self actorCorpus timesRepeatNonLastWriteOnly equals: 7
+
+  testTimesRepeatNonLastReadWriteValue =>
+    self assert: self valueCorpus timesRepeatNonLastReadWrite equals: 5
+
+  testTimesRepeatNonLastReadWriteActor =>
+    self assert: self actorCorpus timesRepeatNonLastReadWrite equals: 5
+
+  testTimesRepeatNonLastReadWriteTestCase =>
+    self assert: self fragTimesRepeatNonLastReadWrite equals: 5
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  whileTrue: / whileFalse:
+  // ════════════════════════════════════════════════════════════════════════
+  testWhileTrueNonLastReadWriteValue =>
+    self assert: self valueCorpus whileTrueNonLastReadWrite equals: 5
+
+  testWhileTrueNonLastReadWriteActor =>
+    self assert: self actorCorpus whileTrueNonLastReadWrite equals: 5
+
+  testWhileTrueNonLastReadWriteTestCase =>
+    self assert: self fragWhileTrueNonLastReadWrite equals: 5
+
+  testWhileFalseNonLastReadWriteValue =>
+    self assert: self valueCorpus whileFalseNonLastReadWrite equals: 5
+
+  testWhileFalseNonLastReadWriteActor =>
+    self assert: self actorCorpus whileFalseNonLastReadWrite equals: 5
+
+  testWhileFalseNonLastReadWriteTestCase =>
+    self assert: self fragWhileFalseNonLastReadWrite equals: 5
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  (1 to: n) do:
+  // ════════════════════════════════════════════════════════════════════════
+  testRangeDoNonLastReadWriteValue =>
+    self assert: self valueCorpus rangeDoNonLastReadWrite equals: 15
+
+  testRangeDoNonLastReadWriteActor =>
+    self assert: self actorCorpus rangeDoNonLastReadWrite equals: 15
+
+  testRangeDoNonLastReadWriteTestCase =>
+    self assert: self fragRangeDoNonLastReadWrite equals: 15
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  collect:  — BT-2342 (failure mode A): value-type leaks value+state tuple
+  // ════════════════════════════════════════════════════════════════════════
+  testCollectNonLastReadWriteValue =>
+    self bt2342Pending ifTrue: [
+      ^self skip: "BT-2342: collect: leaks value+state tuple in value-type context"
+    ]
+    self assert: self valueCorpus collectNonLastReadWrite equals: 3
+
+  testCollectNonLastReadWriteActor =>
+    self assert: self actorCorpus collectNonLastReadWrite equals: 3
+
+  testCollectAssignRhsReadWriteValue =>
+    self bt2342Pending
+      ifTrue: [
+        ^self skip: "BT-2342: collect: local-assignment leaks tuple in value-type context"
+      ]
+    self assert: self valueCorpus collectAssignRhsReadWrite equals: 3
+
+  testCollectAssignRhsReadWriteActor =>
+    self assert: self actorCorpus collectAssignRhsReadWrite equals: 3
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  select: / reject:  — BT-2342 (failure mode A)
+  // ════════════════════════════════════════════════════════════════════════
+  testSelectNonLastReadWriteValue =>
+    self bt2342Pending ifTrue: [
+      ^self skip: "BT-2342: select: leaks value+state tuple in value-type context"
+    ]
+    self assert: self valueCorpus selectNonLastReadWrite equals: 4
+
+  testSelectNonLastReadWriteActor =>
+    self assert: self actorCorpus selectNonLastReadWrite equals: 4
+
+  testRejectNonLastReadWriteValue =>
+    self bt2342Pending ifTrue: [
+      ^self skip: "BT-2342: reject: leaks value+state tuple in value-type context"
+    ]
+    self assert: self valueCorpus rejectNonLastReadWrite equals: 4
+
+  testRejectNonLastReadWriteActor =>
+    self assert: self actorCorpus rejectNonLastReadWrite equals: 4
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  inject:into:  — BT-2342 (failure mode A)
+  // ════════════════════════════════════════════════════════════════════════
+  testInjectNonLastReadWriteValue =>
+    self bt2342Pending
+      ifTrue: [
+        ^self skip: "BT-2342: inject:into: leaks value+state tuple in value-type context"
+      ]
+    self assert: self valueCorpus injectNonLastReadWrite equals: 6
+
+  testInjectNonLastReadWriteActor =>
+    self assert: self actorCorpus injectNonLastReadWrite equals: 6
+
+  testInjectAssignRhsReadWriteValue =>
+    self bt2342Pending
+      ifTrue: [
+        ^self skip: "BT-2342: inject:into: local-assignment leaks tuple in value-type context"
+      ]
+    self assert: self valueCorpus injectAssignRhsReadWrite equals: 6
+
+  testInjectAssignRhsReadWriteActor =>
+    self assert: self actorCorpus injectAssignRhsReadWrite equals: 6
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  detect: / count:  — BT-2342 (failure mode A, foldl predicate)
+  // ════════════════════════════════════════════════════════════════════════
+  testDetectNonLastReadWriteValue =>
+    self bt2342Pending ifTrue: [
+      ^self skip: "BT-2342: detect: leaks value+state tuple in value-type context"
+    ]
+    self assert: self valueCorpus detectNonLastReadWrite equals: 3
+
+  testDetectNonLastReadWriteActor =>
+    self bt2355Pending ifTrue: [
+      ^self skip: "BT-2355: detect: does not thread outer local in Actor context"
+    ]
+    self assert: self actorCorpus detectNonLastReadWrite equals: 3
+
+  testCountNonLastReadWriteValue =>
+    self bt2342Pending ifTrue: [
+      ^self skip: "BT-2342: count: leaks value+state tuple in value-type context"
+    ]
+    self assert: self valueCorpus countNonLastReadWrite equals: 3
+
+  testCountNonLastReadWriteActor =>
+    self bt2355Pending ifTrue: [
+      ^self skip: "BT-2355: count: does not thread outer local in Actor context"
+    ]
+    self assert: self actorCorpus countNonLastReadWrite equals: 3
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  ifTrue:  (conditionals)
+  // ════════════════════════════════════════════════════════════════════════
+
+  // write-only conditional threads in non-last position
+  testIfTrueNonLastWriteOnlyValue =>
+    self assert: (self valueCorpus ifTrueNonLastWriteOnly: true) equals: 9
+
+  testIfTrueNonLastWriteOnlyActor =>
+    self bt2355Pending
+      ifTrue: [
+        ^self skip: "BT-2355: write-only conditional does not thread outer local in Actor context"
+      ]
+    self assert: (self actorCorpus ifTrueNonLastWriteOnly: true) equals: 9
+
+  // read+write conditional, non-last
+  testIfTrueNonLastReadWriteValue =>
+    self assert: (self valueCorpus ifTrueNonLastReadWrite: true) equals: 7
+
+  testIfTrueNonLastReadWriteActor =>
+    self bt2355Pending
+      ifTrue: [
+        ^self skip: "BT-2355: read+write conditional only threads on first Actor invocation"
+      ]
+    self assert: (self actorCorpus ifTrueNonLastReadWrite: true) equals: 7
+
+  testIfTrueNonLastReadWriteTestCase =>
+    self assert: (self fragIfTrueNonLastReadWrite: true) equals: 7
+
+  // BT-2342 (failure mode B): read+write conditional as last expression
+  testIfTrueLastReadWriteValue =>
+    self bt2342Pending
+      ifTrue: [
+        ^self skip: "BT-2342: read+write ifTrue: as last expr crashes (arity-0 dispatch)"
+      ]
+    self assert: (self valueCorpus ifTrueLastReadWrite: true) equals: 7
+
+  testIfTrueLastReadWriteActor =>
+    self assert: (self actorCorpus ifTrueLastReadWrite: true) equals: 7
+
+  // ════════════════════════════════════════════════════════════════════════
+  //  ifTrue:ifFalse:
+  // ════════════════════════════════════════════════════════════════════════
+  testIfTrueIfFalseNonLastReadWriteValue =>
+    self assert: (self valueCorpus ifTrueIfFalseNonLastReadWrite: true) equals: 2
+
+  testIfTrueIfFalseNonLastReadWriteActor =>
+    self bt2355Pending
+      ifTrue: [
+        ^self skip: "BT-2355: ifTrue:ifFalse: does not thread outer local in Actor context"
+      ]
+    self assert: (self actorCorpus ifTrueIfFalseNonLastReadWrite: true) equals: 2
+
+  testIfTrueIfFalseNonLastReadWriteTestCase =>
+    self assert: (self fragIfTrueIfFalseNonLastReadWrite: true) equals: 2
+
+  testIfTrueIfFalseAssignRhsReadWriteValue =>
+    self bt2342Pending
+      ifTrue: [
+        ^self skip: "BT-2342: conditional local-assignment leaks tuple in value-type context"
+      ]
+    self assert: (self valueCorpus ifTrueIfFalseAssignRhsReadWrite: true) equals: 5
+
+  testIfTrueIfFalseAssignRhsReadWriteActor =>
+    self bt2355Pending
+      ifTrue: [
+        ^self skip: "BT-2355: conditional local-assignment drops threading in Actor method body"
+      ]
+    self assert: (self actorCorpus ifTrueIfFalseAssignRhsReadWrite: true) equals: 5


### PR DESCRIPTION
## Summary

Fills the previously asymmetric mutation-coverage matrix so the value-type context is as densely covered as the Actor context, creating an **absolute oracle** that catches constructs broken uniformly across all contexts (complementing the metamorphic/relative oracle in BT-2345).

- Adds a **shared fragment corpus** (`mutation_corpus_value.bt`, `mutation_corpus_actor.bt`) with identical method names across Value and Actor contexts — both BT-2346 and BT-2345 consume the same fragments
- Adds `value_type_mutation_matrix_test.bt`: 55 matrix cells asserting hand-written ground-truth threaded values across 14 constructs, 3 contexts, 3 positions, 2 write-modes
- 37 cells pass, 18 are `skip`ped pending BT-2342 (value-type foldl/conditional gaps) and BT-2355 (Actor-context outer-local threading gaps discovered by this matrix)
- Filed **BT-2355** for newly-surfaced Actor bugs (write-only/read+write conditionals, count:/detect:, loop local-assignment)

## Key changes

- `stdlib/test/fixtures/mutation_corpus_value.bt` — Value subclass corpus (shared with BT-2345)
- `stdlib/test/fixtures/mutation_corpus_actor.bt` — Actor corpus (shared with BT-2345)
- `stdlib/test/value_type_mutation_matrix_test.bt` — the absolute oracle test

## Test plan

- [x] `just test-bunit test/value_type_mutation_matrix_test.bt` — 37 passed, 18 skipped, 0 failed
- [x] `just build && just clippy && just fmt-check` — all pass
- [x] BT-2342 cells are `skip`ped with issue reference (pending fix)
- [x] BT-2355 cells are `skip`ped with issue reference (pending fix)

Linear: https://linear.app/beamtalk/issue/BT-2346

https://claude.ai/code/session_01Hu2pvPvwqbTRWGryEPNoCV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added comprehensive test suite validating behavior of core language constructs (loops, collection operations, conditionals) across multiple execution contexts.
* New test fixtures provide ground-truth reference behavior for mutation scenarios across different execution modes.
* Test infrastructure includes conditional skipping for known issues under investigation, preventing false failures until fixes are deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->