### PR TITLE
docs: daily refresh 2026-06-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,9 @@
 - Migrate remaining codegen modules (`expressions.rs`, `intrinsics.rs`, `repl/codegen.rs`, `control_flow/`, `dispatch_codegen.rs`, `value_type_codegen.rs`, `gen_server/`, `mod.rs`, primitives) to `document::leaf` API (ADR 0089 Phase 2) (BT-2320..BT-2330).
 - Use canonical `safe_class_method_fn_name` in supervisor and spec codegen — adds atom-length safety guard for pathologically long selectors (BT-2339).
 - Remove `capture_expression` in favour of direct `Document` splicing, closing the value-type raw-fragment leaf seam (BT-2348).
+- Fix ADR 0089 leaf-API violations in `instantiation_error_stub` and `build_dnu_error_doc` — replaced manual `'...'` atom quoting with `leaf::atom()` and `core_erlang_binary_string` with `leaf::binary_lit` (BT-2390).
+- **Phoenix LiveView topology spike (ADR 0017 Phase 3)** — validated the Attach topology (Livebook-style: Phoenix as a separate BEAM node connecting to the workspace over Erlang distribution) end-to-end with zero runtime changes. Report in `docs/research/phoenix-topology-spike.md`; throwaway code in `spikes/phoenix_topology/` (BT-2394).
+- Document integration-testing strategy for modules only reachable via live external clients (`beamtalk_ws_handler`, `beamtalk_build_worker`) — added to `docs/development/testing-strategy.md` (BT-2389).
 
 ## 0.4.0 — 2026-04-27
 


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 6 commits merged to main on 2026-06-05.

### Commits reviewed

| Commit | PR | Classification | Doc change |
|---|---|---|---|
| `0713db5` | #2450 | Internal — Phoenix LiveView topology spike (BT-2394) | CHANGELOG Internal entry added |
| `90a486a` | #2449 | Internal — WebSocket handler + build_worker EUnit coverage (BT-2389) | CHANGELOG Internal entry added |
| `4833d3a` | #2446 | Internal — ADR 0089 leaf-API violations fix (BT-2390) | CHANGELOG Internal entry added |
| `fbf20cc` | #2445 | Docs — yesterday's daily refresh | Skipped |
| `a16908c` | #2447 | Test-only — stdlib EUnit tests (BT-2391) | Skipped |
| `8b3981d` | #2448 | Test-only — setUp/tearDown refactor (BT-2392) | Skipped |

### Skipped (with reasons)

- **fbf20cc** (#2445) — previous day's doc refresh, no user-visible changes
- **a16908c** (#2447) — purely under `runtime/apps/*/test/`, test-only
- **8b3981d** (#2448) — purely under `stdlib/test/`, test-only

### Docs updated

- `CHANGELOG.md` — 3 Internal entries added (BT-2390, BT-2394, BT-2389)

### Notes

Light day — all 3 doc-relevant commits are internal (codegen fix, research spike, test coverage methodology). No user-visible language, stdlib, runtime, or tooling changes. The Phoenix topology spike (BT-2394) already shipped its own research report at `docs/research/phoenix-topology-spike.md`, and the coverage commit (BT-2389) already updated `docs/development/testing-strategy.md` inline.

https://claude.ai/code/session_013wsTvdQvkbBHjbEgSSN5YD

---
_Generated by [Claude Code](https://claude.ai/code/session_013wsTvdQvkbBHjbEgSSN5YD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed violations in error handling for specific edge cases.

* **Documentation**
  * Added integration-testing strategy documentation for external client scenarios.
  * Added infrastructure validation research documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->