### PR TITLE
Cover WebSocket handler + build_worker spec reader via EUnit (BT-2389)

### DIFF
--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -81,6 +81,46 @@ carry no Erlang abstract code (`erlc +from_core` emits empty abstract
 forms), so `cover` cannot instrument them and they are auto-excluded
 (BT-1672). They are exercised instead by the `.bt` BUnit suite.
 
+#### Integration-shaped modules (BT-2389)
+
+Some modules are only reached by a live external client, not by the
+TCP `repl_protocol` E2E suite or plain unit tests:
+
+- **`beamtalk_ws_handler`** — the Cowboy WebSocket handler for the REPL
+  protocol (used by MCP/LSP/browser clients). Its callbacks (`init/2`,
+  `websocket_init/1`, `websocket_handle/2`, `websocket_info/2`,
+  `terminate/3`) are largely pure frame-builders over a `#ws_state{}`
+  record. Rather than stand up a live WS client, they are driven
+  **directly** by EUnit: the record is shared via
+  `apps/beamtalk_workspace/include/beamtalk_ws_state.hrl`, and tests
+  construct handler state + decode real protocol messages
+  (`beamtalk_repl_protocol:decode/1`) to exercise each clause. The
+  post-auth `create_session`/resume paths use a lightweight fixture that
+  starts only `beamtalk_session_sup`. This is deterministic and needs no
+  socket.
+- **`beamtalk_build_worker`** — its pure compilation helpers
+  (`compile_core_erlang/1`, `compile_core_file/2`, `compile_modules/2`,
+  `handle_read_specs/1`) are unit-tested via `-ifdef(TEST)` exports; only
+  the escript stdin loop (`main/0`/`compile_loop/0`) needs a real port.
+- **`beamtalk_compiler_port` / `beamtalk_compiler_server`** — success
+  paths are covered by live-port integration EUnit tests (they spawn the
+  real Rust compiler port).
+
+> **`--app` discovery gotcha:** `coverage-runtime` runs
+> `rebar3 eunit --app=<app>`, which only auto-discovers a source module's
+> `Module_tests` **companion**. A standalone `*_callbacks_tests` suite
+> compiles fine but is silently skipped under `--app`, so its coverage
+> never reaches the merged badge. Keep callback/unit tests for a source
+> module in that module's `_tests` companion (e.g.
+> `beamtalk_ws_handler_tests`).
+
+**Genuinely unreachable (documented out-of-scope, not forced):** the
+`create_session` `{error, Reason}` arm (the session supervisor's
+`simple_one_for_one` child start does not fail deterministically), the
+`actor_snapshot_frames/0` live-registry branch, the `compile_core_file/2`
+beam-write-error arm, and root-only `permission_denied` / TOCTOU
+`error:badarg` / `exit:{noproc}` defensive catches in `beamtalk_file`.
+
 Coverage reports are saved to:
 - Rust HTML: `target/llvm-cov/html/index.html`
 - Erlang HTML: `runtime/_build/test/cover/index.html`

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_build_worker_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_build_worker_tests.erl
@@ -162,9 +162,10 @@ handle_read_specs_mixed_test_() ->
             {ok, _} = beamtalk_build_worker:compile_core_file(CoreFile, OutDir),
             BeamFile = filename:join(OutDir, "test_build_worker_mod.beam"),
             ?assert(filelib:is_regular(BeamFile)),
-            Result = beamtalk_build_worker:handle_read_specs(
-                [BeamFile, "/nonexistent/missing.beam"]
-            ),
+            %% A path under TmpDir that we never create exercises the per-module
+            %% {error, Reason} branch without hardcoding an absolute path.
+            MissingBeam = filename:join(TmpDir, "missing.beam"),
+            Result = beamtalk_build_worker:handle_read_specs([BeamFile, MissingBeam]),
             ?assertEqual(ok, Result)
         end
     end}.

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_build_worker_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_build_worker_tests.erl
@@ -140,6 +140,41 @@ compile_modules_mixed(TmpDir) ->
     ?assertEqual(error, Result).
 
 %%% ---------------------------------------------------------------
+%%% handle_read_specs/1 — {read_specs, BeamFiles} command
+%%% ---------------------------------------------------------------
+
+%% Empty file list still emits a result-ok line.
+handle_read_specs_empty_test() ->
+    ?assertEqual(ok, beamtalk_build_worker:handle_read_specs([])).
+
+%% A readable .beam exercises the {ok, Specs} branch and a missing .beam
+%% exercises the per-module {error, Reason} warning branch. The batch still
+%% completes with result-ok (per-module errors are warnings, not fatal).
+%% We compile a real .beam to a temp dir rather than using code:which/1, which
+%% returns the atom `cover_compiled` for cover-instrumented modules.
+handle_read_specs_mixed_test_() ->
+    {setup, fun setup_temp_dir/0, fun cleanup_temp_dir/1, fun(TmpDir) ->
+        fun() ->
+            OutDir = filename:join(TmpDir, "specs_ebin"),
+            ok = filelib:ensure_dir(filename:join(OutDir, "dummy")),
+            CoreFile = filename:join(TmpDir, "test_build_worker_mod.core"),
+            ok = file:write_file(CoreFile, valid_core_erlang_source()),
+            {ok, _} = beamtalk_build_worker:compile_core_file(CoreFile, OutDir),
+            BeamFile = filename:join(OutDir, "test_build_worker_mod.beam"),
+            ?assert(filelib:is_regular(BeamFile)),
+            Result = beamtalk_build_worker:handle_read_specs(
+                [BeamFile, "/nonexistent/missing.beam"]
+            ),
+            ?assertEqual(ok, Result)
+        end
+    end}.
+
+%% A non-list argument makes read_specs_batch/1 raise inside lists:map, which
+%% the handler's try/catch turns into a result-error line.
+handle_read_specs_crash_caught_test() ->
+    ?assertEqual(ok, beamtalk_build_worker:handle_read_specs(not_a_list)).
+
+%%% ---------------------------------------------------------------
 %%% Helpers
 %%% ---------------------------------------------------------------
 

--- a/runtime/apps/beamtalk_workspace/include/beamtalk_ws_state.hrl
+++ b/runtime/apps/beamtalk_workspace/include/beamtalk_ws_state.hrl
@@ -11,7 +11,7 @@
     session_id :: binary() | undefined,
     session_pid :: pid() | undefined,
     session_mon :: reference() | undefined,
-    authenticated :: boolean(),
+    authenticated = false :: boolean(),
     peer :: term(),
     %% BT-696: Pending eval request for streaming output correlation
     pending_eval :: term() | undefined,
@@ -19,5 +19,5 @@
     io_capture_pid :: pid() | undefined,
     stdin_ref :: reference() | undefined,
     %% BT-1433: Whether this session is subscribed to log streaming
-    log_subscribed :: boolean()
+    log_subscribed = false :: boolean()
 }).

--- a/runtime/apps/beamtalk_workspace/include/beamtalk_ws_state.hrl
+++ b/runtime/apps/beamtalk_workspace/include/beamtalk_ws_state.hrl
@@ -1,0 +1,23 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%%% WebSocket handler session state (beamtalk_ws_handler).
+%%%
+%%% Extracted to a shared header so EUnit suites can construct handler
+%%% state and drive the websocket_handle/2 + websocket_info/2 callbacks
+%%% directly (deterministic coverage without a live WS client). BT-2389.
+
+-record(ws_state, {
+    session_id :: binary() | undefined,
+    session_pid :: pid() | undefined,
+    session_mon :: reference() | undefined,
+    authenticated :: boolean(),
+    peer :: term(),
+    %% BT-696: Pending eval request for streaming output correlation
+    pending_eval :: term() | undefined,
+    %% BT-698: IO capture process pid and correlation ref for stdin routing
+    io_capture_pid :: pid() | undefined,
+    stdin_ref :: reference() | undefined,
+    %% BT-1433: Whether this session is subscribed to log streaming
+    log_subscribed :: boolean()
+}).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
@@ -14,6 +14,7 @@ accepting any protocol operations.
 """.
 
 -include_lib("kernel/include/logger.hrl").
+-include("beamtalk_ws_state.hrl").
 
 -export([
     init/2,
@@ -22,21 +23,6 @@ accepting any protocol operations.
     websocket_info/2,
     terminate/3
 ]).
-
--record(ws_state, {
-    session_id :: binary() | undefined,
-    session_pid :: pid() | undefined,
-    session_mon :: reference() | undefined,
-    authenticated :: boolean(),
-    peer :: term(),
-    %% BT-696: Pending eval request for streaming output correlation
-    pending_eval :: term() | undefined,
-    %% BT-698: IO capture process pid and correlation ref for stdin routing
-    io_capture_pid :: pid() | undefined,
-    stdin_ref :: reference() | undefined,
-    %% BT-1433: Whether this session is subscribed to log streaming
-    log_subscribed :: boolean()
-}).
 
 -doc "HTTP upgrade to WebSocket.".
 init(Req, _Opts) ->

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_ws_handler_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_ws_handler_tests.erl
@@ -637,14 +637,13 @@ shutdown_invalid_cookie_denied_test() ->
     {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
     ?assertMatch([{text, _} | _], Frames).
 
-shutdown_valid_cookie_succeeds_test() ->
-    %% Correct cookie hits the success path. erlang:send_after/3 to an
-    %% unregistered name (beamtalk_repl_server may be down here) drops the
-    %% message silently at expiry, so this is side-effect-free.
-    Cookie = atom_to_binary(erlang:get_cookie(), utf8),
-    Json = op_json(<<"shutdown">>, #{<<"cookie">> => Cookie}),
-    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
-    ?assertMatch([{text, _} | _], Frames).
+%% NB: the valid-cookie shutdown success path is deliberately NOT tested here.
+%% On a valid cookie the handler arms `send_after(100, beamtalk_repl_server,
+%% shutdown_requested)`, and `beamtalk_repl_server` handles that message by
+%% calling `init:stop()` — halting the whole node. Firing it from an in-node
+%% EUnit suite (where other tests start a real `beamtalk_repl_server`) would be
+%% an order/timing-dependent way to kill the entire run. That branch is covered
+%% by the WebSocket E2E surface instead.
 
 shutdown_non_binary_cookie_denied_test() ->
     Json = op_json(<<"shutdown">>, #{<<"cookie">> => 42}),

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_ws_handler_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_ws_handler_tests.erl
@@ -9,8 +9,17 @@ Tests for beamtalk_ws_handler WebSocket push behaviour (BT-1020).
 Tests the class-loaded push event pub/sub via beamtalk_class_events,
 which is the server-side mechanism that delivers class-loaded events
 to authenticated WebSocket subscribers.
+
+Also drives the Cowboy WebSocket callbacks (`init/2`, `websocket_init/1`,
+`websocket_handle/2`, `websocket_info/2`, `terminate/3`) directly (BT-2389).
+These live in this module — the `_tests` companion of `beamtalk_ws_handler` —
+rather than a standalone suite, because `rebar3 eunit --app=...` (used by the
+coverage harness) only auto-discovers a source module's `Module_tests`
+companion. A standalone `*_callbacks_tests` module compiles but is silently
+skipped under `--app`, so its coverage never reaches the merged badge.
 """.
 -include_lib("eunit/include/eunit.hrl").
+-include("beamtalk_ws_state.hrl").
 
 %%% ===========================================================================
 %%% beamtalk_class_events: Lifecycle Tests
@@ -398,3 +407,593 @@ flush_messages() ->
         _ -> flush_messages()
     after 0 -> ok
     end.
+
+%%% ===========================================================================
+%%% WebSocket handler callbacks — direct coverage (BT-2389)
+%%% ===========================================================================
+
+%%% ===========================================================================
+%%% Helpers
+%%% ===========================================================================
+
+%% A fresh, unauthenticated state as produced by init/2.
+unauth_state() ->
+    #ws_state{
+        authenticated = false,
+        peer = {{127, 0, 0, 1}, 54321},
+        pending_eval = undefined,
+        io_capture_pid = undefined,
+        stdin_ref = undefined,
+        log_subscribed = false
+    }.
+
+%% An authenticated state with no eval in flight. Uses self() as the session
+%% pid so is_process_alive/1 checks see a live process.
+authed_state() ->
+    #ws_state{
+        authenticated = true,
+        session_id = <<"sess-1">>,
+        session_pid = self(),
+        session_mon = make_ref(),
+        peer = {{127, 0, 0, 1}, 54321},
+        pending_eval = undefined,
+        io_capture_pid = undefined,
+        stdin_ref = undefined,
+        log_subscribed = false
+    }.
+
+%% Decode a valid protocol message for use as a pending_eval correlation token.
+make_msg(Op) ->
+    Json = iolist_to_binary(
+        json:encode(#{
+            <<"op">> => Op,
+            <<"id">> => <<"msg-1">>,
+            <<"params">> => #{<<"code">> => <<"1 + 1">>}
+        })
+    ),
+    {ok, Msg} = beamtalk_repl_protocol:decode(Json),
+    Msg.
+
+%% Build a raw protocol JSON frame for handle_protocol/websocket_handle.
+%% Protocol params are the top-level message keys (alongside op/id), not a
+%% nested "params" object.
+op_json(Op, Params) ->
+    Base = #{<<"op">> => Op, <<"id">> => <<"req-1">>},
+    iolist_to_binary(json:encode(maps:merge(Base, Params))).
+
+%% Decode the text frame out of a {[{text, Bin}], State} reply.
+first_text([{text, Bin} | _]) -> json:decode(Bin).
+
+%% Spawn a process and wait for it to be dead, returning its (now dead) pid.
+dead_pid() ->
+    {Pid, Ref} = spawn_monitor(fun() -> ok end),
+    receive
+        {'DOWN', Ref, process, Pid, _} -> Pid
+    after 1000 ->
+        error(timeout_waiting_for_dead_pid)
+    end.
+
+%%% ===========================================================================
+%%% init/2 + websocket_init/1
+%%% ===========================================================================
+
+init_returns_cowboy_websocket_with_unauth_state_test() ->
+    Req = #{peer => {{127, 0, 0, 1}, 12345}},
+    {cowboy_websocket, Req, State, Opts} = beamtalk_ws_handler:init(Req, []),
+    ?assertEqual(false, State#ws_state.authenticated),
+    ?assertEqual({{127, 0, 0, 1}, 12345}, State#ws_state.peer),
+    ?assertEqual(infinity, maps:get(idle_timeout, Opts)),
+    ?assert(maps:is_key(max_frame_size, Opts)).
+
+websocket_init_sends_auth_required_test() ->
+    {[{text, Bin}], _State} = beamtalk_ws_handler:websocket_init(unauth_state()),
+    ?assertEqual(<<"auth-required">>, maps:get(<<"op">>, json:decode(Bin))).
+
+%%% ===========================================================================
+%%% websocket_handle/2 — authentication (unauthenticated state)
+%%% ===========================================================================
+
+auth_malformed_json_closes_test() ->
+    {Frames, State} = beamtalk_ws_handler:websocket_handle({text, <<"{not json">>}, unauth_state()),
+    ?assertEqual(false, State#ws_state.authenticated),
+    Decoded = first_text(Frames),
+    ?assertEqual(<<"auth_error">>, maps:get(<<"type">>, Decoded)),
+    ?assert(lists:keymember(close, 1, Frames)).
+
+auth_non_auth_message_rejected_test() ->
+    Json = iolist_to_binary(json:encode(#{<<"type">> => <<"eval">>})),
+    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, unauth_state()),
+    Decoded = first_text(Frames),
+    ?assertEqual(<<"auth_error">>, maps:get(<<"type">>, Decoded)),
+    ?assertEqual(<<"First message must be auth">>, maps:get(<<"message">>, Decoded)),
+    ?assert(lists:keymember(close, 1, Frames)).
+
+auth_invalid_cookie_rejected_test() ->
+    %% A cookie whose byte size differs from the node cookie short-circuits to
+    %% false (the byte_size guard before crypto:hash_equals).
+    WrongCookie = <<"definitely-not-the-node-cookie-xyzzy">>,
+    Json = iolist_to_binary(
+        json:encode(#{<<"type">> => <<"auth">>, <<"cookie">> => WrongCookie})
+    ),
+    {Frames, State} = beamtalk_ws_handler:websocket_handle({text, Json}, unauth_state()),
+    ?assertEqual(false, State#ws_state.authenticated),
+    Decoded = first_text(Frames),
+    ?assertEqual(<<"auth_error">>, maps:get(<<"type">>, Decoded)),
+    ?assertEqual(<<"Invalid cookie">>, maps:get(<<"message">>, Decoded)),
+    ?assert(lists:keymember(close, 1, Frames)).
+
+%%% ===========================================================================
+%%% websocket_handle/2 — non-text frames + post-auth dispatch
+%%% ===========================================================================
+
+non_text_frame_ignored_test() ->
+    State = authed_state(),
+    ?assertEqual({ok, State}, beamtalk_ws_handler:websocket_handle({binary, <<1, 2, 3>>}, State)).
+
+protocol_decode_error_returns_error_frame_test() ->
+    %% Valid JSON that is not an object decodes to {error, _}, exercising the
+    %% decode-error branch of handle_protocol (a non-JSON frame would instead
+    %% be treated as a legacy raw-eval expression).
+    {Frames, State} = beamtalk_ws_handler:websocket_handle({text, <<"[1,2,3]">>}, authed_state()),
+    ?assert(State#ws_state.authenticated),
+    ?assertMatch([{text, _} | _], Frames).
+
+eval_empty_code_returns_error_test() ->
+    Json = op_json(<<"eval">>, #{<<"code">> => <<>>}),
+    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    Decoded = first_text(Frames),
+    ?assert(maps:is_key(<<"error">>, Decoded) orelse maps:is_key(<<"status">>, Decoded)).
+
+eval_non_binary_code_returns_error_test() ->
+    Json = op_json(<<"eval">>, #{<<"code">> => 42}),
+    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertMatch([{text, _} | _], Frames).
+
+eval_with_dead_session_returns_session_down_test() ->
+    Json = op_json(<<"eval">>, #{<<"code">> => <<"1 + 1">>}),
+    State = (authed_state())#ws_state{session_pid = dead_pid()},
+    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, State),
+    ?assertMatch([{text, _} | _], Frames).
+
+eval_with_live_session_sets_pending_test() ->
+    Json = op_json(<<"eval">>, #{<<"code">> => <<"1 + 1">>}),
+    %% session_pid = self() is alive; eval_async is a cast to our own mailbox.
+    {ok, State1} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertNotEqual(undefined, State1#ws_state.pending_eval),
+    %% Drain the cast we sent ourselves.
+    receive
+        {'$gen_cast', {eval_async, _, _}} -> ok
+    after 0 -> ok
+    end.
+
+eval_when_already_pending_returns_busy_test() ->
+    Json = op_json(<<"eval">>, #{<<"code">> => <<"2 + 2">>}),
+    State = (authed_state())#ws_state{pending_eval = make_msg(<<"eval">>)},
+    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, State),
+    ?assertMatch([{text, _} | _], Frames).
+
+stdin_without_pending_input_errors_test() ->
+    Json = op_json(<<"stdin">>, #{<<"value">> => <<"hello\n">>}),
+    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertMatch([{text, _} | _], Frames).
+
+stdin_with_pending_routes_value_test() ->
+    Ref = make_ref(),
+    State = (authed_state())#ws_state{io_capture_pid = self(), stdin_ref = Ref},
+    Json = op_json(<<"stdin">>, #{<<"value">> => <<"line\n">>}),
+    {ok, State1} = beamtalk_ws_handler:websocket_handle({text, Json}, State),
+    ?assertEqual(undefined, State1#ws_state.io_capture_pid),
+    ?assertEqual(undefined, State1#ws_state.stdin_ref),
+    receive
+        {stdin_input, Ref, <<"line\n">>} -> ok
+    after 500 -> ?assert(false)
+    end.
+
+stdin_with_pending_routes_eof_test() ->
+    Ref = make_ref(),
+    State = (authed_state())#ws_state{io_capture_pid = self(), stdin_ref = Ref},
+    Json = op_json(<<"stdin">>, #{<<"value">> => <<"eof">>}),
+    {ok, _State1} = beamtalk_ws_handler:websocket_handle({text, Json}, State),
+    receive
+        {stdin_input, Ref, eof} -> ok
+    after 500 -> ?assert(false)
+    end.
+
+stdin_with_pending_invalid_value_errors_test() ->
+    Ref = make_ref(),
+    State = (authed_state())#ws_state{io_capture_pid = self(), stdin_ref = Ref},
+    Json = op_json(<<"stdin">>, #{<<"value">> => 99}),
+    {Frames, State1} = beamtalk_ws_handler:websocket_handle({text, Json}, State),
+    %% Invalid value keeps the capture pid so the client can retry.
+    ?assertEqual(self(), State1#ws_state.io_capture_pid),
+    ?assertMatch([{text, _} | _], Frames).
+
+subscribe_logs_sets_subscribed_test() ->
+    Json = op_json(<<"subscribe-logs">>, #{<<"level">> => <<"warning">>}),
+    {Frames, State1} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assert(State1#ws_state.log_subscribed),
+    ?assertMatch([{text, _} | _], Frames),
+    %% Re-subscribe path (already subscribed -> unsubscribe then subscribe).
+    Json2 = op_json(<<"subscribe-logs">>, #{<<"level">> => <<"error">>}),
+    {_, State2} = beamtalk_ws_handler:websocket_handle({text, Json2}, State1),
+    ?assert(State2#ws_state.log_subscribed),
+    %% Clean up subscription.
+    beamtalk_ws_log_handler:unsubscribe().
+
+unsubscribe_logs_clears_subscribed_test() ->
+    State = (authed_state())#ws_state{log_subscribed = true},
+    Json = op_json(<<"unsubscribe-logs">>, #{}),
+    {Frames, State1} = beamtalk_ws_handler:websocket_handle({text, Json}, State),
+    ?assertEqual(false, State1#ws_state.log_subscribed),
+    ?assertMatch([{text, _} | _], Frames).
+
+shutdown_missing_cookie_denied_test() ->
+    Json = op_json(<<"shutdown">>, #{}),
+    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertMatch([{text, _} | _], Frames).
+
+shutdown_invalid_cookie_denied_test() ->
+    Json = op_json(<<"shutdown">>, #{<<"cookie">> => <<"wrong-cookie-value-here">>}),
+    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertMatch([{text, _} | _], Frames).
+
+shutdown_valid_cookie_succeeds_test() ->
+    %% Correct cookie hits the success path. erlang:send_after/3 to an
+    %% unregistered name (beamtalk_repl_server may be down here) drops the
+    %% message silently at expiry, so this is side-effect-free.
+    Cookie = atom_to_binary(erlang:get_cookie(), utf8),
+    Json = op_json(<<"shutdown">>, #{<<"cookie">> => Cookie}),
+    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertMatch([{text, _} | _], Frames).
+
+shutdown_non_binary_cookie_denied_test() ->
+    Json = op_json(<<"shutdown">>, #{<<"cookie">> => 42}),
+    {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertMatch([{text, _} | _], Frames).
+
+subscribe_logs_all_levels_test() ->
+    %% Drive every parse_log_level/1 clause (including the unknown -> debug
+    %% fallback) and the no-level default.
+    Levels = [
+        <<"emergency">>,
+        <<"alert">>,
+        <<"critical">>,
+        <<"error">>,
+        <<"warning">>,
+        <<"notice">>,
+        <<"info">>,
+        <<"debug">>,
+        <<"bogus-level">>
+    ],
+    lists:foreach(
+        fun(Level) ->
+            Json = op_json(<<"subscribe-logs">>, #{<<"level">> => Level}),
+            {_, S} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+            ?assert(S#ws_state.log_subscribed)
+        end,
+        Levels
+    ),
+    %% No level key -> defaults to debug.
+    NoLevel = op_json(<<"subscribe-logs">>, #{}),
+    {_, S2} = beamtalk_ws_handler:websocket_handle({text, NoLevel}, authed_state()),
+    ?assert(S2#ws_state.log_subscribed),
+    beamtalk_ws_log_handler:unsubscribe().
+
+%%% ===========================================================================
+%%% websocket_info/2 — streaming + push frames (authenticated, pending eval)
+%%% ===========================================================================
+
+eval_out_streams_chunk_test() ->
+    State = (authed_state())#ws_state{pending_eval = make_msg(<<"eval">>)},
+    Reply = beamtalk_ws_handler:websocket_info({eval_out, <<"chunk">>}, State),
+    %% Either streams a text frame or (legacy client) drops to {ok, State}.
+    ?assert(element(1, Reply) =:= ok orelse is_list(element(1, Reply))).
+
+need_input_sets_capture_pid_test() ->
+    State = (authed_state())#ws_state{pending_eval = make_msg(<<"eval">>)},
+    Ref = make_ref(),
+    {Frames, State1} = beamtalk_ws_handler:websocket_info(
+        {need_input, self(), Ref, <<"Name? ">>}, State
+    ),
+    ?assertEqual(self(), State1#ws_state.io_capture_pid),
+    ?assertEqual(Ref, State1#ws_state.stdin_ref),
+    ?assertMatch([{text, _} | _], Frames).
+
+eval_done_sends_result_and_clears_pending_test() ->
+    State = (authed_state())#ws_state{pending_eval = make_msg(<<"eval">>)},
+    {Frames, State1} = beamtalk_ws_handler:websocket_info(
+        {eval_done, 42, <<"out">>, []}, State
+    ),
+    ?assertEqual(undefined, State1#ws_state.pending_eval),
+    ?assertMatch([{text, _} | _], Frames).
+
+eval_error_sends_error_and_clears_pending_test() ->
+    State = (authed_state())#ws_state{pending_eval = make_msg(<<"eval">>)},
+    {Frames, State1} = beamtalk_ws_handler:websocket_info(
+        {eval_error, {error, boom}, <<>>, []}, State
+    ),
+    ?assertEqual(undefined, State1#ws_state.pending_eval),
+    ?assertMatch([{text, _} | _], Frames).
+
+eval_error_with_compile_location_test() ->
+    %% A compile_error reason carrying line + hint exercises
+    %% extract_compile_error_location/1's success branch.
+    State = (authed_state())#ws_state{pending_eval = make_msg(<<"eval">>)},
+    Reason = {compile_error, [#{line => 7, hint => <<"missing period">>}]},
+    {Frames, State1} = beamtalk_ws_handler:websocket_info(
+        {eval_error, Reason, <<>>, []}, State
+    ),
+    ?assertEqual(undefined, State1#ws_state.pending_eval),
+    ?assertMatch([{text, _} | _], Frames).
+
+eval_error_with_compile_error_no_line_test() ->
+    %% compile_error whose diagnostic map lacks a line falls to the #{} branch.
+    State = (authed_state())#ws_state{pending_eval = make_msg(<<"eval">>)},
+    Reason = {compile_error, [#{message => <<"oops">>}]},
+    {Frames, _State1} = beamtalk_ws_handler:websocket_info(
+        {eval_error, Reason, <<>>, []}, State
+    ),
+    ?assertMatch([{text, _} | _], Frames).
+
+actor_stopped_truncates_long_reason_test() ->
+    %% A reason that formats to > 4096 bytes exercises the truncate_utf8/2
+    %% truncation branch.
+    BigReason = lists:duplicate(5000, $x),
+    Stop = #{pid => self(), class => 'Big', reason => BigReason},
+    {Frames, _State} = beamtalk_ws_handler:websocket_info({actor_stopped, Stop}, authed_state()),
+    Data = maps:get(<<"data">>, first_text(Frames)),
+    ?assert(byte_size(maps:get(<<"reason">>, Data)) =< 4096).
+
+bindings_changed_pushes_frame_test() ->
+    {Frames, _State} = beamtalk_ws_handler:websocket_info(
+        {bindings_changed, <<"sess-1">>}, authed_state()
+    ),
+    Decoded = first_text(Frames),
+    ?assertEqual(<<"bindings">>, maps:get(<<"channel">>, Decoded)).
+
+transcript_output_pushes_frame_test() ->
+    {Frames, _State} = beamtalk_ws_handler:websocket_info(
+        {transcript_output, <<"hello">>}, authed_state()
+    ),
+    Decoded = first_text(Frames),
+    ?assertEqual(<<"transcript">>, maps:get(<<"push">>, Decoded)).
+
+actor_spawned_pushes_frame_test() ->
+    Meta = #{pid => self(), class => 'Counter', spawned_at => 123},
+    {Frames, _State} = beamtalk_ws_handler:websocket_info({actor_spawned, Meta}, authed_state()),
+    Decoded = first_text(Frames),
+    ?assertEqual(<<"actors">>, maps:get(<<"channel">>, Decoded)),
+    ?assertEqual(<<"spawned">>, maps:get(<<"event">>, Decoded)),
+    Data = maps:get(<<"data">>, Decoded),
+    ?assertEqual(<<"Counter">>, maps:get(<<"class">>, Data)),
+    ?assertEqual(123, maps:get(<<"spawned_at">>, Data)).
+
+actor_spawned_without_timestamp_test() ->
+    Meta = #{pid => self(), class => 'Worker'},
+    {Frames, _State} = beamtalk_ws_handler:websocket_info({actor_spawned, Meta}, authed_state()),
+    Data = maps:get(<<"data">>, first_text(Frames)),
+    ?assertNot(maps:is_key(<<"spawned_at">>, Data)).
+
+actor_stopped_pushes_frame_test() ->
+    Stop = #{pid => self(), class => 'Counter', reason => normal},
+    {Frames, _State} = beamtalk_ws_handler:websocket_info({actor_stopped, Stop}, authed_state()),
+    Decoded = first_text(Frames),
+    ?assertEqual(<<"stopped">>, maps:get(<<"event">>, Decoded)).
+
+actor_stopped_unknown_class_test() ->
+    Stop = #{pid => self(), class => undefined, reason => normal},
+    {Frames, _State} = beamtalk_ws_handler:websocket_info({actor_stopped, Stop}, authed_state()),
+    Data = maps:get(<<"data">>, first_text(Frames)),
+    ?assertEqual(<<"unknown">>, maps:get(<<"class">>, Data)).
+
+class_loaded_pushes_frame_test() ->
+    {Frames, _State} = beamtalk_ws_handler:websocket_info(
+        {class_loaded, 'Counter'}, authed_state()
+    ),
+    Decoded = first_text(Frames),
+    ?assertEqual(<<"classes">>, maps:get(<<"channel">>, Decoded)),
+    ?assertEqual(<<"Counter">>, maps:get(<<"class">>, maps:get(<<"data">>, Decoded))).
+
+flush_completed_normalises_files_test() ->
+    %% Mix of binary, charlist, and invalid entries exercises every
+    %% normalise_files_for_push/1 branch.
+    Files = [<<"src/a.bt">>, "src/b.bt", 12345, {bad, tuple}],
+    {Frames, _State} = beamtalk_ws_handler:websocket_info({flush_completed, Files}, authed_state()),
+    Decoded = first_text(Frames),
+    ?assertEqual(<<"workspace">>, maps:get(<<"channel">>, Decoded)),
+    Out = maps:get(<<"files">>, maps:get(<<"data">>, Decoded)),
+    %% Only the two valid path entries survive.
+    ?assertEqual([<<"src/a.bt">>, <<"src/b.bt">>], Out).
+
+log_event_subscribed_pushes_frame_test() ->
+    State = (authed_state())#ws_state{log_subscribed = true},
+    {Frames, _State} = beamtalk_ws_handler:websocket_info(
+        {log_event, #{level => <<"info">>, msg => <<"hi">>, extra => undefined}}, State
+    ),
+    Decoded = first_text(Frames),
+    ?assertEqual(<<"logs">>, maps:get(<<"channel">>, Decoded)),
+    Data = maps:get(<<"data">>, Decoded),
+    ?assertEqual(<<"info">>, maps:get(<<"level">>, Data)),
+    %% undefined values are stripped.
+    ?assertNot(maps:is_key(<<"extra">>, Data)).
+
+log_event_not_subscribed_dropped_test() ->
+    State = (authed_state())#ws_state{log_subscribed = false},
+    ?assertEqual(
+        {ok, State},
+        beamtalk_ws_handler:websocket_info({log_event, #{level => <<"info">>}}, State)
+    ).
+
+%%% ===========================================================================
+%%% websocket_info/2 — late messages dropped when no eval pending
+%%% ===========================================================================
+
+late_eval_out_dropped_test() ->
+    State = authed_state(),
+    ?assertEqual({ok, State}, beamtalk_ws_handler:websocket_info({eval_out, <<"x">>}, State)).
+
+late_eval_done_dropped_test() ->
+    State = authed_state(),
+    ?assertEqual({ok, State}, beamtalk_ws_handler:websocket_info({eval_done, 1, <<>>, []}, State)).
+
+late_eval_error_dropped_test() ->
+    State = authed_state(),
+    ?assertEqual(
+        {ok, State}, beamtalk_ws_handler:websocket_info({eval_error, oops, <<>>, []}, State)
+    ).
+
+late_need_input_dropped_test() ->
+    State = authed_state(),
+    ?assertEqual(
+        {ok, State},
+        beamtalk_ws_handler:websocket_info({need_input, self(), make_ref(), <<"?">>}, State)
+    ).
+
+unknown_info_ignored_test() ->
+    State = authed_state(),
+    ?assertEqual({ok, State}, beamtalk_ws_handler:websocket_info(some_random_message, State)).
+
+%%% ===========================================================================
+%%% websocket_info/2 — session DOWN
+%%% ===========================================================================
+
+session_down_closes_and_clears_test() ->
+    beamtalk_session_table:new(),
+    beamtalk_session_table:insert(<<"sess-1">>, self()),
+    MonRef = make_ref(),
+    State = (authed_state())#ws_state{session_mon = MonRef},
+    {Frames, State1} = beamtalk_ws_handler:websocket_info(
+        {'DOWN', MonRef, process, self(), shutdown}, State
+    ),
+    ?assertEqual(false, State1#ws_state.authenticated),
+    ?assertEqual(undefined, State1#ws_state.session_id),
+    ?assert(lists:keymember(close, 1, Frames)).
+
+%%% ===========================================================================
+%%% terminate/3
+%%% ===========================================================================
+
+terminate_no_session_is_noop_test() ->
+    ?assertEqual(ok, beamtalk_ws_handler:terminate(normal, #{}, unauth_state())).
+
+terminate_with_session_unsubscribes_test() ->
+    %% All five pub/sub unsubscribes are gen_server:cast (safe when the server
+    %% is down) and ws_log_handler:unsubscribe guards on ets:info, so this runs
+    %% without the workspace supervision tree.
+    State = authed_state(),
+    ?assertEqual(ok, beamtalk_ws_handler:terminate(normal, #{}, State)).
+
+%%% ===========================================================================
+%%% Authentication success + session create/resume (needs session supervisor)
+%%% ===========================================================================
+%%%
+%%% These drive the post-auth `create_session`/`start_or_resume_session`
+%%% success paths. They need a live `beamtalk_session_sup` (which spawns a real
+%%% `beamtalk_repl_shell`) plus the session ETS table. The pub/sub subscribe
+%%% calls are casts that are safe when their servers are down, and
+%%% `actor_snapshot_frames/0` falls back to [] without a registry, so this
+%%% fixture stays lightweight.
+
+session_setup() ->
+    beamtalk_session_table:new(),
+    case beamtalk_session_sup:start_link() of
+        {ok, Pid} ->
+            %% start_link links the sup to this test process; unlink so the
+            %% cleanup kill below doesn't propagate and take down the runner.
+            unlink(Pid),
+            {started, Pid};
+        {error, {already_started, Pid}} ->
+            {existing, Pid}
+    end.
+
+session_cleanup({started, Pid}) ->
+    case is_process_alive(Pid) of
+        true ->
+            Ref = monitor(process, Pid),
+            exit(Pid, kill),
+            receive
+                {'DOWN', Ref, process, Pid, _} -> ok
+            after 1000 -> ok
+            end;
+        false ->
+            ok
+    end;
+session_cleanup({existing, _Pid}) ->
+    %% A supervisor we didn't start (e.g. the workspace app is running in a
+    %% combined eunit run) — leave it alone.
+    ok.
+
+node_cookie() ->
+    atom_to_binary(erlang:get_cookie(), utf8).
+
+auth_json(Extra) ->
+    Base = #{<<"type">> => <<"auth">>, <<"cookie">> => node_cookie()},
+    iolist_to_binary(json:encode(maps:merge(Base, Extra))).
+
+%% Pull the first decoded text frame whose JSON has a key K equal to V.
+has_frame_with(Frames, K, V) ->
+    lists:any(
+        fun
+            ({text, Bin}) ->
+                case catch json:decode(Bin) of
+                    M when is_map(M) -> maps:get(K, M, undefined) =:= V;
+                    _ -> false
+                end;
+            (_) ->
+                false
+        end,
+        Frames
+    ).
+
+auth_session_test_() ->
+    {foreach, fun session_setup/0, fun session_cleanup/1, [
+        fun(_) -> {"auth success creates session", fun auth_success_creates_session/0} end,
+        fun(_) -> {"resume alive session", fun resume_alive_session/0} end,
+        fun(_) -> {"resume dead session creates new", fun resume_dead_session_creates_new/0} end,
+        fun(_) -> {"resume unknown session creates new", fun resume_unknown_creates_new/0} end,
+        fun(_) -> {"non-binary resume creates new", fun resume_non_binary_creates_new/0} end
+    ]}.
+
+auth_success_creates_session() ->
+    {Frames, State} = beamtalk_ws_handler:websocket_handle({text, auth_json(#{})}, unauth_state()),
+    ?assert(State#ws_state.authenticated),
+    ?assertNotEqual(undefined, State#ws_state.session_id),
+    ?assert(is_pid(State#ws_state.session_pid)),
+    ?assert(has_frame_with(Frames, <<"type">>, <<"auth_ok">>)),
+    ?assert(has_frame_with(Frames, <<"op">>, <<"session-started">>)).
+
+resume_alive_session() ->
+    %% A live process registered as an existing session triggers the resume
+    %% branch (monitor + auth_ok + session-started for the SAME id).
+    {ok, Pid} = beamtalk_session_sup:start_session(<<"resume-me">>),
+    beamtalk_session_table:insert(<<"resume-me">>, Pid),
+    Json = auth_json(#{<<"resume">> => <<"resume-me">>}),
+    {Frames, State} = beamtalk_ws_handler:websocket_handle({text, Json}, unauth_state()),
+    ?assert(State#ws_state.authenticated),
+    ?assertEqual(<<"resume-me">>, State#ws_state.session_id),
+    ?assertEqual(Pid, State#ws_state.session_pid),
+    ?assert(has_frame_with(Frames, <<"op">>, <<"session-started">>)).
+
+resume_dead_session_creates_new() ->
+    DeadId = <<"dead-sess">>,
+    beamtalk_session_table:insert(DeadId, dead_pid()),
+    Json = auth_json(#{<<"resume">> => DeadId}),
+    {_Frames, State} = beamtalk_ws_handler:websocket_handle({text, Json}, unauth_state()),
+    ?assert(State#ws_state.authenticated),
+    %% A fresh id was generated, not the dead one.
+    ?assertNotEqual(DeadId, State#ws_state.session_id),
+    ?assert(is_pid(State#ws_state.session_pid)).
+
+resume_unknown_creates_new() ->
+    Json = auth_json(#{<<"resume">> => <<"never-existed">>}),
+    {_Frames, State} = beamtalk_ws_handler:websocket_handle({text, Json}, unauth_state()),
+    ?assert(State#ws_state.authenticated),
+    ?assertNotEqual(<<"never-existed">>, State#ws_state.session_id),
+    ?assert(is_pid(State#ws_state.session_pid)).
+
+resume_non_binary_creates_new() ->
+    %% A non-binary resume value falls through to the catch-all clause.
+    Json = auth_json(#{<<"resume">> => 12345}),
+    {_Frames, State} = beamtalk_ws_handler:websocket_handle({text, Json}, unauth_state()),
+    ?assert(State#ws_state.authenticated),
+    ?assert(is_pid(State#ws_state.session_pid)).


### PR DESCRIPTION
## Summary

Raises Erlang coverage on two integration-shaped modules that the TCP `repl_protocol` E2E suite and plain unit tests never reach. Part of BT-2389 (raise merged Erlang coverage toward 85% via integration coverage).

| Module | Before | After |
|---|---|---|
| `beamtalk_ws_handler` | ~28% | **88%** |
| `beamtalk_build_worker` | 57% | **68%** |
| **Merged Erlang badge** | 82.2% | **~83%** |

## `beamtalk_ws_handler` 28% → 88%

The Cowboy WebSocket callbacks are normally only reached by a live WS client (MCP/LSP/browser), so the TCP E2E suite never touches them.

- Extracted the `#ws_state{}` record to a shared header (`include/beamtalk_ws_state.hrl`) so EUnit can construct handler state.
- Drive every callback directly — `init/2`, `websocket_init/1`, `websocket_handle/2`, `websocket_info/2`, `terminate/3`: auth success/failure, every push frame, streaming/late-message drops, stdin routing, shutdown error paths, log-level parsing, plus a lightweight `beamtalk_session_sup` fixture for the create/resume paths. Deterministic — no live socket, no flaky WS client.
- **`--app` discovery gotcha (documented):** `rebar3 eunit --app=...` (used by `coverage-runtime`) only auto-discovers a source module's `Module_tests` companion. A standalone `*_callbacks_tests` module compiles but is silently skipped under `--app`, so its coverage never reaches the merged badge. The callback tests therefore live in `beamtalk_ws_handler_tests` (the companion of the source module).

## `beamtalk_build_worker` 57% → 68%

Added `handle_read_specs/1` tests (ok / per-module error / caught crash).

## Docs

`docs/development/testing-strategy.md` documents the integration-coverage approach, the `--app` companion-discovery gotcha, and the genuinely-unreachable defensive arms that are out-of-scope (`create_session` error arm, live actor-registry snapshot, beam-write error, root-only/TOCTOU catches).

## Notes on the 85% target

Merged coverage moved 82.2% → ~83%. The remaining gap is concentrated in work the issue itself flags as out-of-scope or that is large/separate:
- `beamtalk_compiler_port` malformed-response/exit/timeout **defensive arms** (issue says document, not force).
- `beamtalk_file` root-only / TOCTOU defensive catches (out-of-scope).
- `beamtalk_test_case` assertion-**failure** formatting (passing BUnit tests never hit it) and the workspace live-compiler load paths — sizeable integration-test efforts.

## Review note

Code review caught and removed a latent node-halt flake: a valid-cookie shutdown test would arm `send_after(100, beamtalk_repl_server, shutdown_requested)`, which `beamtalk_repl_server` services with `init:stop()` — halting the whole node. Since other workspace suites start a real `beamtalk_repl_server`, timing could have killed the eunit run. Dropped that one test; auth-validation error paths stay covered.

## Verification

- Workspace suite: 2119 tests, 0 failures
- Compiler suite: 245 tests, 0 failures
- BUnit: 2403 tests, 0 failed
- dialyzer clean, erlfmt clean
- `just coverage-all` merged badge ~83%

https://claude.ai/code/session_01MhWbn7CCiETgQB4LKHsguD

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhWbn7CCiETgQB4LKHsguD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded testing strategy with guidance for integration-shaped runtime modules, test discovery/coverage gotchas, and clearly scoped unreachable paths.

* **Tests**
  * Large end-to-end WebSocket handler test suite covering authentication flows, message handling (eval/stdin/logs), session lifecycle/resume, termination, and error/late-message behavior.
  * Added tests for build-worker spec handling and helper utilities for constructing handler state and protocol frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->