### PR TITLE
BUnit: testArrayAtPutReturnsArray fails with identical displayed values (BT-2362)

### DIFF
--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_array.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_array.erl
@@ -95,6 +95,12 @@ The result is re-canonicalised via `from_list/1` so that its internal
 with the same elements. `array:set/3` alone leaves a stale copy-on-write cache
 node inside the `array` tuple, which makes `#[1,2,3] at: 2 put: 99` compare
 unequal to the literal `#[1,99,3]` even though both render the same (BT-2362).
+
+Complexity: the re-canonicalisation is `O(n)` in the array size (vs `array:set/3`'s
+`O(log n)`), so repeated `at:put:` over a large array in a loop is `O(n^2)`. This is
+deliberate — element-wise structural equality and hash consistency are required for
+arrays used as dict/set keys. A future option is to compare arrays structurally in
+`=`/`hash` instead, letting `at:put:` stay `O(log n)`.
 """.
 -spec at_put(map(), integer(), term()) -> map().
 at_put(#{'$beamtalk_class' := 'Array', 'data' := Arr}, Index, Value) when

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_array.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_array.erl
@@ -87,7 +87,15 @@ at(#{'$beamtalk_class' := 'Array'}, _Index) ->
     Error1 = beamtalk_error:with_selector(Error0, 'at:'),
     beamtalk_error:raise(beamtalk_error:with_hint(Error1, <<"Index must be an Integer">>)).
 
--doc "Return a new Array with the element at `Index` (1-based) replaced by `Value`.".
+-doc """
+Return a new Array with the element at `Index` (1-based) replaced by `Value`.
+
+The result is re-canonicalised via `from_list/1` so that its internal
+`array` representation is structurally identical (`=:=`) to an array literal
+with the same elements. `array:set/3` alone leaves a stale copy-on-write cache
+node inside the `array` tuple, which makes `#[1,2,3] at: 2 put: 99` compare
+unequal to the literal `#[1,99,3]` even though both render the same (BT-2362).
+""".
 -spec at_put(map(), integer(), term()) -> map().
 at_put(#{'$beamtalk_class' := 'Array', 'data' := Arr}, Index, Value) when
     is_integer(Index), Index >= 1
@@ -100,7 +108,8 @@ at_put(#{'$beamtalk_class' := 'Array', 'data' := Arr}, Index, Value) when
             Error2 = beamtalk_error:with_hint(Error1, <<"Index is beyond array size">>),
             beamtalk_error:raise(Error2);
         true ->
-            #{'$beamtalk_class' => 'Array', 'data' => array:set(Index - 1, Value, Arr)}
+            Updated = array:set(Index - 1, Value, Arr),
+            from_list(array:to_list(Updated))
     end;
 at_put(#{'$beamtalk_class' := 'Array'}, Index, _Value) when is_integer(Index) ->
     Error0 = beamtalk_error:new(index_out_of_bounds, 'Array'),

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_array_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_array_tests.erl
@@ -131,6 +131,31 @@ at_put_non_integer_index_test() ->
         beamtalk_array:at_put(A, <<"1">>, 99)
     ).
 
+%% BT-2362: at_put must return an Array whose internal representation is
+%% structurally identical (=:=) to a literal-equivalent Array, so that
+%% `#[1,2,3] at: 2 put: 99` compares equal to `#[1,99,3]`. array:set/3 alone
+%% leaves a stale copy-on-write cache node and breaks this invariant.
+at_put_equals_literal_equivalent_test() ->
+    Updated = beamtalk_array:at_put(make_array([1, 2, 3]), 2, 99),
+    Literal = make_array([1, 99, 3]),
+    ?assert(Updated =:= Literal),
+    ?assertEqual(Literal, Updated).
+
+%% BT-2362: equality must be reflected by hashing — two arrays that compare
+%% equal must produce the same phash2, otherwise dictionary/set keys break.
+at_put_hash_matches_literal_equivalent_test() ->
+    Updated = beamtalk_array:at_put(make_array([1, 2, 3]), 2, 99),
+    Literal = make_array([1, 99, 3]),
+    ?assertEqual(erlang:phash2(Literal), erlang:phash2(Updated)).
+
+%% BT-2362: chained at_put calls must also stay canonical.
+at_put_chained_equals_literal_equivalent_test() ->
+    Updated = beamtalk_array:at_put(
+        beamtalk_array:at_put(make_array([1, 2, 3]), 1, 7), 3, 9
+    ),
+    Literal = make_array([7, 2, 9]),
+    ?assert(Updated =:= Literal).
+
 %%% ============================================================================
 %%% do/2
 %%% ============================================================================


### PR DESCRIPTION
Fixes the failing BUnit test `testArrayAtPutReturnsArray` where `#[1,2,3] at: 2 put: 99` rendered identically to `#[1, 99, 3]` but compared unequal.

Linear: https://linear.app/beamtalk/issue/BT-2362

## Root cause

Arrays are backed by Erlang's `array` module (`#{'$beamtalk_class' => 'Array', 'data' => ErlangArray}`). The `array` term is a tuple that carries a copy-on-write cache node. `array:set/3` (used by `at:put:`) leaves the *old* element tree in that cache slot, so the resulting tuple is **not** `=:=` to one built by `array:from_list/1` even when every element is identical:

```
from_list([1,99,3]) -> {array,3,0,false,undefined,{1,99,3,...},0,{1,99,3,...},0}
set(1,99,from_list([1,2,3])) -> {array,3,0,false,undefined,{1,99,3,...},0,{1,2,3,...},0}
                                                                          ^^ stale cache
```

`assert:equals:` uses `=:=`, which compares the raw tuples, so the two arrays compared unequal. `at:put:` was the **only** `array:set` caller — every other Array op (`collect`, `select`, `slice_from`, literals) builds via `array:from_list`/`array:map`, which produce a canonical representation. So `at:put:` was the outlier.

## Fix

Re-canonicalize the `at:put:` result via `from_list(array:to_list(...))` so it is structurally identical to a literal-equivalent array.

## Key changes

- `beamtalk_array:at_put/3` routes its result through `from_list/1`.
- New EUnit regressions: structural `=:=` equality vs literal, `erlang:phash2` consistency (equal arrays must hash equally for dict/set keys), and chained `at_put` updates.

## Verification

- `just test-bunit` — 2281 passed, 0 failed (`testArrayAtPutReturnsArray` now passes).
- `beamtalk_array_tests` EUnit — 50 tests, 0 failures.
- `just test-rust` — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)