### PR TITLE
Extend value-type local-threading consumption to class-method codegen (BT-2349)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -2294,10 +2294,65 @@ impl CoreErlangGenerator {
         expr: &Expression,
         has_class_vars: bool,
     ) -> Result<Document<'static>> {
+        // BT-2349: A last-position threading construct (counted/while loop or foldl list-op
+        // yielding a `{value, StateAcc}` tuple) or a read+write conditional must unwrap the
+        // construct's logical value rather than leak the raw tuple (or crash on the 0-arg
+        // stateful-block dispatch). Handled here because the `{class_var_result, ...}` wrapping
+        // is identical whether or not the class declares class vars — threading constructs
+        // mutate *locals*, not class vars, so the wrapping is driven solely by whether an
+        // earlier statement mutated a class var (`class_var_mutated()`).
+        if let Some(doc) = self.try_generate_class_method_threaded_last(expr)? {
+            return Ok(doc);
+        }
         if has_class_vars {
             self.generate_class_method_last_expr_with_class_vars(expr)
         } else {
             self.generate_class_method_last_expr_no_class_vars(expr)
+        }
+    }
+
+    /// BT-2349: Handles a class method's last expression when it is a value-type threading
+    /// construct (counted/while loop or foldl list-op) or a read+write conditional.
+    ///
+    /// Returns `None` when `expr` is neither, so the caller falls back to the standard
+    /// last-expression paths.
+    ///
+    /// Both shapes produce a logical value bound to a fresh result var (via the shared BT-2342
+    /// value-type primitives), which is then wrapped in `{class_var_result, Result, ClassVarsN}`
+    /// when an earlier statement mutated a class var, or returned bare otherwise.
+    fn try_generate_class_method_threaded_last(
+        &mut self,
+        expr: &Expression,
+    ) -> Result<Option<Document<'static>>> {
+        let mut parts: Vec<Document<'static>> = Vec::new();
+        let result_var = if self.expr_yields_vt_threaded_tuple(expr) {
+            self.emit_vt_threaded_tuple_unwrap_to_var(expr, &mut parts)?
+        } else if self.is_conditional_with_vt_local_threading(expr) {
+            match self.emit_vt_conditional_case_to_var(expr, &mut parts)? {
+                Some(result_var) => result_var,
+                None => return Ok(None),
+            }
+        } else {
+            return Ok(None);
+        };
+        parts.push(self.class_method_result_tail(&result_var));
+        Ok(Some(Document::Vec(parts)))
+    }
+
+    /// BT-2349: Builds the tail that returns an already-bound class-method result var:
+    /// `{class_var_result, Result, ClassVarsN}` when a class var was mutated, else `Result`.
+    fn class_method_result_tail(&self, result_var: &str) -> Document<'static> {
+        if self.class_var_mutated() {
+            let final_cv = self.current_class_var();
+            docvec![
+                "{'class_var_result', ",
+                leaf::var(result_var.to_string()),
+                ", ",
+                leaf::var(final_cv),
+                "}",
+            ]
+        } else {
+            leaf::var(result_var.to_string())
         }
     }
 
@@ -2416,6 +2471,19 @@ impl CoreErlangGenerator {
         } else if self.is_do_with_vt_local_threading(expr) {
             // BT-1414: Non-last `do:` loop that mutates captured outer locals.
             self.generate_value_type_do_open(expr)
+        } else if self.is_counted_loop_with_vt_local_threading(expr) {
+            // BT-2349: Non-last counted loop (to:do:/to:by:do:/timesRepeat:) that
+            // mutates captured outer locals. Extracts the threaded locals from the
+            // `{'nil', StateAcc}` tuple so subsequent statements see the updates.
+            self.generate_vt_counted_loop_open(expr)
+        } else if self.is_while_with_vt_local_threading(expr) {
+            // BT-2349: Non-last whileTrue:/whileFalse: that mutates captured outer locals.
+            self.generate_vt_while_open(expr)
+        } else if self.is_foldl_list_op_with_vt_local_threading(expr) {
+            // BT-2349: Non-last collect:/select:/reject:/inject:into: that mutates captured
+            // outer locals. Extracts the threaded locals from the `{value, StateAcc}` tuple
+            // (the logical value is discarded in non-last position).
+            self.generate_vt_foldl_list_op_open(expr)
         } else if self.is_conditional_with_vt_local_threading(expr) {
             // BT-1392: Non-last conditional that mutates captured outer locals.
             self.generate_vt_conditional_open(expr)
@@ -2449,6 +2517,16 @@ impl CoreErlangGenerator {
     ) -> Result<Document<'static>> {
         if let Expression::Assignment { target, value, .. } = expr {
             if let Expression::Identifier(id) = target.as_ref() {
+                // BT-2349: When the RHS is a threading construct (value-type loop or foldl
+                // list-op) it returns a `{value, StateAcc}` tuple. Bind the target to the
+                // logical value (element 1) and rebind the threaded locals from the StateAcc
+                // (element 2), rather than binding the target to the raw tuple. Mirrors the
+                // value-type instance-method body sequencer (BT-2342).
+                if self.expr_yields_vt_threaded_tuple(value) {
+                    let mut parts: Vec<Document<'static>> = Vec::new();
+                    self.emit_vt_threaded_local_assignment(&id.name, value, &mut parts)?;
+                    return Ok(Document::Vec(parts));
+                }
                 let var_name = &id.name;
                 let core_var = self
                     .lookup_var(var_name)

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -939,7 +939,7 @@ impl CoreErlangGenerator {
     ///
     /// When NLR is active, wraps the expression in a `{Result, Self{N}}` tuple.
     /// Otherwise, emits the expression value directly (with proper indentation).
-    fn emit_vt_last_expr(
+    pub(in crate::codegen::core_erlang) fn emit_vt_last_expr(
         &mut self,
         expr: &Expression,
         index: usize,
@@ -953,32 +953,8 @@ impl CoreErlangGenerator {
         // those locals don't escape, so the method value is the construct's *logical*
         // result — element 1 — not the raw tuple. Unwrap it here.
         if self.expr_yields_vt_threaded_tuple(expr) {
-            let tuple_var = self.fresh_temp_var("ThreadedResult");
-            let loop_doc = self.expression_doc(expr)?;
-            if has_nlr {
-                let final_self = self.current_self_var();
-                body_parts.push(docvec![
-                    "    let ",
-                    leaf::var(tuple_var.clone()),
-                    " = ",
-                    loop_doc,
-                    " in\n    {call 'erlang':'element'(1, ",
-                    leaf::var(tuple_var),
-                    "), ",
-                    leaf::var(final_self),
-                    "}\n",
-                ]);
-            } else {
-                body_parts.push(docvec![
-                    "    let ",
-                    leaf::var(tuple_var.clone()),
-                    " = ",
-                    loop_doc,
-                    " in\n    call 'erlang':'element'(1, ",
-                    leaf::var(tuple_var),
-                    ")\n",
-                ]);
-            }
+            let result_var = self.emit_vt_threaded_tuple_unwrap_to_var(expr, body_parts)?;
+            self.emit_vt_value_return(&result_var, has_nlr, body_parts);
             return Ok(());
         }
 
@@ -1012,6 +988,37 @@ impl CoreErlangGenerator {
         Ok(())
     }
 
+    /// BT-2308/BT-2342/BT-2349: Emits a last-position threading construct (loop or foldl
+    /// list-op yielding a `{value, StateAcc}` tuple) as an open let chain that binds the
+    /// logical value (element 1) to a fresh result var, returning that var name.
+    ///
+    /// The threaded locals don't escape in last position, so element 2 (the `StateAcc`) is
+    /// discarded. Used both by [`Self::emit_vt_last_expr`] (value-type bodies wrap the result
+    /// in `{Result, Self{N}}` when NLR is active) and by the class-method body generator
+    /// (which wraps it in `{class_var_result, Result, ClassVarsN}` when class vars were
+    /// mutated).
+    pub(in crate::codegen::core_erlang) fn emit_vt_threaded_tuple_unwrap_to_var(
+        &mut self,
+        expr: &Expression,
+        body_parts: &mut Vec<Document<'static>>,
+    ) -> Result<String> {
+        let tuple_var = self.fresh_temp_var("ThreadedResult");
+        let result_var = self.fresh_temp_var("ThreadedValue");
+        let loop_doc = self.expression_doc(expr)?;
+        body_parts.push(docvec![
+            "    let ",
+            leaf::var(tuple_var.clone()),
+            " = ",
+            loop_doc,
+            " in\n    let ",
+            leaf::var(result_var.clone()),
+            " = call 'erlang':'element'(1, ",
+            leaf::var(tuple_var),
+            ") in\n",
+        ]);
+        Ok(result_var)
+    }
+
     /// BT-2308/BT-2342: Returns `true` if `expr` evaluates to a `{value, StateAcc}` threaded
     /// tuple in value-type / class-method context, whose element 1 is the logical result and
     /// element 2 is the `StateAcc` map of mutated outer locals.
@@ -1029,7 +1036,10 @@ impl CoreErlangGenerator {
     /// stay consistent.
     ///
     /// `do:` is excluded — its value-type codegen already returns a bare `nil`.
-    fn expr_yields_vt_threaded_tuple(&self, expr: &Expression) -> bool {
+    pub(in crate::codegen::core_erlang) fn expr_yields_vt_threaded_tuple(
+        &self,
+        expr: &Expression,
+    ) -> bool {
         self.is_while_with_vt_local_threading(expr)
             || self.is_counted_loop_with_vt_local_threading(expr)
             || self.is_foldl_list_op_with_vt_local_threading(expr)
@@ -1577,7 +1587,10 @@ impl CoreErlangGenerator {
     /// to decide whether to emit the stateful variant (returning `{'nil', StateAcc}`)
     /// or the simple variant (returning `'nil'`). This ensures the detection and codegen
     /// are consistent — we only extract threaded locals when the codegen actually packed them.
-    fn is_while_with_vt_local_threading(&self, expr: &Expression) -> bool {
+    pub(in crate::codegen::core_erlang) fn is_while_with_vt_local_threading(
+        &self,
+        expr: &Expression,
+    ) -> bool {
         if !self.in_class_method() && !matches!(self.context, CodeGenContext::ValueType) {
             return false;
         }
@@ -1624,7 +1637,10 @@ impl CoreErlangGenerator {
     /// 2. Extracts the `StateAcc` from element 2
     /// 3. Extracts each threaded local from the `StateAcc` via `maps:get`
     /// 4. Rebinds the variable names in scope so subsequent code sees the updated values
-    fn generate_vt_while_open(&mut self, expr: &Expression) -> Result<Document<'static>> {
+    pub(in crate::codegen::core_erlang) fn generate_vt_while_open(
+        &mut self,
+        expr: &Expression,
+    ) -> Result<Document<'static>> {
         // Generate the while loop expression (returns {'nil', StateAcc} tuple)
         let loop_doc = self.expression_doc(expr)?;
         let threaded_locals = self.get_while_threaded_locals(expr);
@@ -1709,7 +1725,10 @@ impl CoreErlangGenerator {
     /// Used by [`Self::emit_vt_threaded_local_assignment`] to rebind the threaded locals
     /// after extracting them from the `StateAcc`. Returns the same set the construct's
     /// codegen packed into the `StateAcc` (`compute_threaded_locals_for_loop`).
-    fn vt_construct_threaded_locals(&self, expr: &Expression) -> Vec<String> {
+    pub(in crate::codegen::core_erlang) fn vt_construct_threaded_locals(
+        &self,
+        expr: &Expression,
+    ) -> Vec<String> {
         if self.is_while_with_vt_local_threading(expr) {
             self.get_while_threaded_locals(expr)
         } else if self.is_counted_loop_with_vt_local_threading(expr) {
@@ -1733,7 +1752,7 @@ impl CoreErlangGenerator {
     /// locals would keep their pre-construct values.
     ///
     /// Returns the Core Erlang variable bound to the assignment target.
-    fn emit_vt_threaded_local_assignment(
+    pub(in crate::codegen::core_erlang) fn emit_vt_threaded_local_assignment(
         &mut self,
         var_name: &str,
         value: &Expression,
@@ -1826,7 +1845,10 @@ impl CoreErlangGenerator {
     /// Mirrors `is_while_with_vt_local_threading`: only triggers when the loop codegen
     /// will actually pack threaded locals into the `{'nil', StateAcc}` result, so the
     /// detection and the extraction stay consistent.
-    fn is_counted_loop_with_vt_local_threading(&self, expr: &Expression) -> bool {
+    pub(in crate::codegen::core_erlang) fn is_counted_loop_with_vt_local_threading(
+        &self,
+        expr: &Expression,
+    ) -> bool {
         if !self.in_class_method() && !matches!(self.context, CodeGenContext::ValueType) {
             return false;
         }
@@ -1865,7 +1887,10 @@ impl CoreErlangGenerator {
     /// with value-type captured local threading as an **open let chain**, extracting the
     /// threaded locals from the loop's `{'nil', StateAcc}` result (see
     /// [`Self::emit_vt_loop_open_extraction`]).
-    fn generate_vt_counted_loop_open(&mut self, expr: &Expression) -> Result<Document<'static>> {
+    pub(in crate::codegen::core_erlang) fn generate_vt_counted_loop_open(
+        &mut self,
+        expr: &Expression,
+    ) -> Result<Document<'static>> {
         // Generate the counted loop expression (returns {'nil', StateAcc} tuple).
         let loop_doc = self.expression_doc(expr)?;
         let threaded_locals = Self::counted_loop_body_block(expr)
@@ -1887,7 +1912,10 @@ impl CoreErlangGenerator {
     /// codegen will actually pack threaded locals into the `{value, StateAcc}` result
     /// (i.e. the mutation-threading path is taken), so detection and the extraction stay
     /// consistent.
-    fn is_foldl_list_op_with_vt_local_threading(&self, expr: &Expression) -> bool {
+    pub(in crate::codegen::core_erlang) fn is_foldl_list_op_with_vt_local_threading(
+        &self,
+        expr: &Expression,
+    ) -> bool {
         if !self.in_class_method() && !matches!(self.context, CodeGenContext::ValueType) {
             return false;
         }
@@ -1931,7 +1959,10 @@ impl CoreErlangGenerator {
     ///
     /// In non-last position the list-op's logical value (element 1) is discarded; only the
     /// threaded-local mutations need to escape.
-    fn generate_vt_foldl_list_op_open(&mut self, expr: &Expression) -> Result<Document<'static>> {
+    pub(in crate::codegen::core_erlang) fn generate_vt_foldl_list_op_open(
+        &mut self,
+        expr: &Expression,
+    ) -> Result<Document<'static>> {
         // Generate the list-op expression (returns a {value, StateAcc} tuple).
         let loop_doc = self.expression_doc(expr)?;
         let threaded_locals = Self::foldl_list_op_body_block(expr)
@@ -2178,12 +2209,39 @@ impl CoreErlangGenerator {
     /// entirely. The threaded locals don't need to escape in last position, so the case just
     /// yields each branch's logical value (the block's last expression, or `'nil'` for the
     /// missing branch of `ifTrue:`/`ifFalse:`).
-    fn emit_vt_conditional_last(
+    pub(in crate::codegen::core_erlang) fn emit_vt_conditional_last(
         &mut self,
         expr: &Expression,
         has_nlr: bool,
         body_parts: &mut Vec<Document<'static>>,
     ) -> Result<()> {
+        match self.emit_vt_conditional_case_to_var(expr, body_parts)? {
+            Some(result_var) => {
+                self.emit_vt_value_return(&result_var, has_nlr, body_parts);
+                Ok(())
+            }
+            // Not a recognized read+write conditional — fall back to the generic path.
+            None => self.emit_vt_last_expr(expr, 0, has_nlr, body_parts),
+        }
+    }
+
+    /// BT-2342/BT-2349: Emits a read+write conditional (`ifTrue:`/`ifFalse:`/`ifTrue:ifFalse:`
+    /// whose branch blocks read+write an outer local) as an inline `case` binding its logical
+    /// value to a fresh result var, pushed onto `body_parts` as an open let chain
+    /// (`let CondVal = case ... in\n`). Returns the result var name.
+    ///
+    /// Returns `None` when `expr` is not one of the supported conditional shapes, so the caller
+    /// can fall back to the generic last-expression path. The threaded locals don't escape in
+    /// last position, so each branch yields only its logical value (its last expression).
+    ///
+    /// Used both by [`Self::emit_vt_conditional_last`] (value-type bodies, which wrap the result
+    /// in `{Result, Self{N}}` when NLR is active) and by the class-method body generator (which
+    /// wraps it in `{class_var_result, Result, ClassVarsN}` when class vars were mutated).
+    pub(in crate::codegen::core_erlang) fn emit_vt_conditional_case_to_var(
+        &mut self,
+        expr: &Expression,
+        body_parts: &mut Vec<Document<'static>>,
+    ) -> Result<Option<String>> {
         let (receiver, selector_name, arguments) = match expr {
             Expression::MessageSend {
                 receiver,
@@ -2194,21 +2252,20 @@ impl CoreErlangGenerator {
                 let sel: String = parts.iter().map(|p| p.keyword.as_str()).collect();
                 (receiver.as_ref(), sel, arguments)
             }
-            // Not a keyword conditional — fall back to the generic last-expression path.
-            _ => return self.emit_vt_last_expr(expr, 0, has_nlr, body_parts),
+            _ => return Ok(None),
         };
 
         let nil_branch = || Document::Str("'nil'");
         let (true_branch, false_branch) = match selector_name.as_str() {
             "ifTrue:" => {
                 let Some(Expression::Block(block)) = arguments.first() else {
-                    return self.emit_vt_last_expr(expr, 0, has_nlr, body_parts);
+                    return Ok(None);
                 };
                 (self.build_vt_conditional_branch_value(block)?, nil_branch())
             }
             "ifFalse:" => {
                 let Some(Expression::Block(block)) = arguments.first() else {
-                    return self.emit_vt_last_expr(expr, 0, has_nlr, body_parts);
+                    return Ok(None);
                 };
                 (nil_branch(), self.build_vt_conditional_branch_value(block)?)
             }
@@ -2216,14 +2273,14 @@ impl CoreErlangGenerator {
                 let (Some(Expression::Block(tb)), Some(Expression::Block(fb))) =
                     (arguments.first(), arguments.get(1))
                 else {
-                    return self.emit_vt_last_expr(expr, 0, has_nlr, body_parts);
+                    return Ok(None);
                 };
                 (
                     self.build_vt_conditional_branch_value(tb)?,
                     self.build_vt_conditional_branch_value(fb)?,
                 )
             }
-            _ => return self.emit_vt_last_expr(expr, 0, has_nlr, body_parts),
+            _ => return Ok(None),
         };
 
         let cond_var = self.fresh_temp_var("Cond");
@@ -2244,8 +2301,7 @@ impl CoreErlangGenerator {
             false_branch,
             " end in\n",
         ]);
-        self.emit_vt_value_return(&result_var, has_nlr, body_parts);
-        Ok(())
+        Ok(Some(result_var))
     }
 
     /// BT-2342: Inlines a conditional branch's block body, returning the block's logical

--- a/stdlib/test/class_method_block_test.bt
+++ b/stdlib/test/class_method_block_test.bt
@@ -50,3 +50,50 @@ TestCase subclass: ClassMethodBlockTest
   testActorClassMethodDoWithMutation =>
     result := ActorClassMethodBlock countItems: #(1, 2, 3, 4, 5)
     self assert: result equals: 5
+
+  // BT-2349: last-position inject:into: in a class method returns the accumulator,
+  // not the raw {value, StateAcc} threading tuple.
+  testClassMethodInjectLastReturnsValue =>
+    result := ClassMethodBlock sumCounting: #(1, 2, 3)
+    self assert: result equals: 6
+
+  // BT-2349: local-assignment of collect: in a class method binds the collected Array
+  // and threads the mutated counter out to later statements.
+  testClassMethodCollectAssignmentThreads =>
+    result := ClassMethodBlock doubleCounting: #(1, 2, 3)
+    self assert: result equals: #(#(2, 4, 6), 3)
+
+  // BT-2349: last-position select: in a class method returns the filtered Array.
+  testClassMethodSelectLastReturnsValue =>
+    result := ClassMethodBlock evensCounting: #(1, 2, 3, 4)
+    self assert: result equals: #(2, 4)
+
+  // BT-2349: last-position counted loop in a class method unwraps to the loop value (nil).
+  testClassMethodCountedLoopLastReturnsNil =>
+    result := ClassMethodBlock countToLast: 3
+    self assert: result equals: nil
+
+  // BT-2349: counted loop in local-assignment position threads the mutated total out.
+  testClassMethodLoopAssignmentThreads =>
+    result := ClassMethodBlock sumViaLoop: 3
+    self assert: result equals: 6
+
+  // BT-2349: last-position read+write conditional returns the branch value (true).
+  testClassMethodConditionalLastTrue =>
+    result := ClassMethodBlock condLast: true
+    self assert: result equals: 7
+
+  // BT-2349: last-position read+write conditional returns nil when the branch is skipped.
+  testClassMethodConditionalLastFalse =>
+    result := ClassMethodBlock condLast: false
+    self assert: result equals: nil
+
+  // BT-2349: last-position ifTrue:ifFalse: read+write conditional returns the true branch.
+  testClassMethodConditionalBothTrue =>
+    result := ClassMethodBlock condBothLast: true
+    self assert: result equals: 11
+
+  // BT-2349: last-position ifTrue:ifFalse: read+write conditional returns the false branch.
+  testClassMethodConditionalBothFalse =>
+    result := ClassMethodBlock condBothLast: false
+    self assert: result equals: 101

--- a/stdlib/test/class_var_subexpr_test.bt
+++ b/stdlib/test/class_var_subexpr_test.bt
@@ -208,3 +208,14 @@ TestCase subclass: ClassVarSubExprTest
 
   testTickReturnIsNilReturnsFalse =>
     self assert: ClassVarSubExpr tickReturnIsNil equals: false
+
+  // BT-2349: class var mutated earlier, then a last-position foldl list-op that
+  // mutates an outer local. The folded value must be returned (not the raw
+  // {value, StateAcc} tuple) AND the earlier class var mutation must persist —
+  // i.e. the result is wrapped in `{class_var_result, Value, ClassVarsN}`.
+  testTickThenSumReturnsAccumulator =>
+    self assert: (ClassVarSubExpr tickThenSum: #(1, 2, 3)) equals: 6
+
+  testTickThenSumPersistsClassVar =>
+    ClassVarSubExpr tickThenSum: #(1, 2, 3)
+    self assert: ClassVarSubExpr currentCounter equals: 1

--- a/stdlib/test/fixtures/class_method_block.bt
+++ b/stdlib/test/fixtures/class_method_block.bt
@@ -60,3 +60,59 @@ Object subclass: ClassMethodBlock
         count := count + 1
       ]
     #(sum, count)
+
+  // BT-2349: last-position foldl list-op (inject:into:) that mutates an outer local.
+  // Must return the accumulator (the folded value), not the {value, StateAcc} tuple.
+  class sumCounting: items =>
+    n := 0
+    items
+      inject: 0
+      into: [:acc :x |
+        n := n + 1
+        acc + x
+      ]
+
+  // BT-2349: local-assignment of a foldl list-op (collect:) that mutates an outer local.
+  // result is bound to the collected Array; n must thread out the mutated count.
+  class doubleCounting: items =>
+    n := 0
+    result := items
+      collect: [:x |
+        n := n + 1
+        x * 2
+      ]
+    #(result, n)
+
+  // BT-2349: last-position select: that reads+writes an outer local.
+  // Must return the filtered Array (element 1), threading dropped is fine in last position.
+  class evensCounting: items =>
+    seen := 0
+    items
+      select: [:x |
+        seen := seen + 1
+        x isEven
+      ]
+
+  // BT-2349: last-position counted loop (to:do:) that mutates an outer local.
+  // Must unwrap the {'nil', StateAcc} tuple and return the loop's logical value (nil).
+  class countToLast: n =>
+    total := 0
+    1 to: n do: [:i | total := total + i]
+
+  // BT-2349: counted loop in local-assignment position. total threads out; the loop's
+  // logical value (nil) is assigned to _ignored, then total is returned.
+  class sumViaLoop: n =>
+    total := 0
+    _ignored := 1 to: n do: [:i | total := total + i]
+    total
+
+  // BT-2349: last-position read+write conditional. Must return the branch value
+  // (no 0-arg stateful-block dispatch crash) and not leak the tuple.
+  class condLast: flag =>
+    sum := 0
+    flag ifTrue: [sum := sum + 7]
+
+  // BT-2349: last-position ifTrue:ifFalse: that reads+writes an outer local in both branches.
+  class condBothLast: flag =>
+    sum := 1
+    flag ifTrue: [sum := sum + 10] ifFalse: [sum := sum + 100]

--- a/stdlib/test/fixtures/class_var_subexpr.bt
+++ b/stdlib/test/fixtures/class_var_subexpr.bt
@@ -125,3 +125,17 @@ Object subclass: ClassVarSubExpr
 
   // BT-1942: Explicit `^` return of a nil-protocol intrinsic result.
   class tickReturnIsNil => ^(self tick) isNil
+
+  // BT-2349: class var mutated earlier, then a last-position foldl list-op that
+  // mutates an outer local. The method result must be the folded value wrapped in
+  // `{class_var_result, Value, ClassVarsN}` so the earlier counter mutation persists
+  // AND the call returns the accumulator (not the raw threading tuple).
+  class tickThenSum: items =>
+    _ignored := self tick
+    seen := 0
+    items
+      inject: 0
+      into: [:acc :x |
+        seen := seen + 1
+        acc + x
+      ]


### PR DESCRIPTION
## Summary

BT-2342 unified value-type method-body consumption of local-threading constructs (loops, foldl list-ops `collect:`/`select:`/`reject:`/`inject:into:`, conditionals) so a `{value, StateAcc}` threading tuple is consumed correctly in **every** position — but only via the value-type **instance-method** body sequencer. **Class methods** use a separate body generator (`gen_server/methods.rs`) that handled only non-last `do:` and conditionals, so identical source **leaked or lost threaded locals** in a class-method context. This is exactly the context-dependent codegen divergence epic **BT-2344** targets.

This wires the class-method body generator to the shared BT-2342 primitives.

## Changes

- **Last position** (`try_generate_class_method_threaded_last`): unwraps a threaded `{value, StateAcc}` tuple (counted/while loops, foldl list-ops) or a read+write conditional to a logical-value result var, then wraps it in `{class_var_result, Result, ClassVarsN}` when an earlier statement mutated a class var (else returns it bare). Fixes the raw-tuple leak **and** the 0-arg stateful-block conditional crash (BT-2342 mode B).
- **Non-last**: counted/while loops and foldl list-ops now extract threaded locals from the StateAcc so subsequent statements observe the mutations (previously discarded as a side effect).
- **Local assignment**: binds the target to `element(1)` and rebinds threaded locals from `element(2)`, instead of binding the target to the raw tuple.

All Core Erlang fragments go through the `document::leaf` API (`leaf::var`); no `format!`/string concatenation.

## Reproducers (now correct)

```beamtalk
class sumCounting: items =>            // last-position foldl → returns accumulator, not {6, StateAcc}
  n := 0
  items inject: 0 into: [:acc :x | n := n + 1. acc + x]

class doubleCounting: items =>         // local-assignment of foldl → result is the Array, n threaded
  n := 0
  result := items collect: [:x | n := n + 1. x * 2]
  #(result, n)

class condLast: flag =>                // last-position read+write conditional → branch value, no crash
  sum := 0
  flag ifTrue: [sum := sum + 7]
```

## Testing

- New class-method reproducers in `stdlib/test/class_method_block_test.bt` (+ `fixtures/class_method_block.bt`) covering last / non-last / local-assignment positions for foldl list-ops, loops, and read+write conditionals.
- Added `class_var_subexpr` coverage for the class-var-mutation × threading-construct interaction (the `{class_var_result, ...}` wrapping path).
- `just build`, `just clippy`, `cargo fmt --check`: clean.
- `just test-bunit`: **2188 passed, 0 failed**.

> Note: `just build` emits a pre-existing stale-`@expect` warning in `stdlib/src/WorkspaceInterface.bt:119` (identical directive on `main`, untouched by this PR, non-fatal). Not introduced here.

## Acceptance criteria

- [x] `collect:`/`select:`/`reject:`/`inject:into:` thread outer-local mutations and return the correct value/type in non-last, last, and local-assignment positions (class-method context).
- [x] Counted/while loops thread and unwrap correctly in last and local-assignment positions in class methods.
- [x] A read+write conditional as a class method's last expression returns the branch value (no arity crash) and does not leak the tuple.
- [x] BUnit tests covering the reproducers.

Part of epic **BT-2344**. Built on **BT-2342** (#2389, merged).

https://claude.ai/code/session_01Hu2pvPvwqbTRWGryEPNoCV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed value returns from folding operations (`inject:into:`, `collect:`), loops, and conditionals in class methods.
  * Corrected local variable mutation threading in collection and loop constructs.
  * Ensured counted loops return correct values in class method contexts.
  * Fixed read+write conditionals to return branch values properly.

* **Tests**
  * Added regression tests for class method semantics with threading constructs and variable mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->