### PR TITLE
Enforce warnings-as-errors on stdlib build; fix SystemNavigation warnings

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -139,7 +139,7 @@ build-erlang:
 # Build standard library (stdlib/src/*.bt → BEAM, incremental — skips if up to date)
 build-stdlib: build-rust build-erlang
     @echo "🔨 Building standard library..."
-    @cargo run --bin beamtalk --quiet -- build-stdlib --quiet
+    @cargo run --bin beamtalk --quiet -- build-stdlib --quiet --warnings-as-errors
     @echo "✅ Stdlib build complete"
 
 # Build all example programs (examples/**/*.bt → BEAM)

--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -34,7 +34,7 @@ const STDLIB_EBIN_DIR: &str = "runtime/apps/beamtalk_stdlib/ebin";
 /// and writes `.beam` files to `runtime/apps/beamtalk_stdlib/ebin/`.
 /// Skips the build if all outputs are newer than all inputs (incremental).
 #[instrument(skip_all)]
-pub fn build_stdlib(quiet: bool) -> Result<()> {
+pub fn build_stdlib(quiet: bool, warnings_as_errors: bool) -> Result<()> {
     info!("Starting stdlib build");
 
     let lib_dir = Utf8PathBuf::from(STDLIB_SOURCE_DIR);
@@ -84,6 +84,7 @@ pub fn build_stdlib(quiet: bool) -> Result<()> {
         stdlib_mode: true,
         allow_primitives: false,
         workspace_mode: false,
+        warnings_as_errors,
         ..Default::default()
     };
 

--- a/crates/beamtalk-cli/src/main.rs
+++ b/crates/beamtalk-cli/src/main.rs
@@ -67,6 +67,10 @@ enum Command {
         /// Suppress per-file compilation output
         #[arg(long, short)]
         quiet: bool,
+
+        /// Treat compiler warnings as errors (fail the build on any warning)
+        #[arg(long)]
+        warnings_as_errors: bool,
     },
 
     /// Compile and run a Beamtalk program
@@ -448,7 +452,10 @@ fn run() -> Result<()> {
             };
             commands::build::build(&path, &options, force)
         }
-        Command::BuildStdlib { quiet } => commands::build_stdlib::build_stdlib(quiet),
+        Command::BuildStdlib {
+            quiet,
+            warnings_as_errors,
+        } => commands::build_stdlib::build_stdlib(quiet, warnings_as_errors),
         Command::Run {
             class_or_dot,
             selector,

--- a/stdlib/src/SystemNavigation.bt
+++ b/stdlib/src/SystemNavigation.bt
@@ -1222,6 +1222,7 @@ sealed typed Object subclass: SystemNavigation
         // BT-2254: `entry at: 3` is the extension source, typed `String | Binary`
         // because the FFI spec uses `binary()`. It is always source text (a
         // String), so `matchesRegex:` is valid; suppress the union-member dnu.
+        @expect type
         (extSource matchesRegex: aRegex) ifTrue: [
           acc add: #{#class => extClass, #selector => extSelector}
         ] ifFalse: [acc]
@@ -1458,6 +1459,7 @@ sealed typed Object subclass: SystemNavigation
         // BT-2254: `extSource` (entry at: 3) is typed `String | Binary` from the
         // `binary()` FFI spec but is always source text (a String), which
         // `appendAllSendsIn:` requires; suppress the union arg-type warning.
+        @expect type
         self
           appendAllSendsIn: extSource
           owner: extClass
@@ -1705,6 +1707,7 @@ sealed typed Object subclass: SystemNavigation
         // BT-2254: `extSource` (entry at: 3) is typed `String | Binary` from the
         // `binary()` FFI spec but is always source text (a String), which
         // `addSentSelectorsIn:` requires; suppress the union arg-type warning.
+        @expect type
         self addSentSelectorsIn: extSource into: acc
       ]
 


### PR DESCRIPTION
## What

Brings the Beamtalk stdlib build under the same warnings-as-errors policy as Rust (`clippy -D warnings`) and Erlang src (#2429). Two parts:

### 1. Fix the existing warnings
`SystemNavigation.bt` had three sites where `entry at: 3` — the extension source, FFI-typed `String | Binary` but always source text — flowed into String-expecting operations (`matchesRegex:`, `appendAllSendsIn:`, `addSentSelectorsIn:`), producing union-member dnu / arg-type warnings. The **BT-2254 comments already documented the intent to suppress these** ("suppress the union-member dnu", "suppress the union arg-type warning"); the sanctioned `@expect type` annotation was just never applied. Added it at all three sites.

### 2. Enforce going forward
Added a `--warnings-as-errors` flag to the `build-stdlib` CLI command (plumbed into `CompilerOptions`, which the compiler already honours), and the `build-stdlib` Justfile recipe now passes it — so every `just build` fails on a new stdlib warning.

## Verification

- `just build-stdlib` builds all **81 modules clean** with enforcement on.
- End-to-end enforcement check: temporarily removing one `@expect` reintroduces the warning and fails the build (`× Failed to compile 'stdlib/src/SystemNavigation.bt'`) — confirming the flag is not a no-op.
- rustfmt + clippy clean on the CLI changes.

## Context

Completes the "warnings = errors across all three languages" goal:
| Language | Status |
|---|---|
| Rust | already enforced (`clippy -- -D warnings`) |
| Erlang | #2429 |
| **Beamtalk** | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--warnings-as-errors` flag to stdlib build command for stricter compilation validation.

* **Improvements**
  * Enhanced stdlib type safety with additional type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->