### PR TITLE
Codegen: nested timesRepeat: drops inner-loop mutation of an outer local (BT-2363)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/counted_loops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/counted_loops.rs
@@ -601,4 +601,17 @@ mod bt2363_nested_counted_loops {
             "write-only nested mutation of 'last' must be threaded. Got:\n{code}"
         );
     }
+
+    // BT-2363 (Copilot review): the inner counted loop may be parenthesized
+    // (`(2 timesRepeat: [...])`). The cross-scope mutation collectors must peel
+    // parens or the write-only detection is silently skipped.
+    #[test]
+    fn test_nested_parenthesized_times_repeat_threaded() {
+        let src = "Object subclass: NestedRepro\n\n  run =>\n    last := 0\n    3 timesRepeat: [(2 timesRepeat: [last := 7])]\n    last\n";
+        let code = codegen(src);
+        assert!(
+            code.contains("maps':'get'('__local__last'"),
+            "parenthesized nested mutation of 'last' must be threaded. Got:\n{code}"
+        );
+    }
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/counted_loops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/counted_loops.rs
@@ -553,3 +553,52 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod bt2363_nested_counted_loops {
+    use crate::codegen::core_erlang::tests::codegen;
+
+    // BT-2363: A nested `timesRepeat:` mutating an outer local must thread the inner
+    // loop's `{value, StateAcc}` result back out through the OUTER loop. Previously the
+    // outer loop was emitted as a plain `beamtalk_message_dispatch:send` (no threading)
+    // and the inner mutation was dropped, returning 0 instead of the accumulated value.
+    #[test]
+    fn test_nested_times_repeat_threads_outer_local() {
+        let src = "Object subclass: NestedRepro\n\n  run =>\n    total := 0\n    3 timesRepeat: [2 timesRepeat: [total := total + 1]]\n    total\n";
+        let code = codegen(src);
+        // Outer loop must thread via StateAcc (not direct-params), so it can unpack the
+        // inner loop's tuple result.
+        assert!(
+            code.contains("fun (_loopidx") && code.contains(", StateAcc) ->"),
+            "outer nested-loop must use StateAcc threading, not direct-params. Got:\n{code}"
+        );
+        // The inner loop's tuple result is unpacked via element(2, _NestTuple...) and the
+        // updated StateAcc is fed to the next outer iteration.
+        assert!(
+            code.contains("_NestTuple"),
+            "outer loop must bind the inner loop result to a _NestTuple var. Got:\n{code}"
+        );
+        assert!(
+            code.contains("element'(2, _NestTuple"),
+            "outer loop must extract element(2) of the inner loop tuple. Got:\n{code}"
+        );
+        // `total` is packed/unpacked under the __local__ key throughout.
+        assert!(
+            code.contains("maps':'get'('__local__total'")
+                && code.contains("maps':'put'('__local__total'"),
+            "nested loop must thread 'total' under the __local__ key. Got:\n{code}"
+        );
+    }
+
+    // BT-2363: write-only outer-local mutation inside a nested counted loop must also be
+    // threaded back (the read+write detector alone misses write-only mutations).
+    #[test]
+    fn test_nested_times_repeat_write_only_outer_local_threaded() {
+        let src = "Object subclass: NestedRepro\n\n  run =>\n    last := 0\n    3 timesRepeat: [2 timesRepeat: [last := 7]]\n    last\n";
+        let code = codegen(src);
+        assert!(
+            code.contains("maps':'get'('__local__last'"),
+            "write-only nested mutation of 'last' must be threaded. Got:\n{code}"
+        );
+    }
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -178,6 +178,11 @@ struct BodyEffects {
     has_tier2_threaded_assign: bool,
     /// Body has nested list ops incompatible with direct-params (BT-1329).
     has_non_tuple_safe_list_op: bool,
+    /// BT-2363: Body has a nested counted loop (`timesRepeat:`/`to:do:`/`to:by:do:`)
+    /// that mutates a threaded outer local. The inner loop returns a `{value, StateAcc}`
+    /// tuple that must be unpacked via `element(2, …)` to thread the local back out —
+    /// incompatible with direct-params mode (which has no `StateAcc` to rebuild into).
+    has_nested_counted_loop_mutation: bool,
     /// Body has control-flow sub-expressions with field mutations.
     has_cf_mutations: bool,
     /// Body has inline conditionals writing to threaded locals.
@@ -226,6 +231,13 @@ impl BodyEffects {
             )
         });
 
+        // BT-2363: Detect a nested counted loop that mutates a threaded outer local.
+        // Such an inner loop returns a `{value, StateAcc}` tuple; the outer loop must
+        // unpack `element(2, …)` to propagate the local — only possible in StateAcc mode.
+        let has_nested_counted_loop_mutation = body.body.iter().any(|s| {
+            generator.expr_has_nested_counted_loop_threading(&s.expression, threaded_locals)
+        });
+
         // Guard: control-flow sub-expressions with field mutations (e.g.
         // `flag ifTrue: [self.n := ...]`). These generate `StateAcc`-dependent code.
         let has_cf_mutations = body
@@ -255,6 +267,7 @@ impl BodyEffects {
             cond_has_state_effects,
             has_tier2_threaded_assign,
             has_non_tuple_safe_list_op,
+            has_nested_counted_loop_mutation,
             has_cf_mutations,
             has_conditional_threaded_writes,
             last_is_destructure,
@@ -421,6 +434,7 @@ impl ThreadingPlan {
             && !effects.cond_has_state_effects
             && !effects.has_tier2_threaded_assign
             && !effects.has_non_tuple_safe_list_op
+            && !effects.has_nested_counted_loop_mutation
     }
 
     /// BT-1276: Select tuple accumulator for foldl list-ops when eligible: body has
@@ -2729,6 +2743,15 @@ impl CoreErlangGenerator {
                 &mut list_op_cross_scope_writes,
             );
         }
+        // BT-2363: also thread write-only outer locals mutated inside nested counted/list-op
+        // loops (those that the read+write `collect_list_op_cross_scope_mutations` misses).
+        for stmt in &body.body {
+            self.collect_nested_loop_outer_local_writes(
+                &stmt.expression,
+                &block_params,
+                &mut list_op_cross_scope_writes,
+            );
+        }
 
         match self.context {
             CodeGenContext::Actor => {
@@ -3131,16 +3154,33 @@ impl CoreErlangGenerator {
         };
         let sel: String = parts.iter().map(|p| p.keyword.as_str()).collect();
         let body_block = match sel.as_str() {
-            "do:" | "collect:" | "select:" | "reject:" | "anySatisfy:" | "allSatisfy:" => {
-                if let Some(Expression::Block(block)) = arguments.first() {
+            "do:" | "collect:" | "select:" | "reject:" | "anySatisfy:" | "allSatisfy:"
+            // BT-2363: nested counted loops (`timesRepeat:`/`to:do:`/`to:by:do:`)
+            // capture and mutate outer locals just like list ops. Their body block
+            // is the last argument. Including them here makes the *outer* loop's
+            // threaded-locals computation see writes buried in an inner counted loop,
+            // so the outer loop threads them via StateAcc instead of dropping them.
+            | "timesRepeat:" => {
+                if let Some(Expression::Block(block)) = arguments.last() {
                     block
                 } else {
                     return;
                 }
             }
-            "inject:into:" => {
+            "inject:into:" | "to:do:" => {
                 if arguments.len() == 2 {
                     if let Expression::Block(block) = &arguments[1] {
+                        block
+                    } else {
+                        return;
+                    }
+                } else {
+                    return;
+                }
+            }
+            "to:by:do:" => {
+                if arguments.len() == 3 {
+                    if let Expression::Block(block) = &arguments[2] {
                         block
                     } else {
                         return;
@@ -3168,6 +3208,76 @@ impl CoreErlangGenerator {
                 out.insert(v.clone());
             }
         }
+
+        // BT-2363: Recurse into the inner block's statements so deeper nesting
+        // (a counted/list op nested two or more levels deep) is still detected.
+        // `analyze_block` does not propagate writes out of nested non-conditional
+        // blocks, so a write buried in a doubly-nested loop is invisible above
+        // without this recursion. Block parameters of the inner block are not
+        // outer locals, so drop any cross-scope name shadowed by a block param.
+        let mut nested = std::collections::HashSet::new();
+        for stmt in &body_block.body {
+            Self::collect_list_op_cross_scope_mutations_recursive(
+                &stmt.expression,
+                facts,
+                &mut nested,
+            );
+        }
+        for v in nested {
+            if !block_params.contains(v.as_str()) {
+                out.insert(v);
+            }
+        }
+    }
+
+    /// BT-2363: Returns `true` if `expr` is (or wraps, via assignment RHS or parens) a
+    /// nested counted loop (`timesRepeat:`/`to:do:`/`to:by:do:`) whose body mutates one
+    /// of the outer loop's `threaded_locals`.
+    ///
+    /// Such an inner loop returns a `{value, StateAcc}` tuple whose `element(2, …)` must
+    /// be unpacked to thread the local back out; that is only possible when the outer loop
+    /// uses `StateAcc` mode, so the presence of this pattern disqualifies direct-params.
+    pub(super) fn expr_has_nested_counted_loop_threading(
+        &self,
+        expr: &Expression,
+        threaded_locals: &[String],
+    ) -> bool {
+        use crate::ast::MessageSelector;
+
+        let inner = match Self::peel_parens(expr) {
+            Expression::Assignment { value, .. } => Self::peel_parens(value),
+            other => other,
+        };
+        let Expression::MessageSend {
+            selector: MessageSelector::Keyword(parts),
+            arguments,
+            ..
+        } = inner
+        else {
+            return false;
+        };
+        let sel: String = parts.iter().map(|p| p.keyword.as_str()).collect();
+        let body_block = match sel.as_str() {
+            "timesRepeat:" => match arguments.last() {
+                Some(Expression::Block(block)) => block,
+                _ => return false,
+            },
+            "to:do:" if arguments.len() == 2 => match &arguments[1] {
+                Expression::Block(block) => block,
+                _ => return false,
+            },
+            "to:by:do:" if arguments.len() == 3 => match &arguments[2] {
+                Expression::Block(block) => block,
+                _ => return false,
+            },
+            _ => return false,
+        };
+
+        // The inner counted loop threads back exactly the outer locals its own body
+        // mutates (read+write or write-only). If any of those overlap the threaded set
+        // the outer loop must thread, the inner tuple must be unpacked into StateAcc.
+        let inner_threaded = self.compute_threaded_locals_for_loop(body_block, None);
+        inner_threaded.iter().any(|v| threaded_locals.contains(v))
     }
 
     /// BT-1329: Returns `true` if `expr` is a list op (do:, collect:, select:, reject:,
@@ -3298,6 +3408,7 @@ mod tests {
             cond_has_state_effects: false,
             has_tier2_threaded_assign: false,
             has_non_tuple_safe_list_op: false,
+            has_nested_counted_loop_mutation: false,
             has_cf_mutations: false,
             has_conditional_threaded_writes: false,
             last_is_destructure: false,

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -1865,12 +1865,12 @@ impl CoreErlangGenerator {
         facts: &crate::semantic_analysis::SemanticFacts,
         out: &mut std::collections::HashSet<String>,
     ) {
-        match expr {
+        match Self::peel_parens(expr) {
             Expression::Assignment { value, .. } => {
                 Self::collect_list_op_cross_scope_mutations_recursive(value, facts, out);
             }
-            Expression::MessageSend { .. } => {
-                Self::collect_list_op_cross_scope_mutations(expr, facts, out);
+            send @ Expression::MessageSend { .. } => {
+                Self::collect_list_op_cross_scope_mutations(send, facts, out);
             }
             _ => {}
         }
@@ -1895,8 +1895,11 @@ impl CoreErlangGenerator {
         use crate::ast::MessageSelector;
         use crate::codegen::core_erlang::block_analysis::analyze_block;
 
-        let inner = match expr {
-            Expression::Assignment { value, .. } => value.as_ref(),
+        // Peel parens then an assignment RHS (which may itself be parenthesized) so
+        // forms like `_r := (1 to: 5 do: [...])` are still inspected — mirrors
+        // `expr_has_nested_counted_loop_threading`.
+        let inner = match Self::peel_parens(expr) {
+            Expression::Assignment { value, .. } => Self::peel_parens(value),
             other => other,
         };
         let Expression::MessageSend {

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -1876,6 +1876,77 @@ impl CoreErlangGenerator {
         }
     }
 
+    /// BT-2363: Collects outer-scope locals that are *written* inside a nested
+    /// counted loop (`timesRepeat:`/`to:do:`/`to:by:do:`) or list op, including
+    /// write-only mutations that `collect_list_op_cross_scope_mutations` (read+write
+    /// only) misses.
+    ///
+    /// A name is collected when it is in the nested block's `local_writes`, is not a
+    /// parameter of any enclosing block (`excluded_params` or the nested block's own
+    /// params), and resolves to an existing outer-scope binding (`lookup_var`). The
+    /// `lookup_var` guard is why this needs `&self` rather than being a free function:
+    /// it distinguishes a genuine outer local from a block-internal temporary.
+    fn collect_nested_loop_outer_local_writes(
+        &self,
+        expr: &Expression,
+        excluded_params: &HashSet<String>,
+        out: &mut HashSet<String>,
+    ) {
+        use crate::ast::MessageSelector;
+        use crate::codegen::core_erlang::block_analysis::analyze_block;
+
+        let inner = match expr {
+            Expression::Assignment { value, .. } => value.as_ref(),
+            other => other,
+        };
+        let Expression::MessageSend {
+            selector: MessageSelector::Keyword(parts),
+            arguments,
+            ..
+        } = inner
+        else {
+            return;
+        };
+        let sel: String = parts.iter().map(|p| p.keyword.as_str()).collect();
+        let body_block = match sel.as_str() {
+            "do:" | "collect:" | "select:" | "reject:" | "anySatisfy:" | "allSatisfy:"
+            | "timesRepeat:" => match arguments.last() {
+                Some(Expression::Block(block)) => block,
+                _ => return,
+            },
+            "inject:into:" | "to:do:" if arguments.len() == 2 => match &arguments[1] {
+                Expression::Block(block) => block,
+                _ => return,
+            },
+            "to:by:do:" if arguments.len() == 3 => match &arguments[2] {
+                Expression::Block(block) => block,
+                _ => return,
+            },
+            _ => return,
+        };
+
+        let analysis = self
+            .semantic_facts
+            .block_profile(&body_block.span)
+            .cloned()
+            .unwrap_or_else(|| analyze_block(body_block));
+        // Accumulate enclosing params with this block's own params so a loop variable
+        // bound at any enclosing level is never mistaken for a threadable outer local.
+        let mut all_excluded: HashSet<String> = excluded_params.clone();
+        all_excluded.extend(Self::block_param_names(body_block));
+
+        for v in &analysis.local_writes {
+            if !all_excluded.contains(v.as_str()) && self.lookup_var(v).is_some() {
+                out.insert(v.clone());
+            }
+        }
+
+        // Recurse so deeper nesting (loops two or more levels deep) is detected.
+        for stmt in &body_block.body {
+            self.collect_nested_loop_outer_local_writes(&stmt.expression, &all_excluded, out);
+        }
+    }
+
     /// Allocates fresh temporary variable names for an NLR try/catch wrapper.
     fn alloc_nlr_catch_vars(&mut self) -> NlrCatchVars {
         NlrCatchVars {
@@ -2728,7 +2799,7 @@ impl CoreErlangGenerator {
     /// BT-2355: Peels any `Expression::Parenthesized` wrappers, returning the inner
     /// expression. Used so control-flow classification/threading sees through the
     /// parentheses in forms like `_r := (1 to: 5 do: [...])`.
-    fn peel_parens(expr: &Expression) -> &Expression {
+    pub(super) fn peel_parens(expr: &Expression) -> &Expression {
         let mut current = expr;
         while let Expression::Parenthesized { expression, .. } = current {
             current = expression;
@@ -3001,6 +3072,20 @@ impl CoreErlangGenerator {
         }
         *captured = captured.union(&cross_scope).cloned().collect();
         *writes = writes.union(&cross_scope).cloned().collect();
+        // BT-2363: Include write-only outer locals mutated inside nested counted/list-op
+        // loops. `collect_list_op_cross_scope_mutations` only sees read+write (captured ∩
+        // writes) names; a write-only inner mutation (e.g. `[2 timesRepeat: [last := 7]]`)
+        // needs `self` to confirm the name is an outer-scope local before threading it.
+        let mut nested_writes = HashSet::new();
+        for stmt in &block.body {
+            self.collect_nested_loop_outer_local_writes(
+                &stmt.expression,
+                excluded_params,
+                &mut nested_writes,
+            );
+        }
+        *captured = captured.union(&nested_writes).cloned().collect();
+        *writes = writes.union(&nested_writes).cloned().collect();
         // BT-1329: Include outer-scope write-only variables.
         for v in &writes.clone() {
             if !excluded_params.contains(v.as_str())

--- a/stdlib/test/counted_loop_mutation_test.bt
+++ b/stdlib/test/counted_loop_mutation_test.bt
@@ -119,3 +119,35 @@ TestCase subclass: CountedLoopMutationTest
       by: 2
       do: [:j | i := i + 1]
     self assert: i equals: 5
+
+  // ── BT-2363: nested counted loops must thread the outer local back out ────────
+  // A nested timesRepeat: previously dropped the inner loop's mutation of an outer
+  // local (the inner {value, StateAcc} tuple was never threaded through the outer
+  // loop), returning 0 instead of the accumulated value.
+  testNestedTimesRepeatReadWrite =>
+    total := 0
+    3 timesRepeat: [2 timesRepeat: [total := total + 1]]
+    self assert: total equals: 6
+
+  testNestedTimesRepeatWriteOnly =>
+    last := 0
+    3 timesRepeat: [2 timesRepeat: [last := 7]]
+    self assert: last equals: 7
+
+  // Inner to:do: accumulates the index inside an outer timesRepeat:.
+  testNestedToDoInsideTimesRepeat =>
+    sum := 0
+    2 timesRepeat: [1 to: 3 do: [:i | sum := sum + i]]
+    self assert: sum equals: 12
+
+  // Outer to:do: with an inner timesRepeat: mutating an outer local.
+  testNestedTimesRepeatInsideToDo =>
+    count := 0
+    1 to: 3 do: [:i | 4 timesRepeat: [count := count + 1]]
+    self assert: count equals: 12
+
+  // Triple nesting: 2 * 2 * 2 = 8 increments.
+  testTriplyNestedTimesRepeat =>
+    total := 0
+    2 timesRepeat: [2 timesRepeat: [2 timesRepeat: [total := total + 1]]]
+    self assert: total equals: 8

--- a/stdlib/test/counted_loop_mutation_test.bt
+++ b/stdlib/test/counted_loop_mutation_test.bt
@@ -151,3 +151,9 @@ TestCase subclass: CountedLoopMutationTest
     total := 0
     2 timesRepeat: [2 timesRepeat: [2 timesRepeat: [total := total + 1]]]
     self assert: total equals: 8
+
+  // Parenthesized inner loop must still thread the outer local.
+  testNestedParenthesizedTimesRepeat =>
+    last := 0
+    3 timesRepeat: [(2 timesRepeat: [last := 7])]
+    self assert: last equals: 7


### PR DESCRIPTION
Fixes the codegen bug where a nested counted loop (`timesRepeat:` / `to:do:` / `to:by:do:`) that mutates an outer local dropped the inner loop's accumulated value — e.g. `3 timesRepeat: [2 timesRepeat: [total := total + 1]]` returned `0` instead of `6`.

Linear: https://linear.app/beamtalk/issue/BT-2363

## Root cause

Two compounding gaps in the outer loop's state-threading codegen:

1. **Detection** — `compute_threaded_locals_for_loop` / `body_has_list_op_cross_scope_mutations` only looked through nested *list ops*, not nested *counted loops*. So the outer loop did not recognize that its body mutated `total` and was emitted as a plain `beamtalk_message_dispatch:send` (no threading at all).
2. **Propagation** — even once threaded, the outer loop ran in direct-params mode, which cannot unpack the inner loop's `{value, StateAcc}` tuple, so the recursion passed a stale value.

## Changes

- Extend `collect_list_op_cross_scope_mutations` to recurse into nested counted loops (`timesRepeat:`/`to:do:`/`to:by:do:`), keeping the pack/extract sides symmetric.
- Add `collect_nested_loop_outer_local_writes` (a `&self` collector) to catch *write-only* outer-local mutations buried in nested loops, with correct enclosing-block-param exclusion at every nesting depth.
- Add a `has_nested_counted_loop_mutation` body-effect that disqualifies direct-params mode, forcing StateAcc mode so the outer loop unpacks the inner loop's tuple via `element(2, ...)` and threads the mutation across iterations.

## Tests

- Codegen unit tests in `counted_loops.rs` (read+write and write-only nested threading).
- BUnit regression tests in `stdlib/test/counted_loop_mutation_test.bt`: nested read+write (=6), write-only (=7), inner `to:do:` in outer `timesRepeat:` (=12), inner `timesRepeat:` in outer `to:do:` (=12), and triple nesting (=8).

`just test-bunit` (only the pre-existing, unrelated BT-2362 `testArrayAtPutReturnsArray` failure remains), `just test-rust` (all pass, no snapshot diffs), `just clippy`, and `just fmt-check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)