### PR TITLE
E2E btscript for Session API + documentation (BT-2370)

### DIFF
--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -3087,8 +3087,12 @@ to read the user's session from a separate completion session. Cross-session
 **reads** are allowed; **writes** raise `cross_session_mutation_unsupported`:
 
 ```beamtalk
-ids := Workspace sessions collect: [:s | s id]
-other := Session withId: (ids first)
+// Pick a session that is NOT this one — session ordering is not guaranteed, so
+// `sessions first` could be the current session, where a write would succeed
+// (self-session) rather than raise. Tooling normally already knows the target id.
+myId    := Session current id
+otherId := (Workspace sessions collect: [:s | s id]) detect: [:each | each /= myId]
+other   := Session withId: otherId
 
 other bindings keys          // => cross-session READ, allowed
 other bindings at: #x put: 9 // => Error: Cannot mutate another session's bindings

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -2836,7 +2836,9 @@ workspace. Analogous to Pharo's `Smalltalk` project facade.
 | `newClass: source at: path` | `List(Behaviour)` | Create a brand-new class from source at `path`; logs a `kind: #'new-class'` ChangeEntry (ADR 0082) |
 | `classes` | `List` | All loaded user classes (those with a recorded source file) |
 | `testClasses` | `List` | Loaded classes that inherit from `TestCase` |
-| `globals` | `Dictionary` | Project namespace: singletons + loaded user classes |
+| `globals` | `BindingsView` | Live, write-through view of the workspace-globals layer: singletons + `bind:as:` entries (see [Sessions and binding layers](#sessions-and-binding-layers-adr-0081)) |
+| `currentSession` | `Session` or `nil` | The calling process's REPL session (same value as `Session current`); `nil` outside a REPL eval |
+| `sessions` | `List(Session)` | All live REPL sessions as `Session` values |
 | `test` | `TestResult` | Run all loaded test classes |
 | `test: AClass` | `TestResult` | Run a specific test class |
 | `actors` | `List` | All live actors as object references |
@@ -2982,6 +2984,114 @@ nav fieldWritersOf: #value in: Counter
 
 nav ffiSitesFor: "lists:reverse"
 // => [#{#class => MyList, #selector => #reversed, #line => 7}, ...]
+```
+
+### Sessions and binding layers (ADR 0081)
+
+The REPL resolves a bare name (`x`, `Transcript`, `Counter`) against **two
+binding layers**, each owned by a different object:
+
+| Layer | Owner | Source | Accessor |
+|-------|-------|--------|----------|
+| **Session locals** | the session (per connection) | `x := 42` typed in the shell | `Session current bindings` |
+| **Workspace globals** | the workspace (shared) | singletons (`Transcript`, `Beamtalk`, `Workspace`) + `bind:as:` entries | `Workspace globals` |
+
+Locals are checked first, so a local **shadows** a global of the same name.
+Names not found in either layer fall through to the class registry (`Counter`,
+`Integer`), then raise `undefined_variable`.
+
+#### `Session` — a first-class session value
+
+`Session` is a factory, mirroring `Date today` / `Smalltalk current`: two
+class-side methods return a session *value* you then message. There is **no**
+class-side operation mirror (no `Session bindings`) and **no** `globals`
+accessor on `Session` — globals are workspace state, reached via `Workspace
+globals`.
+
+| Class method | Returns | Description |
+|--------------|---------|-------------|
+| `Session current` | `Session` or `nil` | The calling process's session; `nil` outside a REPL eval (compiled code has no session) |
+| `Session withId: anId` | `Session` or `nil` | Look up a session by its protocol id; `nil` if unknown or no longer alive |
+
+| Instance method | Returns | Description |
+|-----------------|---------|-------------|
+| `bindings` | `BindingsView` | Live view of this session's locals (the `x := 42` layer) |
+| `resolve: #name` | `Object` | Resolve a name the way bare-name lookup does (locals → globals → classes). Shares the one resolver with bare-name lookup, so it raises `undefined_variable` for a name that resolves nowhere — exactly as typing the bare name would |
+| `clear` | `nil` | Clear this session's locals (globals remain) |
+| `id` | `String` | Stable session identifier (matches the protocol session id) |
+
+```beamtalk
+x := 42
+// => 42
+
+Session current bindings keys
+// => #(#x)
+
+Session current bindings at: #x
+// => 42
+
+Session current resolve: #Transcript
+// => the Transcript singleton
+
+Session current resolve: #notDefinedAnywhere
+// => Error: Undefined variable: notDefinedAnywhere
+
+Session current clear
+// => nil
+```
+
+Outside a REPL eval (e.g. in a `.bt` file run via `beamtalk run`), `Session
+current` returns `nil`. Guard with `ifNotNil:` rather than a predicate:
+
+```beamtalk
+Session current ifNotNil: [:s | s clear]
+```
+
+#### `BindingsView` — a live, write-through Dictionary view
+
+Both `Session current bindings` and `Workspace globals` return a `BindingsView`:
+a small Dictionary-protocol value (`at:`, `at:put:`, `removeKey:`,
+`includesKey:`, `keys`, `values`, `size`, `do:`) backed by live state. `at:put:`
+returns the value put; `removeKey:` returns `nil`.
+
+```beamtalk
+// Session-local write — DEFERRED to end of eval, visible on the NEXT line:
+Session current bindings at: #y put: 99
+// => 99
+y
+// => 99
+
+// Workspace-global write — SYNCHRONOUS (routes through bind:as:),
+// visible immediately on the next line:
+Workspace globals at: #answer put: 42
+// => 42
+answer
+// => 42
+```
+
+**One documented asymmetry under the shared type:** session-local writes are
+deferred to the end of the current eval (the eval worker holds a state
+snapshot), so a same-expression read-back sees the *old* value; workspace-global
+writes hit shared ETS immediately. Writing a protected system name through the
+globals view raises the same conflict as `Workspace bind:as:`:
+
+```beamtalk
+Workspace globals at: #Workspace put: nil
+// => Error: Workspace is a system name and cannot be shadowed
+```
+
+#### Cross-session access (read-only)
+
+`Session withId:` returns another session by id — used by tooling (LSP, VS Code)
+to read the user's session from a separate completion session. Cross-session
+**reads** are allowed; **writes** raise `cross_session_mutation_unsupported`:
+
+```beamtalk
+ids := Workspace sessions collect: [:s | s id]
+other := Session withId: (ids first)
+
+other bindings keys          // => cross-session READ, allowed
+other bindings at: #x put: 9 // => Error: Cannot mutate another session's bindings
 ```
 
 ### REPL shortcuts (`:` commands) are thin wrappers

--- a/tests/repl-protocol/cases/session.btscript
+++ b/tests/repl-protocol/cases/session.btscript
@@ -1,0 +1,177 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E tests for the first-class Session API (ADR 0081, Phase 6 / BT-2370).
+//
+// This case complements `session_object.btscript` (which exercises the basic
+// read/write-through view) by covering the surface the ADR singles out as
+// integration-critical: `bindings keys`, `resolve:` for undefined names, the
+// `Workspace globals` protected-name conflict, and `Session withId:` (re-acquire
+// by id, instance reads, unknown-id nil). The cross-session WRITE-rejection path
+// needs a second live session and is covered by EUnit (see the note below).
+//
+// These require E2E because `Session current` resolves the calling REPL session
+// from process context (seeded only on a real eval-worker spawn), and the
+// BindingsView reads/writes live session-local + workspace-global state.
+// Session-local writes are deferred to end of eval, so they are observed on the
+// NEXT line, not within the same expression.
+
+// ===========================================================================
+// SESSION CURRENT BINDINGS — keys / at: / at:put: / removeKey:
+// ===========================================================================
+
+// Establish two session locals.
+a := 1
+// => 1
+
+b := 2
+// => 2
+
+// keys lists the session-local names (locals only, no globals/singletons).
+Session current bindings keys includes: #a
+// => true
+
+(Session current bindings keys includes: #b)
+// => true
+
+// Globals/singletons do NOT leak into the session-locals layer.
+Session current bindings keys includes: #Transcript
+// => false
+
+// Reading a local through the view.
+Session current bindings at: #a
+// => 1
+
+// at:put: returns the value put (Dictionary protocol); write is deferred.
+Session current bindings at: #c put: 3
+// => 3
+
+// The deferred write is visible on the next line, both as a bare name...
+c
+// => 3
+
+// ...and through the view.
+Session current bindings at: #c
+// => 3
+
+// removeKey: returns nil; removal is deferred.
+Session current bindings removeKey: #c
+// => nil
+
+// The removed local is gone on the next line.
+Session current bindings includesKey: #c
+// => false
+
+// ===========================================================================
+// SESSION RESOLVE: — local / singleton / undefined
+// ===========================================================================
+
+// A session local resolves to its value.
+Session current resolve: #a
+// => 1
+
+// A singleton resolves through the workspace-globals layer (non-nil).
+(Session current resolve: #Transcript) notNil
+// => true
+
+// An undefined name resolves like bare-name lookup: it raises undefined_variable
+// (resolve: shares the one resolver, so it cannot disagree with how the name
+// actually resolves).
+Session current resolve: #notDefinedAnywhere
+// => ERROR: Undefined variable
+
+// ===========================================================================
+// WORKSPACE GLOBALS — live view: write-through + protected-name conflict
+// ===========================================================================
+
+// Workspace globals is the same live BindingsView type.
+Workspace globals class
+// => BindingsView
+
+// Workspace-global writes are SYNCHRONOUS (route through bind:as:): the new
+// binding is observable immediately as a bare name on the next line.
+Workspace globals at: #gTool put: 7
+// => 7
+
+gTool
+// => 7
+
+// removeKey: routes through unbind: and returns nil.
+Workspace globals removeKey: #gTool
+// => nil
+
+Workspace globals includesKey: #gTool
+// => false
+
+// Writing a protected system name through the globals view raises a conflict
+// (same check as Workspace bind:as:).
+Workspace globals at: #Workspace put: nil
+// => ERROR: is a system name and cannot be shadowed
+
+// ===========================================================================
+// WORKSPACE CURRENTSESSION / SESSIONS — discover this session's id
+// ===========================================================================
+
+// currentSession is the SAME value as Session current (same id).
+(Workspace currentSession id) =:= (Session current id)
+// => true
+
+// The current session's id is discoverable via the live session list, without
+// knowing it out-of-band — this is how cross-session tooling finds an id.
+myId := Session current id
+// => _
+
+(Workspace sessions collect: [:s | s id]) includes: myId
+// => true
+
+// ===========================================================================
+// WITHID: — re-acquire a live session by id; instance reads work
+// ===========================================================================
+//
+// This E2E harness drives a SINGLE REPL connection, so the only live session id
+// is this connection's own. `Session withId: myId` therefore returns the *same*
+// session (same PID), against which reads — and writes — are the self-session
+// path (not cross-session). The cross-session WRITE-rejection path
+// (`cross_session_mutation_unsupported`), which needs a genuinely *different*
+// live session, is covered by EUnit in
+// `runtime/apps/beamtalk_workspace/test/beamtalk_session_primitives_tests.erl`.
+
+// Re-acquire this session by its id.
+other := Session withId: myId
+// => _
+
+// The re-acquired handle is a Session.
+other class
+// => Session
+
+// Reads through the withId: handle see this session's locals.
+other bindings keys includes: #a
+// => true
+
+// withId: against our own id is the SAME session as Session current.
+(other id) =:= (Session current id)
+// => true
+
+// ===========================================================================
+// UNKNOWN / DEAD SESSION — withId: returns nil
+// ===========================================================================
+
+// An unknown session id returns nil (liveness check, no dead-PID call).
+Session withId: "nonexistent"
+// => nil
+
+// nil is messageable with ifNil: — the documented guard pattern.
+(Session withId: "nonexistent") ifNil: ["gone"]
+// => gone
+
+// ===========================================================================
+// SESSION CLEAR — empties this session's locals (deferred)
+// ===========================================================================
+
+// Clear empties the calling session's locals (returns nil).
+Session current clear
+// => nil
+
+// After clear, a previously-set local is gone on the next line.
+Session current bindings includesKey: #a
+// => false


### PR DESCRIPTION
Final phase (6 of 6) of ADR 0081 — First-Class Session Object. End-to-end validation from the REPL plus user-facing documentation.

Linear: https://linear.app/beamtalk/issue/BT-2370

## What changed

### tests/repl-protocol/cases/session.btscript (new e2e)
Exercises the Session API with `// =>` assertions on every expression: `Session current bindings` (keys/at:/at:put: deferred write-through/removeKey:), `resolve:` (local/singleton/undefined raises undefined_variable), `Workspace globals` live BindingsView (synchronous write-through + protected-name conflict), `Workspace currentSession`/`sessions` discovery, `Session withId:` (re-acquire + unknown-id nil), `Session current clear`.

Cross-session write-rejection (`cross_session_mutation_unsupported`) needs a second live session the single-connection btscript harness cannot create; it is covered by EUnit and documented inline.

### docs/beamtalk-language-features.md
New 'Sessions and binding layers (ADR 0081)' section: two-layer locals/globals model, Session factory + instance API, BindingsView with deferred-vs-synchronous write asymmetry, cross-session read-only access. Upgraded `Workspace globals` row to BindingsView; added `currentSession`/`sessions` rows.

### docs/repl-protocol.md
Already updated in BT-2369 (Phase 6); no change needed.

## Verification
- `just test-repl-protocol` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)