### PR TITLE
Bake method_xref into register_class for native and protocol classes (BT-2385)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -1545,7 +1545,7 @@ impl CoreErlangGenerator {
     /// line pointing at the generating slot declaration (or the class header).
     /// Included by default so `implementorsOf: #value` on an auto-accessor is
     /// non-empty — a documented parity exception, not a regression.
-    fn build_method_xref_list(
+    pub(in crate::codegen::core_erlang::gen_server) fn build_method_xref_list(
         &self,
         class: &ClassDefinition,
         instance_methods: &[&MethodDefinition],

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/native_facade.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/native_facade.rs
@@ -503,6 +503,25 @@ impl CoreErlangGenerator {
                 .filter(|m| m.kind == MethodKind::Primary)
                 .collect();
 
+            // Class-side primary methods (used for both the signature/source maps
+            // below and the xref index).
+            let class_methods_primary: Vec<_> = class
+                .class_methods
+                .iter()
+                .filter(|m| m.kind == MethodKind::Primary)
+                .collect();
+
+            // ADR 0087 Phase 2 (BT-2298) / BT-2385: per-method cross-reference
+            // index. The standard `register_class/0` path bakes this for every
+            // class; native-facade classes (`native:` actors like Subprocess and
+            // TranscriptStream) went down their own builder-state path that
+            // omitted it, so their methods were absent from `beamtalk_xref` and
+            // every navigation query source-scanned them via the miss-policy
+            // fallback. Bake the same `methodXref` list here so native classes
+            // are indexed like the rest.
+            let method_xref_doc =
+                self.build_method_xref_list(class, &instance_methods, &class_methods_primary);
+
             // Method source
             let mut method_source_docs: Vec<Document<'static>> = Vec::new();
             for (method_idx, method) in instance_methods.iter().enumerate() {
@@ -656,6 +675,13 @@ impl CoreErlangGenerator {
                         "'classMethodSignatures' => ~{",
                         class_method_sigs_doc,
                         "}~,",
+                        line(),
+                        // ADR 0087 Phase 2 (BT-2298) / BT-2385: per-method xref
+                        // index. A list of maps, not a `~{ }~` map, so it is
+                        // wrapped only by build_method_xref_list.
+                        "'methodXref' => ",
+                        method_xref_doc,
+                        ",",
                         line(),
                         "'classState' => ~{",
                         class_vars_doc,

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -3306,6 +3306,43 @@ fn test_native_facade_register_class_includes_meta() {
     );
 }
 
+/// BT-2385: `native:` facade `register_class/0` bakes a `methodXref` list into
+/// its `BuilderState`, exactly like the standard `register_class/0` path. Before
+/// this fix native classes (e.g. `Subprocess`, `TranscriptStream`) loaded with no
+/// baked `method_xref`, so they were absent from `beamtalk_xref` and every
+/// navigation query source-scanned them via the miss-policy fallback.
+#[test]
+fn test_native_facade_register_class_bakes_method_xref() {
+    let module = make_native_actor_module();
+    let result = generate_module(&module, CodegenOptions::new("bt@test_native"));
+    let code = result.unwrap();
+    let register_fn =
+        extract_core_fn(&code, "'register_class'/0 = fun").expect("register_class/0 not found");
+    // The methodXref field is present and a list (not a `~{ }~` map).
+    assert!(
+        register_fn.contains("'methodXref' => ["),
+        "native register_class/0 should bake a methodXref list. Got:\n{register_fn}"
+    );
+    // The instance methods `doWork` and `process:` are recorded, instance-side,
+    // and tagged indexed (they carry analysable Beamtalk source).
+    assert!(
+        register_fn.contains("'selector' => 'doWork'"),
+        "doWork xref entry missing. Got:\n{register_fn}"
+    );
+    assert!(
+        register_fn.contains("'selector' => 'process:'"),
+        "process: xref entry missing. Got:\n{register_fn}"
+    );
+    assert!(
+        register_fn.contains("'class_side' => 'false'"),
+        "instance-side entries should carry 'class_side' => 'false'. Got:\n{register_fn}"
+    );
+    assert!(
+        register_fn.contains("'source_status' => 'indexed'"),
+        "native instance-method rows should be tagged indexed. Got:\n{register_fn}"
+    );
+}
+
 #[test]
 fn test_native_facade_spawn_error_raises_instantiation_error() {
     // ADR 0056: spawn failure should raise instantiation_error with reason in details

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
@@ -449,6 +449,20 @@ create_protocol_class(Name, Info) ->
             requiredMethods => <<"Return the required method selectors for this protocol.">>,
             conformingClasses => <<"Return the classes conforming to this protocol.">>
         },
+        %% ADR 0087 Phase 2 (BT-2298) / BT-2385: protocol class objects expose two
+        %% class-side methods (`requiredMethods`, `conformingClasses`) dispatched
+        %% by the shared Erlang module `beamtalk_protocol_object` — they have no
+        %% analysable Beamtalk body, so codegen never bakes a method_xref for
+        %% them. Without this the protocol class (e.g. Printable) is absent from
+        %% beamtalk_xref and every navigation query source-scans it via the
+        %% miss-policy fallback. Record both as `unindexed_runtime_fun` rows
+        %% (the genuine sourceless category, mirroring beamtalk_bootstrap's stub
+        %% classes) so the class is indexed. `beamtalk_object_class:init/1`
+        %% forwards this list to beamtalk_xref before start/2 yields.
+        method_xref => [
+            protocol_class_xref_entry(requiredMethods),
+            protocol_class_xref_entry(conformingClasses)
+        ],
         instance_methods => #{},
         fields => [],
         doc => Doc
@@ -471,3 +485,26 @@ create_protocol_class(Name, Info) ->
             ),
             ok
     end.
+
+-doc """
+Build a single `unindexed_runtime_fun` method_xref entry for a protocol class
+object's class-side method (BT-2385).
+
+Protocol class objects share the Erlang dispatch module
+`beamtalk_protocol_object`, so `requiredMethods` / `conformingClasses` have no
+analysable Beamtalk source. They are recorded with empty `sends` / `references`
+and `source_status => unindexed_runtime_fun`, matching the sourceless stub-class
+convention in `beamtalk_bootstrap:stub_method_entry/2`. The `line` is a
+placeholder (`1`) because `beamtalk_xref` requires a `pos_integer()`.
+""".
+-spec protocol_class_xref_entry(atom()) -> map().
+protocol_class_xref_entry(Selector) ->
+    #{
+        class_side => true,
+        selector => Selector,
+        line => 1,
+        sends => [],
+        references => [],
+        source_status => unindexed_runtime_fun,
+        provenance => class_body
+    }.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_stdlib_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_stdlib_tests.erl
@@ -23,6 +23,20 @@ stdlib_setup() ->
     end,
     %% Initialize extensions ETS table
     beamtalk_extensions:init(),
+    %% BT-2385: Initialize the protocol registry ETS table so protocol-only
+    %% modules (e.g. Printable) can register during stdlib load. Without this
+    %% their on_load `register_protocol/1` crashes on a missing ETS table and
+    %% the protocol class object (with its xref rows) is never created.
+    beamtalk_protocol_registry:init(),
+    %% BT-2385: Start beamtalk_xref before loading stdlib so that class on_load
+    %% (`register_class/0`) and protocol registration forward their baked
+    %% method_xref rows into the index. In the real runtime xref is the first
+    %% supervisor child, ahead of bootstrap; mirror that ordering here so the
+    %% xref-indexing regression test sees a populated index.
+    case whereis(beamtalk_xref) of
+        undefined -> {ok, _} = beamtalk_xref:start_link();
+        _ -> ok
+    end,
     %% Start bootstrap (starts pg) then load stdlib classes
     {ok, _} = beamtalk_bootstrap:start_link(),
     beamtalk_stdlib:init(),
@@ -45,6 +59,8 @@ stdlib_test_() ->
         {"Tuple class is registered", fun tuple_class_registered_test/0},
         {"BeamtalkInterface class is registered", fun system_dictionary_class_registered_test/0},
         {"TranscriptStream class is registered", fun transcript_stream_class_registered_test/0},
+        {"method-bearing stdlib classes carry baked method_xref (BT-2385)",
+            fun method_bearing_classes_indexed_test/0},
         {"Integer class has correct superclass", fun integer_superclass_test/0},
         {"Integer class has expected methods", fun integer_methods_test/0},
         %% Beamtalk class method tests
@@ -146,6 +162,23 @@ transcript_stream_class_registered_test() ->
     Pid = beamtalk_class_registry:whereis_class('TranscriptStream'),
     ?assertNotEqual(undefined, Pid),
     ?assertEqual('TranscriptStream', beamtalk_object_class:class_name(Pid)).
+
+%% BT-2385: Regression — these method-bearing stdlib classes previously loaded
+%% with NO baked method_xref, so they were absent from `xref_class_gen` and every
+%% navigation query source-scanned them via the miss-policy fallback (one
+%% `xref_miss` warning per query). The gaps were three distinct class shapes:
+%%   * `Printable` — a `Protocol define:`; its class object's two class-side
+%%     methods (`requiredMethods`/`conformingClasses`) are runtime funs created
+%%     in beamtalk_protocol_registry, which now bakes their method_xref.
+%%   * `TranscriptStream` / `Subprocess` — `native:` actors whose facade
+%%     `register_class/0` (native_facade.rs) now bakes method_xref like the
+%%     standard path.
+%% Asserts each appears in the `xref_class_gen` index after a normal stdlib load.
+method_bearing_classes_indexed_test() ->
+    Indexed = fun(Class) -> ets:lookup(xref_class_gen, Class) =/= [] end,
+    ?assert(Indexed('Printable')),
+    ?assert(Indexed('TranscriptStream')),
+    ?assert(Indexed('Subprocess')).
 
 integer_superclass_test() ->
     Pid = beamtalk_class_registry:whereis_class('Integer'),


### PR DESCRIPTION
## Summary

Closes the BT-2228 Phase 2 completeness gap surfaced by BT-2299's benchmark: three method-bearing stdlib classes loaded with **no baked `method_xref`**, so they were absent from the xref index (`xref_class_gen`) and every `SystemNavigation` query source-scanned them via the miss-policy fallback, logging an `xref_miss` warning per query:

- `Printable` (0 instance, 2 class-side methods)
- `TranscriptStream` (6 instance, 3 class-side)
- `Subprocess` (9 instance, 3 class-side)

## Root cause

The gap was **two distinct codegen/runtime paths**, not one — and they map to two of the class shapes the issue suspected:

### 1. `native:` actors (`Subprocess`, `TranscriptStream`)
These compile through `generate_native_register_class` in `native_facade.rs`, a **separate** `register_class/0` path from the standard `generate_register_class`. It builds its own `BuilderState` Core Erlang map and never populated the `methodXref` key. The runtime fallback (`beamtalk_class_builder:builder_method_xref/1`) can derive xref rows from `methodSource`/`classMethodSource` — but only after intersecting them with the installed `methodSpecs`/`classMethods` selector sets. The native facade emits **no** `methodSpecs`, so the intersection was empty and **zero** rows were derived. (`ReactiveSubprocess` is a plain `Actor subclass:`, not `native:`, which is why it was already indexed.)

### 2. Protocol class objects (`Printable`)
A `Protocol define:` registers via `beamtalk_protocol_registry:register_protocol/1`, which creates the protocol's class object at runtime in `create_protocol_class/2`. That class exposes exactly two class-side methods — `requiredMethods` and `conformingClasses` — dispatched by the shared Erlang module `beamtalk_protocol_object`. They are sourceless Erlang funs, so codegen never bakes a `method_xref`, and the hand-built `ClassInfo` carried none.

(Zero-method classes — Error, BEAMError, RuntimeError, etc. — are correctly left unindexed; the miss-policy `class_defines_methods/1` gate already excludes them.)

## Fix

- **`native_facade.rs`**: `generate_native_register_class` now bakes the same `methodXref` list as the standard path, reusing `build_method_xref_list` (widened to `pub(in ...gen_server)`).
- **`beamtalk_protocol_registry.erl`**: `create_protocol_class` adds a `method_xref` key with two `unindexed_runtime_fun` rows — the genuine sourceless category, mirroring `beamtalk_bootstrap`'s stub-class convention. `beamtalk_object_class:init/1` forwards it to `beamtalk_xref` before `start/2` yields, so this covers **every** protocol, not just Printable.

## Tests

- **Codegen unit test** (`tests/gen_server.rs`): asserts the native facade `register_class/0` bakes a `methodXref` list with indexed instance-method rows.
- **Runtime EUnit regression** (`beamtalk_stdlib_tests.erl`): asserts `Printable`, `TranscriptStream`, `Subprocess` all appear in `xref_class_gen` after a normal stdlib load. The fixture now starts `beamtalk_xref` and inits the protocol registry so the index is populated.

## Validation

- `just clippy`, `just fmt-check`, `just dialyzer` — clean
- `cargo test -p beamtalk-core` — 4068 + new test pass (no snapshot covers the native facade path, so none regenerated)
- `touch SystemNavigation.bt && just build-stdlib` (warnings-as-errors) — clean
- `just test-stdlib` (250/250), `just test-bunit` (2401/2401)
- Runtime EUnit `beamtalk_xref` / `beamtalk_stdlib` / `beamtalk_protocol_*` suites — pass
- Full `rebar3 eunit`: only the 4 documented pre-existing flaky failures (`beamtalk_binary_tests` x2, `beamtalk_stream_tests`, `beamtalk_test_case_tests` — binary/stream/test_case timing); they vary run-to-run and touch none of the modules changed here
- Empirically confirmed: `xref_class_gen` count 71 → 74, and **zero** `xref_miss` warnings across `senders_of_bt` / `references_to_bt` / `implementors_of_bt` / `defined_selectors_bt`

https://claude.ai/code/session_01DBseMAGL4WcX6j4h4orjVF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code organization for method indexing across actor registration paths.

* **Tests**
  * Added verification tests for method index generation in class registration.
  * Enhanced test infrastructure to validate indexing functionality.

* **Chores**
  * Updated protocol registry initialization to support improved method discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->