### PR TITLE
Add a class-method context to the mutation coverage matrix (BT-2360)

### DIFF
--- a/stdlib/test/fixtures/mutation_corpus_class_method.bt
+++ b/stdlib/test/fixtures/mutation_corpus_class_method.bt
@@ -1,0 +1,203 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2360: Shared mutation-fragment corpus — class-method context.
+//
+// Peer of mutation_corpus_value.bt (Value subclass) and mutation_corpus_actor.bt
+// (Actor). Exposes the SAME fragment method names as those corpora, but as
+// *class methods* (ADR 0048 — prefix `class`, called on the class name directly),
+// so the outer-local threading runs in class-method codegen.
+//
+// Class-method block threading was hardened by BT-2349 (loops / foldl list-ops /
+// conditionals in last / non-last / assignment-RHS positions), BT-2350 (collect:/
+// select:/inject:into: combining a self-send and a captured local), and BT-2358
+// (explicit `^` return of a threading construct). All three have landed, so these
+// fragments thread correctly and the matrix asserts their ground-truth values.
+//
+// Each method is one corpus fragment, named `<construct><Position><WriteMode>`,
+// and returns the *final threaded value* of an outer local mutated inside the
+// construct — identical semantics to the value/actor corpora (same expected
+// ground-truth values). See mutation_corpus_value.bt for the axis legend.
+
+Object subclass: MutationCorpusClassMethod
+
+  // ── to:do: ────────────────────────────────────────────────────────────────
+  class toDoNonLastWriteOnly =>
+    last := 0
+    1 to: 5 do: [:i | last := i]
+    last
+
+  class toDoNonLastReadWrite =>
+    sum := 0
+    1 to: 5 do: [:i | sum := sum + i]
+    sum
+
+  class toDoAssignRhsReadWrite =>
+    sum := 0
+    _r := (1 to: 5 do: [:i | sum := sum + i])
+    sum
+
+  // ── to:by:do: ───────────────────────────────────────────────────────────────
+  class toByDoNonLastWriteOnly =>
+    last := 0
+    1
+      to: 10
+      by: 2
+      do: [:i | last := i]
+    last
+
+  class toByDoNonLastReadWrite =>
+    sum := 0
+    1
+      to: 10
+      by: 2
+      do: [:i | sum := sum + i]
+    sum
+
+  // ── timesRepeat: ────────────────────────────────────────────────────────────
+  class timesRepeatNonLastWriteOnly =>
+    last := 0
+    3 timesRepeat: [last := 7]
+    last
+
+  class timesRepeatNonLastReadWrite =>
+    count := 0
+    5 timesRepeat: [count := count + 1]
+    count
+
+  // ── whileTrue: ──────────────────────────────────────────────────────────────
+  class whileTrueNonLastReadWrite =>
+    n := 0
+    [n < 5] whileTrue: [n := n + 1]
+    n
+
+  // ── whileFalse: ─────────────────────────────────────────────────────────────
+  class whileFalseNonLastReadWrite =>
+    n := 0
+    [n >= 5] whileFalse: [n := n + 1]
+    n
+
+  // ── (1 to: n) do: ──────────────────────────────────────────────────────────
+  class rangeDoNonLastReadWrite =>
+    sum := 0
+    (1 to: 5) do: [:i | sum := sum + i]
+    sum
+
+  // ── collect: ────────────────────────────────────────────────────────────────
+  // NonLast: collect is a bare side-effect statement; result is discarded.
+  class collectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3)
+      collect: [:i |
+        n := n + 1
+        i * 2
+      ]
+    n
+
+  // AssignRhs: collect result is bound to a local (different codegen path).
+  class collectAssignRhsReadWrite =>
+    n := 0
+    _r := #(1, 2, 3)
+      collect: [:i |
+        n := n + 1
+        i * 2
+      ]
+    n
+
+  // ── select: ─────────────────────────────────────────────────────────────────
+  class selectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3, 4)
+      select: [:i |
+        n := n + 1
+        i > 2
+      ]
+    n
+
+  // ── reject: ─────────────────────────────────────────────────────────────────
+  class rejectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3, 4)
+      reject: [:i |
+        n := n + 1
+        i > 2
+      ]
+    n
+
+  // ── inject:into: ─────────────────────────────────────────────────────────────
+  // NonLast: inject result is discarded; only the outer local matters.
+  class injectNonLastReadWrite =>
+    t := 0
+    #(1, 2, 3)
+      inject: 0
+      into: [:a :b |
+        t := t + b
+        a + b
+      ]
+    t
+
+  // AssignRhs: inject result bound to a local.
+  class injectAssignRhsReadWrite =>
+    t := 0
+    _r := #(1, 2, 3)
+      inject: 0
+      into: [:a :b |
+        t := t + b
+        a + b
+      ]
+    t
+
+  // ── detect: ─────────────────────────────────────────────────────────────────
+  class detectNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3)
+      detect: [:i |
+        n := n + 1
+        i > 10
+      ]
+      ifNone: [-1]
+    n
+
+  // ── count: ──────────────────────────────────────────────────────────────────
+  class countNonLastReadWrite =>
+    n := 0
+    #(1, 2, 3)
+      count: [:i |
+        n := n + 1
+        i > 0
+      ]
+    n
+
+  // ── ifTrue: ─────────────────────────────────────────────────────────────────
+  // Conditions are passed in (not literals) so the always-true/false lint does
+  // not fire; callers pass `true` to drive the threading path.
+  class ifTrueNonLastWriteOnly: flag =>
+    m := 0
+    flag ifTrue: [m := 9]
+    m
+
+  class ifTrueNonLastReadWrite: flag =>
+    sum := 0
+    flag ifTrue: [sum := sum + 7]
+    sum
+
+  // read+write conditional as the last expression.
+  class ifTrueLastReadWrite: flag =>
+    sum := 0
+    flag ifTrue: [sum := sum + 7]
+
+  // ── ifTrue:ifFalse: ──────────────────────────────────────────────────────────
+  class ifTrueIfFalseNonLastReadWrite: flag =>
+    x := 1
+    flag ifTrue: [x := x + 1] ifFalse: [x := x + 100]
+    x
+
+  class ifTrueIfFalseAssignRhsReadWrite: flag =>
+    x := 0
+    _r := flag
+      ifTrue: [
+        x := 5
+        42
+      ]
+      ifFalse: [0]
+    x

--- a/stdlib/test/value_type_mutation_matrix_test.bt
+++ b/stdlib/test/value_type_mutation_matrix_test.bt
@@ -11,8 +11,9 @@
 // see. The two oracles are only jointly complete because they share one
 // fragment corpus:
 //
-//   stdlib/test/fixtures/mutation_corpus_value.bt   (Value subclass context)
-//   stdlib/test/fixtures/mutation_corpus_actor.bt   (Actor context)
+//   stdlib/test/fixtures/mutation_corpus_value.bt          (Value subclass context)
+//   stdlib/test/fixtures/mutation_corpus_actor.bt          (Actor context)
+//   stdlib/test/fixtures/mutation_corpus_class_method.bt   (class-method context, BT-2360)
 //
 // plus the TestCase-context fragments defined as `frag*` helpers in this file.
 // BT-2345, when it lands, consumes the same fragment names for its equality
@@ -28,6 +29,11 @@
 // remaining `skip`ped cells track still-open gaps: BT-2355 (Actor-context
 // outer-local threading) and BT-2359 (value-type count:/detect: predicates and
 // parenthesized assignment-RHS threading). Loop regression cells come from BT-2308.
+//
+// BT-2360 adds the class-method context (`*ClassMethod` cells, fragments in
+// mutation_corpus_class_method.bt). Class-method block threading was hardened by
+// BT-2349/BT-2350/BT-2358 (all landed), so these cells run their ground-truth
+// asserts un-gated.
 
 TestCase subclass: ValueTypeMutationMatrixTest
 
@@ -54,6 +60,15 @@ TestCase subclass: ValueTypeMutationMatrixTest
   // value-type cells now run their ground-truth asserts. Kept as a switch for
   // documentation/bisection.
   bt2359Pending => false
+
+  // Pending switch for BT-2371: in class-method context, a conditional
+  // (ifTrue:ifFalse:) used as a *parenthesized assignment RHS* still drops the
+  // sibling outer-local mutation (returns 0 instead of 5). BT-2359 fixed this in
+  // value_type_codegen.rs, but class methods route through a separate
+  // class-method block-threading path (BT-2349/BT-2350/BT-2358) that covered the
+  // loop paren-assign-RHS shape and count:/detect: predicates but NOT the
+  // conditional paren-assign-RHS shape. Flip off when BT-2371 lands.
+  bt2360ClassMethodCondAssignRhsPending => true
 
   // ── TestCase-context fragments (the test class is itself a value-type) ──────
   // `frag` prefix keeps BUnit from treating them as test methods.
@@ -119,6 +134,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   testToDoNonLastWriteOnlyTestCase =>
     self assert: self fragToDoNonLastWriteOnly equals: 5
 
+  testToDoNonLastWriteOnlyClassMethod =>
+    self assert: MutationCorpusClassMethod toDoNonLastWriteOnly equals: 5
+
   // to:do: × non-last × read+write
   testToDoNonLastReadWriteValue =>
     self assert: self valueCorpus toDoNonLastReadWrite equals: 15
@@ -128,6 +146,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
 
   testToDoNonLastReadWriteTestCase =>
     self assert: self fragToDoNonLastReadWrite equals: 15
+
+  testToDoNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod toDoNonLastReadWrite equals: 15
 
   // to:do: × local-assignment RHS × read+write
   testToDoAssignRhsReadWriteValue =>
@@ -144,6 +165,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
       ]
     self assert: self actorCorpus toDoAssignRhsReadWrite equals: 15
 
+  testToDoAssignRhsReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod toDoAssignRhsReadWrite equals: 15
+
   // ════════════════════════════════════════════════════════════════════════
   //  to:by:do:  — BT-2308 regression cells
   // ════════════════════════════════════════════════════════════════════════
@@ -152,6 +176,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
 
   testToByDoNonLastWriteOnlyActor =>
     self assert: self actorCorpus toByDoNonLastWriteOnly equals: 9
+
+  testToByDoNonLastWriteOnlyClassMethod =>
+    self assert: MutationCorpusClassMethod toByDoNonLastWriteOnly equals: 9
 
   testToByDoNonLastReadWriteValue =>
     self assert: self valueCorpus toByDoNonLastReadWrite equals: 25
@@ -162,6 +189,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   testToByDoNonLastReadWriteTestCase =>
     self assert: self fragToByDoNonLastReadWrite equals: 25
 
+  testToByDoNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod toByDoNonLastReadWrite equals: 25
+
   // ════════════════════════════════════════════════════════════════════════
   //  timesRepeat:  — BT-2308 regression cells
   // ════════════════════════════════════════════════════════════════════════
@@ -171,6 +201,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   testTimesRepeatNonLastWriteOnlyActor =>
     self assert: self actorCorpus timesRepeatNonLastWriteOnly equals: 7
 
+  testTimesRepeatNonLastWriteOnlyClassMethod =>
+    self assert: MutationCorpusClassMethod timesRepeatNonLastWriteOnly equals: 7
+
   testTimesRepeatNonLastReadWriteValue =>
     self assert: self valueCorpus timesRepeatNonLastReadWrite equals: 5
 
@@ -179,6 +212,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
 
   testTimesRepeatNonLastReadWriteTestCase =>
     self assert: self fragTimesRepeatNonLastReadWrite equals: 5
+
+  testTimesRepeatNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod timesRepeatNonLastReadWrite equals: 5
 
   // ════════════════════════════════════════════════════════════════════════
   //  whileTrue: / whileFalse:
@@ -192,6 +228,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   testWhileTrueNonLastReadWriteTestCase =>
     self assert: self fragWhileTrueNonLastReadWrite equals: 5
 
+  testWhileTrueNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod whileTrueNonLastReadWrite equals: 5
+
   testWhileFalseNonLastReadWriteValue =>
     self assert: self valueCorpus whileFalseNonLastReadWrite equals: 5
 
@@ -200,6 +239,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
 
   testWhileFalseNonLastReadWriteTestCase =>
     self assert: self fragWhileFalseNonLastReadWrite equals: 5
+
+  testWhileFalseNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod whileFalseNonLastReadWrite equals: 5
 
   // ════════════════════════════════════════════════════════════════════════
   //  (1 to: n) do:
@@ -213,6 +255,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   testRangeDoNonLastReadWriteTestCase =>
     self assert: self fragRangeDoNonLastReadWrite equals: 15
 
+  testRangeDoNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod rangeDoNonLastReadWrite equals: 15
+
   // ════════════════════════════════════════════════════════════════════════
   //  collect:  — BT-2342 (failure mode A): value-type leaks value+state tuple
   // ════════════════════════════════════════════════════════════════════════
@@ -225,6 +270,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   testCollectNonLastReadWriteActor =>
     self assert: self actorCorpus collectNonLastReadWrite equals: 3
 
+  testCollectNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod collectNonLastReadWrite equals: 3
+
   testCollectAssignRhsReadWriteValue =>
     self bt2342Pending
       ifTrue: [
@@ -234,6 +282,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
 
   testCollectAssignRhsReadWriteActor =>
     self assert: self actorCorpus collectAssignRhsReadWrite equals: 3
+
+  testCollectAssignRhsReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod collectAssignRhsReadWrite equals: 3
 
   // ════════════════════════════════════════════════════════════════════════
   //  select: / reject:  — BT-2342 (failure mode A)
@@ -247,6 +298,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   testSelectNonLastReadWriteActor =>
     self assert: self actorCorpus selectNonLastReadWrite equals: 4
 
+  testSelectNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod selectNonLastReadWrite equals: 4
+
   testRejectNonLastReadWriteValue =>
     self bt2342Pending ifTrue: [
       ^self skip: "BT-2342: reject: leaks value+state tuple in value-type context"
@@ -255,6 +309,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
 
   testRejectNonLastReadWriteActor =>
     self assert: self actorCorpus rejectNonLastReadWrite equals: 4
+
+  testRejectNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod rejectNonLastReadWrite equals: 4
 
   // ════════════════════════════════════════════════════════════════════════
   //  inject:into:  — BT-2342 (failure mode A)
@@ -269,6 +326,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   testInjectNonLastReadWriteActor =>
     self assert: self actorCorpus injectNonLastReadWrite equals: 6
 
+  testInjectNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod injectNonLastReadWrite equals: 6
+
   testInjectAssignRhsReadWriteValue =>
     self bt2342Pending
       ifTrue: [
@@ -278,6 +338,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
 
   testInjectAssignRhsReadWriteActor =>
     self assert: self actorCorpus injectAssignRhsReadWrite equals: 6
+
+  testInjectAssignRhsReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod injectAssignRhsReadWrite equals: 6
 
   // ════════════════════════════════════════════════════════════════════════
   //  detect: / count:  — BT-2342 (failure mode A, foldl predicate)
@@ -295,6 +358,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
     ]
     self assert: self actorCorpus detectNonLastReadWrite equals: 3
 
+  testDetectNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod detectNonLastReadWrite equals: 3
+
   testCountNonLastReadWriteValue =>
     self bt2359Pending
       ifTrue: [
@@ -307,6 +373,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
       ^self skip: "BT-2355: count: does not thread outer local in Actor context"
     ]
     self assert: self actorCorpus countNonLastReadWrite equals: 3
+
+  testCountNonLastReadWriteClassMethod =>
+    self assert: MutationCorpusClassMethod countNonLastReadWrite equals: 3
 
   // ════════════════════════════════════════════════════════════════════════
   //  ifTrue:  (conditionals)
@@ -323,6 +392,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
       ]
     self assert: (self actorCorpus ifTrueNonLastWriteOnly: true) equals: 9
 
+  testIfTrueNonLastWriteOnlyClassMethod =>
+    self assert: (MutationCorpusClassMethod ifTrueNonLastWriteOnly: true) equals: 9
+
   // read+write conditional, non-last
   testIfTrueNonLastReadWriteValue =>
     self assert: (self valueCorpus ifTrueNonLastReadWrite: true) equals: 7
@@ -337,6 +409,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   testIfTrueNonLastReadWriteTestCase =>
     self assert: (self fragIfTrueNonLastReadWrite: true) equals: 7
 
+  testIfTrueNonLastReadWriteClassMethod =>
+    self assert: (MutationCorpusClassMethod ifTrueNonLastReadWrite: true) equals: 7
+
   // BT-2342 (failure mode B): read+write conditional as last expression
   testIfTrueLastReadWriteValue =>
     self bt2342Pending
@@ -347,6 +422,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
 
   testIfTrueLastReadWriteActor =>
     self assert: (self actorCorpus ifTrueLastReadWrite: true) equals: 7
+
+  testIfTrueLastReadWriteClassMethod =>
+    self assert: (MutationCorpusClassMethod ifTrueLastReadWrite: true) equals: 7
 
   // ════════════════════════════════════════════════════════════════════════
   //  ifTrue:ifFalse:
@@ -364,6 +442,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   testIfTrueIfFalseNonLastReadWriteTestCase =>
     self assert: (self fragIfTrueIfFalseNonLastReadWrite: true) equals: 2
 
+  testIfTrueIfFalseNonLastReadWriteClassMethod =>
+    self assert: (MutationCorpusClassMethod ifTrueIfFalseNonLastReadWrite: true) equals: 2
+
   testIfTrueIfFalseAssignRhsReadWriteValue =>
     self bt2359Pending
       ifTrue: [
@@ -377,3 +458,10 @@ TestCase subclass: ValueTypeMutationMatrixTest
         ^self skip: "BT-2355: conditional local-assignment drops threading in Actor method body"
       ]
     self assert: (self actorCorpus ifTrueIfFalseAssignRhsReadWrite: true) equals: 5
+
+  testIfTrueIfFalseAssignRhsReadWriteClassMethod =>
+    self bt2360ClassMethodCondAssignRhsPending
+      ifTrue: [
+        ^self skip: "BT-2371: conditional as a parenthesized assignment RHS drops sibling-local threading in class-method context"
+      ]
+    self assert: (MutationCorpusClassMethod ifTrueIfFalseAssignRhsReadWrite: true) equals: 5


### PR DESCRIPTION
Closes [BT-2360](https://linear.app/beamtalk/issue/BT-2360).

## Summary

Adds a **class-method** peer context to the absolute mutation-coverage matrix (`stdlib/test/value_type_mutation_matrix_test.bt`), closing the gap called out by BT-2346 (which only filled Value / Actor / TestCase). Class methods are exactly where the most recent outer-local threading divergences lived (BT-2349/BT-2350/BT-2358), so a dense class-method context turns those fixes into a regression wall.

This is a **test-only** change — no codegen or runtime touched.

## Key changes

- **New fixture** `stdlib/test/fixtures/mutation_corpus_class_method.bt`: the value corpus mirrored as `class` methods (ADR 0048 — prefix `class`, called on the class name directly), exposing the same fragment method names so threading runs in class-method codegen.
- **24 new `test...ClassMethod` cells** in the matrix test covering every construct × position × write-mode the Value/Actor contexts already cover (toDo, toByDo, timesRepeat, whileTrue, whileFalse, rangeDo, collect, select, reject, inject, detect, count, ifTrue, ifTrueIfFalse — incl. non-last / write-only / read-write / assign-RHS / last variants). Each asserts the same ground-truth final value as the peer contexts.

## Empirical gating result

All class-method cells **pass un-gated** except one. Verified by running:
- `count:` / `detect:` predicates → **pass** (class-method codegen threads them).
- loop paren-assign-RHS (`toDoAssignRhsReadWrite`) → **pass**.
- conditional paren-assign-RHS (`ifTrueIfFalseAssignRhsReadWrite`) → **fails** (returns 0, expected 5): the parenthesized `ifTrue:ifFalse:` assignment-RHS still drops the sibling outer-local mutation in class-method context.

This is a distinct, class-method-specific gap (BT-2359 fixed the value-type path in `value_type_codegen.rs`; class methods use a separate threading path). It is gated behind a new documented `bt2360ClassMethodCondAssignRhsPending => true` switch referencing the follow-up issue **[BT-2371](https://linear.app/beamtalk/issue/BT-2371)**.

Matrix test result: 77 passed, 1 skipped (the BT-2371-gated cell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for class method contexts across multiple Smalltalk language constructs including loops, collections, and conditionals.
  * Added comprehensive test scenarios covering non-last positioning and assignment right-hand side threading variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->