### PR TITLE
Class-method context drops sibling-local threading for a conditional used as a parenthesized assignment RHS (BT-2371)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -2545,6 +2545,19 @@ impl CoreErlangGenerator {
                     self.emit_vt_threaded_local_assignment(&id.name, value, &mut parts)?;
                     return Ok(Document::Vec(parts));
                 }
+                // BT-2371: When the RHS is a read+write conditional (`ifTrue:`/`ifFalse:`/
+                // `ifTrue:ifFalse:` whose branches mutate sibling outer-locals), each branch
+                // emits `{LogicalValue, Mut1..MutN}`. Bind the target to element 1 and rebind
+                // the threaded siblings from elements 2.., so a later read of a sibling local
+                // sees the branch's mutation rather than its pre-conditional value. This is the
+                // class-method-context analogue of the value-type fix (BT-2359). See-through
+                // parentheses first (BT-2358), mirroring the loop/foldl assign-RHS path.
+                let rhs = Self::peel_parens(value);
+                if self.is_conditional_with_vt_local_threading(rhs) {
+                    let mut parts: Vec<Document<'static>> = Vec::new();
+                    self.emit_vt_conditional_assign_rhs(&id.name, rhs, &mut parts)?;
+                    return Ok(Document::Vec(parts));
+                }
                 let var_name = &id.name;
                 let core_var = self
                     .lookup_var(var_name)

--- a/stdlib/test/value_type_mutation_matrix_test.bt
+++ b/stdlib/test/value_type_mutation_matrix_test.bt
@@ -67,8 +67,9 @@ TestCase subclass: ValueTypeMutationMatrixTest
   // value_type_codegen.rs, but class methods route through a separate
   // class-method block-threading path (BT-2349/BT-2350/BT-2358) that covered the
   // loop paren-assign-RHS shape and count:/detect: predicates but NOT the
-  // conditional paren-assign-RHS shape. Flip off when BT-2371 lands.
-  bt2360ClassMethodCondAssignRhsPending => true
+  // conditional paren-assign-RHS shape. Fixed by BT-2371 (class-method-context
+  // analogue of BT-2359, applied in gen_server/methods.rs).
+  bt2360ClassMethodCondAssignRhsPending => false
 
   // ── TestCase-context fragments (the test class is itself a value-type) ──────
   // `frag` prefix keeps BUnit from treating them as test methods.


### PR DESCRIPTION
## Summary

In a **class method**, a conditional (`ifTrue:`/`ifFalse:`/`ifTrue:ifFalse:`) used as a parenthesized assignment RHS dropped the sibling outer-local mutation:

```beamtalk
class ifTrueIfFalseAssignRhsReadWrite: flag =>
  x := 0
  _r := flag ifTrue: [x := 5. 42] ifFalse: [0]
  x   // returned 0, expected 5
```

This is the class-method-context analogue of BT-2359's value-type case #4. Class methods do NOT route through `value_type_codegen.rs`; they use the class-method block-threading path (BT-2349/BT-2350/BT-2358). That path handled the loop/foldl threaded-tuple assign-RHS shape and `count:`/`detect:` predicates, but not the conditional assign-RHS shape.

## Changes

- `crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs`: In `generate_class_method_local_var_binding`, after the existing `expr_yields_vt_threaded_tuple` (loop/foldl) branch, add a branch that peels parens (BT-2358) and, when the RHS is a read+write conditional (`is_conditional_with_vt_local_threading`), routes it through the shared `emit_vt_conditional_assign_rhs` helper. Each branch emits `{LogicalValue, Mut1..MutN}`; the target binds to element 1 and threaded siblings rebind from elements 2.. — directly mirroring the value-type fix (BT-2359). The two branches are mutually exclusive (`expr_yields_vt_threaded_tuple` never matches conditionals).
- `stdlib/test/value_type_mutation_matrix_test.bt`: Flip `bt2360ClassMethodCondAssignRhsPending => false` so the gated cell `testIfTrueIfFalseAssignRhsReadWriteClassMethod` asserts the ground-truth final value (5) and passes.

## Acceptance criteria

- [x] A conditional used as a parenthesized assignment RHS in a class method threads the sibling outer-local mutation; the matrix cell asserts ground truth (5).
- [x] `bt2360ClassMethodCondAssignRhsPending` flipped to false.

## Testing

- `just build`, `just clippy`, `just fmt-check`: clean.
- `just test-rust`: all pass (no snapshot regeneration needed).
- `just test-bunit`: `ValueTypeMutationMatrixTest` 78/78 pass (the previously skipped BT-2371 cell now asserts 5). The sole BUnit failure (`GenericStdlibTest testArrayAtPutReturnsArray`) is pre-existing on `origin/main` and unrelated to this change.

Linear: https://linear.app/beamtalk/issue/BT-2371

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed compiler support for conditional expressions when used as the right-hand side of class method assignments.
  * Resolved issues with value threading and local variable mutations in conditional assignment patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->