### PR TITLE
Runtime: hot-reload atomicity for xref index — gen-filtered reads + async sweep (BT-2300)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
@@ -13,13 +13,18 @@ Owns four ETS tables that maintain a runtime-resident `selector → sites` /
 `class → references` index, populated at class-load time via
 `register_class/2`. Reads (`senders_of/1`, `references_to/1`,
 `implementors_of/1`, `defined_selectors/2`) hit ETS directly and do not
-serialize through the gen_server. Writes serialize through the gen_server
-so per-class generation bumps stay atomic.
+serialize through the gen_server; each filters rows to the owning class's
+current generation. Writes serialize through the gen_server so per-class
+generation bumps stay atomic.
 
 Phase 1 (BT-2297) provides the skeleton: tables, API contract, supervisor
 wiring. Subsequent phases land producers (codegen → `register_class/0`,
-lifecycle hooks) and read-path migration in `SystemNavigation`. The
-multi-generation reload sweep lands in Phase 4 (BT-2300).
+lifecycle hooks) and read-path migration in `SystemNavigation`. Phase 4
+(BT-2300) adds the atomic install protocol: a whole-class (re)register
+inserts the new generation's rows, publishes the gen bump in one ETS write,
+and reclaims the superseded generation's rows via an async sweep — readers
+filter by `current_gen` throughout, so they never observe a partially-built
+or stale generation.
 
 Storage layout (all `protected, named_table, {read_concurrency, true}`):
 - `beamtalk_xref_methods` (bag): per-method definitions
@@ -71,6 +76,10 @@ See also: docs/ADR/0087-maintained-xref-index-for-system-navigation.md
 -define(SENDERS_TABLE, beamtalk_xref_senders).
 -define(REFERENCES_TABLE, beamtalk_xref_references).
 -define(CLASS_GEN_TABLE, xref_class_gen).
+
+%% Bound on `read_stable/1` revalidation retries (Phase 4 / BT-2300). Converges
+%% in 0-1 retries in practice; the bound only caps spin under a write storm.
+-define(READ_STABLE_RETRIES, 100).
 
 %%====================================================================
 %% Types
@@ -156,14 +165,14 @@ start_link() ->
 -doc """
 Register all per-method xref rows for a class. Synchronous.
 
-Bumps the class's generation counter, inserts new rows under the new
-generation, then atomically publishes the new generation in
-`xref_class_gen`. Readers observing during the call see either the
-pre- or post-write state (the gen-bump is the atomic publish).
-
-Phase 1 (BT-2297): the multi-gen reload sweep (old-gen `select_delete`)
-is out of scope and lands in Phase 4 / BT-2300. For now `purge_class/1`
-is the primary way to drop old rows before re-registering.
+Whole-class (re)load follows the ADR 0087 §Atomicity protocol: the new
+generation's rows are inserted first, then the generation is published in
+`xref_class_gen` in one ETS write (the atomic publish), then the superseded
+generation's rows are reclaimed by an async sweep. Readers filter by the
+published `current_gen`, so an observer always sees a complete generation —
+either the pre-register one or the fully-built post-register one — and never
+an empty or partially-built view. No `purge_class/1` is required between
+re-registers; the sweep handles stale rows.
 """.
 -spec register_class(class_name(), [method_xref_entry()]) -> ok.
 register_class(Class, MethodXref) when is_atom(Class), is_list(MethodXref) ->
@@ -182,8 +191,12 @@ Replace the xref rows for a single method without touching siblings.
 
 Used for method-level edits (`put_method/4` source patches, ADR 0082;
 extension registers, ADR 0066) where only one method's data changes.
-Synchronous. Bumps the owning class's generation so the new rows are
-visible atomically.
+Synchronous. Unlike `register_class/2`, a single-method patch does NOT bump
+the class generation — the unbumped sibling methods must stay on the current
+generation rather than being stranded behind the reader's `current_gen`
+filter. The addressed method's prior rows are deleted synchronously and the
+new rows installed under the class's current generation (establishing
+generation 1 for a never-before-registered class).
 """.
 -spec put_method(class_name(), class_side(), selector(), method_xref_entry()) -> ok.
 put_method(Class, ClassSide, Selector, MethodXref) when
@@ -328,12 +341,24 @@ go through the gen_server.
 Phase 1 (BT-2297): no miss-policy fallback. Callers should treat an
 empty result as "no known senders"; the source-scan fallback for
 unloaded / unindexed classes lands with Phase 3 (BT-2299).
+
+Phase 4 (BT-2300): rows are filtered to each owner class's current
+generation. Because `register_class/2` and `put_method/4` install under a
+new generation without synchronously purging the old one (the sweep is
+async), the bag can transiently hold stale rows from an earlier
+generation. Filtering by the owner's `current_gen` guarantees a reader
+never observes a stale site.
 """.
 -spec senders_of(selector()) -> [site()].
 senders_of(Selector) when is_atom(Selector) ->
     case ets:whereis(?SENDERS_TABLE) of
-        undefined -> [];
-        _ -> [Site || {_Sel, Site} <- ets:lookup(?SENDERS_TABLE, Selector)]
+        undefined ->
+            [];
+        _ ->
+            {Snapshot, Sites} = read_stable(fun() ->
+                [Site || {_Sel, Site} <- ets:lookup(?SENDERS_TABLE, Selector)]
+            end),
+            live_gen_sites(Sites, Snapshot)
     end.
 
 -doc """
@@ -343,12 +368,14 @@ correct result without re-parsing every method (BT-2299, Phase 3).
 
 The return map has two keys:
 
-- `indexed` — the sender sites drawn straight from the ETS index, but with
-  **stale rows dropped**: a site whose `owner` class is no longer reported as
-  loaded by `beamtalk_class_registry` is silently discarded. Each surviving
-  row is shaped `#{owner := atom(), class_side := boolean(), method := atom(),
-  line := pos_integer()}` for the BT side to map onto `#{#class, #selector,
-  #line}` records.
+- `indexed` — the sender sites drawn from the ETS index, with **stale rows
+  dropped** on two axes: (1) `senders_of/1` already filters to each owner's
+  current generation (Phase 4 / BT-2300), so a re-register can never surface a
+  site from a superseded generation here; and (2) this function additionally
+  discards any site whose `owner` class is no longer reported as loaded by
+  `beamtalk_class_registry`. Each surviving row is shaped `#{owner := atom(),
+  class_side := boolean(), method := atom(), line := pos_integer()}` for the BT
+  side to map onto `#{#class, #selector, #line}` records.
 
 - `fallback_classes` — the class names that the registry reports as loaded,
   that have **no rows in the index at all** (an index miss, per ADR 0087
@@ -395,18 +422,26 @@ senders_of_bt(Selector) when is_atom(Selector) ->
 
 -doc """
 Return all sites that reference `Class` (type annotations, class
-literals, etc.). Direct ETS lookup.
+literals, etc.). Direct ETS lookup, filtered to each owner's current
+generation (Phase 4 / BT-2300 — see `senders_of/1`).
 """.
 -spec references_to(class_name()) -> [site()].
 references_to(Class) when is_atom(Class) ->
     case ets:whereis(?REFERENCES_TABLE) of
-        undefined -> [];
-        _ -> [Site || {_Cls, Site} <- ets:lookup(?REFERENCES_TABLE, Class)]
+        undefined ->
+            [];
+        _ ->
+            {Snapshot, Sites} = read_stable(fun() ->
+                [Site || {_Cls, Site} <- ets:lookup(?REFERENCES_TABLE, Class)]
+            end),
+            live_gen_sites(Sites, Snapshot)
     end.
 
 -doc """
 Return all `{Class, ClassSide}` pairs that implement `Selector`.
-Direct ETS lookup via `match_object` on the methods bag.
+Direct ETS lookup via `match_object` on the methods bag, filtered to each
+class's current generation (Phase 4 / BT-2300) so a stale row left by an
+un-swept reload never reports a phantom implementor.
 """.
 -spec implementors_of(selector()) -> [{class_name(), class_side()}].
 implementors_of(Selector) when is_atom(Selector) ->
@@ -414,15 +449,25 @@ implementors_of(Selector) when is_atom(Selector) ->
         undefined ->
             [];
         _ ->
-            %% Match keys of shape {Class, ClassSide, Selector} where Selector matches.
-            %% Use ets:match/2 with key wildcard on Class and ClassSide.
-            Matches = ets:match(?METHODS_TABLE, {{'$1', '$2', Selector}, '_'}),
-            lists:usort([{Cls, CS} || [Cls, CS] <- Matches])
+            %% Pull the full {Key, Info} rows (not just the key fields) so the
+            %% per-row `gen` is available for the current-generation filter,
+            %% under a stable gen snapshot so a concurrent reload cannot make
+            %% the rows and the gens disagree.
+            {Snapshot, Rows} = read_stable(fun() ->
+                ets:match_object(?METHODS_TABLE, {{'_', '_', Selector}, '_'})
+            end),
+            lists:usort([
+                {Cls, CS}
+             || {{Cls, CS, _Sel}, Info} <- Rows, is_live_gen(Cls, Info, Snapshot)
+            ])
     end.
 
 -doc """
 Return the selectors defined on `Class` for the given side
 (`ClassSide = true` for class-side methods, `false` for instance-side).
+
+Filtered to `Class`'s current generation (Phase 4 / BT-2300): a selector
+that only survives in a stale, un-swept generation is not reported.
 """.
 -spec defined_selectors(class_name(), class_side()) -> [selector()].
 defined_selectors(Class, ClassSide) when is_atom(Class), is_boolean(ClassSide) ->
@@ -430,8 +475,17 @@ defined_selectors(Class, ClassSide) when is_atom(Class), is_boolean(ClassSide) -
         undefined ->
             [];
         _ ->
-            Matches = ets:match(?METHODS_TABLE, {{Class, ClassSide, '$1'}, '_'}),
-            lists:usort([Sel || [Sel] <- Matches])
+            %% `Class` is fixed; capture its generation and the matching rows
+            %% under one stable snapshot so a concurrent reload cannot strand
+            %% the filter on a generation whose rows the fetch missed or whose
+            %% rows the sweep removed mid-read.
+            {Snapshot, Rows} = read_stable(fun() ->
+                ets:match_object(?METHODS_TABLE, {{Class, ClassSide, '_'}, '_'})
+            end),
+            lists:usort([
+                Sel
+             || {{_Cls, _CS, Sel}, Info} <- Rows, is_live_gen(Class, Info, Snapshot)
+            ])
     end.
 
 -doc """
@@ -441,6 +495,14 @@ class+selector+side triple is not registered.
 Used by the LSP `nav-query` op (BT-2239) to surface the method-header line
 number to `textDocument/implementation` consumers (BT-2241). Direct ETS
 lookup — does not go through the gen_server.
+
+Phase 4 (BT-2300): `?METHODS_TABLE` is a bag, and `register_class/2` /
+`put_method/4` install under a new generation without synchronously
+purging the old one (the sweep is async). Multiple rows can therefore
+share `{Class, ClassSide, Selector}`. The lookup is filtered to `Class`'s
+current generation: the live row wins over any un-swept predecessor, and
+a selector that survives *only* in a stale generation (it was dropped by
+the latest `register_class/2`) correctly reads as `undefined`.
 """.
 -spec method_info(class_name(), class_side(), selector()) -> method_info() | undefined.
 method_info(Class, ClassSide, Selector) when
@@ -450,27 +512,12 @@ method_info(Class, ClassSide, Selector) when
         undefined ->
             undefined;
         _ ->
-            %% `?METHODS_TABLE` is a bag — after a class re-register without an
-            %% intervening `purge_class/1` (allowed by the write contract),
-            %% multiple rows can share `{Class, ClassSide, Selector}`. Pick the
-            %% row carrying the highest `gen` so live patches and reloads always
-            %% win over stale generations.
-            case ets:lookup(?METHODS_TABLE, {Class, ClassSide, Selector}) of
-                [] ->
-                    undefined;
-                [{_Key, Info}] ->
-                    Info;
-                [{_Key, First} | Rest] ->
-                    lists:foldl(
-                        fun({_K, Cur}, Best) ->
-                            case maps:get(gen, Cur, 0) >= maps:get(gen, Best, 0) of
-                                true -> Cur;
-                                false -> Best
-                            end
-                        end,
-                        First,
-                        Rest
-                    )
+            {Snapshot, Rows} = read_stable(fun() ->
+                ets:lookup(?METHODS_TABLE, {Class, ClassSide, Selector})
+            end),
+            case [Info || {_Key, Info} <- Rows, is_live_gen(Class, Info, Snapshot)] of
+                [] -> undefined;
+                [Info | _] -> Info
             end
     end.
 
@@ -513,6 +560,104 @@ indexed_class_set() ->
             Classes = [Class || {Class, _Gen} <- ets:tab2list(?CLASS_GEN_TABLE)],
             sets:from_list(Classes)
     end.
+
+%%====================================================================
+%% Internal: generation filtering (Phase 4 / BT-2300)
+%%====================================================================
+
+-doc """
+Current generation for `Class`, or `0` when the class has never been
+registered. `xref_class_gen` is a `set` table, so the lookup is O(1) and a
+registered class always has exactly one row.
+""".
+-spec current_gen(class_name()) -> non_neg_integer().
+current_gen(Class) ->
+    case ets:whereis(?CLASS_GEN_TABLE) of
+        undefined ->
+            0;
+        _ ->
+            case ets:lookup(?CLASS_GEN_TABLE, Class) of
+                [] -> 0;
+                [{_, Gen}] -> Gen
+            end
+    end.
+
+%% A snapshot of the per-class generation table: class → current gen.
+-type gen_snapshot() :: #{class_name() => gen()}.
+
+-doc """
+Run `Fetch` against ETS under a *stable* generation snapshot, returning
+`{Snapshot, Result}`.
+
+The lock-free atomicity protocol (ADR 0087 §Atomicity). Writers insert a new
+generation's rows BEFORE publishing the gen bump, and the async sweep only
+ever reclaims *strictly older* generations. So if the `xref_class_gen`
+snapshot is identical immediately before and immediately after `Fetch` runs,
+no publish completed during the fetch, and therefore:
+
+- every row carrying a snapshot gen was already installed before the fetch
+  began (insert-before-publish), so the fetch cannot miss a live row; and
+- no row carrying a snapshot gen was swept during the fetch (the sweep that
+  removes generation `G` only runs once `G` is no longer current, i.e. only
+  after a later publish — which would have changed the snapshot).
+
+If the snapshot changed across the fetch, a publish raced us; we retry, up to
+`?READ_STABLE_RETRIES` times. Retries converge almost immediately because the
+fetch is a single ETS read while each racing write is a full gen_server
+round-trip; the bound only guards against a pathological write storm and
+caps CPU spin. On the (practically unreachable) final attempt we accept the
+last fetch paired with its *post*-fetch snapshot — still a correct filter for
+any row installed before that snapshot, never a hang. `Fetch` MUST be
+side-effect-free (it may run several times).
+""".
+-spec read_stable(fun(() -> T)) -> {gen_snapshot(), T} when T :: term().
+read_stable(Fetch) ->
+    case ets:whereis(?CLASS_GEN_TABLE) of
+        undefined ->
+            {#{}, Fetch()};
+        _ ->
+            read_stable_loop(Fetch, ?READ_STABLE_RETRIES)
+    end.
+
+-spec read_stable_loop(fun(() -> T), non_neg_integer()) -> {gen_snapshot(), T} when
+    T :: term().
+read_stable_loop(Fetch, 0) ->
+    %% Exhausted retries — accept the fetch paired with the snapshot taken
+    %% immediately after it, which is consistent with every row installed up to
+    %% that point. Reachable only under a sustained write storm.
+    Result = Fetch(),
+    {gen_snapshot(), Result};
+read_stable_loop(Fetch, Retries) ->
+    Before = gen_snapshot(),
+    Result = Fetch(),
+    After = gen_snapshot(),
+    case Before =:= After of
+        true -> {Before, Result};
+        false -> read_stable_loop(Fetch, Retries - 1)
+    end.
+
+-spec gen_snapshot() -> gen_snapshot().
+gen_snapshot() ->
+    maps:from_list(ets:tab2list(?CLASS_GEN_TABLE)).
+
+-doc """
+Whether `Info`/site map's `gen` is the live generation for `Class` per the
+captured `Snapshot`. A row with no `gen` field (legacy / hand-rolled) is
+treated as gen `0`, and an unregistered class as gen `0`, so such a row only
+survives before any real registration has bumped the counter.
+""".
+-spec is_live_gen(class_name(), map(), gen_snapshot()) -> boolean().
+is_live_gen(Class, Info, Snapshot) ->
+    maps:get(gen, Info, 0) =:= maps:get(Class, Snapshot, 0).
+
+-doc """
+Filter a list of sender / reference `site()` maps to the rows whose `gen`
+matches their `owner`'s generation in the captured `Snapshot`, dropping stale
+rows left behind by an un-swept reload.
+""".
+-spec live_gen_sites([site()], gen_snapshot()) -> [site()].
+live_gen_sites(Sites, Snapshot) ->
+    [Site || Site <- Sites, is_live_gen(maps:get(owner, Site), Site, Snapshot)].
 
 -doc "Project a full `site()` down to the `bt_row()` fields the BT layer needs.".
 -spec site_to_bt_row(site()) -> bt_row().
@@ -565,19 +710,47 @@ init([]) ->
     {ok, #state{}}.
 
 handle_call({register_class, Class, MethodXref}, _From, State) ->
-    Gen = bump_gen(Class),
-    insert_method_xref_rows(Class, MethodXref, Gen),
+    %% ADR 0087 §Atomicity, steps (1)-(4). Compute the next generation
+    %% WITHOUT publishing it, insert the new rows under it, THEN publish the
+    %% gen bump in one ETS write. Readers filter by `current_gen`, so until
+    %% the publish they see the previous (consistent) generation and after it
+    %% the fully-built new generation — never a partially-built view, and
+    %% never an empty one. The old-gen rows are reclaimed asynchronously.
+    NewGen = next_gen(Class),
+    insert_method_xref_rows(Class, MethodXref, NewGen),
+    publish_gen(Class, NewGen),
+    schedule_sweep(Class, NewGen),
     {reply, ok, State};
 handle_call({purge_class, Class}, _From, State) ->
     do_purge_class(Class),
     {reply, ok, State};
 handle_call({put_method, Class, ClassSide, Selector, MethodXref}, _From, State) ->
-    Gen = bump_gen(Class),
+    %% `put_method/4` is a SURGICAL single-method patch, not a whole-class
+    %% reload, so it must NOT bump the class generation: the class's sibling
+    %% methods keep their existing rows, all of which carry the current gen,
+    %% and a gen bump here would strand every sibling behind the reader's
+    %% `current_gen` filter. Instead, install the one method's rows under the
+    %% class's *current* generation (1 for a never-registered class) and delete
+    %% the addressed method's prior rows synchronously. Siblings stay live
+    %% throughout. The addressed method itself is delete-then-insert on the same
+    %% generation, so a reader can observe a sub-call window where just that one
+    %% method is absent — the documented single-method-patch semantics (same as
+    %% `purge_method/3`); whole-class atomicity is `register_class/2`'s job.
+    %%
+    %% For a never-registered class the gen-1 publish is deferred until AFTER
+    %% the row insert (insert-before-publish, ADR 0087 §Atomicity): publishing
+    %% gen 1 first would let a `read_stable` observer snapshot a stable gen 1
+    %% while the row is not yet inserted and report the fresh method as absent.
+    {Gen, NeedsPublish} = put_method_gen(Class),
     delete_method_rows(Class, ClassSide, Selector),
     %% Force the entry's class_side/selector to match the addressed slot —
     %% protects against accidental drift between the call args and the map.
     Normalised = MethodXref#{class_side => ClassSide, selector => Selector},
     insert_method_xref_rows(Class, [Normalised], Gen),
+    case NeedsPublish of
+        true -> publish_gen(Class, Gen);
+        false -> ok
+    end,
     {reply, ok, State};
 handle_call({purge_method, Class, ClassSide, Selector}, _From, State) ->
     delete_method_rows(Class, ClassSide, Selector),
@@ -585,6 +758,20 @@ handle_call({purge_method, Class, ClassSide, Selector}, _From, State) ->
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
+handle_cast({sweep, Class, _RequestedGen}, State) ->
+    %% ADR 0087 §Atomicity step (4): reclaim rows left under a generation
+    %% older than the published one. Pure memory hygiene — readers already
+    %% ignore these rows via the `current_gen` filter, so a delayed or dropped
+    %% sweep is never a correctness problem.
+    %%
+    %% The keep-gen is re-read here rather than taken from the cast payload:
+    %% several writes to the same class can enqueue several sweep casts, and an
+    %% earlier sweep must not delete rows belonging to a generation a later
+    %% write has since published. Re-reading the live `current_gen` makes every
+    %% sweep converge on "keep only the current generation", which is always
+    %% safe regardless of cast ordering.
+    sweep_stale_gens(Class, current_gen(Class)),
+    {noreply, State};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -593,9 +780,9 @@ handle_info(_Info, State) ->
 
 terminate(_Reason, _State) ->
     %% ETS tables are owned by this process; they die automatically. The
-    %% supervisor restart brings up fresh empty tables — Phase 4's
-    %% miss-policy fallback / re-register hook will repopulate from the
-    %% class registry as classes are reloaded.
+    %% supervisor restart brings up fresh empty tables — the miss-policy
+    %% fallback (Phase 3) repopulates them at read time as classes are
+    %% navigated, and subsequent reloads re-bake their rows via register_class.
     ok.
 
 code_change(OldVsn, State, Extra) ->
@@ -606,22 +793,102 @@ code_change(OldVsn, State, Extra) ->
 %%====================================================================
 
 -doc """
-Increment the per-class generation counter and return the new generation.
-On first registration the counter starts at 1.
+Compute the next per-class generation WITHOUT publishing it. On first
+registration the next generation is 1, otherwise `current + 1`.
 
-The increment + new-gen-row insert is the atomic publish step described
-in ADR 0087 §Atomicity. Phase 1 only writes the new-gen rows; the
-async sweep of old-gen rows lands in Phase 4 (BT-2300).
+ADR 0087 §Atomicity separates computing the new generation (this) from
+publishing it (`publish_gen/2`): rows are inserted under the new gen first,
+and only then is the gen made visible to readers, so there is no instant at
+which `current_gen` points at a half-built generation.
 """.
--spec bump_gen(class_name()) -> gen().
-bump_gen(Class) ->
-    NewGen =
-        case ets:lookup(?CLASS_GEN_TABLE, Class) of
-            [] -> 1;
-            [{_, Current}] -> Current + 1
-        end,
-    true = ets:insert(?CLASS_GEN_TABLE, {Class, NewGen}),
-    NewGen.
+-spec next_gen(class_name()) -> gen().
+next_gen(Class) ->
+    case ets:lookup(?CLASS_GEN_TABLE, Class) of
+        [] -> 1;
+        [{_, Current}] -> Current + 1
+    end.
+
+-doc """
+Publish `Gen` as `Class`'s current generation in one ETS write — the atomic
+publish step (ADR 0087 §Atomicity step 3). After this returns, readers
+filtering by `current_gen` observe the just-installed rows.
+""".
+-spec publish_gen(class_name(), gen()) -> ok.
+publish_gen(Class, Gen) ->
+    true = ets:insert(?CLASS_GEN_TABLE, {Class, Gen}),
+    ok.
+
+-doc """
+Resolve the generation under which a `put_method/4` patch installs its row,
+returning `{Gen, NeedsPublish}`.
+
+A single-method patch does NOT bump the class generation (that would strand
+the unbumped siblings behind the reader's `current_gen` filter); it joins the
+class's current generation, so `NeedsPublish` is `false`. A class that has
+never been registered has no gen row, so the patch establishes generation 1
+and `NeedsPublish` is `true` — but the caller must publish *after* inserting
+the row (insert-before-publish), so the publish is the caller's job, not this
+function's. Establishing the gen here (rather than publishing it) keeps this
+read-only: it never makes a half-built generation visible.
+""".
+-spec put_method_gen(class_name()) -> {gen(), boolean()}.
+put_method_gen(Class) ->
+    case ets:lookup(?CLASS_GEN_TABLE, Class) of
+        [] -> {1, true};
+        [{_, Current}] -> {Current, false}
+    end.
+
+-doc """
+Asynchronously reclaim rows for `Class` carrying a generation other than
+`KeepGen` (ADR 0087 §Atomicity step 4). Cast to self so the synchronous
+write call returns to the caller immediately; the sweep is memory hygiene,
+not a correctness step (readers already filter stale gens out).
+""".
+-spec schedule_sweep(class_name(), gen()) -> ok.
+schedule_sweep(Class, KeepGen) ->
+    gen_server:cast(?MODULE, {sweep, Class, KeepGen}),
+    ok.
+
+-doc """
+Delete every row for `Class` whose `gen` is not `KeepGen`, across all three
+index tables. Runs inside the gen_server (the tables are `protected`), so it
+never races a concurrent write to the same class.
+
+`methods` rows are matched by their `{Class, _, _}` key with the owner gen
+inside the value map; `senders` / `references` rows are keyed by selector /
+referenced class with the owner + gen inside the value map. All three use a
+`select_delete` guard `owner =:= Class andalso gen < KeepGen`.
+
+The guard is `<` (strictly older), not `=/=`: when several writes to the
+same class enqueue several sweep casts, an earlier sweep re-reads the live
+`current_gen` (see `handle_cast`), but a row carrying a *newer* generation
+than the one this sweep computed must never be deleted. Bounding deletion to
+strictly-older generations makes every sweep idempotent and order-insensitive
+— it only ever reclaims rows a later generation has already superseded.
+""".
+-spec sweep_stale_gens(class_name(), gen()) -> ok.
+sweep_stale_gens(Class, KeepGen) ->
+    %% Methods: key carries the class; value carries the gen.
+    _ = ets:select_delete(
+        ?METHODS_TABLE,
+        [
+            {
+                {{Class, '_', '_'}, #{gen => '$1'}},
+                [{'<', '$1', {const, KeepGen}}],
+                [true]
+            }
+        ]
+    ),
+    StaleSiteSpec = [
+        {
+            {'_', #{owner => '$1', gen => '$2'}},
+            [{'=:=', '$1', {const, Class}}, {'<', '$2', {const, KeepGen}}],
+            [true]
+        }
+    ],
+    _ = ets:select_delete(?SENDERS_TABLE, StaleSiteSpec),
+    _ = ets:select_delete(?REFERENCES_TABLE, StaleSiteSpec),
+    ok.
 
 %%====================================================================
 %% Internal: write helpers

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
@@ -622,11 +622,17 @@ read_stable(Fetch) ->
 -spec read_stable_loop(fun(() -> T), non_neg_integer()) -> {gen_snapshot(), T} when
     T :: term().
 read_stable_loop(Fetch, 0) ->
-    %% Exhausted retries — accept the fetch paired with the snapshot taken
-    %% immediately after it, which is consistent with every row installed up to
-    %% that point. Reachable only under a sustained write storm.
+    %% Exhausted retries — pin the snapshot BEFORE the fetch. Because writers
+    %% insert a generation's rows before publishing its gen bump, a fetch taken
+    %% at or after this snapshot observes a superset of every row the snapshot's
+    %% generations had installed, so filtering by it can only drop rows from
+    %% *later* generations, never miss one of its own. Pairing with a
+    %% *post*-fetch snapshot instead could race a publish and filter the older
+    %% fetch as if its rows were stale, yielding a false empty/partial view.
+    %% Reachable only under a sustained write storm.
+    Snapshot = gen_snapshot(),
     Result = Fetch(),
-    {gen_snapshot(), Result};
+    {Snapshot, Result};
 read_stable_loop(Fetch, Retries) ->
     Before = gen_snapshot(),
     Result = Fetch(),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_xref_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_xref_tests.erl
@@ -250,7 +250,11 @@ generation_increments_test_() ->
                 ok = beamtalk_xref:register_class('Counter', counter_xref()),
                 ?assertEqual(2, current_gen('Counter')),
 
-                %% put_method also bumps the gen.
+                %% put_method is a surgical single-method patch and must NOT
+                %% bump the class generation (Phase 4 / BT-2300) — a bump would
+                %% strand the unbumped sibling methods behind the reader's
+                %% current-gen filter. The patched method joins the class's
+                %% current generation, leaving it unchanged at 2.
                 NewEntry = #{
                     class_side => false,
                     selector => 'increment',
@@ -261,7 +265,7 @@ generation_increments_test_() ->
                     provenance => put_method
                 },
                 ok = beamtalk_xref:put_method('Counter', false, 'increment', NewEntry),
-                ?assertEqual(3, current_gen('Counter')),
+                ?assertEqual(2, current_gen('Counter')),
 
                 %% A fresh class starts at gen 1.
                 ok = beamtalk_xref:register_class('Point', point_xref()),
@@ -356,24 +360,24 @@ put_method_normalises_selector_and_side_test_() ->
 %% method_info reads — current generation wins on stale bag rows
 %%====================================================================
 
-method_info_picks_highest_generation_test_() ->
+method_info_picks_current_generation_test_() ->
     {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
         [
             ?_test(begin
-                %% `?METHODS_TABLE` is a bag; `register_class` does NOT purge
-                %% before inserting under the new gen, so re-registering a
-                %% class without an intervening `purge_class/1` accumulates
-                %% rows from older generations. `method_info/3` must pick the
-                %% row carrying the highest `gen` so live patches always win.
+                %% `?METHODS_TABLE` is a bag; `register_class` inserts under a
+                %% new gen and publishes it before the async old-gen sweep
+                %% runs, so a window exists where rows from two generations
+                %% coexist. `method_info/3` must return the row carrying the
+                %% class's *current* gen, never a stale one (Phase 4 / BT-2300).
                 ok = beamtalk_xref:register_class('Counter', counter_xref()),
                 Info1 = beamtalk_xref:method_info('Counter', false, 'increment'),
                 ?assertEqual(1, maps:get(gen, Info1)),
                 ?assertEqual(14, maps:get(line, Info1)),
 
-                %% Re-register with the same selector at a different line; the
-                %% old row at line 8 (gen 1) stays in the bag alongside the new
-                %% gen-2 row at line 42. `method_info/3` must return the gen-2
-                %% row, not whichever row ETS picks first.
+                %% Re-register the same selector at a different line. Before the
+                %% async sweep lands, the old line-14 (gen 1) row can still sit
+                %% in the bag beside the new line-42 (gen 2) row. `method_info/3`
+                %% must return the gen-2 row regardless of ETS bag order.
                 Counter2 = lists:map(
                     fun
                         (#{selector := 'increment'} = E) ->
@@ -388,11 +392,16 @@ method_info_picks_highest_generation_test_() ->
                 ?assertEqual(2, maps:get(gen, Info2)),
                 ?assertEqual(42, maps:get(line, Info2)),
 
-                %% Sanity: the bag really does still hold both generations
-                %% — the read picks the higher one rather than relying on a
-                %% prior purge.
+                %% After the async sweep drains, only the current-gen row
+                %% survives in the bag (memory hygiene, ADR 0087 §Atomicity
+                %% step 4). Flush the gen_server mailbox so the sweep cast has
+                %% certainly been processed before asserting.
+                flush_xref(),
                 Rows = ets:lookup(beamtalk_xref_methods, {'Counter', false, 'increment'}),
-                ?assertEqual(2, length(Rows)),
+                ?assertEqual(1, length(Rows)),
+                [{_, OnlyInfo}] = Rows,
+                ?assertEqual(2, maps:get(gen, OnlyInfo)),
+                ?assertEqual(42, maps:get(line, OnlyInfo)),
 
                 %% Unknown method → undefined.
                 ?assertEqual(
@@ -404,6 +413,145 @@ method_info_picks_highest_generation_test_() ->
                     undefined,
                     beamtalk_xref:method_info('NoSuchClass', false, 'increment')
                 )
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Generation filtering on the read path (Phase 4 / BT-2300)
+%%====================================================================
+
+%% A re-register that drops a method/send/reference must not leave the
+%% dropped item visible through any list reader, even before the async
+%% old-gen sweep has run. Correctness comes from the reader's current-gen
+%% filter, not from the sweep — so this test deliberately does NOT flush.
+read_path_filters_stale_generation_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                %% Gen 1: increment sends '+' and references Integer; value and
+                %% class-side new also present.
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+                ?assertEqual(1, length(beamtalk_xref:senders_of('+'))),
+                ?assertEqual(1, length(beamtalk_xref:references_to('Integer'))),
+                ?assertEqual([{'Counter', false}], beamtalk_xref:implementors_of('value')),
+                ?assert(lists:member('value', beamtalk_xref:defined_selectors('Counter', false))),
+
+                %% Gen 2: re-register WITHOUT the `value` method, with
+                %% `increment` now sending '-' (not '+') and referencing Float
+                %% (not Integer). The gen-1 rows linger in the bag until the
+                %% async sweep, but no reader may surface them.
+                Gen2Xref = [
+                    #{
+                        class_side => false,
+                        selector => 'increment',
+                        line => 14,
+                        sends => [#{selector => '-', line => 17, recv_kind => self_recv}],
+                        references => [#{class => 'Float', line => 16}],
+                        source_status => indexed,
+                        provenance => class_body
+                    },
+                    #{
+                        class_side => true,
+                        selector => 'new',
+                        line => 8,
+                        sends => [#{selector => 'basicNew', line => 9, recv_kind => super_recv}],
+                        references => [],
+                        source_status => indexed,
+                        provenance => class_body
+                    }
+                ],
+                ok = beamtalk_xref:register_class('Counter', Gen2Xref),
+
+                %% senders_of: the dropped '+' send is gone; the new '-' is live.
+                ?assertEqual([], beamtalk_xref:senders_of('+')),
+                MinusSites = beamtalk_xref:senders_of('-'),
+                ?assertEqual(1, length(MinusSites)),
+                [MinusSite] = MinusSites,
+                ?assertEqual(2, maps:get(gen, MinusSite)),
+
+                %% references_to: Integer dropped, Float live.
+                ?assertEqual([], beamtalk_xref:references_to('Integer')),
+                ?assertEqual(1, length(beamtalk_xref:references_to('Float'))),
+
+                %% implementors_of: the removed `value` no longer reports Counter.
+                ?assertEqual([], beamtalk_xref:implementors_of('value')),
+                ?assertEqual([{'Counter', false}], beamtalk_xref:implementors_of('increment')),
+
+                %% defined_selectors: `value` dropped, `increment` retained.
+                InstSels = beamtalk_xref:defined_selectors('Counter', false),
+                ?assertEqual(['increment'], InstSels),
+                ?assertEqual(['new'], beamtalk_xref:defined_selectors('Counter', true))
+            end)
+        ]
+    end}.
+
+%% The async sweep eventually reclaims the stale-gen rows from every table.
+%% Filtering already hides them; this asserts the memory-hygiene step.
+async_sweep_reclaims_old_generation_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+                ok = beamtalk_xref:register_class('Counter', counter_xref()),
+
+                %% Drain the sweep casts.
+                flush_xref(),
+
+                %% Only the current generation (3) survives in every table.
+                MethodRows = ets:tab2list(beamtalk_xref_methods),
+                CounterMethodGens = [
+                    maps:get(gen, Info)
+                 || {{'Counter', _, _}, Info} <- MethodRows
+                ],
+                ?assertEqual([3], lists:usort(CounterMethodGens)),
+
+                SenderGens = [
+                    maps:get(gen, Site)
+                 || {_, Site} <- ets:tab2list(beamtalk_xref_senders),
+                    maps:get(owner, Site) =:= 'Counter'
+                ],
+                ?assertEqual([3], lists:usort(SenderGens)),
+
+                RefGens = [
+                    maps:get(gen, Site)
+                 || {_, Site} <- ets:tab2list(beamtalk_xref_references),
+                    maps:get(owner, Site) =:= 'Counter'
+                ],
+                ?assertEqual([3], lists:usort(RefGens)),
+
+                %% The view is still complete after the sweep.
+                ?assertEqual(1, length(beamtalk_xref:senders_of('+'))),
+                ?assert(lists:member('value', beamtalk_xref:defined_selectors('Counter', false)))
+            end)
+        ]
+    end}.
+
+%% A never-registered class patched via put_method/4 establishes generation 1
+%% and the patched method is immediately visible through the read path — the
+%% reader's current-gen filter must not hide it.
+put_method_on_fresh_class_is_visible_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Entry = #{
+                    class_side => false,
+                    selector => 'ping',
+                    line => 3,
+                    sends => [#{selector => 'pong', line => 4, recv_kind => self_recv}],
+                    references => [#{class => 'Boolean', line => 5}],
+                    source_status => indexed,
+                    provenance => put_method
+                },
+                ok = beamtalk_xref:put_method('Fresh', false, 'ping', Entry),
+
+                ?assertEqual(1, current_gen('Fresh')),
+                ?assert(lists:member('ping', beamtalk_xref:defined_selectors('Fresh', false))),
+                ?assertEqual([{'Fresh', false}], beamtalk_xref:implementors_of('ping')),
+                ?assertEqual(1, length(beamtalk_xref:senders_of('pong'))),
+                ?assertEqual(1, length(beamtalk_xref:references_to('Boolean'))),
+                #{owner := 'Fresh'} = beamtalk_xref:method_info('Fresh', false, 'ping')
             end)
         ]
     end}.
@@ -697,6 +845,67 @@ miss_policy_fallback_test_() ->
             end)}
     end}.
 
+%% The CodeRabbit finding deferred from BT-2299 to BT-2300: the `indexed`
+%% partition of senders_of_bt/1 must be filtered to the live generation so a
+%% re-register never exposes a stale sender row. Re-register a loaded class
+%% twice with a *different* send selector each generation and assert the
+%% partition only ever reflects the current generation.
+senders_of_bt_indexed_is_gen_filtered_test_() ->
+    {setup, fun setup_app/0, fun cleanup_app/1, fun(_) ->
+        {timeout, 30,
+            ?_test(begin
+                Class = first_method_bearing_class(),
+                ?assertNotEqual(undefined, Class),
+
+                Gen1 = [
+                    #{
+                        class_side => false,
+                        selector => 'someSel',
+                        line => 1,
+                        sends => [#{selector => 'genOneSend', line => 2, recv_kind => other}],
+                        references => [],
+                        source_status => indexed,
+                        provenance => class_body
+                    }
+                ],
+                ok = beamtalk_xref:register_class(Class, Gen1),
+                try
+                    %% Gen 1 send is visible in the indexed partition.
+                    #{indexed := Idx1} = beamtalk_xref:senders_of_bt('genOneSend'),
+                    ?assert(lists:any(fun(R) -> maps:get(owner, R) =:= Class end, Idx1)),
+
+                    %% Re-register the class WITHOUT the gen-1 send (it now sends
+                    %% `genTwoSend` instead). The gen-1 sender row lingers in the
+                    %% bag until the async sweep, but the gen filter inside
+                    %% senders_of/1 must keep it out of the indexed partition.
+                    Gen2 = [
+                        #{
+                            class_side => false,
+                            selector => 'someSel',
+                            line => 1,
+                            sends => [
+                                #{selector => 'genTwoSend', line => 2, recv_kind => other}
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        }
+                    ],
+                    ok = beamtalk_xref:register_class(Class, Gen2),
+
+                    %% Stale gen-1 send no longer surfaces for this class...
+                    #{indexed := Idx2} = beamtalk_xref:senders_of_bt('genOneSend'),
+                    ?assertNot(lists:any(fun(R) -> maps:get(owner, R) =:= Class end, Idx2)),
+                    %% ...and the current gen-2 send does.
+                    #{indexed := Idx3} = beamtalk_xref:senders_of_bt('genTwoSend'),
+                    ?assert(lists:any(fun(R) -> maps:get(owner, R) =:= Class end, Idx3))
+                after
+                    %% Drop the synthetic rows so sibling tests are unaffected.
+                    ok = beamtalk_xref:purge_class(Class)
+                end
+            end)}
+    end}.
+
 setup_app() ->
     %% The miss policy needs both a live class registry (to report a class as
     %% loaded) and a running xref server. Bring up the full runtime app when we
@@ -816,3 +1025,11 @@ current_gen(Class) ->
         [] -> 0;
         [{_, Gen}] -> Gen
     end.
+
+%% Barrier that guarantees every async sweep cast enqueued by a prior write
+%% has been processed. A `sys:get_state/1` is a synchronous call into the
+%% gen_server, so it cannot be handled until the gen_server has drained all
+%% earlier mailbox messages (the sweep casts) ahead of it.
+flush_xref() ->
+    _ = sys:get_state(beamtalk_xref),
+    ok.


### PR DESCRIPTION
## Summary

Phase 4 of ADR 0087 (maintained xref index). Makes a class reload **atomic from a reader's perspective** and stops stale generations from ever surfacing through `SystemNavigation` queries. Builds on BT-2298 (codegen-baked `method_xref`), BT-2299 (`sendersOf:` migration + miss-policy), and BT-2301 (`put_method`/extension/ClassBuilder lifecycle hooks).

## Write path

- **`register_class/2`** now follows the ADR §Atomicity protocol: insert the new generation's rows → publish the generation bump in one ETS write → reclaim the superseded generation's rows via an **async `select_delete` cast**. Insert-before-publish means a reader never sees a half-built generation.
- **`put_method/4`** is a surgical single-method patch and deliberately does **not** bump the class generation — a bump would strand the unbumped sibling methods behind the reader's current-gen filter. It joins the class's current generation, establishing/publishing generation 1 for a never-registered class *after* the row insert.
- The async sweep deletes **strictly-older** generations only (`gen < current`), so out-of-order or re-queued sweep casts are idempotent and can never delete a newer generation's live rows.

## Read path

`senders_of/1`, `references_to/1`, `implementors_of/1`, `defined_selectors/2`, and `method_info/3` now filter rows to the owning class's current generation. Reads use a lock-free `read_stable/1` revalidation primitive — snapshot the gen table, run the fetch, re-snapshot, retry if it changed (bounded) — so a concurrent reload can never show a reader a partial or empty view. `method_info/3` switches from "highest gen wins" to "current gen wins", which also correctly returns `undefined` for a selector that survives only in a stale, un-swept generation.

## CodeRabbit finding (deferred from BT-2299)

> filter `indexed` sender rows to the live generation so a re-register never exposes stale rows

Resolved: `senders_of_bt/1`'s `indexed` partition is built from `senders_of/1`, which is now generation-filtered, so a re-register can never surface a stale sender row. The `senders_of_bt` docstring documents both stale-drop axes (generation + loaded-class).

## Tests

- `read_path_filters_stale_generation_test_` — dropped sends/refs/selectors are invisible to every list reader *before* the sweep runs (correctness comes from the filter, not the sweep).
- `async_sweep_reclaims_old_generation_test_` — the sweep reclaims old-gen rows in all three tables.
- `put_method_on_fresh_class_is_visible_test_` — a fresh-class patch is immediately visible.
- `method_info_picks_current_generation_test_` (renamed) — current-gen semantics + post-sweep single-row bag.
- `senders_of_bt_indexed_is_gen_filtered_test_` — the CodeRabbit finding, exercised against the live registry.
- The existing concurrent-reader stress test now exercises the atomic install; it caught a read-skew in an earlier per-row-gen implementation, which the `read_stable/1` snapshot protocol fixes.
- Updated `generation_increments_test_` for the no-bump `put_method`.

## Verification

- `beamtalk_xref.erl` and the test module compile clean with `+warnings_as_errors`, `+warn_unused_function`, `+warn_unused_vars`.
- 13/13 runnable EUnit generators pass locally. The 2 `setup_app`-gated tests (miss-policy + the new `senders_of_bt` gen-filter test) require the full runtime app (cowboy dep, network-blocked locally) and run in CI.
- `cargo check --workspace` clean — changes are isolated to Erlang.
- Public API arities unchanged; no caller updates required.

Closes BT-2300.

https://claude.ai/code/session_01DBseMAGL4WcX6j4h4orjVF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBseMAGL4WcX6j4h4orjVF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented multi-generation atomicity protocol for cross-reference operations, enhancing data consistency during concurrent updates.
  * Added automatic async cleanup of stale generation data for improved memory efficiency.

* **Bug Fixes**
  * Read operations now consistently filter and return only current generation data, preventing stale information from appearing in results.

* **Tests**
  * Expanded test coverage for generation filtering, async cleanup, and method registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->