### PR TITLE
Enable warnings_as_errors for Erlang src; convert deprecated catch

### DIFF
--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -563,7 +563,7 @@ recover_from_beam_modules() ->
                 false ->
                     Acc;
                 true ->
-                    case (catch Module:'__beamtalk_meta'()) of
+                    try Module:'__beamtalk_meta'() of
                         Meta when is_map(Meta) ->
                             ClassName = maps:get(class, Meta, undefined),
                             case
@@ -575,6 +575,9 @@ recover_from_beam_modules() ->
                                 false -> Acc
                             end;
                         _ ->
+                            Acc
+                    catch
+                        _:_ ->
                             Acc
                     end
             end

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_registry.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_registry.erl
@@ -782,7 +782,12 @@ restart_class(ClassName) ->
             %% Clean up stale pid entries for this class before restarting.
             %% On crash, terminate doesn't run, so old {DeadPid, ClassName} entries
             %% linger. Remove them so they don't accumulate on repeated crashes.
-            _ = (catch ets:match_delete(beamtalk_class_pids, {'_', ClassName})),
+            _ =
+                (try
+                    ets:match_delete(beamtalk_class_pids, {'_', ClassName})
+                catch
+                    _:_ -> ok
+                end),
             case beamtalk_object_class:start(ClassName, ClassInfo) of
                 {ok, NewPid} ->
                     ?LOG_WARNING(

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -887,11 +887,26 @@ terminate(_Reason, #class_state{name = ClassName}) ->
     %% ensuring the class is fully removed from the runtime registries.
     %% Wrapped in catch/try to be safe during node shutdown when ETS/pg may be gone.
     %% BT-2222: Single metadata row → single delete (was a three-table fan-out).
-    _ = (catch beamtalk_class_metadata:delete(ClassName)),
+    _ =
+        (try
+            beamtalk_class_metadata:delete(ClassName)
+        catch
+            _:_ -> ok
+        end),
     %% BT-1768: Clean up pid reverse index. Only cleaned on graceful shutdown —
     %% on crash, the entry intentionally survives for auto-restart recovery.
-    _ = (catch ets:delete(beamtalk_class_pids, self())),
-    _ = (catch pg:leave(beamtalk_classes, self())),
+    _ =
+        (try
+            ets:delete(beamtalk_class_pids, self())
+        catch
+            _:_ -> ok
+        end),
+    _ =
+        (try
+            pg:leave(beamtalk_classes, self())
+        catch
+            _:_ -> ok
+        end),
     ok.
 
 %% ADR 0032 Phase 1: No flattened tables to rebuild after hot reload.

--- a/runtime/apps/beamtalk_runtime/test_fixtures/compile_fixtures.escript
+++ b/runtime/apps/beamtalk_runtime/test_fixtures/compile_fixtures.escript
@@ -117,7 +117,7 @@ collect_port_output(Port, Acc) ->
         {Port, {exit_status, Code}} ->
             {error, {exit_status, Code}, iolist_to_binary(Acc)}
     after 60000 ->
-        catch port_close(Port),
+        (try port_close(Port) catch _:_ -> ok end),
         {error, timeout, iolist_to_binary(Acc)}
     end.
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_json.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_json.erl
@@ -315,13 +315,15 @@ term_to_json(Value) when is_map(Value) ->
         undefined ->
             beamtalk_runtime_api:print_string(Value);
         ClassName ->
-            case
-                (catch beamtalk_runtime_api:dispatch_lookup(
+            try
+                beamtalk_runtime_api:dispatch_lookup(
                     'printString', [], Value, Value, ClassName
-                ))
+                )
             of
                 {reply, Result, _} when is_binary(Result) -> Result;
                 _ -> beamtalk_runtime_api:print_string(Value)
+            catch
+                _:_ -> beamtalk_runtime_api:print_string(Value)
             end
     end;
 term_to_json(#beamtalk_error{} = Error) ->
@@ -335,9 +337,11 @@ term_to_json(Value) when is_tuple(Value) ->
             PidStr = pid_to_list(Pid),
             Inner = lists:sublist(PidStr, 2, length(PidStr) - 2),
             Prefix =
-                case (catch beamtalk_runtime_api:inherits_from(Class, 'DynamicSupervisor')) of
+                try beamtalk_runtime_api:inherits_from(Class, 'DynamicSupervisor') of
                     true -> <<"#DynamicSupervisor<">>;
                     _ -> <<"#Supervisor<">>
+                catch
+                    _:_ -> <<"#Supervisor<">>
                 end,
             iolist_to_binary([Prefix, ClassBin, <<",">>, Inner, <<">">>]);
         #beamtalk_object{class = 'Metaclass', pid = Pid} ->

--- a/runtime/rebar.config
+++ b/runtime/rebar.config
@@ -1,7 +1,7 @@
 %% Umbrella project layout (ADR 0007)
 {project_app_dirs, ["apps/*"]}.
 
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info, warnings_as_errors]}.
 
 {deps, [
     %% why: WebSocket transport for REPL protocol (ADR 0020)

--- a/runtime/rebar.config
+++ b/runtime/rebar.config
@@ -15,6 +15,10 @@
 {profiles, [
     {test, [
         {erl_opts, [debug_info]},
+        %% Top-level erl_opts (warnings_as_errors) merges into every profile, so
+        %% del it here — test helpers/fixtures compile with debug_info only and
+        %% aren't held to the strict src bar.
+        {overrides, [{del, [{erl_opts, [warnings_as_errors]}]}]},
         {eunit_opts, [
             {sys_config, ["apps/beamtalk_runtime/test/sys.config"]}
         ]}


### PR DESCRIPTION
## What

Adds `warnings_as_errors` to the runtime `erl_opts`, so Erlang compile warnings fail the build — matching the policy Rust already enforces (`cargo clippy -- -D warnings`). Part of the "keep all languages clean" ratchet.

This gates the **src/** compile; the `test` profile keeps `[debug_info]` so test helpers aren't held to the same bar (empirically the full eunit suite already compiles clean under the flag anyway).

## The only blocker: OTP 27's deprecated `catch`

OTP 27 warns on the legacy `catch Expr` expression form, which was the **only** thing failing a clean warnings-as-errors build in our code. Converted all 7 sites to `try ... catch ... end`:

| Site | Conversion |
|---|---|
| `class_registry` (ets cleanup), `object_class` (metadata/ets/pg cleanup) | fire-and-forget → `try X catch _:_ -> ok end` |
| `repl_json` (`printString`, `inherits_from`), `compiler_server` (`__beamtalk_meta`) | value-using → faithful `try X of … catch _:_ -> <original fallback> end` |
| `compile_fixtures.escript` (`port_close` on timeout) | cleanup → `try … catch _:_ -> ok end` |

Each value-using conversion preserves the exact fallback the old `catch` produced when the call raised.

## Not affected

Dependency warnings (ranch's `catch`, cowboy's exported-variable) compile with **their own** `erl_opts`, so `warnings_as_errors` does not propagate to them.

## Verification

- Clean `src` compile under the flag → no failures.
- erlfmt clean on all changed files.
- Full `beamtalk_runtime,beamtalk_workspace,beamtalk_compiler` eunit: **4252 tests**, compiles + runs. The lone failure is the **pre-existing** TMPDIR-path test (`status_returns_ok_map_when_meta_started`), unrelated to this change.

Independent of the other open coverage PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved error handling across runtime components for more robust class registration, object shutdown, JSON conversion, and REPL output—reducing failures during cleanup and lookup operations.
  * Made port timeout handling more resilient to unexpected errors.

* **Chores**
  * Compiler configuration updated to treat warnings as errors for stricter code quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->