### PR TITLE
Raise stdlib EUnit coverage: test_runner 40→91%, interface 28→82%

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_interface_registry_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_interface_registry_tests.erl
@@ -1,7 +1,7 @@
 %% Copyright 2026 James Casey
 %% SPDX-License-Identifier: Apache-2.0
 
--module(beamtalk_interface_tests).
+-module(beamtalk_interface_registry_tests).
 
 %%% **DDD Context:** Object System Context
 

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_interface_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_interface_tests.erl
@@ -19,6 +19,7 @@ in findSendersIn/2 and findReferencesToIn/2, while [] is still returned
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/logger.hrl").
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
 
 %%% ============================================================================
 %%% Logger handler callback
@@ -166,3 +167,390 @@ find_references_to_in_returns_list_test() ->
     %% log_compiler_diagnostics/2 directly.
     Result = beamtalk_interface:findReferencesToIn(<<"x + 1">>, 'Integer'),
     ?assert(is_list(Result)).
+
+%%% ============================================================================
+%%% Navigation FFI type-error and degrade-to-[] paths (BT-2384)
+%%%
+%%% These exercise the navigation FFI exports without a running class registry:
+%%% the input-validation error clauses and (where the compiler port is not
+%%% running under EUnit) the {error, Diagnostics} -> [] degrade branch.
+%%% ============================================================================
+
+find_senders_in_rejects_bad_args_test() ->
+    ?assertError(
+        #{error := #beamtalk_error{kind = type_error, class = 'BeamtalkInterface'}},
+        beamtalk_interface:findSendersIn(not_a_binary, ifTrue)
+    ).
+
+all_sends_in_returns_list_test() ->
+    Result = beamtalk_interface:allSendsIn(<<"x foo: 1">>),
+    ?assert(is_list(Result)).
+
+all_sends_in_rejects_bad_args_test() ->
+    ?assertError(
+        #{error := #beamtalk_error{kind = type_error, selector = 'allSendsIn:'}},
+        beamtalk_interface:allSendsIn(not_a_binary)
+    ).
+
+find_references_to_in_rejects_bad_args_test() ->
+    ?assertError(
+        #{error := #beamtalk_error{kind = type_error, class = 'BeamtalkInterface'}},
+        beamtalk_interface:findReferencesToIn(123, 'Integer')
+    ).
+
+find_field_readers_in_returns_list_test() ->
+    Result = beamtalk_interface:findFieldReadersIn(<<"x + 1">>, count),
+    ?assert(is_list(Result)).
+
+find_field_writers_in_returns_list_test() ->
+    Result = beamtalk_interface:findFieldWritersIn(<<"x + 1">>, count),
+    ?assert(is_list(Result)).
+
+find_field_access_rejects_bad_args_test() ->
+    ?assertError(
+        #{error := #beamtalk_error{kind = type_error}},
+        beamtalk_interface:findFieldReadersIn(not_a_binary, count)
+    ).
+
+ffi_sites_in_returns_list_test() ->
+    Result = beamtalk_interface:ffiSitesIn(<<"x + 1">>, <<"lists">>, <<"reverse">>, any),
+    ?assert(is_list(Result)).
+
+ffi_sites_in_integer_arity_test() ->
+    Result = beamtalk_interface:ffiSitesIn(<<"x + 1">>, lists, reverse, 1),
+    ?assert(is_list(Result)).
+
+ffi_sites_in_rejects_bad_args_test() ->
+    ?assertError(
+        #{
+            error := #beamtalk_error{
+                kind = type_error, selector = 'ffiSitesIn:module:function:arity:'
+            }
+        },
+        beamtalk_interface:ffiSitesIn(<<"x">>, <<"lists">>, <<"reverse">>, -1)
+    ).
+
+%%% ============================================================================
+%%% version/0 fallback (BT-2384)
+%%%
+%%% Under EUnit the beamtalk_runtime app is typically not started, so version/0
+%%% takes the <<"unknown">> fallback. Either way it must return a binary.
+%%% ============================================================================
+
+version_returns_binary_test() ->
+    ?assert(is_binary(beamtalk_interface:version())).
+
+version_matches_app_vsn_when_loaded_test() ->
+    %% Load (not start) the runtime app so application:get_key/2 returns {ok, Vsn},
+    %% driving the {ok, Vsn} -> list_to_binary(Vsn) branch of version/0.
+    _ = application:load(beamtalk_runtime),
+    Result = beamtalk_interface:version(),
+    case application:get_key(beamtalk_runtime, vsn) of
+        {ok, Vsn} -> ?assertEqual(list_to_binary(Vsn), Result);
+        _ -> ?assertEqual(<<"unknown">>, Result)
+    end.
+
+dispatch_version_matches_app_vsn_when_loaded_test() ->
+    _ = application:load(beamtalk_runtime),
+    Result = beamtalk_interface:dispatch(version, [], fake_self()),
+    case application:get_key(beamtalk_runtime, vsn) of
+        {ok, Vsn} -> ?assertEqual(list_to_binary(Vsn), Result);
+        _ -> ?assertEqual(<<"unknown">>, Result)
+    end.
+
+dispatch_version_returns_binary_test() ->
+    ?assert(is_binary(beamtalk_interface:dispatch(version, [], fake_self()))).
+
+dispatch_unknown_selector_raises_dnu_test() ->
+    ?assertError(
+        #{error := #beamtalk_error{kind = does_not_understand, class = 'BeamtalkInterface'}},
+        beamtalk_interface:dispatch(noSuchSelectorXyz, [], fake_self())
+    ).
+
+%%% ============================================================================
+%%% Live registry tests (BT-2384)
+%%%
+%%% Load the full stdlib so the class registry is populated with real classes
+%%% (Integer, Object, etc.) and exercise allClasses/0, classNamed/1, findClass/1,
+%%% globals/0, help/1, help/2, erlangHelp/1, erlangHelp/2 — including the
+%%% format_class_help / format_method_help / collect_flattened_methods /
+%%% find_defining_class hierarchy-walking helpers and the not-found error paths.
+%%% ============================================================================
+
+%% A fake Self value — BeamtalkInterface primitives ignore Self entirely.
+fake_self() ->
+    {beamtalk_object, 'BeamtalkInterface class', 'bt@stdlib@beamtalk_interface', self()}.
+
+live_setup() ->
+    case whereis(pg) of
+        undefined -> pg:start_link();
+        _ -> ok
+    end,
+    beamtalk_extensions:init(),
+    case whereis(beamtalk_bootstrap) of
+        undefined -> {ok, _} = beamtalk_bootstrap:start_link();
+        _ -> ok
+    end,
+    beamtalk_stdlib:init(),
+    ok.
+
+live_teardown(_) ->
+    ok.
+
+live_registry_test_() ->
+    {setup, fun live_setup/0, fun live_teardown/1, fun(_) ->
+        [
+            {"allClasses returns a non-empty list of class objects", fun() ->
+                Classes = beamtalk_interface:allClasses(),
+                ?assert(is_list(Classes)),
+                ?assert(length(Classes) > 0),
+                lists:foreach(
+                    fun(C) -> ?assertMatch({beamtalk_object, _, _, _}, C) end,
+                    Classes
+                )
+            end},
+            {"globals returns a map keyed by class name", fun() ->
+                G = beamtalk_interface:globals(),
+                ?assert(is_map(G)),
+                ?assert(maps:is_key('Integer', G)),
+                ?assertMatch({beamtalk_object, _, _, _}, maps:get('Integer', G))
+            end},
+            {"classNamed by atom returns a class object", fun() ->
+                ?assertMatch(
+                    {beamtalk_object, 'Integer class', _, _},
+                    beamtalk_interface:classNamed('Integer')
+                )
+            end},
+            {"classNamed by binary returns a class object", fun() ->
+                ?assertMatch(
+                    {beamtalk_object, 'Integer class', _, _},
+                    beamtalk_interface:classNamed(<<"Integer">>)
+                )
+            end},
+            {"classNamed unknown binary returns nil", fun() ->
+                ?assertEqual(nil, beamtalk_interface:classNamed(<<"ZzzNoSuchClass">>))
+            end},
+            {"classNamed metaclass tag returns a metaclass object", fun() ->
+                ?assertMatch(
+                    {beamtalk_object, 'Metaclass', beamtalk_metaclass_bt, _},
+                    beamtalk_interface:classNamed('Integer class')
+                )
+            end},
+            {"findClass resolves a known class", fun() ->
+                ?assertMatch(
+                    {beamtalk_object, 'Integer class', _, _},
+                    beamtalk_interface:findClass('Integer')
+                )
+            end},
+            {"findClass unknown metaclass tag returns nil", fun() ->
+                ?assertEqual(nil, beamtalk_interface:findClass('ZzzNope class'))
+            end},
+            {"classNamed integer arg raises type_error", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = type_error}},
+                    beamtalk_interface:classNamed(42)
+                )
+            end},
+            {"help: on a known class returns its formatted help", fun() ->
+                H = beamtalk_interface:help('Integer'),
+                ?assert(is_binary(H)),
+                ?assertNotEqual(nomatch, binary:match(H, <<"Integer">>))
+            end},
+            {"help: by binary class name works", fun() ->
+                H = beamtalk_interface:help(<<"Integer">>),
+                ?assert(is_binary(H))
+            end},
+            {"help: unknown class raises class_not_found", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = class_not_found}},
+                    beamtalk_interface:help('ZzzNoSuchClass')
+                )
+            end},
+            {"help:selector: on an own method returns its signature", fun() ->
+                H = beamtalk_interface:help('Integer', '+'),
+                ?assert(is_binary(H)),
+                ?assertNotEqual(nomatch, binary:match(H, <<"Integer">>)),
+                ?assertNotEqual(nomatch, binary:match(H, <<"+">>))
+            end},
+            {"help:selector: with a binary selector works", fun() ->
+                H = beamtalk_interface:help('Integer', <<"+">>),
+                ?assert(is_binary(H))
+            end},
+            {"help:selector: unknown selector raises does_not_understand", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = does_not_understand}},
+                    beamtalk_interface:help('Integer', zzzNoSuchMethod)
+                )
+            end},
+            {"help:selector: unknown class raises class_not_found", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = class_not_found}},
+                    beamtalk_interface:help('ZzzNoSuchClass', foo)
+                )
+            end},
+            {"help:selector: on Metaclass new returns metaclass doc", fun() ->
+                H = beamtalk_interface:help('Metaclass', new),
+                ?assert(is_binary(H)),
+                ?assertNotEqual(nomatch, binary:match(H, <<"Metaclass">>))
+            end},
+            {"help:selector: on Metaclass unknown selector raises dnu", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = does_not_understand}},
+                    beamtalk_interface:help('Metaclass', zzzNoSuchMeta)
+                )
+            end},
+            {"dispatch help: routes to handle_help", fun() ->
+                H = beamtalk_interface:dispatch('help:', ['Integer'], fake_self()),
+                ?assert(is_binary(H))
+            end},
+            {"dispatch help:selector: routes to handle_help_selector", fun() ->
+                H = beamtalk_interface:dispatch(
+                    'help:selector:', ['Integer', '+'], fake_self()
+                ),
+                ?assert(is_binary(H))
+            end},
+            {"dispatch erlangHelp: routes through", fun() ->
+                H = beamtalk_interface:dispatch('erlangHelp:', [<<"lists">>], fake_self()),
+                ?assert(is_binary(H))
+            end},
+            {"erlangHelp: on a known module returns docs", fun() ->
+                ?assert(is_binary(beamtalk_interface:erlangHelp(<<"lists">>)))
+            end},
+            {"erlangHelp: unknown module raises not_found", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = not_found}},
+                    beamtalk_interface:erlangHelp(<<"zzz_no_such_module_xyz">>)
+                )
+            end},
+            {"erlangHelp: non-binary arg raises type_error", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = type_error}},
+                    beamtalk_interface:erlangHelp(123)
+                )
+            end},
+            {"erlangHelp:selector: on a known function returns docs", fun() ->
+                ?assert(is_binary(beamtalk_interface:erlangHelp(<<"lists">>, <<"reverse">>)))
+            end},
+            {"erlangHelp:selector: with an atom selector works", fun() ->
+                ?assert(is_binary(beamtalk_interface:erlangHelp(<<"lists">>, reverse)))
+            end},
+            {"erlangHelp:selector: unknown function raises not_found", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = not_found}},
+                    beamtalk_interface:erlangHelp(<<"lists">>, <<"zzzNoSuchFn">>)
+                )
+            end},
+            {"erlangHelp:selector: unknown module raises not_found", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = not_found}},
+                    beamtalk_interface:erlangHelp(<<"zzz_no_module">>, <<"reverse">>)
+                )
+            end},
+            {"erlangHelp:selector: non-binary module raises type_error", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = type_error}},
+                    beamtalk_interface:erlangHelp(123, <<"reverse">>)
+                )
+            end},
+            {"findSendersIn on real source returns a list", fun() ->
+                R = beamtalk_interface:findSendersIn(<<"self foo: 1. self foo: 2">>, 'foo:'),
+                ?assert(is_list(R))
+            end},
+            {"dispatch allClasses routes to allClasses/0", fun() ->
+                R = beamtalk_interface:dispatch(allClasses, [], fake_self()),
+                ?assert(is_list(R)),
+                ?assert(length(R) > 0)
+            end},
+            {"dispatch classNamed: routes to handle_class_named", fun() ->
+                ?assertMatch(
+                    {beamtalk_object, 'Integer class', _, _},
+                    beamtalk_interface:dispatch('classNamed:', ['Integer'], fake_self())
+                )
+            end},
+            {"dispatch globals routes to handle_globals", fun() ->
+                ?assert(is_map(beamtalk_interface:dispatch(globals, [], fake_self())))
+            end},
+            {"dispatch erlangHelp:selector: routes through", fun() ->
+                R = beamtalk_interface:dispatch(
+                    'erlangHelp:selector:', [<<"lists">>, <<"reverse">>], fake_self()
+                ),
+                ?assert(is_binary(R))
+            end},
+            {"help: on the root class renders a header without '<'", fun() ->
+                %% ProtoObject is the hierarchy root (superclass none) — exercises
+                %% the header branch that omits the '< Super' part
+                %% (format_class_help line 991).
+                H = beamtalk_interface:help('ProtoObject'),
+                ?assert(is_binary(H)),
+                ?assertNotEqual(nomatch, binary:match(H, <<"== ProtoObject ==">>))
+            end},
+            {"help: on a subclass lists inherited methods", fun() ->
+                %% Integer < Number < Object: the help output groups inherited
+                %% methods by their defining class (collect_flattened_methods +
+                %% group_by_class + InheritedParts).
+                H = beamtalk_interface:help('Integer'),
+                ?assertNotEqual(nomatch, binary:match(H, <<"Inherited from">>))
+            end},
+            {"help:selector: on an inherited method notes inheritance", fun() ->
+                %% asString is defined on Object; asking Integer about it walks
+                %% find_defining_class and emits an "(inherited from ...)" note.
+                H = beamtalk_interface:help('Integer', asString),
+                ?assert(is_binary(H))
+            end},
+            {"findClass non-class binary returns nil", fun() ->
+                %% A binary that is not a class name and not a metaclass tag.
+                ?assertEqual(nil, beamtalk_interface:findClass(<<"not a class name!">>))
+            end},
+            {"help: accepts a class-object tuple (resolve_class_name pid path)", fun() ->
+                %% Passing the class object itself exercises the
+                %% resolve_class_name(#beamtalk_object{pid=...}) clause.
+                ClassObj = beamtalk_interface:classNamed('Integer'),
+                H = beamtalk_interface:help(ClassObj),
+                ?assert(is_binary(H))
+            end},
+            {"help: with a non-class argument raises type_error", fun() ->
+                ?assertError(
+                    #{error := #beamtalk_error{kind = type_error}},
+                    beamtalk_interface:help(3.14)
+                )
+            end},
+            {"help: on an abstract class shows the [abstract] modifier", fun() ->
+                %% Number is abstract — exercises the {false, true} modifier branch.
+                H = beamtalk_interface:help('Number'),
+                ?assert(is_binary(H)),
+                ?assertNotEqual(nomatch, binary:match(H, <<"[abstract]">>))
+            end},
+            {"help: on a sealed class shows the [sealed] modifier", fun() ->
+                %% Symbol is sealed — exercises the {true, false} modifier branch.
+                H = beamtalk_interface:help('Symbol'),
+                ?assert(is_binary(H)),
+                ?assertNotEqual(nomatch, binary:match(H, <<"[sealed]">>))
+            end},
+            {"dispatch help:selector: unknown class raises class_not_found", fun() ->
+                %% Drives the dispatch('help:selector:', ...) {error,Err} ->
+                %% beamtalk_error:raise branch.
+                ?assertError(
+                    #{error := #beamtalk_error{kind = class_not_found}},
+                    beamtalk_interface:dispatch(
+                        'help:selector:', ['ZzzNoSuchClass', foo], fake_self()
+                    )
+                )
+            end},
+            {"findClass integer arg raises type_error", fun() ->
+                %% Drives the findClass/1 {error,Err} -> raise branch.
+                ?assertError(
+                    #{error := #beamtalk_error{kind = type_error}},
+                    beamtalk_interface:findClass(42)
+                )
+            end},
+            {"help:selector: resolves a class-side method", fun() ->
+                %% `new` is a class-side method (inherited from Value): the
+                %% instance-side resolve returns nil, so resolve_help_method
+                %% falls through to the {class_method, Selector} branch and
+                %% find_defining_class_method walks the class-side tables.
+                H = beamtalk_interface:help('Integer', new),
+                ?assert(is_binary(H)),
+                ?assertNotEqual(nomatch, binary:match(H, <<"new">>))
+            end}
+        ]
+    end}.

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_test_runner_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_test_runner_tests.erl
@@ -395,6 +395,318 @@ ensure_loaded_or_warn_nonexistent_module_test() ->
     ?assertEqual(ok, beamtalk_test_runner:ensure_loaded_or_warn(nonexistent_module_bt2230)).
 
 %%% ============================================================================
+%%% TestResult instance FFI shim tests
+%%%
+%%% The lowercase shims (passed/1, failed/1, ...) are the selectors dispatched
+%%% from compiled Beamtalk for `aResult passed` etc. They delegate to the
+%%% result_* accessors. Cover them directly.
+%%% ============================================================================
+
+shim_passed_test() ->
+    Result = make_result(3, 2, 1, 0, 1.0, []),
+    ?assertEqual(2, beamtalk_test_runner:passed(Result)).
+
+shim_failed_test() ->
+    Result = make_result(3, 2, 1, 0, 1.0, []),
+    ?assertEqual(1, beamtalk_test_runner:failed(Result)).
+
+shim_skipped_test() ->
+    Result = make_result(4, 2, 1, 1, 1.0, []),
+    ?assertEqual(1, beamtalk_test_runner:skipped(Result)).
+
+shim_total_test() ->
+    Result = make_result(4, 2, 1, 1, 1.0, []),
+    ?assertEqual(4, beamtalk_test_runner:total(Result)).
+
+shim_duration_test() ->
+    Result = make_result(1, 1, 0, 0, 2.5, []),
+    ?assertEqual(2.5, beamtalk_test_runner:duration(Result)).
+
+shim_failures_test() ->
+    Result = make_result(2, 1, 1, 0, 1.0, [
+        #{name => testA, class => 'T', status => pass},
+        #{name => testB, class => 'T', status => fail, error => <<"boom">>}
+    ]),
+    Failures = beamtalk_test_runner:failures(Result),
+    ?assertEqual(1, length(Failures)),
+    ?assertEqual(testB, maps:get(name, hd(Failures))).
+
+shim_has_passed_true_test() ->
+    Result = make_result(2, 2, 0, 0, 1.0, []),
+    ?assert(beamtalk_test_runner:hasPassed(Result)).
+
+shim_has_passed_false_test() ->
+    Result = make_result(2, 1, 1, 0, 1.0, []),
+    ?assertNot(beamtalk_test_runner:hasPassed(Result)).
+
+shim_summary_test() ->
+    Result = make_result(3, 3, 0, 0, 1.5, []),
+    ?assertEqual(<<"3 tests, 3 passed (1.5s)">>, beamtalk_test_runner:summary(Result)).
+
+shim_print_string_test() ->
+    Result = make_result(2, 2, 0, 0, 1.0, [
+        #{name => testA, class => 'T', status => pass},
+        #{name => testB, class => 'T', status => pass}
+    ]),
+    ?assertEqual(
+        <<"TestResult(2 tests, 2 passed (1.0s))">>, beamtalk_test_runner:printString(Result)
+    ).
+
+%%% ============================================================================
+%%% Non-binary error formatting (BT-2384)
+%%%
+%%% format_single_failure / serialize_test_result both have a branch for an
+%%% error term that is not a binary (it is printed via beamtalk_primitive),
+%%% plus a fallback for a fail entry that carries no error key at all.
+%%% ============================================================================
+
+print_string_non_binary_error_test() ->
+    %% error is an atom, not a binary — exercises print_string conversion.
+    Result = make_result(1, 0, 1, 0, 0.5, [
+        #{name => testX, class => 'T', status => fail, error => some_atom_error}
+    ]),
+    Str = beamtalk_test_runner:result_print_string(Result),
+    ?assertNotEqual(nomatch, binary:match(Str, <<"T>>testX">>)),
+    ?assertNotEqual(nomatch, binary:match(Str, <<"some_atom_error">>)).
+
+print_string_fail_without_error_key_test() ->
+    %% fail entry with no error key — exercises the fallback format clause.
+    Result = make_result(1, 0, 1, 0, 0.5, [
+        #{name => testY, class => 'T', status => fail}
+    ]),
+    Str = beamtalk_test_runner:result_print_string(Result),
+    ?assertNotEqual(nomatch, binary:match(Str, <<"T>>testY">>)).
+
+to_json_non_binary_error_test() ->
+    Result = make_result(1, 0, 1, 0, 0.5, [
+        #{name => testZ, class => 'T', status => fail, error => {tuple, error}}
+    ]),
+    Json = beamtalk_test_runner:result_to_json(Result),
+    Decoded = json:decode(Json),
+    [Test] = maps:get(<<"tests">>, Decoded),
+    %% error key present, printed from the non-binary term.
+    ?assert(is_binary(maps:get(<<"error">>, Test))).
+
+to_json_test_without_class_key_test() ->
+    %% A test entry with no class key — serialize_test_result omits "class".
+    Result = make_result(1, 1, 0, 0, 0.1, [
+        #{name => testW, status => pass}
+    ]),
+    Json = beamtalk_test_runner:result_to_json(Result),
+    Decoded = json:decode(Json),
+    [Test] = maps:get(<<"tests">>, Decoded),
+    ?assertNot(maps:is_key(<<"class">>, Test)),
+    ?assertEqual(<<"testW">>, maps:get(<<"name">>, Test)).
+
+%%% ============================================================================
+%%% Live execution tests (BT-2384)
+%%%
+%%% These tests drive the real test-execution paths (run_class_by_name,
+%%% discover_methods_via_registry, run_all, concurrent execution, run_file,
+%%% run_class/run_method on a real class tuple) by loading the stdlib and
+%%% registering a synthetic TestCase subclass whose backing module implements
+%%% new/0 + dispatch/3 for setUp/tearDown/test methods. A passing test
+%%% (testAlpha), a failing test (testBravo), and a skipped test (testCharlie)
+%%% exercise the pass/fail/skip aggregation branches.
+%%% ============================================================================
+
+-define(SYNTH_CLASS, 'BtTestRunnerSynthTest').
+-define(SYNTH_MODULE, bt_test_runner_synth_mod).
+
+live_setup() ->
+    case whereis(pg) of
+        undefined -> pg:start_link();
+        _ -> ok
+    end,
+    beamtalk_extensions:init(),
+    case whereis(beamtalk_bootstrap) of
+        undefined -> {ok, _} = beamtalk_bootstrap:start_link();
+        _ -> ok
+    end,
+    beamtalk_stdlib:init(),
+    load_synth_module(),
+    register_synth_class(),
+    %% Two extra concurrent classes so run_all(2) exceeds MaxJobs and exercises
+    %% the feed-and-collect loop (spawn-next-on-result) in run_classes_concurrent.
+    register_extra_class('BtTestRunnerSynthTest2'),
+    register_extra_class('BtTestRunnerSynthTest3'),
+    ok.
+
+live_teardown(_) ->
+    ok.
+
+%% Compile and load a tiny Erlang module that backs the synthetic TestCase.
+load_synth_module() ->
+    Src =
+        "-module(bt_test_runner_synth_mod).\n"
+        "-beamtalk_source([\"test/bt_test_runner_synth_test.bt\"]).\n"
+        "-export([new/0, dispatch/3, module_info/0, module_info/1]).\n"
+        "new() -> #{'$beamtalk_class' => 'BtTestRunnerSynthTest'}.\n"
+        "dispatch(setUp, _, Self) -> Self;\n"
+        "dispatch(tearDown, _, Self) -> Self;\n"
+        "dispatch(testAlpha, _, Self) -> Self;\n"
+        "dispatch(testBravo, _, _Self) -> beamtalk_test_case:fail(<<\"intentional failure\">>);\n"
+        "dispatch(testCharlie, _, _Self) -> beamtalk_test_case:skip(<<\"intentional skip\">>).\n",
+    {ok, Tokens, _} = erl_scan:string(Src),
+    Forms = [
+        begin
+            {ok, Form} = erl_parse:parse_form(Ts),
+            Form
+        end
+     || Ts <- split_token_forms(Tokens)
+    ],
+    {ok, Mod, Bin} = compile:forms(Forms, [return_errors]),
+    {module, Mod} = code:load_binary(Mod, "bt_test_runner_synth_mod.erl", Bin),
+    ok.
+
+register_synth_class() ->
+    Info = #{
+        name => ?SYNTH_CLASS,
+        module => ?SYNTH_MODULE,
+        superclass => 'TestCase',
+        instance_methods => #{
+            setUp => #{arity => 0},
+            tearDown => #{arity => 0},
+            testAlpha => #{arity => 0},
+            testBravo => #{arity => 0},
+            testCharlie => #{arity => 0}
+        },
+        instance_variables => []
+    },
+    case beamtalk_object_class:start_link(?SYNTH_CLASS, Info) of
+        {ok, _Pid} -> ok;
+        {error, {already_started, _Pid}} -> ok
+    end.
+
+%% Register an additional TestCase subclass backed by the same synthetic
+%% module so multiple classes run concurrently in run_all(N>1).
+register_extra_class(Name) ->
+    Info = #{
+        name => Name,
+        module => ?SYNTH_MODULE,
+        superclass => 'TestCase',
+        instance_methods => #{
+            setUp => #{arity => 0},
+            tearDown => #{arity => 0},
+            testAlpha => #{arity => 0},
+            testBravo => #{arity => 0},
+            testCharlie => #{arity => 0}
+        },
+        instance_variables => []
+    },
+    case beamtalk_object_class:start_link(Name, Info) of
+        {ok, _Pid} -> ok;
+        {error, {already_started, _Pid}} -> ok
+    end.
+
+%% Split a flat token list into per-form token lists at each `dot`.
+split_token_forms(Tokens) -> split_token_forms(Tokens, [], []).
+split_token_forms([], _Cur, Acc) ->
+    lists:reverse(Acc);
+split_token_forms([{dot, _} = Dot | Rest], Cur, Acc) ->
+    split_token_forms(Rest, [], [lists:reverse([Dot | Cur]) | Acc]);
+split_token_forms([Tok | Rest], Cur, Acc) ->
+    split_token_forms(Rest, [Tok | Cur], Acc).
+
+%% A class-reference tuple for the synthetic class (element 2 = 'Name class').
+synth_class_ref() ->
+    {beamtalk_object, 'BtTestRunnerSynthTest class', ?SYNTH_MODULE, self()}.
+
+live_execution_test_() ->
+    {setup, fun live_setup/0, fun live_teardown/1, fun(_) ->
+        [
+            {"find_test_classes includes the synthetic class", fun() ->
+                Classes = beamtalk_test_case:find_test_classes(),
+                ?assert(lists:member(?SYNTH_CLASS, Classes))
+            end},
+            {"run_class_by_name returns a TestResult with pass/fail/skip counts", fun() ->
+                R = beamtalk_test_runner:run_class_by_name(?SYNTH_CLASS),
+                ?assertEqual('TestResult', maps:get('$beamtalk_class', R)),
+                ?assertEqual(3, maps:get(total, R)),
+                ?assertEqual(1, maps:get(passed, R)),
+                ?assertEqual(1, maps:get(failed, R)),
+                ?assertEqual(1, maps:get(skipped, R))
+            end},
+            {"run_class on a class tuple delegates to run_class_by_name", fun() ->
+                R = beamtalk_test_runner:run_class(synth_class_ref()),
+                ?assertEqual(3, maps:get(total, R)),
+                ?assertEqual(1, maps:get(failed, R))
+            end},
+            {"run_method runs a single passing test method", fun() ->
+                R = beamtalk_test_runner:run_method(synth_class_ref(), testAlpha),
+                ?assertEqual(1, maps:get(total, R)),
+                ?assertEqual(1, maps:get(passed, R)),
+                ?assertEqual(0, maps:get(failed, R))
+            end},
+            {"run_method runs a single failing test method", fun() ->
+                R = beamtalk_test_runner:run_method(synth_class_ref(), testBravo),
+                ?assertEqual(1, maps:get(total, R)),
+                ?assertEqual(1, maps:get(failed, R))
+            end},
+            {"run_all (sequential) includes the synthetic class results", fun() ->
+                R = beamtalk_test_runner:run_all(1),
+                ?assertEqual('TestResult', maps:get('$beamtalk_class', R)),
+                %% At least our 3 synthetic tests are present.
+                ?assert(maps:get(total, R) >= 3),
+                ?assert(maps:get(failed, R) >= 1),
+                ?assert(maps:get(skipped, R) >= 1)
+            end},
+            {"run_all (concurrent) aggregates with wall-clock duration", fun() ->
+                R = beamtalk_test_runner:run_all(2),
+                ?assertEqual('TestResult', maps:get('$beamtalk_class', R)),
+                ?assert(maps:get(total, R) >= 3),
+                ?assert(is_float(maps:get(duration, R)))
+            end},
+            {"run_all (auto / 0 jobs) resolves to scheduler count", fun() ->
+                R = beamtalk_test_runner:run_all(0),
+                ?assertEqual('TestResult', maps:get('$beamtalk_class', R)),
+                ?assert(maps:get(total, R) >= 3)
+            end},
+            {"runAll/0 shim runs the full suite", fun() ->
+                R = beamtalk_test_runner:runAll(),
+                ?assertEqual('TestResult', maps:get('$beamtalk_class', R)),
+                ?assert(maps:get(total, R) >= 3)
+            end},
+            {"run/1 shim delegates to run_class", fun() ->
+                R = beamtalk_test_runner:run(synth_class_ref()),
+                ?assertEqual(3, maps:get(total, R))
+            end},
+            {"run/2 shim delegates to run_method", fun() ->
+                R = beamtalk_test_runner:run(synth_class_ref(), testAlpha),
+                ?assertEqual(1, maps:get(passed, R))
+            end},
+            {"run_class_by_name on an unknown class raises class_not_found", fun() ->
+                ?assertError(
+                    #{
+                        error := #beamtalk_error{
+                            kind = class_not_found, class = 'TestRunner'
+                        }
+                    },
+                    beamtalk_test_runner:run_class_by_name('ZzzNoSuchClass')
+                )
+            end},
+            {"run_file with a non-matching path yields an empty TestResult", fun() ->
+                R = beamtalk_test_runner:run_file(<<"no/such/path_zzz_test.bt">>),
+                ?assertEqual(0, maps:get(total, R)),
+                ?assertEqual([], maps:get(tests, R))
+            end},
+            {"run_file matching the synthetic class source runs its tests", fun() ->
+                %% All three synthetic classes share the same backing module
+                %% (and thus the same beamtalk_source attribute), so matching
+                %% by path suffix drives class_source_matches/2 + the run_file
+                %% match branch for each: 3 classes x 3 tests = 9 total.
+                R = beamtalk_test_runner:run_file(
+                    <<"test/bt_test_runner_synth_test.bt">>
+                ),
+                ?assertEqual(9, maps:get(total, R)),
+                ?assertEqual(3, maps:get(passed, R)),
+                ?assertEqual(3, maps:get(failed, R)),
+                ?assertEqual(3, maps:get(skipped, R))
+            end}
+        ]
+    end}.
+
+%%% ============================================================================
 %%% Helpers
 %%% ============================================================================
 

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_test_runner_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_test_runner_tests.erl
@@ -533,7 +533,31 @@ live_setup() ->
     ok.
 
 live_teardown(_) ->
+    %% Inverse of live_setup/0: stop the synthetic class gen_servers (their
+    %% terminate/2 leaves the pg group and clears the registry ETS tables) and
+    %% unload the synthetic module, so fixture state doesn't leak into later
+    %% EUnit modules sharing this VM and make find_test_classes/0 + run_all/*
+    %% order-dependent across the suite.
+    stop_synth_class(?SYNTH_CLASS),
+    stop_synth_class('BtTestRunnerSynthTest2'),
+    stop_synth_class('BtTestRunnerSynthTest3'),
+    code:purge(?SYNTH_MODULE),
+    code:delete(?SYNTH_MODULE),
     ok.
+
+%% Stop a synthetic class gen_server if still registered. Its terminate/2
+%% removes the class from pg + the registry tables.
+stop_synth_class(Name) ->
+    case whereis(beamtalk_class_registry:registry_name(Name)) of
+        undefined ->
+            ok;
+        Pid ->
+            try
+                gen_server:stop(Pid)
+            catch
+                _:_ -> ok
+            end
+    end.
 
 %% Compile and load a tiny Erlang module that backs the synthetic TestCase.
 load_synth_module() ->


### PR DESCRIPTION
## What

Extends the EUnit suites for two under-tested `beamtalk_stdlib` FFI modules, ahead of bringing the stdlib app into the coverage badge (#2426):

| Module | Before | After |
|---|---|---|
| `beamtalk_test_runner` | 92/228 (~40%) | **208/228 (91.2%)** |
| `beamtalk_interface` | ~102/363 (~28%) | **298/363 (82.1%)** |

- **test_runner**: a live-execution fixture registers synthetic `TestCase` subclasses (in-memory module exporting `new/0` + `dispatch/3` with passing/failing/skipping methods) to drive the real `run_class_by_name`, `discover_methods_via_registry`, sequential + concurrent `run_all`, `run_file` source-path matching, and the `runAll`/`run` FFI shims — plus direct tests for every TestResult instance shim.
- **interface**: a live-registry fixture (full `beamtalk_stdlib:init/0`) exercises `allClasses`, `globals`, `classNamed`, `findClass` (atom/binary/metaclass-tag/nil/type_error), `help/1,2` against real classes, `version` (both branches), `dispatch/3` routing, and type-error / degrade-to-`[]` paths for the navigation FFI.

**Deliberately left uncovered** (genuinely unreachable in EUnit): compiler-subprocess `{ok,_}` navigation branches (no compiler server under EUnit → documented degrade-to-`[]`), and defensive `exit:{noproc,_}`/`{timeout,_}` catches that only fire on hard process death.

## Also fixes a pre-existing module-name collision

Both `beamtalk_runtime/test` and `beamtalk_stdlib/test` defined a `beamtalk_interface_tests` module (added independently by #2253 and #2256). Two `.beam`s with the same module name can't coexist on the path, so in any **combined** run one shadowed the other and its tests were silently **cancelled**.

Renamed the runtime-app copy to **`beamtalk_interface_registry_tests`** (it drives `beamtalk_interface` through the class registry). Verified all three modules now run together: **168 tests, 0 failures**.

## Follow-ups (not in this PR)
- The renamed `beamtalk_interface_registry_tests` overlaps the (now comprehensive) stdlib `beamtalk_interface_tests`; a later pass could dedup.
- Pre-existing flaky `beamtalk_test_case_tests:ensure_test_context_appends_context_test` (fails on unmodified tree) — will file separately.

Depends on nothing; complements #2426 (stdlib in the badge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive test coverage added for FFI navigation, input validation, and dispatch routing behavior.
  * Test runner functionality now includes validation of result formatting, serialization, and live execution scenarios.
  * Test module structure improved for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->