### PR TITLE
Term-returning op layer + push-subscription facade (BT-2399)

### DIFF
--- a/docs/development/repl-op-term-contract.md
+++ b/docs/development/repl-op-term-contract.md
@@ -1,0 +1,120 @@
+# REPL Op Term Contract
+
+**Status:** Active · **Introduced:** BT-2399 · **Context:** ADR 0017 Phase 3
+(Browser Connectivity), ADR 0085 (read-surface), ADR 0082 (write-surface)
+
+This is the cross-surface API boundary for the curated REPL op layer. It lets
+the **browser** (WebSocket), **Phoenix LiveView** (Erlang distribution / Attach
+topology), and runtime-attached **LSP / MCP** clients share one op contract,
+while only the WebSocket edge pays the JSON cost.
+
+## Why terms, not JSON
+
+The op layer (`beamtalk_repl_server:handle_protocol_request/2` →
+`beamtalk_repl_ops:dispatch/4`) does the dispatch, validation, and
+error-wrapping every surface needs. Historically it also encoded JSON inline,
+which makes it the JSON boundary.
+
+Over Erlang distribution, JSON is both overhead and **lossy in the way that
+matters**: `Counter spawn` is a live term —
+`{beamtalk_object, 'Counter', bt@counter, <0.369.0>}` carrying a real,
+messageable remote pid — that JSON flattens to the dead string
+`"#Actor<Counter,…>"`. An inspector, "send a message to this object", or
+reference-following all need the term, not its `printString`. That liveness is
+the whole point of a live-image IDE.
+
+So the op layer is split:
+
+```
+                       ┌─ Phoenix / LSP / MCP (dist): consume terms directly
+  dispatch/4 ─ term ───┤
+                       └─ encode/2 ─ JSON ─ WebSocket (browser)
+```
+
+* `beamtalk_repl_ops:dispatch/4` returns a structured **term** (`op_result()`),
+  never JSON.
+* `beamtalk_repl_ops:encode/2` encodes that term to the protocol JSON binary
+  at the **WebSocket transport edge only**. The browser wire format is
+  unchanged.
+
+## The `op_result()` contract
+
+`op_result()` is a small, deliberately stable tagged union — not raw internal
+shapes — so the contract does not leak compiler/runtime internals. Phoenix
+matches on the `beamtalk_error` record tag, so no shared `.hrl` is required.
+
+| Tag | Shape | Produced by |
+|-----|-------|-------------|
+| result | `{ok, Value, Output, Warnings}` | `eval` |
+| trace | `{trace, Steps, Output, Warnings}` | `eval` (trace mode) |
+| actors | `{actors, [ActorMeta]}` | `actors` |
+| inspect | `{inspect, map() \| binary()}` | `inspect` |
+| status | `{status, ok}` | `kill`, `interrupt` |
+| error | `{error, #beamtalk_error{}}` | any op |
+| error+io | `{error, #beamtalk_error{}, Output, Warnings}` | `eval` |
+| json | `{json, binary()}` | ops not yet ported (see below) |
+
+* `Value` and the `inspect` payload are **live terms** — over distribution they
+  retain messageable pids and structure; only `encode/2` flattens them.
+* `Output` is captured stdout (`binary()`); `Warnings` is `[binary()]`.
+* Errors are the structured `#beamtalk_error{}` record (tag `beamtalk_error`),
+  the same record used everywhere else in the runtime for user-facing errors.
+
+## Porting status
+
+`eval` (the canonical core path) and the actor read-surface ops (`actors`,
+`inspect`, `kill`, `interrupt`) return native term shapes today.
+
+The remaining ops — `load-source` / `load-project` / `unload`,
+`sessions` / `clone` / `close` / `health` / `shutdown`,
+`complete` / `describe` / `methods` / `list-classes` / `show-codegen` /
+`test` / `test-all` / `erlang-help` / `erlang-complete`, the tracing ops, and
+`nav-query` / `nav-symbols` — are still JSON-internally and are surfaced
+through the `{json, Binary}` escape tag, so every op still flows through the one
+`dispatch/4` → `encode/2` seam with no wire-format change. Porting those to
+native term shapes is incremental follow-up work for the LiveView IDE epic
+(read-surface ADR 0085, write-surface ADR 0082).
+
+## Live push streams: the subscription facade
+
+`dispatch/4` covers request/response ops. The workspace also pushes **live
+streams**. These are owned by `beamtalk_repl_subscriptions`, the stable
+subscription facade — rather than casting `{subscribe, self()}` tuples at the
+underlying gen_servers, a client calls the facade and the **calling process**
+becomes the subscriber. Over distribution a LiveView process subscribes its own
+location-transparent pid and receives the push messages natively.
+
+| Stream | Push message to the subscriber |
+|--------|--------------------------------|
+| `transcript` | `{transcript_output, Text :: binary()}` |
+| `actors` | `{actor_spawned, Meta}` / `{actor_stopped, StopInfo}` |
+| `classes` | `{class_loaded, ClassName :: atom()}` |
+| `bindings` | `{bindings_changed, SessionId :: binary()}` |
+| `flush` | `{flush_completed, Files :: [binary()]}` |
+
+```erlang
+%% Subscribe the calling process to everything the browser sees:
+beamtalk_repl_subscriptions:subscribe_all().
+%% …or a single stream:
+beamtalk_repl_subscriptions:subscribe(transcript).
+```
+
+The browser edge (`beamtalk_ws_handler`) re-encodes these push messages to JSON
+push frames; dist clients consume the messages directly.
+
+## Where this lives
+
+| Concern | Module |
+|---------|--------|
+| Dispatch + term contract + JSON edge | `beamtalk_repl_ops` |
+| `eval` term handler | `beamtalk_repl_ops_eval:handle_term/4` |
+| Actor read-surface term handlers | `beamtalk_repl_ops_actors:handle_term/4` |
+| Subscription facade | `beamtalk_repl_subscriptions` |
+| WebSocket transport edge | `beamtalk_repl_server:handle_op/4`, `beamtalk_ws_handler` |
+
+## References
+
+* `docs/research/phoenix-topology-spike.md` — "API shape: return terms, encode
+  JSON only at the WebSocket edge".
+* ADR 0017 (Browser Connectivity — Phase 3).
+* ADR 0085 (read-surface), ADR 0082 (write-surface).

--- a/docs/development/repl-op-term-contract.md
+++ b/docs/development/repl-op-term-contract.md
@@ -25,7 +25,7 @@ the whole point of a live-image IDE.
 
 So the op layer is split:
 
-```
+```text
                        ┌─ Phoenix / LSP / MCP (dist): consume terms directly
   dispatch/4 ─ term ───┤
                        └─ encode/2 ─ JSON ─ WebSocket (browser)

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops.erl
@@ -1,0 +1,191 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_repl_ops).
+
+%%% **DDD Context:** REPL Session Context
+
+-moduledoc """
+Term-returning op-layer seam for the curated REPL protocol (BT-2399, ADR 0017
+Phase 3).
+
+This module is the single dispatch table for protocol ops and the **only**
+place JSON is produced for the WebSocket transport. It splits the curated op
+layer into two halves:
+
+* `dispatch/4` — routes an op to its handler and returns a structured Erlang
+  **term** (`op_result()`), never JSON. This is the contract that
+  dist-attached clients (Phoenix LiveView, runtime-attached LSP / MCP) consume
+  directly over Erlang distribution, where JSON is both overhead and *lossy*
+  (a live `{beamtalk_object, Class, Module, Pid}` carries a real remote pid
+  that JSON would flatten to a dead display string).
+* `encode/2` — encodes an `op_result()` to the protocol JSON binary at the
+  **WebSocket transport edge only**. The browser wire format is unchanged.
+
+So the data flow is:
+
+```
+                       ┌─ Phoenix / LSP / MCP (dist): consume terms directly
+  dispatch/4 ─ term ───┤
+                       └─ encode/2 ─ JSON ─ WebSocket (browser)
+```
+
+## The cross-surface contract (`op_result()`)
+
+`op_result()` — together with the `#beamtalk_error{}` record (tagged
+`beamtalk_error`, so Phoenix can match on the tag without sharing a `.hrl`) —
+is the **documented, stable API boundary** across surfaces. It is deliberately
+a small tagged union rather than raw internal shapes, so the contract does not
+leak compiler/runtime internals.
+
+| Tag | Shape | Produced by |
+|-----|-------|-------------|
+| result | `{ok, Value, Output, Warnings}` | `eval` |
+| trace | `{trace, Steps, Output, Warnings}` | `eval` (trace mode) |
+| actors | `{actors, [ActorMeta]}` | `actors` |
+| inspect | `{inspect, map() \| binary()}` | `inspect` |
+| status | `{status, ok}` | `kill`, `interrupt` |
+| error | `{error, #beamtalk_error{}}` | any op |
+| error+io | `{error, #beamtalk_error{}, Output, Warnings}` | `eval` |
+| json | `{json, binary()}` | ops not yet ported (see below) |
+
+`Value` and `inspect` payloads are live terms — over distribution they retain
+messageable pids and structure; only `encode/2` flattens them to JSON.
+
+## Incremental porting
+
+`eval` (the canonical core path) and the actor read-surface ops (`actors`,
+`inspect`, `kill`, `interrupt`) return native term shapes. The remaining ops
+(`load-*`, `unload`, `sessions`/`clone`/`close`/`health`/`shutdown`,
+`complete`/`describe`/…, tracing, `nav-*`) are still JSON-internally and are
+surfaced through the `{json, Binary}` escape tag so every op flows through the
+one `dispatch/4` → `encode/2` seam without a wire-format change. Porting those
+to native term shapes is tracked as follow-up work for the LiveView IDE epic
+(read-surface ADR 0085 / write-surface ADR 0082).
+
+## References
+
+* `docs/development/repl-op-term-contract.md` — the contract reference.
+* `docs/research/phoenix-topology-spike.md` — "API shape: return terms, encode
+  JSON only at the WebSocket edge".
+* ADR 0017 Phase 3 (Browser Connectivity).
+""".
+
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+-export([dispatch/4, encode/2]).
+
+-export_type([op_result/0]).
+
+-type protocol_msg() :: beamtalk_repl_protocol:protocol_msg().
+
+-doc """
+The cross-surface op result contract. A dispatched op returns one of these
+tagged terms; `encode/2` is the only thing that turns them into JSON.
+""".
+-type op_result() ::
+    {ok, Value :: term(), Output :: binary(), Warnings :: [binary()]}
+    | {trace, Steps :: [term()], Output :: binary(), Warnings :: [binary()]}
+    | {actors, [map()]}
+    | {inspect, map() | binary()}
+    | {status, ok}
+    | {error, #beamtalk_error{}}
+    | {error, #beamtalk_error{}, Output :: binary(), Warnings :: [binary()]}
+    | {json, binary()}.
+
+%%% Dispatch — op name → term result
+
+-doc """
+Route a protocol op to its handler, returning a structured `op_result()` term.
+
+This is the term-returning entry point for dist-attached clients. It mirrors
+the op routing previously inlined in `beamtalk_repl_server:handle_op/4`. Ops
+that have been ported to the term contract return native term shapes; the rest
+are surfaced via the `{json, Binary}` escape tag.
+""".
+-spec dispatch(binary(), map(), protocol_msg(), pid()) -> op_result().
+dispatch(<<"eval">>, Params, Msg, SessionPid) ->
+    beamtalk_repl_ops_eval:handle_term(<<"eval">>, Params, Msg, SessionPid);
+dispatch(Op, Params, Msg, SessionPid) when
+    Op =:= <<"actors">>;
+    Op =:= <<"inspect">>;
+    Op =:= <<"kill">>;
+    Op =:= <<"interrupt">>
+->
+    beamtalk_repl_ops_actors:handle_term(Op, Params, Msg, SessionPid);
+dispatch(<<"load-source">>, Params, Msg, SessionPid) ->
+    {json, beamtalk_repl_ops_load:handle(<<"load-source">>, Params, Msg, SessionPid)};
+dispatch(<<"load-project">>, Params, Msg, SessionPid) ->
+    {json, beamtalk_repl_ops_load:handle(<<"load-project">>, Params, Msg, SessionPid)};
+dispatch(<<"unload">>, Params, Msg, SessionPid) ->
+    {json, beamtalk_repl_ops_load:handle(<<"unload">>, Params, Msg, SessionPid)};
+dispatch(Op, Params, Msg, SessionPid) when
+    Op =:= <<"sessions">>;
+    Op =:= <<"clone">>;
+    Op =:= <<"close">>;
+    Op =:= <<"health">>;
+    Op =:= <<"shutdown">>
+->
+    {json, beamtalk_repl_ops_session:handle(Op, Params, Msg, SessionPid)};
+dispatch(Op, Params, Msg, SessionPid) when
+    Op =:= <<"complete">>;
+    Op =:= <<"describe">>;
+    Op =:= <<"methods">>;
+    Op =:= <<"list-classes">>;
+    Op =:= <<"show-codegen">>;
+    Op =:= <<"test">>;
+    Op =:= <<"test-all">>;
+    Op =:= <<"erlang-help">>;
+    Op =:= <<"erlang-complete">>
+->
+    {json, beamtalk_repl_ops_dev:handle(Op, Params, Msg, SessionPid)};
+dispatch(Op, Params, Msg, SessionPid) when
+    Op =:= <<"enable-tracing">>;
+    Op =:= <<"disable-tracing">>;
+    Op =:= <<"get-traces">>;
+    Op =:= <<"actor-stats">>;
+    Op =:= <<"export-traces">>
+->
+    {json, beamtalk_repl_ops_perf:handle(Op, Params, Msg, SessionPid)};
+dispatch(<<"nav-query">>, Params, Msg, SessionPid) ->
+    {json, beamtalk_repl_ops_nav:handle(<<"nav-query">>, Params, Msg, SessionPid)};
+dispatch(<<"nav-symbols">>, Params, Msg, SessionPid) ->
+    {json, beamtalk_repl_ops_nav_symbols:handle(<<"nav-symbols">>, Params, Msg, SessionPid)};
+dispatch(Op, _Params, _Msg, _SessionPid) ->
+    Err0 = beamtalk_error:new(unknown_op, 'REPL'),
+    Err1 = beamtalk_error:with_message(
+        Err0,
+        iolist_to_binary([<<"Unknown operation: ">>, Op])
+    ),
+    {error, Err1}.
+
+%%% Encode — term result → protocol JSON (WebSocket transport edge only)
+
+-doc """
+Encode an `op_result()` term to the protocol JSON binary. This is the only
+place JSON is produced for the curated op layer; dist-attached clients never
+call it.
+""".
+-spec encode(op_result(), protocol_msg()) -> binary().
+encode({ok, Value, Output, Warnings}, Msg) ->
+    beamtalk_repl_protocol:encode_result(
+        Value, Msg, fun beamtalk_repl_json:term_to_json/1, Output, Warnings
+    );
+encode({trace, Steps, Output, Warnings}, Msg) ->
+    beamtalk_repl_protocol:encode_trace_result(
+        Steps, Msg, fun beamtalk_repl_json:term_to_json/1, Output, Warnings
+    );
+encode({actors, Actors}, Msg) ->
+    beamtalk_repl_protocol:encode_actors(Actors, Msg, fun beamtalk_repl_json:term_to_json/1);
+encode({inspect, Map}, Msg) when is_map(Map) ->
+    beamtalk_repl_protocol:encode_inspect(Map, Msg, fun beamtalk_repl_json:term_to_json/1);
+encode({inspect, Bin}, Msg) when is_binary(Bin) ->
+    beamtalk_repl_protocol:encode_inspect(Bin, Msg);
+encode({status, ok}, Msg) ->
+    beamtalk_repl_protocol:encode_status(ok, Msg, fun beamtalk_repl_json:term_to_json/1);
+encode({error, Err}, Msg) ->
+    beamtalk_repl_json:encode_error(Err, Msg);
+encode({error, Err, Output, Warnings}, Msg) ->
+    beamtalk_repl_json:encode_error(Err, Msg, Output, Warnings);
+encode({json, Bin}, _Msg) when is_binary(Bin) ->
+    Bin.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_actors.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_actors.erl
@@ -8,46 +8,65 @@
 -moduledoc """
 Op handlers for actors, inspect, kill, and interrupt operations.
 
-Extracted from beamtalk_repl_server (BT-705).
+Extracted from beamtalk_repl_server (BT-705). These are the actor read-surface
+ops; `handle_term/4` returns native `beamtalk_repl_ops:op_result()` terms
+(BT-2399, ADR 0017 Phase 3) so dist-attached clients receive live actor pids
+and field maps rather than flattened JSON. `handle/4` is the WebSocket-edge
+wrapper that encodes the term result via `beamtalk_repl_ops:encode/2`.
 """.
 
 -include_lib("kernel/include/logger.hrl").
 
--export([handle/4, validate_actor_pid/1, is_known_actor/1]).
+-export([handle/4, handle_term/4, validate_actor_pid/1, is_known_actor/1]).
 
--spec encode_invalid_pid_error(atom(), string(), beamtalk_repl_protocol:protocol_msg()) -> binary().
-encode_invalid_pid_error(Reason, PidStr, Msg) ->
+-spec invalid_pid_error(atom(), string()) -> beamtalk_error:error().
+invalid_pid_error(Reason, PidStr) ->
     PidBin = list_to_binary(PidStr),
     Err0 = beamtalk_error:new(Reason, 'Actor'),
     Err1 = beamtalk_error:with_message(
         Err0,
         iolist_to_binary([<<"Invalid actor PID: ">>, PidBin])
     ),
-    Err2 = beamtalk_error:with_hint(
+    beamtalk_error:with_hint(
         Err1,
         <<"Use :actors to list valid actor PIDs.">>
-    ),
-    beamtalk_repl_json:encode_error(Err2, Msg).
+    ).
 
--doc "Handle actors/inspect/kill/interrupt ops.".
+-doc """
+Handle actors/inspect/kill/interrupt ops for the WebSocket transport — encodes
+the term result to JSON at the edge.
+""".
 -spec handle(binary(), map(), beamtalk_repl_protocol:protocol_msg(), pid()) -> binary().
-handle(<<"actors">>, _Params, Msg, _SessionPid) ->
+handle(Op, Params, Msg, SessionPid) ->
+    beamtalk_repl_ops:encode(handle_term(Op, Params, Msg, SessionPid), Msg).
+
+-doc """
+Term-returning handler for actors/inspect/kill/interrupt. Returns
+`{actors, [Meta]}`, `{inspect, map() | binary()}`, `{status, ok}`, or
+`{error, #beamtalk_error{}}` — no JSON in this path.
+""".
+-spec handle_term(binary(), map(), beamtalk_repl_protocol:protocol_msg(), pid()) ->
+    beamtalk_repl_ops:op_result().
+handle_term(<<"actors">>, _Params, _Msg, _SessionPid) ->
     case whereis(beamtalk_actor_registry) of
         undefined ->
-            beamtalk_repl_protocol:encode_actors([], Msg, fun beamtalk_repl_json:term_to_json/1);
+            {actors, []};
         RegistryPid ->
-            Actors = beamtalk_repl_actors:list_actors(RegistryPid),
-            beamtalk_repl_protocol:encode_actors(Actors, Msg, fun beamtalk_repl_json:term_to_json/1)
+            {actors, beamtalk_repl_actors:list_actors(RegistryPid)}
     end;
-handle(<<"inspect">>, Params, Msg, _SessionPid) ->
+handle_term(<<"inspect">>, Params, _Msg, _SessionPid) ->
     PidStr = binary_to_list(maps:get(<<"actor">>, Params, <<>>)),
     PidBin = list_to_binary(PidStr),
     case validate_actor_pid(PidStr) of
         {error, Reason} ->
-            encode_invalid_pid_error(Reason, PidStr, Msg);
+            {error, invalid_pid_error(Reason, PidStr)};
         {ok, Pid} ->
             case is_process_alive(Pid) of
                 true ->
+                    %% Keep the whole introspection inside the try body (not a
+                    %% `try ... of`): is_tagged/field_names/maps:with must also be
+                    %% guarded, so a failure there returns inspect_failed rather
+                    %% than crashing the op handler.
                     try
                         State = sys:get_state(Pid, 5000),
                         case State of
@@ -57,18 +76,12 @@ handle(<<"inspect">>, Params, Msg, _SessionPid) ->
                                         %% Return only user-visible instance fields
                                         %% (filters out $beamtalk_class, __methods__, etc.)
                                         UserFields = beamtalk_runtime_api:field_names(M),
-                                        FieldMap = maps:with(UserFields, M),
-                                        beamtalk_repl_protocol:encode_inspect(
-                                            FieldMap, Msg, fun beamtalk_repl_json:term_to_json/1
-                                        );
+                                        {inspect, maps:with(UserFields, M)};
                                     false ->
-                                        beamtalk_repl_protocol:encode_inspect(
-                                            M, Msg, fun beamtalk_repl_json:term_to_json/1
-                                        )
+                                        {inspect, M}
                                 end;
                             _ ->
-                                InspectStr = iolist_to_binary(io_lib:format("~p", [State])),
-                                beamtalk_repl_protocol:encode_inspect(InspectStr, Msg)
+                                {inspect, iolist_to_binary(io_lib:format("~p", [State]))}
                         end
                     catch
                         _:_ ->
@@ -77,7 +90,7 @@ handle(<<"inspect">>, Params, Msg, _SessionPid) ->
                                 Err3,
                                 iolist_to_binary([<<"Failed to inspect actor: ">>, PidBin])
                             ),
-                            beamtalk_repl_json:encode_error(Err4, Msg)
+                            {error, Err4}
                     end;
                 false ->
                     Err3 = beamtalk_error:new(actor_not_alive, 'Actor'),
@@ -85,19 +98,19 @@ handle(<<"inspect">>, Params, Msg, _SessionPid) ->
                         Err3,
                         iolist_to_binary([<<"Actor is not alive: ">>, PidBin])
                     ),
-                    beamtalk_repl_json:encode_error(Err4, Msg)
+                    {error, Err4}
             end
     end;
-handle(<<"kill">>, Params, Msg, _SessionPid) ->
+handle_term(<<"kill">>, Params, _Msg, _SessionPid) ->
     PidStr = binary_to_list(maps:get(<<"actor">>, Params, maps:get(<<"pid">>, Params, <<>>))),
     case validate_actor_pid(PidStr) of
         {error, Reason} ->
-            encode_invalid_pid_error(Reason, PidStr, Msg);
+            {error, invalid_pid_error(Reason, PidStr)};
         {ok, Pid} ->
             exit(Pid, kill),
-            beamtalk_repl_protocol:encode_status(ok, Msg, fun beamtalk_repl_json:term_to_json/1)
+            {status, ok}
     end;
-handle(<<"interrupt">>, _Params, Msg, SessionPid) ->
+handle_term(<<"interrupt">>, _Params, Msg, SessionPid) ->
     %% BT-666: Interrupt a running evaluation.
     %% BT-1045: session is stripped from Params by the protocol decoder — use get_session(Msg).
     TargetPid =
@@ -118,10 +131,10 @@ handle(<<"interrupt">>, _Params, Msg, SessionPid) ->
         end,
     try
         ok = beamtalk_repl_shell:interrupt(TargetPid),
-        beamtalk_repl_protocol:encode_status(ok, Msg, fun beamtalk_repl_json:term_to_json/1)
+        {status, ok}
     catch
         exit:{noproc, _} ->
-            beamtalk_repl_protocol:encode_status(ok, Msg, fun beamtalk_repl_json:term_to_json/1)
+            {status, ok}
     end.
 
 %%% Internal helpers

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
@@ -12,13 +12,32 @@ Extracted from beamtalk_repl_server (BT-705). The `clear` and `bindings`
 ops were removed in BT-2369 (ADR 0081 Phase 6) — session state is now read
 and mutated through the Beamtalk-native `Session` API
 (`Session current bindings`, `Session current clear`) via `eval`.
+
+`eval` is the canonical term-returning core path (BT-2399, ADR 0017 Phase 3):
+`handle_term/4` returns a structured `beamtalk_repl_ops:op_result()` term and
+never produces JSON. `handle/4` is the WebSocket-edge wrapper that encodes that
+term to the protocol JSON binary via `beamtalk_repl_ops:encode/2`.
 """.
 
--export([handle/4]).
+-export([handle/4, handle_term/4]).
 
--doc "Handle the eval op.".
+-doc """
+Handle the eval op for the WebSocket transport — encodes the term result to
+JSON at the edge.
+""".
 -spec handle(binary(), map(), beamtalk_repl_protocol:protocol_msg(), pid()) -> binary().
 handle(<<"eval">>, Params, Msg, SessionPid) ->
+    beamtalk_repl_ops:encode(handle_term(<<"eval">>, Params, Msg, SessionPid), Msg).
+
+-doc """
+Term-returning eval handler. Returns `{ok, Value, Output, Warnings}` on success,
+`{trace, Steps, Output, Warnings}` in trace mode, or
+`{error, #beamtalk_error{}}` / `{error, #beamtalk_error{}, Output, Warnings}` on
+failure. No JSON in this path — dist-attached clients consume the term directly.
+""".
+-spec handle_term(binary(), map(), beamtalk_repl_protocol:protocol_msg(), pid()) ->
+    beamtalk_repl_ops:op_result().
+handle_term(<<"eval">>, Params, _Msg, SessionPid) ->
     Code = binary_to_list(maps:get(<<"code">>, Params, <<>>)),
     Trace = maps:get(<<"trace">>, Params, false) =:= true,
     case Code of
@@ -26,25 +45,21 @@ handle(<<"eval">>, Params, Msg, SessionPid) ->
             Err = beamtalk_error:new(empty_expression, 'REPL'),
             Err1 = beamtalk_error:with_message(Err, <<"Empty expression">>),
             Err2 = beamtalk_error:with_hint(Err1, <<"Enter an expression to evaluate.">>),
-            beamtalk_repl_json:encode_error(Err2, Msg);
+            {error, Err2};
         _ when Trace ->
             case beamtalk_repl_shell:eval_trace(SessionPid, Code) of
                 {ok, Steps, Output, Warnings} ->
-                    beamtalk_repl_protocol:encode_trace_result(
-                        Steps, Msg, fun beamtalk_repl_json:term_to_json/1, Output, Warnings
-                    );
+                    {trace, Steps, Output, Warnings};
                 {error, ErrorReason, Output, Warnings} ->
                     WrappedReason = beamtalk_repl_errors:ensure_structured_error(ErrorReason),
-                    beamtalk_repl_json:encode_error(WrappedReason, Msg, Output, Warnings)
+                    {error, WrappedReason, Output, Warnings}
             end;
         _ ->
             case beamtalk_repl_shell:eval(SessionPid, Code) of
                 {ok, Result, Output, Warnings} ->
-                    beamtalk_repl_protocol:encode_result(
-                        Result, Msg, fun beamtalk_repl_json:term_to_json/1, Output, Warnings
-                    );
+                    {ok, Result, Output, Warnings};
                 {error, ErrorReason, Output, Warnings} ->
                     WrappedReason = beamtalk_repl_errors:ensure_structured_error(ErrorReason),
-                    beamtalk_repl_json:encode_error(WrappedReason, Msg, Output, Warnings)
+                    {error, WrappedReason, Output, Warnings}
             end
     end.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
@@ -385,77 +385,26 @@ handle_protocol_request(Msg, SessionPid) ->
     end.
 
 -doc """
-Dispatch protocol ops to domain-specific handler modules (BT-705).
+Dispatch a protocol op and encode the result for the WebSocket transport.
 
-The deprecated ops `docs`, `load-file`, `reload`, and `modules` were removed
-in BT-2091 (protocol 2.0); sending them now returns `unknown_op`. The
-`bindings` and `clear` ops were removed in BT-2369 (ADR 0081 Phase 6) —
-session state is now read and mutated through the Beamtalk-native `Session`
-API (`Session current bindings`, `Session current clear`) via `eval`, so
-sending `bindings`/`clear` now returns `unknown_op`.
+Routing and term-result production live in `beamtalk_repl_ops:dispatch/4`; JSON
+encoding happens at this transport edge via `beamtalk_repl_ops:encode/2`
+(BT-2399, ADR 0017 Phase 3). The browser wire format is unchanged. Dist-attached
+clients (Phoenix LiveView, runtime-attached LSP / MCP) call
+`beamtalk_repl_ops:dispatch/4` directly and consume the live term result without
+this JSON step.
+
+The deprecated ops `docs`, `load-file`, `reload`, and `modules` were removed in
+BT-2091 (protocol 2.0); sending them now returns `unknown_op`. The `bindings`
+and `clear` ops were removed in BT-2369 (ADR 0081 Phase 6) — session state is
+now read and mutated through the Beamtalk-native `Session` API
+(`Session current bindings`, `Session current clear`) via `eval`, so sending
+`bindings`/`clear` now returns `unknown_op`.
 """.
-handle_op(<<"eval">>, Params, Msg, SessionPid) ->
-    beamtalk_repl_ops_eval:handle(<<"eval">>, Params, Msg, SessionPid);
-handle_op(<<"load-source">>, Params, Msg, SessionPid) ->
-    beamtalk_repl_ops_load:handle(<<"load-source">>, Params, Msg, SessionPid);
-handle_op(<<"load-project">>, Params, Msg, SessionPid) ->
-    beamtalk_repl_ops_load:handle(<<"load-project">>, Params, Msg, SessionPid);
-handle_op(Op, Params, Msg, SessionPid) when
-    Op =:= <<"actors">>;
-    Op =:= <<"inspect">>;
-    Op =:= <<"kill">>;
-    Op =:= <<"interrupt">>
-->
-    beamtalk_repl_ops_actors:handle(Op, Params, Msg, SessionPid);
-handle_op(Op, Params, Msg, SessionPid) when
-    Op =:= <<"sessions">>;
-    Op =:= <<"clone">>;
-    Op =:= <<"close">>;
-    Op =:= <<"health">>;
-    Op =:= <<"shutdown">>
-->
-    beamtalk_repl_ops_session:handle(Op, Params, Msg, SessionPid);
-handle_op(Op, Params, Msg, SessionPid) when
-    Op =:= <<"complete">>;
-    Op =:= <<"describe">>;
-    Op =:= <<"methods">>;
-    Op =:= <<"list-classes">>;
-    Op =:= <<"show-codegen">>;
-    Op =:= <<"test">>;
-    Op =:= <<"test-all">>;
-    Op =:= <<"erlang-help">>;
-    Op =:= <<"erlang-complete">>
-->
-    beamtalk_repl_ops_dev:handle(Op, Params, Msg, SessionPid);
-handle_op(Op, Params, Msg, SessionPid) when Op =:= <<"unload">> ->
-    %% BT-1239: Restored — fully removes class from the system (actors, gen_server,
-    %% BEAM module, workspace_meta, session tracker). Previously returned a deprecation
-    %% error (BT-785) but that left orphaned bt@* BEAM modules.
-    beamtalk_repl_ops_load:handle(<<"unload">>, Params, Msg, SessionPid);
-handle_op(Op, Params, Msg, SessionPid) when
-    Op =:= <<"enable-tracing">>;
-    Op =:= <<"disable-tracing">>;
-    Op =:= <<"get-traces">>;
-    Op =:= <<"actor-stats">>;
-    Op =:= <<"export-traces">>
-->
-    beamtalk_repl_ops_perf:handle(Op, Params, Msg, SessionPid);
-%% BT-2239: structured navigation queries for runtime-attached LSP / MCP clients.
-handle_op(<<"nav-query">>, Params, Msg, SessionPid) ->
-    beamtalk_repl_ops_nav:handle(<<"nav-query">>, Params, Msg, SessionPid);
-%% BT-2244: bulk class+method symbol outline for runtime-attached LSP
-%% `textDocument/documentSymbol` and `workspace/symbol`. Sibling of
-%% `nav-query` — kept on a separate op so `nav-query`'s wire shape stays
-%% locked to selector-shaped navigation.
-handle_op(<<"nav-symbols">>, Params, Msg, SessionPid) ->
-    beamtalk_repl_ops_nav_symbols:handle(<<"nav-symbols">>, Params, Msg, SessionPid);
-handle_op(Op, _Params, Msg, _SessionPid) ->
-    Err0 = beamtalk_error:new(unknown_op, 'REPL'),
-    Err1 = beamtalk_error:with_message(
-        Err0,
-        iolist_to_binary([<<"Unknown operation: ">>, Op])
-    ),
-    beamtalk_repl_json:encode_error(Err1, Msg).
+handle_op(Op, Params, Msg, SessionPid) ->
+    beamtalk_repl_ops:encode(
+        beamtalk_repl_ops:dispatch(Op, Params, Msg, SessionPid), Msg
+    ).
 
 %%% Protocol Parsing and Formatting
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_subscriptions.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_subscriptions.erl
@@ -1,0 +1,101 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_repl_subscriptions).
+
+%%% **DDD Context:** REPL Session Context
+
+-moduledoc """
+Stable subscription facade for the workspace live push streams (BT-2399, ADR
+0017 Phase 3).
+
+The curated op layer (`beamtalk_repl_ops`) covers request/response ops, but the
+workspace also pushes **live streams** — Transcript output, actor lifecycle,
+class loads, bindings changes, and flush completions. Previously those were
+wired only inside `beamtalk_ws_handler`, which called each underlying event
+module (`beamtalk_transcript_stream:subscribe/1`, `beamtalk_repl_actors:subscribe/0`,
+…) directly. A dist-attached client (Phoenix LiveView, runtime-attached LSP)
+had no stable surface and would otherwise cast `{subscribe, self()}` tuples at
+the gen_servers — coupling to internal message shapes.
+
+This module is that stable surface: one place that names the streams and owns
+the subscribe/unsubscribe calls. The **calling process** becomes the subscriber
+(the underlying event servers register `self()`), so over Erlang distribution a
+LiveView process subscribes its own location-transparent pid and receives the
+push messages natively.
+
+## Streams and the messages they push
+
+| Stream | Push message to the subscriber |
+|--------|--------------------------------|
+| `transcript` | `{transcript_output, Text :: binary()}` |
+| `actors` | `{actor_spawned, Meta}` / `{actor_stopped, StopInfo}` |
+| `classes` | `{class_loaded, ClassName :: atom()}` |
+| `bindings` | `{bindings_changed, SessionId :: binary()}` |
+| `flush` | `{flush_completed, Files :: [binary()]}` |
+
+These message shapes are part of the documented push contract; clients pattern
+match on them (the browser edge re-encodes them to JSON push frames in
+`beamtalk_ws_handler`).
+
+## References
+
+* `docs/development/repl-op-term-contract.md` — the op + subscription contract.
+* `docs/research/phoenix-topology-spike.md` — "One genuine gap: push-stream
+  subscription".
+* ADR 0017 Phase 3 (Browser Connectivity).
+""".
+
+-export([streams/0, subscribe/1, unsubscribe/1, subscribe_all/0, unsubscribe_all/0]).
+
+-type stream() :: transcript | actors | classes | bindings | flush.
+
+-export_type([stream/0]).
+
+-doc "The ordered list of live push streams a client can subscribe to.".
+-spec streams() -> [stream()].
+streams() ->
+    [transcript, actors, classes, bindings, flush].
+
+-doc """
+Subscribe the calling process to a single live push stream. The subscriber
+receives the stream's push messages (see the module doc table).
+""".
+-spec subscribe(stream()) -> ok.
+subscribe(transcript) ->
+    beamtalk_transcript_stream:subscribe('Transcript');
+subscribe(actors) ->
+    beamtalk_repl_actors:subscribe();
+subscribe(classes) ->
+    beamtalk_class_events:subscribe();
+subscribe(bindings) ->
+    beamtalk_bindings_events:subscribe();
+subscribe(flush) ->
+    beamtalk_flush_events:subscribe().
+
+-doc "Unsubscribe the calling process from a single live push stream.".
+-spec unsubscribe(stream()) -> ok.
+unsubscribe(transcript) ->
+    beamtalk_transcript_stream:unsubscribe('Transcript');
+unsubscribe(actors) ->
+    beamtalk_repl_actors:unsubscribe();
+unsubscribe(classes) ->
+    beamtalk_class_events:unsubscribe();
+unsubscribe(bindings) ->
+    beamtalk_bindings_events:unsubscribe();
+unsubscribe(flush) ->
+    beamtalk_flush_events:unsubscribe().
+
+-doc """
+Subscribe the calling process to every live push stream. Used by the WebSocket
+handler on connect/resume, and the one call a dist-attached client makes to
+mirror the browser's live surface.
+""".
+-spec subscribe_all() -> ok.
+subscribe_all() ->
+    lists:foreach(fun subscribe/1, streams()).
+
+-doc "Unsubscribe the calling process from every live push stream.".
+-spec unsubscribe_all() -> ok.
+unsubscribe_all() ->
+    lists:foreach(fun unsubscribe/1, streams()).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
@@ -247,17 +247,11 @@ terminate(_Reason, _Req, #ws_state{session_id = SessionId, session_pid = Session
         peer => Peer,
         domain => [beamtalk, runtime]
     }),
-    %% Unsubscribe from Transcript push messages (ADR 0017)
-    beamtalk_transcript_stream:unsubscribe('Transcript'),
-    %% Unsubscribe from actor lifecycle push messages (BT-690)
-    beamtalk_repl_actors:unsubscribe(),
-    %% Unsubscribe from class-loaded push messages (BT-1020)
-    beamtalk_class_events:unsubscribe(),
-    %% Unsubscribe from bindings-changed push messages
-    beamtalk_bindings_events:unsubscribe(),
-    %% Unsubscribe from flush-completion push messages (ADR 0082 Phase 3, BT-2289)
-    beamtalk_flush_events:unsubscribe(),
-    %% Unsubscribe from log streaming (BT-1433)
+    %% BT-2399: unsubscribe from all live push streams (Transcript, actors,
+    %% classes, bindings, flush) via the stable facade.
+    beamtalk_repl_subscriptions:unsubscribe_all(),
+    %% Unsubscribe from log streaming (BT-1433) — a separate diagnostic stream,
+    %% not part of the workspace push-stream facade.
     beamtalk_ws_log_handler:unsubscribe(),
     %% Keep session alive for resume — session idle monitor handles cleanup.
     %% Don't delete from ETS or stop the process here.
@@ -380,13 +374,11 @@ start_or_resume_session(ResumeId, State) when is_binary(ResumeId) ->
                         domain => [beamtalk, runtime]
                     }),
                     beamtalk_workspace_meta:update_activity(),
-                    beamtalk_transcript_stream:subscribe('Transcript'),
-                    beamtalk_repl_actors:subscribe(),
-                    beamtalk_class_events:subscribe(),
-                    beamtalk_bindings_events:subscribe(),
-                    %% ADR 0082 Phase 3 (BT-2289): receive `{flush_completed, Files}`
-                    %% so LSP clients can emit `workspace/applyEdit` per touched file.
-                    beamtalk_flush_events:subscribe(),
+                    %% BT-2399: subscribe to all live push streams (Transcript,
+                    %% actors, classes, bindings, flush) via the stable facade.
+                    %% ADR 0082 Phase 3 (BT-2289): the flush stream lets LSP
+                    %% clients emit `workspace/applyEdit` per touched file.
+                    beamtalk_repl_subscriptions:subscribe_all(),
                     InitialActors = actor_snapshot_frames(),
                     AuthOk = iolist_to_binary(json:encode(#{<<"type">> => <<"auth_ok">>})),
                     SessionMsg = iolist_to_binary(
@@ -438,13 +430,11 @@ create_session(SessionId, State) ->
                 domain => [beamtalk, runtime]
             }),
             beamtalk_workspace_meta:update_activity(),
-            beamtalk_transcript_stream:subscribe('Transcript'),
-            beamtalk_repl_actors:subscribe(),
-            beamtalk_class_events:subscribe(),
-            beamtalk_bindings_events:subscribe(),
-            %% ADR 0082 Phase 3 (BT-2289): flush-completion subscription so
-            %% LSP clients can emit `workspace/applyEdit` on flush.
-            beamtalk_flush_events:subscribe(),
+            %% BT-2399: subscribe to all live push streams (Transcript, actors,
+            %% classes, bindings, flush) via the stable facade. ADR 0082 Phase 3
+            %% (BT-2289): the flush stream lets LSP clients emit
+            %% `workspace/applyEdit` on flush.
+            beamtalk_repl_subscriptions:subscribe_all(),
             InitialActors = actor_snapshot_frames(),
             AuthOk = iolist_to_binary(json:encode(#{<<"type">> => <<"auth_ok">>})),
             SessionMsg = iolist_to_binary(

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_actors_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_actors_tests.erl
@@ -110,7 +110,7 @@ handle_inspect_missing_actor_param_returns_error_test() ->
 
 handle_inspect_unknown_actor_pid_returns_error_test() ->
     %% Valid PID string format but not registered in actor registry → unknown_actor.
-    %% encode_invalid_pid_error wraps it with the same "Invalid actor PID" message.
+    %% invalid_pid_error wraps it with the same "Invalid actor PID" message.
     PidBin = list_to_binary(pid_to_list(self())),
     Msg = make_msg(<<"inspect">>, <<"i-4">>, undefined, false),
     Result = beamtalk_repl_ops_actors:handle(

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_actors_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_actors_tests.erl
@@ -13,6 +13,11 @@ the handle/4 operation paths that require no running actor registry:
 - actors op → empty list when registry absent
 - inspect/kill ops with invalid or unknown PID strings → error JSON
 - interrupt op with a dead SessionPid → noproc catch → ok status JSON
+
+Plus the term-returning `handle_term/4` (BT-2399): the inspect success path
+through a live tagged-map actor must return an `{inspect, FieldMap}` term with
+internal fields filtered — exercising the introspection inside the `inspect`
+`try` body (the body whose exception-safety the BT-2399 fix restored).
 """.
 
 -include_lib("eunit/include/eunit.hrl").
@@ -23,6 +28,22 @@ the handle/4 operation paths that require no running actor registry:
 
 make_msg(Op, Id, Session, Legacy) ->
     {protocol_msg, Op, Id, Session, #{}, Legacy}.
+
+%% Stop any stale globally-registered actor registry so start_link/4 below
+%% does not fail with {already_started, _}. Mirrors the pattern in
+%% beamtalk_repl_server_tests.
+stop_registry_if_running() ->
+    case whereis(beamtalk_actor_registry) of
+        undefined ->
+            ok;
+        Old ->
+            Ref = erlang:monitor(process, Old),
+            catch gen_server:stop(Old),
+            receive
+                {'DOWN', Ref, process, Old, _} -> ok
+            after 1000 -> ok
+            end
+    end.
 
 %%====================================================================
 %% validate_actor_pid/1
@@ -171,3 +192,37 @@ handle_interrupt_dead_session_catches_noproc_test() ->
     Result = beamtalk_repl_ops_actors:handle(<<"interrupt">>, #{}, Msg, Pid),
     Decoded = json:decode(Result),
     ?assertEqual([<<"done">>], maps:get(<<"status">>, Decoded)).
+
+%%====================================================================
+%% handle_term/4 — inspect success path (live tagged-map actor)
+%%====================================================================
+
+handle_term_inspect_live_tagged_actor_returns_inspect_map_term_test() ->
+    %% BT-2399: the term-returning inspect path must return an {inspect, FieldMap}
+    %% *term* (not JSON) for a live tagged-map actor, with internal bookkeeping
+    %% keys filtered out. This drives the whole introspection body of the inspect
+    %% `try` (is_tagged → field_names → maps:with) to its normal completion — the
+    %% body the BT-2399 fix moved back inside the `try` so any future throw there
+    %% is caught rather than escaping the op handler.
+    stop_registry_if_running(),
+    {ok, RegistryPid} = gen_server:start_link(
+        {local, beamtalk_actor_registry}, beamtalk_repl_actors, [], []
+    ),
+    {ok, ActorPid} = test_counter:start_link(0),
+    ok = beamtalk_repl_actors:register_actor(RegistryPid, ActorPid, 'Counter', test_counter),
+    PidBin = list_to_binary(pid_to_list(ActorPid)),
+    Msg = make_msg(<<"inspect">>, <<"i-live">>, undefined, false),
+    try
+        Result = beamtalk_repl_ops_actors:handle_term(
+            <<"inspect">>, #{<<"actor">> => PidBin}, Msg, self()
+        ),
+        ?assertMatch({inspect, M} when is_map(M), Result),
+        {inspect, Fields} = Result,
+        %% User-visible field is present; internal bookkeeping keys are filtered.
+        ?assert(maps:is_key(value, Fields)),
+        ?assertNot(maps:is_key('$beamtalk_class', Fields)),
+        ?assertNot(maps:is_key('__methods__', Fields))
+    after
+        catch gen_server:stop(ActorPid),
+        catch gen_server:stop(RegistryPid)
+    end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_tests.erl
@@ -1,0 +1,137 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_repl_ops_tests).
+
+%%% **DDD Context:** REPL Session Context
+
+-moduledoc """
+EUnit tests for the term-returning op seam (`beamtalk_repl_ops`) and the live
+push-stream subscription facade (`beamtalk_repl_subscriptions`), BT-2399.
+
+These assert the *term* contract (`op_result()`) that dist-attached clients
+consume — distinct from the JSON wire format covered by the per-op handle/4
+tests. They also assert that encoding a dispatched term at the edge reproduces
+the same JSON the WebSocket transport returns via `handle_op/4`.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+make_msg(Op) ->
+    make_msg(Op, false).
+
+make_msg(Op, Legacy) ->
+    {protocol_msg, Op, <<"id-1">>, undefined, #{}, Legacy}.
+
+%%====================================================================
+%% dispatch/4 — term shapes (no JSON in the core path)
+%%====================================================================
+
+dispatch_eval_empty_code_returns_error_term_test() ->
+    Msg = make_msg(<<"eval">>),
+    %% Empty code short-circuits before touching the session pid.
+    Result = beamtalk_repl_ops:dispatch(<<"eval">>, #{<<"code">> => <<>>}, Msg, self()),
+    ?assertMatch({error, #beamtalk_error{}}, Result).
+
+dispatch_actors_no_registry_returns_actors_term_test() ->
+    Msg = make_msg(<<"actors">>),
+    %% No beamtalk_actor_registry in unit tests → empty actor list term.
+    ?assertEqual({actors, []}, beamtalk_repl_ops:dispatch(<<"actors">>, #{}, Msg, self())).
+
+dispatch_inspect_invalid_pid_returns_error_term_test() ->
+    Msg = make_msg(<<"inspect">>),
+    Result = beamtalk_repl_ops:dispatch(
+        <<"inspect">>, #{<<"actor">> => <<"not-a-pid">>}, Msg, self()
+    ),
+    ?assertMatch({error, #beamtalk_error{}}, Result).
+
+dispatch_kill_invalid_pid_returns_error_term_test() ->
+    Msg = make_msg(<<"kill">>),
+    Result = beamtalk_repl_ops:dispatch(
+        <<"kill">>, #{<<"actor">> => <<"bad-pid">>}, Msg, self()
+    ),
+    ?assertMatch({error, #beamtalk_error{}}, Result).
+
+dispatch_interrupt_dead_session_returns_status_term_test() ->
+    %% Dead SessionPid → noproc caught → {status, ok} term.
+    Pid = spawn(fun() -> ok end),
+    MRef = monitor(process, Pid),
+    receive
+        {'DOWN', MRef, process, Pid, _} -> ok
+    end,
+    Msg = make_msg(<<"interrupt">>),
+    ?assertEqual({status, ok}, beamtalk_repl_ops:dispatch(<<"interrupt">>, #{}, Msg, Pid)).
+
+dispatch_unknown_op_returns_error_term_test() ->
+    Msg = make_msg(<<"no-such-op">>),
+    Result = beamtalk_repl_ops:dispatch(<<"no-such-op">>, #{}, Msg, self()),
+    ?assertMatch({error, #beamtalk_error{}}, Result),
+    {error, Err} = Result,
+    ?assertEqual(unknown_op, Err#beamtalk_error.kind).
+
+dispatch_unported_op_returns_json_passthrough_test() ->
+    %% `close` is not yet ported to a native term shape — it is surfaced via the
+    %% {json, Binary} escape tag so it still flows through the one seam.
+    Msg = make_msg(<<"close">>),
+    Result = beamtalk_repl_ops:dispatch(<<"close">>, #{}, Msg, self()),
+    ?assertMatch({json, Bin} when is_binary(Bin), Result).
+
+%%====================================================================
+%% encode/2 — term result → JSON at the WebSocket edge
+%%====================================================================
+
+encode_actors_term_matches_handle_op_json_test() ->
+    %% Encoding a dispatched term at the edge must reproduce exactly what the
+    %% WebSocket transport returns via handle_op/4 (wire format unchanged).
+    Msg = make_msg(<<"actors">>),
+    Term = beamtalk_repl_ops:dispatch(<<"actors">>, #{}, Msg, self()),
+    Encoded = beamtalk_repl_ops:encode(Term, Msg),
+    ViaServer = beamtalk_repl_server:handle_op(<<"actors">>, #{}, Msg, self()),
+    ?assertEqual(ViaServer, Encoded),
+    Decoded = json:decode(Encoded),
+    ?assertEqual([], maps:get(<<"actors">>, Decoded)).
+
+encode_error_term_produces_error_json_test() ->
+    Msg = make_msg(<<"inspect">>),
+    Term = beamtalk_repl_ops:dispatch(
+        <<"inspect">>, #{<<"actor">> => <<"not-a-pid">>}, Msg, self()
+    ),
+    Decoded = json:decode(beamtalk_repl_ops:encode(Term, Msg)),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ?assert(binary:match(maps:get(<<"error">>, Decoded), <<"Invalid actor PID">>) =/= nomatch).
+
+encode_json_passthrough_is_identity_test() ->
+    Msg = make_msg(<<"close">>),
+    Bin = beamtalk_repl_protocol:encode_status(ok, Msg, fun beamtalk_repl_json:term_to_json/1),
+    ?assertEqual(Bin, beamtalk_repl_ops:encode({json, Bin}, Msg)).
+
+%%====================================================================
+%% beamtalk_repl_subscriptions — facade
+%%====================================================================
+
+streams_lists_all_five_push_streams_test() ->
+    ?assertEqual(
+        [transcript, actors, classes, bindings, flush],
+        beamtalk_repl_subscriptions:streams()
+    ).
+
+subscribe_all_returns_ok_test() ->
+    %% The underlying event servers are not running in unit tests; gen_server:cast
+    %% to an unregistered name is a silent no-op, so the facade still returns ok.
+    ?assertEqual(ok, beamtalk_repl_subscriptions:subscribe_all()),
+    ?assertEqual(ok, beamtalk_repl_subscriptions:unsubscribe_all()).
+
+subscribe_single_stream_returns_ok_test() ->
+    [
+        ?assertEqual(ok, beamtalk_repl_subscriptions:subscribe(S))
+     || S <- beamtalk_repl_subscriptions:streams()
+    ],
+    [
+        ?assertEqual(ok, beamtalk_repl_subscriptions:unsubscribe(S))
+     || S <- beamtalk_repl_subscriptions:streams()
+    ].


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2399

The keystone refactor for the LiveView IDE epic (BT-2398), per the ADR 0017 Phase 3 Attach-topology spike (BT-2394). Factors the curated REPL op layer so it returns **live Erlang terms**, with JSON encoding pushed to the WebSocket transport edge only — so dist-attached clients (Phoenix LiveView, runtime-attached LSP/MCP) consume terms natively over Erlang distribution, where JSON is both overhead and lossy. **Browser wire format is unchanged.**

## What changed

- **`beamtalk_repl_ops` (new)** — the single op dispatch table. `dispatch/4` routes an op to a structured `op_result()` term (never JSON); `encode/2` is the only JSON boundary, at the WebSocket edge. `op_result()` + the `#beamtalk_error{}` record are the documented, stable cross-surface contract.
- **`eval`** (canonical core path) and the **actor read-surface** (`actors`/`inspect`/`kill`/`interrupt`) ported to native term shapes via `handle_term/4`. Remaining ops flow through a documented `{json, Binary}` escape tag — incremental porting tracked as **BT-2402**.
- **`beamtalk_repl_server:handle_op/4`** collapsed to `encode(dispatch(...))` at the transport edge.
- **`beamtalk_repl_subscriptions` (new)** — stable subscription facade for the live push streams (transcript / actors / classes / bindings / flush). `beamtalk_ws_handler` now calls `subscribe_all`/`unsubscribe_all` instead of casting at each gen_server.
- **`docs/development/repl-op-term-contract.md` (new)** — the contract reference.
- **`beamtalk_repl_ops_tests` (new)** — term-path + facade coverage.

## Acceptance criteria

- [x] Op handlers expose a term-returning entry (`{ok, Value, Output, Warnings} | {error, #beamtalk_error{}}`); no JSON in the eval/actor core path.
- [x] `handle_protocol_request/2` / `handle_op/4` keep JSON behaviour by encoding at the edge; browser wire format unchanged.
- [x] Stable subscription facade for the live streams.
- [x] Term result contract documented as the cross-surface boundary.
- [x] Existing REPL-protocol / WS tests stay green; added term-path coverage.

## Verification

- Full runtime EUnit: **4678 tests, 0 failures**
- REPL-protocol e2e: **3 passed** (wire-format parity)
- `erlfmt` clean · `dialyzer` clean

## Review note

A `try ... of` regression in `inspect` (which would have let introspection failures escape the `inspect_failed` guard) was caught and fixed during self-review before pushing.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PibNE1XcDTfiLDM8qdqSg5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized REPL routing with a stable term-shaped op contract and edge JSON encoding; unified live-stream subscription facade so clients receive consistent workspace push events.

* **Documentation**
  * Added REPL operation protocol contract documenting op result shapes and stream message formats.

* **Tests**
  * New unit tests for dispatch/encoding, subscription facade, and actor inspect term behavior.

* **Bug Fixes**
  * Improved error handling for invalid or unsupported operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->