### PR TITLE
LiveView IDE Wave 3: method-level edit/save/flush (write-surface, ADR 0082) (BT-2409)

### DIFF
--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -338,6 +338,190 @@ defmodule BtAttach.Workspace do
 
   def inspect_value(_term), do: {:error, :not_inspectable}
 
+  # ── write-surface: method-level edit / save / flush (ADR 0082, BT-2409) ─────
+
+  @doc """
+  Save (durably patch) a single method on a class in the attached workspace,
+  through the write-surface (ADR 0082, Wave 3).
+
+  This is the method editor's "Save" action. Per ADR 0082 the operation is the
+  Beamtalk-level `aClass compile: #selector source: body` primitive — but rather
+  than building a `compile:source:` *eval string* (which would force escaping the
+  body's quotes, backslashes, and `{` interpolation markers back into Beamtalk
+  source — exactly the fragility ADR 0082 calls out), we call the runtime install
+  chokepoint `beamtalk_repl_eval:compile_method/6` directly over distribution,
+  passing the body as a **String value**. `>>`, `compile:source:`, and this entry
+  all converge at the same in-memory install + ChangeLog append, so the saved
+  method is compiled, flushed into the live BEAM module, and recorded in the
+  workspace's change history (the ChangeLog coherence criterion) in one step.
+
+  `selector` is the method selector (e.g. `"increment"` or `"at:put:"`), `source`
+  the method definition body. Author metadata is stamped as `liveview` / `human`
+  for the audit trail.
+
+  Returns:
+
+    * success → `{:ok, class}` where `class` is the class-name binary the install
+      confirmed
+    * error   → `{:error, reason_term}` where `reason_term` is the structured
+      `#beamtalk_error{}` for a failed compile/save (rendered via
+      `render_error/1`), or `{:unreachable, _}` if the workspace is gone
+
+  The term contract is the only coupling: no JSON crosses the Attach path.
+  """
+  def save_method(class, selector, source)
+      when is_binary(class) and is_binary(selector) and is_binary(source) do
+    # compile_method/6: (ClassNameBin, Selector, SourceBin, Intent, Author, AuthorKind).
+    # Intent `durable` so the patch is logged as a keepable change (ADR 0082); the
+    # selector and body are passed as values — no source-string round-trip.
+    args = [class, selector, source, :durable, "liveview", :human]
+
+    case rpc(:beamtalk_repl_eval, :compile_method, args) do
+      {:ok, class_bin} ->
+        {:ok, to_string(class_bin)}
+
+      # A compile/install failure returns {error, Reason}; structure it so the
+      # LiveView renders an actionable #beamtalk_error{} rather than a flattened
+      # internal term.
+      {:error, reason} ->
+        {:error, structure_error(reason)}
+
+      {:badrpc, reason} ->
+        {:error, {:unreachable, reason}}
+
+      other ->
+        {:error, {:unexpected_reply, other}}
+    end
+  end
+
+  @doc """
+  Flush the workspace's pending durable changes to disk (ADR 0082 `Workspace
+  flush`). This is the "Save All to Disk" action — it replays the ChangeLog
+  entries written by `save_method/3` into their `.bt` source files.
+
+  Calls `beamtalk_workspace_flush:flush/0` directly, which returns a term
+  contract (never raises on a normal conflict): a `FlushResult`-shaped summary
+  map on success, or `{error, #beamtalk_error{}}` on a hard runtime error. The
+  summary's `conflicts` / `skipped` lists carry recoverable conditions
+  (external-edit conflicts, non-flushable stdlib patches) for the caller to
+  render.
+
+  Returns `{:ok, summary_map}` or `{:error, reason_term}`.
+  """
+  def flush do
+    case rpc(:beamtalk_workspace_flush, :flush, []) do
+      {:ok, summary} when is_map(summary) -> {:ok, summary}
+      {:error, reason} -> {:error, structure_error(reason)}
+      {:badrpc, reason} -> {:error, {:unreachable, reason}}
+      other -> {:error, {:unexpected_reply, other}}
+    end
+  end
+
+  @doc """
+  List the workspace's active change history (ADR 0082 `Workspace changes`) — the
+  per-method ChangeLog entries that are dirty (installed in memory, not yet
+  flushed to disk). This is the ChangeLog-coherence view: after `save_method/3`,
+  the saved `(class, selector)` should appear here.
+
+  Reads `beamtalk_workspace_changelog:change_entries/0` — the same
+  `$beamtalk_class`-tagged value maps that back the `ChangeLog.bt` /
+  `ChangeEntry.bt` value objects — in a **single RPC**. Each entry is already a
+  plain atom-keyed map (not an opaque `#entry{}` record), so nothing fragile
+  crosses the node boundary and there is no per-entry round-trip. We keep only the
+  entries flagged `active` (current epoch, not orphaned, not yet flushed — the
+  exact `Workspace changes` predicate) and render display rows newest-first.
+
+  Returns a list of row maps, or `{:error, reason}` if the workspace is
+  unreachable or returns an unexpected shape.
+  """
+  def change_history do
+    case rpc(:beamtalk_workspace_changelog, :change_entries, []) do
+      entries when is_list(entries) ->
+        entries
+        |> Enum.filter(&active_entry?/1)
+        |> Enum.map(&entry_to_row/1)
+        |> Enum.reverse()
+
+      {:badrpc, reason} ->
+        {:error, {:unreachable, reason}}
+
+      other ->
+        {:error, {:unexpected_reply, other}}
+    end
+  end
+
+  # The change-entry value map carries an `active` boolean (current epoch, not
+  # orphaned, not flushed) — the same predicate `Workspace changes` filters on.
+  defp active_entry?(%{active: active}), do: active == true
+  defp active_entry?(_), do: false
+
+  @doc """
+  Render a `FlushResult` summary map (ADR 0082 `Workspace flush`) to a one-line
+  status string for the page. Pure (no RPC), so it is unit-tested directly.
+
+  Over distribution the workspace returns an atom-keyed map; keys are read
+  defensively (atom or string) so an unexpected shape degrades to `inspect/1`
+  rather than crashing the pane. Conflicts and skipped (non-flushable) counts are
+  appended when present, since they are the recoverable conditions the user acts
+  on.
+  """
+  def format_flush_summary(summary) when is_map(summary) do
+    flushed = summary_field(summary, :flushed, 0)
+    files = summary |> summary_field(:files, []) |> List.wrap()
+    conflicts = summary |> summary_field(:conflicts, []) |> List.wrap()
+    skipped = summary |> summary_field(:skipped, []) |> List.wrap()
+
+    base = "Flushed #{flushed} change(s) across #{length(files)} file(s)"
+
+    parts =
+      [base]
+      |> maybe_append(conflicts != [], "#{length(conflicts)} conflict(s)")
+      |> maybe_append(skipped != [], "#{length(skipped)} skipped")
+
+    Enum.join(parts, " · ")
+  end
+
+  def format_flush_summary(other), do: inspect(other)
+
+  defp summary_field(map, key, default) do
+    Map.get(map, key, Map.get(map, Atom.to_string(key), default))
+  end
+
+  defp maybe_append(parts, false, _text), do: parts
+  defp maybe_append(parts, true, text), do: parts ++ [text]
+
+  # Render one ChangeEntry value map (atom-keyed, from `change_entries/0`) to a
+  # display row. `className` arrives as an atom and `selector` as a Symbol (atom)
+  # or `nil` for a new-class entry; `to_string/1` renders atoms verbatim. We read
+  # every key defensively with a default so a future field addition can't crash
+  # the pane.
+  defp entry_to_row(entry) when is_map(entry) do
+    %{
+      class: to_string(Map.get(entry, :className, "")),
+      selector: present_selector(Map.get(entry, :selector)),
+      kind: to_string(Map.get(entry, :kind, "")),
+      intent: to_string(Map.get(entry, :intent, "")),
+      flushable: Map.get(entry, :flushable, false) == true,
+      flushed: Map.get(entry, :flushed, false) == true,
+      author_kind: to_string(Map.get(entry, :authorKind, ""))
+    }
+  end
+
+  # ChangeLog selector is nil for a new-class entry; show a placeholder.
+  defp present_selector(nil), do: "(class)"
+  defp present_selector(value), do: to_string(value)
+
+  # Turn a runtime `{error, Reason}` into a structured `#beamtalk_error{}` term so
+  # the LiveView renders an actionable message. `ensure_structured_error/1` is the
+  # workspace's own wrapper — already structured reasons pass through unchanged,
+  # raw reasons get wrapped — so we never flatten an error to an opaque string.
+  defp structure_error(reason) do
+    case rpc(:beamtalk_repl_errors, :ensure_structured_error, [reason]) do
+      {:badrpc, _} -> reason
+      structured -> structured
+    end
+  end
+
   defp dispatch_inspect_result(result) do
     case result do
       {:inspect, fields} when is_map(fields) -> {:ok, fields}

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -76,7 +76,16 @@ defmodule BtAttachWeb.WorkspaceLive do
                 |> assign(:inspect_target, nil)
                 |> assign(:inspect_rows, [])
                 |> assign(:inspect_error, nil)
+                # Method editor (Wave 3): the write-surface edit/save/flush pane.
+                |> assign(:edit_class, "")
+                |> assign(:edit_selector, "")
+                |> assign(:edit_source, "")
+                |> assign(:save_result, nil)
+                |> assign(:save_error, nil)
+                |> assign(:flush_result, nil)
+                |> assign(:flush_error, nil)
                 |> assign_bindings(pid)
+                |> assign_changes()
                 |> stream(:transcript, [])
               else
                 other ->
@@ -166,6 +175,30 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   def handle_event("drill", _params, socket), do: {:noreply, socket}
 
+  # ── method editor (Wave 3, write-surface ADR 0082) ──────────────────────────
+
+  # Save (durably patch) the edited method on the workspace via the write-surface.
+  # On success the method is compiled + flushed into the live BEAM module and an
+  # entry is recorded in the workspace ChangeLog, so a subsequent eval observes the
+  # new behaviour and the change appears in the change-history pane. A failed
+  # compile/save returns a structured #beamtalk_error{} we render as an actionable
+  # message (not a flattened string).
+  @impl true
+  def handle_event(
+        "save_method",
+        %{"class" => class, "selector" => selector, "source" => source},
+        socket
+      ) do
+    {:noreply, save_method(socket, class, selector, source)}
+  end
+
+  # Flush all pending durable changes to disk ("Save All to Disk", ADR 0082
+  # `Workspace flush`). The summary's conflicts/skipped lists carry recoverable
+  # conditions; a hard runtime failure renders as a structured error.
+  def handle_event("flush", _params, socket) do
+    {:noreply, flush_changes(socket)}
+  end
+
   # Transcript push, delivered directly over distribution to this LiveView pid.
   @impl true
   def handle_info({:transcript_output, text}, socket) do
@@ -212,6 +245,76 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp present(""), do: nil
   defp present(nil), do: nil
   defp present(output) when is_binary(output), do: output
+
+  # ── method editor helpers (Wave 3) ──────────────────────────────────────────
+
+  # Validate the edit form, then drive the write-surface save. Empty class or
+  # selector is a local validation error (rendered without a round-trip); a real
+  # save threads the body value straight to the workspace install chokepoint.
+  defp save_method(socket, class, selector, source) do
+    class = String.trim(class)
+    selector = String.trim(selector)
+
+    socket =
+      assign(socket,
+        edit_class: class,
+        edit_selector: selector,
+        edit_source: source
+      )
+
+    cond do
+      class == "" ->
+        assign(socket, save_result: nil, save_error: "Enter a class name to save a method.")
+
+      selector == "" ->
+        assign(socket, save_result: nil, save_error: "Enter a selector to save a method.")
+
+      true ->
+        case Workspace.save_method(class, selector, source) do
+          {:ok, saved_class} ->
+            # The patch is live + logged; refresh the change-history pane so the
+            # new entry is visible (ChangeLog coherence).
+            socket
+            |> assign(
+              save_result: "Saved #{selector} on #{saved_class}",
+              save_error: nil,
+              flush_result: nil,
+              flush_error: nil
+            )
+            |> assign_changes()
+
+          {:error, reason} ->
+            assign(socket, save_result: nil, save_error: Workspace.render_error(reason))
+        end
+    end
+  end
+
+  # Drive the write-surface flush and render its summary, then refresh changes so
+  # the (now-flushed) entries drop out of the active view.
+  defp flush_changes(socket) do
+    case Workspace.flush() do
+      {:ok, summary} ->
+        socket
+        |> assign(flush_result: Workspace.format_flush_summary(summary), flush_error: nil)
+        |> assign_changes()
+
+      {:error, reason} ->
+        assign(socket, flush_result: nil, flush_error: Workspace.render_error(reason))
+    end
+  end
+
+  # Read the active ChangeLog ("Workspace changes", ADR 0082) and assign display
+  # rows. A workspace that is unreachable or returns an unexpected shape renders an
+  # error rather than crashing the pane.
+  defp assign_changes(socket) do
+    case Workspace.change_history() do
+      rows when is_list(rows) ->
+        assign(socket, changes: rows, changes_error: nil)
+
+      {:error, reason} ->
+        assign(socket, changes: [], changes_error: Workspace.render_error(reason))
+    end
+  end
 
   # ── bindings + inspector helpers ────────────────────────────────────────────
 
@@ -418,6 +521,85 @@ defmodule BtAttachWeb.WorkspaceLive do
               follow its live references.
             </p>
           <% end %>
+        <% end %>
+
+        <h2>Method Editor (write-surface)</h2>
+        <p style="color:#666;">
+          Edit a method and Save to compile + flush it onto the workspace
+          (<code>Counter compile: #increment source: …</code>, ADR 0082). A later
+          eval observes the new behaviour.
+        </p>
+        <form phx-submit="save_method" style="margin:1rem 0;">
+          <div style="display:flex; gap:.5rem; margin-bottom:.5rem;">
+            <input
+              name="class"
+              value={@edit_class}
+              placeholder="Class (e.g. Counter)"
+              autocomplete="off"
+              style="flex:1; padding:.5rem; font-family:inherit;"
+            />
+            <input
+              name="selector"
+              value={@edit_selector}
+              placeholder="selector (e.g. increment)"
+              autocomplete="off"
+              style="flex:1; padding:.5rem; font-family:inherit;"
+            />
+          </div>
+          <textarea
+            name="source"
+            rows="4"
+            placeholder="increment => self.value := self.value + 1"
+            style="width:100%; padding:.5rem; font-family:inherit; box-sizing:border-box;"
+          ><%= @edit_source %></textarea>
+          <div style="display:flex; gap:.5rem; margin-top:.5rem;">
+            <button type="submit" style="padding:.5rem 1rem;">Save Method</button>
+            <button type="button" phx-click="flush" style="padding:.5rem 1rem;">
+              Save All to Disk (flush)
+            </button>
+          </div>
+        </form>
+
+        <%= if @save_result do %>
+          <pre style="background:#f0fff0; padding:.75rem; border:1px solid #cec;"><%= @save_result %></pre>
+        <% end %>
+        <%= if @save_error do %>
+          <pre style="background:#fff0f0; padding:.75rem; border:1px solid #ecc;"><%= @save_error %></pre>
+        <% end %>
+        <%= if @flush_result do %>
+          <pre style="background:#eef6ff; padding:.75rem; border:1px solid #cce;"><%= @flush_result %></pre>
+        <% end %>
+        <%= if @flush_error do %>
+          <pre style="background:#fff0f0; padding:.75rem; border:1px solid #ecc;"><%= @flush_error %></pre>
+        <% end %>
+
+        <h2>Changes (ChangeLog)</h2>
+        <%= if @changes_error do %>
+          <pre style="background:#fff0f0; padding:.75rem; border:1px solid #ecc;"><%= @changes_error %></pre>
+        <% end %>
+        <%= if @changes == [] do %>
+          <p style="color:#666;">No pending changes. Save a method to record one.</p>
+        <% else %>
+          <table style="width:100%; border-collapse:collapse;">
+            <thead>
+              <tr style="border-bottom:1px solid #ccc; text-align:left;">
+                <th style="padding:.25rem .5rem;">Class</th>
+                <th style="padding:.25rem .5rem;">Selector</th>
+                <th style="padding:.25rem .5rem;">Intent</th>
+                <th style="padding:.25rem .5rem;">Flushable</th>
+                <th style="padding:.25rem .5rem;">Author</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr :for={c <- @changes} style="border-bottom:1px solid #eee;">
+                <td style="padding:.25rem .5rem; font-weight:bold;">{c.class}</td>
+                <td style="padding:.25rem .5rem;">{c.selector}</td>
+                <td style="padding:.25rem .5rem;">{c.intent}</td>
+                <td style="padding:.25rem .5rem;">{if c.flushable, do: "yes", else: "no"}</td>
+                <td style="padding:.25rem .5rem;">{c.author_kind}</td>
+              </tr>
+            </tbody>
+          </table>
         <% end %>
 
         <h2>Transcript (live)</h2>

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -188,8 +188,16 @@ defmodule BtAttachWeb.WorkspaceLive do
         "save_method",
         %{"class" => class, "selector" => selector, "source" => source},
         socket
-      ) do
+      )
+      when is_binary(class) and is_binary(selector) and is_binary(source) do
     {:noreply, save_method(socket, class, selector, source)}
+  end
+
+  # Malformed payload (missing keys or non-binary values): never let a crafted
+  # form event crash the LiveView — `save_method/4` calls `String.trim/1`, which
+  # would raise on a non-binary. Surface a validation error instead.
+  def handle_event("save_method", _params, socket) do
+    {:noreply, assign(socket, save_result: nil, save_error: "Invalid method form payload.")}
   end
 
   # Flush all pending durable changes to disk ("Save All to Disk", ADR 0082

--- a/editors/liveview/test/bt_attach/workspace_test.exs
+++ b/editors/liveview/test/bt_attach/workspace_test.exs
@@ -73,4 +73,49 @@ defmodule BtAttach.WorkspaceTest do
       assert Workspace.format_value(%{"items" => [1, 2]}) == "{items: #(1, 2)}"
     end
   end
+
+  describe "format_flush_summary/1 — write-surface flush rendering (BT-2409, ADR 0082)" do
+    test "a clean flush reports the written count and file count" do
+      # The workspace returns a FlushResult-shaped atom-keyed map over distribution.
+      summary = %{
+        :"$beamtalk_class" => :FlushResult,
+        flushed: 2,
+        files: ["src/counter.bt", "src/greeter.bt"],
+        newClasses: 0,
+        skipped: [],
+        conflicts: []
+      }
+
+      assert Workspace.format_flush_summary(summary) ==
+               "Flushed 2 change(s) across 2 file(s)"
+    end
+
+    test "nothing-to-flush renders zero counts without conflict/skip suffixes" do
+      summary = %{flushed: 0, files: [], skipped: [], conflicts: []}
+      assert Workspace.format_flush_summary(summary) == "Flushed 0 change(s) across 0 file(s)"
+    end
+
+    test "conflicts and skipped entries are surfaced as recoverable suffixes" do
+      summary = %{
+        flushed: 1,
+        files: ["src/counter.bt"],
+        skipped: [%{seq: 7, reason: "stdlib"}],
+        conflicts: [%{file: "src/other.bt", reason: "external_edit", seqs: [9]}]
+      }
+
+      result = Workspace.format_flush_summary(summary)
+      assert result =~ "Flushed 1 change(s) across 1 file(s)"
+      assert result =~ "1 conflict(s)"
+      assert result =~ "1 skipped"
+    end
+
+    test "string-keyed summary (e.g. JSON-decoded) reads the same fields" do
+      summary = %{"flushed" => 1, "files" => ["a.bt"], "skipped" => [], "conflicts" => []}
+      assert Workspace.format_flush_summary(summary) == "Flushed 1 change(s) across 1 file(s)"
+    end
+
+    test "an unexpected non-map shape degrades to inspect/1 rather than crashing" do
+      assert Workspace.format_flush_summary({:error, :boom}) == "{:error, :boom}"
+    end
+  end
 end

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -94,6 +94,100 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert html =~ "7"
   end
 
+  test "method editor: save a method, then an eval observes the new behaviour (BT-2409)", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/")
+    suffix = System.unique_integer([:positive])
+    class = "EditCounter#{suffix}"
+
+    # Define a real Actor subclass with a value field and a getter returning it.
+    class_src = """
+    Actor subclass: #{class}
+      state: value = 1
+
+      value => self.value
+    """
+
+    view |> form("form") |> render_submit(%{expr: class_src})
+
+    # Sanity: the original method returns the initial field value.
+    name = "ec_#{suffix}"
+    view |> form("form") |> render_submit(%{expr: "#{name} := #{class} spawn"})
+    html = view |> form("form") |> render_submit(%{expr: "#{name} value"})
+    assert html =~ "1"
+
+    # Save a NEW body for `value` via the write-surface method editor (ADR 0082).
+    # The body is passed as a String value end-to-end — no eval-string escaping.
+    save_html =
+      view
+      |> form("form[phx-submit='save_method']")
+      |> render_submit(%{
+        "class" => class,
+        "selector" => "value",
+        "source" => "value => self.value + 100"
+      })
+
+    assert save_html =~ "Saved value on #{class}"
+    # ChangeLog coherence: the saved (class, selector) appears in the changes pane.
+    assert save_html =~ class
+    assert save_html =~ "value"
+
+    # A subsequent eval on a freshly-spawned actor observes the patched behaviour
+    # (compiled + flushed into the live BEAM module on the workspace node).
+    name2 = "ec2_#{suffix}"
+    view |> form("form") |> render_submit(%{expr: "#{name2} := #{class} spawn"})
+
+    assert eventually(fn ->
+             html = view |> form("form") |> render_submit(%{expr: "#{name2} value"})
+             html =~ "101"
+           end)
+  end
+
+  test "method editor: an invalid edit renders a structured error (BT-2409)", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    suffix = System.unique_integer([:positive])
+    class = "BadEdit#{suffix}"
+
+    class_src = """
+    Actor subclass: #{class}
+      state: value = 0
+
+      value => self.value
+    """
+
+    view |> form("form") |> render_submit(%{expr: class_src})
+
+    # A syntactically broken body fails to compile; the write-surface returns a
+    # structured #beamtalk_error{} which the LiveView renders as an actionable
+    # message (NOT a flattened internal tuple/string).
+    html =
+      view
+      |> form("form[phx-submit='save_method']")
+      |> render_submit(%{
+        "class" => class,
+        "selector" => "value",
+        "source" => "value => self.value +"
+      })
+
+    # The save-result success line must NOT appear; an error message must.
+    refute html =~ "Saved value on #{class}"
+    # Rendered via render_error/1 — a human-readable message, not a raw {error, …}.
+    refute html =~ "{:error,"
+    assert html =~ "Could not compile" or html =~ "compile" or html =~ "error"
+  end
+
+  test "method editor validates an empty class before any save (BT-2409)", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+
+    html =
+      view
+      |> form("form[phx-submit='save_method']")
+      |> render_submit(%{"class" => "", "selector" => "value", "source" => "value => 1"})
+
+    assert html =~ "Enter a class name"
+  end
+
   # ~6s total — generous for cross-node async transcript delivery under CI load.
   defp eventually(fun, retries \\ 120) do
     cond do


### PR DESCRIPTION
Wave 3 of the LiveView IDE epic ([BT-2398](https://linear.app/beamtalk/issue/BT-2398), ADR 0017 Phase 3). Builds on the merged Wave 1 (BT-2407) + Wave 2 (BT-2408) to add **writing** code from the LiveView: method-level edit / save / flush through the **write-surface (ADR 0082)**.

Linear: https://linear.app/beamtalk/issue/BT-2409

## What this does

Under Attach this is structurally clean: Phoenix's dev reloader and the workspace hot-patch (compile/flush/ChangeLog, ADR 0082) live in separate VMs / code servers and do not fight. Editing a class is just another RPC against the workspace; a subsequent eval reflects the new code with no Phoenix-side reload.

Per ADR 0082 there are **no new workspace-side ops** — method save / flush / changes are existing Beamtalk-level operations. The LiveView consumes them over the Attach term path (JSON stays at the WS edge):

- **`BtAttach.Workspace.save_method/3`** — durable live-patch via the runtime install chokepoint `beamtalk_repl_eval:compile_method/6`, passing the method body as a **String value** (not a `compile:source:` eval-string, which would force escaping quotes / backslashes / `{` interpolation markers — the exact fragility ADR 0082 calls out). `>>`, `compile:source:`, and this entry converge at the same in-memory install + ChangeLog append, so the saved method is compiled, flushed into the live BEAM module, and recorded in the change history in one step. Author stamped `liveview` / `human`.
- **`Workspace.flush/0`** — "Save All to Disk" via `beamtalk_workspace_flush:flush/0` (term contract, never raises on a normal conflict); renders the `FlushResult` summary with conflicts / skipped surfaced.
- **`Workspace.change_history/0`** — the active `Workspace changes` view via a single `change_entries/0` RPC returning plain `$beamtalk_class`-tagged maps (no opaque `#entry{}` records crossing the node boundary, no N+1 round-trips).
- **Method Editor + Changes panes** in `workspace_live.ex` — edit class/selector/source, Save, Flush; failed compile/save renders the structured `#beamtalk_error{}` via `render_error/1` (not a flattened string); the ChangeLog pane shows the recorded entry (ChangeLog coherence).

## Acceptance criteria

- ✅ Method editor: edit + save a method via the write-surface op (ADR 0082).
- ✅ Save → flush: the saved method is compiled + flushed; a subsequent eval observes the new behaviour (covered by the `:workspace` e2e).
- ✅ Errors surface structurally: a failed compile/save returns `#beamtalk_error{}` through the term contract and renders as an actionable error.
- ✅ ChangeLog coherence: edits are recorded per ADR 0082 and shown in the Changes pane.
- ✅ Tests: default-run units for flush rendering/validation; `@tag :workspace` e2e for edit→save→eval-observes-change and an invalid-edit structured error.

## Notes

- **No Erlang changes** — purely consumes the existing write-surface (`compile_method/6`, `flush/0`, `change_entries/0`, `ensure_structured_error/1`, all already exported).
- No surface-parity table change: the LiveView is a UI consumer of the existing `eval`-driven write-surface (`live-edit-method`, `flush`, `new-class` rows already documented), not a new operation.
- `mix compile --warnings-as-errors` clean, `mix format --check-formatted` clean, `mix test` (default, non-`:workspace`) green (35 tests, 8 `:workspace` excluded as expected).

https://claude.ai/code/session_01SooajdpU9eNrWvq3hNMoTK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SooajdpU9eNrWvq3hNMoTK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Method Editor pane for creating and editing durable class methods.
  * Save workflow with validation and user-facing success/error feedback.
  * Flush (persist) workflow with concise flush-summary status messages.
  * Change history table showing newest-first pending changes.

* **Tests**
  * End-to-end coverage for save, compile-error rendering, and empty-field validation.
  * Unit tests for flush-summary rendering and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->