### PR TITLE
Add codegen unit tests for pure select: and BT-909 non-literal callable list ops (BT-2387)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
@@ -901,3 +901,87 @@ fn test_flat_map_with_field_mutation_uses_foldl() {
         "flatMap: body should update 'n' field via maps:put. Got:\n{code}"
     );
 }
+
+// ── select: pure (no mutations) ───────────────────────────────────────
+
+#[test]
+fn test_list_select_pure_generates_lists_filter() {
+    // Pure select: with a literal block and no mutations delegates to lists:filter.
+    // This exercises the path: generate_list_select → generate_simple_list_op("filter")
+    // covering filter_ops.rs:38 and the "filter" => "select:" match arm in mod.rs.
+    let src = "Actor subclass: Srv\n  state: x = 0\n\n  run: items =>\n    items select: [:item | item > 0]\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'lists':'filter'"),
+        "Pure select: should generate lists:filter. Got:\n{code}"
+    );
+    // Runtime fallback for non-list receivers uses the 'select:' selector (mapped
+    // from the 'filter' operation string by generate_simple_list_op).
+    assert!(
+        code.contains("'select:'"),
+        "Runtime fallback should use 'select:' selector. Got:\n{code}"
+    );
+    // Pure path must NOT use foldl (that's the mutation-threading path).
+    assert!(
+        !code.contains("'lists':'foldl'"),
+        "Pure select: must NOT use lists:foldl. Got:\n{code}"
+    );
+}
+
+// ── BT-909: non-literal callable in simple list ops ───────────────────
+
+#[test]
+fn test_list_do_non_literal_callable_emits_arity_check() {
+    // BT-909: do: with a non-literal callable (method parameter) must emit an
+    // is_function/2 arity check so that Tier-2 (2-arg) blocks are wrapped to
+    // satisfy lists:foreach's arity-1 contract.
+    let src =
+        "Actor subclass: Srv\n  state: x = 0\n\n  run: items with: block =>\n    items do: block\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'lists':'foreach'"),
+        "Non-literal callable do: should still generate lists:foreach. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'erlang':'is_function'"),
+        "Non-literal callable do: should emit is_function/2 arity check (BT-909). Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_list_collect_non_literal_callable_emits_arity_check() {
+    // BT-909: collect: with a non-literal callable emits the same arity-check
+    // wrapper as do:, here wrapping for lists:map (arity-1 contract).
+    let src = "Actor subclass: Srv\n  state: x = 0\n\n  run: items with: block =>\n    items collect: block\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'lists':'map'"),
+        "Non-literal callable collect: should still generate lists:map. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'erlang':'is_function'"),
+        "Non-literal callable collect: should emit is_function/2 arity check (BT-909). Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_list_select_non_literal_callable_emits_arity_check() {
+    // BT-909: select: with a non-literal callable also emits the arity-check wrapper.
+    // This additionally covers the "filter" => "select:" match arm in mod.rs via the
+    // non-literal code path (the non-literal else branch still uses the selector).
+    let src = "Actor subclass: Srv\n  state: x = 0\n\n  run: items with: block =>\n    items select: block\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'lists':'filter'"),
+        "Non-literal callable select: should generate lists:filter. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'erlang':'is_function'"),
+        "Non-literal callable select: should emit is_function/2 arity check (BT-909). Got:\n{code}"
+    );
+    // Runtime fallback selector is 'select:' (mapped from 'filter').
+    assert!(
+        code.contains("'select:'"),
+        "Non-literal callable select: fallback should use 'select:' selector. Got:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `test_list_select_pure_generates_lists_filter`: covers the pure `select:` path (literal block, no mutations) which was not previously exercised by any Rust unit test, closing the gap in `filter_ops.rs:38` and the `"filter" => "select:"` match arm in `mod.rs`.
- Add `test_list_do_non_literal_callable_emits_arity_check`: covers the BT-909 non-literal callable path for `do:` — when the body is a method parameter, `generate_simple_list_op` emits an `is_function/2` arity check to wrap Tier-2 blocks for `lists:foreach`.
- Add `test_list_collect_non_literal_callable_emits_arity_check`: same BT-909 path for `collect:` / `lists:map`.
- Add `test_list_select_non_literal_callable_emits_arity_check`: same BT-909 path for `select:` / `lists:filter`.

## Coverage gap closed

From CI coverage artifact (2026-06-02, run 26848677300):

| File | Before | After (projected) |
|---|---|---|
| `list_ops/mod.rs` | 35.9% (28/78) | ~70% |
| `list_ops/filter_ops.rs` | 58.4% (111/190) | ~65% |

Previously all `select:` tests used the mutation-threading path (`generate_list_filter_with_mutations`), leaving `generate_simple_list_op("filter")` and the entire BT-909 non-literal callable path at zero coverage.

## Test plan

- [x] `cargo test -p beamtalk-core -- control_flow::list_ops` passes: 50 tests (46 existing + 4 new)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] No production code changed

Linear: https://linear.app/beamtalk/issue/BT-2387

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQSg8hPSB97f9MyzDqCxCK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for list operations code generation, ensuring proper compilation behavior for both literal and non-literal callables
  * Verifies arity checks are emitted for runtime safety validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->