### PR TITLE
Raise Erlang test coverage 74.6% → 82.2% (BUnit cover fold-in + module test suites)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -751,11 +751,32 @@ coverage-stdlib: build-stdlib
         exit 1
     fi
 
-# Unix-only: depends on Unix-only coverage recipes
-# Runs eunit with --cover, then E2E with cover, then stdlib with cover, then merges all into one report.
-# Generate combined Erlang coverage (eunit + E2E + stdlib)
+# Collect BUnit test coverage (runs the .bt TestCase suite with Erlang cover
+# instrumentation). The BUnit suite drives beamtalk_test_case, beamtalk_test_runner,
+# and the full dispatch/object/class machinery via real TestCase classes — code that
+# eunit/E2E/bootstrap barely touch. [working-directory: 'stdlib'] so `beamtalk test`
+# discovers the default `test/` dir (matching the test-bunit recipe).
 [unix]
-coverage-all: coverage-runtime coverage-e2e coverage-stdlib
+[working-directory: 'stdlib']
+coverage-bunit: build-stdlib
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "📊 Running BUnit tests with Erlang cover instrumentation..."
+    echo "   (This is slower than normal BUnit tests due to cover overhead)"
+    BUNIT_COVER=1 cargo run --bin beamtalk --quiet -- test --warnings-as-errors || true
+    if [ -f ../runtime/_build/test/cover/bunit.coverdata ]; then
+        SIZE=$(wc -c < ../runtime/_build/test/cover/bunit.coverdata)
+        echo "  📁 Coverdata: runtime/_build/test/cover/bunit.coverdata (${SIZE} bytes)"
+    else
+        echo "⚠️  No BUnit coverdata produced"
+        exit 1
+    fi
+
+# Unix-only: depends on Unix-only coverage recipes
+# Runs eunit with --cover, then E2E with cover, then stdlib + BUnit with cover, then merges all into one report.
+# Generate combined Erlang coverage (eunit + E2E + stdlib + BUnit)
+[unix]
+coverage-all: coverage-runtime coverage-e2e coverage-stdlib coverage-bunit
     #!/usr/bin/env bash
     set -euo pipefail
     cd runtime

--- a/crates/beamtalk-cli/src/commands/test.rs
+++ b/crates/beamtalk-cli/src/commands/test.rs
@@ -1701,6 +1701,48 @@ fn parse_bunit_result_json(stdout: &str, stderr: &str) -> Result<BunitResult> {
 /// Calls the `BUnit` runner directly, bypassing `EUnit` wrappers. The runner
 /// discovers test classes, executes them with the specified concurrency level,
 /// and returns aggregated results as JSON.
+/// Build cover instrumentation preamble/epilogue for the BUnit eval command.
+///
+/// Gated on the `BUNIT_COVER` env var (mirrors `STDLIB_COVER` in
+/// `test_stdlib.rs`). Instruments all four Beamtalk app ebins that carry
+/// Erlang abstract code; the compiled `bt@*` stdlib modules have no abstract
+/// code and are silently skipped by `cover:compile_beam_directory/1`. The
+/// result is exported to `_build/test/cover/bunit.coverdata` so the
+/// `coverage-all` wildcard merge folds it into the badge.
+fn bunit_cover_fragments(
+    beam_paths: &beamtalk_cli::repl_startup::BeamPaths,
+    runtime_dir: &std::path::Path,
+) -> (String, String) {
+    if std::env::var("BUNIT_COVER").is_err() {
+        return (String::new(), String::new());
+    }
+
+    let cover_dir = runtime_dir.join("_build/test/cover");
+    let _ = std::fs::create_dir_all(&cover_dir);
+    let cover_export_path = cover_dir.join("bunit.coverdata");
+    info!(
+        "BUnit cover mode enabled, will export to {}",
+        cover_export_path.display()
+    );
+
+    let preamble = format!(
+        "cover:start(), \
+         cover:compile_beam_directory(\"{runtime_ebin}\"), \
+         cover:compile_beam_directory(\"{workspace_ebin}\"), \
+         cover:compile_beam_directory(\"{compiler_ebin}\"), \
+         cover:compile_beam_directory(\"{stdlib_ebin}\"), ",
+        runtime_ebin = beam_paths.runtime_ebin.display(),
+        workspace_ebin = beam_paths.workspace_ebin.display(),
+        compiler_ebin = beam_paths.compiler_ebin.display(),
+        stdlib_ebin = beam_paths.stdlib_erlang_ebin.display(),
+    );
+    let epilogue = format!(
+        "cover:export(\"{export}\"), cover:stop(), ",
+        export = cover_export_path.display(),
+    );
+    (preamble, epilogue)
+}
+
 fn run_bunit_tests(pipeline: &TestPipeline) -> Result<BunitResult> {
     debug!("Running BUnit tests with jobs={}", pipeline.jobs);
 
@@ -1715,9 +1757,18 @@ fn run_bunit_tests(pipeline: &TestPipeline) -> Result<BunitResult> {
     let hex_deps_start_cmd =
         beamtalk_cli::repl_startup::hex_deps_start_fragment(&pipeline.hex_dep_names);
 
+    // BUNIT_COVER: instrument the runtime under Erlang `cover` so the BUnit
+    // suite (which drives beamtalk_test_case, beamtalk_test_runner, and the
+    // full dispatch/object/class machinery via real .bt TestCase classes)
+    // contributes to the Erlang coverage badge — mirroring the existing
+    // STDLIB_COVER / E2E_COVER passes. The exported bunit.coverdata is picked
+    // up by `just coverage-all`'s wildcard merge.
+    let (cover_preamble, cover_epilogue) = bunit_cover_fragments(&beam_paths, &runtime_dir);
+
     // Call beamtalk_test_runner:run_all(Jobs) and serialize result to JSON
     let eval_cmd = format!(
-        "{{ok, _}} = application:ensure_all_started(beamtalk_stdlib), \
+        "{cover_preamble}\
+         {{ok, _}} = application:ensure_all_started(beamtalk_stdlib), \
          {hex_deps_start_cmd}\
          {package_load_cmd}\
          {fixture_load_cmd}\
@@ -1725,6 +1776,7 @@ fn run_bunit_tests(pipeline: &TestPipeline) -> Result<BunitResult> {
          Result = beamtalk_test_runner:run_all({jobs}), \
          JSON = beamtalk_test_runner:result_to_json(Result), \
          io:format(\"~s~n\", [JSON]), \
+         {cover_epilogue}\
          init:stop(case beamtalk_test_runner:result_has_passed(Result) of true -> 0; _ -> 1 end).",
         jobs = pipeline.jobs
     );

--- a/crates/beamtalk-cli/src/commands/test.rs
+++ b/crates/beamtalk-cli/src/commands/test.rs
@@ -1698,9 +1698,6 @@ fn parse_bunit_result_json(stdout: &str, stderr: &str) -> Result<BunitResult> {
     })
 }
 
-/// Calls the `BUnit` runner directly, bypassing `EUnit` wrappers. The runner
-/// discovers test classes, executes them with the specified concurrency level,
-/// and returns aggregated results as JSON.
 /// Build cover instrumentation preamble/epilogue for the `BUnit` eval command.
 ///
 /// Gated on the `BUNIT_COVER` env var (mirrors `STDLIB_COVER` in
@@ -1743,6 +1740,9 @@ fn bunit_cover_fragments(
     (preamble, epilogue)
 }
 
+/// Calls the `BUnit` runner directly, bypassing `EUnit` wrappers. The runner
+/// discovers test classes, executes them with the specified concurrency level,
+/// and returns aggregated results as JSON.
 fn run_bunit_tests(pipeline: &TestPipeline) -> Result<BunitResult> {
     debug!("Running BUnit tests with jobs={}", pipeline.jobs);
 

--- a/crates/beamtalk-cli/src/commands/test.rs
+++ b/crates/beamtalk-cli/src/commands/test.rs
@@ -1701,7 +1701,7 @@ fn parse_bunit_result_json(stdout: &str, stderr: &str) -> Result<BunitResult> {
 /// Calls the `BUnit` runner directly, bypassing `EUnit` wrappers. The runner
 /// discovers test classes, executes them with the specified concurrency level,
 /// and returns aggregated results as JSON.
-/// Build cover instrumentation preamble/epilogue for the BUnit eval command.
+/// Build cover instrumentation preamble/epilogue for the `BUnit` eval command.
 ///
 /// Gated on the `BUNIT_COVER` env var (mirrors `STDLIB_COVER` in
 /// `test_stdlib.rs`). Instruments all four Beamtalk app ebins that carry

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
@@ -316,3 +316,374 @@ class_module_index_used_for_spawn_with_args_expression_test() ->
             binary:match(CoreErlang, <<"'bt@counter':'spawn'">>)
         )
     end).
+
+%%% ---------------------------------------------------------------
+%%% compile_expression_trace/4,5 — trace-mode compile (live port)
+%%% ---------------------------------------------------------------
+
+compile_expression_trace_test() ->
+    with_port(fun(Port) ->
+        {ok, CoreErlang, []} =
+            beamtalk_compiler_port:compile_expression_trace(Port, <<"1 + 2">>, <<"tr">>, []),
+        ?assert(is_binary(CoreErlang)),
+        ?assert(binary:match(CoreErlang, <<"'erlang':'+'">>) =/= nomatch)
+    end).
+
+%% Non-empty index/hierarchy options exercise the Request1/Request2/Request
+%% build branches (the `_ -> Request#{...}` arms).
+compile_expression_trace_with_options_test() ->
+    with_port(fun(Port) ->
+        Options = #{
+            class_superclass_index => #{<<"Counter">> => <<"Object">>},
+            class_module_index => #{<<"Counter">> => <<"bt@app@counter">>},
+            class_hierarchy => #{'Counter' => #{superclass => 'Object'}}
+        },
+        {ok, CoreErlang, _Warnings} =
+            beamtalk_compiler_port:compile_expression_trace(
+                Port, <<"1 + 2">>, <<"tr_opts">>, [], Options
+            ),
+        ?assert(is_binary(CoreErlang))
+    end).
+
+compile_expression_trace_invalid_returns_error_test() ->
+    with_port(fun(Port) ->
+        {error, Diagnostics} =
+            beamtalk_compiler_port:compile_expression_trace(Port, <<"+++">>, <<"tr">>, []),
+        ?assert(length(Diagnostics) > 0)
+    end).
+
+%%% ---------------------------------------------------------------
+%%% find_senders_in_source/3 (BT-2190) — live port
+%%% ---------------------------------------------------------------
+
+find_senders_in_source_atom_selector_test() ->
+    with_port(fun(Port) ->
+        {ok, Lines} =
+            beamtalk_compiler_port:find_senders_in_source(Port, <<"x printNl">>, printNl),
+        ?assert(is_list(Lines)),
+        ?assert(lists:member(1, Lines))
+    end).
+
+find_senders_in_source_binary_selector_test() ->
+    with_port(fun(Port) ->
+        {ok, Lines} =
+            beamtalk_compiler_port:find_senders_in_source(Port, <<"x printNl">>, <<"printNl">>),
+        ?assert(is_list(Lines))
+    end).
+
+%% Guard-fail clause: selector must be an atom or binary (no port needed).
+find_senders_in_source_invalid_selector_test() ->
+    {error, [Diag]} =
+        beamtalk_compiler_port:find_senders_in_source(fake_port, <<"x printNl">>, 42),
+    ?assert(binary:match(maps:get(message, Diag), <<"selector must be">>) =/= nomatch).
+
+%%% ---------------------------------------------------------------
+%%% find_all_sends_in_source/2 (BT-2206) — live port
+%%% ---------------------------------------------------------------
+
+find_all_sends_in_source_test() ->
+    with_port(fun(Port) ->
+        {ok, Sends} =
+            beamtalk_compiler_port:find_all_sends_in_source(Port, <<"x printNl">>),
+        ?assert(is_list(Sends)),
+        ?assert(lists:any(fun(S) -> maps:get(selector, S) =:= <<"printNl">> end, Sends))
+    end).
+
+find_all_sends_in_source_invalid_source_test() ->
+    {error, [Diag]} =
+        beamtalk_compiler_port:find_all_sends_in_source(fake_port, not_a_binary),
+    ?assert(binary:match(maps:get(message, Diag), <<"source must be a binary">>) =/= nomatch).
+
+%%% ---------------------------------------------------------------
+%%% find_references_to_in_source/3 (BT-2203) — live port
+%%% ---------------------------------------------------------------
+
+find_references_to_in_source_atom_test() ->
+    with_port(fun(Port) ->
+        {ok, Lines} =
+            beamtalk_compiler_port:find_references_to_in_source(
+                Port, <<"x := MyClass new">>, 'MyClass'
+            ),
+        ?assert(is_list(Lines)),
+        ?assert(lists:member(1, Lines))
+    end).
+
+find_references_to_in_source_binary_test() ->
+    with_port(fun(Port) ->
+        {ok, Lines} =
+            beamtalk_compiler_port:find_references_to_in_source(
+                Port, <<"x := MyClass new">>, <<"MyClass">>
+            ),
+        ?assert(is_list(Lines))
+    end).
+
+find_references_to_in_source_invalid_test() ->
+    {error, [Diag]} =
+        beamtalk_compiler_port:find_references_to_in_source(fake_port, <<"x">>, 42),
+    ?assert(binary:match(maps:get(message, Diag), <<"class name must be">>) =/= nomatch).
+
+%%% ---------------------------------------------------------------
+%%% find_field_readers/writers_in_source/3 (BT-2208) — live port
+%%% ---------------------------------------------------------------
+
+find_field_readers_in_source_test() ->
+    with_port(fun(Port) ->
+        {ok, Lines} =
+            beamtalk_compiler_port:find_field_readers_in_source(Port, <<"^ self.value">>, value),
+        ?assert(is_list(Lines)),
+        ?assert(lists:member(1, Lines))
+    end).
+
+find_field_writers_in_source_test() ->
+    with_port(fun(Port) ->
+        {ok, Lines} =
+            beamtalk_compiler_port:find_field_writers_in_source(
+                Port, <<"self.value := 42">>, <<"value">>
+            ),
+        ?assert(is_list(Lines)),
+        ?assert(lists:member(1, Lines))
+    end).
+
+%% Guard-fail clause of the shared field_access_query/5 driver.
+find_field_readers_invalid_field_test() ->
+    {error, [Diag]} =
+        beamtalk_compiler_port:find_field_readers_in_source(fake_port, <<"^ self.value">>, 42),
+    ?assert(binary:match(maps:get(message, Diag), <<"field name must be">>) =/= nomatch).
+
+%%% ---------------------------------------------------------------
+%%% find_ffi_sites_in_source/5 (BT-2211) — live port
+%%% ---------------------------------------------------------------
+
+%% A non-negative integer constrains the match to that argument count (the
+%% `arity => N' request branch). `reverse: x' is a 1-arg keyword send.
+find_ffi_sites_in_source_with_arity_test() ->
+    with_port(fun(Port) ->
+        {ok, Lines} =
+            beamtalk_compiler_port:find_ffi_sites_in_source(
+                Port, <<"(Erlang lists) reverse: x">>, lists, reverse, 1
+            ),
+        ?assert(is_list(Lines))
+    end).
+
+%% `any' arity omits the field entirely (the BaseRequest branch) and must match
+%% the FFI call site regardless of argument count.
+find_ffi_sites_in_source_any_arity_test() ->
+    with_port(fun(Port) ->
+        {ok, Lines} =
+            beamtalk_compiler_port:find_ffi_sites_in_source(
+                Port, <<"(Erlang lists) reverse: x">>, <<"lists">>, <<"reverse">>, any
+            ),
+        ?assert(is_list(Lines))
+    end).
+
+find_ffi_sites_in_source_invalid_arity_test() ->
+    {error, [Diag]} =
+        beamtalk_compiler_port:find_ffi_sites_in_source(
+            fake_port, <<"src">>, lists, reverse, -1
+        ),
+    ?assert(binary:match(maps:get(message, Diag), <<"arity">>) =/= nomatch).
+
+%%% ---------------------------------------------------------------
+%%% resolve_method_span/5 (ADR 0082 Phase 1) — live port
+%%% ---------------------------------------------------------------
+
+span_fixture() ->
+    <<
+        "Object subclass: SpanCounter\n"
+        "\n"
+        "  increment => self.value := self.value + 1\n"
+        "\n"
+        "  class new => self basicNew\n"
+    >>.
+
+resolve_method_span_instance_test() ->
+    with_port(fun(Port) ->
+        Source = span_fixture(),
+        {ok, #{start := Start, 'end' := End}, PrevSource} =
+            beamtalk_compiler_port:resolve_method_span(
+                Port, Source, <<"SpanCounter">>, <<"increment">>, instance
+            ),
+        %% Splicing PrevSource back over its byte span is a no-op.
+        ?assertEqual(PrevSource, binary:part(Source, Start, End - Start)),
+        ?assert(binary:match(PrevSource, <<"increment =>">>) =/= nomatch)
+    end).
+
+resolve_method_span_class_test() ->
+    with_port(fun(Port) ->
+        {ok, _Span, PrevSource} =
+            beamtalk_compiler_port:resolve_method_span(
+                Port, span_fixture(), <<"SpanCounter">>, <<"new">>, class
+            ),
+        ?assert(binary:match(PrevSource, <<"class new =>">>) =/= nomatch)
+    end).
+
+resolve_method_span_not_found_test() ->
+    with_port(fun(Port) ->
+        Result =
+            beamtalk_compiler_port:resolve_method_span(
+                Port, span_fixture(), <<"SpanCounter">>, <<"nope">>, instance
+            ),
+        ?assertMatch({error, selector_not_found, _}, Result)
+    end).
+
+%% Guard-fail clause: invalid Side returns {error, bad_argument, _}.
+resolve_method_span_invalid_side_test() ->
+    Result =
+        beamtalk_compiler_port:resolve_method_span(
+            fake_port, <<"src">>, <<"C">>, <<"m">>, bogus_side
+        ),
+    ?assertMatch({error, bad_argument, _}, Result).
+
+%%% ---------------------------------------------------------------
+%%% resolve_completion_type/3 (BT-1068) — live port
+%%% ---------------------------------------------------------------
+
+resolve_completion_type_test() ->
+    with_port(fun(Port) ->
+        Result = beamtalk_compiler_port:resolve_completion_type(Port, <<"42">>, #{}),
+        %% Either statically resolved to a class atom, or unknown — both are
+        %% well-formed outcomes of the completion-type query.
+        ?assert(
+            Result =:= {error, type_unknown} orelse
+                (is_tuple(Result) andalso element(1, Result) =:= ok)
+        )
+    end).
+
+%%% ---------------------------------------------------------------
+%%% Closed-port degradation — each query's `catch error:badarg' arm
+%%% (the "compiler port is not available" path) returns a structured
+%%% error rather than crashing the caller.
+%%% ---------------------------------------------------------------
+
+%% Open a port and immediately close it, then run Fun(ClosedPort).
+with_closed_port(Fun) ->
+    Port = beamtalk_compiler_port:open(compiler_binary()),
+    beamtalk_compiler_port:close(Port),
+    Fun(Port).
+
+compile_expression_trace_on_closed_port_test() ->
+    with_closed_port(fun(Port) ->
+        ?assertMatch(
+            {error, [_ | _]},
+            beamtalk_compiler_port:compile_expression_trace(Port, <<"1 + 2">>, <<"t">>, [])
+        )
+    end).
+
+resolve_completion_type_on_closed_port_test() ->
+    with_closed_port(fun(Port) ->
+        ?assertEqual(
+            {error, type_unknown},
+            beamtalk_compiler_port:resolve_completion_type(Port, <<"42">>, #{})
+        )
+    end).
+
+find_senders_on_closed_port_test() ->
+    with_closed_port(fun(Port) ->
+        ?assertMatch(
+            {error, [_ | _]},
+            beamtalk_compiler_port:find_senders_in_source(Port, <<"x printNl">>, printNl)
+        )
+    end).
+
+find_all_sends_on_closed_port_test() ->
+    with_closed_port(fun(Port) ->
+        ?assertMatch(
+            {error, [_ | _]},
+            beamtalk_compiler_port:find_all_sends_in_source(Port, <<"x printNl">>)
+        )
+    end).
+
+find_references_on_closed_port_test() ->
+    with_closed_port(fun(Port) ->
+        ?assertMatch(
+            {error, [_ | _]},
+            beamtalk_compiler_port:find_references_to_in_source(Port, <<"x">>, 'MyClass')
+        )
+    end).
+
+find_field_readers_on_closed_port_test() ->
+    with_closed_port(fun(Port) ->
+        ?assertMatch(
+            {error, [_ | _]},
+            beamtalk_compiler_port:find_field_readers_in_source(Port, <<"^ self.value">>, value)
+        )
+    end).
+
+find_ffi_sites_on_closed_port_test() ->
+    with_closed_port(fun(Port) ->
+        ?assertMatch(
+            {error, [_ | _]},
+            beamtalk_compiler_port:find_ffi_sites_in_source(Port, <<"src">>, lists, reverse, any)
+        )
+    end).
+
+resolve_method_span_on_closed_port_test() ->
+    with_closed_port(fun(Port) ->
+        ?assertMatch(
+            {error, port_error, _},
+            beamtalk_compiler_port:resolve_method_span(
+                Port, span_fixture(), <<"SpanCounter">>, <<"increment">>, instance
+            )
+        )
+    end).
+
+%%% ---------------------------------------------------------------
+%%% Invalid-source error responses — the `{error, diagnostics}' arm of
+%%% the source-analysis response handlers.
+%%% ---------------------------------------------------------------
+
+find_senders_invalid_source_returns_error_test() ->
+    with_port(fun(Port) ->
+        Result =
+            beamtalk_compiler_port:find_senders_in_source(Port, <<"@@@ ))) +++">>, printNl),
+        %% Unparseable source surfaces as a diagnostics list (or, if the analyzer
+        %% tolerates it, an empty result) — both are documented {ok|error} shapes.
+        ?assert(
+            case Result of
+                {error, Diags} when is_list(Diags) -> true;
+                {ok, Lines} when is_list(Lines) -> true;
+                _ -> false
+            end
+        )
+    end).
+
+%%% ---------------------------------------------------------------
+%%% handle_response/1 — additional ok-kind and diagnostic shapes (pure)
+%%% ---------------------------------------------------------------
+
+%% BT-903: a class_definition response carrying trailing_core_erlang must
+%% forward it into the returned info map.
+handle_response_class_definition_with_trailing_test() ->
+    Response = #{
+        status => ok,
+        kind => class_definition,
+        core_erlang => <<"core">>,
+        module_name => <<"mod">>,
+        classes => [<<"Foo">>],
+        trailing_core_erlang => <<"trailing">>,
+        warnings => []
+    },
+    {ok, class_definition, Info} = beamtalk_compiler_port:handle_response(Response),
+    ?assertEqual(<<"trailing">>, maps:get(trailing_core_erlang, Info)).
+
+%% BT-1612: protocol_definition response shape.
+handle_response_protocol_definition_test() ->
+    Response = #{
+        status => ok,
+        kind => protocol_definition,
+        core_erlang => <<"core">>,
+        module_name => <<"proto_mod">>,
+        protocols => [<<"Drawable">>],
+        warnings => []
+    },
+    {ok, protocol_definition, Info} = beamtalk_compiler_port:handle_response(Response),
+    ?assertEqual(<<"proto_mod">>, maps:get(module_name, Info)),
+    ?assertEqual([<<"Drawable">>], maps:get(protocols, Info)).
+
+%% BT-1235: a diagnostic map whose `message` is not a binary is coerced to a
+%% binary via ensure_binary/1 (the non-binary fallback arm).
+handle_response_diagnostic_non_binary_message_test() ->
+    Response = #{status => error, diagnostics => [#{message => 12345, line => 3}]},
+    {error, [Diag]} = beamtalk_compiler_port:handle_response(Response),
+    ?assert(is_binary(maps:get(message, Diag))),
+    ?assertEqual(3, maps:get(line, Diag)).

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
@@ -211,6 +211,114 @@ unknown_info() ->
 %%% Helpers
 %%% ---------------------------------------------------------------
 
+%%% ---------------------------------------------------------------
+%%% Public API integration — drive each server call through to the live
+%%% compiler port (covers the API wrappers + handle_call clauses + the
+%%% do_compile / do_diagnostics / do_version / send_port_request plumbing).
+%%% ---------------------------------------------------------------
+
+server_api_test_() ->
+    {setup, fun start_compiler/0, fun stop_compiler/1, [
+        {"compile_expression/3", fun api_compile_expression/0},
+        {"compile_expression/4 with options", fun api_compile_expression_opts/0},
+        {"compile_expression_trace/3", fun api_compile_trace/0},
+        {"compile_expression_trace/4 with options", fun api_compile_trace_opts/0},
+        {"compile/2 class definition", fun api_compile/0},
+        {"diagnostics/1", fun api_diagnostics/0},
+        {"version/0", fun api_version/0},
+        {"resolve_completion_type/1", fun api_resolve_completion_type/0},
+        {"find_senders_in_source/2", fun api_find_senders/0},
+        {"find_all_sends_in_source/1", fun api_find_all_sends/0},
+        {"find_references_to_in_source/2", fun api_find_references/0},
+        {"find_field_readers_in_source/2", fun api_find_field_readers/0},
+        {"find_field_writers_in_source/2", fun api_find_field_writers/0},
+        {"find_ffi_sites_in_source/4", fun api_find_ffi_sites/0},
+        {"resolve_method_span/4", fun api_resolve_method_span/0}
+    ]}.
+
+api_compile_expression() ->
+    {ok, Core, []} = beamtalk_compiler_server:compile_expression(<<"1 + 2">>, <<"m">>, []),
+    ?assert(binary:match(Core, <<"'erlang':'+'">>) =/= nomatch).
+
+api_compile_expression_opts() ->
+    Options = #{class_module_index => #{<<"Counter">> => <<"bt@app@counter">>}},
+    {ok, Core, _} =
+        beamtalk_compiler_server:compile_expression(<<"1 + 2">>, <<"m">>, [], Options),
+    ?assert(is_binary(Core)).
+
+api_compile_trace() ->
+    {ok, Core, []} =
+        beamtalk_compiler_server:compile_expression_trace(<<"1 + 2">>, <<"m">>, []),
+    ?assert(is_binary(Core)).
+
+api_compile_trace_opts() ->
+    Options = #{class_hierarchy => #{'Counter' => #{superclass => 'Object'}}},
+    {ok, Core, _} =
+        beamtalk_compiler_server:compile_expression_trace(<<"1 + 2">>, <<"m">>, [], Options),
+    ?assert(is_binary(Core)).
+
+api_compile() ->
+    Source = <<"Object subclass: TmpServerC\n\n  foo => 1\n">>,
+    Result = beamtalk_compiler_server:compile(Source, #{}),
+    ?assertMatch({ok, _}, Result).
+
+api_diagnostics() ->
+    Result = beamtalk_compiler_server:diagnostics(<<"1 + 2">>),
+    ?assertMatch({ok, _}, Result).
+
+api_version() ->
+    Result = beamtalk_compiler_server:version(),
+    ?assertMatch({ok, _}, Result).
+
+api_resolve_completion_type() ->
+    Result = beamtalk_compiler_server:resolve_completion_type(<<"42">>),
+    ?assert(
+        Result =:= {error, type_unknown} orelse
+            (is_tuple(Result) andalso element(1, Result) =:= ok)
+    ).
+
+api_find_senders() ->
+    {ok, Lines} = beamtalk_compiler_server:find_senders_in_source(<<"x printNl">>, printNl),
+    ?assert(lists:member(1, Lines)).
+
+api_find_all_sends() ->
+    {ok, Sends} = beamtalk_compiler_server:find_all_sends_in_source(<<"x printNl">>),
+    ?assert(lists:any(fun(S) -> maps:get(selector, S) =:= <<"printNl">> end, Sends)).
+
+api_find_references() ->
+    {ok, Lines} =
+        beamtalk_compiler_server:find_references_to_in_source(<<"x := MyClass new">>, 'MyClass'),
+    ?assert(lists:member(1, Lines)).
+
+api_find_field_readers() ->
+    {ok, Lines} =
+        beamtalk_compiler_server:find_field_readers_in_source(<<"^ self.value">>, value),
+    ?assert(lists:member(1, Lines)).
+
+api_find_field_writers() ->
+    {ok, Lines} =
+        beamtalk_compiler_server:find_field_writers_in_source(<<"self.value := 42">>, value),
+    ?assert(lists:member(1, Lines)).
+
+api_find_ffi_sites() ->
+    {ok, Lines} =
+        beamtalk_compiler_server:find_ffi_sites_in_source(
+            <<"(Erlang lists) reverse: x">>, lists, reverse, any
+        ),
+    ?assert(is_list(Lines)).
+
+api_resolve_method_span() ->
+    Source = <<
+        "Object subclass: SpanServerC\n"
+        "\n"
+        "  increment => self.value := self.value + 1\n"
+    >>,
+    {ok, #{start := Start, 'end' := End}, Prev} =
+        beamtalk_compiler_server:resolve_method_span(
+            Source, <<"SpanServerC">>, <<"increment">>, instance
+        ),
+    ?assertEqual(Prev, binary:part(Source, Start, End - Start)).
+
 start_compiler() ->
     application:ensure_all_started(compiler),
     case application:ensure_all_started(beamtalk_compiler) of

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
@@ -2152,3 +2152,374 @@ bt1982_metaclass_all_methods_returns_list_test_() ->
             end)
         ]
     end}.
+
+%%% ============================================================================
+%%% Live method patch primitives — compile:source: / tryCompile:source:
+%%% ============================================================================
+
+%% ensure_source_binary/4 raises a type_error when the body is not a String
+%% (binary). compile:source: form (durable) names compile:source: in the
+%% message — covers the durable intent_selector/1 clause.
+compile_source_non_binary_raises_type_error_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {ClassObj, Pid} = register_class('BTCompileSrcBadType', #{}, #{}),
+                try
+                    ?assertError(
+                        #{
+                            '$beamtalk_class' := _,
+                            error := #beamtalk_error{kind = type_error}
+                        },
+                        %% Pass an atom (not a binary) as the source body.
+                        beamtalk_behaviour_intrinsics:classCompileSource(
+                            ClassObj, 'foo', not_a_binary
+                        )
+                    )
+                after
+                    try
+                        gen_server:stop(Pid, normal, 5000)
+                    catch
+                        _:_ -> ok
+                    end
+                end
+            end)
+        ]
+    end}.
+
+%% tryCompile:source: (ephemeral) with a non-binary body also raises a
+%% type_error — covers the ephemeral intent_selector/1 clause and the
+%% classTryCompileSource/3 entry point.
+try_compile_source_non_binary_raises_type_error_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {ClassObj, Pid} = register_class('BTTryCompileSrcBadType', #{}, #{}),
+                try
+                    ?assertError(
+                        #{
+                            '$beamtalk_class' := _,
+                            error := #beamtalk_error{kind = type_error}
+                        },
+                        beamtalk_behaviour_intrinsics:classTryCompileSource(
+                            ClassObj, 'foo', 12345
+                        )
+                    )
+                after
+                    try
+                        gen_server:stop(Pid, normal, 5000)
+                    catch
+                        _:_ -> ok
+                    end
+                end
+            end)
+        ]
+    end}.
+
+%% A binary body that cannot be compiled (syntactic garbage) drives the full
+%% do_compile_source/4 path: current_author_context/0 (default repl/human),
+%% the erlang:apply into beamtalk_repl_eval:compile_method/6, and the
+%% {error, Reason} -> compile_failed branch.
+compile_source_invalid_body_raises_compile_failed_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {ClassObj, Pid} = register_class('BTCompileSrcInvalid', #{}, #{}),
+                try
+                    ?assertError(
+                        #{
+                            '$beamtalk_class' := _,
+                            error := #beamtalk_error{kind = compile_failed}
+                        },
+                        beamtalk_behaviour_intrinsics:classCompileSource(
+                            ClassObj, 'foo', <<"@@@ not valid beamtalk @@@">>
+                        )
+                    )
+                after
+                    try
+                        gen_server:stop(Pid, normal, 5000)
+                    catch
+                        _:_ -> ok
+                    end
+                end
+            end)
+        ]
+    end}.
+
+%% The agent author branch of current_author_context/0: stamp the process
+%% dictionary with $beamtalk_author_kind = agent and a custom author binary,
+%% then drive a (failing) compile. The compile still fails (invalid body) but
+%% the agent author-context branch is exercised on the way.
+compile_source_agent_author_context_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {ClassObj, Pid} = register_class('BTCompileSrcAgent', #{}, #{}),
+                erlang:put('$beamtalk_author_kind', agent),
+                erlang:put('$beamtalk_author', <<"copilot">>),
+                try
+                    ?assertError(
+                        #{
+                            '$beamtalk_class' := _,
+                            error := #beamtalk_error{kind = compile_failed}
+                        },
+                        beamtalk_behaviour_intrinsics:classCompileSource(
+                            ClassObj, 'foo', <<"@@@ still invalid @@@">>
+                        )
+                    )
+                after
+                    erlang:erase('$beamtalk_author_kind'),
+                    erlang:erase('$beamtalk_author'),
+                    try
+                        gen_server:stop(Pid, normal, 5000)
+                    catch
+                        _:_ -> ok
+                    end
+                end
+            end)
+        ]
+    end}.
+
+%%% ============================================================================
+%%% meta_for_module/1 — modules exporting __beamtalk_meta/0
+%%% ============================================================================
+
+%% A class backed by a module exporting __beamtalk_meta/0 takes the meta fast
+%% path in classFieldNames/1, classLocalMethods/1, classClassVarNames/1 and
+%% classIncludesSelector/2 instead of the gen_server fallback.
+meta_fast_path_reflection_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                MetaMod = load_meta_module(bt_meta_fixture_a, #{
+                    superclass => nil,
+                    fields => [alpha, beta],
+                    method_info => #{'doThing' => #{}, 'doOther' => #{}},
+                    class_method_info => #{'factory' => #{}},
+                    class_fields => [counter]
+                }),
+                ClassName = 'BTMetaFixtureA',
+                ClassInfo = #{
+                    name => ClassName,
+                    module => MetaMod,
+                    superclass => none,
+                    instance_methods => #{},
+                    class_methods => #{}
+                },
+                {ok, Pid} = beamtalk_object_class:start(ClassName, ClassInfo),
+                ClassObj = #beamtalk_object{
+                    class = 'BTMetaFixtureA class', class_mod = MetaMod, pid = Pid
+                },
+                try
+                    %% classFieldNames -> maps:get(fields, Meta)
+                    ?assertEqual(
+                        [alpha, beta],
+                        beamtalk_behaviour_intrinsics:classFieldNames(ClassObj)
+                    ),
+                    %% classLocalMethods -> maps:keys(method_info)
+                    LocalMethods = beamtalk_behaviour_intrinsics:classLocalMethods(ClassObj),
+                    ?assert(lists:member('doThing', LocalMethods)),
+                    ?assert(lists:member('doOther', LocalMethods)),
+                    %% classClassVarNames -> maps:get(class_fields, Meta)
+                    ?assertEqual(
+                        [counter],
+                        beamtalk_behaviour_intrinsics:classClassVarNames(ClassObj)
+                    ),
+                    %% classIncludesSelector -> maps:is_key(_, method_info)
+                    ?assert(
+                        beamtalk_behaviour_intrinsics:classIncludesSelector(ClassObj, 'doThing')
+                    ),
+                    ?assertNot(
+                        beamtalk_behaviour_intrinsics:classIncludesSelector(ClassObj, 'nope')
+                    )
+                after
+                    (try
+                        gen_server:stop(Pid, normal, 5000)
+                    catch
+                        _:_ -> ok
+                    end),
+                    purge_meta_module(MetaMod)
+                end
+            end)
+        ]
+    end}.
+
+%% classIncludesSelector/2 on a metaclass-tagged object backed by a meta module
+%% uses the class_method_info fast path (maps:is_key over class_method_info).
+meta_fast_path_metaclass_includes_selector_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                MetaMod = load_meta_module(bt_meta_fixture_b, #{
+                    superclass => nil,
+                    fields => [],
+                    method_info => #{},
+                    class_method_info => #{'build' => #{}},
+                    class_fields => []
+                }),
+                ClassName = 'BTMetaFixtureB',
+                ClassInfo = #{
+                    name => ClassName,
+                    module => MetaMod,
+                    superclass => none,
+                    instance_methods => #{},
+                    class_methods => #{}
+                },
+                {ok, Pid} = beamtalk_object_class:start(ClassName, ClassInfo),
+                MetaObj = #beamtalk_object{
+                    class = 'Metaclass', class_mod = beamtalk_metaclass_bt, pid = Pid
+                },
+                try
+                    ?assert(
+                        beamtalk_behaviour_intrinsics:classIncludesSelector(MetaObj, 'build')
+                    ),
+                    ?assertNot(
+                        beamtalk_behaviour_intrinsics:classIncludesSelector(MetaObj, 'missing')
+                    )
+                after
+                    (try
+                        gen_server:stop(Pid, normal, 5000)
+                    catch
+                        _:_ -> ok
+                    end),
+                    purge_meta_module(MetaMod)
+                end
+            end)
+        ]
+    end}.
+
+%%% ============================================================================
+%%% stop_class_actors/1 — via removeFromSystem with a live actor registry
+%%% ============================================================================
+
+%% classRemoveFromSystemByName/1 calls stop_class_actors/1 in its success
+%% branch. With a stub registry process registered under beamtalk_actor_registry
+%% that answers list_actors, the actor-collection + kill loop is exercised.
+stop_class_actors_with_registry_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                %% A removable module so code:delete succeeds on the happy path.
+                ModAtom = bt_stopactors_removable_mod,
+                Forms = [
+                    {attribute, 1, module, ModAtom},
+                    {attribute, 2, export, []}
+                ],
+                {ok, ModAtom, Bin} = compile:forms(Forms, [return_errors]),
+                {module, ModAtom} = code:load_binary(
+                    ModAtom, "bt_stopactors_removable_mod.erl", Bin
+                ),
+                ClassName = 'BTStopActorsClass',
+                ClassInfo = #{
+                    name => ClassName,
+                    module => ModAtom,
+                    superclass => none,
+                    instance_methods => #{},
+                    class_methods => #{}
+                },
+                {ok, _ClassPid} = beamtalk_object_class:start(ClassName, ClassInfo),
+
+                %% A fake actor belonging to this class.
+                ActorPid = spawn(fun() ->
+                    receive
+                        stop -> ok
+                    after 10000 -> ok
+                    end
+                end),
+                %% Stub registry: answers list_actors with one matching actor and
+                %% {kill, Pid} by stopping it.
+                Registry = spawn(fun() -> stub_registry_loop(ClassName, ActorPid) end),
+                register(beamtalk_actor_registry, Registry),
+                try
+                    ?assertEqual(
+                        nil,
+                        beamtalk_behaviour_intrinsics:classRemoveFromSystemByName(ClassName)
+                    ),
+                    %% The class is gone from the registry.
+                    ?assertEqual(
+                        undefined, beamtalk_class_registry:whereis_class(ClassName)
+                    )
+                after
+                    catch unregister(beamtalk_actor_registry),
+                    catch exit(Registry, kill),
+                    catch exit(ActorPid, kill)
+                end
+            end)
+        ]
+    end}.
+
+%%% ============================================================================
+%%% walk_hierarchy/3 — max depth cycle guard
+%%% ============================================================================
+
+%% A self-referential class (its own superclass) makes walk_hierarchy/3 loop;
+%% the ?MAX_HIERARCHY_DEPTH guard halts it and returns the accumulator. We drive
+%% it via classAllSuperclasses/1, which folds class objects up the chain.
+walk_hierarchy_cycle_guard_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                ClassName = 'BTCycleSelf',
+                ClassInfo = #{
+                    name => ClassName,
+                    module => test_class,
+                    %% Superclass points back at itself — an artificial cycle.
+                    superclass => ClassName,
+                    instance_methods => #{},
+                    class_methods => #{}
+                },
+                {ok, Pid} = beamtalk_object_class:start(ClassName, ClassInfo),
+                ClassObj = #beamtalk_object{
+                    class = 'BTCycleSelf class', class_mod = test_class, pid = Pid
+                },
+                try
+                    %% Must terminate (depth guard) and return a bounded list.
+                    Supers = beamtalk_behaviour_intrinsics:classAllSuperclasses(ClassObj),
+                    ?assert(is_list(Supers))
+                after
+                    try
+                        gen_server:stop(Pid, normal, 5000)
+                    catch
+                        _:_ -> ok
+                    end
+                end
+            end)
+        ]
+    end}.
+
+%%% ============================================================================
+%%% Helpers for coverage additions
+%%% ============================================================================
+
+%% Compile and load a module exporting __beamtalk_meta/0 returning MetaMap.
+%% Returns the module atom.
+load_meta_module(ModAtom, MetaMap) ->
+    MetaAbstract = erl_parse:abstract(MetaMap, [{line, 3}]),
+    Forms = [
+        {attribute, 1, module, ModAtom},
+        {attribute, 2, export, [{'__beamtalk_meta', 0}]},
+        {function, 3, '__beamtalk_meta', 0, [{clause, 3, [], [], [MetaAbstract]}]}
+    ],
+    {ok, ModAtom, Bin} = compile:forms(Forms, [return_errors]),
+    {module, ModAtom} = code:load_binary(ModAtom, atom_to_list(ModAtom) ++ ".erl", Bin),
+    ModAtom.
+
+purge_meta_module(ModAtom) ->
+    _ = code:purge(ModAtom),
+    _ = code:delete(ModAtom),
+    _ = code:purge(ModAtom),
+    ok.
+
+%% Minimal stub for beamtalk_actor_registry used by stop_class_actors_with_registry.
+stub_registry_loop(ClassName, ActorPid) ->
+    receive
+        {'$gen_call', From, list_actors} ->
+            gen_server:reply(From, [#{pid => ActorPid, class => ClassName}]),
+            stub_registry_loop(ClassName, ActorPid);
+        {'$gen_call', From, {kill, Pid}} ->
+            catch exit(Pid, kill),
+            gen_server:reply(From, ok),
+            stub_registry_loop(ClassName, ActorPid);
+        _ ->
+            stub_registry_loop(ClassName, ActorPid)
+    end.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_module_activation_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_module_activation_tests.erl
@@ -348,8 +348,361 @@ extract_source_path_no_attribute_test() ->
     ?assertEqual(undefined, beamtalk_module_activation:extract_source_path(lists)).
 
 %%% ============================================================================
+%%% is_valid_module_name/1 — digit characters
+%%% ============================================================================
+
+valid_module_name_with_digits_test() ->
+    %% Exercises the digit clause of is_valid_module_char/1.
+    ?assert(beamtalk_module_activation:is_valid_module_name("bt@pkg2@Class9")).
+
+%%% ============================================================================
+%%% sort_modules_by_dependency/2 — real beam attribute scan
+%%% ============================================================================
+
+%% Compiling beam files with `beamtalk_class` attributes and sorting them
+%% exercises extract_class_info_from_beam/2 (beam_lib scan) and the
+%% topo-sort-by-superclass path of sort_modules_by_dependency/2.
+sort_modules_orders_subclass_after_superclass_test() ->
+    TmpDir = create_temp_dir(),
+    try
+        ParentMod = write_class_beam(TmpDir, "bt@srt@Parent", 'SrtParent', 'Object'),
+        ChildMod = write_class_beam(TmpDir, "bt@srt@Child", 'SrtChild', 'SrtParent'),
+        %% Pass child before parent — sort must reorder so parent precedes child.
+        Sorted = beamtalk_module_activation:sort_modules_by_dependency(
+            TmpDir, [ChildMod, ParentMod]
+        ),
+        ?assertEqual([ParentMod, ChildMod], Sorted)
+    after
+        remove_temp_dir(TmpDir)
+    end.
+
+%% A beam file with no beamtalk_class attribute is placed first (WithoutClass
+%% branch of sort_modules_by_dependency/2 + the error branch of
+%% extract_class_info_from_beam/2).
+sort_modules_no_attribute_placed_first_test() ->
+    TmpDir = create_temp_dir(),
+    try
+        PlainMod = write_plain_beam(TmpDir, "bt@srt@Plain"),
+        ClassMod = write_class_beam(TmpDir, "bt@srt@Klass", 'SrtKlass', 'Object'),
+        Sorted = beamtalk_module_activation:sort_modules_by_dependency(
+            TmpDir, [ClassMod, PlainMod]
+        ),
+        %% Modules without a class attribute come first.
+        ?assertEqual([PlainMod, ClassMod], Sorted)
+    after
+        remove_temp_dir(TmpDir)
+    end.
+
+%%% ============================================================================
+%%% activate_ebin/2 — directory with real beam modules
+%%% ============================================================================
+
+%% A populated ebin dir drives the full activate_ebin/2 pipeline: code path,
+%% load_app_from_ebin, find_bt_modules_in_dir, sort, and activate_module per
+%% module (covering the filtermap success branch where activate_module -> ok).
+activate_ebin_with_modules_test() ->
+    TmpDir = create_temp_dir(),
+    try
+        %% Module with register_class/0 returning ok — activates cleanly.
+        Mod = write_registering_beam(TmpDir, "bt@aeb@Ok"),
+        {ok, Errors} = beamtalk_module_activation:activate_ebin(TmpDir),
+        ?assertEqual([], Errors),
+        ?assert(erlang:function_exported(Mod, register_class, 0))
+    after
+        _ = code:del_path(TmpDir),
+        purge_mod('bt@aeb@Ok'),
+        remove_temp_dir(TmpDir)
+    end.
+
+%% A module whose register_class/0 crashes surfaces as an error pair in the
+%% activate_ebin/2 result (covers the {error, Reason} -> {true, ...} branch
+%% of the filtermap in activate_ebin/2).
+activate_ebin_collects_module_errors_test() ->
+    TmpDir = create_temp_dir(),
+    try
+        Mod = write_crashing_register_beam(TmpDir, "bt@aeb@Crash"),
+        {ok, Errors} = beamtalk_module_activation:activate_ebin(TmpDir),
+        ?assertMatch([{Mod, {error, _}}], Errors)
+    after
+        _ = code:del_path(TmpDir),
+        purge_mod('bt@aeb@Crash'),
+        remove_temp_dir(TmpDir)
+    end.
+
+%%% ============================================================================
+%%% activate_dependencies/1,2
+%%% ============================================================================
+
+%% No _build/deps directory and no native ebin — returns [] without crashing.
+activate_dependencies_no_deps_dir_test() ->
+    TmpDir = create_temp_dir(),
+    try
+        ?assertEqual([], beamtalk_module_activation:activate_dependencies(TmpDir))
+    after
+        remove_temp_dir(TmpDir)
+    end.
+
+%% A project layout with a dependency ebin containing a registering module
+%% drives the deps-scan + activate_ebin loop, plus the native/hex ebin path
+%% additions. Returns [] errors.
+activate_dependencies_with_dep_test() ->
+    ProjectDir = create_temp_dir(),
+    try
+        DepEbin = filename:join([ProjectDir, "_build", "deps", "mydep", "ebin"]),
+        ok = filelib:ensure_dir(filename:join(DepEbin, "dummy")),
+        _ = write_registering_beam(DepEbin, "bt@dep@Thing"),
+        %% Also create the native + hex lib dirs to exercise those code-path
+        %% branches (empty hex lib so the inner loop runs over no deps).
+        NativeEbin = filename:join([ProjectDir, "_build", "dev", "native", "ebin"]),
+        ok = filelib:ensure_dir(filename:join(NativeEbin, "dummy")),
+        HexLib = filename:join([ProjectDir, "_build", "dev", "native", "default", "lib"]),
+        ok = filelib:ensure_dir(filename:join(HexLib, "dummy")),
+        Errors = beamtalk_module_activation:activate_dependencies(ProjectDir, #{}),
+        ?assertEqual([], Errors)
+    after
+        _ = code:del_path(filename:join([ProjectDir, "_build", "deps", "mydep", "ebin"])),
+        _ = code:del_path(filename:join([ProjectDir, "_build", "dev", "native", "ebin"])),
+        purge_mod('bt@dep@Thing'),
+        remove_temp_dir_recursive(ProjectDir)
+    end.
+
+%% A dependency ebin holding a hex lib dir with its own nested ebin exercises
+%% the inner add_pathz branch of the rebar3 hex-dep loop.
+activate_dependencies_hex_lib_ebin_test() ->
+    ProjectDir = create_temp_dir(),
+    try
+        HexEbin = filename:join([
+            ProjectDir, "_build", "dev", "native", "default", "lib", "cowboy", "ebin"
+        ]),
+        ok = filelib:ensure_dir(filename:join(HexEbin, "dummy")),
+        Errors = beamtalk_module_activation:activate_dependencies(ProjectDir, #{}),
+        ?assertEqual([], Errors),
+        %% The hex ebin should have been added to the code path.
+        ?assert(lists:member(HexEbin, code:get_path()))
+    after
+        _ = code:del_path(
+            filename:join([
+                ProjectDir, "_build", "dev", "native", "default", "lib", "cowboy", "ebin"
+            ])
+        ),
+        remove_temp_dir_recursive(ProjectDir)
+    end.
+
+%%% ============================================================================
+%%% load_app_from_ebin/1 — invalid .app basename
+%%% ============================================================================
+
+%% A .app file whose basename is not a valid module name is skipped (the
+%% `false -> false` branch of load_app_from_ebin/1's filtermap).
+load_app_invalid_basename_skipped_test() ->
+    TmpDir = create_temp_dir(),
+    try
+        %% Basename "bad name" contains a space — invalid module name.
+        BadApp = filename:join(TmpDir, "bad name.app"),
+        ok = file:write_file(BadApp, <<"{application, ignored, []}.">>),
+        ?assertEqual({ok, []}, beamtalk_module_activation:load_app_from_ebin(TmpDir))
+    after
+        remove_temp_dir(TmpDir)
+    end.
+
+%%% ============================================================================
+%%% extract_source_path/1 — module with a beamtalk_source attribute
+%%% ============================================================================
+
+%% A loaded module carrying `beamtalk_source = ["path.bt"]` returns the path
+%% (covers the `[Path] when is_list(Path)` clause of extract_source_path/1).
+extract_source_path_with_attribute_test() ->
+    Mod = bt_test_source_attr_mod,
+    Forms = [
+        {attribute, 1, module, Mod},
+        {attribute, 2, beamtalk_source, ["src/Foo.bt"]},
+        {attribute, 3, export, []}
+    ],
+    {ok, Mod, Bin} = compile:forms(Forms, [return_errors]),
+    {module, Mod} = code:load_binary(Mod, "bt_test_source_attr_mod.beam", Bin),
+    try
+        ?assertEqual("src/Foo.bt", beamtalk_module_activation:extract_source_path(Mod))
+    after
+        purge_mod(Mod)
+    end.
+
+%%% ============================================================================
+%%% extract_class_names/1 — module with a beamtalk_class attribute
+%%% ============================================================================
+
+%% A loaded module with `beamtalk_class = [{Name, Super}]` yields the class
+%% name list.
+extract_class_names_with_attribute_test() ->
+    Mod = bt_test_class_attr_mod,
+    Forms = [
+        {attribute, 1, module, Mod},
+        {attribute, 2, beamtalk_class, [{'MyClass', 'Object'}]},
+        {attribute, 3, export, []}
+    ],
+    {ok, Mod, Bin} = compile:forms(Forms, [return_errors]),
+    {module, Mod} = code:load_binary(Mod, "bt_test_class_attr_mod.beam", Bin),
+    try
+        ?assertEqual(['MyClass'], beamtalk_module_activation:extract_class_names(Mod))
+    after
+        purge_mod(Mod)
+    end.
+
+%%% ============================================================================
+%%% sort_modules_by_dependency/2 — beam with multiple class entries
+%%% ============================================================================
+
+%% A beam whose beamtalk_class attribute lists more than one class exercises
+%% the `[{ClassName, Superclass} | _]` multi-entry clause of
+%% extract_class_info_from_beam/2 (only the first pair is used for sorting).
+sort_modules_multi_class_attribute_test() ->
+    TmpDir = create_temp_dir(),
+    try
+        ModName = "bt@srt@Multi",
+        Mod = list_to_atom(ModName),
+        Forms = [
+            {attribute, 1, module, Mod},
+            {attribute, 2, beamtalk_class, [{'SrtFirst', 'Object'}, {'SrtSecond', 'SrtFirst'}]},
+            {attribute, 3, export, []}
+        ],
+        {ok, Mod, Bin} = compile:forms(Forms, [return_errors]),
+        ok = file:write_file(filename:join(TmpDir, ModName ++ ".beam"), Bin),
+        Sorted = beamtalk_module_activation:sort_modules_by_dependency(TmpDir, [Mod]),
+        ?assertEqual([Mod], Sorted)
+    after
+        remove_temp_dir(TmpDir)
+    end.
+
+%%% ============================================================================
+%%% activate_module/2 — register_class/0 unexpected return
+%%% ============================================================================
+
+%% register_class/0 returning a non-ok value is logged but still treated as
+%% success (covers the `Other ->` branch of try_register_class/2).
+activate_module_register_class_unexpected_return_test() ->
+    Mod = bt_test_unexpected_register,
+    Forms = [
+        {attribute, 1, module, Mod},
+        {attribute, 2, export, [{register_class, 0}]},
+        {function, 3, register_class, 0, [
+            {clause, 3, [], [], [{atom, 3, surprise}]}
+        ]}
+    ],
+    {ok, Mod, Bin} = compile:forms(Forms, [return_errors]),
+    {module, Mod} = code:load_binary(Mod, "bt_test_unexpected_register.beam", Bin),
+    try
+        ?assertEqual(ok, beamtalk_module_activation:activate_module(Mod))
+    after
+        purge_mod(Mod)
+    end.
+
+%%% ============================================================================
+%%% load_app_from_ebin/1 — malformed .app surfaces an error
+%%% ============================================================================
+
+%% A syntactically valid but unloadable .app (wrong term shape) makes
+%% application:load/1 fail, surfacing a {AppName, Reason} error pair (covers
+%% the {error, Reason} branch of load_single_app/1).
+load_app_malformed_surfaces_error_test() ->
+    TmpDir = create_temp_dir(),
+    try
+        %% Valid module-name basename, but the file content is not a proper
+        %% {application, Name, Props} term — application:load/1 returns error.
+        AppName = "beamtalk_bad_app_xyz",
+        AppFile = filename:join(TmpDir, AppName ++ ".app"),
+        ok = file:write_file(AppFile, <<"{not_an_application, oops}.">>),
+        _ = code:add_pathz(TmpDir),
+        _ = application:unload(list_to_atom(AppName)),
+        {ok, Errors} = beamtalk_module_activation:load_app_from_ebin(TmpDir),
+        ?assertMatch([{_, _}], Errors)
+    after
+        _ = code:del_path(TmpDir),
+        remove_temp_dir(TmpDir)
+    end.
+
+%%% ============================================================================
 %%% Helpers
 %%% ============================================================================
+
+%% Compile and write a beam carrying a beamtalk_class attribute into Dir.
+%% Returns the module atom.
+write_class_beam(Dir, ModName, ClassName, Superclass) ->
+    Mod = list_to_atom(ModName),
+    Forms = [
+        {attribute, 1, module, Mod},
+        {attribute, 2, beamtalk_class, [{ClassName, Superclass}]},
+        {attribute, 3, export, []}
+    ],
+    {ok, Mod, Bin} = compile:forms(Forms, [return_errors]),
+    ok = file:write_file(filename:join(Dir, ModName ++ ".beam"), Bin),
+    Mod.
+
+%% Compile and write a plain beam (no beamtalk_class attribute) into Dir.
+write_plain_beam(Dir, ModName) ->
+    Mod = list_to_atom(ModName),
+    Forms = [
+        {attribute, 1, module, Mod},
+        {attribute, 2, export, []}
+    ],
+    {ok, Mod, Bin} = compile:forms(Forms, [return_errors]),
+    ok = file:write_file(filename:join(Dir, ModName ++ ".beam"), Bin),
+    Mod.
+
+%% Compile and write a beam exporting register_class/0 -> ok into Dir.
+write_registering_beam(Dir, ModName) ->
+    Mod = list_to_atom(ModName),
+    Forms = [
+        {attribute, 1, module, Mod},
+        {attribute, 2, export, [{register_class, 0}]},
+        {function, 3, register_class, 0, [{clause, 3, [], [], [{atom, 3, ok}]}]}
+    ],
+    {ok, Mod, Bin} = compile:forms(Forms, [return_errors]),
+    ok = file:write_file(filename:join(Dir, ModName ++ ".beam"), Bin),
+    Mod.
+
+%% Compile and write a beam whose register_class/0 crashes into Dir.
+write_crashing_register_beam(Dir, ModName) ->
+    Mod = list_to_atom(ModName),
+    Forms = [
+        {attribute, 1, module, Mod},
+        {attribute, 2, export, [{register_class, 0}]},
+        {function, 3, register_class, 0, [
+            {clause, 3, [], [], [
+                {call, 3, {remote, 3, {atom, 3, erlang}, {atom, 3, error}}, [
+                    {atom, 3, boom}
+                ]}
+            ]}
+        ]}
+    ],
+    {ok, Mod, Bin} = compile:forms(Forms, [return_errors]),
+    ok = file:write_file(filename:join(Dir, ModName ++ ".beam"), Bin),
+    Mod.
+
+purge_mod(ModName) when is_list(ModName) ->
+    purge_mod(list_to_atom(ModName));
+purge_mod(Mod) when is_atom(Mod) ->
+    _ = code:purge(Mod),
+    _ = code:delete(Mod),
+    _ = code:purge(Mod),
+    ok.
+
+%% Recursively remove a temp directory tree (for nested _build layouts).
+remove_temp_dir_recursive(Dir) ->
+    case file:list_dir(Dir) of
+        {ok, Entries} ->
+            lists:foreach(
+                fun(E) ->
+                    Path = filename:join(Dir, E),
+                    case filelib:is_dir(Path) of
+                        true -> remove_temp_dir_recursive(Path);
+                        false -> file:delete(Path)
+                    end
+                end,
+                Entries
+            ),
+            file:del_dir(Dir);
+        _ ->
+            ok
+    end.
 
 index_of(Elem, List) ->
     index_of(Elem, List, 1).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
@@ -274,7 +274,13 @@ classes_handles_legacy_tuple_entries_test() ->
     App = bt_fake_legacy_pkg,
     load_fake_app(
         App,
-        [{env, [{classes, [#{package => legacyp, name => 'LegacyA'}, {some_mod, 'LegacyB', 'Object'}]}]}]
+        [
+            {env, [
+                {classes, [
+                    #{package => legacyp, name => 'LegacyA'}, {some_mod, 'LegacyB', 'Object'}
+                ]}
+            ]}
+        ]
     ),
     try
         Classes = beamtalk_package:classes(<<"legacyp">>),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
@@ -190,3 +190,104 @@ dependencies_returns_binaries_test() ->
         fun(Name) -> ?assert(is_binary(Name)) end,
         Result
     ).
+
+%%% ============================================================================
+%%% Synthetic-app tests — exercise package metadata branches that need OTP
+%%% application env shapes the stdlib package does not provide (BT coverage push).
+%%% ============================================================================
+
+%% Load a throwaway OTP application from an in-memory spec so we control its
+%% `classes`/`applications`/`vsn` env. Unloads any prior copy first.
+load_fake_app(Name, ExtraProps) ->
+    _ = application:unload(Name),
+    Props = [{description, "fake"}, {vsn, "1.0.0"} | ExtraProps],
+    ok = application:load({application, Name, Props}).
+
+%% all/0 must drop an app whose classes carry no package key
+%% (package_name_from_classes/1 -> undefined -> filtered out).
+all_excludes_app_with_unpackaged_classes_test() ->
+    setup(),
+    App = bt_fake_nopkg_app,
+    load_fake_app(App, [{env, [{classes, [#{name => 'FooNoPkg'}]}]}]),
+    try
+        Result = beamtalk_package:all(),
+        ?assert(is_list(Result)),
+        %% A classes list without a `package` key never surfaces as a package.
+        ?assertNot(lists:member(undefined, Result))
+    after
+        _ = application:unload(App)
+    end.
+
+%% all/0 surfaces a package declared with a binary `package` value
+%% (package_name_from_classes/1 binary clause).
+all_includes_binary_package_test() ->
+    setup(),
+    App = bt_fake_binpkg_app,
+    load_fake_app(App, [{env, [{classes, [#{package => <<"binpkg">>, name => 'FooBin'}]}]}]),
+    try
+        ?assert(lists:member(<<"binpkg">>, beamtalk_package:all()))
+    after
+        _ = application:unload(App)
+    end.
+
+%% dependencies/1 includes deps that are themselves Beamtalk packages.
+dependencies_includes_beamtalk_package_deps_test() ->
+    setup(),
+    Dep = bt_fake_dep_pkg,
+    Main = bt_fake_main_pkg,
+    load_fake_app(Dep, [{env, [{classes, [#{package => depp, name => 'D'}]}]}]),
+    load_fake_app(
+        Main,
+        [{applications, [Dep]}, {env, [{classes, [#{package => mainp, name => 'M'}]}]}]
+    ),
+    try
+        Deps = beamtalk_package:dependencies(<<"mainp">>),
+        ?assert(lists:member(<<"depp">>, Deps))
+    after
+        _ = application:unload(Main),
+        _ = application:unload(Dep)
+    end.
+
+%% dependencies/1 drops a dep app whose classes carry no package key.
+dependencies_excludes_unpackaged_dep_test() ->
+    setup(),
+    Dep = bt_fake_dep_nopkg,
+    Main = bt_fake_main2_pkg,
+    load_fake_app(Dep, [{env, [{classes, [#{name => 'XNoPkg'}]}]}]),
+    load_fake_app(
+        Main,
+        [{applications, [Dep]}, {env, [{classes, [#{package => main2p, name => 'M2'}]}]}]
+    ),
+    try
+        Deps = beamtalk_package:dependencies(<<"main2p">>),
+        ?assert(is_list(Deps)),
+        ?assertNot(lists:member(undefined, Deps))
+    after
+        _ = application:unload(Main),
+        _ = application:unload(Dep)
+    end.
+
+%% classes/1 accepts the legacy `{Mod, Name, Super}` tuple entry shape alongside
+%% the map shape (class_entry_name/1 tuple clause).
+classes_handles_legacy_tuple_entries_test() ->
+    setup(),
+    App = bt_fake_legacy_pkg,
+    load_fake_app(
+        App,
+        [{env, [{classes, [#{package => legacyp, name => 'LegacyA'}, {some_mod, 'LegacyB', 'Object'}]}]}]
+    ),
+    try
+        Classes = beamtalk_package:classes(<<"legacyp">>),
+        ?assert(lists:member('LegacyA', Classes)),
+        ?assert(lists:member('LegacyB', Classes))
+    after
+        _ = application:unload(App)
+    end.
+
+%% packageNameFor/1 is the Beamtalk FFI shim and must mirror package_name/1.
+package_name_for_delegates_to_package_name_test() ->
+    setup(),
+    ?assertEqual(
+        beamtalk_package:package_name('Object'),
+        beamtalk_package:packageNameFor('Object')
+    ).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_compiler_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_compiler_tests.erl
@@ -312,3 +312,243 @@ compile_file_core_class_extraction_test() ->
     ]),
     %% Core erlang compile will fail, but we're just verifying it handles the error
     ?assertMatch({error, _}, Result).
+
+%%====================================================================
+%% Success-path tests (require the beamtalk_compiler OTP app + port)
+%%
+%% These exercise the compile pipeline end-to-end: Beamtalk source ->
+%% Core Erlang (Rust port) -> BEAM bytecode. They cover the cold success
+%% branches of compile_expression/compile_file/compile_for_codegen/etc.
+%% that the noproc error-path tests above cannot reach.
+%%====================================================================
+
+setup_compiler() ->
+    application:ensure_all_started(compiler),
+    %% Start the runtime so the class-hierarchy ETS table is populated; this
+    %% lets build_class_superclass_index/0 and build_class_module_index/0
+    %% return non-empty maps and add_class_indexes/1 take its populated branches.
+    application:ensure_all_started(beamtalk_runtime),
+    case application:ensure_all_started(beamtalk_compiler) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    %% Give the runtime a moment to register its bootstrap classes.
+    timer:sleep(300),
+    ok.
+
+teardown_compiler(_) ->
+    %% Stop the compiler app so later test modules in the shared EUnit node see
+    %% the baseline "compiler not running" state (noproc error-path tests in
+    %% beamtalk_repl_eval_tests depend on it).
+    _ = application:stop(beamtalk_compiler),
+    ok.
+
+compiler_success_test_() ->
+    {setup, fun setup_compiler/0, fun teardown_compiler/1, [
+        {"compile_expression standard expr succeeds", fun compile_expression_standard_ok/0},
+        {"compile_expression with known vars succeeds", fun compile_expression_known_vars_ok/0},
+        {"compile_expression class definition succeeds", fun compile_expression_class_def_ok/0},
+        {"compile_expression method definition succeeds", fun compile_expression_method_def_ok/0},
+        {"compile_expression invalid returns diagnostics", fun compile_expression_invalid/0},
+        {"compile_expression_via_port standard succeeds", fun compile_via_port_standard_ok/0},
+        {"compile_expression_trace standard succeeds", fun compile_trace_standard_ok/0},
+        {"compile_expression_trace invalid returns error", fun compile_trace_invalid/0},
+        {"compile_file class succeeds", fun compile_file_ok/0},
+        {"compile_file invalid returns compile_error", fun compile_file_invalid/0},
+        {"compile_file/5 with prebuilt indexes succeeds", fun compile_file_prebuilt_ok/0},
+        {"compile_for_codegen standard succeeds", fun compile_for_codegen_ok/0},
+        {"compile_for_codegen class succeeds", fun compile_for_codegen_class_ok/0},
+        {"compile_for_codegen method def rejected", fun compile_for_codegen_method_rejected/0},
+        {"compile_for_codegen invalid returns error", fun compile_for_codegen_invalid/0},
+        {"compile_file_for_codegen succeeds", fun compile_file_for_codegen_ok/0},
+        {"compile_file_for_codegen invalid returns error", fun compile_file_for_codegen_invalid/0},
+        {"compile_for_method_reload succeeds", fun compile_for_method_reload_ok/0},
+        {"compile_for_method_reload invalid returns error",
+            fun compile_for_method_reload_invalid/0},
+        {"compile_standard_expression valid core succeeds", fun compile_standard_expression_ok/0},
+        {"compile_file_core valid core succeeds", fun compile_file_core_ok/0},
+        {"build_class_indexes returns map", fun build_class_indexes_ok/0},
+        {"build_class_module_index returns map", fun build_class_module_index_ok/0},
+        {"compile_expression protocol definition succeeds", fun compile_expression_protocol_ok/0},
+        {"compile_for_codegen protocol rejected", fun compile_for_codegen_protocol_rejected/0},
+        {"compile_expression_trace with known vars succeeds", fun compile_trace_known_vars_ok/0}
+    ]}.
+
+compile_expression_standard_ok() ->
+    Result = beamtalk_repl_compiler:compile_expression("1 + 2", expr_std_mod, #{}),
+    {ok, Binary, _ResultExpr, Warnings} = Result,
+    ?assert(is_binary(Binary)),
+    ?assert(byte_size(Binary) > 0),
+    ?assert(is_list(Warnings)).
+
+compile_expression_known_vars_ok() ->
+    %% Bindings keys are forwarded as known vars (internal keys filtered out).
+    Result = beamtalk_repl_compiler:compile_expression(
+        "x + 1", expr_kv_mod, #{x => 41, '__internal__' => skip}
+    ),
+    ?assertMatch({ok, _Binary, _ResultExpr, _Warnings}, Result).
+
+compile_expression_class_def_ok() ->
+    Source = "Actor subclass: ReplCompClassDef\n  value => 42",
+    Result = beamtalk_repl_compiler:compile_expression(Source, expr_classdef_mod, #{}),
+    {ok, class_definition, ClassInfo, _Warnings} = Result,
+    ?assert(is_binary(maps:get(binary, ClassInfo))),
+    ?assert(is_atom(maps:get(module_name, ClassInfo))),
+    ?assert(is_list(maps:get(classes, ClassInfo))).
+
+compile_expression_method_def_ok() ->
+    %% `ClassName >> selector => body` is a standalone method definition.
+    Source = "Object >> doubled => self * 2",
+    Result = beamtalk_repl_compiler:compile_expression(Source, expr_methoddef_mod, #{}),
+    {ok, method_definition, MethodInfo, _Warnings} = Result,
+    ?assert(is_map(MethodInfo)),
+    ?assert(maps:is_key(selector, MethodInfo)).
+
+compile_expression_invalid() ->
+    Result = beamtalk_repl_compiler:compile_expression("+++", expr_bad_mod, #{}),
+    %% Invalid expression returns structured diagnostics (a list of maps/binaries).
+    ?assertMatch({error, _}, Result),
+    {error, Diagnostics} = Result,
+    ?assert(is_list(Diagnostics)).
+
+compile_via_port_standard_ok() ->
+    Result = beamtalk_repl_compiler:compile_expression_via_port("3 * 4", via_port_ok_mod, #{}),
+    ?assertMatch({ok, _Binary, _ResultExpr, _Warnings}, Result).
+
+compile_trace_standard_ok() ->
+    Result = beamtalk_repl_compiler:compile_expression_trace("1. 2. 3", trace_ok_mod, #{}),
+    {ok, Binary, _ResultExpr, Warnings} = Result,
+    ?assert(is_binary(Binary)),
+    ?assert(is_list(Warnings)).
+
+compile_trace_invalid() ->
+    Result = beamtalk_repl_compiler:compile_expression_trace("+++", trace_bad_mod, #{}),
+    ?assertMatch({error, _}, Result).
+
+compile_file_ok() ->
+    Source = "Actor subclass: ReplCompFile\n  value => 7",
+    Result = beamtalk_repl_compiler:compile_file(Source, "/src/ReplCompFile.bt", false, undefined),
+    {ok, Binary, Classes, ModuleName} = Result,
+    ?assert(is_binary(Binary)),
+    ?assert(is_list(Classes)),
+    ?assert(is_atom(ModuleName)),
+    %% Class metadata is transformed into #{name, superclass} string maps.
+    [#{name := Name, superclass := Super} | _] = Classes,
+    ?assert(is_list(Name)),
+    ?assert(is_list(Super)).
+
+compile_file_invalid() ->
+    Result = beamtalk_repl_compiler:compile_file("+++ not valid", "/src/Bad.bt", false, undefined),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+compile_file_prebuilt_ok() ->
+    Source = "Actor subclass: ReplCompPrebuilt\n  value => 9",
+    %% Empty prebuilt index map (not use_runtime_indexes) exercises the merge branch.
+    Result = beamtalk_repl_compiler:compile_file(
+        Source, "/src/ReplCompPrebuilt.bt", false, undefined, #{}
+    ),
+    ?assertMatch({ok, _Binary, _Classes, _ModuleName}, Result).
+
+compile_for_codegen_ok() ->
+    Result = beamtalk_repl_compiler:compile_for_codegen(<<"1 + 2">>, <<"codegen_ok_mod">>, []),
+    {ok, CoreErlang, Warnings} = Result,
+    ?assert(is_binary(CoreErlang)),
+    ?assert(byte_size(CoreErlang) > 0),
+    ?assert(is_list(Warnings)).
+
+compile_for_codegen_class_ok() ->
+    Source = <<"Actor subclass: ReplCodegenClass\n  value => 1">>,
+    Result = beamtalk_repl_compiler:compile_for_codegen(Source, <<"codegen_class_mod">>, []),
+    {ok, CoreErlang, _Warnings} = Result,
+    ?assert(is_binary(CoreErlang)).
+
+compile_for_codegen_method_rejected() ->
+    %% Standalone method definitions are not supported by show-codegen.
+    Source = <<"Object >> tripled => self * 3">>,
+    Result = beamtalk_repl_compiler:compile_for_codegen(Source, <<"codegen_method_mod">>, []),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+compile_for_codegen_invalid() ->
+    Result = beamtalk_repl_compiler:compile_for_codegen(<<"+++">>, <<"codegen_bad_mod">>, []),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+compile_file_for_codegen_ok() ->
+    Source = <<"Actor subclass: ReplFileCodegen\n  value => 2">>,
+    Result = beamtalk_repl_compiler:compile_file_for_codegen(Source, "/src/ReplFileCodegen.bt"),
+    {ok, CoreErlang, Warnings} = Result,
+    ?assert(is_binary(CoreErlang)),
+    ?assert(is_list(Warnings)).
+
+compile_file_for_codegen_invalid() ->
+    Result = beamtalk_repl_compiler:compile_file_for_codegen(<<"+++ bad">>, "/src/Bad.bt"),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+compile_for_method_reload_ok() ->
+    Source = <<"Actor subclass: ReplMethodReload\n  value => 5">>,
+    Result = beamtalk_repl_compiler:compile_for_method_reload(Source, #{}),
+    {ok, Binary, ModName, Classes, Warnings} = Result,
+    ?assert(is_binary(Binary)),
+    ?assert(is_atom(ModName)),
+    ?assert(is_list(Classes)),
+    ?assert(is_list(Warnings)).
+
+compile_for_method_reload_invalid() ->
+    Result = beamtalk_repl_compiler:compile_for_method_reload(<<"+++ bad">>, #{}),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+compile_standard_expression_ok() ->
+    %% Generate real Core Erlang from the compiler, then feed it back to
+    %% compile_standard_expression/2 to exercise the success branch.
+    {ok, CoreErlang, _} =
+        beamtalk_compiler:compile_expression(<<"40 + 2">>, <<"std_expr_core">>, []),
+    Result = beamtalk_repl_compiler:compile_standard_expression(CoreErlang, [<<"w">>]),
+    {ok, Binary, {port_compiled}, Warnings} = Result,
+    ?assert(is_binary(Binary)),
+    ?assertEqual([<<"w">>], Warnings).
+
+compile_file_core_ok() ->
+    {ok, CoreErlang, _} =
+        beamtalk_compiler:compile_expression(<<"1 + 1">>, <<"file_core_ok">>, []),
+    %% binary_to_atom of the module name in the Core Erlang would mismatch, but
+    %% compile_file_core only needs a valid atom + the class metadata transform.
+    Result = beamtalk_repl_compiler:compile_file_core(CoreErlang, file_core_ok_mod, [
+        #{name => <<"Foo">>, superclass => <<"Object">>}
+    ]),
+    {ok, Binary, ClassNames, ModuleName} = Result,
+    ?assert(is_binary(Binary)),
+    ?assertEqual(file_core_ok_mod, ModuleName),
+    ?assertEqual([#{name => "Foo", superclass => "Object"}], ClassNames).
+
+build_class_indexes_ok() ->
+    Result = beamtalk_repl_compiler:build_class_indexes(),
+    ?assert(is_map(Result)).
+
+build_class_module_index_ok() ->
+    Result = beamtalk_repl_compiler:build_class_module_index(),
+    ?assert(is_map(Result)).
+
+compile_expression_protocol_ok() ->
+    %% `Protocol define: Name` compiles to a protocol_definition result, exercising
+    %% compile_protocol_definition_result/1 (Core Erlang -> BEAM for the protocol module).
+    Result = beamtalk_repl_compiler:compile_expression(
+        "Protocol define: ReplCompProto", proto_ok_mod, #{}
+    ),
+    {ok, protocol_definition, ProtocolInfo, _Warnings} = Result,
+    ?assert(is_binary(maps:get(binary, ProtocolInfo))),
+    ?assert(is_atom(maps:get(module_name, ProtocolInfo))),
+    ?assert(is_list(maps:get(protocols, ProtocolInfo))).
+
+compile_for_codegen_protocol_rejected() ->
+    %% show-codegen does not support protocol definitions.
+    Result = beamtalk_repl_compiler:compile_for_codegen(
+        <<"Protocol define: ReplCodegenProto">>, <<"codegen_proto_mod">>, []
+    ),
+    ?assertMatch({error, {compile_error, _}}, Result).
+
+compile_trace_known_vars_ok() ->
+    %% Non-internal atom binding keys are forwarded as known vars to the trace
+    %% compiler; internal `__`-prefixed keys are filtered out.
+    Result = beamtalk_repl_compiler:compile_expression_trace(
+        "x + 1", trace_kv_mod, #{x => 10, '__skip__' => true}
+    ),
+    ?assertMatch({ok, _Binary, _ResultExpr, _Warnings}, Result).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
@@ -1529,3 +1529,210 @@ normalize_method_source_leading_whitespace_test() ->
         Source,
         beamtalk_repl_eval:normalize_method_source(<<"increment">>, Source)
     ).
+
+%%====================================================================
+%% Success-path tests (require the beamtalk_compiler + beamtalk_runtime apps)
+%%
+%% The tests above exercise pure helpers and the compile-error path that
+%% occurs when no compiler is running. These tests start the compiler port
+%% and the runtime so do_eval/do_eval_trace/do_show_codegen and the
+%% class/protocol/method definition handlers reach their success branches:
+%% compile -> load_binary -> eval_loaded_module -> execute_and_process.
+%%====================================================================
+
+eval_setup() ->
+    application:ensure_all_started(compiler),
+    application:ensure_all_started(beamtalk_runtime),
+    case application:ensure_all_started(beamtalk_compiler) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    %% Allow the runtime to register its bootstrap classes before compiling.
+    timer:sleep(300),
+    ok.
+
+eval_teardown(_) ->
+    %% Stop the compiler app so this module's no-compiler / noproc error-path
+    %% tests (and later test modules in the shared EUnit node) see the baseline
+    %% "compiler not running" state this fixture started from.
+    _ = application:stop(beamtalk_compiler),
+    ok.
+
+eval_success_test_() ->
+    {setup, fun eval_setup/0, fun eval_teardown/1, [
+        {"do_eval arithmetic returns value", fun do_eval_arithmetic_value/0},
+        {"do_eval captures empty output", fun do_eval_output_is_binary/0},
+        {"do_eval assignment binds variable", fun do_eval_assignment_binds/0},
+        {"do_eval reads existing binding", fun do_eval_reads_binding/0},
+        {"do_eval multi-statement returns last", fun do_eval_multi_statement/0},
+        {"do_eval runtime error wraps in _error", fun do_eval_runtime_error/0},
+        {"do_eval inline class definition", fun do_eval_class_definition/0},
+        {"do_eval protocol definition", fun do_eval_protocol_definition/0},
+        {"do_eval/3 with undefined subscriber", fun do_eval_with_undefined_subscriber/0},
+        {"do_show_codegen returns core erlang", fun do_show_codegen_success/0},
+        {"do_show_codegen invalid returns error", fun do_show_codegen_error/0},
+        {"do_eval_trace single statement", fun do_eval_trace_single/0},
+        {"do_eval_trace multi statement", fun do_eval_trace_multi/0},
+        {"do_eval_trace assignment rebuilds binding", fun do_eval_trace_assignment/0},
+        {"do_eval_trace runtime error wraps", fun do_eval_trace_runtime_error/0},
+        {"compile_method on unrecorded class returns error", fun compile_method_unrecorded/0},
+        {"compile_method invalid body returns error", fun compile_method_invalid_body/0},
+        {"compile_method non-method expression rejected", fun compile_method_not_a_method/0},
+        {"do_show_codegen with binding known var", fun do_show_codegen_with_binding/0},
+        {"reload_class_file/1 missing file", fun reload_class_file_arity1/0},
+        {"handle_load/3 missing file delegates", fun handle_load3_missing/0},
+        {"handle_load_source/3 invalid delegates", fun handle_load_source3_invalid/0},
+        {"new_class/2 invalid delegates", fun new_class_invalid/0}
+    ]}.
+
+state0() ->
+    beamtalk_repl_state:new(undefined, 0).
+
+do_eval_arithmetic_value() ->
+    {ok, Value, Output, Warnings, _State} = beamtalk_repl_eval:do_eval("1 + 1", state0()),
+    ?assertEqual(2, Value),
+    ?assert(is_binary(Output)),
+    ?assert(is_list(Warnings)).
+
+do_eval_output_is_binary() ->
+    %% A non-printing expression yields an empty captured output binary.
+    {ok, _Value, Output, _Warnings, _State} = beamtalk_repl_eval:do_eval("3 * 7", state0()),
+    ?assertEqual(<<>>, Output).
+
+do_eval_assignment_binds() ->
+    {ok, Value, _Output, _Warnings, State} =
+        beamtalk_repl_eval:do_eval("answer := 40 + 2", state0()),
+    ?assertEqual(42, Value),
+    Bindings = beamtalk_repl_state:get_bindings(State),
+    ?assertEqual(42, maps:get(answer, Bindings)).
+
+do_eval_reads_binding() ->
+    %% A previously-bound variable is visible to a subsequent eval.
+    S0 = beamtalk_repl_state:set_bindings(#{base => 100}, state0()),
+    {ok, Value, _Output, _Warnings, _State} = beamtalk_repl_eval:do_eval("base + 1", S0),
+    ?assertEqual(101, Value).
+
+do_eval_multi_statement() ->
+    %% Multiple statements separated by `.` — result is the final expression.
+    {ok, Value, _Output, _Warnings, _State} =
+        beamtalk_repl_eval:do_eval("1 + 1. 2 + 2. 10 * 5", state0()),
+    ?assertEqual(50, Value).
+
+do_eval_runtime_error() ->
+    %% Sending an unknown message raises a does_not_understand; do_eval catches
+    %% it, wraps it, and stores it under '_error' in the returned bindings.
+    {error, _Reason, _Output, _Warnings, State} =
+        beamtalk_repl_eval:do_eval("1 frobnicate: 2", state0()),
+    Bindings = beamtalk_repl_state:get_bindings(State),
+    ?assert(maps:is_key('_error', Bindings)).
+
+do_eval_class_definition() ->
+    %% An inline class definition loads the class module and returns its name.
+    Source = "Actor subclass: EvalSuccessCls\n  value => 5",
+    {ok, ClassName, Output, _Warnings, _State} = beamtalk_repl_eval:do_eval(Source, state0()),
+    ?assertEqual(<<"EvalSuccessCls">>, ClassName),
+    ?assertEqual(<<>>, Output).
+
+do_eval_protocol_definition() ->
+    Source = "Protocol define: EvalSuccessProto",
+    {ok, Display, _Output, _Warnings, _State} = beamtalk_repl_eval:do_eval(Source, state0()),
+    ?assert(is_binary(Display)),
+    ?assert(binary:match(Display, <<"EvalSuccessProto">>) =/= nomatch).
+
+do_eval_with_undefined_subscriber() ->
+    %% do_eval/3 with an explicit undefined subscriber exercises the streaming arg.
+    {ok, Value, _Output, _Warnings, _State} =
+        beamtalk_repl_eval:do_eval("6 * 7", state0(), undefined),
+    ?assertEqual(42, Value).
+
+do_show_codegen_success() ->
+    {ok, CoreErlang, Warnings, _State} = beamtalk_repl_eval:do_show_codegen("1 + 2", state0()),
+    ?assert(is_binary(CoreErlang)),
+    ?assert(byte_size(CoreErlang) > 0),
+    ?assert(is_list(Warnings)).
+
+do_show_codegen_error() ->
+    {error, _Reason, Warnings, _State} = beamtalk_repl_eval:do_show_codegen("+++", state0()),
+    ?assertEqual([], Warnings).
+
+do_eval_trace_single() ->
+    {ok, Steps, Output, _Warnings, _State} = beamtalk_repl_eval:do_eval_trace("21 * 2", state0()),
+    ?assertMatch([{_Src, 42}], Steps),
+    ?assert(is_binary(Output)).
+
+do_eval_trace_multi() ->
+    {ok, Steps, _Output, _Warnings, _State} =
+        beamtalk_repl_eval:do_eval_trace("1 + 1. 2 + 3", state0()),
+    %% One step per top-level statement.
+    ?assertEqual(2, length(Steps)),
+    [{_, FirstVal}, {_, SecondVal}] = Steps,
+    ?assertEqual(2, FirstVal),
+    ?assertEqual(5, SecondVal).
+
+do_eval_trace_assignment() ->
+    {ok, _Steps, _Output, _Warnings, State} =
+        beamtalk_repl_eval:do_eval_trace("total := 30 + 12", state0()),
+    Bindings = beamtalk_repl_state:get_bindings(State),
+    ?assertEqual(42, maps:get(total, Bindings)).
+
+do_eval_trace_runtime_error() ->
+    %% A runtime error (does_not_understand) during trace execution is caught,
+    %% wrapped, and stored under '_error', returning a structured error tuple.
+    {error, _Reason, Output, _Warnings, State} =
+        beamtalk_repl_eval:do_eval_trace("1 frobnicate: 2", state0()),
+    ?assert(is_binary(Output)),
+    Bindings = beamtalk_repl_state:get_bindings(State),
+    ?assert(maps:is_key('_error', Bindings)).
+
+compile_method_unrecorded() ->
+    %% Compiling a method onto a class whose source is not recorded compiles the
+    %% standalone definition (method_definition path) then fails to install
+    %% because there is no recorded source — returns {error, _}.
+    Result = beamtalk_repl_eval:compile_method(<<"Object">>, <<"doubled">>, <<"self">>, ephemeral),
+    ?assertMatch({error, _}, Result).
+
+compile_method_invalid_body() ->
+    Result = beamtalk_repl_eval:compile_method(
+        <<"Object">>, <<"bad">>, <<"+++ garbage">>, ephemeral
+    ),
+    ?assertMatch({error, _}, Result).
+
+compile_method_not_a_method() ->
+    %% A plain expression body for a class that exists but whose source is not a
+    %% method definition still routes through compile_expression; a bare unary
+    %% body is wrapped as `bad => <body>` and may fail to install. Assert error.
+    Result = beamtalk_repl_eval:compile_method(
+        <<"Object">>, <<"plainExpr">>, <<"1 + 1">>, ephemeral
+    ),
+    ?assertMatch({error, _}, Result).
+
+do_show_codegen_with_binding() ->
+    %% A non-internal binding key is forwarded as a known var to the codegen
+    %% compiler (exercises the KnownVars comprehension in do_show_codegen).
+    S = beamtalk_repl_state:set_bindings(#{myvar => 5}, state0()),
+    {ok, CoreErlang, _Warnings, _State} = beamtalk_repl_eval:do_show_codegen("myvar + 1", S),
+    ?assert(is_binary(CoreErlang)),
+    %% The known var name appears in the generated Core Erlang lookup.
+    ?assert(binary:match(CoreErlang, <<"myvar">>) =/= nomatch).
+
+reload_class_file_arity1() ->
+    %% reload_class_file/1 (no expected class name) delegates to the loader.
+    Result = beamtalk_repl_eval:reload_class_file("/nonexistent/reload1.bt"),
+    ?assertEqual({error, {file_not_found, "/nonexistent/reload1.bt"}}, Result).
+
+handle_load3_missing() ->
+    %% handle_load/3 with prebuilt indexes delegates to beamtalk_repl_loader.
+    Result = beamtalk_repl_eval:handle_load("/nonexistent/load3.bt", state0(), #{}),
+    ?assertMatch({error, {file_not_found, _}, _}, Result).
+
+handle_load_source3_invalid() ->
+    %% handle_load_source/3 delegates to the loader; invalid source fails to compile.
+    Result = beamtalk_repl_eval:handle_load_source(<<"+++ not valid">>, "inline-label", state0()),
+    ?assertMatch({error, _, _}, Result).
+
+new_class_invalid() ->
+    %% new_class/2 delegates to the loader; an invalid target path is rejected.
+    Result = beamtalk_repl_eval:new_class(
+        <<"Actor subclass: NewClsInvalid\n  v => 1">>, <<"/nonexistent/dir/x.bt">>
+    ),
+    ?assertMatch({error, _}, Result).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
@@ -286,6 +286,44 @@ handle_load_compile_error_test() ->
     ?assertMatch({error, {compile_error, _}, _}, Result).
 
 %%====================================================================
+%% handle_load/3 — error paths (no compiler/runtime needed)
+%%====================================================================
+
+handle_load_3_not_found_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    ?assertMatch(
+        {error, {file_not_found, _}, _},
+        beamtalk_repl_loader:handle_load("/nonexistent/y.bt", State, #{})
+    ).
+
+handle_load_3_directory_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    ?assertMatch(
+        {error, {read_error, _}, _},
+        beamtalk_repl_loader:handle_load(temp_dir(), State, #{})
+    ).
+
+handle_load_3_compile_error_test() ->
+    UniqueId = erlang:unique_integer([positive]),
+    TempFile = filename:join(temp_dir(), io_lib:format("loader_h3_~p.bt", [UniqueId])),
+    ok = file:write_file(TempFile, <<"invalid syntax @@@">>),
+    State = beamtalk_repl_state:new(undefined, 0),
+    Result = beamtalk_repl_loader:handle_load(TempFile, State, #{}),
+    file:delete(TempFile),
+    ?assertMatch({error, _, _}, Result).
+
+%%====================================================================
+%% handle_load_source/3 — error path
+%%====================================================================
+
+handle_load_source_compile_error_test() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    Result = beamtalk_repl_loader:handle_load_source(
+        <<"invalid @@@ syntax">>, "inline-bad", State
+    ),
+    ?assertMatch({error, _, _}, Result).
+
+%%====================================================================
 %% reload_class_file/1,2 — error paths
 %%====================================================================
 
@@ -612,4 +650,469 @@ validate_target_path_existing_directory_is_target_exists_test() ->
         ?assertEqual('newClass:at:', Err#beamtalk_error.selector)
     after
         file:del_dir(Dir)
+    end.
+
+%%====================================================================
+%% new_class/2 type-error guard (pure — no runtime needed)
+%%====================================================================
+
+new_class_non_string_args_type_error_test() ->
+    %% Neither argument is a String/list, so the catch-all clause raises a
+    %% type_error #beamtalk_error{} without touching the filesystem or compiler.
+    {error, Err} = beamtalk_repl_loader:new_class(42, 99),
+    ?assertEqual(type_error, Err#beamtalk_error.kind),
+    ?assertEqual('newClass:at:', Err#beamtalk_error.selector).
+
+%%====================================================================
+%% method_source_binary/1 — list expression fallback (pure)
+%%====================================================================
+
+method_source_binary_falls_back_to_list_expression_test() ->
+    %% No method_source key; expression is a string (list) — converted to binary.
+    Info = #{expression => "Counter >> tick => self"},
+    ?assertEqual(<<"Counter >> tick => self">>, beamtalk_repl_loader:method_source_binary(Info)).
+
+%%====================================================================
+%% Integration fixture: real compile + load + activate
+%%
+%% Starts the beamtalk_compiler port backend and the beamtalk_runtime
+%% application (class registry) so the full success paths of handle_load,
+%% handle_load_source, load_class_module, reload_class_file,
+%% reload_method_definition and new_class can be exercised end-to-end.
+%%====================================================================
+
+loader_setup() ->
+    application:ensure_all_started(compiler),
+    case application:ensure_all_started(beamtalk_compiler) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    application:ensure_all_started(beamtalk_runtime),
+    Tmp = unicode:characters_to_list(beamtalk_file:'tempDirectory'()),
+    Proj = Tmp ++ "/bt_loader_proj_" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = file:make_dir(Proj),
+    %% A beamtalk.toml lets workspace_meta auto-detect a package name, which in
+    %% turn exercises compute_package_module_name/1's package-qualified branch.
+    ok = file:write_file(
+        filename:join(Proj, "beamtalk.toml"),
+        <<"[package]\nname = \"loaderpkg\"\n">>
+    ),
+    %% A workspace_meta with a real project_path makes classify_source_file/1
+    %% treat files under Proj as flushable (in-project).
+    case whereis(beamtalk_workspace_meta) of
+        undefined -> ok;
+        MetaPid -> gen_server:stop(MetaPid)
+    end,
+    {ok, _} = beamtalk_workspace_meta:start_link(#{
+        workspace_id => <<"loader_test_ws">>,
+        project_path => list_to_binary(Proj),
+        created_at => erlang:system_time(second)
+    }),
+    %% A live ChangeLog server lets do_emit_change_entry / emit_new_class_entry
+    %% append successfully instead of taking only their best-effort catch path.
+    case whereis(beamtalk_workspace_changelog) of
+        undefined ->
+            {ok, _} = beamtalk_workspace_changelog:start_link(#{
+                workspace_id => <<"loader_test_ws">>
+            });
+        _ ->
+            ok
+    end,
+    Proj.
+
+loader_teardown(Proj) ->
+    %% Stop the singleton servers this fixture started so later test modules
+    %% (e.g. beamtalk_workspace_changelog_tests, which start_link their own
+    %% registered server with a {ok, Pid} match) see a clean slate.
+    case whereis(beamtalk_workspace_changelog) of
+        undefined -> ok;
+        ClPid -> gen_server:stop(ClPid)
+    end,
+    case whereis(beamtalk_workspace_meta) of
+        undefined -> ok;
+        MetaPid -> gen_server:stop(MetaPid)
+    end,
+    %% Best-effort recursive cleanup of the temp project directory.
+    rm_rf(Proj),
+    ok.
+
+rm_rf(Path) ->
+    case filelib:is_dir(Path) of
+        true ->
+            case file:list_dir(Path) of
+                {ok, Entries} ->
+                    lists:foreach(fun(E) -> rm_rf(filename:join(Path, E)) end, Entries),
+                    file:del_dir(Path);
+                {error, _} ->
+                    ok
+            end;
+        false ->
+            file:delete(Path)
+    end.
+
+%% Write a .bt file inside the project src dir and return its absolute path.
+write_bt(Proj, Name, Source) ->
+    Path = filename:join(Proj, Name),
+    ok = file:write_file(Path, Source),
+    Path.
+
+loader_integration_test_() ->
+    {setup, fun loader_setup/0, fun loader_teardown/1, fun(Proj) ->
+        [
+            {"handle_load/2 success", fun() -> t_handle_load_success(Proj) end},
+            {"handle_load/3 prebuilt indexes success", fun() ->
+                t_handle_load_prebuilt_success(Proj)
+            end},
+            {"handle_load_source/3 success", fun() -> t_handle_load_source_success() end},
+            {"load_class_module/3 success", fun() -> t_load_class_module_success(Proj) end},
+            {"reload_class_file/1 success", fun() -> t_reload_class_file_success(Proj) end},
+            {"reload_class_file/2 matching class", fun() ->
+                t_reload_class_file_2_match(Proj)
+            end},
+            {"reload_class_file/2 class mismatch", fun() ->
+                t_reload_class_file_2_mismatch(Proj)
+            end},
+            {"reload_method_definition success", fun() ->
+                t_reload_method_definition_success(Proj)
+            end},
+            {"reload_method_definition no source", fun() ->
+                t_reload_method_definition_no_source()
+            end},
+            {"reload_method_definition compile error", fun() ->
+                t_reload_method_definition_compile_error(Proj)
+            end},
+            {"new_class/2 success", fun() -> t_new_class_success(Proj) end},
+            {"new_class/2 target exists", fun() -> t_new_class_target_exists(Proj) end},
+            {"new_class/2 outside project", fun() -> t_new_class_outside_project() end},
+            {"new_class/2 name mismatch", fun() -> t_new_class_name_mismatch(Proj) end},
+            {"new_class/2 already loaded", fun() -> t_new_class_already_loaded(Proj) end},
+            {"new_class/2 compile error", fun() -> t_new_class_compile_error(Proj) end},
+            {"compute_package_module_name with metadata", fun() ->
+                t_compute_package_module_name(Proj)
+            end},
+            {"compute_package_module_name test dir", fun() ->
+                t_compute_package_module_name_test_dir(Proj)
+            end},
+            {"compute_package_module_name outside subdirs", fun() ->
+                t_compute_package_module_name_outside_subdirs(Proj)
+            end},
+            {"new_class/2 multiple classes", fun() -> t_new_class_multiple_classes(Proj) end},
+            {"new_class/2 agent author", fun() -> t_new_class_agent_author(Proj) end},
+            {"handle_load/2 protocol", fun() -> t_handle_load_protocol(Proj) end},
+            {"handle_load/3 protocol", fun() -> t_handle_load_3_protocol(Proj) end},
+            {"new_class/2 author_kind only", fun() -> t_new_class_author_kind_only(Proj) end},
+            {"handle_load_source/3 protocol", fun() -> t_handle_load_source_protocol() end},
+            {"reload_class_file/1 protocol", fun() -> t_reload_class_file_protocol(Proj) end},
+            {"reload_method_definition existing method span", fun() ->
+                t_reload_method_definition_existing(Proj)
+            end},
+            {"reload_method_definition autoflush", fun() ->
+                t_reload_method_definition_autoflush(Proj)
+            end}
+        ]
+    end}.
+
+t_handle_load_success(Proj) ->
+    Path = write_bt(Proj, "LoaderOne.bt", <<"Object subclass: LoaderOne\n  value => 42\n">>),
+    State = beamtalk_repl_state:new(undefined, 0),
+    {ok, ClassNames, NewState} = beamtalk_repl_loader:handle_load(Path, State),
+    ?assertEqual([#{name => "LoaderOne", superclass => "Object"}], ClassNames),
+    %% The compiled module is recorded in the loaded-modules list.
+    ?assert(length(beamtalk_repl_state:get_loaded_modules(NewState)) >= 1).
+
+t_handle_load_prebuilt_success(Proj) ->
+    Path = write_bt(Proj, "LoaderTwo.bt", <<"Object subclass: LoaderTwo\n  v => 1\n">>),
+    State = beamtalk_repl_state:new(undefined, 0),
+    %% Empty prebuilt indexes still exercise the /3 arity path.
+    {ok, ClassNames, _NewState} = beamtalk_repl_loader:handle_load(Path, State, #{}),
+    ?assertEqual([#{name => "LoaderTwo", superclass => "Object"}], ClassNames).
+
+t_handle_load_source_success() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    {ok, ClassNames, _NewState} = beamtalk_repl_loader:handle_load_source(
+        <<"Object subclass: LoaderInline\n  v => 9\n">>, "inline", State
+    ),
+    ?assertEqual([#{name => "LoaderInline", superclass => "Object"}], ClassNames).
+
+t_load_class_module_success(Proj) ->
+    %% Compile a class to obtain a real binary + module name, then drive
+    %% load_class_module/3 directly with a ClassInfo map.
+    Path = write_bt(Proj, "LoaderThree.bt", <<"Object subclass: LoaderThree\n  v => 3\n">>),
+    {ok, Source} = file:read_file(Path),
+    {ok, Binary, ClassNames, ModuleName} = beamtalk_repl_compiler:compile_file(
+        binary_to_list(Source), Path, false, undefined
+    ),
+    ClassInfo = #{binary => Binary, module_name => ModuleName, classes => ClassNames},
+    State = beamtalk_repl_state:new(undefined, 0),
+    {ok, ClassName, Trailing, _NewState} = beamtalk_repl_loader:load_class_module(
+        ClassInfo, "Object subclass: LoaderThree", State
+    ),
+    ?assertEqual(<<"LoaderThree">>, ClassName),
+    ?assertEqual(no_trailing, Trailing).
+
+t_reload_class_file_success(Proj) ->
+    Path = write_bt(Proj, "LoaderReload.bt", <<"Object subclass: LoaderReload\n  v => 7\n">>),
+    Result = beamtalk_repl_loader:reload_class_file(Path),
+    ?assertMatch({ok, [#{name := "LoaderReload"}]}, Result).
+
+t_reload_class_file_2_match(Proj) ->
+    Path = write_bt(Proj, "LoaderRl2.bt", <<"Object subclass: LoaderRl2\n  v => 1\n">>),
+    Result = beamtalk_repl_loader:reload_class_file(Path, 'LoaderRl2'),
+    ?assertMatch({ok, [#{name := "LoaderRl2"}]}, Result).
+
+t_reload_class_file_2_mismatch(Proj) ->
+    Path = write_bt(Proj, "LoaderRl3.bt", <<"Object subclass: LoaderRl3\n  v => 1\n">>),
+    %% Expected class name does not appear in the compiled class list → error.
+    Result = beamtalk_repl_loader:reload_class_file(Path, 'NotThere'),
+    ?assertMatch({error, {class_not_found, 'NotThere', _, ["LoaderRl3"]}}, Result).
+
+t_reload_method_definition_success(Proj) ->
+    %% Load the class first so its source is recorded in workspace_meta, then
+    %% patch a new method. This exercises recompile_with_method,
+    %% load_recompiled_method, emit_change_entry and the flushability helpers.
+    Path = write_bt(Proj, "LoaderMethod.bt", <<"Object subclass: LoaderMethod\n  v => 1\n">>),
+    State0 = beamtalk_repl_state:new(undefined, 0),
+    {ok, _, State1} = beamtalk_repl_loader:handle_load(Path, State0),
+    MethodInfo = #{class_name => <<"LoaderMethod">>, selector => <<"doubled">>},
+    Result = beamtalk_repl_loader:reload_method_definition(
+        MethodInfo, [], "LoaderMethod >> doubled => self.v * 2", State1
+    ),
+    {ok, Display, EmptyBin, _Warnings, _NewState} = Result,
+    ?assertEqual(<<"LoaderMethod>>doubled">>, Display),
+    ?assertEqual(<<>>, EmptyBin).
+
+t_reload_method_definition_no_source() ->
+    %% No class source recorded for this name → compile_error, empty binary.
+    MethodInfo = #{class_name => <<"NoSuchClassForReload9999">>, selector => <<"foo">>},
+    State = beamtalk_repl_state:new(undefined, 0),
+    Result = beamtalk_repl_loader:reload_method_definition(
+        MethodInfo, [<<"w">>], "foo => 1", State
+    ),
+    ?assertMatch({error, {compile_error, _}, <<>>, [<<"w">>], _}, Result).
+
+t_reload_method_definition_compile_error(Proj) ->
+    %% A class with recorded source, but a method body that fails to recompile,
+    %% takes the {error, Reason} branch of recompile_with_method.
+    Path = write_bt(Proj, "LoaderBadM.bt", <<"Object subclass: LoaderBadM\n  v => 1\n">>),
+    State0 = beamtalk_repl_state:new(undefined, 0),
+    {ok, _, State1} = beamtalk_repl_loader:handle_load(Path, State0),
+    MethodInfo = #{class_name => <<"LoaderBadM">>, selector => <<"broken">>},
+    Result = beamtalk_repl_loader:reload_method_definition(
+        MethodInfo, [], "LoaderBadM >> broken => @@@ invalid @@@", State1
+    ),
+    ?assertMatch({error, _, <<>>, [], _}, Result).
+
+%% Read the live workspace project_path so new-class targets land inside the
+%% project tree that classify_source_file/1 actually checks (robust against any
+%% workspace_meta restart between setup and test execution).
+live_project_dir() ->
+    {ok, #{project_path := PP}} = beamtalk_workspace_meta:get_metadata(),
+    binary_to_list(PP).
+
+t_new_class_success(_Proj) ->
+    Proj = live_project_dir(),
+    Name = "NewClassOk" ++ integer_to_list(erlang:unique_integer([positive])),
+    Path = filename:join(Proj, Name ++ ".bt"),
+    file:delete(Path),
+    Src = "Object subclass: " ++ Name ++ "\n  greet => 1\n",
+    Result = beamtalk_repl_loader:new_class(list_to_binary(Src), list_to_binary(Path)),
+    ?assertMatch({ok, [_ | _]}, Result).
+
+t_new_class_target_exists(_Proj) ->
+    Proj = live_project_dir(),
+    Path = filename:join(Proj, "NewClassExists.bt"),
+    ok = file:write_file(Path, <<"placeholder">>),
+    {error, Err} = beamtalk_repl_loader:new_class(
+        <<"Object subclass: NewClassExists">>, list_to_binary(Path)
+    ),
+    ?assertEqual(target_exists, Err#beamtalk_error.kind).
+
+t_new_class_outside_project() ->
+    %% A path outside the workspace project_path is rejected before compiling.
+    Tmp = unicode:characters_to_list(beamtalk_file:'tempDirectory'()),
+    Path =
+        Tmp ++ "/bt_outside_" ++ integer_to_list(erlang:unique_integer([positive])) ++
+            "/Outsider.bt",
+    {error, Err} = beamtalk_repl_loader:new_class(
+        <<"Object subclass: Outsider">>, list_to_binary(Path)
+    ),
+    ?assertEqual(target_outside_project, Err#beamtalk_error.kind).
+
+t_new_class_name_mismatch(_Proj) ->
+    Proj = live_project_dir(),
+    %% Declared class name does not match the file basename.
+    Path = filename:join(Proj, "MismatchFile.bt"),
+    file:delete(Path),
+    {error, Err} = beamtalk_repl_loader:new_class(
+        <<"Object subclass: SomethingElse\n  v => 1\n">>, list_to_binary(Path)
+    ),
+    ?assertEqual(class_name_mismatch, Err#beamtalk_error.kind).
+
+t_new_class_already_loaded(_Proj) ->
+    Proj = live_project_dir(),
+    %% Create a class, then attempt to create it again at a fresh path → the
+    %% name is already loaded in the registry.
+    Name = "NewClassDup" ++ integer_to_list(erlang:unique_integer([positive])),
+    Path1 = filename:join(Proj, Name ++ ".bt"),
+    file:delete(Path1),
+    Src = "Object subclass: " ++ Name ++ "\n  v => 1\n",
+    {ok, _} = beamtalk_repl_loader:new_class(list_to_binary(Src), list_to_binary(Path1)),
+    %% Second attempt at a different in-project path whose basename equals the
+    %% class name (so the name check passes) reaches the already-loaded branch.
+    Path3 = filename:join(filename:join(Proj, "sub"), Name ++ ".bt"),
+    ok = filelib:ensure_dir(Path3),
+    file:delete(Path3),
+    {error, Err} = beamtalk_repl_loader:new_class(list_to_binary(Src), list_to_binary(Path3)),
+    ?assertEqual(class_already_loaded, Err#beamtalk_error.kind).
+
+t_new_class_compile_error(_Proj) ->
+    Proj = live_project_dir(),
+    Path = filename:join(Proj, "BadNewClass.bt"),
+    file:delete(Path),
+    {error, Err} = beamtalk_repl_loader:new_class(
+        <<"@@@ not valid beamtalk @@@">>, list_to_binary(Path)
+    ),
+    %% Compile failure is surfaced as a structured #beamtalk_error{}.
+    ?assert(is_record(Err, beamtalk_error)).
+
+t_compute_package_module_name(_Proj) ->
+    %% With workspace_meta carrying a project_path AND a package name (from the
+    %% beamtalk.toml written in setup), a file under src/ resolves to a
+    %% package-qualified module name bt@loaderpkg@widget.
+    Proj = live_project_dir(),
+    Path = filename:join([Proj, "src", "Widget.bt"]),
+    Result = beamtalk_repl_loader:compute_package_module_name(Path),
+    ?assertEqual(<<"bt@loaderpkg@widget">>, Result).
+
+t_compute_package_module_name_test_dir(_Proj) ->
+    %% A file under test/ resolves to bt@loaderpkg@test@<module>.
+    Proj = live_project_dir(),
+    Path = filename:join([Proj, "test", "WidgetTest.bt"]),
+    Result = beamtalk_repl_loader:compute_package_module_name(Path),
+    ?assertEqual(<<"bt@loaderpkg@test@widget_test">>, Result).
+
+t_compute_package_module_name_outside_subdirs(_Proj) ->
+    %% A file in the project root but outside src/ and test/ falls back to the
+    %% bt@<stem> form via stem_module_name/1.
+    Proj = live_project_dir(),
+    Path = filename:join([Proj, "Widget.bt"]),
+    Result = beamtalk_repl_loader:compute_package_module_name(Path),
+    ?assertEqual(<<"bt@widget">>, Result).
+
+t_new_class_agent_author(_Proj) ->
+    %% When the submission boundary stamps $beamtalk_author / $beamtalk_author_kind
+    %% into the process dictionary, emit_new_class_entry records them. This drives
+    %% new_class_author/0 and new_class_author_kind/0's agent branches.
+    Proj = live_project_dir(),
+    Name = "AgentClass" ++ integer_to_list(erlang:unique_integer([positive])),
+    Path = filename:join(Proj, Name ++ ".bt"),
+    file:delete(Path),
+    erlang:put('$beamtalk_author', <<"agent">>),
+    erlang:put('$beamtalk_author_kind', agent),
+    try
+        Src = "Object subclass: " ++ Name ++ "\n  v => 1\n",
+        Result = beamtalk_repl_loader:new_class(list_to_binary(Src), list_to_binary(Path)),
+        ?assertMatch({ok, [_ | _]}, Result)
+    after
+        erlang:erase('$beamtalk_author'),
+        erlang:erase('$beamtalk_author_kind')
+    end.
+
+t_handle_load_protocol(Proj) ->
+    %% A protocol definition file routes through load_protocol_module/3 instead
+    %% of the class path (the {ok, protocol_definition, ...} compile result).
+    Path = write_bt(
+        Proj, "GreetableProto.bt", <<"Protocol define: GreetableProto\n  greet -> String\n">>
+    ),
+    State = beamtalk_repl_state:new(undefined, 0),
+    {ok, ClassNames, NewState} = beamtalk_repl_loader:handle_load(Path, State),
+    ?assertEqual([#{name => "GreetableProto", superclass => "Object"}], ClassNames),
+    ?assert(length(beamtalk_repl_state:get_loaded_modules(NewState)) >= 1).
+
+t_handle_load_3_protocol(Proj) ->
+    %% Protocol routing through the /3 (prebuilt-indexes) arity.
+    Path = write_bt(
+        Proj, "Greetable3Proto.bt", <<"Protocol define: Greetable3Proto\n  hi -> String\n">>
+    ),
+    State = beamtalk_repl_state:new(undefined, 0),
+    {ok, ClassNames, _NewState} = beamtalk_repl_loader:handle_load(Path, State, #{}),
+    ?assertEqual([#{name => "Greetable3Proto", superclass => "Object"}], ClassNames).
+
+t_new_class_author_kind_only(_Proj) ->
+    %% Only $beamtalk_author_kind is set (no explicit $beamtalk_author): the
+    %% default-author path maps the agent kind to <<"agent">> (line in
+    %% new_class_default_author/0).
+    Proj = live_project_dir(),
+    Name = "KindOnly" ++ integer_to_list(erlang:unique_integer([positive])),
+    Path = filename:join(Proj, Name ++ ".bt"),
+    file:delete(Path),
+    erlang:put('$beamtalk_author_kind', agent),
+    try
+        Src = "Object subclass: " ++ Name ++ "\n  v => 1\n",
+        Result = beamtalk_repl_loader:new_class(list_to_binary(Src), list_to_binary(Path)),
+        ?assertMatch({ok, [_ | _]}, Result)
+    after
+        erlang:erase('$beamtalk_author_kind')
+    end.
+
+t_handle_load_source_protocol() ->
+    State = beamtalk_repl_state:new(undefined, 0),
+    {ok, ClassNames, _NewState} = beamtalk_repl_loader:handle_load_source(
+        <<"Protocol define: InlineProto\n  tick -> Integer\n">>, "inline-proto", State
+    ),
+    ?assertEqual([#{name => "InlineProto", superclass => "Object"}], ClassNames).
+
+t_reload_class_file_protocol(Proj) ->
+    %% Stateless reload of a protocol file → load_protocol_module_stateless/2.
+    Path = write_bt(
+        Proj, "ReloadProto.bt", <<"Protocol define: ReloadProto\n  ping -> Boolean\n">>
+    ),
+    Result = beamtalk_repl_loader:reload_class_file(Path),
+    ?assertMatch({ok, [#{name := "ReloadProto"}]}, Result).
+
+t_new_class_multiple_classes(_Proj) ->
+    %% A source declaring two classes is rejected by declared_class_name/1,
+    %% surfacing through new_class_validate_and_install's NameErr passthrough.
+    Proj = live_project_dir(),
+    Path = filename:join(Proj, "MultiClass.bt"),
+    file:delete(Path),
+    Src = "Object subclass: MultiClass\n  v => 1\nObject subclass: SecondClass\n  w => 2\n",
+    Result = beamtalk_repl_loader:new_class(list_to_binary(Src), list_to_binary(Path)),
+    ?assertMatch({error, _}, Result).
+
+t_reload_method_definition_existing(_Proj) ->
+    Proj = live_project_dir(),
+    %% Patch a method that already exists on disk. The flushability path then
+    %% reads the disk source and resolves the method span (prev_source + span),
+    %% exercising resolve_span_entry's success branch.
+    Path = write_bt(
+        Proj,
+        "LoaderExisting.bt",
+        <<"Object subclass: LoaderExisting\n  value => 1\n  doubled => self.value * 2\n">>
+    ),
+    State0 = beamtalk_repl_state:new(undefined, 0),
+    {ok, _, State1} = beamtalk_repl_loader:handle_load(Path, State0),
+    MethodInfo = #{class_name => <<"LoaderExisting">>, selector => <<"doubled">>},
+    Result = beamtalk_repl_loader:reload_method_definition(
+        MethodInfo, [], "LoaderExisting >> doubled => self.value * 3", State1
+    ),
+    ?assertMatch({ok, <<"LoaderExisting>>doubled">>, <<>>, _, _}, Result).
+
+t_reload_method_definition_autoflush(Proj) ->
+    %% With autoflush enabled, a durable method patch triggers do_autoflush/0.
+    %% The flush is best-effort; we only assert the patch itself succeeds.
+    ok = beamtalk_workspace_meta:set_setting(autoflush, true),
+    try
+        Path = write_bt(
+            Proj, "LoaderFlush.bt", <<"Object subclass: LoaderFlush\n  value => 1\n">>
+        ),
+        State0 = beamtalk_repl_state:new(undefined, 0),
+        {ok, _, State1} = beamtalk_repl_loader:handle_load(Path, State0),
+        MethodInfo = #{class_name => <<"LoaderFlush">>, selector => <<"tripled">>},
+        Result = beamtalk_repl_loader:reload_method_definition(
+            MethodInfo, [], "LoaderFlush >> tripled => self.value * 3", State1
+        ),
+        ?assertMatch({ok, <<"LoaderFlush>>tripled">>, <<>>, _, _}, Result)
+    after
+        beamtalk_workspace_meta:set_setting(autoflush, false)
     end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
@@ -732,6 +732,10 @@ loader_teardown(Proj) ->
         undefined -> ok;
         MetaPid -> gen_server:stop(MetaPid)
     end,
+    %% Stop the compiler app so later test modules in the shared EUnit node see
+    %% the baseline "compiler not running" state (noproc error-path tests in
+    %% beamtalk_repl_eval_tests depend on it).
+    _ = application:stop(beamtalk_compiler),
     %% Best-effort recursive cleanup of the temp project directory.
     rm_rf(Proj),
     ok.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl
@@ -840,3 +840,832 @@ parse_bare_qualified_name_test() ->
 
 %% dedupe_keyword_aliases and format_beamtalk_signature tests moved to
 %% beamtalk_erlang_help_tests.erl (these functions were extracted in BT-1903).
+
+%%====================================================================
+%% handle/4 -- erlang-help op (BT-1852)
+%%====================================================================
+
+erlang_help_missing_module_returns_error_test() ->
+    %% Empty module binary -> "Module name required" error.
+    Msg = make_msg(<<"erlang-help">>, <<"eh-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"erlang-help">>, #{<<"module">> => <<>>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ErrMsg = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrMsg, <<"Module name required">>)).
+
+erlang_help_unknown_module_returns_not_found_test() ->
+    %% A module name that is not an existing atom -> badarg -> not-found error.
+    Msg = make_msg(<<"erlang-help">>, <<"eh-2">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"erlang-help">>,
+        #{<<"module">> => <<"no_such_erlang_module_xyz99999">>},
+        Msg,
+        self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ErrMsg = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrMsg, <<"not found">>)).
+
+erlang_help_known_module_returns_docs_test() ->
+    %% `lists` is always loaded; format_module_help should succeed and return docs.
+    Msg = make_msg(<<"erlang-help">>, <<"eh-3">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"erlang-help">>, #{<<"module">> => <<"lists">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    %% Success path encodes docs (no error key).
+    ?assertEqual(false, maps:is_key(<<"error">>, Decoded)).
+
+erlang_help_known_module_unknown_function_returns_error_test() ->
+    %% Known module, function that does not exist -> function not-found error.
+    Msg = make_msg(<<"erlang-help">>, <<"eh-4">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"erlang-help">>,
+        #{<<"module">> => <<"lists">>, <<"function">> => <<"no_such_fn_xyz99999">>},
+        Msg,
+        self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ErrMsg = maps:get(<<"error">>, Decoded),
+    %% Hint mentions using :help Erlang <module> to list functions.
+    ?assertNotEqual(nomatch, binary:match(ErrMsg, <<"not found">>)).
+
+erlang_help_known_module_known_function_returns_docs_test() ->
+    %% `lists:map/2` exists -> function help succeeds.
+    Msg = make_msg(<<"erlang-help">>, <<"eh-5">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"erlang-help">>,
+        #{<<"module">> => <<"lists">>, <<"function">> => <<"map">>},
+        Msg,
+        self()
+    ),
+    Decoded = json:decode(Result),
+    ?assertEqual(false, maps:is_key(<<"error">>, Decoded)).
+
+%%====================================================================
+%% handle/4 -- erlang-complete op (BT-1903)
+%%====================================================================
+
+erlang_complete_module_prefix_test() ->
+    %% No module param -> complete module names by prefix. "list" should match "lists".
+    Msg = make_msg(<<"erlang-complete">>, <<"ec-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"erlang-complete">>, #{<<"prefix">> => <<"list">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    Completions = maps:get(<<"completions">>, Decoded),
+    ?assert(is_list(Completions)),
+    ?assertEqual([<<"done">>], maps:get(<<"status">>, Decoded)),
+    %% Every completion must start with the requested prefix.
+    lists:foreach(
+        fun(C) -> ?assertEqual({0, 4}, binary:match(C, <<"list">>)) end,
+        Completions
+    ).
+
+erlang_complete_function_prefix_loaded_module_test() ->
+    %% Module given + already loaded -> complete its exported function names.
+    %% `lists` is loaded; functions like `map`, `member` start with "m".
+    Msg = make_msg(<<"erlang-complete">>, <<"ec-2">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"erlang-complete">>,
+        #{<<"prefix">> => <<"m">>, <<"module">> => <<"lists">>},
+        Msg,
+        self()
+    ),
+    Decoded = json:decode(Result),
+    Completions = maps:get(<<"completions">>, Decoded),
+    ?assert(is_list(Completions)),
+    %% module_info must be filtered out, and all results start with "m".
+    ?assertEqual(false, lists:member(<<"module_info">>, Completions)),
+    lists:foreach(
+        fun(C) -> ?assertEqual({0, 1}, binary:match(C, <<"m">>)) end,
+        Completions
+    ),
+    %% `map` is a well-known lists export.
+    ?assert(lists:member(<<"map">>, Completions)).
+
+erlang_complete_unknown_module_returns_empty_test() ->
+    %% Module name that is not an existing atom -> badarg -> empty completions.
+    Msg = make_msg(<<"erlang-complete">>, <<"ec-3">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"erlang-complete">>,
+        #{<<"prefix">> => <<"x">>, <<"module">> => <<"no_such_mod_xyz99999">>},
+        Msg,
+        self()
+    ),
+    Decoded = json:decode(Result),
+    ?assertEqual([], maps:get(<<"completions">>, Decoded)).
+
+erlang_complete_legacy_format_test() ->
+    %% Legacy protocol returns a top-level "completions" type response.
+    Msg = make_msg(<<"erlang-complete">>, undefined, undefined, true),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"erlang-complete">>, #{<<"prefix">> => <<"list">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assertEqual(<<"completions">>, maps:get(<<"type">>, Decoded)),
+    ?assert(is_list(maps:get(<<"completions">>, Decoded))).
+
+%%====================================================================
+%% handle/4 -- test / test-all op validation (BT no runtime)
+%%====================================================================
+
+handle_test_class_and_file_mutually_exclusive_test() ->
+    %% Both class and file given -> mutually-exclusive error.
+    Msg = make_msg(<<"test">>, <<"t-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"test">>,
+        #{<<"class">> => <<"FooTest">>, <<"file">> => <<"foo.bt">>},
+        Msg,
+        self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ErrMsg = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrMsg, <<"mutually exclusive">>)).
+
+handle_test_file_not_binary_test() ->
+    %% file param that is not a binary -> "'file' must be a binary path" error.
+    Msg = make_msg(<<"test">>, <<"t-2">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"test">>, #{<<"file">> => 12345}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ErrMsg = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrMsg, <<"binary path">>)).
+
+handle_test_unknown_class_returns_class_not_found_test() ->
+    %% A class name that has never been loaded as an atom -> class-not-found error.
+    Msg = make_msg(<<"test">>, <<"t-3">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"test">>, #{<<"class">> => <<"NoSuchTestClassXyz99999">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ErrMsg = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrMsg, <<"Unknown class">>)).
+
+%%====================================================================
+%% handle/4 -- list-classes filter validation (BT-1404)
+%%====================================================================
+
+handle_list_classes_unknown_filter_returns_error_test() ->
+    %% A filter that is not stdlib/user and not an existing atom -> argument error.
+    Msg = make_msg(<<"list-classes">>, <<"lc-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"list-classes">>,
+        #{<<"filter">> => <<"NoSuchFilterClassXyz99999">>},
+        Msg,
+        self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ErrMsg = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrMsg, <<"Unknown filter">>)).
+
+%%====================================================================
+%% encode helpers: encode_codegen_response via show-codegen success path
+%%====================================================================
+
+%% validate_list_classes_filter/1 is internal; its observable behaviour is
+%% exercised through handle(<<"list-classes">>, ...). The success branch with
+%% an empty registry is covered by the fixture-based list-classes tests below.
+
+%%====================================================================
+%% Fixture: a live class registry with real classes (exercises the
+%% completion + reflection + show-codegen-class paths).
+%%====================================================================
+
+dev_runtime_test_() ->
+    {setup, fun setup_dev_runtime/0, fun teardown_dev_runtime/1, fun(_) ->
+        [
+            {"complete legacy with class prefix", fun complete_legacy_class_prefix_returns_class/0},
+            {"get_completions matches registered class", fun get_completions_matches_class/0},
+            {"get_completions includes builtin keyword", fun get_completions_includes_keyword/0},
+            {"context completion: class receiver -> class methods",
+                fun context_completion_class_receiver/0},
+            {"context completion: class receiver empty prefix",
+                fun context_completion_class_empty_prefix/0},
+            {"context completion: integer literal receiver",
+                fun context_completion_integer_literal/0},
+            {"context completion: string literal receiver",
+                fun context_completion_string_literal/0},
+            {"context completion: binding receiver", fun context_completion_binding_receiver/0},
+            {"context completion: unknown lowercase receiver -> empty",
+                fun context_completion_unknown_lowercase/0},
+            {"methods op returns instance + class methods", fun methods_op_returns_methods/0},
+            {"methods op returns state vars", fun methods_op_returns_state_vars/0},
+            {"list_class_methods_for_ws includes inherited side tags",
+                fun list_class_methods_known_class/0},
+            {"list-classes op returns the registered class", fun list_classes_op_returns_class/0},
+            {"list-classes filter stdlib excludes non-stdlib class",
+                fun list_classes_filter_stdlib/0},
+            {"list-classes superclass filter", fun list_classes_superclass_filter/0},
+            {"show-codegen class: selector not found error",
+                fun show_codegen_class_selector_not_found/0},
+            {"validate_selector_if_present known selector -> ok", fun validate_selector_known/0},
+            {"validate_selector_if_present unknown selector -> error",
+                fun validate_selector_unknown/0},
+            {"classify class receiver via get_methods_for_receiver",
+                fun get_methods_for_receiver_class/0},
+            {"resolve_chain_type class side via registry", fun resolve_chain_type_class_side/0},
+            {"show-codegen class without selector compiles source",
+                fun show_codegen_class_compiles_source/0},
+            {"cross-package internal class excluded from completions",
+                fun completions_exclude_cross_package_internal/0},
+            {"expression completion: class chain -> instance methods",
+                fun context_completion_expression_instance_methods/0},
+            {"expression completion: class-side chain -> class methods",
+                fun context_completion_expression_class_methods/0},
+            {"expression completion: unresolvable chain -> empty",
+                fun context_completion_expression_unresolvable/0},
+            {"methods op via package-qualified class name",
+                fun list_class_methods_qualified_name/0},
+            {"test op for a known (non-TestCase) class returns a response",
+                fun test_op_known_class_returns_response/0},
+            {"walk_chain follows instance return type", fun walk_chain_follows_return_type/0},
+            {"walk_chain instance-then-class transition", fun walk_chain_instance_then_class/0},
+            {"walk_chain_class first hop transitions to instance",
+                fun walk_chain_class_first_hop_instance/0},
+            {"walk_mixed_chain unary class transition",
+                fun walk_mixed_chain_unary_class_transition/0},
+            {"walk_mixed_chain_class first hop transitions to instance",
+                fun walk_mixed_chain_class_first_hop_instance/0},
+            {"resolve_chain_type instance chain via registry",
+                fun resolve_chain_type_instance_chain/0},
+            {"expression completion empty prefix lists all instance methods",
+                fun context_completion_expression_empty_prefix/0},
+            {"uppercase binding (non-class) classifies via binding",
+                fun classify_uppercase_binding/0},
+            {"qualified @ receiver classifies as class",
+                fun context_completion_qualified_receiver/0},
+            {"list-classes user filter includes user class",
+                fun list_classes_user_filter_includes/0},
+            {"single-line doc surfaces verbatim in list-classes",
+                fun list_classes_single_line_doc/0}
+        ]
+    end}.
+
+context_completion_expression_empty_prefix() ->
+    %% "WidgetDev create " — resolved instance receiver with empty prefix returns
+    %% all instance methods (filter_by_prefix empty-prefix usort branch).
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"WidgetDev create ">>),
+    ?assert(lists:member(<<"render">>, Result)),
+    ?assert(lists:member(<<"resize">>, Result)),
+    ?assert(lists:member(<<"next">>, Result)).
+
+classify_uppercase_binding() ->
+    %% `Transcript` is an existing atom but not a registered class here, so the
+    %% uppercase branch of classify_receiver falls back to the binding lookup.
+    %% The binding holds an integer (primitive_class_of → 'Integer'), and the
+    %% Integer fixture class is registered, so completion offers Integer methods.
+    Bindings = #{'Transcript' => 99},
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"Transcript ab">>, Bindings),
+    ?assert(lists:member(<<"abs">>, Result)).
+
+context_completion_qualified_receiver() ->
+    %% "test@WidgetDev re" — the @-qualified receiver resolves to WidgetDev (a
+    %% class object), so class-side completions are offered. Exercises the
+    %% resolve_qualified_class_name branch inside classify_receiver/2.
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"test@WidgetDev cr">>),
+    ?assert(lists:member(<<"create">>, Result)).
+
+list_classes_user_filter_includes() ->
+    %% With WidgetDev registered under a non-stdlib module, the "user" filter
+    %% must include it (exercises should_include_class/4 not-stdlib branch).
+    Msg = make_msg(<<"list-classes">>, <<"lcui-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"list-classes">>, #{<<"filter">> => <<"user">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ClassList = maps:get(<<"class_list">>, Decoded),
+    Names = [maps:get(<<"name">>, C) || C <- ClassList],
+    ?assert(lists:member(<<"WidgetDev">>, Names)).
+
+list_classes_single_line_doc() ->
+    %% OneLineDocDev's doc has no newline; first_line/1 returns it verbatim.
+    Msg = make_msg(<<"list-classes">>, <<"lcd-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(<<"list-classes">>, #{}, Msg, self()),
+    Decoded = json:decode(Result),
+    ClassList = maps:get(<<"class_list">>, Decoded),
+    [Row] = [C || C <- ClassList, maps:get(<<"name">>, C) =:= <<"OneLineDocDev">>],
+    ?assertEqual(<<"Single line doc no newline">>, maps:get(<<"doc">>, Row)).
+
+walk_chain_follows_return_type() ->
+    %% next returns a WidgetDev instance, so walk_chain follows the hop.
+    ?assertEqual(
+        {ok, 'WidgetDev', instance},
+        beamtalk_repl_ops_dev:walk_chain('WidgetDev', [next])
+    ).
+
+walk_chain_instance_then_class() ->
+    %% "next class" — follow next (→ WidgetDev instance) then transition to class.
+    ?assertEqual(
+        {ok, 'WidgetDev', class},
+        beamtalk_repl_ops_dev:walk_chain('WidgetDev', [next, class])
+    ).
+
+walk_chain_class_first_hop_instance() ->
+    %% Class-side create returns a WidgetDev instance, so the chain switches
+    %% to the instance side for the remaining (empty) hops.
+    ?assertEqual(
+        {ok, 'WidgetDev', instance},
+        beamtalk_repl_ops_dev:walk_chain_class('WidgetDev', [create])
+    ).
+
+walk_mixed_chain_unary_class_transition() ->
+    %% {unary, class} after a resolvable hop transitions instance → class.
+    ?assertEqual(
+        {ok, 'WidgetDev', class},
+        beamtalk_repl_ops_dev:walk_mixed_chain('WidgetDev', [{unary, next}, {unary, class}])
+    ).
+
+walk_mixed_chain_class_first_hop_instance() ->
+    %% Class-side create returns an instance; mixed-chain-class switches sides.
+    ?assertEqual(
+        {ok, 'WidgetDev', instance},
+        beamtalk_repl_ops_dev:walk_mixed_chain_class('WidgetDev', [{unary, create}])
+    ).
+
+resolve_chain_type_instance_chain() ->
+    %% "WidgetDev create next" — class create → instance, then next → instance.
+    ?assertEqual(
+        {ok, 'WidgetDev', instance},
+        beamtalk_repl_ops_dev:resolve_chain_type(<<"WidgetDev create next">>, #{})
+    ).
+
+test_op_known_class_returns_response() ->
+    %% WidgetDev is a real registered class atom (so safe_to_existing_atom
+    %% succeeds), but it is not a TestCase subclass. run_test_op/2 therefore
+    %% runs the runner branch: it either returns test results or a structured
+    %% error — both are well-formed JSON with a status field. This exercises
+    %% the run_class_by_name path rather than the early class-not-found return.
+    Msg = make_msg(<<"test">>, <<"tk-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"test">>, #{<<"class">> => <<"WidgetDev">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(is_map(Decoded)),
+    ?assert(maps:is_key(<<"status">>, Decoded)).
+
+setup_dev_runtime() ->
+    case whereis(pg) of
+        undefined -> {ok, _} = pg:start_link();
+        _ -> ok
+    end,
+    beamtalk_class_registry:ensure_hierarchy_table(),
+    %% Base class (superclass) so the hierarchy walk has > 1 level.
+    {ok, BasePid} = beamtalk_object_class:start('WidgetDevBase', #{
+        name => 'WidgetDevBase',
+        module => 'bt@test@widget_dev_base',
+        superclass => none,
+        instance_methods => #{
+            'inheritedGreet' => #{block => fun(_, _) -> ok end, arity => 0}
+        }
+    }),
+    %% Concrete class with instance + class methods, fields, and a doc string.
+    {ok, WidgetPid} = beamtalk_object_class:start('WidgetDev', #{
+        name => 'WidgetDev',
+        module => 'bt@test@widget_dev',
+        superclass => 'WidgetDevBase',
+        doc => <<"A widget for dev tests.\nSecond line ignored.">>,
+        fields => [width, height],
+        instance_methods => #{
+            'render' => #{block => fun(_, _) -> ok end, arity => 0},
+            'resize' => #{block => fun(_, _, _) -> ok end, arity => 2},
+            'next' => #{block => fun(_, _) -> ok end, arity => 0}
+        },
+        method_return_types => #{
+            'next' => 'WidgetDev'
+        },
+        class_methods => #{
+            'create' => #{block => fun(_, _) -> ok end, arity => 0}
+        },
+        class_method_return_types => #{
+            'create' => 'WidgetDev'
+        }
+    }),
+    %% A class named "Integer" so a binding holding an integer (whose
+    %% primitive_class_of is 'Integer') classifies as an instance receiver,
+    %% and "String" for string-literal classification.
+    {ok, IntPid} = beamtalk_object_class:start('Integer', #{
+        name => 'Integer',
+        module => 'bt@test@integer_dev',
+        superclass => none,
+        instance_methods => #{
+            'abs' => #{block => fun(_, _) -> 0 end, arity => 0}
+        }
+    }),
+    {ok, StrPid} = beamtalk_object_class:start('String', #{
+        name => 'String',
+        module => 'bt@test@string_dev',
+        superclass => none,
+        instance_methods => #{
+            'asUppercase' => #{block => fun(_, _) -> ok end, arity => 0}
+        }
+    }),
+    %% ADR 0071 Phase 5: an internal class in a *named* package (test) — the REPL
+    %% runs in the implicit nil package, so this class must be filtered out of
+    %% cross-package completions (exercises is_cross_package_internal/1 true path).
+    {ok, HiddenPid} = beamtalk_object_class:start('HiddenDevWidget', #{
+        name => 'HiddenDevWidget',
+        module => 'bt@test@hidden_dev_widget',
+        superclass => none,
+        is_internal => true,
+        instance_methods => #{
+            'secret' => #{block => fun(_, _) -> ok end, arity => 0}
+        }
+    }),
+    %% A class whose doc has no newline, exercising first_line/1's no-split branch.
+    {ok, OneLinePid} = beamtalk_object_class:start('OneLineDocDev', #{
+        name => 'OneLineDocDev',
+        module => 'bt@test@one_line_doc_dev',
+        superclass => none,
+        doc => <<"Single line doc no newline">>,
+        instance_methods => #{}
+    }),
+    [BasePid, WidgetPid, IntPid, StrPid, HiddenPid, OneLinePid].
+
+teardown_dev_runtime(Pids) ->
+    lists:foreach(
+        fun(Pid) ->
+            case is_process_alive(Pid) of
+                true ->
+                    MRef = monitor(process, Pid),
+                    exit(Pid, kill),
+                    receive
+                        {'DOWN', MRef, process, Pid, _} -> ok
+                    after 1000 -> ok
+                    end;
+                false ->
+                    ok
+            end
+        end,
+        Pids
+    ).
+
+complete_legacy_class_prefix_returns_class() ->
+    %% Old protocol (no cursor): get_completions matches the class by prefix.
+    Msg = make_msg(<<"complete">>, undefined, undefined, true),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"complete">>, #{<<"code">> => <<"WidgetD">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    Completions = maps:get(<<"completions">>, Decoded),
+    ?assert(lists:member(<<"WidgetDev">>, Completions)).
+
+get_completions_matches_class() ->
+    Result = beamtalk_repl_ops_dev:get_completions(<<"WidgetD">>),
+    ?assert(lists:member(<<"WidgetDev">>, Result)),
+    %% A non-matching prefix yields no class names.
+    ?assertEqual(
+        false, lists:member(<<"WidgetDev">>, beamtalk_repl_ops_dev:get_completions(<<"Zzz">>))
+    ).
+
+get_completions_includes_keyword() ->
+    %% "sel" should match the builtin keyword "self".
+    Result = beamtalk_repl_ops_dev:get_completions(<<"sel">>),
+    ?assert(lists:member(<<"self">>, Result)).
+
+context_completion_class_receiver() ->
+    %% "WidgetDev cr" -> class-side method "create" plus ProtoObject methods.
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"WidgetDev cr">>),
+    ?assert(lists:member(<<"create">>, Result)).
+
+context_completion_class_empty_prefix() ->
+    %% "WidgetDev " (empty prefix) -> all class-side methods.
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"WidgetDev ">>),
+    ?assert(lists:member(<<"create">>, Result)).
+
+context_completion_integer_literal() ->
+    %% Integer literal receiver -> instance methods of Integer ("abs").
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"42 ab">>),
+    ?assert(lists:member(<<"abs">>, Result)).
+
+context_completion_string_literal() ->
+    %% String literal receiver -> String instance methods ("asUppercase").
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"\"hi\" asU">>),
+    ?assert(lists:member(<<"asUppercase">>, Result)).
+
+context_completion_binding_receiver() ->
+    %% A lowercase binding holding an integer classifies as Integer instance.
+    Bindings = #{n => 7},
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"n ab">>, Bindings),
+    ?assert(lists:member(<<"abs">>, Result)).
+
+context_completion_unknown_lowercase() ->
+    %% A lowercase identifier with no binding -> no receiver classification -> [].
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"undefinedvar re">>, #{}),
+    ?assertEqual([], Result).
+
+methods_op_returns_methods() ->
+    Msg = make_msg(<<"methods">>, <<"mm-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"methods">>, #{<<"class">> => <<"WidgetDev">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    Methods = maps:get(<<"methods">>, Decoded),
+    Names = [maps:get(<<"name">>, M) || M <- Methods],
+    ?assert(lists:member(<<"render">>, Names)),
+    ?assert(lists:member(<<"create">>, Names)),
+    %% Side tags must distinguish instance from class methods.
+    Sides = [maps:get(<<"side">>, M) || M <- Methods, maps:get(<<"name">>, M) =:= <<"create">>],
+    ?assertEqual([<<"class">>], Sides).
+
+methods_op_returns_state_vars() ->
+    Msg = make_msg(<<"methods">>, <<"mm-2">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"methods">>, #{<<"class">> => <<"WidgetDev">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    StateVars = maps:get(<<"state_vars">>, Decoded),
+    ?assertEqual([<<"height">>, <<"width">>], StateVars).
+
+list_class_methods_known_class() ->
+    Result = beamtalk_repl_ops_dev:list_class_methods_for_ws(<<"WidgetDev">>),
+    Names = [maps:get(<<"name">>, M) || M <- Result],
+    ?assert(lists:member(<<"render">>, Names)),
+    ?assert(lists:member(<<"resize">>, Names)),
+    ?assert(lists:member(<<"create">>, Names)).
+
+list_classes_op_returns_class() ->
+    Msg = make_msg(<<"list-classes">>, <<"lc-2">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(<<"list-classes">>, #{}, Msg, self()),
+    Decoded = json:decode(Result),
+    ?assertEqual([<<"done">>], maps:get(<<"status">>, Decoded)),
+    ClassList = maps:get(<<"class_list">>, Decoded),
+    Names = [maps:get(<<"name">>, C) || C <- ClassList],
+    ?assert(lists:member(<<"WidgetDev">>, Names)),
+    %% The WidgetDev row must carry the first line of its doc and its superclass.
+    [Row] = [C || C <- ClassList, maps:get(<<"name">>, C) =:= <<"WidgetDev">>],
+    ?assertEqual(<<"A widget for dev tests.">>, maps:get(<<"doc">>, Row)),
+    ?assertEqual(<<"WidgetDevBase">>, maps:get(<<"superclass">>, Row)),
+    ?assertEqual(0, maps:get(<<"actor_count">>, Row)).
+
+list_classes_filter_stdlib() ->
+    %% WidgetDev is registered with a non-stdlib module, so the stdlib filter
+    %% must exclude it.
+    Msg = make_msg(<<"list-classes">>, <<"lc-3">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"list-classes">>, #{<<"filter">> => <<"stdlib">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ClassList = maps:get(<<"class_list">>, Decoded),
+    Names = [maps:get(<<"name">>, C) || C <- ClassList],
+    ?assertEqual(false, lists:member(<<"WidgetDev">>, Names)).
+
+list_classes_superclass_filter() ->
+    %% Filtering by superclass WidgetDevBase should include WidgetDev (which
+    %% inherits from it) and exclude unrelated classes.
+    Msg = make_msg(<<"list-classes">>, <<"lc-4">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"list-classes">>, #{<<"filter">> => <<"WidgetDevBase">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    %% Success (not an error) — the filter resolves to an existing atom.
+    ?assertEqual(false, maps:is_key(<<"error">>, Decoded)),
+    ClassList = maps:get(<<"class_list">>, Decoded),
+    Names = [maps:get(<<"name">>, C) || C <- ClassList],
+    ?assert(lists:member(<<"WidgetDev">>, Names)),
+    ?assertEqual(false, lists:member(<<"Integer">>, Names)).
+
+show_codegen_class_selector_not_found() ->
+    %% Class exists, selector does not -> "Selector ... not found" error
+    %% (exercises validate_selector_if_present failure branch).
+    Msg = make_msg(<<"show-codegen">>, <<"scc-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"show-codegen">>,
+        #{<<"class">> => <<"WidgetDev">>, <<"selector">> => <<"noSuchSelectorXyz">>},
+        Msg,
+        self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ErrMsg = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrMsg, <<"not found">>)).
+
+validate_selector_known() ->
+    Pid = beamtalk_runtime_api:whereis_class('WidgetDev'),
+    Msg = make_msg(<<"show-codegen">>, <<"vs-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:validate_selector_if_present(
+        <<"WidgetDev">>, 'WidgetDev', Pid, <<"render">>, Msg
+    ),
+    ?assertEqual(ok, Result).
+
+validate_selector_unknown() ->
+    Pid = beamtalk_runtime_api:whereis_class('WidgetDev'),
+    Msg = make_msg(<<"show-codegen">>, <<"vs-2">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:validate_selector_if_present(
+        <<"WidgetDev">>, 'WidgetDev', Pid, <<"noSuchSelectorXyz">>, Msg
+    ),
+    ?assertMatch({error, _}, Result),
+    {error, Encoded} = Result,
+    Decoded = json:decode(Encoded),
+    ?assert(maps:is_key(<<"error">>, Decoded)).
+
+get_methods_for_receiver_class() ->
+    %% A class-name receiver with empty prefix returns class-side methods plus
+    %% ProtoObject instance methods, via get_context_completions.
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"WidgetDev ">>),
+    ?assert(lists:member(<<"create">>, Result)),
+    %% Instance-only methods (render) must NOT appear for a class-object receiver.
+    ?assertEqual(false, lists:member(<<"render">>, Result)).
+
+resolve_chain_type_class_side() ->
+    %% "WidgetDev create" — class-side send returning WidgetDev (instance).
+    Result = beamtalk_repl_ops_dev:resolve_chain_type(<<"WidgetDev create">>, #{}),
+    ?assertEqual({ok, 'WidgetDev', instance}, Result).
+
+completions_exclude_cross_package_internal() ->
+    %% HiddenDevWidget is internal and lives in the named package "test"; the
+    %% REPL's implicit nil package means it must be filtered from completions.
+    %% WidgetDev (public, package "test") is still offered.
+    Result = beamtalk_repl_ops_dev:get_completions(<<"">>),
+    %% Empty prefix short-circuits to []; use a matching prefix instead.
+    ?assertEqual([], Result),
+    Hidden = beamtalk_repl_ops_dev:get_completions(<<"HiddenDev">>),
+    ?assertEqual(false, lists:member(<<"HiddenDevWidget">>, Hidden)),
+    %% Sanity: the public class with the same package prefix IS offered.
+    Public = beamtalk_repl_ops_dev:get_completions(<<"WidgetD">>),
+    ?assert(lists:member(<<"WidgetDev">>, Public)).
+
+context_completion_expression_instance_methods() ->
+    %% Multi-token receiver "WidgetDev create" resolves (class-side create returns
+    %% a WidgetDev instance) → complete_instance_methods filters by "re".
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"WidgetDev create re">>),
+    ?assert(lists:member(<<"render">>, Result)),
+    ?assert(lists:member(<<"resize">>, Result)).
+
+context_completion_expression_class_methods() ->
+    %% "WidgetDev class cr" — `class` keeps the chain on the class side, so
+    %% complete_class_methods offers the class-side selector "create".
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"WidgetDev class cr">>),
+    ?assert(lists:member(<<"create">>, Result)).
+
+context_completion_expression_unresolvable() ->
+    %% A multi-token receiver whose type cannot be resolved (unknown selector,
+    %% no compiler) yields []. `WidgetDev render` — render has no return-type
+    %% annotation, so the chain breaks → undefined → [].
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"WidgetDev render xy">>),
+    ?assertEqual([], Result).
+
+list_class_methods_qualified_name() ->
+    %% Package-qualified name "test@WidgetDev" resolves to the WidgetDev class
+    %% (its module atom bt@test@widget_dev exists), exercising the qualified
+    %% branch of list_class_methods_for_ws/1.
+    Result = beamtalk_repl_ops_dev:list_class_methods_for_ws(<<"test@WidgetDev">>),
+    Names = [maps:get(<<"name">>, M) || M <- Result],
+    ?assert(lists:member(<<"render">>, Names)).
+
+show_codegen_class_compiles_source() ->
+    %% Class exists, no selector → compile_class_source/4 runs. The fixture
+    %% class has a synthetic module not on disk and no workspace_meta source,
+    %% so resolve_source_path returns "unknown" and we hit the no_source branch
+    %% producing a "No source" runtime error (rather than a class-not-found).
+    Msg = make_msg(<<"show-codegen">>, <<"scs-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"show-codegen">>, #{<<"class">> => <<"WidgetDev">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ErrMsg = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrMsg, <<"No source">>)).
+
+%%====================================================================
+%% Live REPL session: show-codegen `code` path + encode_codegen_response
+%%====================================================================
+
+session_codegen_test_() ->
+    {setup, fun setup_session/0, fun teardown_session/1, fun(Pid) ->
+        [
+            {"show-codegen code routes through the session code path", fun() ->
+                session_show_codegen_code_path(Pid)
+            end},
+            {"show-codegen code compile error returns structured error", fun() ->
+                session_show_codegen_code_error(Pid)
+            end}
+        ]
+    end}.
+
+setup_session() ->
+    application:ensure_all_started(beamtalk_runtime),
+    {ok, Pid} = beamtalk_repl_shell:start_link(<<"ops-dev-codegen-session">>),
+    Pid.
+
+teardown_session(Pid) ->
+    catch beamtalk_repl_shell:stop(Pid),
+    ok.
+
+session_show_codegen_code_path(Pid) ->
+    %% A non-empty `code` param with a live session routes handle/4 through the
+    %% code branch and into beamtalk_repl_shell:show_codegen/2. In the isolated
+    %% EUnit harness the Rust compiler port is unavailable, so show_codegen
+    %% returns {error, Reason, Warnings} which is wrapped into a structured
+    %% error response. (The success/encode_codegen_response path requires the
+    %% compiler port and is covered by the full integration suite.)
+    Msg = make_msg(<<"show-codegen">>, <<"scd-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"show-codegen">>, #{<<"code">> => <<"1 + 2">>}, Msg, Pid
+    ),
+    Decoded = json:decode(Result),
+    %% The response is a well-formed structured error (not a crash); the status
+    %% list always ends with the done marker.
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    Status = maps:get(<<"status">>, Decoded),
+    ?assert(lists:member(<<"done">>, Status)).
+
+session_show_codegen_code_error(Pid) ->
+    %% A syntactically invalid expression also flows through the code path's
+    %% error branch and returns a structured error.
+    Msg = make_msg(<<"show-codegen">>, <<"scd-2">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"show-codegen">>, #{<<"code">> => <<"@@@ invalid syntax @@@">>}, Msg, Pid
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)).
+
+%%====================================================================
+%% Additional coverage: cheap pure helpers + remaining handle branches
+%%====================================================================
+
+handle_complete_with_cursor_no_session_bindings_test() ->
+    %% New protocol with a "cursor" field exercises the binding-merge branch.
+    %% self() is not a real session, so get_session_bindings catches and returns
+    %% #{}; the merge still produces context completions (here: bare prefix → []).
+    Msg = make_msg(<<"complete">>, <<"cc-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"complete">>,
+        #{<<"code">> => <<>>, <<"cursor">> => 0},
+        Msg,
+        self()
+    ),
+    Decoded = json:decode(Result),
+    ?assertEqual([], maps:get(<<"completions">>, Decoded)),
+    ?assertEqual([<<"done">>], maps:get(<<"status">>, Decoded)).
+
+get_session_bindings_dead_pid_returns_empty_test() ->
+    %% A non-session pid (self) makes beamtalk_repl_shell:get_bindings throw,
+    %% which the helper catches, returning an empty map.
+    ?assertEqual(#{}, beamtalk_repl_ops_dev:get_session_bindings(self())).
+
+handle_test_all_returns_response_test() ->
+    %% test-all runs the (possibly empty) TestCase suite. With no TestCase
+    %% subclasses loaded it returns a structured test-results response; if the
+    %% runner raises, a structured error is returned. Either way it is a
+    %% well-formed JSON object — never a crash.
+    Msg = make_msg(<<"test-all">>, <<"ta-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(<<"test-all">>, #{}, Msg, self()),
+    Decoded = json:decode(Result),
+    ?assert(is_map(Decoded)),
+    ?assert(maps:is_key(<<"status">>, Decoded)).
+
+handle_test_file_returns_response_test() ->
+    %% A file path with no matching TestCase subclasses returns a well-formed
+    %% response (empty results or structured error), exercising run_test_op_file/2.
+    Msg = make_msg(<<"test">>, <<"tf-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"test">>, #{<<"file">> => <<"no_such_file_xyz99999.bt">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(is_map(Decoded)),
+    ?assert(maps:is_key(<<"status">>, Decoded)).
+
+validate_list_classes_filter_user_test() ->
+    %% list-classes with the "user" filter takes the not-stdlib branch and must
+    %% include the (non-stdlib) WidgetDev fixture-free path: here we only assert
+    %% the op succeeds and returns a class_list (the user filter resolves cheaply).
+    Msg = make_msg(<<"list-classes">>, <<"lcu-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"list-classes">>, #{<<"filter">> => <<"user">>}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assertEqual(false, maps:is_key(<<"error">>, Decoded)),
+    ?assert(is_list(maps:get(<<"class_list">>, Decoded))).
+
+resolve_qualified_consecutive_uppercase_test() ->
+    %% Class name with consecutive uppercase letters exercises the
+    %% camel_to_snake conversion (PrevWasLower=false branch). The module atom
+    %% bt@stdlib@a_b_c_widget does not exist, so the result is {error, badarg},
+    %% but the conversion path is still walked.
+    ?assertEqual(
+        {error, badarg},
+        beamtalk_repl_ops_dev:resolve_qualified_class_name(<<"stdlib@ABCWidget">>)
+    ).
+
+handle_list_classes_non_binary_filter_test() ->
+    %% A filter that is neither undefined nor a binary hits the catch-all clause
+    %% of validate_list_classes_filter/1 → {error, FilterStr} → argument error.
+    Msg = make_msg(<<"list-classes">>, <<"lcn-1">>, undefined, false),
+    Result = beamtalk_repl_ops_dev:handle(
+        <<"list-classes">>, #{<<"filter">> => 12345}, Msg, self()
+    ),
+    Decoded = json:decode(Result),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ErrMsg = maps:get(<<"error">>, Decoded),
+    ?assertNotEqual(nomatch, binary:match(ErrMsg, <<"Unknown filter">>)).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl
@@ -1254,7 +1254,10 @@ setup_dev_runtime() ->
     %% A class named "Integer" so a binding holding an integer (whose
     %% primitive_class_of is 'Integer') classifies as an instance receiver,
     %% and "String" for string-literal classification.
-    {ok, IntPid} = beamtalk_object_class:start('Integer', #{
+    %% 'Integer'/'String' may already be registered by the runtime bootstrap (or
+    %% by another test module in the shared EUnit node), so tolerate
+    %% already_started and only kill the ones this fixture actually owns.
+    {IntPid, IntOwned} = start_dev_class('Integer', #{
         name => 'Integer',
         module => 'bt@test@integer_dev',
         superclass => none,
@@ -1262,12 +1265,15 @@ setup_dev_runtime() ->
             'abs' => #{block => fun(_, _) -> 0 end, arity => 0}
         }
     }),
-    {ok, StrPid} = beamtalk_object_class:start('String', #{
+    %% Use the real String method name 'uppercase' so the string-literal
+    %% completion test passes whether this fixture's String is used (isolated
+    %% run) or the bootstrap String is reused (combined run).
+    {StrPid, StrOwned} = start_dev_class('String', #{
         name => 'String',
         module => 'bt@test@string_dev',
         superclass => none,
         instance_methods => #{
-            'asUppercase' => #{block => fun(_, _) -> ok end, arity => 0}
+            'uppercase' => #{block => fun(_, _) -> ok end, arity => 0}
         }
     }),
     %% ADR 0071 Phase 5: an internal class in a *named* package (test) — the REPL
@@ -1290,7 +1296,17 @@ setup_dev_runtime() ->
         doc => <<"Single line doc no newline">>,
         instance_methods => #{}
     }),
-    [BasePid, WidgetPid, IntPid, StrPid, HiddenPid, OneLinePid].
+    [BasePid, WidgetPid, HiddenPid, OneLinePid] ++
+        [IntPid || IntOwned] ++ [StrPid || StrOwned].
+
+%% Start a class for the dev-runtime fixture, tolerating a class already
+%% registered by the runtime bootstrap or another module. Returns {Pid, Owned}
+%% where Owned is false for a reused registration (teardown must not kill it).
+start_dev_class(Name, Spec) ->
+    case beamtalk_object_class:start(Name, Spec) of
+        {ok, Pid} -> {Pid, true};
+        {error, {already_started, Pid}} -> {Pid, false}
+    end.
 
 teardown_dev_runtime(Pids) ->
     lists:foreach(
@@ -1349,9 +1365,9 @@ context_completion_integer_literal() ->
     ?assert(lists:member(<<"abs">>, Result)).
 
 context_completion_string_literal() ->
-    %% String literal receiver -> String instance methods ("asUppercase").
-    Result = beamtalk_repl_ops_dev:get_context_completions(<<"\"hi\" asU">>),
-    ?assert(lists:member(<<"asUppercase">>, Result)).
+    %% String literal receiver -> String instance methods ("uppercase").
+    Result = beamtalk_repl_ops_dev:get_context_completions(<<"\"hi\" up">>),
+    ?assert(lists:member(<<"uppercase">>, Result)).
 
 context_completion_binding_receiver() ->
     %% A lowercase binding holding an integer classifies as Integer instance.
@@ -1564,19 +1580,17 @@ teardown_session(Pid) ->
 
 session_show_codegen_code_path(Pid) ->
     %% A non-empty `code` param with a live session routes handle/4 through the
-    %% code branch and into beamtalk_repl_shell:show_codegen/2. In the isolated
-    %% EUnit harness the Rust compiler port is unavailable, so show_codegen
-    %% returns {error, Reason, Warnings} which is wrapped into a structured
-    %% error response. (The success/encode_codegen_response path requires the
-    %% compiler port and is covered by the full integration suite.)
+    %% code branch and into beamtalk_repl_shell:show_codegen/2. Compiler-port
+    %% availability is environment-dependent in the shared EUnit node: with the
+    %% port up show_codegen returns a codegen result, without it a structured
+    %% error. Either way the response is a well-formed, non-crashing map whose
+    %% status list ends with the done marker.
     Msg = make_msg(<<"show-codegen">>, <<"scd-1">>, undefined, false),
     Result = beamtalk_repl_ops_dev:handle(
         <<"show-codegen">>, #{<<"code">> => <<"1 + 2">>}, Msg, Pid
     ),
     Decoded = json:decode(Result),
-    %% The response is a well-formed structured error (not a crash); the status
-    %% list always ends with the done marker.
-    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ?assert(is_map(Decoded)),
     Status = maps:get(<<"status">>, Decoded),
     ?assert(lists:member(<<"done">>, Status)).
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_server_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_server_tests.erl
@@ -2902,3 +2902,77 @@ http_ws_no_upgrade_test(Port) ->
     Response = http_get(Port, <<"/ws">>),
     %% Without Upgrade: websocket header, cowboy should not return 101
     ?assert(binary:match(Response, <<"101">>) =:= nomatch).
+
+%%====================================================================
+%% write_port_file/3 (BT-611) — direct unit tests (no TCP listener)
+%%
+%% Exercises the port-file writer's three top-level branches: undefined
+%% workspace (no-op), and the full atomic tmp+rename success path including
+%% directory creation and PORT\nNONCE content formatting.
+%%====================================================================
+
+%% Cross-platform temp directory as a list path.
+wpf_temp_dir() ->
+    application:ensure_all_started(beamtalk_stdlib),
+    binary_to_list(beamtalk_file:'tempDirectory'()).
+
+write_port_file_undefined_workspace_test() ->
+    %% An undefined workspace id is a no-op (no HOME lookup, no file write).
+    ?assertEqual(ok, beamtalk_repl_server:write_port_file(undefined, 1234, <<"abcdef0123456789">>)).
+
+write_port_file_writes_port_and_nonce_test() ->
+    %% Point HOME at a throwaway directory so the writer creates
+    %% $HOME/.beamtalk/workspaces/<id>/port and writes PORT\nNONCE.
+    Unique = integer_to_list(erlang:unique_integer([positive])),
+    FakeHome = filename:join(wpf_temp_dir(), "bt_wpf_test_" ++ Unique),
+    ok = filelib:ensure_dir(filename:join(FakeHome, "placeholder")),
+    OrigHome = os:getenv("HOME"),
+    OrigUserprofile = os:getenv("USERPROFILE"),
+    try
+        os:putenv("HOME", FakeHome),
+        os:putenv("USERPROFILE", FakeHome),
+        WorkspaceId = list_to_binary("ws-" ++ Unique),
+        Nonce = <<"noncehex01234567">>,
+        ?assertEqual(ok, beamtalk_repl_server:write_port_file(WorkspaceId, 54321, Nonce)),
+        PortFile = filename:join([
+            FakeHome, ".beamtalk", "workspaces", binary_to_list(WorkspaceId), "port"
+        ]),
+        ?assert(filelib:is_regular(PortFile)),
+        {ok, Content} = file:read_file(PortFile),
+        %% Format is PORT, newline, NONCE (two lines for stale detection).
+        ?assertEqual(<<"54321\nnoncehex01234567">>, Content)
+    after
+        restore_env("HOME", OrigHome),
+        restore_env("USERPROFILE", OrigUserprofile),
+        %% Best-effort cleanup of the throwaway home tree.
+        _ = file:del_dir_r(FakeHome)
+    end.
+
+restore_env(Var, false) -> os:unsetenv(Var);
+restore_env(Var, Value) -> os:putenv(Var, Value).
+
+write_port_file_no_home_test() ->
+    %% When neither HOME nor USERPROFILE is set, home_dir/0 returns false and
+    %% the writer logs a warning and returns ok without writing a file.
+    OrigHome = os:getenv("HOME"),
+    OrigUserprofile = os:getenv("USERPROFILE"),
+    try
+        os:unsetenv("HOME"),
+        os:unsetenv("USERPROFILE"),
+        ?assertEqual(
+            ok,
+            beamtalk_repl_server:write_port_file(<<"ws-no-home">>, 9999, <<"noncehex89abcdef">>)
+        )
+    after
+        restore_env("HOME", OrigHome),
+        restore_env("USERPROFILE", OrigUserprofile)
+    end.
+
+%%====================================================================
+%% code_change/3 — gen_server callback (no TCP listener)
+%%====================================================================
+
+code_change_returns_state_test() ->
+    %% code_change/3 is an identity passthrough returning {ok, State}.
+    State = some_opaque_state,
+    ?assertEqual({ok, State}, beamtalk_repl_server:code_change(old_vsn, State, extra)).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
@@ -47,7 +47,19 @@ changelog_test_() ->
         fun find_revert_target_no_entry_when_unknown/1,
         fun find_revert_target_picks_most_recent_entry/1,
         fun find_revert_target_skips_flushed_entries/1,
-        fun find_revert_target_rejects_new_class/1
+        fun find_revert_target_rejects_new_class/1,
+        %% Additional coverage (BT runtime coverage push)
+        fun find_revert_target_accepts_binary_selector/1,
+        fun find_revert_target_no_prev_source_when_ref_absent/1,
+        fun entry_accessors_expose_all_fields/1,
+        fun read_prev_source_body_none_for_new_class/1,
+        fun mark_flushed_empty_is_noop/1,
+        fun mark_flushed_unknown_seqs_is_noop/1,
+        fun unknown_call_returns_error/1,
+        fun unknown_cast_is_ignored/1,
+        fun unknown_info_is_ignored/1,
+        fun code_change_returns_state/1,
+        fun new_class_value_has_nil_source_file/1
     ]}.
 
 %% FFI surface with no gen_server started: must degrade to empty, not crash.
@@ -403,6 +415,140 @@ find_revert_target_rejects_new_class(_Ctx) ->
         ?_assertEqual({error, no_entry}, NoEntry)
     ].
 
+%% revert_selector_binary/1 accepts a binary selector (not just an atom).
+find_revert_target_accepts_binary_selector(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(
+        durable_input(<<"Counter">>, <<"inc">>)
+    ),
+    %% Pass the selector as a binary rather than an atom.
+    Result = beamtalk_workspace_changelog:find_revert_target(<<"Counter">>, <<"inc">>),
+    [
+        ?_assertMatch({ok, <<"^ self value">>, _Entry}, Result)
+    ].
+
+%% A method entry with no prev_source ⇒ prev_source_ref = undefined ⇒
+%% find_revert_target returns {error, no_prev_source} (line 392 branch).
+find_revert_target_no_prev_source_when_ref_absent(_Ctx) ->
+    Input = #{
+        class => <<"Counter">>,
+        selector => <<"inc">>,
+        kind => instance,
+        source => <<"^ 1">>,
+        intent => durable,
+        flushable => true,
+        author => <<"sess-1">>,
+        author_kind => human,
+        source_file => <<"/proj/src/counter.bt">>,
+        span => #{start => 0, 'end' => 3}
+    },
+    {ok, _} = beamtalk_workspace_changelog:append(Input),
+    Result = beamtalk_workspace_changelog:find_revert_target(<<"Counter">>, inc),
+    [
+        ?_assertEqual({error, no_prev_source}, Result)
+    ].
+
+%% Exercise the remaining entry accessors that other tests do not touch.
+entry_accessors_expose_all_fields(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(
+        durable_input(<<"Counter">>, <<"inc">>)
+    ),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    [
+        ?_assertEqual(durable, beamtalk_workspace_changelog:entry_intent(Entry)),
+        ?_assertEqual(true, beamtalk_workspace_changelog:entry_flushable(Entry)),
+        ?_assertEqual(false, beamtalk_workspace_changelog:entry_is_prior_epoch(Entry)),
+        ?_assertEqual(human, beamtalk_workspace_changelog:entry_author_kind(Entry)),
+        ?_assertEqual(<<"000000-source.bt">>, beamtalk_workspace_changelog:entry_source_ref(Entry)),
+        ?_assertEqual(
+            <<"000000-prev.bt">>, beamtalk_workspace_changelog:entry_prev_source_ref(Entry)
+        ),
+        ?_assertEqual(
+            #{start => 0, 'end' => 10}, beamtalk_workspace_changelog:entry_span(Entry)
+        )
+    ].
+
+%% read_prev_source_body/1 returns {error, no_prev_source} for a new-class entry
+%% (which has prev_source_ref = undefined).
+read_prev_source_body_none_for_new_class(_Ctx) ->
+    NewClassInput = #{
+        class => <<"NewThing">>,
+        kind => 'new-class',
+        source => <<"Object subclass: NewThing\nend\n">>,
+        intent => durable,
+        flushable => true,
+        author => <<"sess-1">>,
+        author_kind => human,
+        source_file => <<"/proj/src/new_thing.bt">>
+    },
+    {ok, _} = beamtalk_workspace_changelog:append(NewClassInput),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    [
+        ?_assertEqual(
+            {error, no_prev_source}, beamtalk_workspace_changelog:read_prev_source_body(Entry)
+        )
+    ].
+
+%% mark_flushed([]) is a successful no-op handled before the gen_server call.
+mark_flushed_empty_is_noop(_Ctx) ->
+    [
+        ?_assertEqual(ok, beamtalk_workspace_changelog:mark_flushed([]))
+    ].
+
+%% mark_flushed with seqs not in the log is a successful no-op (idempotent).
+mark_flushed_unknown_seqs_is_noop(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(
+        durable_input(<<"Counter">>, <<"inc">>)
+    ),
+    [
+        ?_assertEqual(ok, beamtalk_workspace_changelog:mark_flushed([999, 1000]))
+    ].
+
+%% An unknown gen_server call returns {error, unknown_request}.
+unknown_call_returns_error(#{pid := Pid}) ->
+    [
+        ?_assertEqual(
+            {error, unknown_request}, gen_server:call(Pid, some_bogus_request)
+        )
+    ].
+
+%% An unknown cast must not crash the server.
+unknown_cast_is_ignored(#{pid := Pid}) ->
+    gen_server:cast(Pid, some_bogus_cast),
+    timer:sleep(20),
+    [?_assert(is_process_alive(Pid))].
+
+%% An unknown info message must not crash the server.
+unknown_info_is_ignored(#{pid := Pid}) ->
+    Pid ! some_bogus_info,
+    timer:sleep(20),
+    [?_assert(is_process_alive(Pid))].
+
+%% code_change/3 returns the state unchanged.
+code_change_returns_state(#{pid := Pid}) ->
+    Result = sys:replace_state(Pid, fun(S) -> S end),
+    %% Drive code_change directly via the module export with a synthetic state.
+    {ok, _} = beamtalk_workspace_changelog:code_change(old_vsn, Result, extra),
+    [?_assert(is_process_alive(Pid))].
+
+%% source_file_value(undefined) -> nil: a new-class entry with no source_file
+%% surfaces sourceFile => nil in the value-object map.
+new_class_value_has_nil_source_file(_Ctx) ->
+    NewClassInput = #{
+        class => <<"NewThing">>,
+        kind => 'new-class',
+        source => <<"Object subclass: NewThing\nend\n">>,
+        intent => durable,
+        flushable => true,
+        author => <<"sess-1">>,
+        author_kind => human
+        %% No source_file key ⇒ source_file = undefined.
+    },
+    {ok, _} = beamtalk_workspace_changelog:append(NewClassInput),
+    [Entry] = beamtalk_workspace_changelog:change_entries(),
+    [
+        ?_assertEqual(nil, maps:get(sourceFile, Entry))
+    ].
+
 %%====================================================================
 %% Restart semantics (separate fixture: stop + restart same workspace)
 %%====================================================================
@@ -658,8 +804,42 @@ load_enforces_ring_bound_when_disk_exceeds_max() ->
 forward_compat_test_() ->
     [
         fun unknown_kind_preserved_not_dropped/0,
-        fun known_kinds_decode_to_atoms/0
+        fun known_kinds_decode_to_atoms/0,
+        fun unknown_intent_preserved_as_unknown/0,
+        fun unknown_author_kind_preserved_as_unknown/0,
+        fun known_intents_decode_to_atoms/0,
+        fun known_author_kinds_decode_to_atoms/0
     ].
+
+known_intents_decode_to_atoms() ->
+    Durable = beamtalk_workspace_changelog:entry_from_json(
+        line_json_with(#{<<"intent">> => <<"durable">>})
+    ),
+    Ephemeral = beamtalk_workspace_changelog:entry_from_json(
+        line_json_with(#{<<"intent">> => <<"ephemeral">>})
+    ),
+    ?assertEqual(durable, beamtalk_workspace_changelog:entry_intent(Durable)),
+    ?assertEqual(ephemeral, beamtalk_workspace_changelog:entry_intent(Ephemeral)).
+
+known_author_kinds_decode_to_atoms() ->
+    Human = beamtalk_workspace_changelog:entry_from_json(
+        line_json_with(#{<<"author_kind">> => <<"human">>})
+    ),
+    Agent = beamtalk_workspace_changelog:entry_from_json(
+        line_json_with(#{<<"author_kind">> => <<"agent">>})
+    ),
+    ?assertEqual(human, beamtalk_workspace_changelog:entry_author_kind(Human)),
+    ?assertEqual(agent, beamtalk_workspace_changelog:entry_author_kind(Agent)).
+
+unknown_intent_preserved_as_unknown() ->
+    Json = line_json_with(#{<<"intent">> => <<"future-intent">>}),
+    Entry = beamtalk_workspace_changelog:entry_from_json(Json),
+    ?assertEqual(unknown, beamtalk_workspace_changelog:entry_intent(Entry)).
+
+unknown_author_kind_preserved_as_unknown() ->
+    Json = line_json_with(#{<<"author_kind">> => <<"future-author">>}),
+    Entry = beamtalk_workspace_changelog:entry_from_json(Json),
+    ?assertEqual(unknown, beamtalk_workspace_changelog:entry_author_kind(Entry)).
 
 unknown_kind_preserved_not_dropped() ->
     %% A newer writer may emit a kind this beam doesn't know. Decoding must keep
@@ -700,8 +880,23 @@ size_returns_zero_when_table_absent() ->
 
 run_mode_test_() ->
     {setup, fun() -> ok end, fun(_) -> ok end, [
-        fun run_mode_is_memory_only/0
+        fun run_mode_is_memory_only/0,
+        fun run_mode_read_source_body_no_workspace/0
     ]}.
+
+%% In run mode (no workspace_id) there is no changes/ dir, so reading a recorded
+%% body returns {error, no_workspace} (the get_sources_dir undefined branch).
+run_mode_read_source_body_no_workspace() ->
+    {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => undefined}),
+    try
+        {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+        [Entry] = beamtalk_workspace_changelog:entries(),
+        ?assertEqual(
+            {error, no_workspace}, beamtalk_workspace_changelog:read_source_body(Entry)
+        )
+    after
+        stop(Pid)
+    end.
 
 run_mode_is_memory_only() ->
     {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => undefined}),

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
@@ -46,7 +46,27 @@ flush_test_() ->
         fun flush_kinds_by_author_kind/1,
         fun flush_kinds_combined_dimensions_intersect/1,
         fun flush_kinds_empty_set_is_rejected/1,
-        fun flush_kinds_unknown_kind_is_rejected/1
+        fun flush_kinds_unknown_kind_is_rejected/1,
+        %% Additional coverage (BT runtime coverage push)
+        fun selector_not_found_appends_method/1,
+        fun selector_not_found_appends_to_file_without_trailing_newline/1,
+        fun source_file_unreadable_is_conflict/1,
+        fun filter_by_class_object/1,
+        fun filter_by_class_object_non_class_is_error/1,
+        fun filter_by_selector_symbol/1,
+        fun flush_kinds_by_class_entry_kind/1,
+        fun flush_kinds_by_human_author_kind/1,
+        fun filter_dict_with_list_file/1,
+        fun filter_dict_missing_file_key_is_error/1,
+        fun filter_non_class_object_atom_lowercase_is_selector/1,
+        fun bad_filter_type_is_error/1,
+        fun flush_kinds_non_list_is_error/1,
+        fun flush_kinds_non_symbol_element_is_error/1,
+        fun filter_by_binary_class_name/1,
+        fun append_into_empty_file/1,
+        fun mixed_span_and_appended_method_in_one_file/1,
+        fun missing_source_body_is_hard_error/1,
+        fun missing_prev_source_body_is_hard_error/1
     ]}.
 
 unit_test_() ->
@@ -833,6 +853,380 @@ flush_kinds_unknown_kind_is_rejected(_Ctx) ->
     ].
 
 %%====================================================================
+%% Additional coverage: selector_not_found append path + filter shapes
+%%====================================================================
+
+%% A splice entry with span = undefined (the install hook recorded
+%% `selector_not_found` — a brand-new method added live). flush must append the
+%% new body after a blank-line separator rather than overwrite a span.
+selector_not_found_appends_method(#{proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "counter.bt"]),
+    %% File already ends in a single trailing newline.
+    Original = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    ok = file:write_file(File, Original),
+    %% No span, no prev_source ⇒ append path.
+    {ok, _} = beamtalk_workspace_changelog:append(
+        append_method_input(
+            <<"Counter">>, <<"step">>, <<"step => 1\n">>, list_to_binary(File)
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush(),
+    {ok, Final} = file:read_file(File),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary)),
+        %% Trailing newlines collapse to one, then a blank line, then the body.
+        ?_assertEqual(
+            <<"Object subclass: Counter\n  value => 0\nend\n\nstep => 1\n">>, Final
+        )
+    ].
+
+%% Same append path, but the on-disk file has NO trailing newline — exercises
+%% the strip/ensure-trailing-newline branches differently.
+selector_not_found_appends_to_file_without_trailing_newline(#{proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "counter.bt"]),
+    Original = <<"Object subclass: Counter\n  value => 0\nend">>,
+    ok = file:write_file(File, Original),
+    %% New body also has no trailing newline ⇒ ensure_trailing_newline adds one.
+    {ok, _} = beamtalk_workspace_changelog:append(
+        append_method_input(
+            <<"Counter">>, <<"step">>, <<"step => 1">>, list_to_binary(File)
+        )
+    ),
+    {ok, _Summary} = beamtalk_workspace_flush:flush(),
+    {ok, Final} = file:read_file(File),
+    [
+        ?_assertEqual(
+            <<"Object subclass: Counter\n  value => 0\nend\n\nstep => 1\n">>, Final
+        )
+    ].
+
+%% prepare_splice on a file that does not exist on disk ⇒ source_file_unreadable
+%% conflict (the read fails with enoent).
+source_file_unreadable_is_conflict(#{proj_dir := ProjDir}) ->
+    %% Reference a file that was never written to disk.
+    File = filename:join([ProjDir, "src", "missing.bt"]),
+    {ok, _} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Counter">>,
+            <<"value">>,
+            <<"value => 1\n">>,
+            <<"value => 0\n">>,
+            list_to_binary(File),
+            0,
+            11
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush(),
+    Conflicts = maps:get(conflicts, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assertEqual(1, length(Conflicts)),
+        ?_assertEqual(<<"source_file_unreadable">>, maps:get(reason, hd(Conflicts)))
+    ].
+
+%% Filter by a class *object* (`#beamtalk_object{class = 'Counter class'}`):
+%% normalise_filter strips the " class" suffix and matches the entry's class.
+filter_by_class_object(#{proj_dir := ProjDir}) ->
+    File1 = filename:join([ProjDir, "src", "counter.bt"]),
+    File2 = filename:join([ProjDir, "src", "widget.bt"]),
+    Original1 = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    Original2 = <<"Object subclass: Widget\n  render => nil\nend\n">>,
+    ok = file:write_file(File1, Original1),
+    ok = file:write_file(File2, Original2),
+    {S1, E1, B1} = locate(Original1, <<"value => 0\n">>),
+    {S2, E2, B2} = locate(Original2, <<"render => nil\n">>),
+    {ok, _} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Counter">>, <<"value">>, <<"value => 1\n">>, B1, list_to_binary(File1), S1, E1
+        )
+    ),
+    {ok, _} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Widget">>, <<"render">>, <<"render => 'x'\n">>, B2, list_to_binary(File2), S2, E2
+        )
+    ),
+    %% The 'Counter class' atom must exist for class_display_name to resolve.
+    ClassObj = #beamtalk_object{
+        class = binary_to_atom(<<"Counter class">>, utf8),
+        class_mod = counter,
+        pid = self()
+    },
+    {ok, Summary} = beamtalk_workspace_flush:flush(ClassObj),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual(
+            {ok, <<"Object subclass: Counter\n  value => 1\nend\n">>}, file:read_file(File1)
+        ),
+        ?_assertEqual({ok, Original2}, file:read_file(File2))
+    ].
+
+%% A `#beamtalk_object{}` whose class atom is NOT a class-object name (no
+%% " class" suffix) is rejected with a structured error.
+filter_by_class_object_non_class_is_error(_Ctx) ->
+    NonClass = #beamtalk_object{class = plain_atom, class_mod = m, pid = self()},
+    Result = beamtalk_workspace_flush:flush(NonClass),
+    [
+        ?_assertMatch({error, #beamtalk_error{kind = type_error}}, Result)
+    ].
+
+%% Filter by a selector Symbol (a lowercase atom): selects entries whose
+%% selector matches, regardless of class.
+filter_by_selector_symbol(#{proj_dir := ProjDir}) ->
+    File1 = filename:join([ProjDir, "src", "counter.bt"]),
+    File2 = filename:join([ProjDir, "src", "widget.bt"]),
+    Original1 = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    Original2 = <<"Object subclass: Widget\n  render => nil\nend\n">>,
+    ok = file:write_file(File1, Original1),
+    ok = file:write_file(File2, Original2),
+    {S1, E1, B1} = locate(Original1, <<"value => 0\n">>),
+    {S2, E2, B2} = locate(Original2, <<"render => nil\n">>),
+    {ok, _} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Counter">>, <<"value">>, <<"value => 1\n">>, B1, list_to_binary(File1), S1, E1
+        )
+    ),
+    {ok, _} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Widget">>, <<"render">>, <<"render => 'x'\n">>, B2, list_to_binary(File2), S2, E2
+        )
+    ),
+    %% `render` is a lowercase atom ⇒ treated as a selector filter.
+    {ok, Summary} = beamtalk_workspace_flush:flush(render),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual({ok, Original1}, file:read_file(File1)),
+        ?_assertEqual(
+            {ok, <<"Object subclass: Widget\n  render => 'x'\nend\n">>}, file:read_file(File2)
+        )
+    ].
+
+%% classify_kind(class) -> entry: exercise the `#class` entry-kind branch.
+flush_kinds_by_class_entry_kind(#{proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "counter.bt"]),
+    Original = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    ok = file:write_file(File, Original),
+    {S, E, Old} = locate(Original, <<"value => 0\n">>),
+    %% A class-side method patch (kind => class).
+    ClassEntry = (method_input(
+        <<"Counter">>, <<"value">>, <<"value => 1\n">>, Old, list_to_binary(File), S, E
+    ))#{
+        kind => class
+    },
+    {ok, _} = beamtalk_workspace_changelog:append(ClassEntry),
+    {ok, Summary} = beamtalk_workspace_flush:flush_kinds([class]),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual(
+            {ok, <<"Object subclass: Counter\n  value => 1\nend\n">>}, file:read_file(File)
+        )
+    ].
+
+%% classify_kind(human) -> author: exercise the `#human` author-kind branch.
+flush_kinds_by_human_author_kind(#{proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "counter.bt"]),
+    Original = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    ok = file:write_file(File, Original),
+    {S, E, Old} = locate(Original, <<"value => 0\n">>),
+    %% method_input defaults author_kind => human.
+    {ok, _} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Counter">>, <<"value">>, <<"value => 1\n">>, Old, list_to_binary(File), S, E
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_kinds([human]),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual(
+            {ok, <<"Object subclass: Counter\n  value => 1\nend\n">>}, file:read_file(File)
+        )
+    ].
+
+%% Dictionary filter where the file value is a *list* (string), not a binary.
+filter_dict_with_list_file(#{proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "counter.bt"]),
+    Original = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    ok = file:write_file(File, Original),
+    {S, E, Old} = locate(Original, <<"value => 0\n">>),
+    {ok, _} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Counter">>, <<"value">>, <<"value => 1\n">>, Old, list_to_binary(File), S, E
+        )
+    ),
+    %% file => File as a *string* (list of chars), not a binary.
+    {ok, Summary} = beamtalk_workspace_flush:flush(#{file => File}),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual(
+            {ok, <<"Object subclass: Counter\n  value => 1\nend\n">>}, file:read_file(File)
+        )
+    ].
+
+%% Dictionary filter missing the `file` key is rejected.
+filter_dict_missing_file_key_is_error(_Ctx) ->
+    Result = beamtalk_workspace_flush:flush(#{not_file => <<"x">>}),
+    [
+        ?_assertMatch({error, #beamtalk_error{kind = type_error}}, Result)
+    ].
+
+%% A lowercase atom that is not a class name is treated as a selector — with no
+%% matching entries the flush is an empty (but successful) no-op.
+filter_non_class_object_atom_lowercase_is_selector(_Ctx) ->
+    {ok, Summary} = beamtalk_workspace_flush:flush(someselector),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary))
+    ].
+
+%% A filter that is neither class/symbol/binary/map/object is rejected.
+bad_filter_type_is_error(_Ctx) ->
+    Result = beamtalk_workspace_flush:flush(12345),
+    [
+        ?_assertMatch({error, #beamtalk_error{kind = type_error}}, Result)
+    ].
+
+%% flush_kinds/1 with a non-list argument is rejected.
+flush_kinds_non_list_is_error(_Ctx) ->
+    Result = beamtalk_workspace_flush:flush_kinds(not_a_list),
+    [
+        ?_assertMatch({error, #beamtalk_error{kind = type_error}}, Result)
+    ].
+
+%% flush_kinds/1 with a non-Symbol element (e.g. a binary) is rejected.
+flush_kinds_non_symbol_element_is_error(_Ctx) ->
+    Result = beamtalk_workspace_flush:flush_kinds([<<"instance">>]),
+    [
+        ?_assertMatch({error, #beamtalk_error{kind = type_error}}, Result)
+    ].
+
+%% Filter by a binary class name (the `normalise_filter(Bin)` clause).
+filter_by_binary_class_name(#{proj_dir := ProjDir}) ->
+    File1 = filename:join([ProjDir, "src", "counter.bt"]),
+    File2 = filename:join([ProjDir, "src", "widget.bt"]),
+    Original1 = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    Original2 = <<"Object subclass: Widget\n  render => nil\nend\n">>,
+    ok = file:write_file(File1, Original1),
+    ok = file:write_file(File2, Original2),
+    {S1, E1, B1} = locate(Original1, <<"value => 0\n">>),
+    {S2, E2, B2} = locate(Original2, <<"render => nil\n">>),
+    {ok, _} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Counter">>, <<"value">>, <<"value => 1\n">>, B1, list_to_binary(File1), S1, E1
+        )
+    ),
+    {ok, _} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Widget">>, <<"render">>, <<"render => 'x'\n">>, B2, list_to_binary(File2), S2, E2
+        )
+    ),
+    %% Pass the class name as a binary directly.
+    {ok, Summary} = beamtalk_workspace_flush:flush(<<"Counter">>),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual(
+            {ok, <<"Object subclass: Counter\n  value => 1\nend\n">>}, file:read_file(File1)
+        ),
+        ?_assertEqual({ok, Original2}, file:read_file(File2))
+    ].
+
+%% Appending a method to an empty (zero-byte) file exercises the empty-binary
+%% branches of strip_trailing_newlines/1 and ensure_trailing_newline/1.
+append_into_empty_file(#{proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "empty.bt"]),
+    ok = file:write_file(File, <<>>),
+    {ok, _} = beamtalk_workspace_changelog:append(
+        append_method_input(
+            <<"Empty">>, <<"go">>, <<"go => 1\n">>, list_to_binary(File)
+        )
+    ),
+    {ok, _Summary} = beamtalk_workspace_flush:flush(),
+    {ok, Final} = file:read_file(File),
+    [
+        %% Empty body trimmed to <<>>, then "\n\n" separator, then the appended body.
+        ?_assertEqual(<<"\n\ngo => 1\n">>, Final)
+    ].
+
+%% One file with both a span-based splice entry AND a span=undefined appended
+%% method entry. apply_splices sorts the two, exercising span_start/1 for the
+%% undefined case (returns -1) so it sorts before the real span.
+mixed_span_and_appended_method_in_one_file(#{proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "counter.bt"]),
+    Original = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    ok = file:write_file(File, Original),
+    {S, E, Old} = locate(Original, <<"value => 0\n">>),
+    %% Splice entry (has a span).
+    {ok, _} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Counter">>, <<"value">>, <<"value => 9\n">>, Old, list_to_binary(File), S, E
+        )
+    ),
+    %% Appended-method entry against the same file (no span).
+    {ok, _} = beamtalk_workspace_changelog:append(
+        append_method_input(
+            <<"Counter">>, <<"step">>, <<"step => 1\n">>, list_to_binary(File)
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush(),
+    {ok, Final} = file:read_file(File),
+    [
+        ?_assertEqual(2, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary)),
+        %% The span splice replaced `value => 0`, and the appended method lands
+        %% after a blank-line separator at the end.
+        ?_assertEqual(
+            <<"Object subclass: Counter\n  value => 9\nend\n\nstep => 1\n">>, Final
+        )
+    ].
+
+%% When the recorded patch body in sources/ is unreadable (deleted out from
+%% under us), flush surfaces a hard {error, #beamtalk_error{}} via
+%% source_body_error/2 + wrap_io_error/2. Exercise the append (span=undefined)
+%% path so read_source_body is the first read that fails.
+missing_source_body_is_hard_error(#{workspace_id := WsId, proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "counter.bt"]),
+    ok = file:write_file(File, <<"Object subclass: Counter\nend\n">>),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        append_method_input(
+            <<"Counter">>, <<"step">>, <<"step => 1\n">>, list_to_binary(File)
+        )
+    ),
+    %% Delete the recorded source body so read_source_body/1 fails with enoent.
+    ChangesDir = beamtalk_workspace_changelog:changes_dir(WsId),
+    SourceBody = filename:join([ChangesDir, "sources", source_ref_name(Seq, "-source.bt")]),
+    ok = file:delete(SourceBody),
+    Result = beamtalk_workspace_flush:flush(),
+    [
+        ?_assertMatch({error, #beamtalk_error{kind = source_body_unreadable}}, Result)
+    ].
+
+%% When the recorded *prior* body in sources/ is unreadable, a span splice
+%% surfaces a hard {error, #beamtalk_error{}} via prev_source_error/2.
+missing_prev_source_body_is_hard_error(#{workspace_id := WsId, proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "counter.bt"]),
+    Original = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    ok = file:write_file(File, Original),
+    {Start, End, OldBody} = locate(Original, <<"value => 0\n">>),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Counter">>,
+            <<"value">>,
+            <<"value => 1\n">>,
+            OldBody,
+            list_to_binary(File),
+            Start,
+            End
+        )
+    ),
+    %% Delete the recorded prev body so read_prev_source_body/1 fails.
+    ChangesDir = beamtalk_workspace_changelog:changes_dir(WsId),
+    PrevBody = filename:join([ChangesDir, "sources", source_ref_name(Seq, "-prev.bt")]),
+    ok = file:delete(PrevBody),
+    Result = beamtalk_workspace_flush:flush(),
+    [
+        ?_assertMatch({error, #beamtalk_error{kind = prev_source_unreadable}}, Result)
+    ].
+
+%%====================================================================
 %% Pure helpers
 %%====================================================================
 
@@ -906,6 +1300,22 @@ method_input(Class, Selector, NewBody, OldBody, File, Start, End) ->
         span => #{start => Start, 'end' => End}
     }.
 
+%% A method entry recorded by the install hook as `selector_not_found`: a
+%% brand-new method added live, with no span and no prev_source. flush appends
+%% it to the file rather than splicing over an existing definition.
+append_method_input(Class, Selector, NewBody, File) ->
+    #{
+        class => Class,
+        selector => Selector,
+        kind => instance,
+        source => NewBody,
+        intent => durable,
+        flushable => true,
+        author => <<"sess-test">>,
+        author_kind => human,
+        source_file => File
+    }.
+
 new_class_input(ClassName, Source, File) ->
     #{
         class => ClassName,
@@ -917,6 +1327,11 @@ new_class_input(ClassName, Source, File) ->
         author_kind => agent,
         source_file => File
     }.
+
+%% Build the sources/ filename for a seq (mirrors the changelog's zero-padded
+%% naming): "000042-source.bt" / "000042-prev.bt".
+source_ref_name(Seq, Suffix) ->
+    lists:flatten(io_lib:format("~6..0b~s", [Seq, Suffix])).
 
 %% Find Needle in Haystack; return {Start, End, ActualBytes}. Crashes if not
 %% found so the test fails loudly rather than silently miscomputing offsets.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_interface_primitives_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_interface_primitives_tests.erl
@@ -22,6 +22,11 @@ Tests the Phase 2 dispatch/3 interface for WorkspaceInterface primitives:
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("beamtalk_runtime/include/beamtalk.hrl").
 
+%% supervisor behaviour callback used by start_bare_workspace_sup/0 in the
+%% supervisors/0 tests (a minimal childless workspace_sup stand-in).
+-behaviour(supervisor).
+-export([init/1]).
+
 %%====================================================================
 %% Fixtures
 %%====================================================================
@@ -981,3 +986,421 @@ sessions_returns_empty_when_no_supervisor_test() ->
         [],
         beamtalk_workspace_interface_primitives:dispatch(sessions, [], fake_self(self()))
     ).
+
+%%====================================================================
+%% dispatch/3 routing coverage for the newer selectors
+%%
+%% The earlier dispatch tests cover actors/load/bind/etc. These hit the
+%% dispatch/3 clauses for the supervisor/newClass/flush/autoflush selectors
+%% so the routing arms (and not just the direct functions) are exercised.
+%% Each lands on a deterministic validation/error path that needs no live
+%% workspace tree.
+%%====================================================================
+
+%% dispatch('newClass:at:', ...) routes to newClass/2; a non-String argument
+%% raises a type_error at the FFI boundary.
+dispatch_new_class_type_error_test() ->
+    try
+        beamtalk_workspace_interface_primitives:dispatch(
+            'newClass:at:', [42, <<"src/Foo.bt">>], fake_self(self())
+        ),
+        ?assert(false)
+    catch
+        error:#{error := Err} ->
+            ?assertEqual(type_error, Err#beamtalk_error.kind),
+            ?assertEqual('WorkspaceInterface', Err#beamtalk_error.class),
+            ?assertEqual('newClass:at:', Err#beamtalk_error.selector)
+    end.
+
+%% dispatch('startSupervisor:', ...) routes to startSupervisor/1; a non-class
+%% argument raises a type_error.
+dispatch_start_supervisor_type_error_test() ->
+    try
+        beamtalk_workspace_interface_primitives:dispatch(
+            'startSupervisor:', [42], fake_self(self())
+        ),
+        ?assert(false)
+    catch
+        error:#{error := Err} ->
+            ?assertEqual(type_error, Err#beamtalk_error.kind),
+            ?assertEqual('startSupervisor:', Err#beamtalk_error.selector)
+    end.
+
+%% dispatch('stopSupervisor:', ...) routes to stopSupervisor/1; a non-class
+%% argument raises a type_error.
+dispatch_stop_supervisor_type_error_test() ->
+    try
+        beamtalk_workspace_interface_primitives:dispatch(
+            'stopSupervisor:', [notAClass], fake_self(self())
+        ),
+        ?assert(false)
+    catch
+        error:#{error := Err} ->
+            ?assertEqual(type_error, Err#beamtalk_error.kind),
+            ?assertEqual('stopSupervisor:', Err#beamtalk_error.selector)
+    end.
+
+%%====================================================================
+%% newClass/2 validation coverage (ADR 0082 Phase 1, BT-2285)
+%%
+%% validate_new_class_args/2 rejects non-String source/path before the
+%% loader is reached. These exercise both error clauses and the
+%% new_class_arg_type_error/2 message builder (which names the offending arg).
+%%====================================================================
+
+%% Non-String source → type_error naming the "source" argument.
+new_class_non_string_source_test() ->
+    try
+        beamtalk_workspace_interface_primitives:newClass(42, <<"src/Foo.bt">>),
+        ?assert(false)
+    catch
+        error:#{error := Err} ->
+            ?assertEqual(type_error, Err#beamtalk_error.kind),
+            ?assertEqual('newClass:at:', Err#beamtalk_error.selector),
+            ?assertNotEqual(nomatch, binary:match(Err#beamtalk_error.message, <<"source">>)),
+            %% value_type_name/1 reports the Integer type in the message.
+            ?assertNotEqual(nomatch, binary:match(Err#beamtalk_error.message, <<"Integer">>))
+    end.
+
+%% String source but non-String path → type_error naming the "path" argument.
+new_class_non_string_path_test() ->
+    try
+        beamtalk_workspace_interface_primitives:newClass(
+            <<"Object subclass: Foo">>, myatom
+        ),
+        ?assert(false)
+    catch
+        error:#{error := Err} ->
+            ?assertEqual(type_error, Err#beamtalk_error.kind),
+            ?assertEqual('newClass:at:', Err#beamtalk_error.selector),
+            ?assertNotEqual(nomatch, binary:match(Err#beamtalk_error.message, <<"path">>)),
+            ?assertNotEqual(nomatch, binary:match(Err#beamtalk_error.message, <<"Symbol">>))
+    end.
+
+%%====================================================================
+%% changeLogClear / autoflush / setAutoflush / flush / changeLogRevert /
+%% changeLogFlushKinds with a live changelog + workspace_meta gen_server.
+%%
+%% These boot a fresh, isolated workspace (temp HOME) and the changelog
+%% gen_server so the *real* delegation paths run, not just the validation
+%% guards. The log starts empty, so flush/revert exercise the empty-log and
+%% no-entry branches deterministically.
+%%====================================================================
+
+changelog_live_test_() ->
+    {foreach, fun setup_changelog_ws/0, fun cleanup_changelog_ws/1, [
+        fun changelog_clear_returns_nil/1,
+        fun autoflush_roundtrips_through_meta/1,
+        fun set_autoflush_via_dispatch/1,
+        fun autoflush_via_dispatch/1,
+        fun flush_empty_log_returns_summary/1,
+        fun flush_via_dispatch_returns_summary/1,
+        fun flush_filter_via_dispatch/1,
+        fun flush_kinds_valid_list_with_empty_log/1,
+        fun revert_no_active_entry_raises_state_error/1,
+        fun revert_via_object_keyed_map/1
+    ]}.
+
+%% changeLogClear/0 returns nil and is idempotent on an empty log.
+changelog_clear_returns_nil(_Ctx) ->
+    [
+        ?_assertEqual(nil, beamtalk_workspace_interface_primitives:changeLogClear()),
+        ?_assertEqual(nil, beamtalk_workspace_interface_primitives:changeLogClear())
+    ].
+
+%% setAutoflush/1 persists through workspace_meta and autoflush/0 reads it back.
+autoflush_roundtrips_through_meta(_Ctx) ->
+    True = beamtalk_workspace_interface_primitives:setAutoflush(true),
+    AfterTrue = beamtalk_workspace_interface_primitives:autoflush(),
+    False = beamtalk_workspace_interface_primitives:setAutoflush(false),
+    AfterFalse = beamtalk_workspace_interface_primitives:autoflush(),
+    [
+        ?_assertEqual(true, True),
+        ?_assertEqual(true, AfterTrue),
+        ?_assertEqual(false, False),
+        ?_assertEqual(false, AfterFalse)
+    ].
+
+%% dispatch('autoflush:', [Bool]) routes to setAutoflush/1 and returns the value.
+set_autoflush_via_dispatch(_Ctx) ->
+    Result = beamtalk_workspace_interface_primitives:dispatch(
+        'autoflush:', [true], fake_self(self())
+    ),
+    [?_assertEqual(true, Result)].
+
+%% dispatch(autoflush, []) routes to autoflush/0; with the default cleared it
+%% reports the most recently set value.
+autoflush_via_dispatch(_Ctx) ->
+    ok = beamtalk_workspace_meta:set_setting(autoflush, false),
+    Result = beamtalk_workspace_interface_primitives:dispatch(
+        autoflush, [], fake_self(self())
+    ),
+    [?_assertEqual(false, Result)].
+
+%% flush/0 over an empty changelog returns a FlushResult summary map with the
+%% zero/empty fields.
+flush_empty_log_returns_summary(_Ctx) ->
+    Summary = beamtalk_workspace_interface_primitives:flush(),
+    [
+        ?_assert(is_map(Summary)),
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(files, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary))
+    ].
+
+%% dispatch(flush, []) routes to flush/0 and returns the same summary map.
+flush_via_dispatch_returns_summary(_Ctx) ->
+    Summary = beamtalk_workspace_interface_primitives:dispatch(
+        flush, [], fake_self(self())
+    ),
+    [
+        ?_assert(is_map(Summary)),
+        ?_assertEqual(0, maps:get(flushed, Summary))
+    ].
+
+%% dispatch('flush:', [Filter]) routes to flush/1. A Symbol filter over an
+%% empty log returns an empty FlushResult summary.
+flush_filter_via_dispatch(_Ctx) ->
+    Summary = beamtalk_workspace_interface_primitives:dispatch(
+        'flush:', ['new-class'], fake_self(self())
+    ),
+    [
+        ?_assert(is_map(Summary)),
+        ?_assertEqual(0, maps:get(flushed, Summary))
+    ].
+
+%% changeLogFlushKinds/1 with a valid List of kind Symbols flows through to
+%% flush_kinds/1; over an empty log it returns an empty summary (a non-empty
+%% list is accepted, unlike the empty-list rejection).
+flush_kinds_valid_list_with_empty_log(_Ctx) ->
+    Summary = beamtalk_workspace_interface_primitives:changeLogFlushKinds([instance, human]),
+    [
+        ?_assert(is_map(Summary)),
+        ?_assertEqual(0, maps:get(flushed, Summary))
+    ].
+
+%% changeLogRevert/1 with a well-formed (class, selector) target but no matching
+%% active entry raises a revert_not_possible state error (exercises
+%% extract_revert_target_from_map ok-branch + do_revert no_entry branch).
+revert_no_active_entry_raises_state_error(_Ctx) ->
+    Entry = #{
+        '$beamtalk_class' => 'ChangeEntry',
+        className => 'NoSuchClass',
+        selector => 'noSuchSelector'
+    },
+    [
+        ?_assertException(
+            error,
+            #{error := #beamtalk_error{kind = revert_not_possible, class = 'ChangeLog'}},
+            beamtalk_workspace_interface_primitives:changeLogRevert(Entry)
+        )
+    ].
+
+%% A map keyed by className (without the $beamtalk_class tag) is also accepted
+%% by extract_revert_target/1 — same no-entry outcome.
+revert_via_object_keyed_map(_Ctx) ->
+    Entry = #{className => 'AlsoMissing', selector => 'gone'},
+    [
+        ?_assertException(
+            error,
+            #{error := #beamtalk_error{kind = revert_not_possible}},
+            beamtalk_workspace_interface_primitives:changeLogRevert(Entry)
+        )
+    ].
+
+%%====================================================================
+%% Changelog/workspace fixture helpers
+%%====================================================================
+
+%% Boot an isolated workspace: a temp HOME plus the changelog and meta
+%% gen_servers so the delegation paths run for real. Returns a context map.
+setup_changelog_ws() ->
+    Unique = integer_to_list(erlang:unique_integer([positive])),
+    WorkspaceId = list_to_binary("test-ws-wip-" ++ Unique),
+    Tmp = filename:join(ws_temp_dir(), "bt-wip-" ++ Unique),
+    ok = filelib:ensure_path(Tmp),
+    OldHome = os:getenv("HOME"),
+    true = os:putenv("HOME", Tmp),
+    {ok, ClogPid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WorkspaceId}),
+    %% workspace_meta is registered under its module name; setAutoflush/autoflush
+    %% and the workspace-up sentinel both depend on it.
+    MetaPid =
+        case
+            beamtalk_workspace_meta:start_link(#{
+                workspace_id => WorkspaceId,
+                project_path => list_to_binary(Tmp),
+                created_at => erlang:system_time(second),
+                last_activity => erlang:system_time(second)
+            })
+        of
+            {ok, P} -> P;
+            {error, {already_started, P}} -> P
+        end,
+    #{
+        clog_pid => ClogPid,
+        meta_pid => MetaPid,
+        workspace_id => WorkspaceId,
+        tmp_home => Tmp,
+        old_home => OldHome
+    }.
+
+cleanup_changelog_ws(#{
+    clog_pid := ClogPid, meta_pid := MetaPid, tmp_home := Tmp, old_home := OldHome
+}) ->
+    stop_proc(MetaPid),
+    stop_proc(ClogPid),
+    case OldHome of
+        false -> os:unsetenv("HOME");
+        _ -> os:putenv("HOME", OldHome)
+    end,
+    _ = file:del_dir_r(Tmp),
+    ok.
+
+ws_temp_dir() ->
+    unicode:characters_to_list(beamtalk_file:'tempDirectory'()).
+
+stop_proc(Pid) when is_pid(Pid) ->
+    case is_process_alive(Pid) of
+        true ->
+            Ref = monitor(process, Pid),
+            unlink(Pid),
+            exit(Pid, shutdown),
+            receive
+                {'DOWN', Ref, process, Pid, _} -> ok
+            after 5000 -> ok
+            end;
+        false ->
+            ok
+    end;
+stop_proc(_) ->
+    ok.
+
+%%====================================================================
+%% dependencies/0 with a package name set (ADR 0070 Phase 5)
+%%
+%% When workspace_meta resolves a package name (from beamtalk.toml at the
+%% project path) dependencies/0 takes the `PkgName ->` branch and builds a
+%% map from the package's dependency list. With a synthetic package that has
+%% no registered OTP application, the dependency list is empty and the result
+%% is an empty map — but via the populated branch, not the `undefined` guard.
+%%====================================================================
+
+dependencies_with_package_name_returns_map_test() ->
+    Unique = integer_to_list(erlang:unique_integer([positive])),
+    WorkspaceId = list_to_binary("test-ws-deps-" ++ Unique),
+    Tmp = filename:join(ws_temp_dir(), "bt-deps-" ++ Unique),
+    ok = filelib:ensure_path(Tmp),
+    %% A beamtalk.toml at the project path makes get_package_name/0 resolve a
+    %% real name, so dependencies/0 leaves the `undefined` short-circuit.
+    ok = file:write_file(
+        filename:join(Tmp, "beamtalk.toml"),
+        <<"[package]\nname = \"bt_deps_probe_pkg\"\n">>
+    ),
+    OldHome = os:getenv("HOME"),
+    true = os:putenv("HOME", Tmp),
+    MetaPid =
+        case
+            beamtalk_workspace_meta:start_link(#{
+                workspace_id => WorkspaceId,
+                project_path => list_to_binary(Tmp),
+                created_at => erlang:system_time(second),
+                last_activity => erlang:system_time(second)
+            })
+        of
+            {ok, P} -> P;
+            {error, {already_started, P}} -> P
+        end,
+    try
+        ?assertEqual(<<"bt_deps_probe_pkg">>, beamtalk_workspace_meta:get_package_name()),
+        Result = beamtalk_workspace_interface_primitives:dependencies(),
+        ?assert(is_map(Result)),
+        %% The synthetic package has no registered OTP app → no resolvable
+        %% dependencies → empty map (but via the populated branch).
+        ?assertEqual(#{}, Result)
+    after
+        stop_proc(MetaPid),
+        case OldHome of
+            false -> os:unsetenv("HOME");
+            _ -> os:putenv("HOME", OldHome)
+        end,
+        _ = file:del_dir_r(Tmp)
+    end.
+
+%%====================================================================
+%% supervisors/0 against a bare, locally-registered beamtalk_workspace_sup
+%%
+%% supervisors/0 reads the (possibly empty) root supervisor plus the user
+%% supervisors attached under beamtalk_workspace_sup. We start a minimal
+%% standalone supervisor registered under that name with no children, so the
+%% which_children scan runs for real and the user-supervisor list is empty.
+%% Combined with a registered root, this exercises both the Root branch and
+%% the filtermap over which_children.
+%%====================================================================
+
+supervisors_lists_root_with_empty_user_tree_test() ->
+    %% Only run when no real workspace_sup is already up (suite-ordering safe).
+    case whereis(beamtalk_workspace_sup) of
+        undefined ->
+            {ok, SupPid} = start_bare_workspace_sup(),
+            (try
+                ets:delete(beamtalk_root_supervisor)
+            catch
+                _:_ -> ok
+            end),
+            RootTuple = {beamtalk_supervisor, 'AppRoot', 'bt@app@root', self()},
+            beamtalk_supervisor:register_root(RootTuple),
+            try
+                Result = beamtalk_workspace_interface_primitives:supervisors(),
+                ?assert(is_list(Result)),
+                %% Root is present; no user supervisors attached.
+                ?assert(lists:member(RootTuple, Result)),
+                ?assertEqual([RootTuple], Result)
+            after
+                (try
+                    ets:delete(beamtalk_root_supervisor)
+                catch
+                    _:_ -> ok
+                end),
+                stop_proc(SupPid)
+            end;
+        _ ->
+            %% A workspace_sup is already running (integration suite); just
+            %% assert the call returns a list.
+            ?assert(is_list(beamtalk_workspace_interface_primitives:supervisors()))
+    end.
+
+supervisors_empty_without_root_test() ->
+    case whereis(beamtalk_workspace_sup) of
+        undefined ->
+            {ok, SupPid} = start_bare_workspace_sup(),
+            (try
+                ets:delete(beamtalk_root_supervisor)
+            catch
+                _:_ -> ok
+            end),
+            try
+                ?assertEqual([], beamtalk_workspace_interface_primitives:supervisors())
+            after
+                stop_proc(SupPid)
+            end;
+        _ ->
+            ?assert(is_list(beamtalk_workspace_interface_primitives:supervisors()))
+    end.
+
+%% Start a minimal one_for_one supervisor with no children registered under
+%% the beamtalk_workspace_sup name. supervisor:start_link with the eunit test
+%% module as callback uses init/1 below.
+start_bare_workspace_sup() ->
+    supervisor:start_link({local, beamtalk_workspace_sup}, ?MODULE, bare_sup).
+
+%% supervisor init/1 callback used only by start_bare_workspace_sup/0.
+init(bare_sup) ->
+    {ok, {#{strategy => one_for_one, intensity => 1, period => 5}, []}}.
+
+%%====================================================================
+%% safe_existing_atom/1 + class_object_for/1 via changeLogRevert
+%%
+%% (covered indirectly above through the no-entry path; the install/lookup
+%% path requires a real compiled class and is exercised by the repl-protocol
+%% e2e suite — see the report notes on integration-only branches.)
+%%====================================================================

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_meta_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_meta_tests.erl
@@ -632,3 +632,274 @@ class_removed_cast_unregisters_module_test() ->
     ?assertNot(lists:keymember(ModuleName, 1, Modules2)),
 
     gen_server:stop(Pid).
+
+%%% BT-1685: file mtime tracking (set/get/clear/remove)
+
+set_get_file_mtimes_test() ->
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+
+    %% Initially empty.
+    ?assertEqual({ok, #{}}, beamtalk_workspace_meta:get_file_mtimes()),
+
+    Mtime1 = {{2026, 1, 1}, {12, 0, 0}},
+    Mtime2 = {{2026, 2, 2}, {9, 30, 15}},
+    ok = beamtalk_workspace_meta:set_file_mtime("/bt_test/a.bt", Mtime1),
+    ok = beamtalk_workspace_meta:set_file_mtime("/bt_test/b.bt", Mtime2),
+    timer:sleep(50),
+
+    {ok, Mtimes} = beamtalk_workspace_meta:get_file_mtimes(),
+    ?assertEqual(Mtime1, maps:get("/bt_test/a.bt", Mtimes)),
+    ?assertEqual(Mtime2, maps:get("/bt_test/b.bt", Mtimes)),
+    ?assertEqual(2, map_size(Mtimes)),
+
+    gen_server:stop(Pid).
+
+remove_file_mtime_test() ->
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+
+    Mtime = {{2026, 1, 1}, {12, 0, 0}},
+    ok = beamtalk_workspace_meta:set_file_mtime("/bt_test/a.bt", Mtime),
+    ok = beamtalk_workspace_meta:set_file_mtime("/bt_test/b.bt", Mtime),
+    timer:sleep(50),
+
+    ok = beamtalk_workspace_meta:remove_file_mtime("/bt_test/a.bt"),
+    timer:sleep(50),
+    {ok, Mtimes} = beamtalk_workspace_meta:get_file_mtimes(),
+    ?assertEqual(false, maps:is_key("/bt_test/a.bt", Mtimes)),
+    ?assert(maps:is_key("/bt_test/b.bt", Mtimes)),
+
+    gen_server:stop(Pid).
+
+clear_file_mtimes_test() ->
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+
+    Mtime = {{2026, 1, 1}, {12, 0, 0}},
+    ok = beamtalk_workspace_meta:set_file_mtime("/bt_test/a.bt", Mtime),
+    ok = beamtalk_workspace_meta:set_file_mtime("/bt_test/b.bt", Mtime),
+    timer:sleep(50),
+    {ok, Before} = beamtalk_workspace_meta:get_file_mtimes(),
+    ?assertEqual(2, map_size(Before)),
+
+    ok = beamtalk_workspace_meta:clear_file_mtimes(),
+    timer:sleep(50),
+    ?assertEqual({ok, #{}}, beamtalk_workspace_meta:get_file_mtimes()),
+
+    gen_server:stop(Pid).
+
+set_file_mtime_when_not_started_test() ->
+    stop_if_running(),
+    %% No server: cast helpers must return ok without crashing.
+    ?assertEqual(ok, beamtalk_workspace_meta:set_file_mtime("/x.bt", {{2026, 1, 1}, {0, 0, 0}})).
+
+clear_file_mtimes_when_not_started_test() ->
+    stop_if_running(),
+    ?assertEqual(ok, beamtalk_workspace_meta:clear_file_mtimes()).
+
+remove_file_mtime_when_not_started_test() ->
+    stop_if_running(),
+    ?assertEqual(ok, beamtalk_workspace_meta:remove_file_mtime("/x.bt")).
+
+get_file_mtimes_when_not_started_test() ->
+    stop_if_running(),
+    ?assertEqual({error, not_started}, beamtalk_workspace_meta:get_file_mtimes()).
+
+%%% BT-775: package name detection
+
+get_package_name_when_not_started_test() ->
+    stop_if_running(),
+    %% No server: must return undefined gracefully.
+    ?assertEqual(undefined, beamtalk_workspace_meta:get_package_name()).
+
+get_package_name_undefined_without_manifest_test() ->
+    %% project_path points at a dir with no beamtalk.toml ⇒ package name undefined.
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+    ?assertEqual(undefined, beamtalk_workspace_meta:get_package_name()),
+    gen_server:stop(Pid).
+
+get_package_name_undefined_when_project_path_undefined_test() ->
+    %% No project_path at all ⇒ detect_package_name(undefined) ⇒ undefined.
+    stop_if_running(),
+    WsId = <<"no_proj_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+    {ok, Pid} = beamtalk_workspace_meta:start_link(#{
+        workspace_id => WsId,
+        created_at => erlang:system_time(second)
+    }),
+    ?assertEqual(undefined, beamtalk_workspace_meta:get_package_name()),
+    {ok, Meta} = beamtalk_workspace_meta:get_metadata(),
+    ?assertEqual(undefined, maps:get(project_path, Meta)),
+    ?assertEqual(undefined, maps:get(package_name, Meta)),
+    gen_server:stop(Pid).
+
+get_package_name_detected_from_manifest_test() ->
+    %% A beamtalk.toml with a [package] name section is parsed at init time.
+    stop_if_running(),
+    Tmp = filename:join(
+        temp_dir_meta(), "bt-meta-pkg-" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    ok = filelib:ensure_path(Tmp),
+    try
+        Manifest = filename:join(Tmp, "beamtalk.toml"),
+        ok = file:write_file(
+            Manifest, <<"[package]\nname = \"my_package\"\nversion = \"0.1.0\"\n">>
+        ),
+        WsId = <<"pkg_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+        {ok, Pid} = beamtalk_workspace_meta:start_link(#{
+            workspace_id => WsId,
+            project_path => list_to_binary(Tmp),
+            created_at => erlang:system_time(second),
+            repl => false
+        }),
+        ?assertEqual(<<"my_package">>, beamtalk_workspace_meta:get_package_name()),
+        {ok, Meta} = beamtalk_workspace_meta:get_metadata(),
+        ?assertEqual(<<"my_package">>, maps:get(package_name, Meta)),
+        gen_server:stop(Pid)
+    after
+        _ = file:del_dir_r(Tmp)
+    end.
+
+get_package_name_undefined_when_no_package_section_test() ->
+    %% A beamtalk.toml without a [package] section ⇒ extract_package_name ⇒ undefined.
+    stop_if_running(),
+    Tmp = filename:join(
+        temp_dir_meta(), "bt-meta-nopkg-" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    ok = filelib:ensure_path(Tmp),
+    try
+        Manifest = filename:join(Tmp, "beamtalk.toml"),
+        ok = file:write_file(Manifest, <<"[dependencies]\nfoo = \"1.0\"\n">>),
+        WsId = <<"nopkg_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+        {ok, Pid} = beamtalk_workspace_meta:start_link(#{
+            workspace_id => WsId,
+            project_path => list_to_binary(Tmp),
+            created_at => erlang:system_time(second),
+            repl => false
+        }),
+        ?assertEqual(undefined, beamtalk_workspace_meta:get_package_name()),
+        gen_server:stop(Pid)
+    after
+        _ = file:del_dir_r(Tmp)
+    end.
+
+get_package_name_undefined_when_name_missing_in_section_test() ->
+    %% [package] present but no name field ⇒ undefined.
+    stop_if_running(),
+    Tmp = filename:join(
+        temp_dir_meta(), "bt-meta-noname-" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    ok = filelib:ensure_path(Tmp),
+    try
+        Manifest = filename:join(Tmp, "beamtalk.toml"),
+        ok = file:write_file(Manifest, <<"[package]\nversion = \"0.1.0\"\n">>),
+        WsId = <<"noname_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+        {ok, Pid} = beamtalk_workspace_meta:start_link(#{
+            workspace_id => WsId,
+            project_path => list_to_binary(Tmp),
+            created_at => erlang:system_time(second),
+            repl => false
+        }),
+        ?assertEqual(undefined, beamtalk_workspace_meta:get_package_name()),
+        gen_server:stop(Pid)
+    after
+        _ = file:del_dir_r(Tmp)
+    end.
+
+%%% Unknown request + code_change coverage
+
+unknown_call_returns_error_test() ->
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+    ?assertEqual(
+        {error, unknown_request},
+        gen_server:call(beamtalk_workspace_meta, some_bogus_request)
+    ),
+    gen_server:stop(Pid).
+
+unknown_cast_is_ignored_test() ->
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+    %% An unknown cast must not crash the server.
+    gen_server:cast(beamtalk_workspace_meta, some_bogus_cast),
+    timer:sleep(20),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+unknown_info_is_ignored_test() ->
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+    %% An unknown info message must not crash the server.
+    Pid ! some_bogus_info,
+    timer:sleep(20),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+code_change_returns_state_test() ->
+    stop_if_running(),
+    {ok, State} = beamtalk_workspace_meta:init(test_metadata()),
+    ?assertEqual({ok, State}, beamtalk_workspace_meta:code_change(old_vsn, State, extra)).
+
+%%% Settings persistence of integer and binary values (whitelist coverage)
+
+settings_int_and_binary_survive_restart_test() ->
+    %% persistable_setting_value/1 whitelists boolean, integer, binary. Exercise
+    %% the integer and binary branches via a persist/restore round-trip.
+    stop_if_running(),
+    WsId = <<"settings_int_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+    MetaFile = metadata_path_for(WsId),
+    _ = file:delete(MetaFile),
+    try
+        Init = #{
+            workspace_id => WsId,
+            project_path => <<"/bt_test/settings_int">>,
+            created_at => erlang:system_time(second)
+        },
+        {ok, Pid1} = beamtalk_workspace_meta:start_link(Init),
+        ok = beamtalk_workspace_meta:set_setting(max_depth, 42),
+        ok = beamtalk_workspace_meta:set_setting(label, <<"hello">>),
+        %% A non-whitelisted value (list) must be dropped from persistence but
+        %% still readable in-memory before restart.
+        ok = beamtalk_workspace_meta:set_setting(weird, [1, 2, 3]),
+        ?assertEqual([1, 2, 3], beamtalk_workspace_meta:get_setting(weird, none)),
+        gen_server:stop(Pid1),
+        timer:sleep(50),
+        {ok, Pid2} = beamtalk_workspace_meta:start_link(Init),
+        ?assertEqual(42, beamtalk_workspace_meta:get_setting(max_depth, none)),
+        ?assertEqual(<<"hello">>, beamtalk_workspace_meta:get_setting(label, none)),
+        %% The non-whitelisted list value was not persisted ⇒ default returned.
+        ?assertEqual(none, beamtalk_workspace_meta:get_setting(weird, none)),
+        gen_server:stop(Pid2)
+    after
+        _ = file:delete(MetaFile)
+    end.
+
+%%% Class source persistence round-trip (covers class_sources restore branch)
+
+class_source_survives_restart_test() ->
+    stop_if_running(),
+    WsId = <<"clssrc_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+    MetaFile = metadata_path_for(WsId),
+    _ = file:delete(MetaFile),
+    try
+        Init = #{
+            workspace_id => WsId,
+            project_path => <<"/bt_test/clssrc">>,
+            created_at => erlang:system_time(second)
+        },
+        {ok, Pid1} = beamtalk_workspace_meta:start_link(Init),
+        Source = "Object subclass: Foo [\n  bar => 1\n]\n",
+        ok = beamtalk_workspace_meta:set_class_source(<<"Foo">>, Source),
+        gen_server:stop(Pid1),
+        timer:sleep(50),
+        {ok, Pid2} = beamtalk_workspace_meta:start_link(Init),
+        ?assertEqual(Source, beamtalk_workspace_meta:get_class_source(<<"Foo">>)),
+        gen_server:stop(Pid2)
+    after
+        _ = file:delete(MetaFile)
+    end.
+
+%% Cross-platform absolute temp dir (CLAUDE.md: never hardcode /tmp in tests).
+temp_dir_meta() ->
+    unicode:characters_to_list(beamtalk_file:'tempDirectory'()).


### PR DESCRIPTION
## Summary

A focused push on Erlang test coverage, taking the merged badge from **74.64% → 82.17%** (~+1,160 covered lines). Two levers:

1. **Fold the BUnit suite into coverage measurement.** `coverage-all` merged eunit + E2E + bootstrap but never the 237-file `.bt` BUnit TestCase suite — even though it exercises `beamtalk_test_case`, `beamtalk_test_runner`, and the full dispatch/object/class machinery. Added a `BUNIT_COVER` cover pass to the CLI (mirroring the existing `STDLIB_COVER`/`E2E_COVER` passes) and a `coverage-bunit` recipe wired into `coverage-all`. The strategy doc already noted BUnit is *meant* to exercise this code — it just was never counted.

2. **Targeted EUnit test suites** across the largest under-covered modules (real assertions only; no source logic changes).

## Coverage

| App | Coverage |
|-----|----------|
| `beamtalk_runtime` | 87.63% |
| `beamtalk_stdlib` | 80.51% |
| `beamtalk_workspace` | 79.71% |
| `beamtalk_compiler` | 70.29% |
| **Merged** | **82.17%** |

## Module improvements (isolated per-module cover)

**Workspace / REPL**
- `beamtalk_repl_ops_dev` 31→79% · `beamtalk_repl_loader` 36→80%
- `beamtalk_repl_compiler` 49→89% · `beamtalk_repl_eval` 43→83% · `beamtalk_repl_server` 59→62%
- `beamtalk_workspace_meta` 71→87% · `beamtalk_workspace_flush` 71→90% · `beamtalk_workspace_changelog` 82→90%
- `beamtalk_workspace_interface_primitives` 48→58%

**Runtime**
- `beamtalk_module_activation` 61→91% · `beamtalk_behaviour_intrinsics` 68→83% · `beamtalk_package` (synthetic-app branch tests)

**Compiler (BT-2389)**
- `beamtalk_compiler_port` 33→55% — live-port integration tests for the source-analysis query functions (senders / all-sends / references / field readers+writers / ffi-sites / `resolve_method_span` / `resolve_completion_type` / `compile_expression_trace`), their guard-fail and closed-port arms, and extra `handle_response` shapes.
- `beamtalk_compiler_server` 28→64% — drives every public API through the running server to the live port, covering the cold navigation `handle_call` clauses and the `do_compile`/`do_diagnostics`/`do_version`/`send_port_request` plumbing.

## Notes

- Fixed 16 cross-module EUnit interaction failures introduced by the new compiler-app fixtures (compiler-app leakage breaking "no-compiler" error-path tests, `{already_started}` class collisions, environment-dependent assertions). Full suites green: workspace 2067/0, runtime 2276/0, compiler 242/0, combined 4536/0.
- erlfmt clean; clippy/`cargo fmt` clean.

## Remaining toward 85% (tracked in BT-2389)

The remaining gap is structurally integration-only: `beamtalk_ws_handler` (Cowboy WebSocket callbacks), `beamtalk_build_worker` (escript stdin loop), and root-unreachable `permission_denied` / TOCTOU `error:badarg` defensive arms. BT-2389 covers extending integration coverage to close it.

https://claude.ai/code/session_015p1No61EhrMPfj38HCK8YD

---
_Generated by [Claude Code](https://claude.ai/code/session_015p1No61EhrMPfj38HCK8YD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for BUnit test suite with Erlang coverage instrumentation.
  * Expanded test suites for compiler port APIs, server integration, runtime intrinsics, module activation, package management, and REPL components including compiler, evaluator, loader, and workspace operations.
  * Added integration and end-to-end test scenarios for workspace metadata, changelog management, and interface primitives.

* **Chores**
  * Updated build system to include BUnit coverage in combined Erlang coverage reporting alongside runtime, E2E, and stdlib coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->