### PR TITLE
Include stdlib + compiler apps in the Erlang coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,10 @@ jobs:
         continue-on-error: true
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          filename: 'runtime/_build/test/covertool/beamtalk_runtime.covertool.xml,runtime/_build/test/covertool/beamtalk_workspace.covertool.xml'
+          # All four runtime apps. bt@* compiled-Beamtalk modules carry no
+          # Erlang abstract code and are auto-excluded from cover (BT-1672), so
+          # the stdlib XML reports only its hand-written FFI .erl modules.
+          filename: 'runtime/_build/test/covertool/beamtalk_runtime.covertool.xml,runtime/_build/test/covertool/beamtalk_workspace.covertool.xml,runtime/_build/test/covertool/beamtalk_stdlib.covertool.xml,runtime/_build/test/covertool/beamtalk_compiler.covertool.xml'
           badge: true
           format: markdown
           output: both

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -69,18 +69,23 @@ cargo llvm-cov --all-targets --workspace --cobertura --output-path coverage.cobe
 
 **Erlang coverage:**
 ```bash
-cd runtime
-rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace --cover
-rebar3 cover --verbose
-# Generate Cobertura XML for CI
-rebar3 covertool generate
+# Runs unit + E2E + stdlib suites under cover, merges, and generates XMLs
+just coverage-all
 ```
+
+The Erlang coverage badge blends all four runtime apps —
+`beamtalk_runtime`, `beamtalk_workspace`, `beamtalk_stdlib`, and
+`beamtalk_compiler`. The `beamtalk_stdlib` figure reflects only the
+hand-written FFI `.erl` modules: the `bt@*` compiled-Beamtalk modules
+carry no Erlang abstract code (`erlc +from_core` emits empty abstract
+forms), so `cover` cannot instrument them and they are auto-excluded
+(BT-1672). They are exercised instead by the `.bt` BUnit suite.
 
 Coverage reports are saved to:
 - Rust HTML: `target/llvm-cov/html/index.html`
 - Erlang HTML: `runtime/_build/test/cover/index.html`
 - Rust Cobertura XML: `coverage.cobertura.xml`
-- Erlang Cobertura XML: `runtime/_build/test/covertool/beamtalk_runtime.covertool.xml`
+- Erlang Cobertura XML: one per app under `runtime/_build/test/covertool/` (`beamtalk_runtime`, `beamtalk_workspace`, `beamtalk_stdlib`, `beamtalk_compiler`)
 
 **CI Integration:**
 


### PR DESCRIPTION
## What

The Erlang coverage badge summed only **2 of the 4** runtime apps:

```yaml
filename: '...beamtalk_runtime.covertool.xml,...beamtalk_workspace.covertool.xml'
```

`covertool` already generates `beamtalk_stdlib.covertool.xml` and `beamtalk_compiler.covertool.xml` — they just weren't fed to the `CodeCoverageSummary` action. So "~79% Erlang" reflected **runtime+workspace only**, hiding the stdlib FFI layer (real shipped product code) from the number. This adds both XMLs.

## "Wasn't there an issue doing this before?"

Yes — and it's already fixed. **BT-1672 (#1714)** resolved a `test-runtime` CI failure where `cover` choked trying to instrument the `bt@*` Core Erlang-compiled beams (they carry empty abstract code — `erlc +from_core` can't emit the `file` attribute cover needs). The fix (`rebar.config.script`) auto-adds every `bt@*` module to `cover_excl_mods`.

So the hazardous part is handled. Verified: the generated `beamtalk_stdlib.covertool.xml` contains **0 `bt@*` modules** and **35 hand-written `.erl` modules**. The compiled-Beamtalk stdlib classes are exercised by the `.bt` BUnit suite instead.

## Expected effect on the badge

The blended number drops from **~79% → ~75%** — honest, not a regression:

| App | line-rate | in badge before | after |
|---|---|---|---|
| beamtalk_runtime + beamtalk_workspace | ~79.5% | ✅ | ✅ |
| beamtalk_stdlib (FFI `.erl` only) | ~67% | ❌ | ✅ |
| beamtalk_compiler | ~42% | ❌ | ✅ |

The compiler app (`beamtalk_compiler_port` / `_server` / `_build_worker`) is the low point. Still well above the 50% fail gate. Follow-up work raises the stdlib drags (`beamtalk_test_runner`, `beamtalk_interface`).

Docs updated (`testing-strategy.md`) to state the badge now blends all four apps and why `bt@*` is excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Erlang testing documentation with a unified coverage command and clarified coverage behavior across components.

* **Chores**
  * Expanded CI pipeline to track coverage across additional Erlang modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->