### PR TITLE
LiveView IDE Wave 2: Inspector + bindings panes (read-surface, ADR 0085) (BT-2408)

### DIFF
--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -235,6 +235,121 @@ defmodule BtAttach.Workspace do
     rpc(:beamtalk_repl_subscriptions, :unsubscribe, [:transcript, pid])
   end
 
+  @doc """
+  Subscribe the given `pid` (the LiveView process) to the workspace's
+  bindings-changed push stream through the BT-2399 subscription facade.
+
+  Like the Transcript stream, this uses the facade's explicit-pid form so the
+  LiveView's own location-transparent pid is registered as the subscriber (not
+  the short-lived RPC proxy). The bindings stream is a *signal* stream: it pushes
+  `{:bindings_changed, session_id}` after each successful eval — a refresh
+  trigger, not the data itself. On that signal the LiveView re-reads the current
+  bindings via `list_bindings/1`, so the pane stays live without polling and
+  without a `{subscribe, self()}` cast at the gen_server.
+  """
+  def subscribe_bindings(pid) when is_pid(pid) do
+    rpc(:beamtalk_repl_subscriptions, :subscribe, [:bindings, pid])
+  end
+
+  @doc "Unsubscribe `pid` from the bindings-changed push stream via the facade."
+  def unsubscribe_bindings(pid) when is_pid(pid) do
+    rpc(:beamtalk_repl_subscriptions, :unsubscribe, [:bindings, pid])
+  end
+
+  @doc """
+  List the current workspace bindings for `session_pid` as `{name, term}` pairs.
+
+  Reads the session's live binding map through the read-surface
+  (`beamtalk_repl_shell:get_bindings/1`, ADR 0085): the values are **live Erlang
+  terms** — a bound `Counter spawn` is a real `{:beamtalk_object, class, module,
+  pid}` handle, not a flattened display string — so the Inspector can follow them
+  by reference. Display rendering is a separate concern handled by the caller via
+  `render_term/1`.
+
+  Returns a name-sorted list of `{name :: String.t(), term}` tuples, or
+  `{:error, reason}` if the workspace is unreachable or the shell returns an
+  unexpected shape (the call site renders the error rather than crashing).
+  """
+  def list_bindings(session_pid) when is_pid(session_pid) do
+    case rpc(:beamtalk_repl_shell, :get_bindings, [session_pid]) do
+      {:ok, bindings} when is_map(bindings) ->
+        bindings
+        |> Enum.map(fn {name, term} -> {to_string(name), term} end)
+        |> Enum.sort_by(fn {name, _term} -> name end)
+
+      {:badrpc, reason} ->
+        {:error, {:unreachable, reason}}
+
+      other ->
+        {:error, {:unexpected_reply, other}}
+    end
+  end
+
+  @doc """
+  True when `term` is a live, messageable Beamtalk object handle — the
+  reference-following case. Over distribution the `#beamtalk_object{}` record
+  arrives as a `{:beamtalk_object, class, module, pid_or_ref}` tuple (see
+  `beamtalk.hrl`). Only object terms backed by a real remote pid are
+  inspectable: name-resolving proxies carry `{:registered, name}` in the identity
+  slot (ADR 0079) and have no pid to `sys:get_state/2`, so they are not
+  drillable here.
+  """
+  def inspectable?({:beamtalk_object, _class, _module, pid}) when is_pid(pid), do: true
+  def inspectable?(_term), do: false
+
+  @doc """
+  Inspect a live object `term` through the read-surface `inspect` op (ADR 0085),
+  returning its structured instance fields as a live-term map.
+
+  This is the reference-following primitive: given a `{:beamtalk_object, class,
+  module, pid}` handle held in the LiveView, it extracts the real remote pid and
+  drives `beamtalk_repl_ops:dispatch("inspect", ...)`, which reads the actor's
+  live state and returns only its user-visible fields (`{:inspect, fields_map}`).
+  Because the fields are themselves live terms, an object-valued slot is again a
+  `{:beamtalk_object, ...}` tuple the caller can drill into recursively — the
+  whole point of carrying terms, not JSON, to the LiveView.
+
+    * success → `{:ok, fields :: map()}` (or `{:ok, binary}` for a non-tagged
+      raw state value the workspace stringified)
+    * error   → `{:error, reason_term}` (`#beamtalk_error{}` or a structured
+      reason); the caller renders it via `render_error/1`
+
+  Returns `{:error, :not_inspectable}` for any term that is not a pid-backed
+  object handle, so the caller never has to guess the term shape.
+  """
+  def inspect_value({:beamtalk_object, _class, _module, pid} = _term) when is_pid(pid) do
+    pid_str = pid |> :erlang.pid_to_list() |> to_string()
+
+    case dispatch_inspect(pid_str) do
+      {:inspect, fields} when is_map(fields) -> {:ok, fields}
+      {:inspect, other} -> {:ok, other}
+      {:error, reason} -> {:error, reason}
+      {:badrpc, reason} -> {:error, {:unreachable, reason}}
+      other -> {:error, {:unexpected_reply, other}}
+    end
+  end
+
+  def inspect_value(_term), do: {:error, :not_inspectable}
+
+  # Build the `inspect` request as a plain map, decode it on the workspace node
+  # (so we don't depend on the protocol record's `.hrl`), then dispatch through
+  # the term-returning op layer. `dispatch/4` returns the `{:inspect, _}` term
+  # directly — JSON encoding (`encode/2`) is never invoked, so the fields stay
+  # live terms with their messageable pids intact.
+  defp dispatch_inspect(pid_str) do
+    request = %{"op" => "inspect", "params" => %{"actor" => pid_str}}
+
+    case rpc(:beamtalk_repl_protocol, :decode, [encode_json(request)]) do
+      {:ok, msg} ->
+        params = rpc(:beamtalk_repl_protocol, :get_params, [msg])
+        # inspect ignores SessionPid; pass self() purely to satisfy dispatch/4.
+        rpc(:beamtalk_repl_ops, :dispatch, ["inspect", params, msg, self()])
+
+      other ->
+        other
+    end
+  end
+
   # ── internals ─────────────────────────────────────────────────────────────
 
   defp ensure_distributed do

--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -318,9 +318,28 @@ defmodule BtAttach.Workspace do
   object handle, so the caller never has to guess the term shape.
   """
   def inspect_value({:beamtalk_object, _class, _module, pid} = _term) when is_pid(pid) do
-    pid_str = pid |> :erlang.pid_to_list() |> to_string()
+    # The `inspect` op identifies the actor by the *textual* pid form, the same
+    # contract the browser uses (`beamtalk_ws_handler` formats with pid_to_list,
+    # the op resolves with list_to_pid). Both sides must run on the SAME node:
+    # `pid_to_list/1` of a node-LOCAL pid yields the canonical `<0.X.Y>` text
+    # that `list_to_pid/1` round-trips on that node. Stringifying a *remote*
+    # workspace pid here on the Phoenix node would instead emit `<N.X.Y>` (N =
+    # the workspace's index in *our* dist table), and the workspace's
+    # `list_to_pid/1` would then `badarg` (or worse, resolve a different pid).
+    # So format the pid ON the workspace node, where it is local, via RPC.
+    case rpc(:erlang, :pid_to_list, [pid]) do
+      pid_chars when is_list(pid_chars) ->
+        dispatch_inspect_result(dispatch_inspect(to_string(pid_chars)))
 
-    case dispatch_inspect(pid_str) do
+      {:badrpc, reason} ->
+        {:error, {:unreachable, reason}}
+    end
+  end
+
+  def inspect_value(_term), do: {:error, :not_inspectable}
+
+  defp dispatch_inspect_result(result) do
+    case result do
       {:inspect, fields} when is_map(fields) -> {:ok, fields}
       {:inspect, other} -> {:ok, other}
       {:error, reason} -> {:error, reason}
@@ -328,8 +347,6 @@ defmodule BtAttach.Workspace do
       other -> {:error, {:unexpected_reply, other}}
     end
   end
-
-  def inspect_value(_term), do: {:error, :not_inspectable}
 
   # Build the `inspect` request as a plain map, decode it on the workspace node
   # (so we don't depend on the protocol record's `.hrl`), then dispatch through

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -154,8 +154,12 @@ defmodule BtAttachWeb.WorkspaceLive do
   # term is carried back to the server by index against the current rows, so we
   # never round-trip a flattened string.
   def handle_event("drill", %{"index" => index}, %{assigns: %{inspect_rows: rows}} = socket) do
-    case Enum.at(rows, String.to_integer(index)) do
-      %{term: term, name: name} -> {:noreply, inspect_term(socket, name, term)}
+    # `index` is client-supplied; parse defensively so a malformed value can't
+    # crash the LiveView (`String.to_integer/1` would raise on non-digits).
+    with {i, ""} when i >= 0 <- Integer.parse(index),
+         %{term: term, name: name} <- Enum.at(rows, i) do
+      {:noreply, inspect_term(socket, name, term)}
+    else
       _ -> {:noreply, socket}
     end
   end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -3,14 +3,24 @@
 
 defmodule BtAttachWeb.WorkspaceLive do
   @moduledoc """
-  Wave-1 LiveView IDE (BT-2407): the two-pane workspace core on the Attach
-  topology (ADR 0017 Phase 3, validated by the BT-2394 spike).
+  LiveView IDE (BT-2407 Wave 1, BT-2408 Wave 2): the four-pane workspace core on
+  the Attach topology (ADR 0017 Phase 3, validated by the BT-2394 spike).
 
     * Workspace pane   — input evaluates Beamtalk source against the attached
       workspace node via the BT-2399 term-returning op layer, rendering the
       result term (surface-consistent with the Phase-1 browser workspace).
     * Transcript pane  — subscribes via the BT-2399 subscription facade and
       renders live `Transcript show:` output pushed over distribution.
+    * Bindings pane (Wave 2) — lists the session's current bindings via the
+      read-surface (`Workspace.list_bindings/1`, ADR 0085) and refreshes live on
+      the BT-2399 `bindings` push stream (a `{:bindings_changed, _}` signal),
+      never by polling or a direct gen_server cast.
+    * Inspector pane (Wave 2) — inspects a selected binding/value through the
+      read-surface `inspect` op (ADR 0085), rendering the **live term's**
+      structured fields. Object-valued slots are themselves live
+      `{:beamtalk_object, …}` handles, so the Inspector can *follow references* —
+      drill from a binding into a referenced object and into its object fields,
+      the whole point of carrying terms (not JSON) to the LiveView.
     * Session lifecycle — each LiveView mount gets its own workspace-supervised
       session; eval state (bindings, loaded classes) persists across evals
       within the session and is released when the LiveView process terminates.
@@ -46,33 +56,41 @@ defmodule BtAttachWeb.WorkspaceLive do
           case Workspace.start_session(session_id) do
             pid when is_pid(pid) ->
               # Subscribe THIS LiveView pid (location-transparent over dist) to
-              # the Transcript stream through the BT-2399 facade — no direct
-              # gen_server cast. The facade's cast returns `:ok`; a `{:badrpc, _}`
-              # (or any non-ok reply) means the transcript is NOT live, so we must
-              # not render the pane as connected and claim a working stream.
-              case Workspace.subscribe_transcript(self()) do
-                :ok ->
-                  socket
-                  |> assign(:connected, true)
-                  |> assign(:node, Workspace.node_name())
-                  |> assign(:session_id, session_id)
-                  |> assign(:session_pid, pid)
-                  |> assign(:result, nil)
-                  |> assign(:output, nil)
-                  |> assign(:error, nil)
-                  |> assign(:expr, "3 + 4")
-                  |> stream(:transcript, [])
-
+              # the Transcript AND bindings streams through the BT-2399 facade —
+              # no direct gen_server cast. The facade's cast returns `:ok`; any
+              # non-ok reply (`{:badrpc, _}`) means a stream is NOT live, so we
+              # must not render the pane as connected and claim a working stream.
+              # Pattern-match both subscribe results (Wave-1 review rule) and tear
+              # the half-started session back down on any failure so it can't leak.
+              with :ok <- Workspace.subscribe_transcript(self()),
+                   :ok <- Workspace.subscribe_bindings(self()) do
+                socket
+                |> assign(:connected, true)
+                |> assign(:node, Workspace.node_name())
+                |> assign(:session_id, session_id)
+                |> assign(:session_pid, pid)
+                |> assign(:result, nil)
+                |> assign(:output, nil)
+                |> assign(:error, nil)
+                |> assign(:expr, "3 + 4")
+                |> assign(:inspect_target, nil)
+                |> assign(:inspect_rows, [])
+                |> assign(:inspect_error, nil)
+                |> assign_bindings(pid)
+                |> stream(:transcript, [])
+              else
                 other ->
-                  # Transcript subscription failed: tear the half-started session
-                  # back down so we don't leak it, then render a non-connected
-                  # error page rather than a dead transcript pane.
-                  Logger.error("transcript subscribe failed: #{inspect(other)}")
+                  Logger.error("subscribe failed: #{inspect(other)}")
+                  # Drop whichever subscription may have succeeded before closing
+                  # the session, so we don't leave a dangling subscriber pushing
+                  # to a pid we're about to abandon.
+                  Workspace.unsubscribe_transcript(self())
+                  Workspace.unsubscribe_bindings(self())
                   Workspace.close_session(pid)
 
                   assign(socket,
                     connected: false,
-                    error: "transcript subscribe failed: #{inspect(other)}"
+                    error: "subscribe failed: #{inspect(other)}"
                   )
               end
 
@@ -122,11 +140,43 @@ defmodule BtAttachWeb.WorkspaceLive do
      assign(socket, result: nil, output: nil, error: "not attached to workspace", expr: expr)}
   end
 
+  # Inspect a binding by name: look up its live term and drill into it via the
+  # read-surface `inspect` op. Reference-following starts here.
+  @impl true
+  def handle_event("inspect", %{"name" => name}, %{assigns: %{session_pid: pid}} = socket)
+      when is_pid(pid) do
+    {:noreply, inspect_binding(socket, pid, name)}
+  end
+
+  # Drill into an object-valued field of the currently-inspected object: the
+  # field term is itself a live `{:beamtalk_object, …}` handle, so following it
+  # is the same read-surface inspect call one level deeper. The clicked field's
+  # term is carried back to the server by index against the current rows, so we
+  # never round-trip a flattened string.
+  def handle_event("drill", %{"index" => index}, %{assigns: %{inspect_rows: rows}} = socket) do
+    case Enum.at(rows, String.to_integer(index)) do
+      %{term: term, name: name} -> {:noreply, inspect_term(socket, name, term)}
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("drill", _params, socket), do: {:noreply, socket}
+
   # Transcript push, delivered directly over distribution to this LiveView pid.
   @impl true
   def handle_info({:transcript_output, text}, socket) do
     line = %{id: System.unique_integer([:positive]), text: to_string(text)}
     {:noreply, stream_insert(socket, :transcript, line)}
+  end
+
+  # Bindings-changed push (BT-2399 `bindings` stream): a *signal*, not the data.
+  # An eval on any session in the workspace may have changed binding values, so
+  # re-read this session's bindings through the read-surface and re-render the
+  # pane. This is the "updating live as bindings change" acceptance criterion,
+  # driven by the facade subscription rather than polling.
+  def handle_info({:bindings_changed, _session_id}, %{assigns: %{session_pid: pid}} = socket)
+      when is_pid(pid) do
+    {:noreply, assign_bindings(socket, pid)}
   end
 
   def handle_info(_msg, socket), do: {:noreply, socket}
@@ -143,6 +193,7 @@ defmodule BtAttachWeb.WorkspaceLive do
     # mount/reconnect (the session-lifecycle acceptance criterion).
     if socket.assigns[:connected] do
       Workspace.unsubscribe_transcript(self())
+      Workspace.unsubscribe_bindings(self())
 
       case socket.assigns[:session_pid] do
         pid when is_pid(pid) -> Workspace.close_session(pid)
@@ -157,6 +208,110 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp present(""), do: nil
   defp present(nil), do: nil
   defp present(output) when is_binary(output), do: output
+
+  # ── bindings + inspector helpers ────────────────────────────────────────────
+
+  # Read the session's live bindings through the read-surface and assign display
+  # rows. Each row keeps the live `term` so the Inspector can follow object
+  # references without a string round-trip; `inspectable?` flags object-valued
+  # bindings the user can drill into.
+  defp assign_bindings(socket, pid) do
+    case Workspace.list_bindings(pid) do
+      {:error, reason} ->
+        assign(socket, bindings: [], bindings_error: Workspace.render_error(reason))
+
+      pairs when is_list(pairs) ->
+        rows =
+          Enum.map(pairs, fn {name, term} ->
+            %{
+              name: name,
+              value: Workspace.render_term(term),
+              inspectable: Workspace.inspectable?(term)
+            }
+          end)
+
+        assign(socket, bindings: rows, bindings_error: nil)
+    end
+  end
+
+  # Inspect a binding selected by name: resolve its live term from the current
+  # binding list, then inspect that term. The term — not a string — drives the op.
+  defp inspect_binding(socket, pid, name) do
+    case Workspace.list_bindings(pid) do
+      pairs when is_list(pairs) ->
+        case List.keyfind(pairs, name, 0) do
+          {^name, term} -> inspect_term(socket, name, term)
+          nil -> assign(socket, inspect_error: "binding not found: #{name}")
+        end
+
+      {:error, reason} ->
+        assign(socket, inspect_error: Workspace.render_error(reason))
+    end
+  end
+
+  # Inspect a single live term via the read-surface `inspect` op and assign the
+  # resulting structured-field rows. Object-valued fields are flagged drillable,
+  # carrying their live term so the next drill follows the reference one level
+  # deeper. Non-object terms are not inspectable, so we say so rather than guess.
+  defp inspect_term(socket, label, term) do
+    if Workspace.inspectable?(term) do
+      case Workspace.inspect_value(term) do
+        {:ok, fields} when is_map(fields) ->
+          assign(socket,
+            inspect_target: %{label: to_string(label), header: Workspace.render_term(term)},
+            inspect_rows: field_rows(fields),
+            inspect_error: nil
+          )
+
+        {:ok, scalar} ->
+          assign(socket,
+            inspect_target: %{label: to_string(label), header: Workspace.render_term(term)},
+            inspect_rows: [
+              %{
+                name: "value",
+                value: Workspace.format_value(scalar),
+                term: scalar,
+                drillable: false
+              }
+            ],
+            inspect_error: nil
+          )
+
+        {:error, reason} ->
+          assign(socket, inspect_error: Workspace.render_error(reason))
+      end
+    else
+      assign(socket,
+        inspect_target: %{label: to_string(label), header: Workspace.render_term(term)},
+        inspect_rows: [],
+        inspect_error: "#{label} is a #{scalar_kind(term)} — no fields to inspect"
+      )
+    end
+  end
+
+  # Turn an inspect fields map (live terms) into ordered display rows. Each row
+  # keeps the live field `term` so a drill on an object-valued slot follows the
+  # real reference; `drillable` marks the object-valued ones.
+  defp field_rows(fields) do
+    fields
+    |> Enum.map(fn {key, term} ->
+      %{
+        name: to_string(key),
+        value: Workspace.render_term(term),
+        term: term,
+        drillable: Workspace.inspectable?(term)
+      }
+    end)
+    |> Enum.sort_by(& &1.name)
+  end
+
+  defp scalar_kind(term) when is_integer(term), do: "number"
+  defp scalar_kind(term) when is_float(term), do: "number"
+  defp scalar_kind(term) when is_binary(term), do: "string"
+  defp scalar_kind(term) when is_boolean(term), do: "boolean"
+  defp scalar_kind(term) when is_list(term), do: "collection"
+  defp scalar_kind(term) when is_map(term), do: "map"
+  defp scalar_kind(_term), do: "value"
 
   @impl true
   def render(assigns) do
@@ -185,6 +340,80 @@ defmodule BtAttachWeb.WorkspaceLive do
         <% end %>
         <%= if @error do %>
           <pre style="background:#fff0f0; padding:.75rem; border:1px solid #ecc;"><%= @error %></pre>
+        <% end %>
+
+        <h2>Bindings (live)</h2>
+        <%= if @bindings_error do %>
+          <pre style="background:#fff0f0; padding:.75rem; border:1px solid #ecc;"><%= @bindings_error %></pre>
+        <% end %>
+        <%= if @bindings == [] do %>
+          <p style="color:#666;">No bindings yet. Try <code>x := 42</code>.</p>
+        <% else %>
+          <table style="width:100%; border-collapse:collapse;">
+            <tbody>
+              <tr :for={b <- @bindings} style="border-bottom:1px solid #eee;">
+                <td style="padding:.25rem .5rem; font-weight:bold; vertical-align:top;">{b.name}</td>
+                <td style="padding:.25rem .5rem; width:100%;">{b.value}</td>
+                <td style="padding:.25rem .5rem; white-space:nowrap;">
+                  <%= if b.inspectable do %>
+                    <button
+                      type="button"
+                      phx-click="inspect"
+                      phx-value-name={b.name}
+                      style="font-family:inherit;"
+                    >
+                      Inspect →
+                    </button>
+                  <% end %>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        <% end %>
+
+        <h2>Inspector</h2>
+        <%= if @inspect_target do %>
+          <p>
+            Inspecting <strong>{@inspect_target.label}</strong>
+            · <code>{@inspect_target.header}</code>
+          </p>
+        <% end %>
+        <%= if @inspect_error do %>
+          <pre style="background:#fff8e8; padding:.75rem; border:1px solid #eda;"><%= @inspect_error %></pre>
+        <% end %>
+        <%= if @inspect_target && @inspect_rows != [] do %>
+          <table style="width:100%; border-collapse:collapse; background:#fafaff; border:1px solid #dde;">
+            <tbody>
+              <tr
+                :for={{row, i} <- Enum.with_index(@inspect_rows)}
+                style="border-bottom:1px solid #eef;"
+              >
+                <td style="padding:.25rem .5rem; font-weight:bold; vertical-align:top;">
+                  {row.name}
+                </td>
+                <td style="padding:.25rem .5rem; width:100%;">{row.value}</td>
+                <td style="padding:.25rem .5rem; white-space:nowrap;">
+                  <%= if row.drillable do %>
+                    <button
+                      type="button"
+                      phx-click="drill"
+                      phx-value-index={i}
+                      style="font-family:inherit;"
+                    >
+                      Follow →
+                    </button>
+                  <% end %>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        <% else %>
+          <%= if @inspect_target == nil && @inspect_error == nil do %>
+            <p style="color:#666;">
+              Spawn an object (<code>Counter spawn</code>), bind it, then Inspect it to
+              follow its live references.
+            </p>
+          <% end %>
         <% end %>
 
         <h2>Transcript (live)</h2>

--- a/editors/liveview/test/bt_attach/workspace_inspect_test.exs
+++ b/editors/liveview/test/bt_attach/workspace_inspect_test.exs
@@ -1,0 +1,54 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttach.WorkspaceInspectTest do
+  @moduledoc """
+  Unit tests for the pure (RPC-free) reference-following predicates the Wave-2
+  Inspector relies on (BT-2408): which live terms are inspectable objects, and
+  the short-circuit that rejects non-objects before any RPC. The RPC-backed
+  read-surface paths (`list_bindings/1`, `inspect_value/1` against a real object)
+  are exercised by the `@tag :workspace` LiveView e2e tests.
+  """
+  use ExUnit.Case, async: true
+
+  alias BtAttach.Workspace
+
+  describe "inspectable?/1 — the reference-following gate" do
+    test "a pid-backed object handle is inspectable" do
+      # Over distribution `#beamtalk_object{}` arrives as this 4-tuple (beamtalk.hrl):
+      # {:beamtalk_object, Class, Module, Pid}. A real pid is messageable, so it
+      # can be followed by reference.
+      obj = {:beamtalk_object, :Counter, :counter, self()}
+      assert Workspace.inspectable?(obj)
+    end
+
+    test "a name-resolving proxy (no pid, ADR 0079) is not inspectable" do
+      # ADR 0079 proxies carry {:registered, Name} in the identity slot — there is
+      # no pid to read live state from, so they are not drillable.
+      proxy = {:beamtalk_object, :Counter, :counter, {:registered, :counter}}
+      refute Workspace.inspectable?(proxy)
+    end
+
+    test "scalar and container terms are not inspectable" do
+      refute Workspace.inspectable?(42)
+      refute Workspace.inspectable?(3.14)
+      refute Workspace.inspectable?("hello")
+      refute Workspace.inspectable?(true)
+      refute Workspace.inspectable?([1, 2, 3])
+      refute Workspace.inspectable?(%{a: 1})
+    end
+  end
+
+  describe "inspect_value/1 — non-object short-circuit (no RPC)" do
+    test "non-object terms are rejected with :not_inspectable" do
+      assert {:error, :not_inspectable} = Workspace.inspect_value(42)
+      assert {:error, :not_inspectable} = Workspace.inspect_value("hello")
+      assert {:error, :not_inspectable} = Workspace.inspect_value([1, 2, 3])
+    end
+
+    test "a registered proxy (no pid) is rejected with :not_inspectable" do
+      proxy = {:beamtalk_object, :Counter, :counter, {:registered, :counter}}
+      assert {:error, :not_inspectable} = Workspace.inspect_value(proxy)
+    end
+  end
+end

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -48,6 +48,52 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert eventually(fn -> render(view) =~ marker end)
   end
 
+  test "bindings pane reflects an eval that defines a binding (BT-2408)", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    name = "bt2408_#{System.unique_integer([:positive])}"
+
+    # Defining a binding fires the BT-2399 `bindings` push; the pane re-reads the
+    # read-surface and should list the new name and its value live.
+    view |> form("form") |> render_submit(%{expr: "#{name} := 123"})
+
+    assert eventually(fn ->
+             html = render(view)
+             html =~ name and html =~ "123"
+           end)
+  end
+
+  test "inspecting an object binding renders its live fields (BT-2408)", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    suffix = System.unique_integer([:positive])
+    class = "Counter#{suffix}"
+    name = "counter_#{suffix}"
+
+    # Define a real Actor subclass with an instance field, then spawn + bind it.
+    # The whole class source is one eval (newlines and all). Over distribution the
+    # binding is a live {:beamtalk_object, …} handle, not a flattened string, so
+    # the bindings pane offers an Inspect button.
+    class_src = """
+    Actor subclass: #{class}
+      state: count = 7
+
+      count => self.count
+    """
+
+    view |> form("form") |> render_submit(%{expr: class_src})
+    view |> form("form") |> render_submit(%{expr: "#{name} := #{class} spawn"})
+
+    assert eventually(fn -> render(view) =~ name end)
+
+    # Follow the reference through the read-surface `inspect` op; the Inspector
+    # reads the live actor state and renders its structured instance fields
+    # (the `count` field, initialised to 7).
+    html = view |> element("button[phx-value-name='#{name}']") |> render_click()
+
+    assert html =~ "Inspecting"
+    assert html =~ "count"
+    assert html =~ "7"
+  end
+
   # ~6s total — generous for cross-node async transcript delivery under CI load.
   defp eventually(fun, retries \\ 120) do
     cond do


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-2408

Second wave of the LiveView IDE epic (BT-2398, ADR 0017 Phase 3). Ports the remaining two Phase-1 read panes — the Inspector and the bindings list — onto the Attach topology, wiring them through the read-surface (ADR 0085) over the BT-2399 term-returning op layer and subscription facade. Live terms reach the LiveView, never JSON-flattened strings, so the Inspector can follow real remote pids.

## What changed

**Workspace client (`editors/liveview/lib/bt_attach/workspace.ex`)**
- `list_bindings/1` — reads the session's live binding map via `beamtalk_repl_shell:get_bindings/1`; values stay live terms (a bound `Counter spawn` is a real `{:beamtalk_object, …}` handle) so the Inspector can follow references. Returns name-sorted `{name, term}` pairs; RPC/shape failures become `{:error, _}`.
- `subscribe_bindings/1` + `unsubscribe_bindings/1` — facade explicit-pid form (`beamtalk_repl_subscriptions` `:bindings` stream); registers the LiveView's own pid, never casts `{subscribe, self()}` at a gen_server.
- `inspectable?/1` + `inspect_value/1` — reference-following: a pid-backed object handle is inspected through the read-surface `inspect` op (`dispatch/4`, term result), returning live structured fields. Registered proxies (ADR 0079, no pid) and scalars short-circuit. The object pid is stringified **on the workspace node** via RPC so the `pid_to_list`/`list_to_pid` contract round-trips (a remote pid stringified on the Phoenix node would mis-resolve).

**WorkspaceLive (`editors/liveview/lib/bt_attach_web/live/workspace_live.ex`)**
- Bindings pane — lists bindings, refreshes live on the `{:bindings_changed}` push signal (re-reads the read-surface), object bindings get an Inspect button.
- Inspector pane — renders an inspected object's structured fields; object fields are drillable (Follow →) and carry their live term, so a drill is the same inspect call one level deeper.
- `attach/2` pattern-matches both subscribe results and tears the half-started session down on any failure; `terminate/2` drops the bindings subscription too. Drill index is parsed defensively so a malformed client value can't crash the LiveView.

**Tests**
- `test/bt_attach/workspace_inspect_test.exs` — default-run unit tests for the `inspectable?` / `inspect_value` predicates and the non-object short-circuit.
- `test/bt_attach_web/workspace_live_test.exs` — `@tag :workspace` e2e: bindings list reflects an eval that defines a binding; inspecting a spawned object renders its live fields.

## Acceptance criteria
- [x] Bindings pane lists current bindings via the read-surface op + bindings subscription facade, updating live.
- [x] Inspector pane inspects a selected value/binding via the read-surface (ADR 0085), rendering structured fields from the live term.
- [x] Reference-following: object-valued slots are navigable (drill into a referenced object).
- [x] Read-surface calls go through the op contract / subscription facade; no direct gen_server `{subscribe, self()}` casts.
- [x] LiveView tests (tag-gated, real workspace) for bindings-reflect-eval and inspecting an object value.

## Verification
`mix compile --warnings-as-errors` clean, `mix format --check-formatted` clean, `mix test` green (27 pass, 5 `@tag :workspace` excluded by default — run in the workspace-gated CI job).

https://claude.ai/code/session_01SooajdpU9eNrWvq3hNMoTK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SooajdpU9eNrWvq3hNMoTK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live Bindings pane displaying session variables with real-time updates
  * Inspector pane for viewing live object fields and their values
  * Click-to-inspect controls to explore object instances in the workspace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->