### PR TITLE
Value-type outer-local threading for count:/detect: and conditional/loop assign-RHS (BT-2359)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -878,3 +878,73 @@ fn test_match_array_pattern_duplicate_variable_emits_equality_check() {
         "Should extract second element into temp for equality check. Got:\n{code}"
     );
 }
+
+// BT-2359: value-type outer-local threading for count:/detect: predicates and
+// threading constructs used as a (parenthesized) assignment RHS.
+
+#[test]
+fn test_vt_count_predicate_threads_outer_local() {
+    // BT-2359: `count:` whose predicate read+writes a captured outer local must
+    // thread the mutation back so the post-`count:` read sees the final value.
+    let src = "Value subclass: V\n  state: dummy = 0\n\n  run =>\n    n := 0\n    #(1, 2, 3) count: [:i | n := n + 1. i > 0]\n    n\n";
+    let code = codegen(src);
+    eprintln!("Generated code for vt count: threading:\n{code}");
+    // The count: foldl packs the threaded local into the StateAcc; the open
+    // extraction must read it back via maps:get('__local__n', ...).
+    assert!(
+        code.contains("'__local__n'"),
+        "count: must thread the captured outer local 'n' via the StateAcc. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'lists':'foldl'"),
+        "count: with a mutating predicate must compile to a stateful lists:foldl. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_vt_detect_if_none_predicate_threads_outer_local() {
+    // BT-2359: `detect:ifNone:` whose predicate read+writes a captured outer
+    // local must thread the mutation back.
+    let src = "Value subclass: V\n  state: dummy = 0\n\n  run =>\n    n := 0\n    #(1, 2, 3) detect: [:i | n := n + 1. i > 10] ifNone: [-1]\n    n\n";
+    let code = codegen(src);
+    eprintln!("Generated code for vt detect:ifNone: threading:\n{code}");
+    assert!(
+        code.contains("'__local__n'"),
+        "detect:ifNone: must thread the captured outer local 'n' via the StateAcc. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_vt_loop_as_parenthesized_assign_rhs_threads_sibling_local() {
+    // BT-2359: a counted loop used as a parenthesized RHS — `_r := (1 to: 5 do:
+    // [...])` — must thread its sibling outer local (`sum`) into method scope.
+    let src = "Value subclass: V\n  state: dummy = 0\n\n  run =>\n    sum := 0\n    _r := (1 to: 5 do: [:i | sum := sum + i])\n    sum\n";
+    let code = codegen(src);
+    eprintln!("Generated code for vt parenthesized loop assign-RHS:\n{code}");
+    // The loop packs sum into the StateAcc; the assignment must extract it back
+    // (element 2 of the {value, StateAcc} tuple → maps:get('__local__sum', ...)).
+    assert!(
+        code.contains("'__local__sum'"),
+        "Parenthesized loop assign-RHS must thread sibling local 'sum'. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_vt_conditional_as_assign_rhs_threads_sibling_local() {
+    // BT-2359: a threading conditional as an assignment RHS — `_r := flag ifTrue:
+    // [x := 5. 42] ifFalse: [0]` — must bind the target to the branch's logical
+    // value AND thread the sibling local (`x`) into method scope.
+    let src = "Value subclass: V\n  state: dummy = 0\n\n  run: flag =>\n    x := 0\n    _r := flag ifTrue: [x := 5. 42] ifFalse: [0]\n    x\n";
+    let code = codegen(src);
+    eprintln!("Generated code for vt conditional assign-RHS:\n{code}");
+    // Each branch returns {LogicalValue, X}; the assignment binds the target to
+    // element 1 and rebinds x from element 2 of the case result.
+    assert!(
+        code.contains("'erlang':'element'(1,") && code.contains("'erlang':'element'(2,"),
+        "Conditional assign-RHS must extract logical value (element 1) and sibling local (element 2). Got:\n{code}"
+    );
+    assert!(
+        code.contains("case "),
+        "Conditional assign-RHS must compile to an inline case. Got:\n{code}"
+    );
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -948,3 +948,19 @@ fn test_vt_conditional_as_assign_rhs_threads_sibling_local() {
         "Conditional assign-RHS must compile to an inline case. Got:\n{code}"
     );
 }
+
+#[test]
+fn test_vt_nested_loop_in_conditional_assign_rhs_threads_local() {
+    // BT-2359 (CodeRabbit follow-up): a threaded loop *nested* inside an
+    // assign-RHS conditional branch must still rebind its outer local, so a
+    // later read in the same branch (and after) sees the update.
+    let src = "Value subclass: V\n  state: dummy = 0\n\n  run: flag =>\n    sum := 0\n    _r := flag ifTrue: [1 to: 5 do: [:i | sum := sum + i]. sum] ifFalse: [0]\n    sum\n";
+    let code = codegen(src);
+    eprintln!("Generated code for nested loop in conditional assign-RHS:\n{code}");
+    // The nested loop packs sum into its StateAcc; the branch must extract it
+    // back via maps:get('__local__sum', ...).
+    assert!(
+        code.contains("'__local__sum'"),
+        "Nested loop inside a conditional assign-RHS branch must thread 'sum'. Got:\n{code}"
+    );
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -2690,6 +2690,7 @@ impl CoreErlangGenerator {
 
     /// Inner implementation for [`Self::build_vt_conditional_value_and_mutations`], bracketed
     /// by `push_scope`/`pop_scope` so the fallible work always restores scope.
+    #[allow(clippy::too_many_lines)] // Branch threading dispatch spans many small arms
     fn build_vt_conditional_value_and_mutations_parts(
         &mut self,
         block: &crate::ast::Block,
@@ -2705,20 +2706,47 @@ impl CoreErlangGenerator {
                 if Self::is_local_var_assignment(body_expr) {
                     if let Expression::Assignment { target, value, .. } = body_expr {
                         if let Expression::Identifier(id) = target.as_ref() {
-                            let core_var = self
-                                .lookup_var(&id.name)
-                                .map_or_else(|| Self::to_core_erlang_var(&id.name), String::clone);
-                            let val_doc = self.expression_doc(value)?;
-                            parts.push(docvec![
-                                "let ",
-                                leaf::var(core_var.clone()),
-                                " = ",
-                                val_doc,
-                                " in ",
-                            ]);
-                            self.bind_var(&id.name, &core_var);
+                            // BT-2359: a nested threading construct as the assignment RHS —
+                            // mirror the method-body / branch-value paths so the outer local
+                            // is rebound (loop/foldl via emit_vt_threaded_local_assignment,
+                            // conditional via emit_vt_conditional_assign_rhs) instead of being
+                            // bound to the raw {value, StateAcc} tuple.
+                            let rhs = Self::peel_parens(value);
+                            if self.expr_yields_vt_threaded_tuple(value) {
+                                self.emit_vt_threaded_local_assignment(
+                                    &id.name, value, &mut parts,
+                                )?;
+                            } else if self.is_conditional_with_vt_local_threading(rhs) {
+                                self.emit_vt_conditional_assign_rhs(&id.name, rhs, &mut parts)?;
+                            } else {
+                                let core_var = self.lookup_var(&id.name).map_or_else(
+                                    || Self::to_core_erlang_var(&id.name),
+                                    String::clone,
+                                );
+                                let val_doc = self.expression_doc(value)?;
+                                parts.push(docvec![
+                                    "let ",
+                                    leaf::var(core_var.clone()),
+                                    " = ",
+                                    val_doc,
+                                    " in ",
+                                ]);
+                                self.bind_var(&id.name, &core_var);
+                            }
                         }
                     }
+                } else if self.expr_yields_vt_threaded_tuple(body_expr) {
+                    // BT-2359: a non-last threaded loop/foldl that mutates a captured local
+                    // returns {value, StateAcc}; extract and rebind the threaded locals so a
+                    // later expression in this branch sees the update (value discarded).
+                    let loop_doc = self.expression_doc(body_expr)?;
+                    let threaded_locals = self.vt_construct_threaded_locals(body_expr);
+                    parts.push(self.emit_vt_loop_open_extraction(
+                        loop_doc,
+                        &threaded_locals,
+                        "BranchThreadedResult",
+                        "BranchThreadedState",
+                    ));
                 } else {
                     let tmp = self.fresh_temp_var("seq");
                     let doc = self.expression_doc(body_expr)?;
@@ -2731,25 +2759,53 @@ impl CoreErlangGenerator {
             if Self::is_local_var_assignment(last_expr) {
                 if let Expression::Assignment { target, value, .. } = last_expr {
                     if let Expression::Identifier(id) = target.as_ref() {
-                        let core_var = self
-                            .lookup_var(&id.name)
-                            .map_or_else(|| Self::to_core_erlang_var(&id.name), String::clone);
-                        let val_doc = self.expression_doc(value)?;
-                        parts.push(docvec![
-                            "let ",
-                            leaf::var(core_var.clone()),
-                            " = ",
-                            val_doc,
-                            " in ",
-                        ]);
-                        self.bind_var(&id.name, &core_var);
-                        leaf::var(core_var)
+                        // BT-2359: a threaded construct as the final assignment RHS rebinds the
+                        // target via element 1 of its {value, StateAcc} tuple and threads any
+                        // sibling local; the block value is the rebound target.
+                        let rhs = Self::peel_parens(value);
+                        if self.expr_yields_vt_threaded_tuple(value) {
+                            let core_var = self
+                                .emit_vt_threaded_local_assignment(&id.name, value, &mut parts)?;
+                            leaf::var(core_var)
+                        } else if self.is_conditional_with_vt_local_threading(rhs) {
+                            let core_var =
+                                self.emit_vt_conditional_assign_rhs(&id.name, rhs, &mut parts)?;
+                            leaf::var(core_var)
+                        } else {
+                            let core_var = self
+                                .lookup_var(&id.name)
+                                .map_or_else(|| Self::to_core_erlang_var(&id.name), String::clone);
+                            let val_doc = self.expression_doc(value)?;
+                            parts.push(docvec![
+                                "let ",
+                                leaf::var(core_var.clone()),
+                                " = ",
+                                val_doc,
+                                " in ",
+                            ]);
+                            self.bind_var(&id.name, &core_var);
+                            leaf::var(core_var)
+                        }
                     } else {
                         self.expression_doc(last_expr)?
                     }
                 } else {
                     self.expression_doc(last_expr)?
                 }
+            } else if self.expr_yields_vt_threaded_tuple(last_expr) {
+                // BT-2359: a threaded construct as the block's logical value — its result is
+                // element 1 of the {value, StateAcc} tuple, not the raw tuple. The threaded
+                // locals don't need to escape in value position, so unwrap without extracting.
+                let tuple_var = self.fresh_temp_var("BranchThreadedResult");
+                let val_doc = self.expression_doc(last_expr)?;
+                parts.push(docvec![
+                    "let ",
+                    leaf::var(tuple_var.clone()),
+                    " = ",
+                    val_doc,
+                    " in ",
+                ]);
+                docvec!["call 'erlang':'element'(1, ", leaf::var(tuple_var), ")"]
             } else {
                 self.expression_doc(last_expr)?
             }

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -1040,6 +1040,11 @@ impl CoreErlangGenerator {
         &self,
         expr: &Expression,
     ) -> bool {
+        // BT-2359: a threading construct used as a (parenthesized) assignment RHS —
+        // `_r := (1 to: 5 do: [...])` — wraps the construct in `Expression::Parenthesized`.
+        // Peel the wrappers so the `{value, StateAcc}` predicates (which only match
+        // `MessageSend`) see the real construct.
+        let expr = Self::peel_parens(expr);
         self.is_while_with_vt_local_threading(expr)
             || self.is_counted_loop_with_vt_local_threading(expr)
             || self.is_foldl_list_op_with_vt_local_threading(expr)
@@ -1168,6 +1173,20 @@ impl CoreErlangGenerator {
                             let var_name = id.name.clone();
                             let core_var = self
                                 .emit_vt_threaded_local_assignment(&var_name, value, body_parts)?;
+                            if is_last {
+                                self.emit_vt_value_return(&core_var, has_nlr, body_parts);
+                            }
+                            return Ok(());
+                        }
+                        // BT-2359: a threading conditional as the assignment RHS — possibly
+                        // parenthesized — threads a sibling outer-local (`x`) that would
+                        // otherwise be dropped. Bind the target to the conditional's logical
+                        // value and rebind the threaded sibling from the same `case`.
+                        let rhs = Self::peel_parens(value);
+                        if self.is_conditional_with_vt_local_threading(rhs) {
+                            let var_name = id.name.clone();
+                            let core_var =
+                                self.emit_vt_conditional_assign_rhs(&var_name, rhs, body_parts)?;
                             if is_last {
                                 self.emit_vt_value_return(&core_var, has_nlr, body_parts);
                             }
@@ -1729,6 +1748,9 @@ impl CoreErlangGenerator {
         &self,
         expr: &Expression,
     ) -> Vec<String> {
+        // BT-2359: peel `Expression::Parenthesized` so a parenthesized construct
+        // (`(1 to: 5 do: [...])`) reports the same threaded locals its codegen packed.
+        let expr = Self::peel_parens(expr);
         if self.is_while_with_vt_local_threading(expr) {
             self.get_while_threaded_locals(expr)
         } else if self.is_counted_loop_with_vt_local_threading(expr) {
@@ -1904,9 +1926,9 @@ impl CoreErlangGenerator {
         ))
     }
 
-    /// BT-2342: Returns `true` if `expr` is a `collect:` / `select:` / `reject:` /
-    /// `inject:into:` foldl list-op whose body block captures and mutates outer local
-    /// variables in value-type or class-method context.
+    /// BT-2342/BT-2359: Returns `true` if `expr` is a `collect:` / `select:` / `reject:` /
+    /// `inject:into:` / `count:` / `detect:` / `detect:ifNone:` foldl list-op whose body
+    /// block captures and mutates outer local variables in value-type or class-method context.
     ///
     /// Mirrors `is_counted_loop_with_vt_local_threading`: only triggers when the list-op
     /// codegen will actually pack threaded locals into the `{value, StateAcc}` result
@@ -1925,11 +1947,15 @@ impl CoreErlangGenerator {
         !self.compute_threaded_locals_for_loop(body, None).is_empty()
     }
 
-    /// BT-2342: Returns the body block of a foldl list-op message send
-    /// (`collect:`, `select:`, `reject:`, `inject:into:`), or `None` if `expr` is not one.
+    /// BT-2342/BT-2359: Returns the body block of a foldl list-op message send
+    /// (`collect:`, `select:`, `reject:`, `inject:into:`, `count:`, `detect:`,
+    /// `detect:ifNone:`), or `None` if `expr` is not one.
     ///
-    /// The block argument position differs by selector: `collect:`/`select:`/`reject:`
-    /// take the block as their only argument; `inject:into:` takes it as the second.
+    /// The block argument position differs by selector: `collect:`/`select:`/`reject:`/
+    /// `count:`/`detect:`/`detect:ifNone:` take the predicate/transform block as their first
+    /// argument; `inject:into:` takes it as the second. All of these emit a `{value, StateAcc}`
+    /// result (state in element 2) when their body threads captured outer locals, so the
+    /// same open-let extraction applies uniformly.
     fn foldl_list_op_body_block(expr: &Expression) -> Option<&Block> {
         let Expression::MessageSend {
             selector: MessageSelector::Keyword(parts),
@@ -1941,8 +1967,11 @@ impl CoreErlangGenerator {
         };
         let sel: String = parts.iter().map(|p| p.keyword.as_str()).collect();
         let body_arg = match sel.as_str() {
-            "collect:" | "select:" | "reject:" if arguments.len() == 1 => &arguments[0],
+            "collect:" | "select:" | "reject:" | "count:" | "detect:" if arguments.len() == 1 => {
+                &arguments[0]
+            }
             "inject:into:" if arguments.len() == 2 => &arguments[1],
+            "detect:ifNone:" if arguments.len() == 2 => &arguments[0],
             _ => return None,
         };
         if let Expression::Block(body) = body_arg {
@@ -2508,6 +2537,257 @@ impl CoreErlangGenerator {
         self.rebind_vt_conditional_mutations(&mut docs, &all_mutations, &result_var);
 
         Ok(Document::Vec(docs))
+    }
+
+    /// BT-2359: Emits a threading conditional (`ifTrue:`/`ifFalse:`/`ifTrue:ifFalse:` whose
+    /// branches read+write a captured outer local) used as the RHS of an assignment to a
+    /// *different* local — `_r := flag ifTrue: [x := 5. 42] ifFalse: [0]` — binding the
+    /// assignment target (`_r`) to the conditional's logical branch value and rebinding each
+    /// threaded outer-local (`x`) from the same `case`, so the sibling mutation escapes into
+    /// the surrounding method scope.
+    ///
+    /// Each `case` branch returns `{LogicalValue, Mut1, ..., MutN}`; element 1 is bound to the
+    /// target and elements 2.. are rebound to the threaded locals. The non-writing arm of an
+    /// `ifTrue:`/`ifFalse:` passes the outer locals through unchanged (and yields `'nil'` as
+    /// its logical value, matching the conditional's run-time result when the branch is absent).
+    ///
+    /// Returns the Core Erlang variable bound to the assignment target.
+    #[allow(clippy::too_many_lines)] // Document-based conditional case scaffolding spans many lines
+    pub(in crate::codegen::core_erlang) fn emit_vt_conditional_assign_rhs(
+        &mut self,
+        var_name: &str,
+        expr: &Expression,
+        body_parts: &mut Vec<Document<'static>>,
+    ) -> Result<String> {
+        let (receiver, selector_name, arguments) = match expr {
+            Expression::MessageSend {
+                receiver,
+                selector: MessageSelector::Keyword(parts),
+                arguments,
+                ..
+            } => {
+                let sel: String = parts.iter().map(|p| p.keyword.as_str()).collect();
+                (receiver.as_ref(), sel, arguments)
+            }
+            _ => unreachable!("emit_vt_conditional_assign_rhs called on non-conditional"),
+        };
+
+        // Collect all outer-scope mutations across every block argument (stable order).
+        let mut all_mutations: Vec<String> = Vec::new();
+        for arg in arguments {
+            if let Expression::Block(block) = arg {
+                for var in self.outer_scope_mutations_in_block(block) {
+                    if !all_mutations.contains(&var) {
+                        all_mutations.push(var);
+                    }
+                }
+            }
+        }
+
+        let cond_var = self.fresh_temp_var("Cond");
+        let cond_doc = self.expression_doc(receiver)?;
+        body_parts.push(docvec![
+            "    let ",
+            leaf::var(cond_var.clone()),
+            " = ",
+            cond_doc,
+            " in\n",
+        ]);
+
+        let (true_branch, false_branch) = match selector_name.as_str() {
+            "ifTrue:" => {
+                let Expression::Block(block) = &arguments[0] else {
+                    unreachable!("ifTrue: argument is not a block");
+                };
+                let tb = self.build_vt_conditional_value_and_mutations(block, &all_mutations)?;
+                let fb = self.build_vt_conditional_passthrough_with_value(&all_mutations);
+                (tb, fb)
+            }
+            "ifFalse:" => {
+                let Expression::Block(block) = &arguments[0] else {
+                    unreachable!("ifFalse: argument is not a block");
+                };
+                let passthrough = self.build_vt_conditional_passthrough_with_value(&all_mutations);
+                let fb = self.build_vt_conditional_value_and_mutations(block, &all_mutations)?;
+                (passthrough, fb)
+            }
+            "ifTrue:ifFalse:" => {
+                let Expression::Block(true_block) = &arguments[0] else {
+                    unreachable!("ifTrue:ifFalse: first argument is not a block");
+                };
+                let Expression::Block(false_block) = &arguments[1] else {
+                    unreachable!("ifTrue:ifFalse: second argument is not a block");
+                };
+                let tb =
+                    self.build_vt_conditional_value_and_mutations(true_block, &all_mutations)?;
+                let fb =
+                    self.build_vt_conditional_value_and_mutations(false_block, &all_mutations)?;
+                (tb, fb)
+            }
+            _ => unreachable!("unsupported conditional selector in assign-rhs path"),
+        };
+
+        let result_var = self.fresh_temp_var("CondAssign");
+        body_parts.push(docvec![
+            "    let ",
+            leaf::var(result_var.clone()),
+            " = case ",
+            leaf::var(cond_var),
+            " of <'true'> when 'true' -> ",
+            true_branch,
+            " <'false'> when 'true' -> ",
+            false_branch,
+            " end in\n",
+        ]);
+
+        // Element 1 of the branch tuple is the conditional's logical value → bind the target.
+        let core_var = self
+            .lookup_var(var_name)
+            .map_or_else(|| Self::to_core_erlang_var(var_name), String::clone);
+        body_parts.push(docvec![
+            "    let ",
+            leaf::var(core_var.clone()),
+            " = call 'erlang':'element'(1, ",
+            leaf::var(result_var.clone()),
+            ") in\n",
+        ]);
+        self.bind_var(var_name, &core_var);
+
+        // Elements 2.. are the threaded outer-locals → rebind each (skip the target itself).
+        for (i, var) in all_mutations.iter().enumerate() {
+            if var == var_name {
+                continue;
+            }
+            let tl_core = self.fresh_var(var);
+            body_parts.push(docvec![
+                "    let ",
+                leaf::var(tl_core.clone()),
+                " = call 'erlang':'element'(",
+                leaf::int_lit(i64::try_from(i + 2).unwrap_or(i64::MAX)),
+                ", ",
+                leaf::var(result_var.clone()),
+                ") in\n",
+            ]);
+            self.bind_var(var, &tl_core);
+        }
+
+        Ok(core_var)
+    }
+
+    /// BT-2359: Builds a conditional branch for the assign-RHS path, inlining the block body
+    /// and returning `{LogicalValue, Mut1, ..., MutN}` — the branch's logical value followed by
+    /// the post-branch values of every threaded outer-local in `all_mutations`.
+    fn build_vt_conditional_value_and_mutations(
+        &mut self,
+        block: &crate::ast::Block,
+        all_mutations: &[String],
+    ) -> Result<Document<'static>> {
+        self.push_scope();
+        let result = self.build_vt_conditional_value_and_mutations_parts(block, all_mutations);
+        self.pop_scope();
+        result
+    }
+
+    /// Inner implementation for [`Self::build_vt_conditional_value_and_mutations`], bracketed
+    /// by `push_scope`/`pop_scope` so the fallible work always restores scope.
+    fn build_vt_conditional_value_and_mutations_parts(
+        &mut self,
+        block: &crate::ast::Block,
+        all_mutations: &[String],
+    ) -> Result<Document<'static>> {
+        let body = super::util::collect_body_exprs(&block.body);
+        let mut parts: Vec<Document<'static>> = Vec::new();
+        let value_doc = if body.is_empty() {
+            Document::Str("'nil'")
+        } else {
+            let last = body.len() - 1;
+            for body_expr in &body[..last] {
+                if Self::is_local_var_assignment(body_expr) {
+                    if let Expression::Assignment { target, value, .. } = body_expr {
+                        if let Expression::Identifier(id) = target.as_ref() {
+                            let core_var = self
+                                .lookup_var(&id.name)
+                                .map_or_else(|| Self::to_core_erlang_var(&id.name), String::clone);
+                            let val_doc = self.expression_doc(value)?;
+                            parts.push(docvec![
+                                "let ",
+                                leaf::var(core_var.clone()),
+                                " = ",
+                                val_doc,
+                                " in ",
+                            ]);
+                            self.bind_var(&id.name, &core_var);
+                        }
+                    }
+                } else {
+                    let tmp = self.fresh_temp_var("seq");
+                    let doc = self.expression_doc(body_expr)?;
+                    parts.push(docvec!["let ", leaf::var(tmp), " = ", doc, " in ",]);
+                }
+            }
+            // The block's logical value is its last expression — for an assignment, the
+            // assigned value (also rebinding the target so the mutation is reflected below).
+            let last_expr = body[last];
+            if Self::is_local_var_assignment(last_expr) {
+                if let Expression::Assignment { target, value, .. } = last_expr {
+                    if let Expression::Identifier(id) = target.as_ref() {
+                        let core_var = self
+                            .lookup_var(&id.name)
+                            .map_or_else(|| Self::to_core_erlang_var(&id.name), String::clone);
+                        let val_doc = self.expression_doc(value)?;
+                        parts.push(docvec![
+                            "let ",
+                            leaf::var(core_var.clone()),
+                            " = ",
+                            val_doc,
+                            " in ",
+                        ]);
+                        self.bind_var(&id.name, &core_var);
+                        leaf::var(core_var)
+                    } else {
+                        self.expression_doc(last_expr)?
+                    }
+                } else {
+                    self.expression_doc(last_expr)?
+                }
+            } else {
+                self.expression_doc(last_expr)?
+            }
+        };
+
+        // Return {LogicalValue, Mut1, ..., MutN}.
+        let mut tuple_parts: Vec<Document<'static>> = vec![Document::Str("{"), value_doc];
+        for var in all_mutations {
+            tuple_parts.push(Document::Str(", "));
+            let core_var = self
+                .lookup_var(var)
+                .cloned()
+                .unwrap_or_else(|| Self::to_core_erlang_var(var));
+            tuple_parts.push(leaf::var(core_var));
+        }
+        tuple_parts.push(Document::Str("}"));
+        parts.push(Document::Vec(tuple_parts));
+        Ok(Document::Vec(parts))
+    }
+
+    /// BT-2359: Pass-through branch for the assign-RHS path — the conditional's logical value
+    /// is `'nil'` (the absent branch's run-time result) and every threaded outer-local keeps
+    /// its current (pre-conditional) value: `{'nil', Mut1, ..., MutN}`.
+    fn build_vt_conditional_passthrough_with_value(
+        &self,
+        all_mutations: &[String],
+    ) -> Document<'static> {
+        let mut tuple_parts: Vec<Document<'static>> = vec![Document::Str("{'nil'")];
+        for var in all_mutations {
+            tuple_parts.push(Document::Str(", "));
+            let core_var = self
+                .lookup_var(var)
+                .cloned()
+                .unwrap_or_else(|| Self::to_core_erlang_var(var));
+            tuple_parts.push(leaf::var(core_var));
+        }
+        tuple_parts.push(Document::Str("}"));
+        Document::Vec(tuple_parts)
     }
 
     /// Generates a branch body for a VT conditional that inlines the block and returns

--- a/stdlib/test/value_type_mutation_matrix_test.bt
+++ b/stdlib/test/value_type_mutation_matrix_test.bt
@@ -50,8 +50,10 @@ TestCase subclass: ValueTypeMutationMatrixTest
   // Pending switch for BT-2359 value-type outer-local threading gaps that
   // BT-2342 did NOT cover: count:/detect: foldl predicates, and a threading
   // construct (loop/conditional) used as a parenthesized assignment RHS that
-  // threads a *sibling* outer local. Flip to `false` once BT-2359 lands.
-  bt2359Pending => true
+  // threads a *sibling* outer local. BT-2359 has landed, so the affected
+  // value-type cells now run their ground-truth asserts. Kept as a switch for
+  // documentation/bisection.
+  bt2359Pending => false
 
   // ── TestCase-context fragments (the test class is itself a value-type) ──────
   // `frag` prefix keeps BUnit from treating them as test methods.


### PR DESCRIPTION
## Summary

Value-type counterpart of BT-2355 (Actor) and follow-up to BT-2342. Fixes two value-type / TestCase-context codegen gaps where a captured outer-local mutation was dropped (the post-construct read returned the stale value).

Linear: https://linear.app/beamtalk/issue/BT-2359

## Root causes & fixes

1. **`count:` / `detect:` / `detect:ifNone:` dropped the threaded local.** The value-type foldl-list-op selector set in `foldl_list_op_body_block` was hardcoded to `collect:`/`select:`/`reject:`/`inject:into:`. The three predicate ops already emit the uniform `{value, StateAcc}` result (state in element 2) when their body threads an outer local, so adding them to the set makes the existing open-let extraction apply unchanged.

2. **Threading construct as a (parenthesized) assignment RHS dropped the sibling local.**
   - *Loop* (`_r := (1 to: 5 do: [:i | sum := sum + i])`): `expr_yields_vt_threaded_tuple` and `vt_construct_threaded_locals` now peel `Expression::Parenthesized` (via the existing `peel_parens` helper), so the construct is recognized and `emit_vt_threaded_local_assignment`'s sibling-rebind machinery threads `sum`.
   - *Conditional* (`_r := flag ifTrue: [x := 5. 42] ifFalse: [0]`): new `emit_vt_conditional_assign_rhs` emits each `case` branch as `{LogicalValue, Mut1, ..., MutN}`, binds the target to element 1 and rebinds each threaded sibling local from the rest.

## Key changes

- `crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs` — predicate-op set, paren-peel, conditional-assign-RHS path.
- `stdlib/test/value_type_mutation_matrix_test.bt` — `bt2359Pending => false`; the four gated cells now assert ground truth (count=3, detect=3, loop=15, conditional=5).
- `crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs` — 4 codegen unit tests.

## Tests

- 4 previously-skipped value-type matrix cells now pass (BUnit total +4 vs main).
- 4 new codegen unit tests; full `beamtalk-core` lib suite green (4045 passed). stdlib 250/250. clippy + fmt clean.
- Note: pre-existing unrelated BUnit failure `GenericStdlibTest testArrayAtPutReturnsArray` is tracked separately as BT-2362 (fails on clean main too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of parenthesized threading constructs when used in conditional assignments.
  * Expanded support for additional list operations with threading functionality.

* **Tests**
  * Enabled comprehensive regression test suite verifying correct threading behavior in conditional assignments and list operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->