### PR TITLE
Remove duplicated to_binary/1 from workspace REPL modules (BT-2381)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
@@ -330,7 +330,7 @@ a ChangeLog entry tagged with `Intent' and the author metadata. Returns
 ) ->
     {ok, binary()} | {error, term()}.
 compile_method(ClassNameBin, Selector, Source, Intent, Author, AuthorKind) ->
-    SelectorBin = to_binary(Selector),
+    SelectorBin = beamtalk_repl_protocol:to_binary(Selector),
     SourceStr = unicode:characters_to_list(normalize_method_source(SelectorBin, Source)),
     Expression =
         unicode:characters_to_list(<<ClassNameBin/binary, " >> ">>) ++ SourceStr,
@@ -439,10 +439,6 @@ first_token(SelectorBin) ->
         [Head | _] when byte_size(Head) > 0 -> Head;
         _ -> SelectorBin
     end.
-
--spec to_binary(atom() | binary()) -> binary().
-to_binary(A) when is_atom(A) -> atom_to_binary(A, utf8);
-to_binary(B) when is_binary(B) -> B.
 
 %%% Internal functions
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -1907,7 +1907,7 @@ camel_to_snake([H | T], _PrevWasLower, Acc) ->
 
 -spec make_class_not_found_error(atom() | binary()) -> #beamtalk_error{}.
 make_class_not_found_error(ClassName) ->
-    NameBin = to_binary(ClassName),
+    NameBin = beamtalk_repl_protocol:to_binary(ClassName),
     Err0 = beamtalk_error:new(class_not_found, 'REPL'),
     Err1 = beamtalk_error:with_message(
         Err0,
@@ -1917,10 +1917,6 @@ make_class_not_found_error(ClassName) ->
         Err1,
         <<"Use Workspace classes to see loaded classes.">>
     ).
-
--spec to_binary(atom() | binary()) -> binary().
-to_binary(A) when is_atom(A) -> atom_to_binary(A, utf8);
-to_binary(B) when is_binary(B) -> B.
 
 -doc """
 Extract the first line of a binary string (up to the first newline).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_protocol.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_protocol.erl
@@ -44,7 +44,8 @@ Legacy format (backward compatible):
     get_id/1,
     get_session/1,
     get_params/1,
-    base_response/1
+    base_response/1,
+    to_binary/1
 ]).
 
 %% Protocol request record

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_protocol.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_protocol.erl
@@ -626,6 +626,19 @@ encode_trace_result(Steps, Msg, TermToJson, Output, Warnings) ->
             )
     end.
 
+%%% Utilities
+
+-doc "Normalise an atom, binary, list, or arbitrary term to a binary.".
+-spec to_binary(term()) -> binary().
+to_binary(Name) when is_atom(Name) ->
+    atom_to_binary(Name, utf8);
+to_binary(Name) when is_binary(Name) ->
+    Name;
+to_binary(Name) when is_list(Name) ->
+    list_to_binary(Name);
+to_binary(Name) ->
+    list_to_binary(io_lib:format("~p", [Name])).
+
 %%% Internal functions
 
 -doc "Decode a parsed JSON map into a protocol message.".
@@ -700,17 +713,6 @@ parse_json(Data) ->
     catch
         _:_ -> {error, not_json}
     end.
-
--doc "Convert a term to binary for use as a JSON key.".
--spec to_binary(term()) -> binary().
-to_binary(Name) when is_atom(Name) ->
-    atom_to_binary(Name, utf8);
-to_binary(Name) when is_binary(Name) ->
-    Name;
-to_binary(Name) when is_list(Name) ->
-    list_to_binary(Name);
-to_binary(Name) ->
-    list_to_binary(io_lib:format("~p", [Name])).
 
 -doc "Add output field to response map only when non-empty.".
 -spec maybe_add_output(map(), binary()) -> map().


### PR DESCRIPTION
## Summary

- Export the existing `to_binary/1` from `beamtalk_repl_protocol` and delete the identical private copies from `beamtalk_repl_eval` and `beamtalk_repl_ops_dev`, updating their two call sites to use the shared function.

## Changes

- `beamtalk_repl_protocol.erl`: add `to_binary/1` to `-export([...])` list
- `beamtalk_repl_eval.erl`: delete local `to_binary/1`, update call site at line 333
- `beamtalk_repl_ops_dev.erl`: delete local `to_binary/1`, update call site at line 1910

## Linear Issue

https://linear.app/beamtalk/issue/BT-2381/remove-duplicated-to-binary1-from-workspace-repl-modules

https://claude.ai/code/session_01TCE3vkZzQXzKSajYLK5N2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCE3vkZzQXzKSajYLK5N2d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate binary-conversion logic into a shared utility and removed local copies.
  * Updated internal error and class-name handling to use the centralized conversion.
  * No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->