### PR TITLE
Unify threading: sweep dead per-context threading branches to the shared emitter (BT-2375)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/threaded_expr.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/threaded_expr.rs
@@ -25,8 +25,8 @@
 //!   construct, [`CoreErlangGenerator::lower_threaded_last`] binds its logical value
 //!   (tuple element 1) to a fresh result var. The threaded locals do not escape in
 //!   last position, so element 2 is discarded. This subsumes the value-type
-//!   `emit_vt_last_expr` threading branch, `emit_vt_conditional_last`, and the
-//!   class-method `try_generate_class_method_threaded_last`.
+//!   `emit_vt_last_expr` threading branch (loops, foldl list-ops, and read+write
+//!   conditionals alike) and the class-method `try_generate_class_method_threaded_last`.
 //! * **Boundary (per-context adapter, the only thing that varies).** A
 //!   [`ThreadingBoundary`] captures how the bound result var is returned/stored:
 //!   the value-type `{Result, Self{N}}` / bare-`Result` shape, the class-method
@@ -229,8 +229,8 @@ impl CoreErlangGenerator {
     /// threading construct, so the caller falls back to its generic path.
     ///
     /// This is the single shared entry point that subsumes the value-type
-    /// `emit_vt_last_expr`/`emit_vt_conditional_last` threading branches and the
-    /// class-method `try_generate_class_method_threaded_last`.
+    /// `emit_vt_last_expr` threading branch (loops, foldl list-ops, and read+write
+    /// conditionals) and the class-method `try_generate_class_method_threaded_last`.
     pub(super) fn emit_threaded_last(
         &mut self,
         expr: &Expression,

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -1252,9 +1252,12 @@ impl CoreErlangGenerator {
                 // local), so the normal dispatch (`True>>ifTrue:`) would call the block with
                 // 0 args and crash. Inline the conditional as a `case` returning the branch's
                 // logical value instead — the threaded locals don't need to escape in last
-                // position.
+                // position. BT-2375: route through the shared `emit_vt_last_expr` like the loop
+                // / foldl-list-op last branches — it dispatches the conditional through the same
+                // unified `emit_threaded_last` emitter, so the dedicated `emit_vt_conditional_last`
+                // wrapper is redundant.
                 if is_last {
-                    self.emit_vt_conditional_last(expr, has_nlr, body_parts)?;
+                    self.emit_vt_last_expr(expr, index, has_nlr, body_parts)?;
                 } else {
                     let doc = self.generate_vt_conditional_open(expr)?;
                     body_parts.push(doc);
@@ -2203,36 +2206,6 @@ impl CoreErlangGenerator {
         result
     }
 
-    /// BT-2342: Emits a last-position `ifTrue:`/`ifFalse:`/`ifTrue:ifFalse:` whose block
-    /// reads+writes an outer local, as an inline `case` returning the branch's logical
-    /// value.
-    ///
-    /// The normal last-expression path dispatches `True>>ifTrue:` (etc.), which invokes the
-    /// block with 0 args — but a block that captures and mutates an outer local is compiled
-    /// to a stateful arity-1 `fun (StateAcc) -> {value, StateAcc1}`, so the 0-arg dispatch
-    /// crashes (BT-2342 failure mode B). Inlining the block into a `case` avoids the dispatch
-    /// entirely. The threaded locals don't need to escape in last position, so the case just
-    /// yields each branch's logical value (the block's last expression, or `'nil'` for the
-    /// missing branch of `ifTrue:`/`ifFalse:`).
-    pub(in crate::codegen::core_erlang) fn emit_vt_conditional_last(
-        &mut self,
-        expr: &Expression,
-        has_nlr: bool,
-        body_parts: &mut Vec<Document<'static>>,
-    ) -> Result<()> {
-        if self.emit_threaded_last(
-            expr,
-            super::threaded_expr::ThreadingPosition::Last,
-            super::threaded_expr::ThreadingBoundary::ValueType { has_nlr },
-            body_parts,
-        )? {
-            Ok(())
-        } else {
-            // Not a recognized read+write conditional — fall back to the generic path.
-            self.emit_vt_last_expr(expr, 0, has_nlr, body_parts)
-        }
-    }
-
     /// BT-2342/BT-2349: Emits a read+write conditional (`ifTrue:`/`ifFalse:`/`ifTrue:ifFalse:`
     /// whose branch blocks read+write an outer local) as an inline `case` binding its logical
     /// value to a fresh result var, pushed onto `body_parts` as an open let chain
@@ -2242,9 +2215,10 @@ impl CoreErlangGenerator {
     /// can fall back to the generic last-expression path. The threaded locals don't escape in
     /// last position, so each branch yields only its logical value (its last expression).
     ///
-    /// Used both by [`Self::emit_vt_conditional_last`] (value-type bodies, which wrap the result
-    /// in `{Result, Self{N}}` when NLR is active) and by the class-method body generator (which
-    /// wraps it in `{class_var_result, Result, ClassVarsN}` when class vars were mutated).
+    /// Reached via the shared [`Self::lower_threaded_last`] transform for both the value-type
+    /// boundary (which wraps the result in `{Result, Self{N}}` when NLR is active) and the
+    /// class-method boundary (which wraps it in `{class_var_result, Result, ClassVarsN}` when
+    /// class vars were mutated).
     pub(in crate::codegen::core_erlang) fn emit_vt_conditional_case_to_var(
         &mut self,
         expr: &Expression,


### PR DESCRIPTION
## Summary

Final step (step 5) of the unify-threading refactor (BT-2361). Sweeps the now-dead per-context **threading-consumption** branch and reduces the threading-related `CodeGenContext::` branching down to the single shared `ThreadedExpr` boundary-selection point established by steps 1–4 + the Actor extension (BT-2373 / BT-2374 / BT-2378).

Linear: https://linear.app/beamtalk/issue/BT-2375

## What was swept

Removed `emit_vt_conditional_last` — a redundant per-context threading wrapper made unreachable by the unified emitter:

- It called the unified `emit_threaded_last`, then fell back to `emit_vt_last_expr` — which **itself** routes through `emit_threaded_last` first.
- The value-type body dispatch only reaches it for `VtBodyExprKind::ConditionalWithLocalThreading`, classified by `is_conditional_with_vt_local_threading` — the exact predicate `lower_threaded_last` re-checks. So the unified emitter always succeeds and the wrapper's fallback was dead.
- The conditional last-position branch now calls `emit_vt_last_expr` directly, matching the sibling loop / foldl-list-op last branches; the wrapper and its doc-comment references are deleted.

## What was deliberately left (genuine context differences, NOT threading dead code)

The ~91 remaining `CodeGenContext::` sites are legitimate, still-needed context distinctions the refactor does not touch, e.g.:

- **field/var access representation** — `maps:get('field', Self/State/Bindings)`;
- **dispatch** — gen_server sync/async vs direct call;
- **REPL** binding persistence;
- **`compute_threaded_locals_for_loop` Actor vs ValueType branch** — Actor additionally unions the condition-block reads/writes; ValueType does not. Merging would change ValueType output (not dead code). BT-2374 intentionally left this branched ("which already branches per context").
- **`seed_state` location** — value-type seeds a fresh empty `WStateAcc` map; Actor/REPL thread from `current_state`. This is the structural Actor-boundary distinction the `ThreadingBoundary::Actor` doc already records.
- value-type threading **predicate guards** (`!in_class_method() && !ValueType`) and the NLR-arity boundary — genuine context axes, not consumption duplication.

The bulk of the threading-path consolidation (the `threaded_vars_*` loop family, the three NLR-catch wrappers, the Actor last-position routing) was already landed by BT-2373 / BT-2374 / BT-2378 and removed there; the `emit_vt_conditional_last` wrapper was the remaining unreachable threading-consumption branch.

## Safety

- **Behaviour-preserving dead-code removal — zero Core Erlang churn.** No insta snapshot changes across 4078 beamtalk-core tests.
- All three oracle suites green: `value_type_mutation_matrix_test.bt`, `metamorphic_threading_test.bt`, `mutation_matrix_test.bt` (2361 BUnit tests pass) — no `bt****Pending` re-gated (all four switches remain `false`).
- `just build` / `just clippy` (warnings = errors) / `just fmt-check` / full rust test suite all green.
- No `format!` for Core Erlang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)