### PR TITLE
Unify threading: ThreadedExpr transform + value-type/class-method boundary adapters (BT-2373)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -2246,7 +2246,10 @@ impl CoreErlangGenerator {
         // the shared helper applies the `{class_var_result, …}` wrapping based on
         // `class_var_mutated()`, identical to the wrapping below — so it is
         // correct for both the class-vars and no-class-vars cases.
-        if let Some(doc) = self.try_generate_class_method_threaded_last(value)? {
+        if let Some(doc) = self.try_generate_class_method_threaded_last(
+            value,
+            super::super::threaded_expr::ThreadingPosition::Return,
+        )? {
             return Ok(doc);
         }
         // BT-1942: Use `expression_doc_with_open_scope` so an explicit
@@ -2313,7 +2316,10 @@ impl CoreErlangGenerator {
         // is identical whether or not the class declares class vars — threading constructs
         // mutate *locals*, not class vars, so the wrapping is driven solely by whether an
         // earlier statement mutated a class var (`class_var_mutated()`).
-        if let Some(doc) = self.try_generate_class_method_threaded_last(expr)? {
+        if let Some(doc) = self.try_generate_class_method_threaded_last(
+            expr,
+            super::super::threaded_expr::ThreadingPosition::Last,
+        )? {
             return Ok(doc);
         }
         if has_class_vars {
@@ -2335,42 +2341,23 @@ impl CoreErlangGenerator {
     fn try_generate_class_method_threaded_last(
         &mut self,
         expr: &Expression,
+        position: super::super::threaded_expr::ThreadingPosition,
     ) -> Result<Option<Document<'static>>> {
-        // BT-2358: see through redundant parentheses (e.g. `^(items collect: …)`
-        // or `(flag ifTrue: [...])`), which are semantically transparent, so the
-        // threading construct inside is unwrapped to its logical value rather than
-        // leaking its raw `{value, StateAcc}` tuple. Applies to both the explicit
-        // `^`-return and the implicit last-expression callers.
-        let expr = Self::peel_parens(expr);
+        // BT-2361: route through the shared `ThreadedExpr` transform + boundary emitter.
+        // BT-2358: it peels redundant parentheses (e.g. `^(items collect: …)` or
+        // `(flag ifTrue: [...])`) so the threading construct inside is unwrapped to its
+        // logical value rather than leaking its raw `{value, StateAcc}` tuple. Applies to
+        // both the explicit `^`-return and the implicit last-expression callers.
         let mut parts: Vec<Document<'static>> = Vec::new();
-        let result_var = if self.expr_yields_vt_threaded_tuple(expr) {
-            self.emit_vt_threaded_tuple_unwrap_to_var(expr, &mut parts)?
-        } else if self.is_conditional_with_vt_local_threading(expr) {
-            match self.emit_vt_conditional_case_to_var(expr, &mut parts)? {
-                Some(result_var) => result_var,
-                None => return Ok(None),
-            }
+        if self.emit_threaded_last(
+            expr,
+            position,
+            super::super::threaded_expr::ThreadingBoundary::ClassMethod,
+            &mut parts,
+        )? {
+            Ok(Some(Document::Vec(parts)))
         } else {
-            return Ok(None);
-        };
-        parts.push(self.class_method_result_tail(&result_var));
-        Ok(Some(Document::Vec(parts)))
-    }
-
-    /// BT-2349: Builds the tail that returns an already-bound class-method result var:
-    /// `{class_var_result, Result, ClassVarsN}` when a class var was mutated, else `Result`.
-    fn class_method_result_tail(&self, result_var: &str) -> Document<'static> {
-        if self.class_var_mutated() {
-            let final_cv = self.current_class_var();
-            docvec![
-                "{'class_var_result', ",
-                leaf::var(result_var.to_string()),
-                ", ",
-                leaf::var(final_cv),
-                "}",
-            ]
-        } else {
-            leaf::var(result_var.to_string())
+            Ok(None)
         }
     }
 
@@ -2535,27 +2522,17 @@ impl CoreErlangGenerator {
     ) -> Result<Document<'static>> {
         if let Expression::Assignment { target, value, .. } = expr {
             if let Expression::Identifier(id) = target.as_ref() {
-                // BT-2349: When the RHS is a threading construct (value-type loop or foldl
-                // list-op) it returns a `{value, StateAcc}` tuple. Bind the target to the
-                // logical value (element 1) and rebind the threaded locals from the StateAcc
-                // (element 2), rather than binding the target to the raw tuple. Mirrors the
-                // value-type instance-method body sequencer (BT-2342).
-                if self.expr_yields_vt_threaded_tuple(value) {
-                    let mut parts: Vec<Document<'static>> = Vec::new();
-                    self.emit_vt_threaded_local_assignment(&id.name, value, &mut parts)?;
-                    return Ok(Document::Vec(parts));
-                }
-                // BT-2371: When the RHS is a read+write conditional (`ifTrue:`/`ifFalse:`/
-                // `ifTrue:ifFalse:` whose branches mutate sibling outer-locals), each branch
-                // emits `{LogicalValue, Mut1..MutN}`. Bind the target to element 1 and rebind
-                // the threaded siblings from elements 2.., so a later read of a sibling local
-                // sees the branch's mutation rather than its pre-conditional value. This is the
-                // class-method-context analogue of the value-type fix (BT-2359). See-through
-                // parentheses first (BT-2358), mirroring the loop/foldl assign-RHS path.
-                let rhs = Self::peel_parens(value);
-                if self.is_conditional_with_vt_local_threading(rhs) {
-                    let mut parts: Vec<Document<'static>> = Vec::new();
-                    self.emit_vt_conditional_assign_rhs(&id.name, rhs, &mut parts)?;
+                // BT-2349/BT-2371: When the RHS is a threading construct (value-type loop /
+                // foldl list-op yielding `{value, StateAcc}`) or a read+write conditional
+                // (each branch emits `{LogicalValue, Mut1..MutN}`), bind the target to the
+                // logical value and rebind the threaded siblings — rather than binding the
+                // target to the raw tuple. BT-2361: shared with the value-type instance-method
+                // body sequencer via `emit_threaded_assign_rhs`.
+                let mut parts: Vec<Document<'static>> = Vec::new();
+                if self
+                    .emit_threaded_assign_rhs(&id.name, value, &mut parts)?
+                    .is_some()
+                {
                     return Ok(Document::Vec(parts));
                 }
                 let var_name = &id.name;

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -104,6 +104,7 @@ pub mod selector_mangler;
 mod spec_codegen;
 mod state_codegen;
 mod supervisor_codegen;
+mod threaded_expr;
 mod util;
 mod value_type_codegen;
 mod variable_context;
@@ -1688,7 +1689,7 @@ impl CoreErlangGenerator {
     }
 
     /// BT-412: Returns the current class variable state variable name.
-    fn current_class_var(&self) -> String {
+    pub(super) fn current_class_var(&self) -> String {
         util::versioned_var("ClassVars", self.class_var_version())
     }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/threaded_expr.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/threaded_expr.rs
@@ -5,14 +5,18 @@
 //!
 //! **DDD Context:** Code Generation
 //!
-//! Every threading construct — a captured-local loop (`whileTrue:`/`whileFalse:`,
-//! `to:do:`/`to:by:do:`/`timesRepeat:`), a foldl list-op
-//! (`collect:`/`select:`/`reject:`/`inject:into:`/`count:`/`detect:`), or a
-//! read+write conditional (`ifTrue:`/`ifFalse:`/`ifTrue:ifFalse:`) — lowers to the
-//! same runtime shape: a `{Value, StateAcc}` 2-tuple whose element 1 is the logical
-//! result and element 2 is a map of the mutated outer locals (ADR 0041's calling
-//! convention). The three former consumption paths (value-type, class-method, …)
-//! did not disagree about that tuple — they only disagreed about what to do with it
+//! A captured-local loop (`whileTrue:`/`whileFalse:`, `to:do:`/`to:by:do:`/
+//! `timesRepeat:`) or a foldl list-op
+//! (`collect:`/`select:`/`reject:`/`inject:into:`/`count:`/`detect:`) lowers to a
+//! `{Value, StateAcc}` 2-tuple whose element 1 is the logical result and element 2 is
+//! a map of the mutated outer locals (ADR 0041's calling convention). A read+write
+//! conditional (`ifTrue:`/`ifFalse:`/`ifTrue:ifFalse:`) is instead inlined as a
+//! `case` — in last position binding only its branch's logical value, in non-last /
+//! assign-RHS position yielding a flat `{LogicalValue, Mut1, …, MutN}` tuple whose
+//! trailing elements rebind the threaded locals positionally. Either way every
+//! construct exposes the same two things — a logical value and the outer-local
+//! mutations — so the three former consumption paths (value-type, class-method, …)
+//! did not disagree about *what* a construct produces, only about what to do with it
 //! at the **method boundary**.
 //!
 //! This module splits that tangle along one line:
@@ -37,10 +41,13 @@ use crate::docvec;
 /// Where a threading construct sits in its enclosing method body. Drives how the
 /// bound logical value (tuple element 1) is returned/stored.
 ///
-/// Only `Last` is currently produced through the unified emitter; the non-last
-/// open-let-chain paths (`generate_vt_*_open`) are already context-shared and feed
-/// the same `{Value, StateAcc}` tuple. `Return` is the explicit `^`-return variant of
-/// `Last` — identical post-construct treatment, recorded distinctly for clarity.
+/// Both `Last` and `Return` flow through the unified emitter (the class-method
+/// generator passes `Return` for explicit `^ expr` and `Last` for the implicit final
+/// expression; the value-type generator passes `Last`). They currently receive
+/// identical post-construct treatment — `Return` is recorded distinctly so the call
+/// site's intent is preserved for the later non-last / assign-RHS migration steps. The
+/// non-last open-let-chain paths (`generate_vt_*_open`) are already context-shared and
+/// are not (yet) routed through this emitter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ThreadingPosition {
     /// Implicit last expression of the method body.

--- a/crates/beamtalk-core/src/codegen/core_erlang/threaded_expr.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/threaded_expr.rs
@@ -1,0 +1,232 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Context-agnostic outer-local mutation threading (BT-2361 steps 1-2).
+//!
+//! **DDD Context:** Code Generation
+//!
+//! Every threading construct — a captured-local loop (`whileTrue:`/`whileFalse:`,
+//! `to:do:`/`to:by:do:`/`timesRepeat:`), a foldl list-op
+//! (`collect:`/`select:`/`reject:`/`inject:into:`/`count:`/`detect:`), or a
+//! read+write conditional (`ifTrue:`/`ifFalse:`/`ifTrue:ifFalse:`) — lowers to the
+//! same runtime shape: a `{Value, StateAcc}` 2-tuple whose element 1 is the logical
+//! result and element 2 is a map of the mutated outer locals (ADR 0041's calling
+//! convention). The three former consumption paths (value-type, class-method, …)
+//! did not disagree about that tuple — they only disagreed about what to do with it
+//! at the **method boundary**.
+//!
+//! This module splits that tangle along one line:
+//!
+//! * **Transform (shared, written once).** Given a last/return-position threading
+//!   construct, [`CoreErlangGenerator::lower_threaded_last`] binds its logical value
+//!   (tuple element 1) to a fresh result var. The threaded locals do not escape in
+//!   last position, so element 2 is discarded. This subsumes the value-type
+//!   `emit_vt_last_expr` threading branch, `emit_vt_conditional_last`, and the
+//!   class-method `try_generate_class_method_threaded_last`.
+//! * **Boundary (per-context adapter, the only thing that varies).** A
+//!   [`ThreadingBoundary`] captures how the bound result var is returned/stored:
+//!   the value-type `{Result, Self{N}}` / bare-`Result` shape, or the class-method
+//!   `{class_var_result, Result, ClassVarsN}` / bare-`Result` shape. This mirrors the
+//!   [`NlrBoundary`](super::NlrBoundary) precedent (BT-2361 step 4 / PR #2408).
+
+use super::document::{Document, leaf};
+use super::{CoreErlangGenerator, Result};
+use crate::ast::Expression;
+use crate::docvec;
+
+/// Where a threading construct sits in its enclosing method body. Drives how the
+/// bound logical value (tuple element 1) is returned/stored.
+///
+/// Only `Last` is currently produced through the unified emitter; the non-last
+/// open-let-chain paths (`generate_vt_*_open`) are already context-shared and feed
+/// the same `{Value, StateAcc}` tuple. `Return` is the explicit `^`-return variant of
+/// `Last` — identical post-construct treatment, recorded distinctly for clarity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ThreadingPosition {
+    /// Implicit last expression of the method body.
+    Last,
+    /// Explicit `^ expr` return.
+    Return,
+}
+
+/// The per-context threading boundary — the *only* thing that differs between the
+/// value-type and class-method consumption of a threaded construct's logical value
+/// once the transform is shared.
+///
+/// Both contexts bind the construct's logical value (tuple element 1) to a result var
+/// identically; they disagree only about the Document that returns/stores it. This
+/// enum captures that single axis so the last/return-position emitter is written once
+/// (see [`CoreErlangGenerator::threading_result_tail`]) instead of being copy-evolved
+/// per context — exactly mirroring the [`NlrBoundary`](super::NlrBoundary) seam.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ThreadingBoundary {
+    /// Value-type methods: the tail yields `{Result, Self{N}}` when a non-local return
+    /// is active (so the normal and NLR-catch paths share a shape), or bare `Result`.
+    ValueType { has_nlr: bool },
+    /// Class methods: the tail yields `{'class_var_result', Result, ClassVarsN}` when an
+    /// earlier statement mutated a class var, or bare `Result` otherwise. Threading
+    /// constructs mutate *locals*, not class vars, so the wrapping is driven solely by
+    /// `class_var_mutated()`.
+    ClassMethod,
+}
+
+/// A threading construct normalized for the boundary to consume.
+///
+/// The transform lowers a construct into this; the boundary lowers it out to Core
+/// Erlang via [`CoreErlangGenerator::threading_result_tail`]. `value_doc` is the open
+/// let-chain that binds the logical value (tuple element 1) to `result_var`;
+/// `threaded_locals` is the set of outer locals carried in tuple element 2 (discarded
+/// in last position, where they do not escape); `position` records last vs explicit
+/// return.
+pub(super) struct ThreadedExpr {
+    /// Open let-chain binding the construct's logical value to `result_var`.
+    pub(super) value_doc: Document<'static>,
+    /// Core Erlang variable bound to the construct's logical value (tuple element 1).
+    pub(super) result_var: String,
+    /// Outer locals the construct threads via tuple element 2. Unused in last position
+    /// (the mutations do not escape), retained for the design's representation and any
+    /// future non-last routing through the unified emitter.
+    #[allow(dead_code)]
+    pub(super) threaded_locals: Vec<String>,
+    /// Last expression vs explicit `^`-return (same post-construct treatment).
+    #[allow(dead_code)]
+    pub(super) position: ThreadingPosition,
+}
+
+impl CoreErlangGenerator {
+    /// Lowers a last/return-position threading construct into a [`ThreadedExpr`],
+    /// binding its logical value (tuple element 1) to a fresh result var via the shared
+    /// value-type transform primitives.
+    ///
+    /// Returns `None` when `expr` (after peeling redundant parentheses) is not a
+    /// recognized threading construct, so the caller falls back to its generic
+    /// last-expression path. Handles:
+    ///
+    /// * loops / foldl list-ops yielding `{Value, StateAcc}` — element 1 is unwrapped
+    ///   (loops put `'nil'` there; foldl list-ops put the collected/folded value);
+    /// * read+write conditionals — inlined as a `case` binding the branch's logical
+    ///   value, avoiding the 0-arg dispatch crash on a stateful arity-1 block.
+    ///
+    /// The threaded locals do not escape in last position, so tuple element 2 is
+    /// discarded. BT-2358: redundant parentheses (`^(items collect: …)`) are peeled so
+    /// the construct inside is unwrapped rather than leaking its raw tuple.
+    pub(super) fn lower_threaded_last(
+        &mut self,
+        expr: &Expression,
+        position: ThreadingPosition,
+    ) -> Result<Option<ThreadedExpr>> {
+        let expr = Self::peel_parens(expr);
+        let mut parts: Vec<Document<'static>> = Vec::new();
+        let result_var = if self.expr_yields_vt_threaded_tuple(expr) {
+            self.emit_vt_threaded_tuple_unwrap_to_var(expr, &mut parts)?
+        } else if self.is_conditional_with_vt_local_threading(expr) {
+            match self.emit_vt_conditional_case_to_var(expr, &mut parts)? {
+                Some(result_var) => result_var,
+                None => return Ok(None),
+            }
+        } else {
+            return Ok(None);
+        };
+        Ok(Some(ThreadedExpr {
+            value_doc: Document::Vec(parts),
+            result_var,
+            threaded_locals: Vec::new(),
+            position,
+        }))
+    }
+
+    /// Emits a last/return-position threading construct, applying `boundary`'s return
+    /// shape — or returns `None` (without mutating `body_parts`) when `expr` is not a
+    /// threading construct, so the caller falls back to its generic path.
+    ///
+    /// This is the single shared entry point that subsumes the value-type
+    /// `emit_vt_last_expr`/`emit_vt_conditional_last` threading branches and the
+    /// class-method `try_generate_class_method_threaded_last`.
+    pub(super) fn emit_threaded_last(
+        &mut self,
+        expr: &Expression,
+        position: ThreadingPosition,
+        boundary: ThreadingBoundary,
+        body_parts: &mut Vec<Document<'static>>,
+    ) -> Result<bool> {
+        let Some(threaded) = self.lower_threaded_last(expr, position)? else {
+            return Ok(false);
+        };
+        body_parts.push(threaded.value_doc);
+        body_parts.push(self.threading_result_tail(&threaded.result_var, boundary));
+        Ok(true)
+    }
+
+    /// Emits a local assignment whose RHS is a threading construct, binding the target
+    /// to the construct's logical value (tuple element 1) and rebinding any threaded
+    /// sibling outer-locals from element 2 — so both the assigned value and the
+    /// mutations are visible to subsequent statements, rather than the target being
+    /// bound to the raw `{value, StateAcc}` tuple.
+    ///
+    /// Returns the Core Erlang variable bound to the assignment target, or `None` (without
+    /// mutating `body_parts`) when the RHS is not a threading construct, so the caller
+    /// falls back to its generic local-binding path. Handles both the loop / foldl
+    /// list-op RHS (`emit_vt_threaded_local_assignment`) and the read+write conditional
+    /// RHS (`emit_vt_conditional_assign_rhs`, BT-2359/BT-2371). BT-2358: the conditional
+    /// RHS is peeled of redundant parentheses first.
+    ///
+    /// Shared by the value-type instance-method body sequencer and the class-method
+    /// non-last local-var binder, which previously re-derived this branch independently.
+    pub(super) fn emit_threaded_assign_rhs(
+        &mut self,
+        var_name: &str,
+        value: &Expression,
+        body_parts: &mut Vec<Document<'static>>,
+    ) -> Result<Option<String>> {
+        if self.expr_yields_vt_threaded_tuple(value) {
+            return Ok(Some(
+                self.emit_vt_threaded_local_assignment(var_name, value, body_parts)?,
+            ));
+        }
+        let rhs = Self::peel_parens(value);
+        if self.is_conditional_with_vt_local_threading(rhs) {
+            return Ok(Some(
+                self.emit_vt_conditional_assign_rhs(var_name, rhs, body_parts)?,
+            ));
+        }
+        Ok(None)
+    }
+
+    /// Builds the Document that returns/stores an already-bound threaded result var for
+    /// `boundary`. This is the single place the value-type vs class-method divergence
+    /// lives — the boundary adapter the design calls for.
+    ///
+    /// BT-875: Use Document/docvec! — never format!() for Core Erlang fragments.
+    pub(super) fn threading_result_tail(
+        &self,
+        result_var: &str,
+        boundary: ThreadingBoundary,
+    ) -> Document<'static> {
+        match boundary {
+            ThreadingBoundary::ValueType { has_nlr: true } => {
+                let final_self = self.current_self_var();
+                docvec![
+                    "    {",
+                    leaf::var(result_var.to_string()),
+                    ", ",
+                    leaf::var(final_self),
+                    "}\n",
+                ]
+            }
+            ThreadingBoundary::ValueType { has_nlr: false } => {
+                docvec!["    ", leaf::var(result_var.to_string()), "\n"]
+            }
+            ThreadingBoundary::ClassMethod if self.class_var_mutated() => {
+                let final_cv = self.current_class_var();
+                docvec![
+                    "{'class_var_result', ",
+                    leaf::var(result_var.to_string()),
+                    ", ",
+                    leaf::var(final_cv),
+                    "}",
+                ]
+            }
+            ThreadingBoundary::ClassMethod => leaf::var(result_var.to_string()),
+        }
+    }
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -946,15 +946,19 @@ impl CoreErlangGenerator {
         has_nlr: bool,
         body_parts: &mut Vec<Document<'static>>,
     ) -> Result<()> {
-        // BT-2308/BT-2342: A last expression that is a local-threading construct — a loop
-        // (whileTrue:/whileFalse:, to:do:/to:by:do:/timesRepeat:) or a foldl list-op
-        // (collect:/select:/reject:/inject:into:) — returns a `{value, StateAcc}` tuple so
-        // the open-extraction machinery can rebind the threaded locals. In last position
-        // those locals don't escape, so the method value is the construct's *logical*
-        // result — element 1 — not the raw tuple. Unwrap it here.
-        if self.expr_yields_vt_threaded_tuple(expr) {
-            let result_var = self.emit_vt_threaded_tuple_unwrap_to_var(expr, body_parts)?;
-            self.emit_vt_value_return(&result_var, has_nlr, body_parts);
+        // BT-2308/BT-2342/BT-2361: A last expression that is a local-threading construct —
+        // a loop (whileTrue:/whileFalse:, to:do:/to:by:do:/timesRepeat:), a foldl list-op
+        // (collect:/select:/reject:/inject:into:), or a read+write conditional — yields a
+        // `{value, StateAcc}` tuple. In last position the threaded locals don't escape, so
+        // the method value is the construct's *logical* result — element 1 — not the raw
+        // tuple. Route through the shared `ThreadedExpr` emitter, which unwraps it and
+        // applies the value-type boundary.
+        if self.emit_threaded_last(
+            expr,
+            super::threaded_expr::ThreadingPosition::Last,
+            super::threaded_expr::ThreadingBoundary::ValueType { has_nlr },
+            body_parts,
+        )? {
             return Ok(());
         }
 
@@ -1163,32 +1167,22 @@ impl CoreErlangGenerator {
                 }
             }
             VtBodyExprKind::LocalAssignment => {
-                // BT-2342: When the RHS is a threading construct (value-type loop or foldl
-                // list-op) it returns a `{value, StateAcc}` tuple. Bind the target to the
-                // logical value (element 1) and rebind the threaded locals from the StateAcc
+                // BT-2342/BT-2359: a threading construct (value-type loop / foldl list-op
+                // yielding `{value, StateAcc}`) or a read+write conditional as the RHS
+                // threads its mutations through the tuple. Bind the target to the logical
+                // value (element 1) and rebind the threaded siblings from the StateAcc
                 // (element 2), rather than binding the target to the raw tuple.
                 if let Expression::Assignment { target, value, .. } = expr {
                     if let Expression::Identifier(id) = target.as_ref() {
-                        if self.expr_yields_vt_threaded_tuple(value) {
-                            let var_name = id.name.clone();
-                            let core_var = self
-                                .emit_vt_threaded_local_assignment(&var_name, value, body_parts)?;
+                        let var_name = id.name.clone();
+                        if let Some(core_var) =
+                            self.emit_threaded_assign_rhs(&var_name, value, body_parts)?
+                        {
                             if is_last {
-                                self.emit_vt_value_return(&core_var, has_nlr, body_parts);
-                            }
-                            return Ok(());
-                        }
-                        // BT-2359: a threading conditional as the assignment RHS — possibly
-                        // parenthesized — threads a sibling outer-local (`x`) that would
-                        // otherwise be dropped. Bind the target to the conditional's logical
-                        // value and rebind the threaded sibling from the same `case`.
-                        let rhs = Self::peel_parens(value);
-                        if self.is_conditional_with_vt_local_threading(rhs) {
-                            let var_name = id.name.clone();
-                            let core_var =
-                                self.emit_vt_conditional_assign_rhs(&var_name, rhs, body_parts)?;
-                            if is_last {
-                                self.emit_vt_value_return(&core_var, has_nlr, body_parts);
+                                body_parts.push(self.threading_result_tail(
+                                    &core_var,
+                                    super::threaded_expr::ThreadingBoundary::ValueType { has_nlr },
+                                ));
                             }
                             return Ok(());
                         }
@@ -1838,28 +1832,6 @@ impl CoreErlangGenerator {
         Ok(core_var)
     }
 
-    /// BT-2342: Emits a value-type method's final return of an already-bound Core Erlang
-    /// variable: `{Var, Self{N}}` when NLR is active, or `Var` otherwise.
-    fn emit_vt_value_return(
-        &self,
-        core_var: &str,
-        has_nlr: bool,
-        body_parts: &mut Vec<Document<'static>>,
-    ) {
-        if has_nlr {
-            let final_self = self.current_self_var();
-            body_parts.push(docvec![
-                "    {",
-                leaf::var(core_var.to_string()),
-                ", ",
-                leaf::var(final_self),
-                "}\n",
-            ]);
-        } else {
-            body_parts.push(docvec!["    ", leaf::var(core_var.to_string()), "\n"]);
-        }
-    }
-
     /// BT-2308: Returns `true` if `expr` is a `to:do:` / `to:by:do:` / `timesRepeat:`
     /// counted loop whose body block captures and mutates outer local variables in
     /// value-type or class-method context.
@@ -2244,13 +2216,16 @@ impl CoreErlangGenerator {
         has_nlr: bool,
         body_parts: &mut Vec<Document<'static>>,
     ) -> Result<()> {
-        match self.emit_vt_conditional_case_to_var(expr, body_parts)? {
-            Some(result_var) => {
-                self.emit_vt_value_return(&result_var, has_nlr, body_parts);
-                Ok(())
-            }
+        if self.emit_threaded_last(
+            expr,
+            super::threaded_expr::ThreadingPosition::Last,
+            super::threaded_expr::ThreadingBoundary::ValueType { has_nlr },
+            body_parts,
+        )? {
+            Ok(())
+        } else {
             // Not a recognized read+write conditional — fall back to the generic path.
-            None => self.emit_vt_last_expr(expr, 0, has_nlr, body_parts),
+            self.emit_vt_last_expr(expr, 0, has_nlr, body_parts)
         }
     }
 


### PR DESCRIPTION
Implements **BT-2361 migration-plan steps 1-2** (the value-type + class-method boundary adapters of the context-agnostic threading pass). Follows the `NlrBoundary` precedent landed in PR #2408 (step 4).

Linear: https://linear.app/beamtalk/issue/BT-2373

## What changed

Introduces a normalized `ThreadedExpr` representation + a unified transform/emitter + a per-context `ThreadingBoundary` adapter, and ports **both** the value-type and class-method last/return-position threading onto it. Contexts now differ only at the *boundary* (how the bound logical value is returned/stored), not in whether/how threading happens.

### New module `threaded_expr.rs`
- `ThreadedExpr { value_doc, result_var, threaded_locals, position }` — the normalized representation.
- `ThreadingPosition { Last, Return }` and `ThreadingBoundary { ValueType { has_nlr }, ClassMethod }`.
- `lower_threaded_last` / `emit_threaded_last` — the shared transform that binds a threading construct's logical value (tuple element 1) to a result var (loops put `'nil'`, foldl list-ops put the folded value, read+write conditionals inline as a `case`).
- `emit_threaded_assign_rhs` — shared non-last assign-RHS threading (loop/foldl + peeled conditional).
- `threading_result_tail` — the single place the value-type vs class-method return-shape divergence lives.

### Value-type (step 1)
- `emit_vt_last_expr`, `emit_vt_conditional_last`, and the `LocalAssignment` assign-RHS branch now route through the unified emitter.
- Deleted `emit_vt_value_return` (subsumed by `threading_result_tail`).

### Class-method (step 2)
- `try_generate_class_method_threaded_last` reimplemented via the shared emitter (now takes a `ThreadingPosition`).
- Deleted `class_method_result_tail` (subsumed by `threading_result_tail`).
- Folded the threading branches of `generate_class_method_local_var_binding` into `emit_threaded_assign_rhs`.

## Safety
- **Byte-for-byte identical Core Erlang** — zero insta snapshot churn across 4049 beamtalk-core tests.
- Both oracle suites green: `value_type_mutation_matrix_test.bt` and `metamorphic_threading_test.bt` (BUnit: 2357 passed / 0 failed). All `bt****Pending` switches remain `false` — none re-gated.
- No `format!` for Core Erlang (Document/docvec!/typed `leaf::*` only); gensym hygiene preserved.
- `just clippy` + `just fmt-check` clean; full `just test-rust` green.

## Scope notes
Steps 3-5 (Actor boundary, `threaded_vars_*` fold, `CodeGenContext` branch sweep) remain deferred per the migration plan. The `is_*_with_vt_local_threading` predicates and `generate_vt_*_open` non-last paths are now the *shared transform primitives* both contexts call through — kept as-is (renaming would be pure churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to the code generation infrastructure, including refactored handling of expression threading patterns. Enhanced consistency across multiple code paths and improved overall maintainability of the code generation system. No impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->