### PR TITLE
Optimize session-context propagation in class-method dispatch (BT-2379)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -253,7 +253,15 @@ class_send_dispatch(ClassPid, Selector, Args) ->
             % 60 seconds — class methods may do network I/O
             false -> 60000
         end,
-    case gen_server:call(ClassPid, {class_method_call, Selector, Args}, Timeout) of
+    %% ADR 0081 / BT-2379: pass the caller's session context explicitly in the
+    %% message instead of having the class gen_server copy our whole process
+    %% dictionary via `process_info/2`. We read our own two keys cheaply with
+    %% `get/1` here and the receiving clause seeds from the tuple.
+    case
+        gen_server:call(
+            ClassPid, {class_method_call, Selector, Args, local_session_context()}, Timeout
+        )
+    of
         {ok, Result} ->
             %% BT-1542 + BT-1994 (ADR 0080 Phase 0a, option 2): run the
             %% initialize: lifecycle hook in the caller's process after a
@@ -335,9 +343,10 @@ class_send_dispatch(ClassPid, Selector, Args) ->
 Send a message to a metaclass object (ADR 0036, BT-823).
 
 Routes messages on metaclass objects (tagged `class='Metaclass'`) through:
-  1. `{metaclass_method_call, Selector, Args}` to the class gen_server via
-     `gen_server:call/2` — resolves user-defined class methods (e.g. `withAll:`)
-     via the superclass chain (ADR-0036 Phase 2).
+  1. `{metaclass_method_call, Selector, Args, SessionCtx}` to the class
+     gen_server via `gen_server:call/2` — resolves user-defined class methods
+     (e.g. `withAll:`) via the superclass chain (ADR-0036 Phase 2). `SessionCtx`
+     carries the caller's session context explicitly (BT-2379).
   2. Fallthrough to `beamtalk_dispatch:lookup/5` starting at 'Metaclass', which
      walks the Metaclass → Class → Behaviour → Object → ProtoObject chain for
      built-in messages (`new`, `class`, etc.).
@@ -367,7 +376,13 @@ metaclass_send_dispatch(Pid, Selector, Args, Self) ->
     %% `self species withAll: x` and similar dynamic class-side sends find
     %% user-defined class methods (e.g. `withAll:`) via the proper handler.
     %% Falls through to the Metaclass chain for built-in messages (`new`, `class`, etc.).
-    case gen_server:call(Pid, {metaclass_method_call, Selector, Args}, 60000) of
+    %% BT-2379: carry the caller's session context explicitly (see
+    %% class_send_dispatch/3) so the class gen_server need not copy our dictionary.
+    case
+        gen_server:call(
+            Pid, {metaclass_method_call, Selector, Args, local_session_context()}, 60000
+        )
+    of
         {ok, Result} ->
             Result;
         {error, not_found} ->
@@ -395,6 +410,22 @@ metaclass_send_dispatch(Pid, Selector, Args, Self) ->
         Other ->
             unwrap_class_call(Other)
     end.
+
+-doc """
+Read this process's session context (`beamtalk_session_pid` /
+`beamtalk_session_id`) for explicit propagation into a class-method call.
+
+ADR 0081 / BT-2379: the eval worker seeds these keys
+(`beamtalk_repl_shell:seed_session_context/2`). Class-method dispatch hops to
+the class gen_server, so factory methods like `Session current` need the
+caller's context there. We read our own two keys cheaply with `get/1` and pass
+them in the message tuple, avoiding a `process_info(CallerPid, dictionary)`
+full-dictionary copy on the receiving side. Returns `{undefined, undefined}`
+when this process has no seeded context (the common non-REPL case).
+""".
+-spec local_session_context() -> {pid() | undefined, binary() | undefined}.
+local_session_context() ->
+    {get(beamtalk_session_pid), get(beamtalk_session_id)}.
 
 -doc """
 Unwrap a class gen_server call result for use in class_send.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -825,10 +825,11 @@ handle_call(
     {MethodCallType, Selector, Args, SessionCtx},
     From,
     #class_state{} = State
-) when
-    (MethodCallType =:= class_method_call orelse MethodCallType =:= metaclass_method_call),
-    is_tuple(SessionCtx)
-->
+) when MethodCallType =:= class_method_call; MethodCallType =:= metaclass_method_call ->
+    %% No guard on SessionCtx: `seed_session_context_from/1` accepts any term and
+    %% safely no-ops on unrecognised shapes, so a malformed/empty context
+    %% degrades to "no context" rather than crashing the class gen_server with a
+    %% function_clause (it would otherwise miss both this and the 3-tuple clause).
     Restore = seed_session_context_from(SessionCtx),
     dispatch_class_method(Selector, Args, From, State, Restore);
 %% BT-2379: backward-compatible fallback for the legacy 3-tuple message shape

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -816,44 +816,31 @@ handle_call({set_method_doc, Selector, DocBinary}, _From, State) ->
 %% BT-411/BT-412/BT-440: Class method dispatch (BT-704).
 %% ADR 0036 Phase 2 (BT-823): Also handles metaclass_method_call with identical logic.
 %% ADR 0032 Phase 1: Passes local class_methods; dispatch walks superclass chain.
+%%
+%% BT-2379: the 4-tuple message carries the caller's session context explicitly
+%% (`{Selector, Args, {SessionPid, SessionId}}`). We seed from the tuple, which
+%% avoids the `process_info(CallerPid, dictionary)` full-dictionary copy the
+%% legacy 3-tuple clause below must use.
+handle_call(
+    {MethodCallType, Selector, Args, SessionCtx},
+    From,
+    #class_state{} = State
+) when
+    (MethodCallType =:= class_method_call orelse MethodCallType =:= metaclass_method_call),
+    is_tuple(SessionCtx)
+->
+    Restore = seed_session_context_from(SessionCtx),
+    dispatch_class_method(Selector, Args, From, State, Restore);
+%% BT-2379: backward-compatible fallback for the legacy 3-tuple message shape
+%% (in-flight messages across a hot-code reload). Mirrors the caller's session
+%% context by reading its process dictionary via `process_info/2`.
 handle_call(
     {MethodCallType, Selector, Args},
     From,
-    #class_state{
-        class_methods = ClassMethods,
-        instance_methods = InstanceMethods,
-        name = ClassName,
-        module = Module,
-        class_state = ClassVars
-    } = State
+    #class_state{} = State
 ) when MethodCallType =:= class_method_call; MethodCallType =:= metaclass_method_call ->
-    %% ADR 0081 (BT-2367): class-method dispatch hops from the eval worker to
-    %% this class gen_server, so the session context that `seed_session_context/2`
-    %% put on the *worker* is invisible here. Factory class methods like
-    %% `Session current` (and the future `Workspace currentSession` navigation
-    %% alias, a later ADR 0081 phase) read that context, so mirror the caller's
-    %% `beamtalk_session_pid`/`beamtalk_session_id` into this process for the
-    %% duration of the call, then restore. Reading the caller's process
-    %% dictionary via `process_info/2` avoids changing the (hot, widely used)
-    %% class_method_call message shape.
     Restore = seed_caller_session_context(From),
-    try
-        beamtalk_class_dispatch:handle_class_method_call(
-            Selector, Args, ClassName, Module, ClassMethods, ClassVars
-        )
-    of
-        {reply, Result, NewClassVars} ->
-            {reply, Result, State#class_state{class_state = NewClassVars}};
-        test_spawn ->
-            beamtalk_test_case:spawn_test_execution(
-                Selector, Args, ClassName, Module, InstanceMethods, From
-            ),
-            {noreply, State};
-        {error, not_found} ->
-            {reply, {error, not_found}, State}
-    after
-        Restore()
-    end;
+    dispatch_class_method(Selector, Args, From, State, Restore);
 handle_call({initialize, _Args}, _From, #class_state{} = State) ->
     {reply, {ok, nil}, State};
 handle_call(get_module, _From, #class_state{module = Module} = State) ->
@@ -902,6 +889,70 @@ code_change(OldVsn, State, Extra) ->
 %%====================================================================
 %% Internal functions
 %%====================================================================
+
+-doc """
+Run a class-method (or metaclass-method) call against this class gen_server's
+state, restoring the previously-seeded session context afterwards.
+
+`Restore` is the zero-arity closure returned by `seed_session_context_from/1`
+(explicit-context path, BT-2379) or `seed_caller_session_context/1` (legacy
+3-tuple fallback). It is always run, even on a method-body crash, so a
+concurrent call from another session never observes a stale mirrored context.
+""".
+-spec dispatch_class_method(
+    atom(), list(), {pid(), term()} | term(), #class_state{}, fun(() -> ok)
+) -> {reply, term(), #class_state{}} | {noreply, #class_state{}}.
+dispatch_class_method(Selector, Args, From, State, Restore) ->
+    #class_state{
+        class_methods = ClassMethods,
+        instance_methods = InstanceMethods,
+        name = ClassName,
+        module = Module,
+        class_state = ClassVars
+    } = State,
+    try
+        beamtalk_class_dispatch:handle_class_method_call(
+            Selector, Args, ClassName, Module, ClassMethods, ClassVars
+        )
+    of
+        {reply, Result, NewClassVars} ->
+            {reply, Result, State#class_state{class_state = NewClassVars}};
+        test_spawn ->
+            beamtalk_test_case:spawn_test_execution(
+                Selector, Args, ClassName, Module, InstanceMethods, From
+            ),
+            {noreply, State};
+        {error, not_found} ->
+            {reply, {error, not_found}, State}
+    after
+        Restore()
+    end.
+
+-doc """
+Seed this class gen_server with a session context passed explicitly in the
+class-method-call message (BT-2379), returning a zero-arity restore closure.
+
+ADR 0081: factory class methods like `Session current` /
+`Workspace currentSession` read `beamtalk_session_pid` / `beamtalk_session_id`
+from the process dictionary. Class-method dispatch hops from the eval worker to
+this gen_server, so the worker now sends its two context keys in the message
+tuple (`beamtalk_class_dispatch:local_session_context/0`) rather than having us
+copy its entire dictionary via `process_info/2`. We `put/2` them locally and
+restore the previous values (or erase) on the way out.
+""".
+-spec seed_session_context_from({pid() | undefined, binary() | undefined} | term()) ->
+    fun(() -> ok).
+seed_session_context_from({SessionPid, SessionId}) ->
+    PrevPid = put(beamtalk_session_pid, SessionPid),
+    PrevId = put(beamtalk_session_id, SessionId),
+    fun() ->
+        restore_dict_key(beamtalk_session_pid, PrevPid),
+        restore_dict_key(beamtalk_session_id, PrevId),
+        ok
+    end;
+seed_session_context_from(_Other) ->
+    %% Unrecognised context shape: seed nothing rather than crash the call.
+    fun() -> ok end.
 
 -doc """
 Mirror the calling process's session context into this class gen_server for the

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_session_primitives_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_session_primitives_tests.erl
@@ -402,6 +402,27 @@ class_current_explicit_context_no_leak_test_() ->
         ]
     end}.
 
+%% BT-2379: a malformed explicit context (a non-pair 4th element) must degrade
+%% to "no context" (nil), not crash the class gen_server. The 4-tuple clause has
+%% no `is_tuple` guard; `seed_session_context_from/1` no-ops on unrecognised
+%% shapes. We assert the gen_server survives and still serves a later call.
+class_current_malformed_context_degrades_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                ClassPid = wait_for_class('Session'),
+                %% A bare atom (not a {Pid, Id} pair) as the context: no crash,
+                %% resolves to nil because no session context is seeded.
+                NilSession = unwrap_class_reply(
+                    gen_server:call(ClassPid, {class_method_call, current, [], not_a_pair})
+                ),
+                ?assertEqual(nil, NilSession),
+                %% The gen_server is still alive and serving after the malformed call.
+                ?assert(is_process_alive(ClassPid))
+            end)
+        ]
+    end}.
+
 %%====================================================================
 %% liveSessions/0 (Workspace sessions, ADR 0081 Phase 7 / BT-2368)
 %%====================================================================

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_session_primitives_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_session_primitives_tests.erl
@@ -370,6 +370,38 @@ class_current_sees_caller_session_context_test_() ->
         ]
     end}.
 
+%% BT-2379: the explicit 4-tuple message shape carries the caller's session
+%% context in the message itself (no `process_info` dictionary copy). The class
+%% gen_server must seed from the tuple, resolve `current` correctly, and still
+%% not leak the mirrored context to a later call that carries no context.
+class_current_explicit_context_no_leak_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Pid = start_session(<<"prim-explicit-ctx">>),
+                ClassPid = wait_for_class('Session'),
+                %% Explicit context tuple in the message → resolves to that session.
+                Session = unwrap_class_reply(
+                    gen_server:call(
+                        ClassPid,
+                        {class_method_call, current, [], {Pid, <<"prim-explicit-ctx">>}}
+                    )
+                ),
+                ?assertMatch(#{'$beamtalk_class' := 'Session'}, Session),
+                ?assertEqual(<<"prim-explicit-ctx">>, maps:get(id, Session)),
+                %% A subsequent call carrying an empty explicit context must see
+                %% nil — the prior call's context must not have leaked.
+                NilSession = unwrap_class_reply(
+                    gen_server:call(
+                        ClassPid, {class_method_call, current, [], {undefined, undefined}}
+                    )
+                ),
+                ?assertEqual(nil, NilSession),
+                beamtalk_repl_shell:stop(Pid)
+            end)
+        ]
+    end}.
+
 %%====================================================================
 %% liveSessions/0 (Workspace sessions, ADR 0081 Phase 7 / BT-2368)
 %%====================================================================


### PR DESCRIPTION
## Summary

Removes the per-call `process_info(CallerPid, dictionary)` full-dictionary copy that BT-2367 introduced for mirroring session context across the eval-worker → class gen_server hop. The two session-context keys are now passed **explicitly** in the dispatch message, so the receiving clause seeds from the tuple instead of copying the caller's entire process dictionary.

Linear: https://linear.app/beamtalk/issue/BT-2379

## Changes

- **`beamtalk_class_dispatch.erl`**: both gen_server-dispatched send sites (`class_send_dispatch/3`, `metaclass_send_dispatch/4`) read `beamtalk_session_pid` / `beamtalk_session_id` cheaply via `get/1` (new `local_session_context/0` helper) and include them in a 4-tuple message `{class_method_call | metaclass_method_call, Selector, Args, {SessionPid, SessionId}}`.
- **`beamtalk_object_class.erl`**: new 4-tuple `handle_call` clause seeds from the message via `seed_session_context_from/1` (no `process_info`). The legacy 3-tuple clause is retained as a **backward-compatible fallback** (hot-code-reload / in-flight messages) and still uses `process_info`. Shared dispatch logic extracted into `dispatch_class_method/5`.
- **`beamtalk_session_primitives_tests.erl`**: added `class_current_explicit_context_no_leak_test_` exercising the explicit-context path, including the no-leak assertion.

This affects only explicit gen_server-dispatched class-method sends. Instantiation (`new`/`spawn`) and the BT-1639 direct-call optimized path are unchanged (they never hop through this message).

## Acceptance criteria

- [x] `class_method_call` / `metaclass_method_call` carry session context explicitly; no `process_info` dictionary copy in the dispatch hot path.
- [x] `Session current` / `Workspace currentSession` continue to resolve correctly through the gen_server path (existing e2e + EUnit stay green).
- [x] No cross-session context leak between serialized calls (no-leak assertion retained, plus new explicit-path assertion).
- [x] Backward-compatible fallback clause for the legacy 3-tuple message shape.

## Testing

- `just dialyzer` clean; clippy + fmt-check pass; erlfmt clean on changed files.
- EUnit: `beamtalk_session_primitives_tests` (21 tests), `beamtalk_class_dispatch_tests` / `beamtalk_object_class_tests` / `beamtalk_class_instantiation_tests` / `beamtalk_protocol_object_tests` (241 tests), and `session_object.btscript` via the REPL-protocol e2e suite — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)