### PR TITLE
Fix Windows nightly: raise eunit timeout for ChangeLog rotation tests

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
@@ -499,11 +499,15 @@ restart_keeps_prior_when_disk_matches() ->
 %%====================================================================
 
 rotation_test_() ->
+    %% These tests drive 1000+ synchronous appends, each triggering source-body
+    %% file writes and (past the ring bound) transactional tar/gzip rotations.
+    %% That comfortably fits eunit's default 5s per-test timeout on Linux/macOS,
+    %% but slow Windows CI disk I/O can exceed it, so allow 60s per test.
     {setup, fun() -> ok end, fun(_) -> ok end, [
-        fun rotation_archives_overflow/0,
-        fun rotation_keeps_state_when_archive_fails/0,
-        fun archive_filenames_unique_within_same_second/0,
-        fun load_enforces_ring_bound_when_disk_exceeds_max/0
+        {timeout, 60, fun rotation_archives_overflow/0},
+        {timeout, 60, fun rotation_keeps_state_when_archive_fails/0},
+        {timeout, 60, fun archive_filenames_unique_within_same_second/0},
+        {timeout, 60, fun load_enforces_ring_bound_when_disk_exceeds_max/0}
     ]}.
 
 rotation_archives_overflow() ->


### PR DESCRIPTION
## Problem

The **nightly Windows** job has failed every run since the ADR-0082 ChangeLog landed. The failing step is *Test Erlang runtime*; the failing test is `beamtalk_workspace_changelog_tests:rotation_archives_overflow` (and its `rotation_test_` siblings), surfacing as a "Pending" `gen_server:call` stacktrace.

## Root cause

Each rotation test drives **1000+ synchronous `append` calls**. Past the 1000-entry ring bound, every append triggers a transactional **tar/gzip archive + full live-log rewrite**. On Linux/macOS this finishes well under eunit's **default 5s per-test timeout**; on the slower Windows runner the many small source-body file writes + tar/gzip exceed 5s, so eunit cancels the test while it's blocked in `gen_server:call`.

This is **test pacing, not a product bug**:
- `rotate_transactional` catches archive errors and returns state (no crash) — a `gen_server:call` failure here can only be a timeout.
- Real appends arrive one at a time; a single rotation archives one entry and is fast. Only the test stacks 1000+ rapid appends + 3 back-to-back rotations.

## Fix

Give each `rotation_test_` case a **60s eunit timeout**. No production behaviour changes.

## Verification

- `rebar3 eunit --module=beamtalk_workspace_changelog_tests` → **73 tests, 0 failures** (Linux).
- `rebar3 fmt --check` → clean.
- Can't run Windows locally, but the 60s window is ~12× the current ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced timeout configuration for archival and rotation test cases to improve test reliability and reduce potential timeout failures during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->