### PR TITLE
Flip bt2355Pending matrix cells on now that BT-2355 has landed (BT-2355)

### DIFF
--- a/stdlib/test/value_type_mutation_matrix_test.bt
+++ b/stdlib/test/value_type_mutation_matrix_test.bt
@@ -42,12 +42,10 @@ TestCase subclass: ValueTypeMutationMatrixTest
   // switch for documentation/bisection.
   bt2342Pending => false
 
-  // Pending switch for BT-2355 Actor-context outer-local threading gaps
-  // surfaced by this matrix (write-only/read+write conditionals, ifTrue:ifFalse:
-  // non-last, count:/detect: foldl predicates, and loop local-assignment all
-  // fail to thread — and the read+write conditional only threads on the first
-  // invocation). Flip to `false` once BT-2355 lands.
-  bt2355Pending => true
+  // Pending switch for BT-2355 Actor-context outer-local threading gaps. BT-2355
+  // has landed, so the affected Actor cells now run their ground-truth asserts.
+  // Kept as a switch for documentation/bisection.
+  bt2355Pending => false
 
   // Pending switch for BT-2359 value-type outer-local threading gaps that
   // BT-2342 did NOT cover: count:/detect: foldl predicates, and a threading


### PR DESCRIPTION
## Summary

Completes BT-2355's final, previously-unfulfillable acceptance criterion: *"the corresponding cells in `value_type_mutation_matrix_test.bt` (currently `skip`ped with this issue's reference) are flipped on."*

That criterion couldn't be satisfied in #2393 (the BT-2355 codegen fix) because the matrix file didn't exist yet — it landed later in BT-2346 (#2391), which gated the 7 Actor cells under `bt2355Pending => true`. With both merged to main, this flips them on.

## Change

- `bt2355Pending => false` (one-line switch; comment updated to note BT-2355 landed, kept as a documentation/bisection switch — same pattern as `bt2342Pending`).

## Verification

Built + ran locally against current main:

- All **7 gated Actor cells pass** — BT-2355's fix fully covers them, so **no re-gating was needed** (in contrast to the value-type flip, where 4 cells had to move to BT-2359).
- `just test-bunit`: **2257 passed, 0 failed**
- `ValueTypeMutationMatrixTest`: **51 passed, 4 skipped** — the only remaining skips are the BT-2359 value-context gaps (`count:`/`detect:` predicates + parenthesized assignment-RHS).
- `just fmt-check-beamtalk`: pass

## References

- BT-2355 (Actor-context threading fix; #2393)
- BT-2346 (the matrix; #2391)
- BT-2359 (remaining value-context gaps, still gated)

https://claude.ai/code/session_01Hu2pvPvwqbTRWGryEPNoCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu2pvPvwqbTRWGryEPNoCV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled previously gated test cases for threading assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->