### PR TITLE
Unwrap value-type threading tuple on explicit class-method `^` return (BT-2358)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -2237,6 +2237,18 @@ impl CoreErlangGenerator {
         value: &Expression,
         has_class_vars: bool,
     ) -> Result<Document<'static>> {
+        // BT-2358: An explicit `^` return of a value-type threading construct
+        // (counted/while loop, foldl list-op, or read+write conditional) must
+        // unwrap the construct's logical value rather than leak the raw
+        // `{value, StateAcc}` tuple (or crash dispatching a read+write
+        // conditional's stateful block at the wrong arity). This mirrors the
+        // implicit last-expression path (`generate_class_method_last_expr`);
+        // the shared helper applies the `{class_var_result, …}` wrapping based on
+        // `class_var_mutated()`, identical to the wrapping below — so it is
+        // correct for both the class-vars and no-class-vars cases.
+        if let Some(doc) = self.try_generate_class_method_threaded_last(value)? {
+            return Ok(doc);
+        }
         // BT-1942: Use `expression_doc_with_open_scope` so an explicit
         // `^ expr` where `expr` produces an open let-chain (e.g.
         // `(self tick) class` or any ProtoObject/Object intrinsic fed a
@@ -2324,6 +2336,12 @@ impl CoreErlangGenerator {
         &mut self,
         expr: &Expression,
     ) -> Result<Option<Document<'static>>> {
+        // BT-2358: see through redundant parentheses (e.g. `^(items collect: …)`
+        // or `(flag ifTrue: [...])`), which are semantically transparent, so the
+        // threading construct inside is unwrapped to its logical value rather than
+        // leaking its raw `{value, StateAcc}` tuple. Applies to both the explicit
+        // `^`-return and the implicit last-expression callers.
+        let expr = Self::peel_parens(expr);
         let mut parts: Vec<Document<'static>> = Vec::new();
         let result_var = if self.expr_yields_vt_threaded_tuple(expr) {
             self.emit_vt_threaded_tuple_unwrap_to_var(expr, &mut parts)?

--- a/stdlib/test/class_method_block_test.bt
+++ b/stdlib/test/class_method_block_test.bt
@@ -129,3 +129,24 @@ TestCase subclass: ClassMethodBlockTest
   testClassMethodInjectNonLastSelfSend =>
     result := ClassMethodBlock addCountingNonLast: #(1, 2, 3)
     self assert: result equals: #(6, 3)
+
+  // BT-2358: explicit `^` return of a parenthesized collect: returns the Array,
+  // not the raw {Array, StateAcc} tuple.
+  testClassMethodReturnCollect =>
+    result := ClassMethodBlock doubleCountingRet: #(1, 2, 3)
+    self assert: result equals: #(2, 4, 6)
+
+  // BT-2358: explicit `^` return of inject:into: (no parens) returns the accumulator.
+  testClassMethodReturnInject =>
+    result := ClassMethodBlock sumCountingRet: #(1, 2, 3)
+    self assert: result equals: 6
+
+  // BT-2358: explicit `^` return of a read+write conditional returns the branch value.
+  testClassMethodReturnConditionalTrue =>
+    result := ClassMethodBlock condRet: true
+    self assert: result equals: 7
+
+  // BT-2358: explicit `^` return of a read+write conditional returns nil when skipped.
+  testClassMethodReturnConditionalFalse =>
+    result := ClassMethodBlock condRet: false
+    self assert: result equals: nil

--- a/stdlib/test/fixtures/class_method_block.bt
+++ b/stdlib/test/fixtures/class_method_block.bt
@@ -117,6 +117,34 @@ Object subclass: ClassMethodBlock
     sum := 1
     flag ifTrue: [sum := sum + 10] ifFalse: [sum := sum + 100]
 
+  // BT-2358: explicit `^` return of a (parenthesized) foldl list-op that mutates a
+  // captured local. Must return the Array (threading the mutation), not the raw
+  // {Array, StateAcc} tuple.
+  class doubleCountingRet: items =>
+    n := 0
+    ^(items
+      collect: [:x |
+        n := n + 1
+        x * 2
+      ])
+
+  // BT-2358: explicit `^` return of a foldl list-op WITHOUT parens — returns the
+  // folded accumulator, threading the captured local.
+  class sumCountingRet: items =>
+    n := 0
+    ^items
+      inject: 0
+      into: [:acc :x |
+        n := n + 1
+        acc + x
+      ]
+
+  // BT-2358: explicit `^` return of a read+write conditional. Must return the
+  // branch value (no 0-arg stateful-block dispatch crash, no tuple leak).
+  class condRet: flag =>
+    sum := 0
+    ^(flag ifTrue: [sum := sum + 7])
+
   // BT-2350: predicate helper for the self-send + captured-local select: case.
   class isBig: x => x > 2
 


### PR DESCRIPTION
## Summary

Fixes BT-2358. BT-2349 (#2392) made the **implicit** last-expression path unwrap a `{value, StateAcc}` threading tuple for loops / foldl list-ops / read+write conditionals in class methods. The **explicit `^` return** path (`generate_class_method_return`) never got the same treatment, so:

- `^(items collect: [:x | n := n + 1. x * 2])` returned the raw `{Array, StateAcc}` tuple instead of the `Array`;
- `^(flag ifTrue: [sum := sum + 7])` dispatched a 1-arg `fun(StateAcc)` stateful block to `ifTrue:` → runtime arity crash.

## Fix

1. **`generate_class_method_return`** now calls `try_generate_class_method_threaded_last` first, mirroring the implicit path. That shared helper applies the `{class_var_result, …}` wrapping via `class_var_mutated()` — identical to the existing return-path wrapping, so it's correct for both the class-vars and no-class-vars cases.
2. **`try_generate_class_method_threaded_last`** now peels `Parenthesized` wrappers (reusing BT-2355's `peel_parens`), so `^(items collect: …)` / `^(flag ifTrue: …)` are recognised. This also closes a **latent gap on the implicit last-expr path**: a parenthesized threading construct as the last expression leaked there too (the issue's reproducer uses parens; I confirmed both paths were affected).

Generated Core Erlang after the fix: the foldl return is wrapped in `let _ThreadedResult = (…) in <unwrap to element(1)>`; the conditional becomes case-based (`let _Cond = flag in case …`) instead of the stateful-block dispatch.

## Tests

Added BUnit coverage in `class_method_block_test.bt` + fixture:

- `^(collect:)` (parenthesized) → `#(2, 4, 6)`
- `^inject:into:` (no parens) → `6`
- `^(ifTrue:)` read+write conditional → `7` (true) / `nil` (false)

## Verification

- Both reproducers compile to correct Core Erlang.
- Full `just test-bunit`: **2267 passed, 0 failed**.
- `cargo test -p beamtalk-core`: **4040 passed, 0 failed**.
- `just clippy`, `cargo fmt --check`, `just fmt-check-beamtalk`: clean.

## References

- BT-2358 (this issue; surfaced by Copilot review on #2392)
- BT-2349 (implicit-position sibling)
- BT-2355 (`peel_parens` reused here)

https://claude.ai/code/session_01Hu2pvPvwqbTRWGryEPNoCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu2pvPvwqbTRWGryEPNoCV)_