### PR TITLE
Tighten erlang:node/0 assertion to check Symbol type (BT-2436)

### DIFF
--- a/stdlib/test/erlang_interop_test.bt
+++ b/stdlib/test/erlang_interop_test.bt
@@ -24,8 +24,8 @@ TestCase subclass: ErlangInteropTest
     self assert: (Erlang lists nth: 2 with: #(10, 20, 30)) equals: 20
 
   testErlangFunctionCallsZeroArgUnaryOnProxy =>
-    // erlang:node/0 — returns current node atom
-    self assert: ((Erlang erlang) node) notNil
+    // erlang:node/0 — returns the current node name as a Symbol (Erlang atom)
+    self assert: ((Erlang erlang) node) class equals: Symbol
 
   testCachedProxy =>
     // Store proxy in variable and reuse


### PR DESCRIPTION
## Summary

Tightens the loose `notNil` assertion in `testErlangFunctionCallsZeroArgUnaryOnProxy` to explicitly verify the return type of `erlang:node/0`.

- `erlang:node/0` is defined to return an Erlang atom in all modes (`nonode@nohost` when non-distributed, `node@host` in distributed mode)
- The Beamtalk FFI maps Erlang atoms to Symbols
- `notNil` only checks that the call didn't return nil; a type regression (e.g. the FFI returning a String instead of a Symbol) would pass silently
- `class equals: Symbol` catches both nil-return bugs and type regressions, and matches the file's existing assertion style (lines 10–12 use the same form)

## Changes

- `stdlib/test/erlang_interop_test.bt`: 1 line changed

## Test plan

- [x] `just test-bunit` — 2403 tests, 0 failed

https://linear.app/beamtalk/issue/BT-2436/tighten-loose-notnil-assertion-in-erlang-interop-testbt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzqAEZoGhjnge1UuzLC47K)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation for Erlang interoperability functionality to verify correct result type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->