### PR TITLE
LiveView IDE Wave 1: skeleton app + eval + Transcript panes (BT-2407)

### DIFF
--- a/docs/development/repl-op-term-contract.md
+++ b/docs/development/repl-op-term-contract.md
@@ -126,6 +126,23 @@ beamtalk_repl_subscriptions:subscribe(transcript).
 The browser edge (`beamtalk_ws_handler`) re-encodes these push messages to JSON
 push frames; dist clients consume the messages directly.
 
+### Subscribing a remote pid over RPC (Attach topology)
+
+The `subscribe_all/0` / `subscribe/1` forms register `self()`. That is correct
+on the workspace node (the WebSocket handler *is* the consumer), but a
+dist-attached client calling over `rpc:call/4` would register the short-lived
+RPC proxy rather than its own pid. The explicit-pid forms take the subscriber
+pid directly, so a Phoenix LiveView registers its own location-transparent pid:
+
+```erlang
+%% Run on the workspace node via rpc:call/4, passing the LiveView pid:
+beamtalk_repl_subscriptions:subscribe_all(LiveViewPid).
+beamtalk_repl_subscriptions:subscribe(transcript, LiveViewPid).
+```
+
+The facade still owns every `gen_server:cast`; clients pass only a `stream()`
+name and a pid, never an internal `{subscribe, …}` tuple (BT-2407).
+
 ## Where this lives
 
 | Concern | Module |

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -41,7 +41,7 @@ Historically meta-commands like `:bindings`, `:sync`, `:test` existed to bootstr
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |
 |---------|---------------|-------------------|----------|----------------|-------|
-| `eval` | -- | *(implicit: any expression)* | `evaluate` | -- | Core evaluation; CLI uses REPL client, LSP has no eval |
+| `eval` | -- | *(implicit: any expression)* | `evaluate` | -- | Core evaluation; CLI uses REPL client, LSP has no eval. The LiveView IDE (Attach topology, `editors/liveview/`, BT-2407) is a further consumer: it dispatches the same `eval` op via the term-returning seam (`beamtalk_repl_ops:dispatch/4`, BT-2399) over Erlang distribution, so it shares the same structured result — surface-consistent by construction, no JSON-flattened string. |
 | `stdin` | -- | *(implicit: interactive input)* | -- | -- | Provides input to a blocked eval; CLI handles interactively |
 | `complete` | -- | *(implicit: tab completion)* | `complete` | `completion` | Autocompletion suggestions |
 | `show-codegen` | -- | `:show-codegen` / `:sc` | `show_codegen` | -- | Show generated Core Erlang |

--- a/editors/liveview/README.md
+++ b/editors/liveview/README.md
@@ -11,9 +11,18 @@ This is the productionised successor to the BT-2394 spike
 
 ## The interesting files
 
-- `lib/bt_attach/workspace.ex` — the entire Attach client (connect, eval, transcript).
-- `lib/bt_attach_web/live/workspace_live.ex` — the LiveView page.
-- `test/bt_attach_web/workspace_live_test.exs` — end-to-end test against a real workspace.
+- `lib/bt_attach/workspace.ex` — the entire Attach client. `eval/2` dispatches
+  through the BT-2399 term-returning op layer (`beamtalk_repl_ops:dispatch/4`)
+  and returns the live Erlang term, not JSON; `render_term/1` reuses the
+  workspace's own formatter so display matches the Phase-1 browser; Transcript
+  is subscribed through the `beamtalk_repl_subscriptions` facade (no direct
+  `{subscribe, self()}` cast at gen_servers).
+- `lib/bt_attach_web/live/workspace_live.ex` — the two-pane LiveView (Workspace +
+  live Transcript). Each mount gets its own workspace-supervised session;
+  eval state persists across evals within the session.
+- `test/bt_attach_web/workspace_live_test.exs` — `:workspace`-tagged end-to-end
+  tests against a real workspace (eval round-trip, session persistence, live
+  Transcript push).
 
 ## Toolchain
 

--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -87,6 +87,20 @@ defmodule BtAttach.Workspace do
   end
 
   @doc """
+  Stop a workspace-supervised session started by `start_session/1`.
+
+  The session is owned by the workspace's `beamtalk_session_sup`, so it does not
+  go away just because the LiveView process exits; we must ask the supervisor to
+  terminate it or it leaks one orphaned session per mount/reconnect. Idempotent
+  and best-effort: a session that is already gone returns `{:error, :not_found}`
+  and an unreachable workspace returns `{:badrpc, _}` — both are non-fatal at the
+  call site (the LiveView is terminating anyway).
+  """
+  def close_session(session_pid) when is_pid(session_pid) do
+    rpc(:beamtalk_session_sup, :stop_session, [session_pid])
+  end
+
+  @doc """
   Evaluate a Beamtalk expression in `session_pid` through the curated op layer's
   term-returning seam (`beamtalk_repl_ops:dispatch/4`, BT-2399).
 

--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -11,8 +11,33 @@ defmodule BtAttach.Workspace do
 
   Topology (BT-2394): **Attach** — Phoenix runs as its own BEAM node and
   connects to the workspace node over Erlang distribution, the same way
-  Livebook attaches to a remote node. No new wire protocol: we call the exact
-  same Erlang functions the WebSocket handler (`beamtalk_ws_handler`) calls.
+  Livebook attaches to a remote node. No new wire protocol: we reuse the exact
+  same curated op layer the WebSocket handler (`beamtalk_ws_handler`) calls.
+
+  ## Term contract, not JSON (BT-2399)
+
+  Eval goes through the term-returning op-layer seam
+  (`beamtalk_repl_ops:dispatch/4`), which returns a live Erlang term
+  (`op_result()`), *not* the JSON the browser receives. Over distribution that
+  means `Counter spawn` hands back a real, messageable remote pid wrapped in a
+  `{:beamtalk_object, class, module, pid}` tuple, not a flattened display
+  string. JSON encoding stays at the WebSocket transport edge only. See
+  `docs/development/repl-op-term-contract.md`.
+
+  Display (`render_term/1`) is a *separate* concern from the data path: it
+  reuses the workspace's own `beamtalk_repl_json:term_to_json/1` formatter — the
+  same one the browser WebSocket protocol uses — so the LiveView shows
+  byte-identical values to the Phase-1 browser workspace, surface-consistent for
+  free, while `eval/2` still returns the live term.
+
+  ## Subscriptions (BT-2399 facade)
+
+  Transcript (and the other live push streams) are subscribed through the stable
+  `beamtalk_repl_subscriptions` facade rather than by casting
+  `{subscribe, self()}` tuples at gen_servers (which is what the BT-2394 spike
+  did as a shortcut). Because the LiveView pid is location-transparent over
+  distribution, the facade's explicit-pid form registers the LiveView's own pid
+  and the workspace pushes `{:transcript_output, text}` messages to it directly.
 
   Configuration comes from the environment so this stays decoupled from the
   workspace's own config:
@@ -47,75 +72,153 @@ defmodule BtAttach.Workspace do
   @doc """
   Create a fresh, workspace-supervised REPL session. Each LiveView mount gets
   its own session, so two browser tabs have isolated bindings (proven in the
-  BT-2394 spike: tab1 `x = 100`, tab2 `x = 999`).
+  BT-2394 spike: tab1 `x = 100`, tab2 `x = 999`). Session state — bindings and
+  loaded classes — persists across evals within the session for the lifetime of
+  the LiveView process.
 
-  Returns the remote session pid.
+  Returns the remote session pid, or `{:error, reason}`.
   """
-  def start_session(session_id) do
+  def start_session(session_id) when is_binary(session_id) do
     case rpc(:beamtalk_session_sup, :start_session, [session_id]) do
       {:ok, pid} when is_pid(pid) -> pid
-      other -> other
+      {:badrpc, reason} -> {:error, {:unreachable, reason}}
+      other -> {:error, other}
     end
   end
 
   @doc """
-  Evaluate a Beamtalk expression in `session_pid`. Returns the **live Erlang
-  term** the workspace produced — no JSON. Over distribution that means
-  `Counter spawn` hands back a real, messageable remote pid wrapped in a
-  `{:beamtalk_object, class, module, pid}` tuple, not a flattened display string.
+  Evaluate a Beamtalk expression in `session_pid` through the curated op layer's
+  term-returning seam (`beamtalk_repl_ops:dispatch/4`, BT-2399).
 
-  The term contract is the only coupling between Phoenix and the workspace:
+  Returns the **live Erlang term** the workspace produced — no JSON. The term
+  contract is the only coupling between Phoenix and the workspace:
+
     * success → `{:ok, term, output, warnings}`
-    * error   → `{:error, reason_term, output, warnings}` (e.g. a `:beamtalk_error` tuple)
+    * error   → `{:error, reason_term, output, warnings}` where `reason_term` is
+      the structured `#beamtalk_error{}` record (a tuple tagged `:beamtalk_error`,
+      so no shared `.hrl` is needed)
+
+  `output` is captured stdout (`String.t/0`) and `warnings` is a list of strings.
   """
-  def eval(session_pid, expression) when is_binary(expression) do
-    case rpc(:beamtalk_repl_shell, :eval, [session_pid, String.to_charlist(expression)]) do
+  def eval(session_pid, expression) when is_pid(session_pid) and is_binary(expression) do
+    case dispatch_eval(session_pid, expression) do
       {:ok, value, output, warnings} ->
         {:ok, value, to_string(output), Enum.map(warnings, &to_string/1)}
 
+      # Term contract: eval may attach captured output + warnings to an error.
       {:error, reason, output, warnings} ->
         {:error, reason, to_string(output), Enum.map(warnings, &to_string/1)}
+
+      {:error, reason} ->
+        {:error, reason, "", []}
 
       {:badrpc, reason} ->
         {:error, {:unreachable, reason}, "", []}
 
-      # The workspace contract is {:ok,…}/{:error,…}; treat anything else as a
-      # data error rather than letting a CaseClauseError crash the LiveView.
+      # The op contract is a small tagged union; treat anything else as a data
+      # error rather than letting a CaseClauseError crash the LiveView.
       other ->
         {:error, {:unexpected_reply, other}, "", []}
     end
   end
 
-  @doc """
-  Render a result *term* as a string for the page. Display is a separate
-  concern from the data path: `eval/2` returns the live term, and this only
-  stringifies it. A spawned actor renders as a live remote pid so it's obvious
-  the object lives on the workspace node, not here.
-  """
-  def render(value) do
-    case value do
-      bin when is_binary(bin) ->
-        bin
+  # Build the protocol request as a plain map, decode it to a `protocol_msg()`
+  # on the workspace node (so we don't depend on the record's `.hrl`), then
+  # dispatch through the term-returning op layer. `dispatch/4` returns the
+  # `op_result()` term directly — JSON encoding (`encode/2`) is never invoked.
+  defp dispatch_eval(session_pid, expression) do
+    request = %{"op" => "eval", "params" => %{"code" => expression}}
 
-      {:beamtalk_object, class, _module, pid} when is_pid(pid) ->
-        "##{class}⟨#{inspect(pid)} on #{node(pid)}⟩"
-
-      # Unwrap a synchronous actor reply (`c value` -> {:ok, 3}).
-      {:ok, inner} ->
-        render(inner)
+    case rpc(:beamtalk_repl_protocol, :decode, [encode_json(request)]) do
+      {:ok, msg} ->
+        params = rpc(:beamtalk_repl_protocol, :get_params, [msg])
+        rpc(:beamtalk_repl_ops, :dispatch, ["eval", params, msg, session_pid])
 
       other ->
-        inspect(other)
+        other
     end
   end
 
   @doc """
-  Subscribe the *calling* process (the LiveView process) to the workspace's
-  Transcript push stream. The LiveView then receives `{:transcript_output, text}`
-  messages directly over distribution — no polling, no extra protocol.
+  Render a result *term* as a string for the page, surface-consistent with the
+  Phase-1 browser workspace.
+
+  Display is a separate concern from the data path: `eval/2` returns the live
+  term, and this stringifies it via the workspace's own
+  `beamtalk_repl_json:term_to_json/1` — the exact formatter the browser
+  WebSocket protocol uses — so values render byte-identically across surfaces. A
+  spawned actor renders as the browser's `#Actor<…>` display while the live,
+  messageable remote pid remains in the term `eval/2` returned.
+
+  Falls back to a local `inspect/1` only if the workspace formatter is
+  unreachable, so the pane degrades gracefully rather than crashing.
   """
-  def subscribe_transcript do
-    :gen_server.cast({:Transcript, node_name()}, {:subscribe, self()})
+  def render_term(value) do
+    case rpc(:beamtalk_repl_json, :term_to_json, [value]) do
+      {:badrpc, _reason} -> inspect(value)
+      json -> format_value(json)
+    end
+  end
+
+  @doc """
+  Render a `term_to_json/1` value (the same JSON-ready value the browser
+  serialises) to a display string using the canonical, surface-shared rules from
+  `beamtalk_repl_protocol::format::format_value` (Rust, BT-2086 — Plain mode), so
+  the LiveView pane matches the CLI / MCP / browser byte-for-byte:
+
+    * scalars render verbatim (strings already carry `#Actor<…>`, float text, …)
+    * lists render as Beamtalk list literals `#(a, b, c)`
+    * maps render as `{k: v, …}`
+
+  Pure (no RPC), so it is unit-tested directly without a live workspace.
+  """
+  def format_value(json) when is_binary(json), do: json
+  def format_value(json) when is_integer(json), do: Integer.to_string(json)
+  def format_value(true), do: "true"
+  def format_value(false), do: "false"
+  def format_value(nil), do: "nil"
+  def format_value(json) when is_float(json), do: Float.to_string(json)
+
+  def format_value(json) when is_list(json) do
+    "#(" <> Enum.map_join(json, ", ", &format_value/1) <> ")"
+  end
+
+  def format_value(json) when is_map(json) do
+    "{" <> Enum.map_join(json, ", ", fn {k, v} -> "#{k}: #{format_value(v)}" end) <> "}"
+  end
+
+  def format_value(json), do: inspect(json)
+
+  @doc """
+  Render an error *term* (`#beamtalk_error{}`) as a user-facing message,
+  surface-consistent with the browser. Reuses
+  `beamtalk_repl_json:format_error_message/1` so the message text matches what
+  the browser shows; falls back to `inspect/1` for non-structured reasons.
+  """
+  def render_error(reason) do
+    case rpc(:beamtalk_repl_json, :format_error_message, [reason]) do
+      msg when is_binary(msg) -> msg
+      _ -> inspect(reason)
+    end
+  end
+
+  @doc """
+  Subscribe the given `pid` (the LiveView process) to the workspace's Transcript
+  push stream through the BT-2399 subscription facade.
+
+  Over Erlang distribution the LiveView pid is location-transparent, so the
+  facade's explicit-pid form registers it as the subscriber on the workspace
+  node. The LiveView then receives `{:transcript_output, text}` messages
+  directly — no polling, no `{subscribe, self()}` cast at the gen_server, no
+  extra protocol.
+  """
+  def subscribe_transcript(pid) when is_pid(pid) do
+    rpc(:beamtalk_repl_subscriptions, :subscribe, [:transcript, pid])
+  end
+
+  @doc "Unsubscribe `pid` from the Transcript push stream via the facade."
+  def unsubscribe_transcript(pid) when is_pid(pid) do
+    rpc(:beamtalk_repl_subscriptions, :unsubscribe, [:transcript, pid])
   end
 
   # ── internals ─────────────────────────────────────────────────────────────
@@ -141,6 +244,12 @@ defmodule BtAttach.Workspace do
       "" -> :ok
       token -> Node.set_cookie(node_name(), String.to_atom(token))
     end
+  end
+
+  # The workspace decoder accepts a JSON binary; build it with the OTP `:json`
+  # module so we don't pull in a JSON dependency for one small request.
+  defp encode_json(map) do
+    :erlang.iolist_to_binary(:json.encode(map))
   end
 
   defp rpc(mod, fun, args) do

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -3,14 +3,21 @@
 
 defmodule BtAttachWeb.WorkspaceLive do
   @moduledoc """
-  Minimal LiveView exercising the BT-2394 Attach-topology critical path:
+  Wave-1 LiveView IDE (BT-2407): the two-pane workspace core on the Attach
+  topology (ADR 0017 Phase 3, validated by the BT-2394 spike).
 
-    * eval round-trip   — input field -> workspace `evaluate` -> rendered result
-    * Transcript stream — live `Transcript show:` output pushed over distribution
-    * isolation         — each mount (tab) gets its own workspace session
+    * Workspace pane   — input evaluates Beamtalk source against the attached
+      workspace node via the BT-2399 term-returning op layer, rendering the
+      result term (surface-consistent with the Phase-1 browser workspace).
+    * Transcript pane  — subscribes via the BT-2399 subscription facade and
+      renders live `Transcript show:` output pushed over distribution.
+    * Session lifecycle — each LiveView mount gets its own workspace-supervised
+      session; eval state (bindings, loaded classes) persists across evals
+      within the session and is released when the LiveView process terminates.
 
   All workspace interaction goes through `BtAttach.Workspace`, which talks to
-  the workspace node via Erlang distribution + `:rpc`.
+  the workspace node via Erlang distribution + `:rpc`. The data path carries
+  live Erlang terms; JSON lives only at the browser WebSocket edge.
   """
   use BtAttachWeb, :live_view
 
@@ -36,7 +43,10 @@ defmodule BtAttachWeb.WorkspaceLive do
 
           case Workspace.start_session(session_id) do
             pid when is_pid(pid) ->
-              Workspace.subscribe_transcript()
+              # Subscribe THIS LiveView pid (location-transparent over dist) to
+              # the Transcript stream through the BT-2399 facade — no direct
+              # gen_server cast.
+              Workspace.subscribe_transcript(self())
 
               socket
               |> assign(:connected, true)
@@ -44,12 +54,16 @@ defmodule BtAttachWeb.WorkspaceLive do
               |> assign(:session_id, session_id)
               |> assign(:session_pid, pid)
               |> assign(:result, nil)
+              |> assign(:output, nil)
               |> assign(:error, nil)
               |> assign(:expr, "3 + 4")
               |> stream(:transcript, [])
 
-            other ->
-              assign(socket, connected: false, error: "session start failed: #{inspect(other)}")
+            {:error, reason} ->
+              assign(socket,
+                connected: false,
+                error: "session start failed: #{inspect(reason)}"
+              )
           end
 
         {:error, reason} ->
@@ -63,18 +77,32 @@ defmodule BtAttachWeb.WorkspaceLive do
   def handle_event("eval", %{"expr" => expr}, %{assigns: %{session_pid: pid}} = socket)
       when is_pid(pid) do
     case Workspace.eval(pid, expr) do
-      {:ok, term, _output, _warnings} ->
-        # eval returns the live term; render is display-only.
-        {:noreply, assign(socket, result: Workspace.render(term), error: nil, expr: expr)}
+      {:ok, term, output, _warnings} ->
+        # eval returns the live term; rendering is display-only and reuses the
+        # workspace's own formatter for surface-consistency with the browser.
+        {:noreply,
+         assign(socket,
+           result: Workspace.render_term(term),
+           output: present(output),
+           error: nil,
+           expr: expr
+         )}
 
-      {:error, reason, _output, _warnings} ->
-        {:noreply, assign(socket, result: nil, error: inspect(reason), expr: expr)}
+      {:error, reason, output, _warnings} ->
+        {:noreply,
+         assign(socket,
+           result: nil,
+           output: present(output),
+           error: Workspace.render_error(reason),
+           expr: expr
+         )}
     end
   end
 
   # No session (attach failed) — don't crash on a missing assign.
   def handle_event("eval", %{"expr" => expr}, socket) do
-    {:noreply, assign(socket, result: nil, error: "not attached to workspace", expr: expr)}
+    {:noreply,
+     assign(socket, result: nil, output: nil, error: "not attached to workspace", expr: expr)}
   end
 
   # Transcript push, delivered directly over distribution to this LiveView pid.
@@ -87,10 +115,27 @@ defmodule BtAttachWeb.WorkspaceLive do
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   @impl true
+  def terminate(_reason, socket) do
+    # Best-effort: drop our Transcript subscription so the workspace doesn't keep
+    # pushing to a dead pid. The event server also auto-removes dead subscribers
+    # via its monitor, so this is belt-and-braces.
+    if socket.assigns[:connected] do
+      Workspace.unsubscribe_transcript(self())
+    end
+
+    :ok
+  end
+
+  # Blank captured output is not worth rendering a pane for.
+  defp present(""), do: nil
+  defp present(nil), do: nil
+  defp present(output) when is_binary(output), do: output
+
+  @impl true
   def render(assigns) do
     ~H"""
     <div style="font-family: ui-monospace, monospace; max-width: 760px; margin: 2rem auto;">
-      <h1>Beamtalk Workspace — Attach spike (BT-2394)</h1>
+      <h1>Beamtalk Workspace</h1>
 
       <%= if @connected do %>
         <p>Attached to <strong>{@node}</strong> · session <code>{@session_id}</code></p>
@@ -105,6 +150,9 @@ defmodule BtAttachWeb.WorkspaceLive do
           <button type="submit" style="padding:.5rem 1rem;">Eval</button>
         </form>
 
+        <%= if @output do %>
+          <pre style="background:#f7f7f7; padding:.75rem; border:1px solid #ddd;"><%= @output %></pre>
+        <% end %>
         <%= if @result do %>
           <pre style="background:#f0fff0; padding:.75rem; border:1px solid #cec;"><%= @result %></pre>
         <% end %>

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -21,6 +21,8 @@ defmodule BtAttachWeb.WorkspaceLive do
   """
   use BtAttachWeb, :live_view
 
+  require Logger
+
   alias BtAttach.Workspace
 
   @impl true
@@ -45,19 +47,34 @@ defmodule BtAttachWeb.WorkspaceLive do
             pid when is_pid(pid) ->
               # Subscribe THIS LiveView pid (location-transparent over dist) to
               # the Transcript stream through the BT-2399 facade — no direct
-              # gen_server cast.
-              Workspace.subscribe_transcript(self())
+              # gen_server cast. The facade's cast returns `:ok`; a `{:badrpc, _}`
+              # (or any non-ok reply) means the transcript is NOT live, so we must
+              # not render the pane as connected and claim a working stream.
+              case Workspace.subscribe_transcript(self()) do
+                :ok ->
+                  socket
+                  |> assign(:connected, true)
+                  |> assign(:node, Workspace.node_name())
+                  |> assign(:session_id, session_id)
+                  |> assign(:session_pid, pid)
+                  |> assign(:result, nil)
+                  |> assign(:output, nil)
+                  |> assign(:error, nil)
+                  |> assign(:expr, "3 + 4")
+                  |> stream(:transcript, [])
 
-              socket
-              |> assign(:connected, true)
-              |> assign(:node, Workspace.node_name())
-              |> assign(:session_id, session_id)
-              |> assign(:session_pid, pid)
-              |> assign(:result, nil)
-              |> assign(:output, nil)
-              |> assign(:error, nil)
-              |> assign(:expr, "3 + 4")
-              |> stream(:transcript, [])
+                other ->
+                  # Transcript subscription failed: tear the half-started session
+                  # back down so we don't leak it, then render a non-connected
+                  # error page rather than a dead transcript pane.
+                  Logger.error("transcript subscribe failed: #{inspect(other)}")
+                  Workspace.close_session(pid)
+
+                  assign(socket,
+                    connected: false,
+                    error: "transcript subscribe failed: #{inspect(other)}"
+                  )
+              end
 
             {:error, reason} ->
               assign(socket,
@@ -119,8 +136,18 @@ defmodule BtAttachWeb.WorkspaceLive do
     # Best-effort: drop our Transcript subscription so the workspace doesn't keep
     # pushing to a dead pid. The event server also auto-removes dead subscribers
     # via its monitor, so this is belt-and-braces.
+    #
+    # Crucially also CLOSE the workspace-supervised session: it is owned by the
+    # workspace's `beamtalk_session_sup`, not by this LiveView process, so it does
+    # NOT go away when we exit. Without this we leak one orphaned session per
+    # mount/reconnect (the session-lifecycle acceptance criterion).
     if socket.assigns[:connected] do
       Workspace.unsubscribe_transcript(self())
+
+      case socket.assigns[:session_pid] do
+        pid when is_pid(pid) -> Workspace.close_session(pid)
+        _ -> :ok
+      end
     end
 
     :ok

--- a/editors/liveview/test/bt_attach/workspace_test.exs
+++ b/editors/liveview/test/bt_attach/workspace_test.exs
@@ -1,0 +1,69 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttach.WorkspaceTest do
+  @moduledoc """
+  Unit tests for the pure, non-RPC parts of the Attach client. These run in the
+  default `mix test` (no `:workspace` tag) because they need no live workspace.
+
+  `format_value/1` must stay surface-consistent with the canonical Rust
+  formatter `beamtalk_repl_protocol::format::format_value` (Plain mode), which
+  the CLI / MCP / browser share — these assertions mirror its snapshot tests so
+  drift is caught here.
+  """
+  use ExUnit.Case, async: true
+
+  alias BtAttach.Workspace
+
+  describe "format_value/1 — surface-consistent with the Rust formatter (Plain mode)" do
+    test "plain string renders verbatim" do
+      assert Workspace.format_value("hello") == "hello"
+    end
+
+    test "actor pid string renders verbatim" do
+      assert Workspace.format_value("#Actor<0.123.0>") == "#Actor<0.123.0>"
+    end
+
+    test "block string renders verbatim" do
+      assert Workspace.format_value("a Block/2") == "a Block/2"
+    end
+
+    test "float arrives as a string (BT-1336) and renders verbatim" do
+      assert Workspace.format_value("6.0") == "6.0"
+    end
+
+    test "integer renders as its digits" do
+      assert Workspace.format_value(42) == "42"
+    end
+
+    test "booleans render as true/false" do
+      assert Workspace.format_value(true) == "true"
+      assert Workspace.format_value(false) == "false"
+    end
+
+    test "null renders as nil" do
+      assert Workspace.format_value(nil) == "nil"
+    end
+
+    test "list renders as a Beamtalk list literal" do
+      assert Workspace.format_value([1, 2, 3]) == "#(1, 2, 3)"
+    end
+
+    test "empty list renders as #()" do
+      assert Workspace.format_value([]) == "#()"
+    end
+
+    test "nested list renders recursively" do
+      assert Workspace.format_value([[1, 2], [3, 4]]) == "#(#(1, 2), #(3, 4))"
+    end
+
+    test "map renders as {k: v, ...}" do
+      # Single key keeps the assertion order-independent (maps are unordered).
+      assert Workspace.format_value(%{"x" => 1}) == "{x: 1}"
+    end
+
+    test "map values are recursively formatted" do
+      assert Workspace.format_value(%{"items" => [1, 2]}) == "{items: #(1, 2)}"
+    end
+  end
+end

--- a/editors/liveview/test/bt_attach/workspace_test.exs
+++ b/editors/liveview/test/bt_attach/workspace_test.exs
@@ -32,6 +32,13 @@ defmodule BtAttach.WorkspaceTest do
       assert Workspace.format_value("6.0") == "6.0"
     end
 
+    test "raw float value renders via Float.to_string/1" do
+      # The is_float/1 guard handles a term that arrives as a native float
+      # (rather than the BT-1336 string form), e.g. from a fallback inspect path.
+      assert Workspace.format_value(6.0) == "6.0"
+      assert Workspace.format_value(3.14159) == "3.14159"
+    end
+
     test "integer renders as its digits" do
       assert Workspace.format_value(42) == "42"
     end

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -3,8 +3,10 @@
 
 defmodule BtAttachWeb.WorkspaceLiveTest do
   @moduledoc """
-  End-to-end proof of the BT-2394 Attach topology through the full Phoenix
-  LiveView stack against a *real* running Beamtalk workspace node.
+  End-to-end proof of the Wave-1 LiveView IDE (BT-2407) through the full Phoenix
+  LiveView stack against a *real* running Beamtalk workspace node, on the
+  BT-2394 Attach topology. Exercises the BT-2399 term-returning op layer (eval)
+  and subscription facade (Transcript), plus session-bound eval state.
 
   Requires a workspace and its cookie in the environment:
 
@@ -13,7 +15,8 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
       export BT_WORKSPACE_COOKIE=$(sed 's/-setcookie //;s/ //g' \\
         ~/.beamtalk/workspaces/spike/vm.args)
 
-  Skipped automatically if no workspace cookie is configured.
+  Tag-gated: excluded from the default `mix test` run (see test_helper.exs) and
+  run only in the workspace-gated CI job.
   """
   use BtAttachWeb.ConnCase
   import Phoenix.LiveViewTest
@@ -21,10 +24,19 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
   # Excluded by default in test_helper.exs unless BT_WORKSPACE_COOKIE is set.
   @moduletag :workspace
 
-  test "eval round-trip renders the workspace result", %{conn: conn} do
+  test "eval round-trip renders the workspace result term", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/")
     html = view |> form("form") |> render_submit(%{expr: "3 + 4"})
     assert html =~ "7"
+  end
+
+  test "eval state persists across evals within a session", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+
+    # Bind a variable, then read it back in a later eval on the same session.
+    view |> form("form") |> render_submit(%{expr: "x := 21 * 2"})
+    html = view |> form("form") |> render_submit(%{expr: "x"})
+    assert html =~ "42"
   end
 
   test "Transcript output streams live into the LiveView", %{conn: conn} do

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_subscriptions.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_subscriptions.erl
@@ -24,6 +24,23 @@ the subscribe/unsubscribe calls. The **calling process** becomes the subscriber
 LiveView process subscribes its own location-transparent pid and receives the
 push messages natively.
 
+## Subscribing on behalf of a remote pid (Attach topology)
+
+The `subscribe/1` / `subscribe_all/0` forms register `self()`, which is correct
+when the caller *is* the long-lived consumer (the WebSocket handler runs on the
+workspace node, so `self()` is the handler pid). A **dist-attached** client
+(Phoenix LiveView, BT-2407) cannot use those forms over `rpc:call/4`: the RPC
+proxy spawned on the workspace node would become the (short-lived) subscriber
+instead of the LiveView pid, and its `'DOWN'` would immediately unsubscribe it.
+
+The `subscribe/2` / `subscribe_all/1` forms take an **explicit subscriber pid**.
+A LiveView passes its own location-transparent pid; the facade registers that
+pid and the workspace pushes messages to it directly over distribution. The
+underlying event servers already accept an explicit pid in their subscribe cast,
+so this is the same registration the WebSocket edge uses — only the subscriber
+identity differs. The facade still owns every cast: clients never cast
+`{subscribe, Pid}` tuples at the gen_servers themselves.
+
 ## Streams and the messages they push
 
 | Stream | Push message to the subscriber |
@@ -46,7 +63,23 @@ match on them (the browser edge re-encodes them to JSON push frames in
 * ADR 0017 Phase 3 (Browser Connectivity).
 """.
 
--export([streams/0, subscribe/1, unsubscribe/1, subscribe_all/0, unsubscribe_all/0]).
+-export([
+    streams/0,
+    subscribe/1,
+    subscribe/2,
+    unsubscribe/1,
+    unsubscribe/2,
+    subscribe_all/0,
+    subscribe_all/1,
+    unsubscribe_all/0,
+    unsubscribe_all/1
+]).
+
+%% Registered names of the underlying event servers (all local to the workspace
+%% node). The facade owns these so the cross-node subscribe cast lives in one
+%% place; clients address the streams by their `stream()` name only.
+-define(TRANSCRIPT_REF, 'Transcript').
+-define(ACTOR_REGISTRY, beamtalk_actor_registry).
 
 -type stream() :: transcript | actors | classes | bindings | flush.
 
@@ -99,3 +132,49 @@ subscribe_all() ->
 -spec unsubscribe_all() -> ok.
 unsubscribe_all() ->
     lists:foreach(fun unsubscribe/1, streams()).
+
+-doc """
+Subscribe an explicit `Pid` to a single live push stream. Used by dist-attached
+clients (Phoenix LiveView, Attach topology) that call this over `rpc:call/4` and
+must register their own location-transparent pid rather than the short-lived RPC
+proxy. The registered pid receives the stream's push messages (see the module
+doc table).
+""".
+-spec subscribe(stream(), pid()) -> ok.
+subscribe(transcript, Pid) when is_pid(Pid) ->
+    gen_server:cast(?TRANSCRIPT_REF, {subscribe, Pid});
+subscribe(actors, Pid) when is_pid(Pid) ->
+    gen_server:cast(?ACTOR_REGISTRY, {subscribe_lifecycle, Pid});
+subscribe(classes, Pid) when is_pid(Pid) ->
+    gen_server:cast(beamtalk_class_events, {subscribe, Pid});
+subscribe(bindings, Pid) when is_pid(Pid) ->
+    gen_server:cast(beamtalk_bindings_events, {subscribe, Pid});
+subscribe(flush, Pid) when is_pid(Pid) ->
+    gen_server:cast(beamtalk_flush_events, {subscribe, Pid}).
+
+-doc "Unsubscribe an explicit `Pid` from a single live push stream.".
+-spec unsubscribe(stream(), pid()) -> ok.
+unsubscribe(transcript, Pid) when is_pid(Pid) ->
+    gen_server:cast(?TRANSCRIPT_REF, {unsubscribe, Pid});
+unsubscribe(actors, Pid) when is_pid(Pid) ->
+    gen_server:cast(?ACTOR_REGISTRY, {unsubscribe_lifecycle, Pid});
+unsubscribe(classes, Pid) when is_pid(Pid) ->
+    gen_server:cast(beamtalk_class_events, {unsubscribe, Pid});
+unsubscribe(bindings, Pid) when is_pid(Pid) ->
+    gen_server:cast(beamtalk_bindings_events, {unsubscribe, Pid});
+unsubscribe(flush, Pid) when is_pid(Pid) ->
+    gen_server:cast(beamtalk_flush_events, {unsubscribe, Pid}).
+
+-doc """
+Subscribe an explicit `Pid` to every live push stream. The one call a
+dist-attached client makes over RPC to mirror the browser's live surface with
+its own pid as the subscriber.
+""".
+-spec subscribe_all(pid()) -> ok.
+subscribe_all(Pid) when is_pid(Pid) ->
+    lists:foreach(fun(Stream) -> subscribe(Stream, Pid) end, streams()).
+
+-doc "Unsubscribe an explicit `Pid` from every live push stream.".
+-spec unsubscribe_all(pid()) -> ok.
+unsubscribe_all(Pid) when is_pid(Pid) ->
+    lists:foreach(fun(Stream) -> unsubscribe(Stream, Pid) end, streams()).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_session_sup.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_session_sup.erl
@@ -17,8 +17,10 @@ Sessions are ephemeral - they start when a REPL connects and
 terminate when the connection closes.
 """.
 
--export([start_link/0, start_session/1]).
+-export([start_link/0, start_session/1, stop_session/1]).
 -export([init/1]).
+
+-include_lib("kernel/include/logger.hrl").
 
 %%% Public API
 
@@ -34,6 +36,30 @@ SessionId should be a unique identifier for the session (e.g., alice, bob).
 -spec start_session(atom() | binary()) -> {ok, pid()} | {error, term()}.
 start_session(SessionId) ->
     supervisor:start_child(?MODULE, [SessionId]).
+
+-doc """
+Stop a session previously started by `start_session/1`.
+
+Sessions are `temporary` children of this `simple_one_for_one` supervisor, so a
+session process does not terminate just because its owner (e.g. a dist-attached
+Phoenix LiveView) exits — the supervisor must be asked to terminate it, or one
+orphaned session leaks per mount/reconnect. Best-effort and non-fatal: a pid
+that was never a child of this supervisor returns `{error, not_found}`, and a
+second stop on a just-terminated child is a harmless `ok` no-op.
+""".
+-spec stop_session(pid()) -> ok | {error, not_found | simple_one_for_one}.
+stop_session(SessionPid) when is_pid(SessionPid) ->
+    case supervisor:terminate_child(?MODULE, SessionPid) of
+        ok ->
+            ok;
+        {error, Reason} = Error ->
+            ?LOG_DEBUG(
+                "stop_session/1 could not terminate ~p: ~p",
+                [SessionPid, Reason],
+                #{domain => [beamtalk, runtime]}
+            ),
+            Error
+    end.
 
 %%% supervisor callbacks
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_subscriptions_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_subscriptions_tests.erl
@@ -1,0 +1,147 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_repl_subscriptions_tests).
+
+%%% **DDD Context:** REPL Session Context
+
+-moduledoc """
+Tests for the beamtalk_repl_subscriptions facade, focused on the explicit-pid
+forms (`subscribe/2`, `unsubscribe/2`, `subscribe_all/1`) added for the Attach
+topology (BT-2407). A dist-attached client (Phoenix LiveView) calls these over
+`rpc:call/4` and must register *its own* pid as the subscriber rather than the
+short-lived RPC proxy that `self()`-based forms would register.
+
+The `classes` stream (`beamtalk_class_events`) is used as the representative
+event server because it has the simplest fire API (`on_class_loaded/1`).
+""".
+-include_lib("eunit/include/eunit.hrl").
+
+%%% ===========================================================================
+%%% streams/0
+%%% ===========================================================================
+
+streams_lists_all_five_streams_test() ->
+    ?assertEqual(
+        [transcript, actors, classes, bindings, flush],
+        beamtalk_repl_subscriptions:streams()
+    ).
+
+%%% ===========================================================================
+%%% subscribe/2 registers the given pid, not the caller
+%%% ===========================================================================
+
+subscribe_pid_registers_that_pid_test() ->
+    {ok, Server} = gen_server:start_link(
+        {local, beamtalk_class_events}, beamtalk_class_events, [], []
+    ),
+    Self = self(),
+    try
+        SubPid = spawn(fun() ->
+            receive
+                {class_loaded, _} = Msg -> Self ! {got, Msg}
+            after 1000 -> Self ! timeout
+            end
+        end),
+
+        %% Facade is called from *this* process but registers SubPid — the
+        %% behaviour the Attach client depends on over RPC.
+        ok = beamtalk_repl_subscriptions:subscribe(classes, SubPid),
+        sys:get_state(Server),
+
+        {state, Subs} = sys:get_state(Server),
+        ?assert(maps:is_key(SubPid, Subs)),
+        %% The caller is NOT registered — only the explicit pid.
+        ?assertNot(maps:is_key(Self, Subs)),
+
+        beamtalk_class_events:on_class_loaded('FacadeClass'),
+        receive
+            {got, {class_loaded, 'FacadeClass'}} -> ok
+        after 1000 -> ?assert(false)
+        end
+    after
+        gen_server:stop(Server),
+        flush_messages()
+    end.
+
+%%% ===========================================================================
+%%% unsubscribe/2 removes the given pid
+%%% ===========================================================================
+
+unsubscribe_pid_removes_that_pid_test() ->
+    {ok, Server} = gen_server:start_link(
+        {local, beamtalk_class_events}, beamtalk_class_events, [], []
+    ),
+    Self = self(),
+    try
+        SubPid = spawn(fun() ->
+            receive
+                stop -> ok
+            after 2000 -> ok
+            end
+        end),
+        ok = beamtalk_repl_subscriptions:subscribe(classes, SubPid),
+        sys:get_state(Server),
+        {state, SubsBefore} = sys:get_state(Server),
+        ?assert(maps:is_key(SubPid, SubsBefore)),
+
+        ok = beamtalk_repl_subscriptions:unsubscribe(classes, SubPid),
+        sys:get_state(Server),
+        {state, SubsAfter} = sys:get_state(Server),
+        ?assertNot(maps:is_key(SubPid, SubsAfter)),
+
+        SubPid ! stop,
+        Self ! done,
+        receive
+            done -> ok
+        after 100 -> ok
+        end
+    after
+        gen_server:stop(Server),
+        flush_messages()
+    end.
+
+%%% ===========================================================================
+%%% subscribe_all/1 covers every stream for the given pid
+%%% ===========================================================================
+
+subscribe_all_pid_covers_classes_stream_test() ->
+    %% Only the classes server is started here; subscribe_all/1 must tolerate the
+    %% other streams' servers being absent (casts to unregistered names are
+    %% caught by gen_server:cast, which is a no-op when the name is unregistered).
+    {ok, Server} = gen_server:start_link(
+        {local, beamtalk_class_events}, beamtalk_class_events, [], []
+    ),
+    Self = self(),
+    try
+        SubPid = spawn(fun() ->
+            receive
+                {class_loaded, _} = Msg -> Self ! {got, Msg}
+            after 1000 -> Self ! timeout
+            end
+        end),
+
+        ok = beamtalk_repl_subscriptions:subscribe_all(SubPid),
+        sys:get_state(Server),
+        {state, Subs} = sys:get_state(Server),
+        ?assert(maps:is_key(SubPid, Subs)),
+
+        beamtalk_class_events:on_class_loaded('AllClass'),
+        receive
+            {got, {class_loaded, 'AllClass'}} -> ok
+        after 1000 -> ?assert(false)
+        end
+    after
+        gen_server:stop(Server),
+        flush_messages()
+    end.
+
+%%% ===========================================================================
+%%% Internal helpers
+%%% ===========================================================================
+
+flush_messages() ->
+    receive
+        _ -> flush_messages()
+    after 0 -> ok
+    end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_session_sup_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_session_sup_tests.erl
@@ -81,3 +81,36 @@ supervisor_count_children_test() ->
 
     %% Cleanup
     exit(Pid, normal).
+
+%%% stop_session/1 tests
+
+stop_session_unknown_pid_returns_not_found_test() ->
+    {ok, Sup} = beamtalk_session_sup:start_link(),
+
+    %% A pid that is not a child of this supervisor cannot be terminated by it.
+    Dead = spawn(fun() -> ok end),
+    ?assertEqual({error, not_found}, beamtalk_session_sup:stop_session(Dead)),
+
+    exit(Sup, normal).
+
+stop_session_terminates_live_session_test() ->
+    {ok, Sup} = beamtalk_session_sup:start_link(),
+
+    %% Start a real session under supervision.
+    {ok, SessionPid} = beamtalk_session_sup:start_session(<<"stop-session-test">>),
+    ?assert(is_process_alive(SessionPid)),
+    ?assertEqual(1, proplists:get_value(active, supervisor:count_children(Sup))),
+
+    %% Stopping it terminates the child and drops the active count.
+    ?assertEqual(ok, beamtalk_session_sup:stop_session(SessionPid)),
+    ?assertNot(is_process_alive(SessionPid)),
+    ?assertEqual(0, proplists:get_value(active, supervisor:count_children(Sup))),
+
+    %% Idempotent: a second stop on the just-terminated child is a non-fatal
+    %% no-op. `supervisor:terminate_child/2` returns `ok` for a dynamic child it
+    %% has recently terminated (vs `{error, not_found}` for a pid that was never
+    %% a child of this supervisor — covered above). Either way the call site
+    %% treats it as best-effort.
+    ?assertEqual(ok, beamtalk_session_sup:stop_session(SessionPid)),
+
+    exit(Sup, normal).


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2407

First wave of the LiveView IDE epic (BT-2398, ADR 0017 Phase 3). Productionises the `editors/liveview` Attach client (BT-2401 scaffold) onto the BT-2399 term-returning op layer and push-subscription facade. The Attach path now consumes live Erlang terms end-to-end; JSON stays at the WebSocket edge only.

## What changed

### Eval — term contract, not JSON (AC 1, 4)
- `BtAttach.Workspace.eval/2` builds a protocol request, `beamtalk_repl_protocol:decode/1`s it on the workspace node (hrl-free), then dispatches through `beamtalk_repl_ops:dispatch/4` — returning the live `op_result()` term. `encode/2` (JSON) is never invoked.
- `render_term/1` is display-only: it gets the workspace's own `beamtalk_repl_json:term_to_json/1` value over RPC and renders it with the canonical, surface-shared rules ported from `beamtalk_repl_protocol::format::format_value` (Plain mode) — lists → `#(a, b, c)`, maps → `{k: v}`, scalars verbatim — so the pane is byte-consistent with the CLI / MCP / browser.
- `render_error/1` reuses `beamtalk_repl_json:format_error_message/1` (which has a `#beamtalk_error{}` clause), matching the browser's error text.

### Transcript — subscription facade (AC 2)
- The LiveView subscribes via `beamtalk_repl_subscriptions` rather than casting `{subscribe, self()}` at gen_servers.
- Extended the facade with explicit-pid forms (`subscribe/2`, `unsubscribe/2`, `subscribe_all/1`, `unsubscribe_all/1`): a dist-attached LiveView calling over `rpc:call/4` must register its own location-transparent pid, not the short-lived RPC proxy that `self()`-based forms would register. The facade still owns every cast.

### Session lifecycle (AC 3)
- Each LiveView mount gets its own workspace-supervised session; eval state (bindings, loaded classes) persists across evals within the session. `terminate/2` unsubscribes from Transcript.

### Tests (AC 5)
- `test/bt_attach/workspace_test.exs` — pure `format_value/1` unit tests (default `mix test`, mirrors the Rust formatter snapshots).
- `test/bt_attach_web/workspace_live_test.exs` — `:workspace`-tagged e2e against a real workspace: eval round-trip, **session persistence**, live Transcript push.
- `beamtalk_repl_subscriptions_tests.erl` — EUnit for the new explicit-pid facade forms.

### Docs
- `docs/development/repl-op-term-contract.md` — explicit-pid subscription over RPC.
- `docs/development/surface-parity.md` — LiveView as a further `eval` consumer.
- `editors/liveview/README.md` — interesting-files update.

## Verification
- `just build`, `just clippy`, `just fmt-check` — clean.
- `mix compile --warnings-as-errors` and `mix test` (default, `:workspace` excluded) — green (19 tests, 0 failures, 3 excluded).
- `rebar3 eunit` facade tests — green (4/0). `just dialyzer` — clean.
- The `:workspace`-tagged e2e tests run in the workspace-gated CI job.

https://claude.ai/code/session_01SooajdpU9eNrWvq3hNMoTK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SooajdpU9eNrWvq3hNMoTK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LiveView IDE now returns structured evaluation results (not JSON) and shows a separate captured-output pane.
  * Sessions can be closed remotely and subscriptions can be registered for an explicit subscriber PID (better distributed client support).

* **Documentation**
  * Clarified subscription semantics for local vs. dist-attached clients and updated LiveView IDE architecture and consumption path.

* **Tests**
  * Added formatting-consistency and eval-state-persistence tests; subscription and session-stop tests added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->