### PR TITLE
Binding-model foundation: locals-only storage + lazy global resolution (BT-2365)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -2361,6 +2361,33 @@ impl CoreErlangGenerator {
                 self.generate_class_send_fallback(class_name, &raw, args_doc.clone())
             };
 
+        // BT-2365 (ADR 0081 Phase 1): the locals `maps:find` miss branch first tries
+        // lazy singleton resolution before the class-side fallback. Singletons
+        // (Transcript/Beamtalk/Workspace) are no longer eagerly injected into the
+        // session map, so `Workspace bind:as:` would otherwise mis-route to a
+        // non-existent `Workspace` class. resolve_singleton_instance/1 returns the
+        // live instance for a singleton name and `error` for any other name, so
+        // real class names (`Counter someClassMethod`) still hit class_fallback.
+        let singleton_val_var = self.fresh_var("SingletonVal");
+        let miss_branch = docvec![
+            "case call 'beamtalk_workspace':'resolve_singleton_instance'(",
+            leaf::atom(class_name.to_string()),
+            ") of ",
+            "<{'ok', ",
+            leaf::var(singleton_val_var.clone()),
+            "}> when 'true' -> ",
+            "call 'beamtalk_message_dispatch':'send'(",
+            leaf::var(singleton_val_var),
+            ", ",
+            leaf::atom(instance_selector.clone()),
+            ", [",
+            args_doc.clone(),
+            "]) ",
+            "<'error'> when 'true' -> ",
+            class_fallback,
+            " end",
+        ];
+
         // BT-1942: `let Lookup = maps:find(...) in <arg_preamble> case Lookup of ...`
         // — lookup first, then args, then the dispatch branches.
         let lookup_binding = docvec![
@@ -2387,7 +2414,7 @@ impl CoreErlangGenerator {
             args_doc,
             "]) ",
             "<'error'> when 'true' -> ",
-            class_fallback,
+            miss_branch,
             " end"
         ];
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -2361,43 +2361,47 @@ impl CoreErlangGenerator {
                 self.generate_class_send_fallback(class_name, &raw, args_doc.clone())
             };
 
-        // BT-2365 (ADR 0081 Phase 1): the locals `maps:find` miss branch first tries
-        // lazy singleton resolution before the class-side fallback. Singletons
+        // BT-2365 (ADR 0081 Phase 1): resolve the receiver — session locals first,
+        // then lazy singleton resolution — BEFORE the arg preamble runs, so the
+        // receiver is fully determined ahead of any argument side effects (the
+        // "receiver first, then args" evaluation order). Singletons
         // (Transcript/Beamtalk/Workspace) are no longer eagerly injected into the
         // session map, so `Workspace bind:as:` would otherwise mis-route to a
-        // non-existent `Workspace` class. resolve_singleton_instance/1 returns the
-        // live instance for a singleton name and `error` for any other name, so
-        // real class names (`Counter someClassMethod`) still hit class_fallback.
+        // non-existent `Workspace` class. resolve_singleton_instance/1 returns
+        // `{ok, Instance}` for a singleton name and `error` for any other name,
+        // so real class names (`Counter someClassMethod`) still fall through to
+        // class_fallback.
+        //
+        // The combined lookup binds `Lookup` to `{ok, Receiver}` (from locals or
+        // singleton registry) or `error` (use class-side fallback):
+        //
+        //   let Lookup = case maps:find(ClassName, State) of
+        //                  {ok, V} -> {ok, V}
+        //                  error   -> resolve_singleton_instance(ClassName)
+        //                end
+        //   in <arg_preamble>
+        //   case Lookup of
+        //     {ok, Receiver} -> beamtalk_message_dispatch:send(Receiver, Sel, Args)
+        //     error          -> class_fallback
+        //   end
         let singleton_val_var = self.fresh_var("SingletonVal");
-        let miss_branch = docvec![
-            "case call 'beamtalk_workspace':'resolve_singleton_instance'(",
-            leaf::atom(class_name.to_string()),
-            ") of ",
-            "<{'ok', ",
-            leaf::var(singleton_val_var.clone()),
-            "}> when 'true' -> ",
-            "call 'beamtalk_message_dispatch':'send'(",
-            leaf::var(singleton_val_var),
-            ", ",
-            leaf::atom(instance_selector.clone()),
-            ", [",
-            args_doc.clone(),
-            "]) ",
-            "<'error'> when 'true' -> ",
-            class_fallback,
-            " end",
-        ];
-
-        // BT-1942: `let Lookup = maps:find(...) in <arg_preamble> case Lookup of ...`
-        // — lookup first, then args, then the dispatch branches.
         let lookup_binding = docvec![
             "let ",
             leaf::var(lookup_var.clone()),
-            " = call 'maps':'find'(",
+            " = case call 'maps':'find'(",
             leaf::atom(class_name.to_string()),
             ", ",
             leaf::var(state_var),
-            ") in ",
+            ") of ",
+            "<{'ok', ",
+            leaf::var(singleton_val_var.clone()),
+            "}> when 'true' -> {'ok', ",
+            leaf::var(singleton_val_var),
+            "} ",
+            "<'error'> when 'true' -> call 'beamtalk_workspace':'resolve_singleton_instance'(",
+            leaf::atom(class_name.to_string()),
+            ") ",
+            "end in ",
         ];
         let case_doc = docvec![
             "case ",
@@ -2414,7 +2418,7 @@ impl CoreErlangGenerator {
             args_doc,
             "]) ",
             "<'error'> when 'true' -> ",
-            miss_branch,
+            class_fallback,
             " end"
         ];
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -256,7 +256,7 @@ impl CoreErlangGenerator {
                             }
                         }
                     };
-                    // BT-2365 (ADR 0081 Phase 1): in REPL top-level context a free
+                    // BT-2365 (ADR 0081 Phase 1): in REPL context a free
                     // identifier is no longer guaranteed to be present in State —
                     // workspace globals (singletons, bind:as:) are resolved lazily
                     // rather than eagerly injected into the session map. So instead
@@ -265,10 +265,22 @@ impl CoreErlangGenerator {
                     // runtime resolver, which checks bind:as: -> singletons ->
                     // classes -> undefined_variable. Actor/ValueType field access is
                     // unchanged (the field must exist in State/Self).
-                    if self.context == super::CodeGenContext::Repl
-                        && !self.in_loop_body
-                        && !self.in_hybrid_loop
-                    {
+                    //
+                    // This applies in loop/hybrid-loop bodies too: `state_var`
+                    // above already resolves to the context-appropriate map
+                    // (`StateAcc`/`StateAccN` for plain loops, `StateN` for hybrid
+                    // loops), and a free workspace global referenced inside a
+                    // `do:`/`collect:` block must resolve lazily rather than crash
+                    // with `badkey`. Captured locals (the loop accumulator and any
+                    // `__local__*` keys) are unpacked into bound vars at the loop
+                    // body entry, so they are handled by the `lookup_var` branch
+                    // above and never reach this fallthrough.
+                    //
+                    // Note: `resolve_name/2` does its own `maps:find(Name, Locals)`
+                    // as tier 1, then falls through to the live workspace tiers, so
+                    // passing `StateAcc`/`StateN` as the locals map is correct — a
+                    // miss there proceeds to bind:as: -> singletons -> classes.
+                    if self.context == super::CodeGenContext::Repl {
                         let resolved_var = self.fresh_var("Resolved");
                         Ok(docvec![
                             "case call 'maps':'find'(",

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -256,13 +256,46 @@ impl CoreErlangGenerator {
                             }
                         }
                     };
-                    Ok(docvec![
-                        "call 'maps':'get'(",
-                        leaf::atom(id.name.to_string()),
-                        ", ",
-                        leaf::var(state_var),
-                        ")",
-                    ])
+                    // BT-2365 (ADR 0081 Phase 1): in REPL top-level context a free
+                    // identifier is no longer guaranteed to be present in State —
+                    // workspace globals (singletons, bind:as:) are resolved lazily
+                    // rather than eagerly injected into the session map. So instead
+                    // of `maps:get/2` (which throws {badkey,_} on a miss) we look up
+                    // the locals map and, on a miss, fall through to the shared
+                    // runtime resolver, which checks bind:as: -> singletons ->
+                    // classes -> undefined_variable. Actor/ValueType field access is
+                    // unchanged (the field must exist in State/Self).
+                    if self.context == super::CodeGenContext::Repl
+                        && !self.in_loop_body
+                        && !self.in_hybrid_loop
+                    {
+                        let resolved_var = self.fresh_var("Resolved");
+                        Ok(docvec![
+                            "case call 'maps':'find'(",
+                            leaf::atom(id.name.to_string()),
+                            ", ",
+                            leaf::var(state_var.clone()),
+                            ") of ",
+                            "<{'ok', ",
+                            leaf::var(resolved_var.clone()),
+                            "}> when 'true' -> ",
+                            leaf::var(resolved_var),
+                            " <'error'> when 'true' -> call 'beamtalk_workspace':'resolve_name'(",
+                            leaf::var(state_var),
+                            ", ",
+                            leaf::atom(id.name.to_string()),
+                            ") ",
+                            "end",
+                        ])
+                    } else {
+                        Ok(docvec![
+                            "call 'maps':'get'(",
+                            leaf::atom(id.name.to_string()),
+                            ", ",
+                            leaf::var(state_var),
+                            ")",
+                        ])
+                    }
                 }
             }
         }

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -2547,15 +2547,18 @@ impl CoreErlangGenerator {
         // Actor methods compiled in workspace mode should NOT check REPL bindings.
         //
         // BT-2365 (ADR 0081 Phase 1): for an unqualified class reference, check the
-        // session locals map first so a local assignment shadows a singleton/class
-        // (`Transcript := 5` then `Transcript` returns `5`). On a miss, delegate to
-        // the shared runtime resolver, which consults the live singleton + class
-        // registries — the singletons (Transcript/Beamtalk/Workspace) are no longer
-        // eagerly injected into State, so this lazy lookup replaces the old inline
-        // class-registry branch. The resolver raises the same class_not_found error
-        // for a genuinely unknown class, preserving REPL output. Package-qualified
-        // references (`json@Parser`) keep the inline path below because the resolver
-        // does not carry the package-qualified display name.
+        // session locals map first so a session local of the same name takes
+        // precedence. (A capitalised name parses as a ClassReference, not an
+        // assignment target, so it cannot itself be rebound via `:=`; the locals
+        // check is for symmetry with resolve_name/2 and is essentially always a
+        // miss.) On a miss, delegate to the shared runtime resolver, which consults
+        // the live singleton + class registries — the singletons
+        // (Transcript/Beamtalk/Workspace) are no longer eagerly injected into
+        // State, so this lazy lookup replaces the old inline class-registry branch.
+        // The resolver raises the same class_not_found error for a genuinely
+        // unknown class, preserving REPL output. Package-qualified references
+        // (`json@Parser`) keep the inline path below because the resolver does not
+        // carry the package-qualified display name.
         if self.workspace_mode() && self.context == CodeGenContext::Repl && package.is_none() {
             let state_var = self.current_state_var();
             let resolved_var = self.fresh_var("ResolvedClass");

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -2545,7 +2545,41 @@ impl CoreErlangGenerator {
 
         // ADR 0019 Phase 3: Only check bindings in REPL top-level context.
         // Actor methods compiled in workspace mode should NOT check REPL bindings.
-        if self.workspace_mode() && self.context == CodeGenContext::Repl {
+        //
+        // BT-2365 (ADR 0081 Phase 1): for an unqualified class reference, check the
+        // session locals map first so a local assignment shadows a singleton/class
+        // (`Transcript := 5` then `Transcript` returns `5`). On a miss, delegate to
+        // the shared runtime resolver, which consults the live singleton + class
+        // registries — the singletons (Transcript/Beamtalk/Workspace) are no longer
+        // eagerly injected into State, so this lazy lookup replaces the old inline
+        // class-registry branch. The resolver raises the same class_not_found error
+        // for a genuinely unknown class, preserving REPL output. Package-qualified
+        // references (`json@Parser`) keep the inline path below because the resolver
+        // does not carry the package-qualified display name.
+        if self.workspace_mode() && self.context == CodeGenContext::Repl && package.is_none() {
+            let state_var = self.current_state_var();
+            let resolved_var = self.fresh_var("ResolvedClass");
+
+            Ok(docvec![
+                "case call 'maps':'find'(",
+                leaf::atom(class_name.to_string()),
+                ", ",
+                leaf::var(state_var.clone()),
+                ") of ",
+                "<{'ok', ",
+                leaf::var(resolved_var.clone()),
+                "}> when 'true' -> ",
+                leaf::var(resolved_var),
+                " <'error'> when 'true' -> call 'beamtalk_workspace':'resolve_class_reference'(",
+                leaf::var(state_var),
+                ", ",
+                leaf::atom(class_name.to_string()),
+                ") ",
+                "end",
+            ])
+        } else if self.workspace_mode() && self.context == CodeGenContext::Repl {
+            // Package-qualified REPL class reference: keep the original
+            // locals-then-registry path with the package-qualified display name.
             let class_pid_var = self.fresh_var("ClassPid");
             let class_mod_var = self.fresh_var("ClassModName");
             let state_var = self.current_state_var();

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -1049,10 +1049,16 @@ fn test_cascade_repl_expression() {
         "Should have module header. Got:\n{code}"
     );
 
-    // Should bind the underlying receiver once
+    // Should bind the underlying receiver once. BT-2365 (ADR 0081 Phase 1): a
+    // free REPL identifier now resolves via a locals maps:find with a runtime
+    // resolve_name fallthrough rather than a bare maps:get.
     assert!(
-        code.contains("let _Receiver1 = call 'maps':'get'('x', State) in"),
-        "Should bind receiver x from State. Got:\n{code}"
+        code.contains("let _Receiver1 = case call 'maps':'find'('x', State) of"),
+        "Should bind receiver x via locals find. Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_workspace':'resolve_name'(State, 'x')"),
+        "Should fall through to resolve_name for free identifier x. Got:\n{code}"
     );
 
     // Should send both messages
@@ -1246,28 +1252,27 @@ fn test_standalone_class_reference_uses_dynamic_module_name() {
     let code = generate_repl_expression(&module.expressions[0].expression, "repl_eval")
         .expect("codegen should succeed");
 
-    // Should call whereis_class to get the class PID
+    // BT-2365 (ADR 0081 Phase 1): an unqualified REPL class reference checks the
+    // session locals map first (so a local shadows the class), then delegates to
+    // the shared runtime resolver. The class object construction and dynamic
+    // module_name lookup now live in beamtalk_workspace:resolve_class_reference/2.
+
+    // Should check the session locals map first (shadowing support).
     assert!(
-        code.contains("call 'beamtalk_class_registry':'whereis_class'('Point')"),
-        "Should call whereis_class to get class PID. Got:\n{code}"
+        code.contains("call 'maps':'find'('Point', "),
+        "Should check locals map for the class name first. Got:\n{code}"
     );
 
-    // Should call module_name to get the module name dynamically
+    // Should delegate the miss path to the shared runtime resolver.
     assert!(
-        code.contains("call 'beamtalk_object_class':'module_name'("),
-        "Should call module_name to get module name dynamically. Got:\n{code}"
+        code.contains("call 'beamtalk_workspace':'resolve_class_reference'("),
+        "Should delegate to resolve_class_reference on a locals miss. Got:\n{code}"
     );
 
-    // Should NOT hardcode 'beamtalk_object_class' as the module name
+    // Should pass the class name as an atom to the resolver.
     assert!(
-        !code.contains("'beamtalk_object', 'Point class', 'beamtalk_object_class'"),
-        "Should not hardcode 'beamtalk_object_class' as module name. Got:\n{code}"
-    );
-
-    // Should create beamtalk_object with dynamic ClassModName variable
-    assert!(
-        code.contains("'beamtalk_object'") && code.contains("'Point class'"),
-        "Should create beamtalk_object with metaclass name. Got:\n{code}"
+        code.contains("'resolve_class_reference'(") && code.contains("'Point')"),
+        "Should pass the class name atom to the resolver. Got:\n{code}"
     );
 }
 
@@ -1297,30 +1302,23 @@ fn test_standalone_class_reference_validates_undefined_classes() {
     let code = generate_repl_expression(&module.expressions[0].expression, "repl_eval")
         .expect("codegen should succeed");
 
-    // Should use a case expression to check for undefined
+    // BT-2365 (ADR 0081 Phase 1): undefined-class validation now happens in the
+    // runtime resolver (beamtalk_workspace:resolve_class_reference/2), which
+    // raises the same class_not_found error. The REPL codegen emits a locals
+    // check then delegates to that resolver.
+
+    // Should check the session locals map first (shadowing support).
     assert!(
-        code.contains("case call 'beamtalk_class_registry':'whereis_class'('NonExistentClass')"),
-        "Should use case expression to handle whereis_class result. Got:\n{code}"
+        code.contains("call 'maps':'find'('NonExistentClass', "),
+        "Should check locals map for the class name first. Got:\n{code}"
     );
 
-    // Should raise class_not_found error when class is undefined (BT-597)
+    // Should delegate to the shared resolver, which raises class_not_found for
+    // a genuinely unknown class.
     assert!(
-        code.contains("beamtalk_error':'new'('class_not_found', 'NonExistentClass')"),
-        "Should raise class_not_found error when whereis_class returns 'undefined'. Got:\n{code}"
-    );
-
-    // Should include actionable hint via with_hint call
-    assert!(
-        code.contains("beamtalk_error':'with_hint'"),
-        "Should include hint via with_hint call. Got:\n{code}"
-    );
-
-    // Should create beamtalk_object in the success branch
-    assert!(
-        code.contains('<')
-            && code.contains("> when 'true' ->")
-            && code.contains("'beamtalk_object'"),
-        "Should create beamtalk_object in success branch of case. Got:\n{code}"
+        code.contains("call 'beamtalk_workspace':'resolve_class_reference'(")
+            && code.contains("'NonExistentClass')"),
+        "Should delegate undefined-class handling to resolve_class_reference. Got:\n{code}"
     );
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -81,10 +81,17 @@ fn test_generate_repl_module_aliases_state_to_bindings() {
         "REPL module should alias State to Bindings. Got:\n{code}"
     );
 
-    // Check that identifier lookup uses maps:get with State
+    // BT-2365 (ADR 0081 Phase 1): a free REPL identifier now resolves via a
+    // locals maps:find against State with a runtime resolve_name fallthrough,
+    // instead of a bare maps:get (which would throw {badkey,_} once workspace
+    // globals are no longer eagerly injected into State).
     assert!(
-        code.contains("call 'maps':'get'('x', State)"),
-        "Identifier lookup should use State (aliased to Bindings). Got:\n{code}"
+        code.contains("call 'maps':'find'('x', State)"),
+        "Identifier lookup should check locals (State, aliased to Bindings). Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_workspace':'resolve_name'(State, 'x')"),
+        "Identifier lookup should fall through to resolve_name. Got:\n{code}"
     );
 }
 
@@ -522,10 +529,16 @@ fn test_generate_repl_module_with_arithmetic() {
         "REPL module should alias State to Bindings. Got:\n{code}"
     );
 
-    // Check that x lookup works through State
+    // Check that x lookup works through State. BT-2365 (ADR 0081 Phase 1): a free
+    // REPL identifier resolves via a locals maps:find with a resolve_name
+    // fallthrough rather than a bare maps:get.
     assert!(
-        code.contains("call 'maps':'get'('x', State)"),
-        "Variable x should be looked up from State. Got:\n{code}"
+        code.contains("call 'maps':'find'('x', State)"),
+        "Variable x should be looked up from State (locals). Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_workspace':'resolve_name'(State, 'x')"),
+        "Variable x lookup should fall through to resolve_name. Got:\n{code}"
     );
 
     // Check the arithmetic operation
@@ -943,10 +956,16 @@ fn test_repl_multi_stmt_loop_accumulates_from_zero() {
         "BT-800: Must extract updated StateAcc from loop result. Got:\n{code}"
     );
 
-    // BT-800: Final read of x must use the state produced by the loop (State2+)
+    // BT-800: Final read of x must use the state produced by the loop (State2+).
+    // BT-2365 (ADR 0081 Phase 1): the post-loop free-identifier read resolves via
+    // a locals maps:find (with a resolve_name fallthrough) against State2.
     assert!(
-        code.contains("maps':'get'('x', State2)"),
+        code.contains("maps':'find'('x', State2)"),
         "BT-800: Final x read must use loop-updated state (State2). Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_workspace':'resolve_name'(State2, 'x')"),
+        "BT-2365: Final x read must fall through to resolve_name. Got:\n{code}"
     );
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -363,10 +363,17 @@ fn test_generate_repl_module_with_while_true_mutation() {
         code.contains("fun (StateAcc) ->"),
         "Condition lambda should accept StateAcc parameter. Got:\n{code}"
     );
-    // BT-181: Condition should read x from StateAcc, not outer scope
+    // BT-181 + BT-2365: Condition should read x from StateAcc, not outer scope.
+    // Lazy resolution (ADR 0081 Phase 1) now applies inside loop bodies too, so
+    // the read is a `maps:find` against StateAcc with a `resolve_name`
+    // fallthrough rather than a bare `maps:get` (which would `badkey` on a miss).
     assert!(
-        code.contains("maps':'get'('x', StateAcc)"),
-        "Condition should read x from StateAcc. Got:\n{code}"
+        code.contains("maps':'find'('x', StateAcc)"),
+        "Condition should look up x in StateAcc via maps:find. Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_workspace':'resolve_name'(StateAcc, 'x')"),
+        "Condition should fall through to resolve_name on a StateAcc miss. Got:\n{code}"
     );
     // BT-181: Condition should be applied with StateAcc argument
     assert!(
@@ -859,11 +866,18 @@ fn test_repl_loop_mutations_accumulate_plain_key() {
         "BT-800: REPL mode must never use __local__ prefix for x. Got:\n{code}"
     );
 
-    // BT-800: Reads inside loop body must use StateAcc (not State) so they get
-    // the accumulated value from the previous iteration.
+    // BT-800 + BT-2365: Reads inside loop body must use StateAcc (not State) so
+    // they get the accumulated value from the previous iteration. Lazy
+    // resolution (ADR 0081 Phase 1) now applies inside loop bodies too, so the
+    // read is a `maps:find` against StateAcc with a `resolve_name` fallthrough
+    // rather than a bare `maps:get` (which would `badkey` on a miss).
     assert!(
-        code.contains("maps':'get'('x', StateAcc)"),
-        "BT-800: Read inside loop must use StateAcc to get accumulated value. Got:\n{code}"
+        code.contains("maps':'find'('x', StateAcc)"),
+        "BT-800: Read inside loop must look up x in StateAcc via maps:find. Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_workspace':'resolve_name'(StateAcc, 'x')"),
+        "BT-800: Read inside loop must fall through to resolve_name on a StateAcc miss. Got:\n{code}"
     );
 
     // BT-800: Loop must thread state correctly (arity-2 letrec, returns {nil, StateAcc}).

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
@@ -60,10 +60,12 @@ known_vars_test() ->
     with_port(fun(Port) ->
         {ok, CoreErlang, []} =
             beamtalk_compiler_port:compile_expression(Port, <<"x + 1">>, <<"test">>, [<<"x">>]),
-        %% Variable x is fetched via `call 'maps':'get'\n\t\t\t ('x', State)`.
-        %% Assert both the qualified call and the `'x'` key are present so that
-        %% the test still guards variable-lookup specifically.
-        ?assert(binary:match(CoreErlang, <<"'maps':'get'">>) =/= nomatch),
+        %% ADR 0081: REPL free identifiers now look up via `maps:find` with a
+        %% `beamtalk_workspace:resolve_name/2` fallthrough (locals-first, then
+        %% the lazy global resolver) instead of a bare `maps:get`. Assert the
+        %% new lookup call and the `'x'` key so the test still guards lookup.
+        ?assert(binary:match(CoreErlang, <<"'maps':'find'">>) =/= nomatch),
+        ?assert(binary:match(CoreErlang, <<"'beamtalk_workspace':'resolve_name'">>) =/= nomatch),
         ?assert(binary:match(CoreErlang, <<"'x'">>) =/= nomatch)
     end).
 

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl
@@ -70,10 +70,12 @@ compile_expression_known_vars() ->
     {ok, CoreErlang, []} =
         beamtalk_compiler:compile_expression(<<"x + 1">>, <<"test_mod">>, [<<"x">>]),
     ?assert(is_binary(CoreErlang)),
-    %% Variable x is fetched via `call 'maps':'get'\n\t\t\t ('x', State)`.
-    %% Assert both the qualified call and the `'x'` key are present so that
-    %% the test still guards variable-lookup specifically.
-    ?assert(binary:match(CoreErlang, <<"'maps':'get'">>) =/= nomatch),
+    %% ADR 0081: REPL free identifiers now look up via `maps:find` with a
+    %% `beamtalk_workspace:resolve_name/2` fallthrough (locals-first, then the
+    %% lazy global resolver) instead of a bare `maps:get`. Assert the new
+    %% lookup call and the `'x'` key so the test still guards variable lookup.
+    ?assert(binary:match(CoreErlang, <<"'maps':'find'">>) =/= nomatch),
+    ?assert(binary:match(CoreErlang, <<"'beamtalk_workspace':'resolve_name'">>) =/= nomatch),
     ?assert(binary:match(CoreErlang, <<"'x'">>) =/= nomatch).
 
 compile_expression_error() ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
@@ -55,7 +55,14 @@ handle(<<"bindings">>, _Params, Msg, SessionPid) ->
     TargetPid = beamtalk_session_table:resolve_pid(
         beamtalk_repl_protocol:get_session(Msg), SessionPid
     ),
-    {ok, Bindings} = beamtalk_repl_shell:get_bindings(TargetPid),
+    {ok, SessionLocals} = beamtalk_repl_shell:get_bindings(TargetPid),
+    %% BT-2365 (ADR 0081 Phase 1): a session's binding map now holds only locals —
+    %% bind:as: entries live in the shared workspace registry and are resolved
+    %% lazily rather than copied into the session. Merge them back in here so the
+    %% :bindings display keeps showing user-registered bind:as: names (locals win
+    %% on key collision, matching shadowing semantics).
+    WorkspaceUserBindings = beamtalk_workspace_interface_primitives:get_user_bindings(),
+    Bindings = maps:merge(WorkspaceUserBindings, SessionLocals),
     %% ADR 0019 Phase 3: Filter out workspace convenience bindings from display.
     UserBindings = maps:without(beamtalk_workspace_config:binding_names(), Bindings),
     beamtalk_repl_protocol:encode_bindings(

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
@@ -155,13 +155,12 @@ remove_from_tracker(SessionPid, Module) ->
 init(SessionId) ->
     %% Create session-specific REPL state
     %% We use undefined for listen_socket and port since session doesn't own TCP connection
-    State0 = beamtalk_repl_state:new(undefined, 0),
-
-    %% BT-883: Inject non-class workspace globals (singletons + bind:as: names)
-    %% as session bindings so they resolve from the bindings map.
-    Bindings0 = inject_workspace_bindings(#{}),
-    State0b = beamtalk_repl_state:set_bindings(Bindings0, State0),
-    State0c = beamtalk_repl_state:set_injected_ws_keys(maps:keys(Bindings0), State0b),
+    %%
+    %% BT-2365 (ADR 0081 Phase 1): the session binding map starts EMPTY — it holds
+    %% only session locals. Workspace globals (singletons + bind:as: names) are no
+    %% longer eagerly injected here; a free identifier that misses the locals map is
+    %% resolved lazily at eval time via beamtalk_workspace:resolve_name/2.
+    State0c = beamtalk_repl_state:new(undefined, 0),
 
     %% Get workspace-wide actor registry
     %% The registry is registered globally in the workspace
@@ -190,6 +189,9 @@ handle_call({eval, Expression}, From, {SessionId, State, undefined}) ->
     %% Spawn eval in a monitored worker process so it can be interrupted (BT-666)
     Self = self(),
     {WorkerPid, MonRef} = spawn_monitor(fun() ->
+        %% BT-2365 (ADR 0081): seed the worker process context so primitives that
+        %% read it (Session current / Workspace currentSession) see this session.
+        seed_session_context(Self, SessionId),
         Result = beamtalk_repl_eval:do_eval(Expression, State),
         Self ! {eval_result, self(), Result}
     end),
@@ -197,6 +199,8 @@ handle_call({eval, Expression}, From, {SessionId, State, undefined}) ->
 handle_call({eval_trace, Expression}, From, {SessionId, State, undefined}) ->
     Self = self(),
     {WorkerPid, MonRef} = spawn_monitor(fun() ->
+        %% BT-2365 (ADR 0081): seed worker process context (same as the eval path).
+        seed_session_context(Self, SessionId),
         Result = beamtalk_repl_eval:do_eval_trace(Expression, State),
         Self ! {eval_result, self(), Result}
     end),
@@ -236,13 +240,12 @@ handle_call(get_bindings, _From, {SessionId, State, Worker}) ->
     Bindings = beamtalk_repl_state:get_bindings(State),
     {reply, {ok, Bindings}, {SessionId, State, Worker}};
 handle_call(clear_bindings, _From, {SessionId, State, Worker}) ->
-    %% BT-883: Re-inject workspace globals after clearing bindings
-    %% so that singletons and bind:as: names remain available.
-    Bindings = inject_workspace_bindings(#{}),
-    NewState = beamtalk_repl_state:set_bindings(Bindings, State),
-    NewState1 = beamtalk_repl_state:set_injected_ws_keys(maps:keys(Bindings), NewState),
+    %% BT-2365 (ADR 0081 Phase 1): clear only the session locals. Workspace globals
+    %% (singletons + bind:as: names) are no longer copied into the session map, so
+    %% there is nothing to re-inject — they remain available via lazy resolution.
+    NewState = beamtalk_repl_state:clear_bindings(State),
     beamtalk_bindings_events:on_bindings_changed(SessionId),
-    {reply, ok, {SessionId, NewState1, Worker}};
+    {reply, ok, {SessionId, NewState, Worker}};
 handle_call({load_file, Path}, _From, {SessionId, State, Worker}) ->
     case beamtalk_repl_eval:handle_load(Path, State) of
         {ok, LoadedModules, NewState} ->
@@ -327,6 +330,9 @@ handle_call(_Request, _From, State) ->
 handle_cast({eval_async, Expression, Subscriber}, {SessionId, State, undefined}) ->
     Self = self(),
     {WorkerPid, MonRef} = spawn_monitor(fun() ->
+        %% BT-2365 (ADR 0081): seed worker process context on the streaming path too
+        %% so Session current behaves identically to the synchronous eval path.
+        seed_session_context(Self, SessionId),
         Result = beamtalk_repl_eval:do_eval(Expression, State, Subscriber),
         Self ! {eval_result, self(), Result}
     end),
@@ -356,10 +362,11 @@ handle_info({eval_result, WorkerPid, Result}, {SessionId, ShellState, {WorkerPid
     case Result of
         {ok, Value, Output, Warnings, WorkerState} ->
             reply_eval(From, {eval_done, Value, Output, Warnings}),
-            MergedState = apply_pending_removals(ShellState, WorkerState),
-            %% Refresh session workspace bindings to reflect any bind:as:/unbind: changes
-            %% made during this expression. Keeps session-local vars, replaces ws-injected keys.
-            FinalState = refresh_ws_bindings(MergedState),
+            %% BT-2365 (ADR 0081 Phase 1): no refresh_ws_bindings — workspace globals
+            %% are resolved live, not injected into the session map, so there is no
+            %% injected copy to reconcile after an eval. The session map holds only
+            %% locals (the worker's returned WorkerState).
+            FinalState = apply_pending_removals(ShellState, WorkerState),
             beamtalk_bindings_events:on_bindings_changed(SessionId),
             {noreply, {SessionId, FinalState, undefined}};
         {error, Reason, Output, Warnings, WorkerState} ->
@@ -424,29 +431,22 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 
 -doc """
-BT-883: Inject workspace globals (minus class objects) as session bindings.
-Walks Workspace globals via beamtalk_workspace_interface_primitives:get_session_bindings/0
-instead of the hardcoded singletons list. Returns singletons (Transcript,
-Beamtalk, Workspace) plus any user-registered bind:as: names.
-""".
-inject_workspace_bindings(Bindings) ->
-    maps:merge(Bindings, beamtalk_workspace_interface_primitives:get_session_bindings()).
+BT-2365 (ADR 0081): seed the eval-worker process dictionary with the session
+context that session-aware primitives read.
 
--doc """
-Refresh workspace bindings in session state after an eval.
-Removes stale workspace-injected keys and overlays fresh ETS bindings,
-so that bind:as:/unbind: changes are reflected immediately in the next eval
-and in get_bindings queries.
+`beamtalk_session_pid` is the shell's pid (the long-lived gen_server, not the
+short-lived worker) so cross-session reads target the shell; `beamtalk_session_id`
+is the protocol session id. A primitive that finds `beamtalk_session_pid =:=
+undefined` (e.g. eval outside a shell-spawned worker) returns nil.
+
+Seeded on BOTH spawn paths (synchronous eval/eval_trace and streaming
+eval_async) so Session current behaves consistently regardless of eval mode.
 """.
--spec refresh_ws_bindings(beamtalk_repl_state:state()) -> beamtalk_repl_state:state().
-refresh_ws_bindings(State) ->
-    InjectedWsKeys = beamtalk_repl_state:get_injected_ws_keys(State),
-    FreshWs = beamtalk_workspace_interface_primitives:get_session_bindings(),
-    CurrentBindings = beamtalk_repl_state:get_bindings(State),
-    WithoutStaleWs = maps:without(InjectedWsKeys, CurrentBindings),
-    FreshBindings = maps:merge(FreshWs, WithoutStaleWs),
-    State1 = beamtalk_repl_state:set_bindings(FreshBindings, State),
-    beamtalk_repl_state:set_injected_ws_keys(maps:keys(FreshWs), State1).
+-spec seed_session_context(pid(), binary()) -> ok.
+seed_session_context(ShellPid, SessionId) ->
+    put(beamtalk_session_pid, ShellPid),
+    put(beamtalk_session_id, SessionId),
+    ok.
 
 -doc """
 BT-1242: Apply pending module removals from ShellState to WorkerState.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
@@ -17,8 +17,6 @@ for manipulating state during REPL sessions.
     get_bindings/1,
     set_bindings/2,
     clear_bindings/1,
-    get_injected_ws_keys/1,
-    set_injected_ws_keys/2,
     get_eval_counter/1,
     increment_eval_counter/1,
     get_loaded_modules/1,
@@ -41,10 +39,10 @@ for manipulating state during REPL sessions.
 -record(state, {
     listen_socket :: gen_tcp:socket() | undefined,
     port :: inet:port_number(),
+    %% BT-2365 (ADR 0081 Phase 1): holds ONLY session locals. Workspace globals
+    %% (singletons + bind:as: names) are resolved lazily at eval time rather than
+    %% injected here, so there is no injected_ws_keys reconciliation field.
     bindings :: map(),
-    %% Keys last injected from workspace (singletons + bind:as: names).
-    %% Used by get_bindings to compute a fresh view after bind:as:/unbind: changes.
-    injected_ws_keys :: [atom()],
     eval_counter :: non_neg_integer(),
     loaded_modules :: [atom()],
     actor_registry :: pid() | undefined,
@@ -70,7 +68,6 @@ new(ListenSocket, Port, _Options) ->
         listen_socket = ListenSocket,
         port = Port,
         bindings = #{},
-        injected_ws_keys = [],
         eval_counter = 0,
         loaded_modules = [],
         actor_registry = undefined,
@@ -88,20 +85,10 @@ get_bindings(#state{bindings = Bindings}) ->
 set_bindings(Bindings, State) ->
     State#state{bindings = Bindings}.
 
--doc "Clear all variable bindings and reset workspace injection state.".
+-doc "Clear all session-local variable bindings (BT-2365: locals only).".
 -spec clear_bindings(state()) -> state().
 clear_bindings(State) ->
-    State#state{bindings = #{}, injected_ws_keys = []}.
-
--doc "Get the set of binding keys last injected from workspace.".
--spec get_injected_ws_keys(state()) -> [atom()].
-get_injected_ws_keys(#state{injected_ws_keys = Keys}) ->
-    Keys.
-
--doc "Set the set of binding keys injected from workspace.".
--spec set_injected_ws_keys([atom()], state()) -> state().
-set_injected_ws_keys(Keys, State) ->
-    State#state{injected_ws_keys = Keys}.
+    State#state{bindings = #{}}.
 
 -doc "Get current eval counter.".
 -spec get_eval_counter(state()) -> non_neg_integer().

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace.erl
@@ -12,7 +12,43 @@ This module provides a high-level API for querying workspace state.
 It delegates to beamtalk_workspace_meta for workspace metadata.
 """.
 
--export([status/0]).
+-export([status/0, resolve_name/2, resolve_class_reference/2, resolve_singleton_instance/1]).
+
+-doc """
+Resolve a bare name against session locals + live workspace sources (ADR 0081).
+
+BT-2365: the public entry point the REPL compiler's free-identifier fallthrough
+targets. Delegates to `beamtalk_workspace_interface_primitives:resolve_name/2`,
+which holds the single shared resolution order (locals → bind:as: → singletons →
+classes → undefined_variable) shared with `Session resolve:`.
+""".
+-spec resolve_name(map(), atom()) -> term().
+resolve_name(Locals, Name) ->
+    beamtalk_workspace_interface_primitives:resolve_name(Locals, Name).
+
+-doc """
+Resolve a capitalised class reference not found in the session locals (ADR 0081).
+
+BT-2365: the REPL compiler emits this for a `ClassReference` after a locals miss.
+Delegates to `beamtalk_workspace_interface_primitives:resolve_class_reference/2`,
+which reuses resolve_name/2's singleton + class tiers but raises class_not_found
+(not undefined_variable) for a genuinely unknown class.
+""".
+-spec resolve_class_reference(map(), atom()) -> term().
+resolve_class_reference(Locals, Name) ->
+    beamtalk_workspace_interface_primitives:resolve_class_reference(Locals, Name).
+
+-doc """
+Resolve a singleton binding name to its live instance, or `error` (ADR 0081).
+
+BT-2365: the REPL compiler emits this on the miss branch of a binding-aware
+class-send so a message to a singleton receiver (`Workspace bind:as:`) reaches
+the live instance. Delegates to
+`beamtalk_workspace_interface_primitives:resolve_singleton_instance/1`.
+""".
+-spec resolve_singleton_instance(atom()) -> {ok, term()} | error.
+resolve_singleton_instance(Name) ->
+    beamtalk_workspace_interface_primitives:resolve_singleton_instance(Name).
 
 -doc """
 Return a summary of the current workspace state.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl
@@ -52,6 +52,17 @@ into REPL session state. Workspace readiness is detected via
 -export([dispatch/3]).
 %% Stable external API (called by repl_eval and repl_shell)
 -export([get_user_bindings/0, get_session_bindings/0]).
+%% BT-2365 (ADR 0081 Phase 1): shared lazy name resolver. Single source of truth
+%% for bare-name resolution (REPL codegen fallthrough) and Session resolve:.
+-export([resolve_name/2]).
+%% BT-2365: capitalised class-reference resolution (REPL codegen). Shares the
+%% singleton + class-registry tiers with resolve_name/2 but keeps the
+%% class_not_found terminal so the "Class 'X' not found" error is preserved.
+-export([resolve_class_reference/2]).
+%% BT-2365: singleton-instance lookup for the binding-aware class-send fallback
+%% (a message sent to a singleton receiver, e.g. `Workspace bind:as:`). Returns
+%% the live instance so dispatch goes to it rather than a non-existent class.
+-export([resolve_singleton_instance/1]).
 %% Called by beamtalk_workspace_bootstrap to create the ETS table under a
 %% long-lived process (prevents table from being deleted when eval workers exit)
 -export([create_bindings_table/0]).
@@ -926,6 +937,176 @@ get_session_bindings() ->
             UserBindings = all_user_bindings(),
             handle_session_bindings(UserBindings)
     end.
+
+-doc """
+Resolve a bare name against the session locals and the live workspace sources.
+
+BT-2365 (ADR 0081 Phase 1): the single shared resolver. Replaces eager workspace
+injection — instead of copying globals into each session at init, a free
+identifier is resolved lazily, in order:
+
+1. session locals map (`Locals`) — checked first so locals **shadow** globals
+   (`Transcript := 5` then `Transcript` returns `5` within that session);
+2. `bind:as:` registry (the workspace user-bindings ETS table);
+3. singleton registry (`Transcript`/`Beamtalk`/`Workspace`, resolved live from
+   their class instances via `beamtalk_workspace_config:singletons/0` +
+   `value_singletons/0`);
+4. class registry (`Counter`, `Integer`, `Session`, …) → a class object;
+5. otherwise raise `undefined_variable`.
+
+Used by **both** the REPL codegen free-identifier fallthrough and (later)
+`Session resolve:`, so the two cannot drift. Internal binding keys
+(`?WORKSPACE_BINDINGS_KEY`, `?INTERNAL_REGISTRY_KEY`) in `Locals` are ignored
+by `maps:find` because callers never reference them as source names.
+""".
+-spec resolve_name(map(), atom()) -> term().
+resolve_name(Locals, Name) when is_map(Locals), is_atom(Name) ->
+    case maps:find(Name, Locals) of
+        {ok, Value} ->
+            Value;
+        error ->
+            resolve_workspace_name(Name)
+    end.
+
+%% Tiers 2–5 of resolve_name/2: the live workspace sources, checked after locals.
+-spec resolve_workspace_name(atom()) -> term().
+resolve_workspace_name(Name) ->
+    case lookup_user_binding(Name) of
+        {ok, BindValue} ->
+            BindValue;
+        error ->
+            case lookup_singleton(Name) of
+                {ok, SingletonValue} ->
+                    SingletonValue;
+                error ->
+                    case lookup_class_object(Name) of
+                        {ok, ClassObj} ->
+                            ClassObj;
+                        error ->
+                            raise_undefined_variable(Name)
+                    end
+            end
+    end.
+
+%% Tier 2: bind:as: registry (workspace user bindings ETS).
+-spec lookup_user_binding(atom()) -> {ok, term()} | error.
+lookup_user_binding(Name) ->
+    case ets:info(?WI_BINDINGS_TABLE, id) of
+        undefined ->
+            error;
+        _ ->
+            case ets:lookup(?WI_BINDINGS_TABLE, Name) of
+                [{Name, Value}] -> {ok, Value};
+                [] -> error
+            end
+    end.
+
+%% Tier 3: singleton registry (Transcript/Beamtalk/Workspace), resolved live.
+%%
+%% Delegates to handle_session_bindings/1 — the same builder the eager-injection
+%% path used — so a singleton resolves to exactly the value it would have had if
+%% injected (including the `Workspace` tagged-map fallback when its class var is
+%% not yet wired). Only the three singleton binding names ever match here; any
+%% other name returns `error` so resolution falls through to the class registry.
+-spec lookup_singleton(atom()) -> {ok, term()} | error.
+lookup_singleton(Name) ->
+    case is_singleton_binding_name(Name) of
+        false ->
+            error;
+        true ->
+            Singletons = handle_session_bindings(#{}),
+            case maps:find(Name, Singletons) of
+                {ok, Value} -> {ok, Value};
+                error -> error
+            end
+    end.
+
+%% True iff Name is one of the configured singleton binding names
+%% (Transcript / Beamtalk / Workspace).
+-spec is_singleton_binding_name(atom()) -> boolean().
+is_singleton_binding_name(Name) ->
+    Configs =
+        beamtalk_workspace_config:singletons() ++
+            beamtalk_workspace_config:value_singletons(),
+    lists:any(fun(#{binding_name := BName}) -> BName =:= Name end, Configs).
+
+%% Tier 4: class registry → a class object tuple, mirroring REPL codegen for a
+%% capitalised name (`{beamtalk_object, '<Name> class', Module, ClassPid}`).
+-spec lookup_class_object(atom()) -> {ok, tuple()} | error.
+lookup_class_object(Name) ->
+    case beamtalk_runtime_api:whereis_class(Name) of
+        undefined ->
+            error;
+        ClassPid ->
+            try beamtalk_runtime_api:module_name(ClassPid) of
+                Module ->
+                    Tag = beamtalk_runtime_api:class_object_tag(Name),
+                    {ok, {beamtalk_object, Tag, Module, ClassPid}}
+            catch
+                %% Class died between whereis and module_name — treat as unknown.
+                _:_ -> error
+            end
+    end.
+
+%% Tier 5: genuinely unknown name — raise undefined_variable (same error the
+%% REPL surfaces today for an unbound identifier).
+-spec raise_undefined_variable(atom()) -> no_return().
+raise_undefined_variable(Name) ->
+    beamtalk_error:raise(beamtalk_repl_errors:ensure_structured_error({undefined_variable, Name})).
+
+-doc """
+Resolve a capitalised class reference whose name is not a session local.
+
+BT-2365 (ADR 0081 Phase 1): the REPL codegen for a `ClassReference` checks the
+session locals map first (so `Transcript := 5` shadows the singleton) and, on a
+miss, calls this. Reuses the same singleton + class-registry tiers as
+`resolve_name/2` so resolution cannot drift, but raises `class_not_found`
+(not `undefined_variable`) for a genuinely unknown class — preserving the
+existing "Class 'X' not found" REPL error.
+
+`Locals` is accepted for symmetry with `resolve_name/2` and to allow a future
+caller to thread the session map; the codegen has already excluded a local hit
+before reaching here.
+""".
+-spec resolve_class_reference(map(), atom()) -> term().
+resolve_class_reference(_Locals, Name) when is_atom(Name) ->
+    case lookup_singleton(Name) of
+        {ok, SingletonValue} ->
+            SingletonValue;
+        error ->
+            case lookup_class_object(Name) of
+                {ok, ClassObj} ->
+                    ClassObj;
+                error ->
+                    raise_class_not_found(Name)
+            end
+    end.
+
+-doc """
+Resolve a singleton binding name to its live instance, or `error`.
+
+BT-2365 (ADR 0081 Phase 1): used by the REPL codegen's binding-aware class-send
+fallback. When a message is sent to a singleton receiver (`Workspace bind:as:`,
+`Transcript show:`) the name is no longer eagerly injected into the session map,
+so the `maps:find` receiver lookup misses. This recovers the live instance so the
+message dispatches to it (via `beamtalk_message_dispatch:send`) instead of being
+mis-routed to a non-existent class. Returns `error` for any non-singleton name so
+real class names still fall through to class-method dispatch.
+""".
+-spec resolve_singleton_instance(atom()) -> {ok, term()} | error.
+resolve_singleton_instance(Name) when is_atom(Name) ->
+    lookup_singleton(Name).
+
+-spec raise_class_not_found(atom()) -> no_return().
+raise_class_not_found(Name) ->
+    Err0 = beamtalk_error:new(class_not_found, Name),
+    Hint = iolist_to_binary([
+        <<"Define ">>,
+        atom_to_binary(Name, utf8),
+        <<" with: Object subclass: ">>,
+        atom_to_binary(Name, utf8)
+    ]),
+    beamtalk_error:raise(beamtalk_error:with_hint(Err0, Hint)).
 
 %%% ============================================================================
 %%% Internal helpers — ETS management

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl
@@ -945,8 +945,9 @@ BT-2365 (ADR 0081 Phase 1): the single shared resolver. Replaces eager workspace
 injection — instead of copying globals into each session at init, a free
 identifier is resolved lazily, in order:
 
-1. session locals map (`Locals`) — checked first so locals **shadow** globals
-   (`Transcript := 5` then `Transcript` returns `5` within that session);
+1. session locals map (`Locals`) — checked first so a session local **shadows**
+   a workspace global of the same name (e.g. `x := 5` then `x` resolves to the
+   local even if `x` is also a `bind:as:` entry);
 2. `bind:as:` registry (the workspace user-bindings ETS table);
 3. singleton registry (`Transcript`/`Beamtalk`/`Workspace`, resolved live from
    their class instances via `beamtalk_workspace_config:singletons/0` +
@@ -955,9 +956,11 @@ identifier is resolved lazily, in order:
 5. otherwise raise `undefined_variable`.
 
 Used by **both** the REPL codegen free-identifier fallthrough and (later)
-`Session resolve:`, so the two cannot drift. Internal binding keys
-(`?WORKSPACE_BINDINGS_KEY`, `?INTERNAL_REGISTRY_KEY`) in `Locals` are ignored
-by `maps:find` because callers never reference them as source names.
+`Session resolve:`, so the two cannot drift. `Locals` is the eval-time
+bindings map, which carries internal keys (the `__`-prefixed convention, e.g.
+`__workspace_user_bindings__`); these never collide with a resolved name
+because they are not valid source identifiers, so callers never look them up
+here.
 """.
 -spec resolve_name(map(), atom()) -> term().
 resolve_name(Locals, Name) when is_map(Locals), is_atom(Name) ->
@@ -1058,11 +1061,15 @@ raise_undefined_variable(Name) ->
 Resolve a capitalised class reference whose name is not a session local.
 
 BT-2365 (ADR 0081 Phase 1): the REPL codegen for a `ClassReference` checks the
-session locals map first (so `Transcript := 5` shadows the singleton) and, on a
-miss, calls this. Reuses the same singleton + class-registry tiers as
+session locals map first (so a session local of the same name takes precedence)
+and, on a miss, calls this. Reuses the same singleton + class-registry tiers as
 `resolve_name/2` so resolution cannot drift, but raises `class_not_found`
 (not `undefined_variable`) for a genuinely unknown class — preserving the
 existing "Class 'X' not found" REPL error.
+
+(Note: a capitalised name parses as a `ClassReference`, not an assignment
+target, so it cannot itself be rebound via `:=`; the locals check still runs
+for symmetry with `resolve_name/2` and is essentially always a miss here.)
 
 `Locals` is accepted for symmetry with `resolve_name/2` and to allow a future
 caller to thread the session map; the codegen has already excluded a local hit

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_interface_primitives_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_interface_primitives_tests.erl
@@ -858,3 +858,82 @@ autoflush_default_is_false_test() ->
             %% it returns a Boolean.
             ?assert(is_boolean(beamtalk_workspace_interface_primitives:autoflush()))
     end.
+
+%%====================================================================
+%% resolve_name/2 Tests (BT-2365, ADR 0081 Phase 1)
+%%
+%% Resolution order: locals -> bind:as: ETS -> singleton registry ->
+%% class registry -> undefined_variable. Tiers 1, 2, 5 and ordering are
+%% deterministic in EUnit; tiers 3/4 need a live workspace and are exercised
+%% by the repl-protocol parity tests.
+%%====================================================================
+
+%% Tier 1: a name present in the locals map resolves to its local value.
+resolve_name_tier1_locals_hit_test() ->
+    Locals = #{x => 42},
+    ?assertEqual(42, beamtalk_workspace_interface_primitives:resolve_name(Locals, x)).
+
+%% Tier 2: a name absent from locals but present in the bind:as: ETS table
+%% resolves to the registered value.
+resolve_name_tier2_bind_as_hit_test() ->
+    cleanup_ets_for(self()),
+    beamtalk_workspace_interface_primitives:create_bindings_table(),
+    ets:insert(beamtalk_wi_user_bindings, {greeting, <<"hi">>}),
+    try
+        ?assertEqual(
+            <<"hi">>,
+            beamtalk_workspace_interface_primitives:resolve_name(#{}, greeting)
+        )
+    after
+        cleanup_ets_for(self())
+    end.
+
+%% Tier 5: a genuinely unknown name raises undefined_variable.
+resolve_name_tier5_undefined_variable_test() ->
+    cleanup_ets_for(self()),
+    try
+        beamtalk_workspace_interface_primitives:resolve_name(#{}, noSuchName),
+        ?assert(false)
+    catch
+        error:#{error := Err} ->
+            ?assertEqual(undefined_variable, Err#beamtalk_error.kind)
+    end.
+
+%% Ordering: locals shadow a bind:as: entry of the same name (tier 1 wins).
+resolve_name_locals_shadow_bind_as_test() ->
+    cleanup_ets_for(self()),
+    beamtalk_workspace_interface_primitives:create_bindings_table(),
+    ets:insert(beamtalk_wi_user_bindings, {shadowed, <<"global">>}),
+    try
+        %% Local value must win over the bind:as: entry.
+        ?assertEqual(
+            <<"local">>,
+            beamtalk_workspace_interface_primitives:resolve_name(
+                #{shadowed => <<"local">>}, shadowed
+            )
+        )
+    after
+        cleanup_ets_for(self())
+    end.
+
+%% A nil local value still resolves as a tier-1 hit (maps:find distinguishes
+%% an absent key from a key bound to nil).
+resolve_name_nil_local_is_a_hit_test() ->
+    ?assertEqual(nil, beamtalk_workspace_interface_primitives:resolve_name(#{n => nil}, n)).
+
+%%====================================================================
+%% resolve_class_reference/2 Tests (BT-2365)
+%%====================================================================
+
+%% A genuinely unknown class raises class_not_found (NOT undefined_variable),
+%% preserving the existing REPL "Class 'X' not found" error.
+resolve_class_reference_unknown_raises_class_not_found_test() ->
+    cleanup_ets_for(self()),
+    try
+        beamtalk_workspace_interface_primitives:resolve_class_reference(#{}, 'NoSuchClassXyz'),
+        ?assert(false)
+    catch
+        error:#{error := Err} ->
+            ?assertEqual(class_not_found, Err#beamtalk_error.kind),
+            ?assertEqual('NoSuchClassXyz', Err#beamtalk_error.class)
+    end.

--- a/tests/repl-protocol/cases/lazy_name_resolution.btscript
+++ b/tests/repl-protocol/cases/lazy_name_resolution.btscript
@@ -1,0 +1,90 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E parity tests for BT-2365 (ADR 0081 Phase 1): locals-only binding storage
+// with lazy global resolution.
+//
+// These tests require E2E because they exercise the runtime name resolver
+// (beamtalk_workspace:resolve_name/2) wired in by the REPL codegen: a free
+// identifier that misses the session locals map falls through to the shared
+// resolver (locals -> bind:as: ETS -> singleton registry -> class registry ->
+// undefined_variable). The behaviour must match the pre-injection model.
+
+// ===========================================================================
+// LAZY SINGLETON RESOLUTION (no eager injection)
+// ===========================================================================
+
+// A workspace singleton resolves even though it is never injected into the
+// session binding map — it is resolved lazily from the singleton registry.
+Transcript
+// => _
+
+// Singleton receiver dispatch still works (binding-aware class send).
+Transcript show: "hi"
+// => _
+
+// ===========================================================================
+// SHADOWING: a session local shadows a workspace binding of the same name
+// ===========================================================================
+//
+// resolve_name/2 checks the session locals map BEFORE the bind:as: registry,
+// so a local assignment shadows a workspace binding within that session.
+// (Singletons like Transcript are capitalised ClassReferences and cannot be
+// assignment targets, so shadowing is demonstrated with a lowercase name.)
+
+// Register a workspace (global) binding.
+Workspace bind: 100 as: #shadowProbe
+// => nil
+
+// Without a local, the bare name resolves to the global value.
+shadowProbe
+// => 100
+
+// Assign a session local of the same name — it shadows the global.
+shadowProbe := 5
+// => 5
+
+// The bare name now resolves to the local value (locals checked first).
+shadowProbe
+// => 5
+
+// Arithmetic confirms it is the integer local, not the global 100.
+shadowProbe + 1
+// => 6
+
+// Clean up the workspace binding (the local stays in this session).
+Workspace unbind: #shadowProbe
+// => nil
+
+// ===========================================================================
+// BIND:AS: VISIBILITY ON THE NEXT EVAL (lazy, read live from ETS)
+// ===========================================================================
+
+// Register a value via bind:as: ...
+Workspace bind: 7 as: #lazyBound
+// => nil
+
+// ... and it is visible on the very next eval via lazy resolution.
+lazyBound
+// => 7
+
+lazyBound * 6
+// => 42
+
+// Clean up the workspace binding.
+Workspace unbind: #lazyBound
+// => nil
+
+// After unbind the name is no longer resolvable — it errors instead of
+// returning a stale injected copy.
+lazyBound
+// => ERROR: Undefined variable
+
+// ===========================================================================
+// UNDEFINED VARIABLE STILL RAISED FOR GENUINELY UNKNOWN NAMES
+// ===========================================================================
+
+// A genuinely unknown bare identifier still raises undefined_variable
+// (same phase as before: caught for a lowercase free name).
+genuinelyUnknownName
+// => ERROR: Undefined variable

--- a/tests/repl-protocol/cases/lazy_name_resolution.btscript
+++ b/tests/repl-protocol/cases/lazy_name_resolution.btscript
@@ -81,6 +81,37 @@ lazyBound
 // => ERROR: Undefined variable
 
 // ===========================================================================
+// LAZY RESOLUTION FROM INSIDE A LOOP / BLOCK BODY (BT-2365 CodeRabbit fix)
+// ===========================================================================
+//
+// Free workspace globals referenced from inside a do:/collect: block body must
+// also resolve lazily. Before the fix, identifiers inside loop bodies still
+// emitted a bare maps:get/2 (and singleton dispatch resolved post-arg), so any
+// singleton or bind:as: name used inside a block crashed with {badkey,_}.
+
+// A singleton (Transcript) dispatched from inside a do: block — no badkey.
+#(1, 2, 3) do: [:n | Transcript show: "tick"]
+// => _
+
+// A bind:as: global read from inside a collect: block resolves lazily and is
+// folded into the result (1000 + each element). A large base keeps the result
+// list out of the small-integer range so it renders as an array rather than a
+// charlist (an unrelated, pre-existing display heuristic).
+Workspace bind: 1000 as: #loopBase
+// => nil
+
+#(1, 2, 3) collect: [:n | loopBase + n]
+// => [1001,1002,1003]
+
+// The same global is also resolvable inside an inject:into: block body.
+#(1, 2, 3) inject: 0 into: [:acc :n | acc + n + loopBase]
+// => 3006
+
+// Clean up.
+Workspace unbind: #loopBase
+// => nil
+
+// ===========================================================================
 // UNDEFINED VARIABLE STILL RAISED FOR GENUINELY UNKNOWN NAMES
 // ===========================================================================
 


### PR DESCRIPTION
Implements **ADR 0081 Phase 1** (foundational, highest-risk): replaces eager workspace-global injection with **lazy resolution**, and seeds the eval-worker process context that `Session current` relies on. Every later issue in the epic assumes a locals-only session map, so this lands first to avoid a throwaway `bindings − injected` subtraction.

Linear: https://linear.app/beamtalk/issue/BT-2365

## What changed

### Lazy name resolution (shared resolver)
- New `beamtalk_workspace:resolve_name/2` (hosted in `beamtalk_workspace_interface_primitives`) — the single source of truth for bare-name resolution, used by REPL codegen and (later) `Session resolve:`. Order: **locals map → `bind:as:` ETS → singleton registry (`singletons/0` + `value_singletons/0`) → class registry → `undefined_variable`**.
- `resolve_class_reference/2` — shares the singleton + class tiers but keeps the `class_not_found` terminal so the existing "Class 'X' not found" REPL error is preserved for capitalised references.
- `resolve_singleton_instance/1` — recovers a singleton's live instance for the binding-aware class-send fallback (e.g. `Workspace bind:as:`).

### REPL codegen
- Free identifiers (REPL top-level, non-loop) now emit a locals `maps:find` with a runtime `resolve_name/2` fallthrough instead of a bare `maps:get` (which would throw `{badkey,_}` once globals are no longer injected).
- Unqualified `ClassReference` resolution delegates its locals-miss path to `resolve_class_reference/2`; package-qualified references keep the inline path.
- Binding-aware class send tries `resolve_singleton_instance/1` before the class-method fallback.

### Shell / state
- `init/1` no longer injects workspace globals — a new session's binding map starts **empty** (locals only).
- `refresh_ws_bindings/1` removed from the eval-result handler; `clear_bindings` no longer re-injects.
- Seeds `beamtalk_session_pid` (shell `self()`) + `beamtalk_session_id` in the eval-worker process dictionary on **all three** spawn paths (`{eval}`, `{eval_trace}`, `{eval_async}`).
- `beamtalk_repl_state`: `injected_ws_keys` field + `get_injected_ws_keys/1` / `set_injected_ws_keys/2` removed.
- `:bindings` op merges workspace user bindings for display so user-facing output is unchanged.

## Tests
- EUnit: `resolve_name/2` per-tier + ordering (locals shadow `bind:as:`, nil-local is a hit, `undefined_variable`), `resolve_class_reference/2` `class_not_found`.
- repl-protocol parity (`lazy_name_resolution.btscript`): lazy singleton resolution, session-local shadowing, `bind:as:` next-eval visibility, `undefined_variable` for unknown names.
- Updated codegen snapshot tests for the new identifier/class-reference shape.

## Verification
- `cargo test --workspace`, `just test-stdlib`, runtime EUnit (2245), workspace server tests (266), repl-protocol e2e, `just clippy`, `just fmt-check`, `rebar3 dialyzer` — all green.
- Pre-existing failures unrelated to this change: `testArrayAtPutReturnsArray` (BUnit), `status_returns_ok_map` workspace test (TMPDIR env), `dialyzer-specs` (broken local erts install) — all confirmed failing identically on clean `main`.

## Out of scope (later epic issues)
- `Session` class + primitives, `pending_mutations` (Issue 2).
- Removing `:bindings` / `:clear` (Issue 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented lazy resolution for variables and class references in the REPL. Workspace bindings are now resolved at evaluation time rather than eagerly injected, and session-local variables take precedence over workspace bindings when names match.

* **Tests**
  * Updated test expectations to reflect new lazy resolution behavior for variables and class references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->