### PR TITLE
Drop OTP/SASL log noise from test output

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/sys.config
+++ b/runtime/apps/beamtalk_runtime/test/sys.config
@@ -6,10 +6,25 @@
         {logger, [
             {handler, default, logger_std_h, #{
                 level => error,
-                formatter => {logger_formatter, #{
-                    single_line => true,
-                    template => [msg]
-                }}
+                %% Drop OTP/SASL reports (domain [otp, sasl]): crash reports,
+                %% supervisor reports, and the "Supervisor received unexpected
+                %% message" noise emitted when ETS tables transfer to a
+                %% supervisor heir during the many tests that *deliberately*
+                %% crash processes. These are error-level, so logger_level alone
+                %% can't filter them, and they drown real signal in CI logs.
+                %% Safe to drop: eunit reports test failures through its own
+                %% channel (the "Failures:" summary), not the logger, and our
+                %% application errors use domain [beamtalk, _] — untouched here.
+                filters => [
+                    {drop_otp,
+                        {fun logger_filters:domain/2, {stop, sub, [otp, sasl]}}}
+                ],
+                filter_default => log,
+                formatter =>
+                    {logger_formatter, #{
+                        single_line => true,
+                        template => [msg]
+                    }}
             }}
         ]}
     ]}


### PR DESCRIPTION
## Problem

The runtime EUnit suite has many tests that **deliberately crash processes** (subprocess init failures, bad-core compilation, supervisor restart paths). Each emits an error-level OTP/SASL crash report, and when an ETS table transfers to a supervisor heir the supervisor logs `Supervisor received unexpected message: {'ETS-TRANSFER',...}`.

These are **error level**, so the existing `logger_level => error` can't filter them — they drown the real signal. (Debugging the Windows nightly failure, the one genuine failure was buried under thousands of lines of expected crash spam.)

## Fix

Add a `logger_filters:domain/2` filter to the test default handler that drops the `[otp, sasl]` domain (crash / supervisor / progress reports).

```erlang
filters => [{drop_otp, {fun logger_filters:domain/2, {stop, sub, [otp, sasl]}}}],
filter_default => log,
```

## Safe by construction

- **EUnit reports test failures through its own `Failures:` channel, not the logger** — so failures still appear in full.
- Application errors use domain `[beamtalk, _]`, which this filter does **not** touch.

## Verified

| | before | after |
|---|---|---|
| `beamtalk_supervisor_tests` | wall of crash/child_terminated/ETS-TRANSFER reports | just `79 tests, 0 failures` |
| `beamtalk_workspace_tests` (a real failure) | — | full `Failures:` block with expected/got still prints |

Scoped to the test `sys.config` only — no runtime/production logging change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test logging configuration to reduce noise during test execution while maintaining error-level reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->