### PR TITLE
Extract setUp in ActorConditionalMutationsTest (BT-2383)

### DIFF
--- a/stdlib/test/actor_conditional_mutations_test.bt
+++ b/stdlib/test/actor_conditional_mutations_test.bt
@@ -9,106 +9,99 @@
 // to the closure and never returned to handle_call
 
 TestCase subclass: ActorConditionalMutationsTest
+  field: c = nil
+
+  setUp => self withC: ConditionalMutationCounter spawn
+
+  tearDown => self.c isNil ifFalse: [self.c stop]
 
   testIfTrueWithTrueFlag =>
     // Verify flag=true causes the increment to be applied
-    c := ConditionalMutationCounter spawn
-    self assert: (c conditionalIncrement: true) equals: 1
-    self assert: (c conditionalIncrement: true) equals: 2
+    self assert: (self.c conditionalIncrement: true) equals: 1
+    self assert: (self.c conditionalIncrement: true) equals: 2
 
   testIfTrueWithFalseFlag =>
     // Verify flag=false leaves state unchanged
-    c := ConditionalMutationCounter spawn
-    result := c conditionalIncrement: false
+    result := self.c conditionalIncrement: false
     self assert: result equals: 0
-    self assert: c getCount equals: 0
+    self assert: self.c getCount equals: 0
 
   testIfFalseWithFalseFlag =>
     // Verify flag=false causes the decrement to be applied
-    c := ConditionalMutationCounter spawn
-    self assert: (c conditionalDecrement: false) equals: -1
-    self assert: c getCount equals: -1
+    self assert: (self.c conditionalDecrement: false) equals: -1
+    self assert: self.c getCount equals: -1
 
   testIfFalseWithTrueFlag =>
     // Verify flag=true leaves state unchanged
-    c := ConditionalMutationCounter spawn
-    result := c conditionalDecrement: true
+    result := self.c conditionalDecrement: true
     self assert: result equals: 0
-    self assert: c getCount equals: 0
+    self assert: self.c getCount equals: 0
 
   testIfTrueIfFalseWithTrueFlag =>
     // Verify true branch of ifTrue:ifFalse: is taken
-    c := ConditionalMutationCounter spawn
-    result := c conditionalToggle: true
+    result := self.c conditionalToggle: true
     self assert: result equals: 10
-    self assert: c getCount equals: 10
+    self assert: self.c getCount equals: 10
 
   testIfTrueIfFalseWithFalseFlag =>
     // Verify false branch of ifTrue:ifFalse: is taken
-    c := ConditionalMutationCounter spawn
-    result := c conditionalToggle: false
+    result := self.c conditionalToggle: false
     self assert: result equals: -1
-    self assert: c getCount equals: -1
+    self assert: self.c getCount equals: -1
 
   testStatePersistedAcrossCalls =>
     // Verify state accumulates across multiple conditional calls
-    c := ConditionalMutationCounter spawn
-    c conditionalIncrement: true;
+    self.c conditionalIncrement: true;
       conditionalIncrement: true;
       conditionalIncrement: false
-    self assert: c getCount equals: 2
+    self assert: self.c getCount equals: 2
 
   testSequentialConditionals =>
     // Verify two sequential conditionals in one method both thread state
-    c := ConditionalMutationCounter spawn
     // a=true, b=true => count = 0 + 1 + 10 = 11
-    self assert: (c doubleConditional: true and: true) equals: 11
-    c reset
+    self assert: (self.c doubleConditional: true and: true) equals: 11
+    self.c reset
     // a=true, b=false => count = 0 + 1 = 1
-    self assert: (c doubleConditional: true and: false) equals: 1
-    c reset
+    self assert: (self.c doubleConditional: true and: false) equals: 1
+    self.c reset
     // a=false, b=true => count = 0 + 10 = 10
-    self assert: (c doubleConditional: false and: true) equals: 10
-    c reset
+    self assert: (self.c doubleConditional: false and: true) equals: 10
+    self.c reset
     // a=false, b=false => count = 0
-    self assert: (c doubleConditional: false and: false) equals: 0
+    self assert: (self.c doubleConditional: false and: false) equals: 0
 
   testNestedConditionals =>
     // Verify nested ifTrue: with mutations threads state correctly
-    c := ConditionalMutationCounter spawn
     // outer=true, inner=true => count = 0 + 100 = 100
-    self assert: (c nestedConditional: true and: true) equals: 100
-    c reset
+    self assert: (self.c nestedConditional: true and: true) equals: 100
+    self.c reset
     // outer=true, inner=false => count = 0 (inner not taken)
-    self assert: (c nestedConditional: true and: false) equals: 0
-    c reset
+    self assert: (self.c nestedConditional: true and: false) equals: 0
+    self.c reset
     // outer=false => count = 0 (outer not taken)
-    self assert: (c nestedConditional: false and: true) equals: 0
+    self assert: (self.c nestedConditional: false and: true) equals: 0
 
   testConditionalAsLastExpression =>
     // Verify conditional as the last expression in a method
-    c := ConditionalMutationCounter spawn
     // flag=true returns the assigned value (5) and mutates state
-    result := c conditionalLast: true
+    result := self.c conditionalLast: true
     self assert: result equals: 5
-    self assert: c getCount equals: 5
-    c reset
+    self assert: self.c getCount equals: 5
+    self.c reset
     // flag=false returns nil and leaves state unchanged
-    result2 := c conditionalLast: false
+    result2 := self.c conditionalLast: false
     self assert: result2 equals: nil
-    self assert: c getCount equals: 0
+    self assert: self.c getCount equals: 0
 
   testLocalVarInIfTrueBlock =>
     // BT-1225: Local var assigned inside ifTrue: block must be readable in subsequent
     // expressions of the same block (no {badkey,y} crash at runtime)
-    c := ConditionalMutationCounter spawn
-    self assert: (c incrementViaLocalVar: true) equals: 1
-    self assert: (c incrementViaLocalVar: true) equals: 2
-    self assert: (c incrementViaLocalVar: false) equals: 2
+    self assert: (self.c incrementViaLocalVar: true) equals: 1
+    self assert: (self.c incrementViaLocalVar: true) equals: 2
+    self assert: (self.c incrementViaLocalVar: false) equals: 2
 
   testLocalVarInIfFalseBlock =>
     // BT-1225: Same fix applies to ifFalse: blocks
-    c := ConditionalMutationCounter spawn
-    self assert: (c decrementViaLocalVar: false) equals: -1
-    self assert: (c decrementViaLocalVar: false) equals: -2
-    self assert: (c decrementViaLocalVar: true) equals: -2
+    self assert: (self.c decrementViaLocalVar: false) equals: -1
+    self assert: (self.c decrementViaLocalVar: false) equals: -2
+    self assert: (self.c decrementViaLocalVar: true) equals: -2


### PR DESCRIPTION
## Summary

Extracts the repeated `c := ConditionalMutationCounter spawn` line from all 12 test methods in `actor_conditional_mutations_test.bt` into a shared `setUp`/`tearDown`, following the established BUnit field pattern already used in `actor_monitor_test.bt`.

- Removes 12 duplicate spawn lines (one per test method)
- Adds `field: c = nil`, `setUp`, and `tearDown` — identical pattern to `actor_monitor_test.bt`
- `tearDown` adds actor lifecycle cleanup that was previously missing
- All 2388 BUnit tests pass unchanged

Linear: https://linear.app/beamtalk/issue/BT-2383/extract-setup-in-actor-conditional-mutations-testbt

## Test plan

- [x] `just test-bunit` — 2388 tests pass, 0 failures
- [x] Pre-push lint hooks pass (clippy, fmt, dialyzer, erlfmt)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9sdY8Y6UCQtCySdMhwiMw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure to improve actor lifecycle management and reduce redundant initialization across test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->