### PR TITLE
Add error-path tests for beamtalk_test_case decode_beam_error clauses (BT-2404)

### DIFF
--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_test_case_stdlib_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_test_case_stdlib_tests.erl
@@ -226,3 +226,229 @@ execute_tests_run_single_not_found_test() ->
         'run:', [testMissing], 'FakeTest', tc_run_helper, #{}
     ),
     ?assertNotEqual(nomatch, binary:match(Result, <<"not found">>)).
+
+%%% ============================================================================
+%%% execute_tests/5 — runAll with no test methods (line 166)
+%%% ============================================================================
+
+execute_tests_runall_no_methods_test() ->
+    %% FlatMethods has no "test*" keys → discover_test_methods returns [] → line 166
+    Result = beamtalk_test_case:execute_tests(
+        runAll, [], 'FakeTest', tc_run_helper, #{setUp => {'FakeTest', {}}}
+    ),
+    ?assert(is_binary(Result)),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"No test methods">>)).
+
+%%% ============================================================================
+%%% decode_beam_error/1 clause coverage via run_test_method/5 (BT-2404)
+%%%
+%%% decode_beam_error is private but reachable through run_test_method when
+%%% errors fall through to the generic `error:TestReason:TestST` catch clause
+%%% (line 830 of beamtalk_test_case.erl). All dispatchers below raise error
+%%% shapes that are NOT #beamtalk_error{} records and NOT `undef`, so they
+%%% bypass the specialised catch clauses and hit format_test_error/3.
+%%% ============================================================================
+
+decode_error_future_rejected_test() ->
+    %% {future_rejected, Inner} → "future rejected: ..."
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testFutureRejected, #{}, nil
+    ),
+    ?assertMatch({fail, testFutureRejected, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"future rejected">>)).
+
+decode_error_error_map_with_key_test() ->
+    %% {error, Map} with error key present → recurses into inner value
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testErrorMapWithKey, #{}, nil
+    ),
+    ?assertMatch({fail, testErrorMapWithKey, _}, Result).
+
+decode_error_error_map_no_key_test() ->
+    %% {error, Map} with no error key → print_string(Map)
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testErrorMapNoKey, #{}, nil
+    ),
+    ?assertMatch({fail, testErrorMapNoKey, _}, Result).
+
+decode_error_exception_map_test() ->
+    %% #{class := 'Exception', error := #beamtalk_error{message}} → extracts message
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testExceptionMap, #{}, nil
+    ),
+    ?assertMatch({fail, testExceptionMap, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"exc msg">>)).
+
+decode_error_class_map_test() ->
+    %% #{'$beamtalk_class' := _, error := #beamtalk_error{message}} → extracts message
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testClassMap, #{}, nil
+    ),
+    ?assertMatch({fail, testClassMap, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"cls msg">>)).
+
+decode_error_badkey_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testBadKey, #{}, nil
+    ),
+    ?assertMatch({fail, testBadKey, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"not found in dictionary">>)).
+
+decode_error_badmap_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testBadMap, #{}, nil
+    ),
+    ?assertMatch({fail, testBadMap, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"is not a map">>)).
+
+decode_error_badmatch_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testBadMatch, #{}, nil
+    ),
+    ?assertMatch({fail, testBadMatch, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"no match of right-hand side">>)).
+
+decode_error_case_clause_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testCaseClause, #{}, nil
+    ),
+    ?assertMatch({fail, testCaseClause, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"no case clause matched">>)).
+
+decode_error_try_clause_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testTryClause, #{}, nil
+    ),
+    ?assertMatch({fail, testTryClause, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"no try clause matched">>)).
+
+decode_error_function_clause_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testFunctionClause, #{}, nil
+    ),
+    ?assertMatch({fail, testFunctionClause, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"no matching function clause">>)).
+
+decode_error_if_clause_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testIfClause, #{}, nil
+    ),
+    ?assertMatch({fail, testIfClause, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"no true branch">>)).
+
+decode_error_badarity_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testBadArity, #{}, nil
+    ),
+    ?assertMatch({fail, testBadArity, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"function expects">>)).
+
+decode_error_badfun_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testBadFun, #{}, nil
+    ),
+    ?assertMatch({fail, testBadFun, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"is not a function">>)).
+
+decode_error_badarg_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testBadArg, #{}, nil
+    ),
+    ?assertMatch({fail, testBadArg, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"bad argument">>)).
+
+decode_error_badarith_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testBadArith, #{}, nil
+    ),
+    ?assertMatch({fail, testBadArith, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"bad arithmetic">>)).
+
+decode_error_noproc_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testNoproc, #{}, nil
+    ),
+    ?assertMatch({fail, testNoproc, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"no such process">>)).
+
+decode_error_timeout_test() ->
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_run_helper, testTimeout, #{}, nil
+    ),
+    ?assertMatch({fail, testTimeout, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"timed out">>)).
+
+%%% ============================================================================
+%%% run_all/1, run_single/2, run_all_structured/1, run_single_structured/2
+%%% BIF-fallback paths (lines 221–360) — require bt@tc_stub on code path
+%%% ============================================================================
+
+run_all_with_tests_test() ->
+    %% resolve_module('TcStub') → 'bt@tc_stub'; discover finds testStubPass + testStubFail
+    Result = beamtalk_test_case:run_all('TcStub'),
+    ?assert(is_binary(Result)),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"failed">>)).
+
+run_all_no_test_methods_test() ->
+    %% resolve_module('EmptyStub') → 'bt@empty_stub'; no test* exports → "No test methods"
+    Result = beamtalk_test_case:run_all('EmptyStub'),
+    ?assert(is_binary(Result)),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"No test methods">>)).
+
+run_single_pass_test() ->
+    Result = beamtalk_test_case:run_single('TcStub', testStubPass),
+    ?assert(is_binary(Result)),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"passed">>)).
+
+run_single_fail_test() ->
+    Result = beamtalk_test_case:run_single('TcStub', testStubFail),
+    ?assert(is_binary(Result)),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"failed">>)).
+
+run_all_structured_no_test_methods_test() ->
+    %% 'bt@empty_stub' has no test* exports → no-test-methods branch (lines 295–307)
+    Result = beamtalk_test_case:run_all_structured('EmptyStub'),
+    ?assert(is_map(Result)),
+    ?assertEqual('EmptyStub', maps:get(class, Result)),
+    ?assertEqual(0, maps:get(total, Result)),
+    ?assertEqual(0, maps:get(passed, Result)),
+    ?assertEqual([], maps:get(tests, Result)).
+
+run_all_structured_with_tests_test() ->
+    Result = beamtalk_test_case:run_all_structured('TcStub'),
+    ?assert(is_map(Result)),
+    ?assertEqual('TcStub', maps:get(class, Result)),
+    ?assert(is_integer(maps:get(total, Result))),
+    ?assert(maps:get(total, Result) > 0),
+    ?assert(is_list(maps:get(tests, Result))).
+
+run_single_structured_pass_test() ->
+    Result = beamtalk_test_case:run_single_structured('TcStub', testStubPass),
+    ?assert(is_map(Result)),
+    ?assertEqual('TcStub', maps:get(class, Result)),
+    ?assertEqual(1, maps:get(total, Result)),
+    ?assertEqual(1, maps:get(passed, Result)),
+    ?assertEqual(0, maps:get(failed, Result)).
+
+run_single_structured_fail_test() ->
+    Result = beamtalk_test_case:run_single_structured('TcStub', testStubFail),
+    ?assert(is_map(Result)),
+    ?assertEqual(1, maps:get(total, Result)),
+    ?assertEqual(0, maps:get(passed, Result)),
+    ?assertEqual(1, maps:get(failed, Result)).

--- a/runtime/apps/beamtalk_stdlib/test/bt@empty_stub.erl
+++ b/runtime/apps/beamtalk_stdlib/test/bt@empty_stub.erl
@@ -1,0 +1,20 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%% Minimal stub with NO test methods.
+%% Named 'bt@empty_stub' so resolve_module('EmptyStub') finds it.
+%% Used by BT-2404 to exercise the no-test-methods branch of run_all/1
+%% (lines 221–226 of beamtalk_test_case.erl).
+-module('bt@empty_stub').
+
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+-export([new/0, dispatch/3]).
+
+new() ->
+    #{'$beamtalk_class' => 'EmptyStub'}.
+
+dispatch(setUp, [], Instance) ->
+    Instance;
+dispatch(tearDown, [], _Instance) ->
+    nil.

--- a/runtime/apps/beamtalk_stdlib/test/bt@tc_stub.erl
+++ b/runtime/apps/beamtalk_stdlib/test/bt@tc_stub.erl
@@ -1,0 +1,36 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%% Minimal stub that mimics a compiled Beamtalk class module.
+%%
+%% Named 'bt@tc_stub' so that beamtalk_test_case:resolve_module('TcStub')
+%% finds this module via the bt@<snake_case> naming convention.
+%% Used by BT-2404 tests of run_all/1, run_single/2, run_all_structured/1,
+%% and run_single_structured/2 (the BIF-fallback paths).
+-module('bt@tc_stub').
+
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+%% Compiled-Beamtalk module contract
+-export([new/0, dispatch/3]).
+
+%% Exported test methods — discovered by discover_test_methods_from_module/1
+%% which scans module_info(exports) for names beginning with "test".
+%% Arity is ignored by the discovery logic; actual execution goes through dispatch/3.
+-export([testStubPass/1, testStubFail/1]).
+
+new() ->
+    #{'$beamtalk_class' => 'TcStub'}.
+
+dispatch(testStubPass, [], _Instance) ->
+    nil;
+dispatch(testStubFail, [], _Instance) ->
+    error(intentional_stub_failure);
+dispatch(setUp, [], Instance) ->
+    Instance;
+dispatch(tearDown, [], _Instance) ->
+    nil.
+
+%% Stub implementations (never called — dispatch/3 is used instead).
+testStubPass(_) -> nil.
+testStubFail(_) -> error(intentional_stub_failure).

--- a/runtime/apps/beamtalk_stdlib/test/tc_run_helper.erl
+++ b/runtime/apps/beamtalk_stdlib/test/tc_run_helper.erl
@@ -30,6 +30,54 @@ dispatch(testBeamtalkError, [], _Instance) ->
     error(#beamtalk_error{kind = type_error, class = 'TestCase', message = <<"generic error">>});
 dispatch(testUndef, [], _Instance) ->
     nonexistent_module_xyz_bt2391:'nope'();
+%% BT-2404: BEAM error-shape dispatchers for decode_beam_error/1 coverage.
+%% These all fall through to error:TestReason:TestST in run_test_method/5
+%% (they are not #beamtalk_error{} records nor `undef`, so they bypass
+%% the specialised catch clauses and reach format_test_error/3).
+dispatch(testFutureRejected, [], _Instance) ->
+    error({future_rejected, inner_reason});
+dispatch(testErrorMapWithKey, [], _Instance) ->
+    error({error, #{error => raw_inner_reason}});
+dispatch(testErrorMapNoKey, [], _Instance) ->
+    error({error, #{unrelated => value}});
+dispatch(testExceptionMap, [], _Instance) ->
+    error(#{
+        class => 'Exception',
+        '$beamtalk_class' => 'Exception',
+        error => #beamtalk_error{kind = type_error, class = 'TestCase', message = <<"exc msg">>}
+    });
+dispatch(testClassMap, [], _Instance) ->
+    error(#{
+        '$beamtalk_class' => 'RuntimeError',
+        error => #beamtalk_error{kind = type_error, class = 'TestCase', message = <<"cls msg">>}
+    });
+dispatch(testBadKey, [], _Instance) ->
+    error({badkey, my_key});
+dispatch(testBadMap, [], _Instance) ->
+    error({badmap, 42});
+dispatch(testBadMatch, [], _Instance) ->
+    error({badmatch, some_value});
+dispatch(testCaseClause, [], _Instance) ->
+    error({case_clause, some_value});
+dispatch(testTryClause, [], _Instance) ->
+    error({try_clause, some_value});
+dispatch(testFunctionClause, [], _Instance) ->
+    error(function_clause);
+dispatch(testIfClause, [], _Instance) ->
+    error(if_clause);
+dispatch(testBadArity, [], _Instance) ->
+    F = fun(X) -> X end,
+    error({badarity, {F, [1, 2]}});
+dispatch(testBadFun, [], _Instance) ->
+    error({badfun, not_a_fun});
+dispatch(testBadArg, [], _Instance) ->
+    error(badarg);
+dispatch(testBadArith, [], _Instance) ->
+    error(badarith);
+dispatch(testNoproc, [], _Instance) ->
+    error(noproc);
+dispatch(testTimeout, [], _Instance) ->
+    error(timeout);
 dispatch(setUp, [], Instance) ->
     Instance;
 dispatch(tearDown, [], _Instance) ->


### PR DESCRIPTION
## Summary

Closes coverage gap in `beamtalk_test_case.erl` (was 54.3%, target ~68%) by adding error-path tests for all reachable `decode_beam_error/1` clauses and the BIF-fallback paths (`run_all`, `run_single`, `run_all_structured`, `run_single_structured`).

Linear: https://linear.app/beamtalk/issue/BT-2404

## Changes

- **`tc_run_helper.erl`** — 17 new `dispatch/3` clauses raising specific BEAM error shapes (`{future_rejected,…}`, `{error,Map}` with/without `error` key, `#{class:='Exception',…}`, `#{'$beamtalk_class':=_,…}`, `{badkey,…}`, `{badmap,…}`, `{badmatch,…}`, `{case_clause,…}`, `{try_clause,…}`, `function_clause`, `if_clause`, `{badarity,…}`, `{badfun,…}`, `badarg`, `badarith`, `noproc`, `timeout`). These fall through to the generic `error:TestReason:TestST` catch in `run_test_method/5`, routing via `format_test_error → decode_beam_error`.

- **`bt@tc_stub.erl`** (new) — Fake compiled-Beamtalk module named `'bt@tc_stub'` so `resolve_module('TcStub')` finds it. Exports `testStubPass/1` and `testStubFail/1` for `discover_test_methods_from_module`, with `dispatch/3` for actual execution.

- **`bt@empty_stub.erl`** (new) — Same contract but no `test*` exports, to exercise the no-test-methods branches in `run_all` and `run_all_structured`.

- **`beamtalk_test_case_stdlib_tests.erl`** — 27 new tests: all `decode_beam_error` reachable clauses, `execute_tests(runAll)` with no methods, `run_all`/`run_single`/`run_all_structured`/`run_single_structured` happy and no-methods paths.

## Test plan

- [x] `rebar3 eunit --module=beamtalk_test_case_stdlib_tests` → 52 tests, 0 failures (was 25)
- [x] `just test` → all suites pass (Rust, stdlib, BUnit, runtime)
- [x] `just clippy && just fmt-check` → clean
- [x] Pre-push hooks (Dialyzer, spec validation, formatting) → all passed

https://claude.ai/code/session_018CjXGUKepiMJDaTF5kkb5h

---
_Generated by [Claude Code](https://claude.ai/code/session_018CjXGUKepiMJDaTF5kkb5h)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for error handling and reporting in stdlib
  * Added validation for edge cases such as no test methods discovery
  * Enhanced error type and exception handling test scenarios with additional error categories
  * Improved test result validation and structured summary verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->