### PR TITLE
Stale @expect type + ChangeLog/Dictionary return-type mismatch on WorkspaceInterface>>changes (BT-2357)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
@@ -424,7 +424,11 @@ object can apply the active-vs-full filtering in Beamtalk. This is what
 `Workspace changes` returns. Called via
 `(Erlang beamtalk_workspace_changelog) changeLog`.
 """.
--spec changeLog() -> map().
+%% The `'$beamtalk_class' := 'ChangeLog'` tag lets the type checker (via
+%% beamtalk_spec_reader) infer this FFI result as the `ChangeLog` Beamtalk
+%% class rather than a bare `Dictionary`, matching `WorkspaceInterface>>changes`
+%% declared `-> ChangeLog` return type. Mirrors `beamtalk_ets:t()`.
+-spec changeLog() -> #{'$beamtalk_class' := 'ChangeLog', entries := [map()]}.
 changeLog() ->
     #{
         '$beamtalk_class' => 'ChangeLog',

--- a/stdlib/src/ChangeLog.bt
+++ b/stdlib/src/ChangeLog.bt
@@ -107,9 +107,8 @@ sealed typed Value subclass: ChangeLog
   /// ```
   dirtyMethods -> Dictionary =>
     // FFI returns a Dictionary `#{ClassSymbol => Set(selectorSymbol)}`
-    // (beamtalk_workspace_changelog:dirtyMethods/0); suppress the untyped-FFI
-    // Dynamic warning since the shape is known.
-    @expect type
+    // (beamtalk_workspace_changelog:dirtyMethods/0), matching the declared
+    // return type.
     (Erlang beamtalk_workspace_changelog) dirtyMethods
 
   /// Re-install the prior body of `anEntry`'s method, undoing the patch

--- a/stdlib/src/WorkspaceInterface.bt
+++ b/stdlib/src/WorkspaceInterface.bt
@@ -115,8 +115,8 @@ sealed typed Object subclass: WorkspaceInterface
   /// ```
   changes -> ChangeLog =>
     // FFI returns a `ChangeLog`-tagged map (beamtalk_workspace_changelog:changeLog/0);
-    // suppress the untyped-FFI Dynamic warning since the shape is known.
-    @expect type
+    // its `'$beamtalk_class' := 'ChangeLog'` spec lets the type checker infer the
+    // result as ChangeLog, matching the declared return type.
     (Erlang beamtalk_workspace_changelog) changeLog
 
   /// Compile and load a .bt file, registering the class.


### PR DESCRIPTION
## Summary

`just build` emitted two non-fatal diagnostics on `WorkspaceInterface>>changes` (plus a third, same-root-cause one on `ChangeLog>>dirtyMethods`). They were noise introduced by #2345 (BT-2311), which added `-spec` annotations to `beamtalk_workspace_changelog`.

`changeLog/0` was spec'd `-> map()`, so the type checker inferred the FFI body of `WorkspaceInterface>>changes` as `Dictionary` rather than the declared `ChangeLog` — producing a return-type mismatch. Because the result was now concrete (not `Dynamic`), the pre-existing `@expect type` directives (added to suppress the *untyped-FFI Dynamic* warning) went stale.

## Fix

The FFI already returns a `'$beamtalk_class' => 'ChangeLog'` tagged map, and `beamtalk_spec_reader` already maps such tagged maps to their Beamtalk class (the mechanism `beamtalk_ets:t()` relies on). So:

- **`beamtalk_workspace_changelog.erl`** — changed `changeLog/0`'s spec from `-> map()` to the typed map `#{'$beamtalk_class' := 'ChangeLog', entries := [map()]}`. The body now infers as `ChangeLog`, matching the declared return type.
- **`WorkspaceInterface.bt`** — removed the now-stale `@expect type` from `changes` (types genuinely agree now).
- **`ChangeLog.bt`** — removed the stale `@expect type` from `dirtyMethods` (its `dirtyMethods/0` spec already infers `Dictionary`, matching its declared return).

This takes the issue's preferred path: make declared and inferred types agree rather than suppress the warning.

## Acceptance criteria

- [x] `just build` emits neither the stale-`@expect` warning nor the `ChangeLog`/`Dictionary` mismatch for `WorkspaceInterface>>changes`.
- [x] The `@expect type` directives are removed (no longer needed).
- [x] No regression in `Workspace changes` behaviour — stdlib (250), BUnit (2177), and runtime (4221 + 1376) tests pass; dialyzer clean.

## Verification

- `just build` — target diagnostic count: 0 (remaining build diagnostics are pre-existing and unrelated, confirmed via `git stash`)
- `just test` — all green
- `just dialyzer` — clean (exit 0)

Linear: https://linear.app/beamtalk/issue/BT-2357

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdEU37oX1R8JKoKTsUsmQo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced type specifications for improved code clarity and maintainability.
  * Removed unnecessary type suppression directives across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->