### PR TITLE
Add setUp/tearDown to ActorSelfSendCollectTest to remove repeated spawn (BT-2392)

### DIFF
--- a/stdlib/test/actor_self_send_collect_test.bt
+++ b/stdlib/test/actor_self_send_collect_test.bt
@@ -5,51 +5,48 @@
 // work correctly in actor methods (state threading through blocks)
 
 TestCase subclass: ActorSelfSendCollectTest
+  field: c = nil
+
+  setUp => self.c := ActorCollectCounter spawn
+
+  tearDown => self.c stop
 
   testCollectWithSelfSend =>
-    c := ActorCollectCounter spawn
-    result := c doubleAll: #(1, 2, 3)
+    result := self.c doubleAll: #(1, 2, 3)
     self assert: result equals: #(2, 4, 6)
-    self assert: c getCount equals: 3
+    self assert: self.c getCount equals: 3
 
   testCollectWithFieldMutation =>
-    c := ActorCollectCounter spawn
-    result := c doubleAllWithFieldMutation: #(1, 2, 3)
+    result := self.c doubleAllWithFieldMutation: #(1, 2, 3)
     self assert: result equals: #(2, 4, 6)
-    self assert: c getCount equals: 3
+    self assert: self.c getCount equals: 3
 
   testCollectWithSelfSendImplicitReturn =>
-    c := ActorCollectCounter spawn
-    result := c doubleAllImplicit: #(1, 2, 3)
+    result := self.c doubleAllImplicit: #(1, 2, 3)
     self assert: result equals: #(2, 4, 6)
-    self assert: c getCount equals: 3
+    self assert: self.c getCount equals: 3
 
   testDoWithSelfSend =>
-    c := ActorCollectCounter spawn
-    result := c countAll: #(10, 20, 30)
+    result := self.c countAll: #(10, 20, 30)
     self assert: result equals: 3
-    self assert: c getCount equals: 3
+    self assert: self.c getCount equals: 3
 
   testSelectWithSelfSend =>
-    c := ActorCollectCounter spawn
-    result := c selectPositive: #(-1, 2, -3, 4)
+    result := self.c selectPositive: #(-1, 2, -3, 4)
     self assert: result equals: #(2, 4)
-    self assert: c getCount equals: 4
+    self assert: self.c getCount equals: 4
 
   testRejectWithSelfSend =>
-    c := ActorCollectCounter spawn
-    result := c rejectNegative: #(-1, 2, -3, 4)
+    result := self.c rejectNegative: #(-1, 2, -3, 4)
     self assert: result equals: #(2, 4)
-    self assert: c getCount equals: 4
+    self assert: self.c getCount equals: 4
 
   testCollectWithSelfSendEmptyList =>
-    c := ActorCollectCounter spawn
-    result := c doubleAll: #()
+    result := self.c doubleAll: #()
     self assert: result equals: #()
-    self assert: c getCount equals: 0
+    self assert: self.c getCount equals: 0
 
   testSelectWithSelfSendEmptyList =>
-    c := ActorCollectCounter spawn
-    result := c selectPositive: #()
+    result := self.c selectPositive: #()
     self assert: result equals: #()
-    self assert: c getCount equals: 0
+    self assert: self.c getCount equals: 0


### PR DESCRIPTION
## Summary

Refactors `stdlib/test/actor_self_send_collect_test.bt` to use the standard `setUp`/`tearDown` lifecycle instead of duplicating `c := ActorCollectCounter spawn` as the first line of every test method.

**Smell fixed:** Repeated setup — all 8 test methods started identically and none called `stop`, leaking actor processes across tests.

**What changed:**
- Added `field: c = nil` slot declaration
- Added `setUp => self.c := ActorCollectCounter spawn` (fresh actor per test)
- Added `tearDown => self.c stop` (actor cleanup — previously missing)
- Removed 8 duplicate `c := ActorCollectCounter spawn` lines
- Replaced all bare `c` references with `self.c`

No assertions were changed. Test isolation is identical — setUp/tearDown runs fresh per test method.

Follows the pattern established in `actor_slot_test.bt` and `actor_monitor_test.bt`.

## Linear

https://linear.app/beamtalk/issue/BT-2392/add-setupteardown-to-actorselfsendcollecttest-to-remove-repeated-spawn

## Test plan

- [x] `just test-bunit` — 2403 tests, 0 failures
- [x] `just clippy` — clean
- [x] `just fmt-check` — clean

https://claude.ai/code/session_01A5oaGnVCdomdjDR9MiuB2o

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5oaGnVCdomdjDR9MiuB2o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite to improve test organization and resource management through enhanced lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->