### PR TITLE
Close class-var open scope in foldl last-position block bodies (BT-2350)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -2098,30 +2098,35 @@ impl CoreErlangGenerator {
                 }
             }
             BodyKind::FoldlDo => {
-                // BT-1290: When preceding let-bindings exist (has_mutations/has_plain_lets),
-                // the last expression must also be bound with `let _ =` before `in StateAcc`.
-                // Without this, `let Y = ... in <expr> in StateAcc` is invalid Core Erlang
-                // (the `in StateAcc` has no corresponding `let`).
-                if !is_last || (has_mutations || has_plain_lets) {
-                    docs.push(Document::Str("let _ = "));
-                }
-                let doc = self.generate_expression(expr)?;
-                docs.push(doc);
-                if is_last && (has_mutations || has_plain_lets) {
-                    if plan.use_tuple_acc {
-                        // BT-1276: Repack threaded locals as tuple.
-                        docs.push(docvec![" in {", plan.current_vars_doc(self), "}"]);
-                    } else {
-                        docs.push(docvec![" in ", leaf::var(self.current_state_var())]);
+                if is_last {
+                    // BT-1290: When preceding let-bindings exist (has_mutations/
+                    // has_plain_lets), the last expression must also be bound with
+                    // `let _ =` before `in StateAcc`. Without this,
+                    // `let Y = ... in <expr> in StateAcc` is invalid Core Erlang
+                    // (the `in StateAcc` has no corresponding `let`).
+                    if has_mutations || has_plain_lets {
+                        docs.push(Document::Str("let _ = "));
                     }
-                } else if !is_last {
-                    docs.push(Document::Str(" in "));
+                    // BT-2350: close any class self-send open scope so the trailing
+                    // `… in {vars}` / `… in StateAcc` does not dangle a second `in`.
+                    let doc = self.closed_expression_doc(expr)?;
+                    docs.push(doc);
+                    if has_mutations || has_plain_lets {
+                        if plan.use_tuple_acc {
+                            // BT-1276: Repack threaded locals as tuple.
+                            docs.push(docvec![" in {", plan.current_vars_doc(self), "}"]);
+                        } else {
+                            docs.push(docvec![" in ", leaf::var(self.current_state_var())]);
+                        }
+                    }
+                } else {
+                    // BT-2350: ClassVars-visible discard for non-last statements
+                    // (a class self-send leaves an open let-chain whose ClassVarsN
+                    // must stay visible to following statements).
+                    self.push_discarded_stmt(docs, expr)?;
                 }
             }
             BodyKind::FoldlCollect => {
-                if !is_last {
-                    docs.push(Document::Str("let _ = "));
-                }
                 if is_last {
                     let result_var = self.fresh_temp_var("CollectItem");
                     let expr_code = self.closed_expression_doc(expr)?;
@@ -2158,9 +2163,10 @@ impl CoreErlangGenerator {
                         ]);
                     }
                 } else {
-                    let doc = self.generate_expression(expr)?;
-                    docs.push(doc);
-                    docs.push(Document::Str(" in "));
+                    // BT-2350: a non-last statement may be a class self-send that
+                    // emits an open let-chain; close it (keeping ClassVarsN visible)
+                    // so the surrounding sequencing does not dangle a second `in`.
+                    self.push_discarded_stmt(docs, expr)?;
                 }
             }
             BodyKind::FoldlFilter { .. }
@@ -2171,9 +2177,6 @@ impl CoreErlangGenerator {
             | BodyKind::FoldlDropWhile { .. }
             | BodyKind::FoldlPartition { .. }
             | BodyKind::FoldlGroupBy { .. } => {
-                if !is_last {
-                    docs.push(Document::Str("let _ = "));
-                }
                 if is_last {
                     if let Some(pv) = pred_var {
                         let expr_code = self.closed_expression_doc(expr)?;
@@ -2186,15 +2189,12 @@ impl CoreErlangGenerator {
                         ]);
                     }
                 } else {
-                    let doc = self.generate_expression(expr)?;
-                    docs.push(doc);
-                    docs.push(Document::Str(" in "));
+                    // BT-2350: see FoldlCollect — close a non-last open scope while
+                    // keeping ClassVarsN visible for following statements.
+                    self.push_discarded_stmt(docs, expr)?;
                 }
             }
             BodyKind::FoldlInject => {
-                if !is_last {
-                    docs.push(Document::Str("let _ = "));
-                }
                 if is_last {
                     let acc_var = self.fresh_temp_var("AccOut");
                     let expr_code = self.closed_expression_doc(expr)?;
@@ -2231,9 +2231,9 @@ impl CoreErlangGenerator {
                         ]);
                     }
                 } else {
-                    let doc = self.generate_expression(expr)?;
-                    docs.push(doc);
-                    docs.push(Document::Str(" in "));
+                    // BT-2350: see FoldlCollect — close a non-last open scope while
+                    // keeping ClassVarsN visible for following statements.
+                    self.push_discarded_stmt(docs, expr)?;
                 }
             }
             BodyKind::FoldlSort => {

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -2124,7 +2124,7 @@ impl CoreErlangGenerator {
                 }
                 if is_last {
                     let result_var = self.fresh_temp_var("CollectItem");
-                    let expr_code = self.expression_doc(expr)?;
+                    let expr_code = self.closed_expression_doc(expr)?;
                     if plan.use_tuple_acc {
                         // BT-1276: Tuple mode — repack current vars.
                         let vars_doc = plan.current_vars_doc(self);
@@ -2176,7 +2176,7 @@ impl CoreErlangGenerator {
                 }
                 if is_last {
                     if let Some(pv) = pred_var {
-                        let expr_code = self.expression_doc(expr)?;
+                        let expr_code = self.closed_expression_doc(expr)?;
                         docs.push(docvec![
                             "let ",
                             leaf::var(pv.clone()),
@@ -2197,7 +2197,7 @@ impl CoreErlangGenerator {
                 }
                 if is_last {
                     let acc_var = self.fresh_temp_var("AccOut");
-                    let expr_code = self.expression_doc(expr)?;
+                    let expr_code = self.closed_expression_doc(expr)?;
                     if plan.use_tuple_acc {
                         // BT-1276: Tuple mode — repack current vars.
                         let vars_doc = plan.current_vars_doc(self);

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -219,6 +219,40 @@ impl CoreErlangGenerator {
         })
     }
 
+    /// Pushes a non-last, result-discarded statement of a threaded foldl block
+    /// body, closing any class-var open scope **while keeping its `ClassVarsN`
+    /// binding visible** to subsequent statements.
+    ///
+    /// BT-2350: a class self-send emits an open let-chain ending in `… in ` and
+    /// bumps the class-var version *without* rolling it back, so later statements
+    /// reference the new `ClassVarsN`. Closing such a chain by wrapping it inside
+    /// `let _ = (<chain> result_var) in …` (as [`closed_expression_doc`] does)
+    /// would scope `ClassVarsN` away and leave the later reference unbound. So we
+    /// keep the chain at the current level and append `let _ = <result_var> in `
+    /// to discard the value and sequence on. With no open scope this is the
+    /// original `let _ = <expr> in `.
+    pub(super) fn push_discarded_stmt(
+        &mut self,
+        docs: &mut Vec<super::document::Document<'static>>,
+        expr: &Expression,
+    ) -> Result<()> {
+        let (doc, open_scope) = self.expression_doc_with_open_scope(expr)?;
+        match open_scope {
+            Some(result_var) => {
+                docs.push(doc);
+                docs.push(docvec![
+                    "let _ = ",
+                    super::document::leaf::var(result_var),
+                    " in "
+                ]);
+            }
+            None => {
+                docs.push(docvec!["let _ = ", doc, " in "]);
+            }
+        }
+        Ok(())
+    }
+
     /// Generates an expression and returns whether it set `repl_loop_mutated`.
     ///
     /// BT-1448: Replaces the manual reset-before/read-after pattern on `repl_loop_mutated`.

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -197,6 +197,28 @@ impl CoreErlangGenerator {
         Ok((doc, self.last_open_scope_result.take()))
     }
 
+    /// Generates an expression as a self-contained doc, closing any open scope.
+    ///
+    /// BT-2350: `expression_doc` forwards to `generate_expression`, which for a
+    /// class-method self-send (or class-var assignment) emits an *open* let-chain
+    /// ending in `... in ` and records the result variable in
+    /// `last_open_scope_result` for the caller to append. When such a doc is used
+    /// directly as the RHS of an enclosing `let X = <doc> in ...` — e.g. the
+    /// `is_last` foldl block bodies (`collect:` / `select:` / `inject:into:` /
+    /// `detect:` / `count:` / …) — the dangling `in` produces invalid Core Erlang
+    /// (`{core_parse_error, …, "syntax error before: in"}`). This helper closes
+    /// the scope by appending the result variable so the doc stands alone.
+    pub(super) fn closed_expression_doc(
+        &mut self,
+        expr: &Expression,
+    ) -> Result<super::document::Document<'static>> {
+        let (doc, open_scope) = self.expression_doc_with_open_scope(expr)?;
+        Ok(match open_scope {
+            Some(result_var) => docvec![doc, super::document::leaf::var(result_var)],
+            None => doc,
+        })
+    }
+
     /// Generates an expression and returns whether it set `repl_loop_mutated`.
     ///
     /// BT-1448: Replaces the manual reset-before/read-after pattern on `repl_loop_mutated`.

--- a/stdlib/test/class_method_block_test.bt
+++ b/stdlib/test/class_method_block_test.bt
@@ -114,3 +114,18 @@ TestCase subclass: ClassMethodBlockTest
   testClassMethodInjectSelfSendAndMutation =>
     result := ClassMethodBlock addCounting: #(1, 2, 3)
     self assert: result equals: #(6, 3)
+
+  // BT-2350 (Copilot follow-up): non-last discarded self-send in a collect: block.
+  testClassMethodCollectNonLastSelfSend =>
+    result := ClassMethodBlock doubleAllCountingNonLast: #(1, 2, 3)
+    self assert: result equals: #(#(2, 4, 6), 3)
+
+  // BT-2350 (Copilot follow-up): non-last discarded self-send in a do: block.
+  testClassMethodDoNonLastSelfSend =>
+    result := ClassMethodBlock doCountingNonLast: #(1, 2, 3)
+    self assert: result equals: 3
+
+  // BT-2350 (Copilot follow-up): non-last discarded self-send in an inject:into: block.
+  testClassMethodInjectNonLastSelfSend =>
+    result := ClassMethodBlock addCountingNonLast: #(1, 2, 3)
+    self assert: result equals: #(6, 3)

--- a/stdlib/test/class_method_block_test.bt
+++ b/stdlib/test/class_method_block_test.bt
@@ -97,3 +97,20 @@ TestCase subclass: ClassMethodBlockTest
   testClassMethodConditionalBothFalse =>
     result := ClassMethodBlock condBothLast: false
     self assert: result equals: 101
+
+  // BT-2350: collect: block combining a self-send AND a captured-local mutation.
+  // Previously emitted invalid Core Erlang (dangling `in`); now the collected
+  // self-send results and the threaded counter both come back.
+  testClassMethodCollectSelfSendAndMutation =>
+    result := ClassMethodBlock doubleAllCounting: #(1, 2, 3)
+    self assert: result equals: #(#(2, 4, 6), 3)
+
+  // BT-2350: select: variant — self-send predicate + captured-local mutation.
+  testClassMethodSelectSelfSendAndMutation =>
+    result := ClassMethodBlock bigCounting: #(1, 2, 3, 4)
+    self assert: result equals: #(#(3, 4), 4)
+
+  // BT-2350: inject:into: variant — self-send + captured-local mutation.
+  testClassMethodInjectSelfSendAndMutation =>
+    result := ClassMethodBlock addCounting: #(1, 2, 3)
+    self assert: result equals: #(6, 3)

--- a/stdlib/test/fixtures/class_method_block.bt
+++ b/stdlib/test/fixtures/class_method_block.bt
@@ -116,3 +116,43 @@ Object subclass: ClassMethodBlock
   class condBothLast: flag =>
     sum := 1
     flag ifTrue: [sum := sum + 10] ifFalse: [sum := sum + 100]
+
+  // BT-2350: predicate helper for the self-send + captured-local select: case.
+  class isBig: x => x > 2
+
+  // BT-2350: collect: block combining a class self-send (`self double:`) AND a
+  // captured-local mutation (`count`). This combination previously emitted invalid
+  // Core Erlang (dangling `in`) — the open class-var scope was not closed before the
+  // enclosing `let _CollectItem = … in {…}`. The collected self-send result and the
+  // threaded counter must both come back.
+  class doubleAllCounting: items =>
+    count := 0
+    result := items
+      collect: [:item |
+        count := count + 1
+        self double: item
+      ]
+    #(result, count)
+
+  // BT-2350: select: variant — self-send predicate (`self isBig:`) + captured-local
+  // mutation (`seen`), exercising the foldl-filter block-body path.
+  class bigCounting: items =>
+    seen := 0
+    result := items
+      select: [:item |
+        seen := seen + 1
+        self isBig: item
+      ]
+    #(result, seen)
+
+  // BT-2350: inject:into: variant — self-send (`self add:to:`) + captured-local
+  // mutation (`n`), exercising the foldl-inject block-body path.
+  class addCounting: items =>
+    n := 0
+    result := items
+      inject: 0
+      into: [:acc :item |
+        n := n + 1
+        self add: acc to: item
+      ]
+    #(result, n)

--- a/stdlib/test/fixtures/class_method_block.bt
+++ b/stdlib/test/fixtures/class_method_block.bt
@@ -156,3 +156,41 @@ Object subclass: ClassMethodBlock
         self add: acc to: item
       ]
     #(result, n)
+
+  // BT-2350: identity helper used as a discarded *non-last* self-send.
+  class logIt: x => x
+
+  // BT-2350 (Copilot follow-up): a *non-last* class self-send (discarded result)
+  // inside a threaded foldl block must close its open class-var scope while
+  // keeping `ClassVarsN` visible to the following self-send. collect: form.
+  class doubleAllCountingNonLast: items =>
+    count := 0
+    result := items
+      collect: [:item |
+        count := count + 1
+        self logIt: item
+        self double: item
+      ]
+    #(result, count)
+
+  // BT-2350 (Copilot follow-up): do: form with a non-last discarded self-send.
+  class doCountingNonLast: items =>
+    count := 0
+    items
+      do: [:item |
+        self logIt: item
+        count := count + 1
+      ]
+    count
+
+  // BT-2350 (Copilot follow-up): inject:into: form with a non-last discarded self-send.
+  class addCountingNonLast: items =>
+    n := 0
+    result := items
+      inject: 0
+      into: [:acc :item |
+        self logIt: item
+        n := n + 1
+        self add: acc to: item
+      ]
+    #(result, n)


### PR DESCRIPTION
## Summary

Fixes BT-2350: a **class method** whose `collect:`/`select:`/`inject:into:` block combined a class **self-send** (`self double: item`) with a **captured-local mutation** (`count := count + 1`) emitted **invalid Core Erlang**, rejected by `erlc` with `{core_parse_error, …, "syntax error before: in"}`.

### Root cause

The `is_last` foldl block bodies build `let _CollectItem = <expr> in {[_CollectItem | AccList], StateAcc}` via `expression_doc`, which forwards to `generate_expression`. For a class self-send that emits an *open* let-chain (the class-var unwrap), `expression_doc` returns the chain ending in `… in ` and leaves the closing result variable in `last_open_scope_result` **un-consumed**, so the chain dangles:

```text
let _CollectItem = let _CMR = … in
                   let ClassVars1 = case … end in
                   let _Unwrapped = case … end in     <-- dangling
                    in {[_CollectItem | AccList], StateAcc}   <-- second `in`
```

### Fix

Add `closed_expression_doc`, which generates via `expression_doc_with_open_scope` and appends the recorded result variable to close the scope. Use it in the three affected `is_last` foldl arms (`FoldlCollect`, the filter/predicate group, `FoldlInject`). When there is **no** open scope the doc is byte-identical to before — non-self-send cases are unchanged (zero regression surface).

Both the self-send result (collected/folded) and the captured local now thread correctly. The generated body becomes `… let _Unwrapped15 = case … end in _Unwrapped15 in {[_CollectItem10 | AccList], StateAcc1}`.

## Tests

Added BUnit regression coverage in `class_method_block_test.bt` + fixture for all three fixed arms — each combining a self-send with a captured-local mutation:

- `collect:` → `#(#(2, 4, 6), 3)`
- `select:` → `#(#(3, 4), 4)`
- `inject:into:` → `#(6, 3)`

## Verification

- Reproducer (previously failed to compile) now compiles to valid Core Erlang.
- `ClassMethodBlockTest`: 21/21 pass (confirmed the new tests execute via a deliberate-break check).
- Full `just test-bunit`: **2260 passed, 0 failed**.
- `cargo test -p beamtalk-core`: **4040 passed, 0 failed**.
- `just clippy`, `cargo fmt --check`, `just fmt-check-beamtalk`: all clean.

## Scope note

Class-var *mutations* inside such a block (a self-send that itself writes a class var) are not threaded through the fold accumulator — out of scope here (the self-send in the reproducer only reads). The AC (self-send result + captured local thread correctly) is met; deeper class-var-through-foldl threading would be a separate issue if a real case arises.

## References

- BT-2350 (this bug; found while adding class-method tests for BT-2342)
- BT-2349 (related class-method threading)

https://claude.ai/code/session_01Hu2pvPvwqbTRWGryEPNoCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu2pvPvwqbTRWGryEPNoCV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scope handling in class method blocks that combine self-send operations with captured variable mutations in block constructs.

* **Tests**
  * Added comprehensive test coverage for class method blocks with self-sends and captured variable mutations, including edge cases for non-last operation positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->