### PR TITLE
Session runtime primitives + pending-mutation plumbing (BT-2366)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
@@ -32,6 +32,7 @@ bindings while sharing access to actors and loaded modules.
     interrupt/1,
     get_bindings/1,
     clear_bindings/1,
+    enqueue_mutation/2,
     load_file/2,
     load_file/3,
     load_source/2,
@@ -112,6 +113,18 @@ get_bindings(SessionPid) ->
 -spec clear_bindings(pid()) -> ok.
 clear_bindings(SessionPid) ->
     gen_server:call(SessionPid, clear_bindings).
+
+-doc """
+Enqueue a deferred session-local mutation (BT-2366, ADR 0081 Phase 2).
+
+Called by `beamtalk_session_primitives` from inside this session's eval worker.
+The `{op, Key, Value}` tuple is appended to `pending_mutations`; it is applied
+(or dropped) by the eval-exit clauses when the worker completes.  Safe from the
+worker because the shell is in `noreply` while the worker runs.
+""".
+-spec enqueue_mutation(pid(), beamtalk_repl_state:mutation()) -> ok.
+enqueue_mutation(SessionPid, Mutation) ->
+    gen_server:call(SessionPid, {enqueue_mutation, Mutation}).
 
 -doc "Load a Beamtalk source file in this session.".
 -spec load_file(pid(), string()) -> {ok, [map()]} | {error, term()}.
@@ -231,11 +244,24 @@ handle_call(interrupt, _From, {SessionId, State, {WorkerPid, MonRef, EvalFrom}})
     %% BT-1242: Apply any pending module removals that accumulated while the
     %% worker was running.  No WorkerState is returned on interrupt, so we
     %% drain directly from ShellState.
-    CleanState = drain_pending_removals(State),
+    CleanState0 = drain_pending_removals(State),
+    %% BT-2366 (ADR 0081 Phase 2): drain session-local mutations too — an
+    %% interrupted eval's issued put/remove/clear edits are not lost.
+    CleanState = drain_pending_mutations(CleanState0),
     {reply, ok, {SessionId, CleanState, undefined}};
 handle_call(interrupt, _From, {_SessionId, _State, undefined} = FullState) ->
     %% No eval in progress — nothing to interrupt
     {reply, ok, FullState};
+handle_call({enqueue_mutation, Mutation}, _From, {SessionId, State, Worker}) ->
+    %% BT-2366 (ADR 0081 Phase 2): a session-scope write issued by a primitive
+    %% running inside this session's eval worker.  Enqueue the {op, Key, Value}
+    %% tuple on pending_mutations rather than writing the bindings directly: the
+    %% worker holds a state snapshot whose returned WorkerState would clobber a
+    %% direct edit when {eval_result, ...} arrives.  This call is synchronous and
+    %% completes before the worker sends {eval_result, ...}, so the ShellState
+    %% bound in the eval-result handler always reflects the enqueued mutation.
+    NewState = beamtalk_repl_state:add_pending_mutation(Mutation, State),
+    {reply, ok, {SessionId, NewState, Worker}};
 handle_call(get_bindings, _From, {SessionId, State, Worker}) ->
     Bindings = beamtalk_repl_state:get_bindings(State),
     {reply, {ok, Bindings}, {SessionId, State, Worker}};
@@ -366,12 +392,23 @@ handle_info({eval_result, WorkerPid, Result}, {SessionId, ShellState, {WorkerPid
             %% are resolved live, not injected into the session map, so there is no
             %% injected copy to reconcile after an eval. The session map holds only
             %% locals (the worker's returned WorkerState).
-            FinalState = apply_pending_removals(ShellState, WorkerState),
+            %% BT-2366 (ADR 0081 Phase 2): apply removals first, then session-local
+            %% mutations on top of the worker's returned locals (so the worker's
+            %% own `x := …` is visible and a same-line `bindings at:put:` overrides
+            %% it).  Success path applies all queued ops, including `clear`.
+            FinalState0 = apply_pending_removals(ShellState, WorkerState),
+            FinalState = apply_pending_mutations(ShellState, FinalState0),
             beamtalk_bindings_events:on_bindings_changed(SessionId),
             {noreply, {SessionId, FinalState, undefined}};
         {error, Reason, Output, Warnings, WorkerState} ->
             reply_eval(From, {eval_error, Reason, Output, Warnings}),
-            MergedState = apply_pending_removals(ShellState, WorkerState),
+            %% BT-2366 (ADR 0081 Phase 2): on the error path apply put/remove only
+            %% (explicit per-key edits the user issued, independent of the failed
+            %% expression) and DROP a queued `clear` — `Session current clear. typo`
+            %% must not wipe every local because the line after `clear` failed.
+            MergedState0 = apply_pending_removals(ShellState, WorkerState),
+            MergedState = apply_pending_mutations_no_clear(ShellState, MergedState0),
+            beamtalk_bindings_events:on_bindings_changed(SessionId),
             {noreply, {SessionId, MergedState, undefined}}
     end;
 %% Worker process crashed (BT-666)
@@ -387,7 +424,10 @@ handle_info(
     reply_eval(From, {eval_error, Err1, <<>>, []}),
     %% BT-1242: Apply any pending module removals that arrived while the
     %% worker was running.  No WorkerState is returned on crash.
-    CleanState = drain_pending_removals(State),
+    CleanState0 = drain_pending_removals(State),
+    %% BT-2366 (ADR 0081 Phase 2): DISCARD session-local mutations — a crashed
+    %% worker's partial mutations are not trustworthy.  Reset the queue to [].
+    CleanState = beamtalk_repl_state:clear_pending_mutations(CleanState0),
     {noreply, {SessionId, CleanState, undefined}};
 %% BT-1242: Class removed via Beamtalk code path — clean up session tracker.
 %% Only updates tracker when no eval worker is active: if a worker is running it
@@ -497,6 +537,83 @@ drain_pending_removals(State) ->
             State1 = beamtalk_repl_state:set_module_tracker(NewTracker, State),
             beamtalk_repl_state:clear_pending_module_removals(State1)
     end.
+
+-doc """
+BT-2366 (ADR 0081 Phase 2): apply queued session-local mutations on the success
+exit path.
+
+Reads the `pending_mutations` queue from ShellState (which accumulated the
+primitive enqueues that completed before `{eval_result, …}`) and folds it over
+TargetState's locals map in enqueue order, then resets the queue to `[]`.
+
+`put`/`remove` edit a single key; `clear` empties the locals map (no
+injected-key caveat now that the map is locals-only, BT-2365).  Mutations apply
+on top of the worker's returned bindings already merged into TargetState, so a
+same-line `bindings at:put:` overrides the worker's own assignment.
+""".
+-spec apply_pending_mutations(beamtalk_repl_state:state(), beamtalk_repl_state:state()) ->
+    beamtalk_repl_state:state().
+apply_pending_mutations(ShellState, TargetState) ->
+    Mutations = beamtalk_repl_state:get_pending_mutations(ShellState),
+    fold_mutations(Mutations, TargetState).
+
+-doc """
+BT-2366 (ADR 0081 Phase 2): apply queued session-local mutations on the error
+exit path — `put`/`remove` only.
+
+A queued `clear` (whole-session destruction) is dropped: `Session current
+clear. someTypo` should not wipe every local because the line after `clear`
+failed.  `clear` applies only on the success path.  `put`/`remove` are explicit
+per-key edits the user issued, independent of the failed expression, so they
+take effect.
+""".
+-spec apply_pending_mutations_no_clear(beamtalk_repl_state:state(), beamtalk_repl_state:state()) ->
+    beamtalk_repl_state:state().
+apply_pending_mutations_no_clear(ShellState, TargetState) ->
+    Mutations = beamtalk_repl_state:get_pending_mutations(ShellState),
+    Kept = [M || M <- Mutations, element(1, M) =/= clear],
+    fold_mutations(Kept, TargetState).
+
+-doc """
+BT-2366 (ADR 0081 Phase 2): apply pending session-local mutations directly to
+State and clear the queue.
+
+Used when the worker exits via interrupt (no WorkerState is returned).  The
+shell resumes using its own ShellState, so we fold the queue over that state's
+locals and reset the queue to `[]`.  All ops apply (interrupt is not an error
+path — the user's issued edits stand).
+""".
+-spec drain_pending_mutations(beamtalk_repl_state:state()) -> beamtalk_repl_state:state().
+drain_pending_mutations(State) ->
+    Mutations = beamtalk_repl_state:get_pending_mutations(State),
+    fold_mutations(Mutations, State).
+
+-doc """
+BT-2366 (ADR 0081 Phase 2): fold a list of `{op, Key, Value}` mutations over the
+locals map of State in order, then clear the pending-mutations queue.
+
+Returns State unchanged (apart from clearing the queue) when the list is empty.
+""".
+-spec fold_mutations([beamtalk_repl_state:mutation()], beamtalk_repl_state:state()) ->
+    beamtalk_repl_state:state().
+fold_mutations([], State) ->
+    %% Always reset the queue, even when empty, so the shell returns to idle with
+    %% a clean slate regardless of which fold path ran.
+    beamtalk_repl_state:clear_pending_mutations(State);
+fold_mutations(Mutations, State) ->
+    Bindings0 = beamtalk_repl_state:get_bindings(State),
+    Bindings1 = lists:foldl(fun apply_one_mutation/2, Bindings0, Mutations),
+    State1 = beamtalk_repl_state:set_bindings(Bindings1, State),
+    beamtalk_repl_state:clear_pending_mutations(State1).
+
+-doc "BT-2366: apply a single {op, Key, Value} mutation to a locals map.".
+-spec apply_one_mutation(beamtalk_repl_state:mutation(), map()) -> map().
+apply_one_mutation({put, Key, Value}, Bindings) ->
+    Bindings#{Key => Value};
+apply_one_mutation({remove, Key, _}, Bindings) ->
+    maps:remove(Key, Bindings);
+apply_one_mutation({clear, _, _}, _Bindings) ->
+    #{}.
 
 -doc "BT-696: Dispatch eval result to sync caller or async subscriber.".
 reply_eval({async, Subscriber}, Msg) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
@@ -31,10 +31,15 @@ for manipulating state during REPL sessions.
     %% BT-1242: pending module removals (deferred during active eval)
     get_pending_module_removals/1,
     add_pending_module_removal/2,
-    clear_pending_module_removals/1
+    clear_pending_module_removals/1,
+    %% BT-2366 (ADR 0081 Phase 2): pending session-local mutations (deferred
+    %% during active eval).
+    get_pending_mutations/1,
+    add_pending_mutation/2,
+    clear_pending_mutations/1
 ]).
 
--export_type([state/0]).
+-export_type([state/0, mutation/0]).
 
 -record(state, {
     listen_socket :: gen_tcp:socket() | undefined,
@@ -51,8 +56,21 @@ for manipulating state during REPL sessions.
     %% is active.  Deferred here so they can be applied to the worker's returned
     %% state when eval_result arrives (prevents the worker snapshot from
     %% reinstating modules that were removed during the eval).
-    pending_module_removals :: [atom()]
+    pending_module_removals :: [atom()],
+    %% BT-2366 (ADR 0081 Phase 2): session-local mutations issued by primitives
+    %% (Session bindings at:put:/removeKey:, Session clear) while an eval worker
+    %% is active.  Primitives enqueue {op, Key, Value} tuples here via a
+    %% gen_server:call to the shell rather than writing directly, because the
+    %% worker holds a state snapshot whose writeback would clobber a direct edit.
+    %% Drained in the eval-exit clauses (apply_pending_mutations/2) in enqueue
+    %% order — preserves insertion order (newest appended at the tail).
+    pending_mutations :: [mutation()]
 }).
+
+-type mutation() ::
+    {put, atom(), term()}
+    | {remove, atom(), undefined}
+    | {clear, undefined, undefined}.
 
 -opaque state() :: #state{}.
 
@@ -72,7 +90,8 @@ new(ListenSocket, Port, _Options) ->
         loaded_modules = [],
         actor_registry = undefined,
         module_tracker = beamtalk_repl_modules:new(),
-        pending_module_removals = []
+        pending_module_removals = [],
+        pending_mutations = []
     }.
 
 -doc "Get current variable bindings.".
@@ -174,3 +193,37 @@ so the shell returns to idle with a clean slate.
 -spec clear_pending_module_removals(state()) -> state().
 clear_pending_module_removals(State) ->
     State#state{pending_module_removals = []}.
+
+-doc """
+Get pending session-local mutations (deferred during active eval).
+
+BT-2366 (ADR 0081 Phase 2): returns the queued `{op, Key, Value}` tuples in
+enqueue order (oldest first).  Drained by the eval-exit clauses in
+`beamtalk_repl_shell` (`apply_pending_mutations/2`).
+""".
+-spec get_pending_mutations(state()) -> [mutation()].
+get_pending_mutations(#state{pending_mutations = Mutations}) ->
+    Mutations.
+
+-doc """
+Append a session-local mutation to the pending queue.
+
+BT-2366 (ADR 0081 Phase 2): called by `beamtalk_session_primitives` (via the
+shell `enqueue_mutation` handler) when a session-scope write is issued during
+an active eval.  Appends at the tail so the queue preserves enqueue order; the
+fold in `apply_pending_mutations/2` then replays `put`/`remove`/`clear` in the
+order the user issued them.
+""".
+-spec add_pending_mutation(mutation(), state()) -> state().
+add_pending_mutation(Mutation, #state{pending_mutations = Mutations} = State) ->
+    State#state{pending_mutations = Mutations ++ [Mutation]}.
+
+-doc """
+Clear the pending session-local mutations queue.
+
+BT-2366 (ADR 0081 Phase 2): called after applying (or discarding) the queue on
+an eval-exit path, so the shell returns to idle with an empty queue.
+""".
+-spec clear_pending_mutations(state()) -> state().
+clear_pending_mutations(State) ->
+    State#state{pending_mutations = []}.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_session_primitives.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_session_primitives.erl
@@ -117,7 +117,7 @@ send to a `Session` value fails consistently once the session is gone.
 """.
 -spec idOf(session() | term()) -> binary().
 idOf(Session) ->
-    {Id, Pid} = session_id_pid(Session, 'id'),
+    {Id, Pid} = session_id_pid(Session, 'idOf:'),
     ensure_alive(Pid, Id),
     Id.
 
@@ -134,7 +134,7 @@ target shell's `get_bindings` (its locals-only map after BT-2365).
 """.
 -spec bindingsViewFor(session() | term()) -> bindings_view().
 bindingsViewFor(Session) ->
-    {Id, Pid} = session_id_pid(Session, 'bindings'),
+    {Id, Pid} = session_id_pid(Session, 'bindingsViewFor:'),
     ensure_alive(Pid, Id),
     #{'$beamtalk_class' => 'BindingsView', scope => session, id => Id, pid => Pid}.
 
@@ -149,7 +149,7 @@ terminal), matching how the name would behave as a bare identifier.
 """.
 -spec resolveFor(session() | term(), atom() | binary() | string() | term()) -> term().
 resolveFor(Session, Name) ->
-    {Id, Pid} = session_id_pid(Session, 'resolve:'),
+    {Id, Pid} = session_id_pid(Session, 'resolveFor:'),
     Locals = session_bindings(Pid, Id),
     NameAtom = to_name_atom(Name),
     beamtalk_workspace:resolve_name(Locals, NameAtom).
@@ -165,8 +165,8 @@ eval's pending queue does not reach the target.
 """.
 -spec clearFor(session() | term()) -> nil.
 clearFor(Session) ->
-    {Id, Pid} = session_id_pid(Session, 'clear'),
-    enqueue_session_mutation(Pid, Id, {clear, undefined, undefined}, 'clear'),
+    {Id, Pid} = session_id_pid(Session, 'clearFor:'),
+    enqueue_session_mutation(Pid, Id, {clear, undefined, undefined}, 'clearFor:'),
     nil.
 
 %%% ============================================================================
@@ -400,8 +400,21 @@ to_binary_id(_) ->
 to_name_atom(Name) when is_atom(Name) -> Name;
 to_name_atom(Name) when is_binary(Name) -> binary_to_atom(Name, utf8);
 to_name_atom(Name) when is_list(Name) ->
-    binary_to_atom(unicode:characters_to_binary(Name), utf8);
+    %% A list with invalid codepoints makes `unicode:characters_to_binary/1`
+    %% return an error tuple (not a binary); feeding that to `binary_to_atom`
+    %% throws a raw badarg. Funnel any such failure into the consistent
+    %% type_error path instead of leaking a badarg.
+    try unicode:characters_to_binary(Name) of
+        Bin when is_binary(Bin) -> binary_to_atom(Bin, utf8);
+        _ -> raise_name_type_error(Name)
+    catch
+        _:_ -> raise_name_type_error(Name)
+    end;
 to_name_atom(Other) ->
+    raise_name_type_error(Other).
+
+-spec raise_name_type_error(term()) -> no_return().
+raise_name_type_error(Other) ->
     Err0 = beamtalk_error:new(type_error, 'BindingsView'),
     beamtalk_error:raise(
         beamtalk_error:with_message(

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_session_primitives.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_session_primitives.erl
@@ -1,0 +1,452 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_session_primitives).
+
+%%% **DDD Context:** REPL Session Context
+
+-moduledoc """
+Runtime primitives backing the `Session` and `BindingsView` stdlib classes
+(ADR 0081 Phase 3, BT-2366).
+
+`Session` is not an actor; its values are tagged maps minted by the factory
+primitives here (the `FileHandle`/`Port` representation pattern):
+
+```erlang
+#{'$beamtalk_class' => 'Session', id => SessionId :: binary(), pid => ShellPid :: pid()}
+```
+
+`current/0` reads the calling session from the eval-worker process dictionary
+(seeded in `beamtalk_repl_shell:seed_session_context/2`).  `withId/1` looks a
+session up by protocol id with a liveness check, so a captured value never
+carries a dead PID.
+
+Instance operations take the `Session` value (`self`) and act on the session it
+names.  Session-local **writes** are enqueued on the *calling* session's
+`pending_mutations` queue (Phase 2) via a `gen_server:call` to the shell — safe
+from the worker because the shell is in `noreply` while the worker runs.
+Cross-session writes are rejected (`cross_session_mutation_unsupported`) because
+the target shell's in-flight eval worker would clobber them.
+
+`BindingsView` values are likewise tagged maps:
+
+```erlang
+%% session scope (read/write the named session's locals)
+#{'$beamtalk_class' => 'BindingsView', scope => session, id => binary(), pid => pid()}
+%% workspace scope (read singletons + bind:as: live; write through bind/2 / unbind/1)
+#{'$beamtalk_class' => 'BindingsView', scope => workspace}
+```
+
+Every cross-session send (`bindingsViewFor`, `resolveFor`, `clearFor`, `idOf`,
+and the view read/write primitives) liveness-checks the carried PID and raises
+`#beamtalk_error{kind = session_not_found}` rather than issuing a `gen_server:call`
+that would block to timeout against a dead PID.
+""".
+
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+%% Factory (class-side)
+-export([current/0, withId/1, idOf/1]).
+%% Session operations (instance-side, take a Session value)
+-export([bindingsViewFor/1, resolveFor/2, clearFor/1]).
+%% Workspace-globals view (not a Session method)
+-export([globalsView/0]).
+%% BindingsView read/write primitives
+-export([view_at/2, view_at_put/3, view_remove/2, view_keys/1, view_values/1, view_size/1]).
+
+-type session() :: #{
+    '$beamtalk_class' := 'Session',
+    id := binary(),
+    pid := pid()
+}.
+
+-type bindings_view() ::
+    #{'$beamtalk_class' := 'BindingsView', scope := session, id := binary(), pid := pid()}
+    | #{'$beamtalk_class' := 'BindingsView', scope := workspace}.
+
+-export_type([session/0, bindings_view/0]).
+
+%%% ============================================================================
+%%% Factory primitives (class-side)
+%%% ============================================================================
+
+-doc """
+Return a `Session` value for the calling session, or `nil` outside an eval
+context.
+
+Reads `beamtalk_session_pid` / `beamtalk_session_id` from the process
+dictionary, seeded by `beamtalk_repl_shell:seed_session_context/2` on every
+eval-worker spawn.  Compiled program code (no shell-spawned worker) finds
+`beamtalk_session_pid =:= undefined` and gets `nil`.
+""".
+-spec current() -> session() | nil.
+current() ->
+    case {get(beamtalk_session_pid), get(beamtalk_session_id)} of
+        {Pid, Id} when is_pid(Pid), is_binary(Id) ->
+            make_session(Id, Pid);
+        _ ->
+            nil
+    end.
+
+-doc """
+Look up a session by its protocol id, returning a `Session` value or `nil`.
+
+Uses `beamtalk_session_table:lookup_alive/1` (the `resolve_pid` liveness
+discipline), so a stale ETS entry pointing at a dead PID returns `nil` rather
+than a `Session` carrying a dead PID.  `aSessionId` may be a binary or a string
+(list of codepoints).
+""".
+-spec withId(binary() | string() | term()) -> session() | nil.
+withId(SessionId) ->
+    case to_binary_id(SessionId) of
+        {ok, Id} ->
+            case beamtalk_session_table:lookup_alive(Id) of
+                {ok, Pid} -> make_session(Id, Pid);
+                error -> nil
+            end;
+        error ->
+            raise_id_type_error('withId:', SessionId)
+    end.
+
+-doc """
+Extract the protocol id (a String) from a `Session` value.
+
+Liveness-checked per ADR 0081 Phase 3: a captured `Session` whose backing shell
+has died raises `session_not_found` rather than returning a stale id, so every
+send to a `Session` value fails consistently once the session is gone.
+""".
+-spec idOf(session() | term()) -> binary().
+idOf(Session) ->
+    {Id, Pid} = session_id_pid(Session, 'id'),
+    ensure_alive(Pid, Id),
+    Id.
+
+%%% ============================================================================
+%%% Session operations (instance-side)
+%%% ============================================================================
+
+-doc """
+Return a `BindingsView` over the named session's locals map.
+
+The view records the target session's id and PID so cross-session writes can be
+rejected.  A read against this view (`view_at/2`, `view_keys/1`, …) goes to the
+target shell's `get_bindings` (its locals-only map after BT-2365).
+""".
+-spec bindingsViewFor(session() | term()) -> bindings_view().
+bindingsViewFor(Session) ->
+    {Id, Pid} = session_id_pid(Session, 'bindings'),
+    ensure_alive(Pid, Id),
+    #{'$beamtalk_class' => 'BindingsView', scope => session, id => Id, pid => Pid}.
+
+-doc """
+Resolve a name in the named session, delegating to the shared resolver.
+
+Reads the target session's locals (via `get_bindings`) and passes them to
+`beamtalk_workspace:resolve_name/2`, so the order matches bare-name lookup:
+locals → bind:as: → singletons → classes.  `aName` may be an atom, binary, or
+string.  A name that resolves nowhere raises `undefined_variable` (the resolver's
+terminal), matching how the name would behave as a bare identifier.
+""".
+-spec resolveFor(session() | term(), atom() | binary() | string() | term()) -> term().
+resolveFor(Session, Name) ->
+    {Id, Pid} = session_id_pid(Session, 'resolve:'),
+    Locals = session_bindings(Pid, Id),
+    NameAtom = to_name_atom(Name),
+    beamtalk_workspace:resolve_name(Locals, NameAtom).
+
+-doc """
+Clear the named session's local bindings.
+
+For the calling session, enqueues a `clear` mutation on its `pending_mutations`
+queue (Phase 2) — the clear is applied on the success exit path and dropped on
+error.  Against any other session, raises `cross_session_mutation_unsupported`:
+the target shell's in-flight worker would clobber a direct edit, and the calling
+eval's pending queue does not reach the target.
+""".
+-spec clearFor(session() | term()) -> nil.
+clearFor(Session) ->
+    {Id, Pid} = session_id_pid(Session, 'clear'),
+    enqueue_session_mutation(Pid, Id, {clear, undefined, undefined}, 'clear'),
+    nil.
+
+%%% ============================================================================
+%%% Workspace-globals view (not a Session method)
+%%% ============================================================================
+
+-doc """
+Return a `BindingsView` tagged for workspace scope.
+
+Reads resolve live against the singleton registry + `bind:as:` ETS (via
+`beamtalk_workspace_interface_primitives:get_session_bindings/0`); writes route
+through `bind/2` / `unbind/1` (synchronous, protected-name conflict checks).
+""".
+-spec globalsView() -> bindings_view().
+globalsView() ->
+    #{'$beamtalk_class' => 'BindingsView', scope => workspace}.
+
+%%% ============================================================================
+%%% BindingsView read/write primitives
+%%% ============================================================================
+
+-doc """
+Read a key from a `BindingsView`, returning its value or `nil`.
+
+Reads reflect committed state: within a single eval they do not observe
+mutations enqueued earlier in that same eval (those land on `pending_mutations`
+and apply at eval exit).
+""".
+-spec view_at(bindings_view() | term(), atom() | binary() | string() | term()) -> term().
+view_at(View, Key) ->
+    Map = view_read_map(View, 'at:'),
+    case to_existing_name_atom(Key) of
+        {ok, KeyAtom} -> maps:get(KeyAtom, Map, nil);
+        %% A never-interned name cannot be a binding key → absent.
+        error -> nil
+    end.
+
+-doc """
+Write a key/value into a `BindingsView`, returning the value put (Dictionary
+protocol).
+
+Session scope, calling session → enqueue a `put` mutation (deferred; the write
+is not read back within the same eval).  Session scope, another session → raise
+`cross_session_mutation_unsupported`.  Workspace scope → `bind/2` (synchronous,
+protected-name conflict checks).
+""".
+-spec view_at_put(bindings_view() | term(), atom() | binary() | string() | term(), term()) ->
+    term().
+view_at_put(#{'$beamtalk_class' := 'BindingsView', scope := workspace}, Key, Value) ->
+    KeyAtom = to_name_atom(Key),
+    _ = beamtalk_workspace_interface_primitives:bind(Value, KeyAtom),
+    Value;
+view_at_put(
+    #{'$beamtalk_class' := 'BindingsView', scope := session, id := Id, pid := Pid}, Key, Value
+) ->
+    KeyAtom = to_name_atom(Key),
+    enqueue_session_mutation(Pid, Id, {put, KeyAtom, Value}, 'at:put:'),
+    Value;
+view_at_put(Other, _Key, _Value) ->
+    raise_view_type_error('at:put:', Other).
+
+-doc """
+Remove a key from a `BindingsView`, returning `nil` (uniform contract — session
+removals are enqueued, so the removed value is not read back synchronously).
+
+Dispatch by scope mirrors `view_at_put/3`.
+""".
+-spec view_remove(bindings_view() | term(), atom() | binary() | string() | term()) -> nil.
+view_remove(#{'$beamtalk_class' := 'BindingsView', scope := workspace}, Key) ->
+    case to_existing_name_atom(Key) of
+        %% unbind/1 raises name_not_found for unknown names; a never-interned
+        %% atom is necessarily unknown, so treat it as already-absent (idempotent
+        %% remove) rather than minting an atom just to fail.
+        {ok, KeyAtom} -> _ = beamtalk_workspace_interface_primitives:unbind(KeyAtom);
+        error -> nil
+    end,
+    nil;
+view_remove(#{'$beamtalk_class' := 'BindingsView', scope := session, id := Id, pid := Pid}, Key) ->
+    case to_existing_name_atom(Key) of
+        {ok, KeyAtom} ->
+            enqueue_session_mutation(Pid, Id, {remove, KeyAtom, undefined}, 'removeKey:');
+        %% Never-interned name cannot be a session local → nothing to remove.
+        error ->
+            nil
+    end,
+    nil;
+view_remove(Other, _Key) ->
+    raise_view_type_error('removeKey:', Other).
+
+-doc "Return the keys of a `BindingsView` as a list of atoms.".
+-spec view_keys(bindings_view() | term()) -> [atom()].
+view_keys(View) ->
+    maps:keys(view_read_map(View, 'keys')).
+
+-doc "Return the values of a `BindingsView` as a list.".
+-spec view_values(bindings_view() | term()) -> [term()].
+view_values(View) ->
+    maps:values(view_read_map(View, 'values')).
+
+-doc "Return the number of entries in a `BindingsView`.".
+-spec view_size(bindings_view() | term()) -> non_neg_integer().
+view_size(View) ->
+    maps:size(view_read_map(View, 'size')).
+
+%%% ============================================================================
+%%% Internal helpers
+%%% ============================================================================
+
+-spec make_session(binary(), pid()) -> session().
+make_session(Id, Pid) ->
+    #{'$beamtalk_class' => 'Session', id => Id, pid => Pid}.
+
+%% Extract {Id, Pid} from a Session value, raising a type error if the shape is
+%% wrong.  Selector names the Session method for the error message.
+-spec session_id_pid(session() | term(), atom()) -> {binary(), pid()}.
+session_id_pid(#{'$beamtalk_class' := 'Session', id := Id, pid := Pid}, _Selector) when
+    is_binary(Id), is_pid(Pid)
+->
+    {Id, Pid};
+session_id_pid(Other, Selector) ->
+    Err0 = beamtalk_error:new(type_error, 'Session', Selector),
+    beamtalk_error:raise(
+        beamtalk_error:with_message(
+            Err0,
+            iolist_to_binary([<<"Expected a Session value, got ">>, type_name(Other)])
+        )
+    ).
+
+%% Read the locals map of a session by PID, liveness-checked.  Raises
+%% session_not_found if the shell has died.  For the calling session this is the
+%% committed snapshot; for a cross-session read it is the target's get_bindings.
+-spec session_bindings(pid(), binary()) -> map().
+session_bindings(Pid, Id) ->
+    ensure_alive(Pid, Id),
+    {ok, Bindings} = beamtalk_repl_shell:get_bindings(Pid),
+    Bindings.
+
+%% Resolve the read map for a BindingsView by scope.  Workspace reads come from
+%% the live singleton + bind:as: snapshot; session reads from the target shell.
+-spec view_read_map(bindings_view() | term(), atom()) -> map().
+view_read_map(#{'$beamtalk_class' := 'BindingsView', scope := workspace}, _Selector) ->
+    beamtalk_workspace_interface_primitives:get_session_bindings();
+view_read_map(
+    #{'$beamtalk_class' := 'BindingsView', scope := session, id := Id, pid := Pid}, _Selector
+) ->
+    session_bindings(Pid, Id);
+view_read_map(Other, Selector) ->
+    raise_view_type_error(Selector, Other).
+
+%% Enqueue a session-local mutation against the *calling* session's queue.
+%% Rejects cross-session writes (the target's worker would clobber them) and
+%% liveness-checks the calling shell before the gen_server:call.
+-spec enqueue_session_mutation(pid(), binary(), beamtalk_repl_state:mutation(), atom()) -> ok.
+enqueue_session_mutation(TargetPid, TargetId, Mutation, Selector) ->
+    CallingPid = get(beamtalk_session_pid),
+    case TargetPid =:= CallingPid of
+        true ->
+            ensure_alive(TargetPid, TargetId),
+            ok = beamtalk_repl_shell:enqueue_mutation(TargetPid, Mutation);
+        false ->
+            raise_cross_session(Selector)
+    end.
+
+%% Liveness guard: raise session_not_found rather than blocking a gen_server:call
+%% to timeout against a dead shell PID.
+-spec ensure_alive(pid(), binary()) -> ok.
+ensure_alive(Pid, Id) ->
+    case is_process_alive(Pid) of
+        true ->
+            ok;
+        false ->
+            Err0 = beamtalk_error:new(session_not_found, 'Session'),
+            beamtalk_error:raise(
+                beamtalk_error:with_message(
+                    Err0,
+                    iolist_to_binary([
+                        <<"Session ">>, Id, <<" is no longer alive">>
+                    ])
+                )
+            )
+    end.
+
+-spec raise_cross_session(atom()) -> no_return().
+raise_cross_session(Selector) ->
+    Err0 = beamtalk_error:new(cross_session_mutation_unsupported, 'Session', Selector),
+    Err1 = beamtalk_error:with_message(
+        Err0,
+        <<"Cannot mutate another session's bindings; cross-session access is read-only">>
+    ),
+    beamtalk_error:raise(
+        beamtalk_error:with_hint(
+            Err1,
+            <<"Use Session current for writes, or read another session's bindings via withId:.">>
+        )
+    ).
+
+-spec raise_view_type_error(atom(), term()) -> no_return().
+raise_view_type_error(Selector, Other) ->
+    Err0 = beamtalk_error:new(type_error, 'BindingsView', Selector),
+    beamtalk_error:raise(
+        beamtalk_error:with_message(
+            Err0,
+            iolist_to_binary([<<"Expected a BindingsView value, got ">>, type_name(Other)])
+        )
+    ).
+
+-spec raise_id_type_error(atom(), term()) -> no_return().
+raise_id_type_error(Selector, Other) ->
+    Err0 = beamtalk_error:new(type_error, 'Session', Selector),
+    beamtalk_error:raise(
+        beamtalk_error:with_message(
+            Err0,
+            iolist_to_binary([<<"Expected a String session id, got ">>, type_name(Other)])
+        )
+    ).
+
+%% Accept binary or string (list of codepoints) ids; return {ok, Binary} | error.
+-spec to_binary_id(term()) -> {ok, binary()} | error.
+to_binary_id(Id) when is_binary(Id) -> {ok, Id};
+to_binary_id(Id) when is_list(Id) ->
+    try
+        {ok, unicode:characters_to_binary(Id)}
+    catch
+        _:_ -> error
+    end;
+to_binary_id(_) ->
+    error.
+
+%% Convert a name (atom | binary | string) to an atom for map keys / resolution.
+-spec to_name_atom(term()) -> atom().
+to_name_atom(Name) when is_atom(Name) -> Name;
+to_name_atom(Name) when is_binary(Name) -> binary_to_atom(Name, utf8);
+to_name_atom(Name) when is_list(Name) ->
+    binary_to_atom(unicode:characters_to_binary(Name), utf8);
+to_name_atom(Other) ->
+    Err0 = beamtalk_error:new(type_error, 'BindingsView'),
+    beamtalk_error:raise(
+        beamtalk_error:with_message(
+            Err0,
+            iolist_to_binary([<<"Expected a Symbol name, got ">>, type_name(Other)])
+        )
+    ).
+
+%% Convert a name to an EXISTING atom for read/remove lookups, returning
+%% `{ok, Atom}` or `error` when the atom has never been created.
+%%
+%% Reads (`view_at`) and removes never need to mint a fresh atom: a name that
+%% was never interned cannot be a binding key, so `error` maps to "absent".
+%% This keeps introspection (`bindings at:`, `globals at:`) from being an
+%% atom-table exhaustion vector when fed arbitrary user strings in a loop —
+%% only genuine *writes* (`view_at_put`, which name a binding) create atoms,
+%% matching the existing eval/`bind:as:` trust model.
+-spec to_existing_name_atom(term()) -> {ok, atom()} | error.
+to_existing_name_atom(Name) when is_atom(Name) ->
+    {ok, Name};
+to_existing_name_atom(Name) when is_binary(Name) ->
+    try
+        {ok, binary_to_existing_atom(Name, utf8)}
+    catch
+        error:badarg -> error
+    end;
+to_existing_name_atom(Name) when is_list(Name) ->
+    try
+        {ok, binary_to_existing_atom(unicode:characters_to_binary(Name), utf8)}
+    catch
+        _:_ -> error
+    end;
+to_existing_name_atom(Other) ->
+    Err0 = beamtalk_error:new(type_error, 'BindingsView'),
+    beamtalk_error:raise(
+        beamtalk_error:with_message(
+            Err0,
+            iolist_to_binary([<<"Expected a Symbol name, got ">>, type_name(Other)])
+        )
+    ).
+
+-spec type_name(term()) -> binary().
+type_name(V) when is_binary(V) -> <<"a String">>;
+type_name(V) when is_atom(V) -> <<"a Symbol">>;
+type_name(V) when is_integer(V) -> <<"an Integer">>;
+type_name(V) when is_map(V) -> <<"a Dictionary">>;
+type_name(V) when is_list(V) -> <<"a List">>;
+type_name(_) -> <<"a value of an unexpected type">>.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_session_table.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_session_table.erl
@@ -17,7 +17,7 @@ delete, and lookup operations go through this module so that:
   * The common "resolve session ID → live PID" pattern lives in one place.
 """.
 
--export([new/0, insert/2, delete/1, lookup/1, resolve_pid/2]).
+-export([new/0, insert/2, delete/1, lookup/1, lookup_alive/1, resolve_pid/2]).
 
 -doc """
 Create the session ETS table if it does not already exist.
@@ -53,6 +53,31 @@ lookup(SessionId) when is_binary(SessionId) ->
     case ets:lookup(beamtalk_sessions, SessionId) of
         [{_, Pid}] -> {ok, Pid};
         [] -> error
+    end.
+
+-doc """
+Look up a session by ID, returning the PID only if its process is alive.
+
+BT-2366 (ADR 0081 Phase 3): the liveness-checked variant of `lookup/1`.  Unlike
+`lookup/1` (which can return a dead PID) and `resolve_pid/2` (which substitutes
+a default), this returns `{ok, Pid}` only when the registered process is alive,
+and `error` for not-found, dead-process, or ETS-unavailable cases.  Used by the
+factory `withId/1` primitive so a captured `Session` never carries a dead PID.
+""".
+-spec lookup_alive(binary()) -> {ok, pid()} | error.
+lookup_alive(SessionId) when is_binary(SessionId) ->
+    try
+        case ets:lookup(beamtalk_sessions, SessionId) of
+            [{_, Pid}] when is_pid(Pid) ->
+                case is_process_alive(Pid) of
+                    true -> {ok, Pid};
+                    false -> error
+                end;
+            _ ->
+                error
+        end
+    catch
+        _:_ -> error
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_shell_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_shell_tests.erl
@@ -471,6 +471,194 @@ class_removed_drained_on_worker_crash_test_() ->
         ]
     end}.
 
+%%====================================================================
+%% BT-2366: pending session-local mutations (ADR 0081 Phase 2)
+%%====================================================================
+
+%% Inject a fake worker + a queued list of pending mutations + seed locals,
+%% then return the shell pid.  Mirrors the BT-1242 worker-injection pattern.
+setup_shell_with_mutations(SessionId, Locals, Mutations) ->
+    {ok, Pid} = beamtalk_repl_shell:start_link(SessionId),
+    FakeWorkerPid = spawn(fun() ->
+        receive
+            _ -> ok
+        end
+    end),
+    sys:replace_state(Pid, fun({SId, State, _W}) ->
+        State1 = beamtalk_repl_state:set_bindings(Locals, State),
+        State2 = lists:foldl(
+            fun(M, S) -> beamtalk_repl_state:add_pending_mutation(M, S) end,
+            State1,
+            Mutations
+        ),
+        {SId, State2, {FakeWorkerPid, make_ref(), {async, self()}}}
+    end),
+    {Pid, FakeWorkerPid}.
+
+%% enqueue_mutation/2 appends to the pending queue (handle_call path).
+enqueue_mutation_appends_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {ok, Pid} = beamtalk_repl_shell:start_link(<<"test-enqueue-1">>),
+                ok = beamtalk_repl_shell:enqueue_mutation(Pid, {put, x, 1}),
+                ok = beamtalk_repl_shell:enqueue_mutation(Pid, {put, y, 2}),
+                {_SId, State, _W} = sys:get_state(Pid),
+                ?assertEqual(
+                    [{put, x, 1}, {put, y, 2}],
+                    beamtalk_repl_state:get_pending_mutations(State)
+                ),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%% Success path: removals + all mutations apply on top of the worker's locals.
+pending_mutations_applied_on_success_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {Pid, FakeWorker} = setup_shell_with_mutations(
+                    <<"test-mut-success-1">>,
+                    #{},
+                    [{put, x, 1}, {put, y, 2}, {remove, z, undefined}]
+                ),
+                %% Worker returns locals carrying z (to be removed) and its own w.
+                WorkerState = worker_state_with_bindings(#{z => 99, w => 7}),
+                Pid ! {eval_result, FakeWorker, {ok, nil, <<>>, [], WorkerState}},
+                timer:sleep(50),
+                {ok, Bindings} = beamtalk_repl_shell:get_bindings(Pid),
+                ?assertEqual(#{x => 1, y => 2, w => 7}, Bindings),
+                {_SId, CleanState, undefined} = sys:get_state(Pid),
+                ?assertEqual([], beamtalk_repl_state:get_pending_mutations(CleanState)),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%% Success path: a queued `clear` empties the worker's locals.
+pending_clear_applied_on_success_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {Pid, FakeWorker} = setup_shell_with_mutations(
+                    <<"test-mut-clear-success-1">>,
+                    #{},
+                    [{clear, undefined, undefined}]
+                ),
+                WorkerState = worker_state_with_bindings(#{a => 1, b => 2}),
+                Pid ! {eval_result, FakeWorker, {ok, nil, <<>>, [], WorkerState}},
+                timer:sleep(50),
+                {ok, Bindings} = beamtalk_repl_shell:get_bindings(Pid),
+                ?assertEqual(#{}, Bindings),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%% Error path: put/remove apply, but a queued `clear` is DROPPED.
+pending_clear_dropped_on_error_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {Pid, FakeWorker} = setup_shell_with_mutations(
+                    <<"test-mut-error-1">>,
+                    #{},
+                    [{put, x, 1}, {clear, undefined, undefined}]
+                ),
+                %% Worker carries an existing local; clear must NOT wipe it.
+                WorkerState = worker_state_with_bindings(#{keep => 42}),
+                Err = beamtalk_error:new(runtime_error, 'Test'),
+                Pid ! {eval_result, FakeWorker, {error, Err, <<>>, [], WorkerState}},
+                timer:sleep(50),
+                {ok, Bindings} = beamtalk_repl_shell:get_bindings(Pid),
+                %% put applied, keep preserved, clear dropped
+                ?assertEqual(#{keep => 42, x => 1}, Bindings),
+                {_SId, CleanState, undefined} = sys:get_state(Pid),
+                ?assertEqual([], beamtalk_repl_state:get_pending_mutations(CleanState)),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%% Interrupt path: all mutations drain over the shell's own state.
+pending_mutations_drained_on_interrupt_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {Pid, _FakeWorker} = setup_shell_with_mutations(
+                    <<"test-mut-interrupt-1">>,
+                    #{existing => 5},
+                    [{put, x, 1}, {clear, undefined, undefined}, {put, y, 2}]
+                ),
+                ok = beamtalk_repl_shell:interrupt(Pid),
+                {ok, Bindings} = beamtalk_repl_shell:get_bindings(Pid),
+                %% clear wipes existing+x, then y is set after clear
+                ?assertEqual(#{y => 2}, Bindings),
+                {_SId, CleanState, undefined} = sys:get_state(Pid),
+                ?assertEqual([], beamtalk_repl_state:get_pending_mutations(CleanState)),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%% Worker-crash path: the mutation queue is DISCARDED.
+pending_mutations_discarded_on_crash_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {ok, Pid} = beamtalk_repl_shell:start_link(<<"test-mut-crash-1">>),
+                {FakeWorkerPid, MonRef} = spawn_monitor(fun() ->
+                    receive
+                        _ -> ok
+                    end
+                end),
+                erlang:demonitor(MonRef, [flush]),
+                sys:replace_state(Pid, fun({SId, State, _W}) ->
+                    State1 = beamtalk_repl_state:set_bindings(#{existing => 5}, State),
+                    State2 = beamtalk_repl_state:add_pending_mutation({put, x, 1}, State1),
+                    WorkerMonRef = erlang:monitor(process, FakeWorkerPid),
+                    {SId, State2, {FakeWorkerPid, WorkerMonRef, {async, self()}}}
+                end),
+                exit(FakeWorkerPid, kill),
+                timer:sleep(50),
+                {ok, Bindings} = beamtalk_repl_shell:get_bindings(Pid),
+                %% Mutation discarded: existing preserved, x NOT applied
+                ?assertEqual(#{existing => 5}, Bindings),
+                {_SId, CleanState, undefined} = sys:get_state(Pid),
+                ?assertEqual([], beamtalk_repl_state:get_pending_mutations(CleanState)),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%% clear-then-put ordering: clear empties, then the later put survives (success).
+pending_clear_then_put_ordering_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {Pid, FakeWorker} = setup_shell_with_mutations(
+                    <<"test-mut-clear-put-1">>,
+                    #{},
+                    [{put, a, 1}, {clear, undefined, undefined}, {put, b, 2}]
+                ),
+                WorkerState = worker_state_with_bindings(#{old => 99}),
+                Pid ! {eval_result, FakeWorker, {ok, nil, <<>>, [], WorkerState}},
+                timer:sleep(50),
+                {ok, Bindings} = beamtalk_repl_shell:get_bindings(Pid),
+                %% a set, then clear wipes (old + a), then b set
+                ?assertEqual(#{b => 2}, Bindings),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%% Build a worker-result state record carrying the given locals map.  The worker
+%% always returns pending_mutations = [] (it never enqueues into its own snapshot).
+worker_state_with_bindings(Bindings) ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    beamtalk_repl_state:set_bindings(Bindings, State).
+
 unload_module_in_use_returns_error_test_() ->
     {setup, fun setup/0, fun teardown/1, fun(_) ->
         [

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_state_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_state_tests.erl
@@ -154,6 +154,39 @@ complex_state_test() ->
     ?assertEqual(2, beamtalk_repl_state:get_eval_counter(State6)),
     ?assertEqual([point, counter], beamtalk_repl_state:get_loaded_modules(State6)).
 
+%%% BT-2366: pending session-local mutations (ADR 0081 Phase 2)
+
+pending_mutations_starts_empty_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    ?assertEqual([], beamtalk_repl_state:get_pending_mutations(State)).
+
+add_pending_mutation_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    State2 = beamtalk_repl_state:add_pending_mutation({put, x, 1}, State),
+    ?assertEqual([{put, x, 1}], beamtalk_repl_state:get_pending_mutations(State2)).
+
+pending_mutations_preserve_enqueue_order_test() ->
+    %% Newest is appended at the tail so the queue replays in issue order.
+    State0 = beamtalk_repl_state:new(undefined, 0),
+    State1 = beamtalk_repl_state:add_pending_mutation({put, x, 1}, State0),
+    State2 = beamtalk_repl_state:add_pending_mutation({remove, y, undefined}, State1),
+    State3 = beamtalk_repl_state:add_pending_mutation({clear, undefined, undefined}, State2),
+    ?assertEqual(
+        [{put, x, 1}, {remove, y, undefined}, {clear, undefined, undefined}],
+        beamtalk_repl_state:get_pending_mutations(State3)
+    ).
+
+clear_pending_mutations_test() ->
+    State0 = beamtalk_repl_state:new(undefined, 0),
+    State1 = beamtalk_repl_state:add_pending_mutation({put, x, 1}, State0),
+    State2 = beamtalk_repl_state:clear_pending_mutations(State1),
+    ?assertEqual([], beamtalk_repl_state:get_pending_mutations(State2)).
+
+pending_mutations_immutability_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    _State2 = beamtalk_repl_state:add_pending_mutation({put, x, 1}, State),
+    ?assertEqual([], beamtalk_repl_state:get_pending_mutations(State)).
+
 state_independence_test() ->
     %% Test that operations on one state don't affect other states
     State1 = beamtalk_repl_state:new(undefined, 0),

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_session_primitives_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_session_primitives_tests.erl
@@ -1,0 +1,380 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_session_primitives_tests).
+
+-moduledoc """
+Unit tests for beamtalk_session_primitives (BT-2366, ADR 0081 Phase 3).
+
+Covers the factory primitives (current/0, withId/1, idOf/1), the session
+operations (bindingsViewFor/1, resolveFor/2, clearFor/1), the workspace-globals
+view, the BindingsView read/write primitives, cross-session read + write
+rejection, and the dead-session liveness error.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+%%====================================================================
+%% Fixtures
+%%====================================================================
+
+setup() ->
+    application:ensure_all_started(beamtalk_runtime),
+    beamtalk_session_table:new(),
+    %% Clear any leftover process-dict session context from other tests.
+    erase(beamtalk_session_pid),
+    erase(beamtalk_session_id),
+    ok.
+
+teardown(_) ->
+    erase(beamtalk_session_pid),
+    erase(beamtalk_session_id),
+    ok.
+
+%% Start a shell and register it in the session table under SessionId.
+start_session(SessionId) ->
+    {ok, Pid} = beamtalk_repl_shell:start_link(SessionId),
+    beamtalk_session_table:insert(SessionId, Pid),
+    Pid.
+
+%% Simulate "this process is the eval worker for SessionId" by seeding the
+%% process dict the way beamtalk_repl_shell:seed_session_context/2 does.
+seed_context(Pid, SessionId) ->
+    put(beamtalk_session_pid, Pid),
+    put(beamtalk_session_id, SessionId),
+    ok.
+
+%%====================================================================
+%% current/0
+%%====================================================================
+
+current_outside_eval_returns_nil_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_assertEqual(nil, beamtalk_session_primitives:current())
+        ]
+    end}.
+
+current_in_eval_returns_session_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Pid = start_session(<<"prim-current-1">>),
+                seed_context(Pid, <<"prim-current-1">>),
+                Session = beamtalk_session_primitives:current(),
+                ?assertMatch(#{'$beamtalk_class' := 'Session'}, Session),
+                ?assertEqual(<<"prim-current-1">>, beamtalk_session_primitives:idOf(Session)),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% withId/1
+%%====================================================================
+
+with_id_live_returns_session_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Pid = start_session(<<"prim-withid-1">>),
+                Session = beamtalk_session_primitives:withId(<<"prim-withid-1">>),
+                ?assertMatch(#{'$beamtalk_class' := 'Session'}, Session),
+                ?assertEqual(<<"prim-withid-1">>, beamtalk_session_primitives:idOf(Session)),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+with_id_missing_returns_nil_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_assertEqual(nil, beamtalk_session_primitives:withId(<<"prim-no-such">>))
+        ]
+    end}.
+
+with_id_dead_returns_nil_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Pid = start_session(<<"prim-withid-dead">>),
+                beamtalk_repl_shell:stop(Pid),
+                wait_dead(Pid),
+                %% Entry still in table but PID dead → liveness check returns nil.
+                ?assertEqual(nil, beamtalk_session_primitives:withId(<<"prim-withid-dead">>))
+            end)
+        ]
+    end}.
+
+with_id_accepts_string_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Pid = start_session(<<"prim-withid-str">>),
+                %% A string (list) id resolves the same as the binary id.
+                Session = beamtalk_session_primitives:withId("prim-withid-str"),
+                ?assertMatch(#{'$beamtalk_class' := 'Session'}, Session),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% bindingsViewFor/1 + cross-session read
+%%====================================================================
+
+bindings_view_reads_own_locals_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Pid = start_session(<<"prim-bv-own">>),
+                set_locals(Pid, #{x => 1, y => 2}),
+                seed_context(Pid, <<"prim-bv-own">>),
+                Session = beamtalk_session_primitives:current(),
+                View = beamtalk_session_primitives:bindingsViewFor(Session),
+                ?assertMatch(#{'$beamtalk_class' := 'BindingsView', scope := session}, View),
+                ?assertEqual(1, beamtalk_session_primitives:view_at(View, x)),
+                ?assertEqual(2, beamtalk_session_primitives:view_size(View)),
+                ?assertEqual(
+                    lists:sort([x, y]), lists:sort(beamtalk_session_primitives:view_keys(View))
+                ),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+bindings_view_cross_session_read_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Caller = start_session(<<"prim-bv-caller">>),
+                Other = start_session(<<"prim-bv-other">>),
+                set_locals(Other, #{remote => 99}),
+                seed_context(Caller, <<"prim-bv-caller">>),
+                OtherSession = beamtalk_session_primitives:withId(<<"prim-bv-other">>),
+                View = beamtalk_session_primitives:bindingsViewFor(OtherSession),
+                %% Cross-session READ is supported.
+                ?assertEqual(99, beamtalk_session_primitives:view_at(View, remote)),
+                beamtalk_repl_shell:stop(Caller),
+                beamtalk_repl_shell:stop(Other)
+            end)
+        ]
+    end}.
+
+%% Reading a never-interned name returns nil without minting a fresh atom
+%% (atom-exhaustion safety for introspection over arbitrary user strings).
+bindings_view_read_unknown_name_is_safe_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Pid = start_session(<<"prim-bv-unknown">>),
+                seed_context(Pid, <<"prim-bv-unknown">>),
+                Session = beamtalk_session_primitives:current(),
+                View = beamtalk_session_primitives:bindingsViewFor(Session),
+                Before = erlang:system_info(atom_count),
+                %% A binary that has never been an atom must not become one.
+                ?assertEqual(
+                    nil,
+                    beamtalk_session_primitives:view_at(
+                        View, <<"definitely_not_an_atom_bt2366_xyz">>
+                    )
+                ),
+                %% Removing it is a no-op (returns nil).
+                ?assertEqual(
+                    nil,
+                    beamtalk_session_primitives:view_remove(
+                        View, <<"another_unknown_bt2366_abc">>
+                    )
+                ),
+                After = erlang:system_info(atom_count),
+                ?assertEqual(Before, After),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Cross-session write rejection
+%%====================================================================
+
+cross_session_write_rejected_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Caller = start_session(<<"prim-xw-caller">>),
+                Other = start_session(<<"prim-xw-other">>),
+                seed_context(Caller, <<"prim-xw-caller">>),
+                OtherSession = beamtalk_session_primitives:withId(<<"prim-xw-other">>),
+                View = beamtalk_session_primitives:bindingsViewFor(OtherSession),
+                ?assertError(
+                    #{error := #beamtalk_error{kind = cross_session_mutation_unsupported}},
+                    beamtalk_session_primitives:view_at_put(View, x, 1)
+                ),
+                ?assertError(
+                    #{error := #beamtalk_error{kind = cross_session_mutation_unsupported}},
+                    beamtalk_session_primitives:view_remove(View, x)
+                ),
+                ?assertError(
+                    #{error := #beamtalk_error{kind = cross_session_mutation_unsupported}},
+                    beamtalk_session_primitives:clearFor(OtherSession)
+                ),
+                beamtalk_repl_shell:stop(Caller),
+                beamtalk_repl_shell:stop(Other)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Own-session writes enqueue
+%%====================================================================
+
+own_session_put_enqueues_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Pid = start_session(<<"prim-put-own">>),
+                seed_context(Pid, <<"prim-put-own">>),
+                Session = beamtalk_session_primitives:current(),
+                View = beamtalk_session_primitives:bindingsViewFor(Session),
+                %% at:put: returns the value put and enqueues a put mutation.
+                ?assertEqual(42, beamtalk_session_primitives:view_at_put(View, foo, 42)),
+                %% removeKey: returns nil and enqueues a remove.
+                ?assertEqual(nil, beamtalk_session_primitives:view_remove(View, bar)),
+                %% clear enqueues a clear and returns nil.
+                ?assertEqual(nil, beamtalk_session_primitives:clearFor(Session)),
+                {_SId, State, _W} = sys:get_state(Pid),
+                ?assertEqual(
+                    [{put, foo, 42}, {remove, bar, undefined}, {clear, undefined, undefined}],
+                    beamtalk_repl_state:get_pending_mutations(State)
+                ),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% resolveFor/2
+%%====================================================================
+
+resolve_for_finds_local_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Pid = start_session(<<"prim-resolve-1">>),
+                set_locals(Pid, #{myvar => 7}),
+                seed_context(Pid, <<"prim-resolve-1">>),
+                Session = beamtalk_session_primitives:current(),
+                ?assertEqual(7, beamtalk_session_primitives:resolveFor(Session, myvar)),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% globalsView/0 — workspace scope read + write-through
+%%====================================================================
+
+globals_view_write_through_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                beamtalk_workspace_interface_primitives:create_bindings_table(),
+                %% get_session_bindings/0 gates reads on the workspace-meta
+                %% sentinel; register this process as that sentinel so reads see
+                %% the bind:as: ETS (the production path always has meta up).
+                maybe_register_meta(),
+                try
+                    View = beamtalk_session_primitives:globalsView(),
+                    ?assertMatch(
+                        #{'$beamtalk_class' := 'BindingsView', scope := workspace}, View
+                    ),
+                    %% Write through to bind:as: ETS.
+                    ?assertEqual(
+                        123, beamtalk_session_primitives:view_at_put(View, gv_test_name, 123)
+                    ),
+                    ?assertEqual(123, beamtalk_session_primitives:view_at(View, gv_test_name)),
+                    %% Remove through unbind.
+                    ?assertEqual(nil, beamtalk_session_primitives:view_remove(View, gv_test_name)),
+                    ?assertEqual(nil, beamtalk_session_primitives:view_at(View, gv_test_name))
+                after
+                    maybe_unregister_meta()
+                end
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Dead-session liveness error
+%%====================================================================
+
+dead_session_raises_session_not_found_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Pid = start_session(<<"prim-dead-send">>),
+                Session = beamtalk_session_primitives:withId(<<"prim-dead-send">>),
+                %% Build a view while alive, then kill the shell.
+                View = beamtalk_session_primitives:bindingsViewFor(Session),
+                beamtalk_repl_shell:stop(Pid),
+                wait_dead(Pid),
+                %% A read against the dead session raises rather than blocking.
+                ?assertError(
+                    #{error := #beamtalk_error{kind = session_not_found}},
+                    beamtalk_session_primitives:view_at(View, x)
+                )
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Type errors
+%%====================================================================
+
+session_id_type_error_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_assertError(
+                #{error := #beamtalk_error{kind = type_error}},
+                beamtalk_session_primitives:withId(42)
+            )
+        ]
+    end}.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+set_locals(Pid, Locals) ->
+    sys:replace_state(Pid, fun({SId, State, Worker}) ->
+        {SId, beamtalk_repl_state:set_bindings(Locals, State), Worker}
+    end).
+
+%% Register/unregister this process as the workspace-meta sentinel, but only if
+%% no real meta process is already registered (so we don't clobber it).
+maybe_register_meta() ->
+    case whereis(beamtalk_workspace_meta) of
+        undefined ->
+            register(beamtalk_workspace_meta, self()),
+            ok;
+        _ ->
+            ok
+    end.
+
+maybe_unregister_meta() ->
+    case whereis(beamtalk_workspace_meta) of
+        Self when Self =:= self() ->
+            unregister(beamtalk_workspace_meta),
+            ok;
+        _ ->
+            ok
+    end.
+
+wait_dead(Pid) ->
+    case is_process_alive(Pid) of
+        false ->
+            ok;
+        true ->
+            timer:sleep(10),
+            wait_dead(Pid)
+    end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_session_primitives_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_session_primitives_tests.erl
@@ -371,10 +371,18 @@ maybe_unregister_meta() ->
     end.
 
 wait_dead(Pid) ->
+    %% Bounded wait via monitor so an unterminated shell fails the test fast
+    %% instead of hanging the whole EUnit run on infinite recursion.
     case is_process_alive(Pid) of
         false ->
             ok;
         true ->
-            timer:sleep(10),
-            wait_dead(Pid)
+            Ref = erlang:monitor(process, Pid),
+            receive
+                {'DOWN', Ref, process, Pid, _Reason} ->
+                    ok
+            after 5000 ->
+                erlang:demonitor(Ref, [flush]),
+                ?assert(false)
+            end
     end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_session_table_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_session_table_tests.erl
@@ -24,7 +24,10 @@ session_table_test_() ->
         fun insert_and_lookup/1,
         fun lookup_missing_returns_error/1,
         fun delete_removes_entry/1,
-        fun delete_missing_is_safe/1
+        fun delete_missing_is_safe/1,
+        fun lookup_alive_returns_live_pid/1,
+        fun lookup_alive_missing_returns_error/1,
+        fun lookup_alive_dead_pid_returns_error/1
     ]}.
 
 setup() ->
@@ -75,3 +78,26 @@ delete_removes_entry(_) ->
 delete_missing_is_safe(_) ->
     %% ets:delete/2 on a missing key returns true — must not raise.
     [?_assertEqual(true, beamtalk_session_table:delete(<<"ghost">>))].
+
+%%% lookup_alive/1 tests (BT-2366)
+
+lookup_alive_returns_live_pid(_) ->
+    Pid = self(),
+    beamtalk_session_table:insert(<<"alive1">>, Pid),
+    [?_assertEqual({ok, Pid}, beamtalk_session_table:lookup_alive(<<"alive1">>))].
+
+lookup_alive_missing_returns_error(_) ->
+    [?_assertEqual(error, beamtalk_session_table:lookup_alive(<<"no_such_session">>))].
+
+lookup_alive_dead_pid_returns_error(_) ->
+    %% A registered entry pointing at a dead process must return error, not the
+    %% dead PID (the whole point of the liveness check).
+    DeadPid = spawn(fun() -> ok end),
+    %% Wait for the spawned process to finish.
+    Ref = monitor(process, DeadPid),
+    receive
+        {'DOWN', Ref, process, DeadPid, _} -> ok
+    after 1000 -> ok
+    end,
+    beamtalk_session_table:insert(<<"dead1">>, DeadPid),
+    [?_assertEqual(error, beamtalk_session_table:lookup_alive(<<"dead1">>))].


### PR DESCRIPTION
Implements ADR 0081 Phases 2–3 (BT-2366): the runtime engine for the first-class `Session` object.

Linear: https://linear.app/beamtalk/issue/BT-2366

## What this adds

**Pending-mutation plumbing (Phase 2)**
- `pending_mutations` field on `beamtalk_repl_state` — a list of `{op, key, value}` tuples (`op ∈ {put, remove, clear}`) with accessors mirroring `pending_module_removals`.
- Eval-exit merge in `beamtalk_repl_shell`:
  - **Success** → `apply_pending_removals` then `apply_pending_mutations` (put/remove/clear).
  - **Error** → put/remove only; a queued `clear` is **dropped** (`Session current clear. typo` must not wipe locals because the next line failed).
  - **Interrupt** → drain mutations alongside removals.
  - **Worker crash** → discard the queue.
- Primitives enqueue via a synchronous `gen_server:call` to the shell, which completes before the worker sends `{eval_result, …}`, so the handler's `ShellState` always reflects the enqueued mutation. **This closes the deferred BT-2365 race** where `clear` during an active eval could be clobbered by the worker-state writeback.

**`beamtalk_session_primitives` (Phase 3, new module)**
- Factory: `current/0` (from process dict, or `nil`), `withId/1` (liveness-checked via `lookup_alive/1`), `idOf/1`.
- Reads: `bindingsViewFor/1`, `resolveFor/2` (delegates to `beamtalk_workspace:resolve_name/2`), `globalsView/0`.
- Writes: `view_at_put/3`, `view_remove/2`, `clearFor/1` — calling-session writes enqueue `pending_mutations`; other-session writes raise `cross_session_mutation_unsupported`; workspace scope routes through `bind/2` / `unbind/1`.
- Every send to a `Session` value liveness-checks the carried PID and raises `#beamtalk_error{kind = session_not_found}` rather than blocking a `gen_server:call` against a dead PID.
- `beamtalk_session_table:lookup_alive/1` — liveness-checked lookup helper.

## Notable review fixes
- `idOf/1` is liveness-checked (ADR Phase 3) so a dead-session value fails consistently rather than returning a stale id.
- BindingsView **reads/removes** use `binary_to_existing_atom` — introspection over arbitrary user strings cannot grow the atom table; only genuine **writes** mint atoms (consistent with the existing eval / `bind:as:` trust model).

## Tests
EUnit: state queue ops + ordering, all four eval-exit paths, a clear-then-put case, and per-primitive coverage (cross-session read, cross-session write rejection, workspace-globals write-through, dead-session error, atom-table safety). `just test-runtime` green apart from a pre-existing, unrelated TMPDIR-dependent failure in `beamtalk_workspace_tests`; `just test-repl-protocol` green; dialyzer + erlfmt clean.

## Out of scope (later issues)
- Stdlib `Session.bt` / `BindingsView.bt` (Issue 3).
- `Workspace currentSession` / `sessions` (Issues 3/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)