### PR TITLE
Extract setUp/tearDown in ConditionalHofStateTest (BT-2414)

### DIFF
--- a/stdlib/test/conditional_hof_state_test.bt
+++ b/stdlib/test/conditional_hof_state_test.bt
@@ -6,115 +6,102 @@
 // in all nested combinations
 
 TestCase subclass: ConditionalHofStateTest
+  field: a = nil
+
+  setUp => self.a := ConditionalHofStateActor spawn
+
+  tearDown => self.a stop
 
   // --- ifTrue: wrapping do: ---
   testIfTrueDoIncrementTrue =>
-    a := ConditionalHofStateActor spawn
     // flag=true, list=#(1, 2, 3) => count = 0 + 1 + 2 + 3 = 6
-    self assert: (a conditionalDoIncrement: true with: #(1, 2, 3)) equals: 6
+    self assert: (self.a conditionalDoIncrement: true with: #(1, 2, 3)) equals: 6
 
   testIfTrueDoIncrementFalse =>
-    a := ConditionalHofStateActor spawn
     // flag=false => count unchanged = 0
-    self assert: (a conditionalDoIncrement: false with: #(1, 2, 3)) equals: 0
+    self assert: (self.a conditionalDoIncrement: false with: #(1, 2, 3)) equals: 0
 
   testIfTrueDoIncrementAccumulates =>
-    a := ConditionalHofStateActor spawn
-    a conditionalDoIncrement: true with: #(1, 2, 3)
+    self.a conditionalDoIncrement: true with: #(1, 2, 3)
     // Second call: count = 6 + 4 + 5 = 15
-    self assert: (a conditionalDoIncrement: true with: #(4, 5)) equals: 15
+    self assert: (self.a conditionalDoIncrement: true with: #(4, 5)) equals: 15
 
   // --- ifFalse: wrapping do: ---
   testIfFalseDoDecrementFalse =>
-    a := ConditionalHofStateActor spawn
     // flag=false => count = 0 - 1 - 2 - 3 = -6
-    self assert: (a conditionalDoDecrement: false with: #(1, 2, 3)) equals: -6
+    self assert: (self.a conditionalDoDecrement: false with: #(1, 2, 3)) equals: -6
 
   testIfFalseDoDecrementTrue =>
-    a := ConditionalHofStateActor spawn
     // flag=true => count unchanged = 0
-    self assert: (a conditionalDoDecrement: true with: #(1, 2, 3)) equals: 0
+    self assert: (self.a conditionalDoDecrement: true with: #(1, 2, 3)) equals: 0
 
   // --- ifTrue:ifFalse: wrapping do: ---
   testIfTrueIfFalseDoTrue =>
-    a := ConditionalHofStateActor spawn
     // flag=true => count = 0 + 1 + 2 + 3 = 6
-    self assert: (a conditionalDoToggle: true with: #(1, 2, 3)) equals: 6
+    self assert: (self.a conditionalDoToggle: true with: #(1, 2, 3)) equals: 6
 
   testIfTrueIfFalseDoFalse =>
-    a := ConditionalHofStateActor spawn
     // flag=false => count = 0 - 1 - 2 - 3 = -6
-    self assert: (a conditionalDoToggle: false with: #(1, 2, 3)) equals: -6
+    self assert: (self.a conditionalDoToggle: false with: #(1, 2, 3)) equals: -6
 
   // --- do: wrapping ifTrue: ---
   testDoWithConditionalMutation =>
-    a := ConditionalHofStateActor spawn
     // Only positives are added: 3 + 1 + 5 = 9
-    self assert: (a doWithConditionalMutation: #(3, -2, 1, -4, 5)) equals: 9
+    self assert: (self.a doWithConditionalMutation: #(3, -2, 1, -4, 5)) equals: 9
 
   testDoWithConditionalMutationAllNegative =>
-    a := ConditionalHofStateActor spawn
     // No positives => count = 0
-    self assert: (a doWithConditionalMutation: #(-1, -2, -3)) equals: 0
+    self assert: (self.a doWithConditionalMutation: #(-1, -2, -3)) equals: 0
 
   // --- collect: wrapping ifTrue: ---
   testCollectWithConditionalMutation =>
-    a := ConditionalHofStateActor spawn
     // 3 positive items (3, 1, 5), count += 1 for each = 3
-    self assert: (a collectWithConditionalMutation: #(3, -2, 1, -4, 5)) equals: 3
+    self assert: (self.a collectWithConditionalMutation: #(3, -2, 1, -4, 5)) equals: 3
 
   // --- ifTrue: wrapping collect: ---
   testConditionalCollectTrue =>
-    a := ConditionalHofStateActor spawn
-    result := a conditionalCollect: true with: #(1, 2, 3)
+    result := self.a conditionalCollect: true with: #(1, 2, 3)
     self assert: result equals: #(2, 4, 6)
 
   testConditionalCollectFalse =>
-    a := ConditionalHofStateActor spawn
-    result := a conditionalCollect: false with: #(1, 2, 3)
+    result := self.a conditionalCollect: false with: #(1, 2, 3)
     // items unchanged (empty array)
     self assert: result equals: #()
 
   // --- Triple nesting: ifTrue: wrapping do: wrapping ifTrue: ---
   testTripleNestedTrue =>
-    a := ConditionalHofStateActor spawn
     // flag=true, list=#(3, -2, 1) => only positives: 3 + 1 = 4
-    self assert: (a tripleNested: true with: #(3, -2, 1)) equals: 4
+    self assert: (self.a tripleNested: true with: #(3, -2, 1)) equals: 4
 
   testTripleNestedFalse =>
-    a := ConditionalHofStateActor spawn
     // flag=false => count unchanged = 0
-    self assert: (a tripleNested: false with: #(3, -2, 1)) equals: 0
+    self assert: (self.a tripleNested: false with: #(3, -2, 1)) equals: 0
 
   // --- select: wrapping ifTrue: ---
   testSelectWithConditionalMutation =>
-    a := ConditionalHofStateActor spawn
     // 3 positive items (3, 1, 5), count += 1 for each = 3
-    self assert: (a selectWithConditionalMutation: #(3, -2, 1, -4, 5)) equals: 3
-    self assert: a getItems equals: #(3, 1, 5)
+    self assert: (self.a selectWithConditionalMutation: #(3, -2, 1, -4, 5)) equals: 3
+    self assert: self.a getItems equals: #(3, 1, 5)
 
   // --- reject: wrapping ifTrue: ---
   testRejectWithConditionalMutation =>
-    a := ConditionalHofStateActor spawn
     // 2 negative items (-2, -4), count += 1 for each = 2
-    self assert: (a rejectWithConditionalMutation: #(3, -2, 1, -4, 5)) equals: 2
-    self assert: a getItems equals: #(3, 1, 5)
+    self assert: (self.a rejectWithConditionalMutation: #(3, -2, 1, -4, 5)) equals: 2
+    self assert: self.a getItems equals: #(3, 1, 5)
 
   // --- inject:into: wrapping ifTrue: ---
   testInjectWithConditionalMutation =>
-    a := ConditionalHofStateActor spawn
     // Sum of positives: 3 + 1 + 5 = 9, count = 3 (three positives)
-    result := a injectWithConditionalMutation: #(3, -2, 1, -4, 5)
+    result := self.a injectWithConditionalMutation: #(3, -2, 1, -4, 5)
     self assert: result equals: 9
-    self assert: a getCount equals: 3
+    self assert: self.a getCount equals: 3
 
   // --- collect: with ifTrue:ifFalse: as last expression ---
   testCollectConditionalLast =>
-    a := ConditionalHofStateActor spawn
-    result := a collectConditionalLast: #(3, -2, 1)
+    result := self.a collectConditionalLast: #(3, -2, 1)
     // Positives get *10 and count++; negatives pass through
     self assert: result equals: #(30, -2, 10)
     // Count should be 2 (two positive items triggered count++)
-    self assert: a getCount equals: 2
+    self assert: self.a getCount equals: 2
     // Items should persist correctly across calls
-    self assert: a getItems equals: #(30, -2, 10)
+    self assert: self.a getItems equals: #(30, -2, 10)


### PR DESCRIPTION
## Summary

18 test methods in `stdlib/test/conditional_hof_state_test.bt` each opened with the identical line `a := ConditionalHofStateActor spawn`. BUnit TestCase lifecycle methods exist precisely for this pattern.

**Changes:**
- Add `field: a = nil` declaration
- Add `setUp => self.a := ConditionalHofStateActor spawn`
- Add `tearDown => self.a stop`
- Remove 18 duplicate spawn lines from test methods
- Rename local `a` → `self.a` throughout all 18 methods

Each test still receives a fresh actor (setUp runs before every test method). No assertion logic changed — this is pure lifecycle extraction.

**Pattern already used in:** `actor_threading_constructs_test.bt`, `actor_self_send_collect_test.bt`, `actor_slot_test.bt`

Resolves: https://linear.app/beamtalk/issue/BT-2414/extract-repeated-actor-spawn-to-setup-in-conditional-hof-state-testbt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDq3QycpgfEwKVzE4yNU2B)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored conditional and higher-order function state tests to use shared actor state management, improving test reliability and ensuring consistent state verification across test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->