### PR TITLE
LiveView IDE Wave 4: multi-tab / session-resume polish + hot-reload coherence (BT-2410)

### DIFF
--- a/editors/liveview/assets/js/app.js
+++ b/editors/liveview/assets/js/app.js
@@ -14,9 +14,29 @@ const csrfToken = document
   .querySelector("meta[name='csrf-token']")
   .getAttribute("content")
 
+// Per-TAB workspace token (BT-2410 Wave 4). Stored in `sessionStorage`, which is
+// scoped to a single browser tab and survives a page reload / socket reconnect
+// of *that* tab — but is NOT shared between tabs. So:
+//   * two tabs  → two distinct tokens → two isolated workspace sessions;
+//   * reload / reconnect of one tab → same token → resume that tab's session.
+// The token rides on the LiveSocket `params`, so the server reads it back on
+// every (re)connect via `get_connect_params/1` and re-binds to the live session.
+function tabToken() {
+  const key = "bt_workspace_token"
+  let token = window.sessionStorage.getItem(key)
+  if (!token) {
+    token =
+      window.crypto && window.crypto.randomUUID
+        ? window.crypto.randomUUID()
+        : `tab-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    window.sessionStorage.setItem(key, token)
+  }
+  return token
+}
+
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
-  params: { _csrf_token: csrfToken },
+  params: { _csrf_token: csrfToken, workspace_token: tabToken() },
 })
 
 // Connect if there are any LiveViews on the page.

--- a/editors/liveview/assets/js/app.js
+++ b/editors/liveview/assets/js/app.js
@@ -23,13 +23,25 @@ const csrfToken = document
 // every (re)connect via `get_connect_params/1` and re-binds to the live session.
 function tabToken() {
   const key = "bt_workspace_token"
-  let token = window.sessionStorage.getItem(key)
+  // tabToken() runs during LiveSocket construction, so a sessionStorage that
+  // throws (private mode, storage disabled) must not abort init — fall back to
+  // an ephemeral per-page token.
+  let token = null
+  try {
+    token = window.sessionStorage.getItem(key)
+  } catch (_err) {
+    token = null
+  }
   if (!token) {
     token =
       window.crypto && window.crypto.randomUUID
         ? window.crypto.randomUUID()
         : `tab-${Date.now()}-${Math.random().toString(36).slice(2)}`
-    window.sessionStorage.setItem(key, token)
+    try {
+      window.sessionStorage.setItem(key, token)
+    } catch (_err) {
+      // Storage unavailable: keep the ephemeral token for this page lifetime.
+    }
   }
   return token
 }

--- a/editors/liveview/config/test.exs
+++ b/editors/liveview/config/test.exs
@@ -10,6 +10,12 @@ config :bt_attach, BtAttachWeb.Endpoint,
 # Print only warnings and errors during test
 config :logger, level: :warning
 
+# A short session-resume grace window for the workspace-gated reconnect tests
+# (BT-2410 Wave 4): long enough to bridge a same-tab reconnect within a test, but
+# short enough that the teardown-on-disconnect assertion does not stall waiting
+# for a reap. Production uses the 30s default in `BtAttach.SessionRegistry`.
+config :bt_attach, :session_reap_after_ms, 300
+
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 

--- a/editors/liveview/lib/bt_attach/application.ex
+++ b/editors/liveview/lib/bt_attach/application.ex
@@ -11,8 +11,11 @@ defmodule BtAttach.Application do
       BtAttachWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:bt_attach, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: BtAttach.PubSub},
-      # Start a worker by calling: BtAttach.Worker.start_link(arg)
-      # {BtAttach.Worker, arg},
+      # Per-tab workspace-session registry (BT-2410 Wave 4): owns the
+      # resume/cleanup lifecycle that lets a reconnecting LiveView re-bind to its
+      # tab's existing session and reaps sessions for tabs that close. Started
+      # before the Endpoint so it is available to the first connected mount.
+      BtAttach.SessionRegistry,
       # Start to serve requests, typically the last entry
       BtAttachWeb.Endpoint
     ]

--- a/editors/liveview/lib/bt_attach/session_registry.ex
+++ b/editors/liveview/lib/bt_attach/session_registry.ex
@@ -1,0 +1,304 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttach.SessionRegistry do
+  @moduledoc """
+  Per-tab workspace-session registry for the LiveView IDE (BT-2410 Wave 4).
+
+  ## Why this exists
+
+  Each browser tab gets its own isolated workspace-supervised session (proven at
+  the raw-distribution level in the BT-2394 spike: tab1 `x=100`, tab2 `x=999`).
+  Wave 1 created a *fresh* session on every connected `mount/3` and tore it down
+  in `terminate/2`. That is correct for isolation, but it loses two things this
+  wave needs:
+
+    * **Session resume.** A LiveView reconnect (transient socket drop, or a page
+      reload that re-establishes the WebSocket) mounts a brand-new LiveView
+      process. Starting a fresh session there discards the tab's accumulated eval
+      state (bindings, spawned actors, loaded classes). We want the reconnecting
+      tab to *re-bind* to the session it already had.
+    * **No leaks across that gap.** If `terminate/2` immediately closed the
+      session, the reconnecting mount would always find it gone. So teardown must
+      be *deferred* through a short grace window — long enough to bridge a
+      reconnect, short enough that a tab that is really gone does not leak an
+      orphaned session.
+
+  This registry owns exactly that lifecycle. It maps a stable, per-tab `token`
+  (minted in the browser's `sessionStorage` and replayed on every (re)connect via
+  the LiveSocket `params`, see `assets/js/app.js`) to the live workspace session.
+
+  ## Lifecycle
+
+    * `checkout/1` — called on the *connected* mount. If a live session exists for
+      the token, its pending reap is cancelled and `{:resumed, session_id, pid}`
+      is returned so the LiveView re-binds (resubscribes streams + re-reads
+      bindings) instead of starting a new session. Otherwise `:miss`.
+    * `register/3` — records a freshly-started session for the token and monitors
+      the remote session pid, so a workspace-side death drops the stale entry.
+    * `release/1` — called from `terminate/2`. Schedules a grace-period reap; a
+      `checkout/1` within the window cancels it (that is the resume). If the
+      window elapses with no reconnect, the registry closes the
+      workspace-supervised session (`Workspace.close_session/1`) and drops the
+      entry — the "no orphaned sessions" guarantee.
+
+  Tokens are isolated per tab, so two tabs never share an entry: multi-tab
+  isolation falls straight out of distinct keys.
+
+  The registry is process-side state on the Phoenix node only; the workspace
+  needs no changes (sessions are looked up here, never re-derived on the
+  workspace, which has no by-id session registry).
+
+  ## Tokens are NOT an auth boundary
+
+  The per-tab token is a random, client-held *resume key*, not a credential. It
+  scopes a tab to its own session and lets that tab reconnect to it; it does not
+  authenticate the client. In today's single-user localhost Attach model the
+  Erlang distribution cookie is the only auth boundary (per the BT-2394 spike's
+  auth notes and the deferred auth ADR). A multi-user deployment must add real
+  per-user authorization in front of this registry — token possession alone must
+  never be allowed to grant access to another user's session.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias BtAttach.Workspace
+
+  # Grace window between a LiveView disconnect and reaping its session. Long
+  # enough to bridge a transient socket drop / quick reload, short enough that a
+  # genuinely-closed tab does not hold a workspace session for long. Overridable
+  # in config (tests use a tiny value to assert reaping without waiting).
+  @default_reap_after_ms 30_000
+
+  defmodule Entry do
+    @moduledoc false
+    @enforce_keys [:session_id, :session_pid]
+    defstruct [:session_id, :session_pid, :monitor_ref, :reap_timer]
+  end
+
+  ## Public API
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @doc """
+  Look up the live session for `token`, cancelling any pending reap.
+
+  Returns `{:resumed, session_id, session_pid}` when a live session is held for
+  the token (the reconnect/resume path), or `:miss` when there is none (the
+  first-connect path, where the caller starts a fresh session and `register/3`s
+  it). A `nil` or non-binary token always misses, so a client that never sent a
+  token simply gets fresh, non-resumable sessions.
+  """
+  @spec checkout(GenServer.server(), term()) ::
+          {:resumed, String.t(), pid()} | :miss
+  def checkout(server \\ __MODULE__, token)
+  def checkout(_server, token) when not is_binary(token), do: :miss
+  def checkout(server, token), do: GenServer.call(server, {:checkout, token})
+
+  @doc """
+  Record a freshly-started session for `token` and monitor its remote pid.
+
+  Idempotent per token: registering a new session for a token that already holds
+  one cancels the old entry's reap and closes the *previous* session, so a token
+  never accumulates more than one live session (no leak if a client re-registers).
+  """
+  @spec register(GenServer.server(), term(), String.t(), pid()) :: :ok
+  def register(server \\ __MODULE__, token, session_id, session_pid)
+
+  def register(_server, token, _session_id, _session_pid) when not is_binary(token), do: :ok
+
+  def register(server, token, session_id, session_pid)
+      when is_binary(session_id) and is_pid(session_pid) do
+    GenServer.call(server, {:register, token, session_id, session_pid})
+  end
+
+  @doc """
+  Close `token`'s session immediately and forget it (no grace window).
+
+  Used when a mount fails mid-bind, so a half-started session can't linger for the
+  grace period. A `nil`/non-binary or unknown token is a harmless no-op.
+  """
+  @spec discard(GenServer.server(), term()) :: :ok
+  def discard(server \\ __MODULE__, token)
+  def discard(_server, token) when not is_binary(token), do: :ok
+  def discard(server, token), do: GenServer.call(server, {:discard, token})
+
+  @doc """
+  Mark `token`'s session releasable: schedule a grace-period reap.
+
+  Called from the LiveView's `terminate/2`. If the same tab reconnects within the
+  grace window, the subsequent `checkout/1` cancels the reap and the session is
+  resumed. Otherwise the registry closes the workspace session and forgets the
+  token. A `nil`/non-binary or unknown token is a harmless no-op.
+  """
+  @spec release(GenServer.server(), term()) :: :ok
+  def release(server \\ __MODULE__, token)
+  def release(_server, token) when not is_binary(token), do: :ok
+  def release(server, token), do: GenServer.cast(server, {:release, token})
+
+  ## GenServer callbacks
+
+  @impl true
+  def init(opts) do
+    reap_after = Keyword.get(opts, :reap_after_ms, configured_reap_after())
+    {:ok, %{entries: %{}, reap_after_ms: reap_after}}
+  end
+
+  @impl true
+  def handle_call({:checkout, token}, _from, state) do
+    case Map.fetch(state.entries, token) do
+      {:ok, %Entry{session_id: session_id, session_pid: pid} = entry} ->
+        # Resume: cancel any pending reap so the session is not torn down out from
+        # under the reconnecting LiveView.
+        entry = cancel_reap(entry)
+        state = put_entry(state, token, entry)
+        {:reply, {:resumed, session_id, pid}, state}
+
+      :error ->
+        {:reply, :miss, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:register, token, session_id, session_pid}, _from, state) do
+    # If this token already had a session (e.g. a re-register without a clean
+    # release), close the old one first so we never leak it.
+    state = close_existing(state, token)
+
+    ref = Process.monitor(session_pid)
+    entry = %Entry{session_id: session_id, session_pid: session_pid, monitor_ref: ref}
+    {:reply, :ok, put_entry(state, token, entry)}
+  end
+
+  @impl true
+  def handle_call({:discard, token}, _from, state) do
+    {:reply, :ok, close_existing(state, token)}
+  end
+
+  @impl true
+  def handle_cast({:release, token}, state) do
+    case Map.fetch(state.entries, token) do
+      {:ok, entry} ->
+        # Replace any existing reap timer (a release after a release just resets
+        # the window) and arm a fresh one.
+        entry = cancel_reap(entry)
+        timer = Process.send_after(self(), {:reap, token}, state.reap_after_ms)
+        {:noreply, put_entry(state, token, %Entry{entry | reap_timer: timer})}
+
+      :error ->
+        {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_info({:reap, token}, state) do
+    case Map.fetch(state.entries, token) do
+      {:ok, %Entry{reap_timer: timer} = entry} when timer != nil ->
+        # The grace window elapsed without a reconnect: close the
+        # workspace-supervised session and forget the token. This is the
+        # no-orphaned-sessions guarantee for genuinely-closed tabs.
+        demonitor(entry)
+        close_session(entry)
+        {:noreply, drop_entry(state, token)}
+
+      _ ->
+        # Timer was cancelled (resumed) or entry gone — nothing to do.
+        {:noreply, state}
+    end
+  end
+
+  # A monitored remote session pid died (e.g. the workspace itself terminated the
+  # session). Drop the now-stale entry; a later checkout will miss and the
+  # LiveView will start a fresh session.
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    state =
+      case Enum.find(state.entries, fn {_t, e} -> e.monitor_ref == ref end) do
+        {token, entry} ->
+          entry = cancel_reap(entry)
+          drop_entry(state, token, entry)
+
+        nil ->
+          state
+      end
+
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  ## Internals
+
+  defp configured_reap_after do
+    Application.get_env(:bt_attach, :session_reap_after_ms, @default_reap_after_ms)
+  end
+
+  defp put_entry(state, token, entry) do
+    %{state | entries: Map.put(state.entries, token, entry)}
+  end
+
+  defp drop_entry(state, token) do
+    %{state | entries: Map.delete(state.entries, token)}
+  end
+
+  # Drop an entry but cancel its monitor first so we don't leak monitors.
+  defp drop_entry(state, token, %Entry{} = entry) do
+    demonitor(entry)
+    drop_entry(state, token)
+  end
+
+  defp close_existing(state, token) do
+    case Map.fetch(state.entries, token) do
+      {:ok, entry} ->
+        entry = cancel_reap(entry)
+        demonitor(entry)
+        close_session(entry)
+        drop_entry(state, token)
+
+      :error ->
+        state
+    end
+  end
+
+  defp cancel_reap(%Entry{reap_timer: nil} = entry), do: entry
+
+  defp cancel_reap(%Entry{reap_timer: timer} = entry) do
+    Process.cancel_timer(timer)
+    %Entry{entry | reap_timer: nil}
+  end
+
+  defp demonitor(%Entry{monitor_ref: nil}), do: :ok
+
+  defp demonitor(%Entry{monitor_ref: ref}) do
+    Process.demonitor(ref, [:flush])
+    :ok
+  end
+
+  # Best-effort close of the workspace-supervised session, performed in a DETACHED
+  # process so a slow/hung workspace RPC can never block the registry GenServer.
+  #
+  # The registry is a shared singleton: every tab's checkout/register goes through
+  # its mailbox. `Workspace.close_session/1` is a synchronous `:rpc.call` with no
+  # timeout, so closing inline would let one unreachable workspace stall every
+  # tab's session lookup (head-of-line blocking). The remote close is fire-and-
+  # forget — the registry's own job (forget the entry) is already done — so we
+  # spawn it. Errors are non-fatal: the session may already be gone, or the
+  # workspace unreachable; either way the entry is dropped.
+  defp close_session(%Entry{session_pid: pid}) when is_pid(pid) do
+    _ =
+      spawn(fn ->
+        case Workspace.close_session(pid) do
+          :ok -> :ok
+          other -> Logger.debug("session reap close returned #{inspect(other)}")
+        end
+      end)
+
+    :ok
+  end
+
+  defp close_session(_entry), do: :ok
+end

--- a/editors/liveview/lib/bt_attach/session_registry.ex
+++ b/editors/liveview/lib/bt_attach/session_registry.ex
@@ -75,7 +75,7 @@ defmodule BtAttach.SessionRegistry do
   defmodule Entry do
     @moduledoc false
     @enforce_keys [:session_id, :session_pid]
-    defstruct [:session_id, :session_pid, :monitor_ref, :reap_timer]
+    defstruct [:session_id, :session_pid, :monitor_ref, :reap_timer, :reap_tag]
   end
 
   ## Public API
@@ -184,10 +184,13 @@ defmodule BtAttach.SessionRegistry do
     case Map.fetch(state.entries, token) do
       {:ok, entry} ->
         # Replace any existing reap timer (a release after a release just resets
-        # the window) and arm a fresh one.
+        # the window) and arm a fresh one. Tag the timer with a unique ref so a
+        # stale {:reap, token, _} still in the mailbox (cancel_timer lost the
+        # race with an already-fired timer) can't reap this newer window.
         entry = cancel_reap(entry)
-        timer = Process.send_after(self(), {:reap, token}, state.reap_after_ms)
-        {:noreply, put_entry(state, token, %Entry{entry | reap_timer: timer})}
+        reap_tag = make_ref()
+        timer = Process.send_after(self(), {:reap, token, reap_tag}, state.reap_after_ms)
+        {:noreply, put_entry(state, token, %Entry{entry | reap_timer: timer, reap_tag: reap_tag})}
 
       :error ->
         {:noreply, state}
@@ -195,9 +198,9 @@ defmodule BtAttach.SessionRegistry do
   end
 
   @impl true
-  def handle_info({:reap, token}, state) do
+  def handle_info({:reap, token, reap_tag}, state) do
     case Map.fetch(state.entries, token) do
-      {:ok, %Entry{reap_timer: timer} = entry} when timer != nil ->
+      {:ok, %Entry{reap_timer: timer, reap_tag: ^reap_tag} = entry} when timer != nil ->
         # The grace window elapsed without a reconnect: close the
         # workspace-supervised session and forget the token. This is the
         # no-orphaned-sessions guarantee for genuinely-closed tabs.
@@ -268,7 +271,7 @@ defmodule BtAttach.SessionRegistry do
 
   defp cancel_reap(%Entry{reap_timer: timer} = entry) do
     Process.cancel_timer(timer)
-    %Entry{entry | reap_timer: nil}
+    %Entry{entry | reap_timer: nil, reap_tag: nil}
   end
 
   defp demonitor(%Entry{monitor_ref: nil}), do: :ok

--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -101,6 +101,44 @@ defmodule BtAttach.Workspace do
   end
 
   @doc """
+  Check whether a workspace session pid is still alive (BT-2410 Wave 4).
+
+  Used by the resume path: before re-binding a reconnecting LiveView to a session
+  the Phoenix-side registry still remembers, we confirm the remote session
+  process actually exists — the workspace could have restarted between the
+  disconnect and the reconnect, leaving the registry entry stale.
+
+  `is_process_alive/1` is evaluated **on the workspace node**, where the session
+  pid is local (a remote `is_process_alive/1` would `badarg`). Returns a boolean
+  for a reachable workspace; an unreachable workspace yields `{:badrpc, _}`, which
+  the caller treats as not-alive (resume falls back to a fresh session).
+  """
+  def session_alive?(session_pid) when is_pid(session_pid) do
+    case rpc(:erlang, :is_process_alive, [session_pid]) do
+      result when is_boolean(result) -> result
+      {:badrpc, _reason} -> false
+    end
+  end
+
+  @doc """
+  Count the workspace-supervised sessions currently alive (BT-2410 Wave 4).
+
+  A read-only probe of `beamtalk_session_sup`'s active children, used by the
+  session-teardown tests to assert that closing a LiveView (after the resume
+  grace window) leaves no orphaned session. Returns the active-child count for a
+  reachable workspace, or `{:error, {:unreachable, _}}` otherwise.
+  """
+  def session_count do
+    case rpc(:supervisor, :count_children, [:beamtalk_session_sup]) do
+      counts when is_list(counts) ->
+        Keyword.get(counts, :active, 0)
+
+      {:badrpc, reason} ->
+        {:error, {:unreachable, reason}}
+    end
+  end
+
+  @doc """
   Evaluate a Beamtalk expression in `session_pid` through the curated op layer's
   term-returning seam (`beamtalk_repl_ops:dispatch/4`, BT-2399).
 

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -33,75 +33,45 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   require Logger
 
+  alias BtAttach.SessionRegistry
   alias BtAttach.Workspace
 
   @impl true
   def mount(_params, _session, socket) do
-    # Only attach over distribution on the *connected* (WebSocket) mount — the
-    # initial disconnected HTTP render would otherwise create a second, orphaned
-    # workspace session on every page load.
+    # LiveView `mount/3` runs TWICE: first on the disconnected HTTP render, then
+    # on the connected WebSocket mount (and again on every reconnect). Only the
+    # *connected* mount attaches over distribution — the disconnected render must
+    # NOT create a workspace session, or every page load would leak an orphaned
+    # one. The per-tab resume token is only present on the connected mount (it
+    # rides the LiveSocket `params`), so `get_connect_params/1` is the right read.
     if connected?(socket) do
-      attach(socket)
+      token = connect_token(socket)
+      attach(assign(socket, :token, token))
     else
-      {:ok, assign(socket, connected: false, error: nil)}
+      {:ok, assign(socket, connected: false, error: nil, token: nil)}
     end
   end
 
-  defp attach(socket) do
+  # The per-tab token minted in `sessionStorage` (assets/js/app.js) and replayed
+  # on every (re)connect. `get_connect_params/1` is only available on the
+  # connected mount; a non-binary/absent value just disables resume (each connect
+  # gets a fresh, non-resumable session) rather than crashing.
+  defp connect_token(socket) do
+    case get_connect_params(socket) do
+      %{"workspace_token" => token} when is_binary(token) -> token
+      _ -> nil
+    end
+  end
+
+  defp attach(%{assigns: %{token: token}} = socket) do
     socket =
       case Workspace.connect() do
         :ok ->
-          session_id = "phoenix-#{System.unique_integer([:positive])}"
-
-          case Workspace.start_session(session_id) do
-            pid when is_pid(pid) ->
-              # Subscribe THIS LiveView pid (location-transparent over dist) to
-              # the Transcript AND bindings streams through the BT-2399 facade —
-              # no direct gen_server cast. The facade's cast returns `:ok`; any
-              # non-ok reply (`{:badrpc, _}`) means a stream is NOT live, so we
-              # must not render the pane as connected and claim a working stream.
-              # Pattern-match both subscribe results (Wave-1 review rule) and tear
-              # the half-started session back down on any failure so it can't leak.
-              with :ok <- Workspace.subscribe_transcript(self()),
-                   :ok <- Workspace.subscribe_bindings(self()) do
-                socket
-                |> assign(:connected, true)
-                |> assign(:node, Workspace.node_name())
-                |> assign(:session_id, session_id)
-                |> assign(:session_pid, pid)
-                |> assign(:result, nil)
-                |> assign(:output, nil)
-                |> assign(:error, nil)
-                |> assign(:expr, "3 + 4")
-                |> assign(:inspect_target, nil)
-                |> assign(:inspect_rows, [])
-                |> assign(:inspect_error, nil)
-                # Method editor (Wave 3): the write-surface edit/save/flush pane.
-                |> assign(:edit_class, "")
-                |> assign(:edit_selector, "")
-                |> assign(:edit_source, "")
-                |> assign(:save_result, nil)
-                |> assign(:save_error, nil)
-                |> assign(:flush_result, nil)
-                |> assign(:flush_error, nil)
-                |> assign_bindings(pid)
-                |> assign_changes()
-                |> stream(:transcript, [])
-              else
-                other ->
-                  Logger.error("subscribe failed: #{inspect(other)}")
-                  # Drop whichever subscription may have succeeded before closing
-                  # the session, so we don't leave a dangling subscriber pushing
-                  # to a pid we're about to abandon.
-                  Workspace.unsubscribe_transcript(self())
-                  Workspace.unsubscribe_bindings(self())
-                  Workspace.close_session(pid)
-
-                  assign(socket,
-                    connected: false,
-                    error: "subscribe failed: #{inspect(other)}"
-                  )
-              end
+          # Resume the tab's existing session if the registry still holds a live
+          # one (reconnect within the grace window); otherwise start fresh.
+          case resume_or_start(token) do
+            {:ok, session_id, pid} ->
+              bind_session(socket, session_id, pid)
 
             {:error, reason} ->
               assign(socket,
@@ -116,6 +86,117 @@ defmodule BtAttachWeb.WorkspaceLive do
 
     {:ok, socket}
   end
+
+  # Resume the tab's session if the registry has a *live* one for this token,
+  # else start a brand-new workspace-supervised session and register it.
+  #
+  # A registry hit is only trusted if the remote session pid is still reachable:
+  # the workspace could have died/restarted between the disconnect and this
+  # reconnect, leaving a stale entry. We probe with a cheap `is_process_alive/1`
+  # on the workspace node (`Workspace.session_alive?/1`) and fall back to a fresh
+  # session on a dead pid, so resume never claims success on a session that is
+  # already gone.
+  defp resume_or_start(token) do
+    case token && SessionRegistry.checkout(token) do
+      {:resumed, session_id, pid} ->
+        if Workspace.session_alive?(pid) do
+          {:ok, session_id, pid}
+        else
+          # Stale entry (workspace restarted): discard it and start fresh.
+          SessionRegistry.discard(token)
+          start_fresh(token)
+        end
+
+      _miss ->
+        start_fresh(token)
+    end
+  end
+
+  defp start_fresh(token) do
+    session_id = "phoenix-#{System.unique_integer([:positive])}"
+
+    case Workspace.start_session(session_id) do
+      pid when is_pid(pid) ->
+        # Register before binding so a crash mid-bind can't leak: the registry
+        # owns the close, keyed by the tab token (a nil token simply skips
+        # registration — that session is non-resumable and closed in terminate/2).
+        SessionRegistry.register(token, session_id, pid)
+        {:ok, session_id, pid}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Subscribe THIS LiveView pid (location-transparent over dist) to the Transcript
+  # AND bindings streams through the BT-2399 facade — no direct gen_server cast.
+  # The facade's cast returns `:ok`; any non-ok reply (`{:badrpc, _}`) means a
+  # stream is NOT live, so we must not render the pane as connected and claim a
+  # working stream. Pattern-match both subscribe results (Wave-1 review rule) and,
+  # on failure, release the session through the registry so it can't leak.
+  #
+  # Shared by the fresh-start and resume paths: on resume the same subscribe +
+  # bindings re-read re-establishes the live streams for the new LiveView pid
+  # (the old pid's subscriptions died with it), so the resumed tab gets its
+  # Transcript and bindings flowing again with its accumulated state intact.
+  defp bind_session(socket, session_id, pid) do
+    with :ok <- Workspace.subscribe_transcript(self()),
+         :ok <- Workspace.subscribe_bindings(self()) do
+      socket
+      |> assign(:connected, true)
+      |> assign(:node, Workspace.node_name())
+      |> assign(:session_id, session_id)
+      |> assign(:session_pid, pid)
+      |> assign(:result, nil)
+      |> assign(:output, nil)
+      |> assign(:error, nil)
+      |> assign(:expr, "3 + 4")
+      |> assign(:inspect_target, nil)
+      |> assign(:inspect_rows, [])
+      |> assign(:inspect_error, nil)
+      # Method editor (Wave 3): the write-surface edit/save/flush pane.
+      |> assign(:edit_class, "")
+      |> assign(:edit_selector, "")
+      |> assign(:edit_source, "")
+      |> assign(:save_result, nil)
+      |> assign(:save_error, nil)
+      |> assign(:flush_result, nil)
+      |> assign(:flush_error, nil)
+      |> assign_bindings(pid)
+      |> assign_changes()
+      |> stream(:transcript, [])
+    else
+      other ->
+        Logger.error("subscribe failed: #{inspect(other)}")
+        # Drop whichever subscription may have succeeded, then release the
+        # session through the registry (which closes it) so we don't leave a
+        # dangling subscriber or an orphaned session behind.
+        Workspace.unsubscribe_transcript(self())
+        Workspace.unsubscribe_bindings(self())
+        force_close(socket.assigns[:token], pid)
+
+        assign(socket,
+          connected: false,
+          error: "subscribe failed: #{inspect(other)}"
+        )
+    end
+  end
+
+  # Close a session immediately (not via the grace timer): used when binding
+  # fails, so a half-started session can't linger. A registered token is
+  # discarded (the registry closes + forgets it now); an unregistered (nil-token)
+  # session is closed directly.
+  defp force_close(token, _pid) when is_binary(token) do
+    SessionRegistry.discard(token)
+    :ok
+  end
+
+  defp force_close(_token, pid) when is_pid(pid) do
+    Workspace.close_session(pid)
+    :ok
+  end
+
+  defp force_close(_token, _pid), do: :ok
 
   @impl true
   def handle_event("eval", %{"expr" => expr}, %{assigns: %{session_pid: pid}} = socket)
@@ -228,21 +309,37 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   @impl true
   def terminate(_reason, socket) do
-    # Best-effort: drop our Transcript subscription so the workspace doesn't keep
-    # pushing to a dead pid. The event server also auto-removes dead subscribers
-    # via its monitor, so this is belt-and-braces.
+    # Best-effort: drop our Transcript + bindings subscriptions so the workspace
+    # doesn't keep pushing to this (now-dead) pid. The event server also
+    # auto-removes dead subscribers via its monitor, so this is belt-and-braces.
     #
-    # Crucially also CLOSE the workspace-supervised session: it is owned by the
-    # workspace's `beamtalk_session_sup`, not by this LiveView process, so it does
-    # NOT go away when we exit. Without this we leak one orphaned session per
-    # mount/reconnect (the session-lifecycle acceptance criterion).
+    # Then hand the session to the registry's grace window rather than closing it
+    # outright. A LiveView `terminate/2` fires on BOTH a real tab close AND a
+    # transient socket drop (the latter immediately re-mounts and reconnects). If
+    # we closed the session here, a reconnect would always find it gone and lose
+    # the tab's accumulated state. So `release/1` schedules a short reap that a
+    # reconnecting `checkout/1` cancels (resume); if no reconnect arrives, the
+    # registry closes the workspace-supervised session — no orphaned sessions.
+    #
+    # The session is owned by the workspace's `beamtalk_session_sup` (not this
+    # LiveView process), so it does NOT go away just because we exit — the
+    # registry's reap is what actually reclaims it.
     if socket.assigns[:connected] do
       Workspace.unsubscribe_transcript(self())
       Workspace.unsubscribe_bindings(self())
 
-      case socket.assigns[:session_pid] do
-        pid when is_pid(pid) -> Workspace.close_session(pid)
-        _ -> :ok
+      case socket.assigns[:token] do
+        token when is_binary(token) ->
+          # Resumable session: defer teardown to the grace window.
+          SessionRegistry.release(token)
+
+        _ ->
+          # No token (resume disabled): nothing in the registry owns this
+          # session, so close it directly here or it would leak.
+          case socket.assigns[:session_pid] do
+            pid when is_pid(pid) -> Workspace.close_session(pid)
+            _ -> :ok
+          end
       end
     end
 

--- a/editors/liveview/test/bt_attach/session_registry_test.exs
+++ b/editors/liveview/test/bt_attach/session_registry_test.exs
@@ -1,0 +1,136 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttach.SessionRegistryTest do
+  @moduledoc """
+  Pure unit tests for the per-tab workspace-session registry (BT-2410 Wave 4).
+
+  These run without a real workspace: the registry's only workspace coupling is
+  `BtAttach.Workspace.close_session/1`, which RPCs to the (absent) workspace node
+  and returns `{:badrpc, :nodedown}` — handled gracefully. So we drive the full
+  resume / grace-reap / monitor lifecycle against ordinary local pids and assert
+  the registry's bookkeeping (checkout/register/release/discard/down) directly.
+  """
+  use ExUnit.Case, async: true
+
+  alias BtAttach.SessionRegistry
+
+  # A fast reap window so the grace-period assertions don't slow the suite.
+  @reap_ms 50
+
+  setup do
+    # A named-per-test registry so async tests don't share state.
+    name = :"reg_#{System.unique_integer([:positive])}"
+    start_supervised!({SessionRegistry, name: name, reap_after_ms: @reap_ms})
+    {:ok, reg: name}
+  end
+
+  # A stand-in for a remote workspace session pid: just a live local process we
+  # can register, monitor, and kill.
+  defp fake_session do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      end
+    end)
+  end
+
+  test "checkout misses for an unknown or nil/non-binary token", %{reg: reg} do
+    assert SessionRegistry.checkout(reg, "never-registered") == :miss
+    assert SessionRegistry.checkout(reg, nil) == :miss
+    assert SessionRegistry.checkout(reg, 123) == :miss
+  end
+
+  test "register then checkout resumes the same session for a token", %{reg: reg} do
+    pid = fake_session()
+    assert :ok = SessionRegistry.register(reg, "tab-1", "phoenix-1", pid)
+
+    assert {:resumed, "phoenix-1", ^pid} = SessionRegistry.checkout(reg, "tab-1")
+    # Resume is repeatable while the entry is live.
+    assert {:resumed, "phoenix-1", ^pid} = SessionRegistry.checkout(reg, "tab-1")
+  end
+
+  test "two tabs map to two isolated entries (multi-tab isolation)", %{reg: reg} do
+    pid1 = fake_session()
+    pid2 = fake_session()
+    SessionRegistry.register(reg, "tab-a", "phoenix-a", pid1)
+    SessionRegistry.register(reg, "tab-b", "phoenix-b", pid2)
+
+    assert {:resumed, "phoenix-a", ^pid1} = SessionRegistry.checkout(reg, "tab-a")
+    assert {:resumed, "phoenix-b", ^pid2} = SessionRegistry.checkout(reg, "tab-b")
+    refute pid1 == pid2
+  end
+
+  test "release schedules a reap that drops the entry after the grace window", %{reg: reg} do
+    pid = fake_session()
+    SessionRegistry.register(reg, "tab-2", "phoenix-2", pid)
+
+    SessionRegistry.release(reg, "tab-2")
+    # Still resumable immediately after release (grace window open)...
+    assert {:resumed, "phoenix-2", ^pid} = SessionRegistry.checkout(reg, "tab-2")
+
+    # ...but a release with NO intervening checkout reaps after the window.
+    SessionRegistry.release(reg, "tab-2")
+    Process.sleep(@reap_ms * 3)
+    assert SessionRegistry.checkout(reg, "tab-2") == :miss
+  end
+
+  test "a checkout within the grace window cancels the reap (resume)", %{reg: reg} do
+    pid = fake_session()
+    SessionRegistry.register(reg, "tab-3", "phoenix-3", pid)
+
+    SessionRegistry.release(reg, "tab-3")
+    # Reconnect promptly — cancels the pending reap.
+    assert {:resumed, "phoenix-3", ^pid} = SessionRegistry.checkout(reg, "tab-3")
+
+    # Past the original window, the entry is still live (reap was cancelled).
+    Process.sleep(@reap_ms * 3)
+    assert {:resumed, "phoenix-3", ^pid} = SessionRegistry.checkout(reg, "tab-3")
+  end
+
+  test "discard forgets the entry immediately (no grace window)", %{reg: reg} do
+    pid = fake_session()
+    SessionRegistry.register(reg, "tab-4", "phoenix-4", pid)
+
+    assert :ok = SessionRegistry.discard(reg, "tab-4")
+    assert SessionRegistry.checkout(reg, "tab-4") == :miss
+  end
+
+  test "a dead remote session pid drops its entry via the monitor", %{reg: reg} do
+    pid = fake_session()
+    SessionRegistry.register(reg, "tab-5", "phoenix-5", pid)
+    assert {:resumed, "phoenix-5", ^pid} = SessionRegistry.checkout(reg, "tab-5")
+
+    # Kill the (stand-in) workspace session: the monitor should reap the entry.
+    ref = Process.monitor(pid)
+    send(pid, :stop)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1_000
+
+    # Give the registry a beat to process its own DOWN, then the entry is gone.
+    eventually(fn -> SessionRegistry.checkout(reg, "tab-5") == :miss end)
+  end
+
+  test "re-registering a token closes/replaces the prior session", %{reg: reg} do
+    pid1 = fake_session()
+    pid2 = fake_session()
+    SessionRegistry.register(reg, "tab-6", "phoenix-6a", pid1)
+    SessionRegistry.register(reg, "tab-6", "phoenix-6b", pid2)
+
+    # The latest registration wins; the token never holds two sessions.
+    assert {:resumed, "phoenix-6b", ^pid2} = SessionRegistry.checkout(reg, "tab-6")
+  end
+
+  defp eventually(fun, retries \\ 50) do
+    cond do
+      fun.() ->
+        :ok
+
+      retries == 0 ->
+        flunk("condition never became true")
+
+      true ->
+        Process.sleep(10)
+        eventually(fun, retries - 1)
+    end
+  end
+end

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -188,6 +188,76 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert html =~ "Enter a class name"
   end
 
+  # ── Wave 4: multi-tab isolation / session resume / teardown (BT-2410) ────────
+
+  test "two tabs map to two isolated workspace sessions (BT-2410)", %{conn: conn} do
+    # Two distinct per-tab tokens — exactly what `sessionStorage` mints per tab —
+    # must yield two isolated sessions: a binding set in one tab is invisible in
+    # the other (the spike's tab1 x=100 / tab2 x=999 property, now first-class).
+    tab1 = with_token(conn, "tab1-#{System.unique_integer([:positive])}")
+    tab2 = with_token(conn, "tab2-#{System.unique_integer([:positive])}")
+
+    {:ok, view1, _} = live(tab1, "/")
+    {:ok, view2, _} = live(tab2, "/")
+
+    view1 |> form("form") |> render_submit(%{expr: "x := 100"})
+    view2 |> form("form") |> render_submit(%{expr: "x := 999"})
+
+    # Each tab reads back ITS OWN x — no cross-tab leakage.
+    assert view1 |> form("form") |> render_submit(%{expr: "x"}) =~ "100"
+    assert view2 |> form("form") |> render_submit(%{expr: "x"}) =~ "999"
+  end
+
+  test "a reconnect resumes the same session and retains state (BT-2410)", %{conn: conn} do
+    # One tab: same token across two mounts simulates a socket drop + reconnect
+    # (or a page reload re-establishing the WebSocket). The reconnecting LiveView
+    # must re-bind to the SAME workspace session and see its accumulated bindings.
+    conn = with_token(conn, "resume-#{System.unique_integer([:positive])}")
+
+    {:ok, view1, _} = live(conn, "/")
+    view1 |> form("form") |> render_submit(%{expr: "y := 7"})
+    assert view1 |> form("form") |> render_submit(%{expr: "y"}) =~ "7"
+
+    # Disconnect: stopping the LiveView fires terminate/2 → release/1, which opens
+    # the grace window (it does NOT close the session). The same-tab reconnect
+    # below lands inside that window.
+    GenServer.stop(view1.pid)
+
+    {:ok, view2, _} = live(conn, "/")
+    # Resumed onto the same session: the earlier binding is still there, with no
+    # re-eval — state survived the reconnect.
+    assert view2 |> form("form") |> render_submit(%{expr: "y"}) =~ "7"
+    # And the live bindings pane was resubscribed + re-read on resume.
+    assert eventually(fn -> render(view2) =~ "y" end)
+  end
+
+  test "closing a tab tears down its session after the grace window (BT-2410)", %{conn: conn} do
+    # The no-orphaned-sessions guarantee: a tab that closes and never reconnects
+    # has its workspace-supervised session reaped after the (test-shortened) grace
+    # window — the active-session count returns to its pre-mount value.
+    conn = with_token(conn, "teardown-#{System.unique_integer([:positive])}")
+
+    before = BtAttach.Workspace.session_count()
+    assert is_integer(before)
+
+    {:ok, view, _} = live(conn, "/")
+    view |> form("form") |> render_submit(%{expr: "z := 1"})
+    # One more active session while the tab is open.
+    assert eventually(fn -> BtAttach.Workspace.session_count() == before + 1 end)
+
+    # Close the tab and DON'T reconnect: after the grace window the registry reaps
+    # the session, so the count returns to baseline (no leak).
+    GenServer.stop(view.pid)
+    assert eventually(fn -> BtAttach.Workspace.session_count() == before end)
+  end
+
+  # Set the per-tab resume token on the conn so the connected mount reads it back
+  # via `get_connect_params/1` — the test analogue of the `sessionStorage` token
+  # the browser replays on the LiveSocket params.
+  defp with_token(conn, token) do
+    Phoenix.LiveViewTest.put_connect_params(conn, %{"workspace_token" => token})
+  end
+
   # ~6s total — generous for cross-node async transcript delivery under CI load.
   defp eventually(fun, retries \\ 120) do
     cond do


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2410

Fourth wave of the LiveView IDE epic (BT-2398, ADR 0017 Phase 3). Makes multi-tab session isolation, session resume across LiveView reconnects, and session cleanup first-class, tested properties of the productionised LiveView (Attach topology), on top of Waves 1-3 (BT-2407/2408/2409). No Erlang/runtime changes — Elixir/JS/config only.

## How it works

**Per-tab token.** `assets/js/app.js` mints a random token in `sessionStorage` (scoped to a single browser tab, surviving a reload/reconnect of that tab but not shared between tabs) and sends it on the LiveSocket `params`. The server reads it back with `get_connect_params/1` on the connected mount only.

**Disconnected vs connected mount.** `mount/3` runs twice (disconnected HTTP render, then connected WebSocket mount, and again on every reconnect). Only the connected mount attaches over distribution and reads the token, so the disconnected render never creates an orphaned session.

**SessionRegistry.** A new singleton GenServer (`BtAttach.SessionRegistry`) keyed by the per-tab token owns the resume/cleanup lifecycle:
- `checkout/1` on the connected mount resumes the tab's existing live session (cancelling any pending reap) or misses;
- `register/3` records a fresh session and monitors the remote session pid (a workspace-side death drops the stale entry);
- `release/1` from `terminate/2` opens a short grace window instead of closing the session, so a reconnecting tab resumes; if no reconnect arrives, the registry reaps the session — no orphans;
- the remote close runs in a detached process so a slow/hung workspace RPC can never block the shared registry.

**Resume safety.** A registry hit is only trusted after `Workspace.session_alive?/1` confirms the remote pid is still reachable (the workspace could have restarted), else it discards the stale entry and starts fresh. On resume the LiveView resubscribes the Transcript + bindings streams for its new pid and re-reads bindings, so the resumed tab gets its live streams back with accumulated state intact.

**Hot-reload coherence** is inherent to the Attach topology: a Wave-3 method edit compiles + flushes into the live module on the shared workspace node, so subsequent evals (in any tab) observe it with no Phoenix-side reload; the `bindings_changed` push keeps panes coherent across tabs.

## Key changes

- `assets/js/app.js` — per-tab `sessionStorage` resume token on the LiveSocket params.
- `lib/bt_attach/session_registry.ex` — new registry GenServer (resume/reap/monitor lifecycle; detached remote close).
- `lib/bt_attach/application.ex` — supervise the registry.
- `lib/bt_attach_web/live/workspace_live.ex` — resume-or-start in `attach`, grace-window `release` in `terminate/2`.
- `lib/bt_attach/workspace.ex` — `session_alive?/1` and `session_count/1` read-only probes.
- `config/test.exs` — short grace window for the reconnect/teardown tests.

## Tests

- Pure unit tests for the registry lifecycle (checkout/register/release/discard/reap/monitor-DOWN, two-tab isolation, re-register replace) — run in the default suite.
- `@tag :workspace` e2e: two-tab isolation, reconnect-resume retains state, teardown on disconnect.

`mix format --check-formatted`, `mix compile --warnings-as-errors`, and the default `mix test` (46 tests, 0 failures, 11 `:workspace` excluded) are green. The `:workspace` e2e require a live workspace + cookie and run in the workspace-gated CI job.

https://claude.ai/code/session_01SooajdpU9eNrWvq3hNMoTK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SooajdpU9eNrWvq3hNMoTK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-tab workspace sessions: sessions can resume on reconnect in the same browser tab, remain isolated across tabs, and are included on reconnect attempts.
  * Grace-window cleanup: sessions are retained briefly after disconnect to allow quick reconnects, then automatically cleaned up.

* **Tests**
  * Added unit and end-to-end tests covering session lifecycle, resumption, isolation, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->