### PR TITLE
docs: add ADR 0093 (announcements substrate) + align ADR 0092 supervisor/navigation API (BT-2396)

### DIFF
--- a/docs/ADR/0092-supervision-tree-introspection.md
+++ b/docs/ADR/0092-supervision-tree-introspection.md
@@ -336,10 +336,13 @@ sup ifNotNil: [:s | s terminate: Worker]    // control goes through the live obj
 deeper := (ProcessNavigation from: node pid) unwrap tree
 ```
 
-`node asSupervisor` returns the registered live `Supervisor` for a
-`#beamtalkSupervisor` node (looked up by `registeredName` via
-`Supervisor current`), and `nil` for foreign processes, dead pids, or
-`#restarting` nodes. This is the only node→live bridge; all mutation stays on
+`node asSupervisor` returns the live `Supervisor` for a `#beamtalkSupervisor`
+node — by `registeredName` via `Supervisor current` when the node is named, and
+by a **pid-based fallback** when it is not (an anonymous Beamtalk supervisor is
+still bridged, since its `pid` is live and its class is known). It returns `nil`
+only for foreign processes, dead pids, or `#restarting` nodes — so a node with
+`kind = #beamtalkSupervisor` and `isSupervisor = true` always bridges while
+alive, named or not. This is the only node→live bridge; all mutation stays on
 the live object (ADR 0080 family), all discovery stays on the navigator, all
 frozen facts stay on the node.
 

--- a/docs/ADR/0092-supervision-tree-introspection.md
+++ b/docs/ADR/0092-supervision-tree-introspection.md
@@ -393,12 +393,14 @@ Kind classification reuses machinery the runtime already has:
 
 This ADR is **pull/snapshot only.** A LiveView IDE wanting live tree updates
 re-snapshots on a timer (cheap) for v1. A genuine *change-event* story —
-subscribe to "child added" / "child crashed" — is the **Announcements
-package's** job (BT-2193), not this surface. The seam: when Announcements
-lands, `ProcessNavigation` can expose `announcer` returning a stream of
-tree-delta events, layered on top of this snapshot API without changing it.
-Designing the event substrate here would duplicate BT-2193 and couple
-introspection to a notification system that does not yet exist.
+subscribe to "child added" / "child crashed" — belongs to the **Announcements
+event substrate (ADR 0093 / BT-2396)**, not this surface. Supervision deltas
+are discrete typed events (`SupervisionChildAdded` / `SupervisionChildCrashed`)
+published on `SystemAnnouncer` (ADR 0093 §5); a tool subscribes there. The
+seam: `ProcessNavigation` can later expose an `announcer` accessor over those
+events, layered on top of this snapshot API without changing it. Designing the
+event substrate here would duplicate ADR 0093 and couple introspection to a
+notification system that did not yet exist when this ADR was written.
 
 ### REPL session
 

--- a/docs/ADR/0092-supervision-tree-introspection.md
+++ b/docs/ADR/0092-supervision-tree-introspection.md
@@ -315,10 +315,11 @@ kept name- and shape-identical. The split is by *role*, not by vocabulary:
 Two alignment changes to the **shipped** live `Supervisor`
 (`stdlib/src/Supervisor.bt`) fall out of this and are part of this ADR's scope:
 
-- **Add `childCount` as the canonical name** for the running-children count;
-  keep the existing `count` (`Supervisor.bt:135`) as a thin deprecated alias so
-  current call sites and tests keep working. (`count` reads as "my own count"
-  on a non-collection; `childCount` is unambiguous and matches the node.)
+- **Rename `count` → `childCount`** (`Supervisor.bt:135`) for the
+  running-children count, updating its call sites and tests in the same change.
+  No deprecated alias is kept — pre-1.0, a clean rename is preferred over
+  carrying two names. (`count` reads as "my own count" on a non-collection;
+  `childCount` is unambiguous and matches the node.)
 - No change to `maxRestarts`/`restartWindow`/`strategy`/`children` — the node
   was aligned to *them*, not the reverse.
 

--- a/docs/ADR/0092-supervision-tree-introspection.md
+++ b/docs/ADR/0092-supervision-tree-introspection.md
@@ -233,14 +233,24 @@ node kind            // => one of #beamtalkSupervisor #beamtalkActor
 node behaviourClass  // => Class | nil   (the Beamtalk class, nil for foreign)
 node strategy        // => Symbol | nil  (#oneForOne … ; supervisors only)
 node childCount      // => Integer       (live children; supervisors only)
-node restartIntensity // => Dictionary | nil  (configured #{maxRestarts, window};
-                     //   supervisors only — see note on restart *counts* below)
-node children        // => List(SupervisionNode)   (snapshot children)
+node maxRestarts     // => Integer | nil (configured budget; supervisors only)
+node restartWindow   // => Integer | nil (configured window, seconds; supervisors only)
+node restartIntensity // => Dictionary | nil  (convenience: #{maxRestarts, restartWindow})
+node childNodes      // => List(SupervisionNode)   (snapshot children)
 node parent          // => SupervisionNode | nil
 node isSupervisor    // => Boolean
 node isBeamtalk      // => Boolean        (kind is one of the #beamtalk* kinds)
 node status          // => Dictionary | nil   (LAZY — see §5)
+node asSupervisor    // => Supervisor | nil    (live handle; see §3a)
 ```
+
+The accessor names and shapes are **deliberately identical to the live
+`Supervisor`'s** so a supervisor reads the same whether you hold it or
+discovered it in a snapshot (see §3a). `childNodes` is the one structural
+exception — it returns child *records* (snapshot navigation), as distinct from
+the live `Supervisor children` which returns child *ids* and the class-side
+`Supervisor class children` which returns child *classes*. Naming it
+`childNodes` keeps `children` from meaning three different things.
 
 `kind` is the load-bearing field: it tells a renderer whether to draw a
 Beamtalk class badge (`#beamtalkActor`/`#beamtalkSupervisor`, `behaviourClass`
@@ -286,6 +296,51 @@ bolted onto this snapshot. The `SupervisionNode` record leaves room to add
 `restartCount` then without a breaking change. The acceptance criterion
 "restart history" is answered as: *budget now; history is a separate,
 deliberately-deferred feature with a documented reason.*
+
+### 3a. API consistency with the live `Supervisor`
+
+A `SupervisionNode` and a live `Supervisor` (the object you get from
+`MySup supervise unwrap`) describe the *same domain thing* — a supervisor, its
+strategy, its restart budget, its children — so their **read** surfaces are
+kept name- and shape-identical. The split is by *role*, not by vocabulary:
+
+| Concept | live `Supervisor` (control + self-inspect) | `SupervisionNode` (snapshot fact) |
+|---|---|---|
+| strategy | `strategy` (class-side config) | `strategy` |
+| restart budget | `maxRestarts`, `restartWindow` | `maxRestarts`, `restartWindow` (+ `restartIntensity` dict) |
+| running child count | `childCount` | `childCount` |
+| is it a supervisor | `isSupervisor` | `isSupervisor` |
+| children | `children` → child **ids** (`List(Symbol)`) | `childNodes` → child **records** |
+
+Two alignment changes to the **shipped** live `Supervisor`
+(`stdlib/src/Supervisor.bt`) fall out of this and are part of this ADR's scope:
+
+- **Add `childCount` as the canonical name** for the running-children count;
+  keep the existing `count` (`Supervisor.bt:135`) as a thin deprecated alias so
+  current call sites and tests keep working. (`count` reads as "my own count"
+  on a non-collection; `childCount` is unambiguous and matches the node.)
+- No change to `maxRestarts`/`restartWindow`/`strategy`/`children` — the node
+  was aligned to *them*, not the reverse.
+
+**Read vs mutate — the rule that makes the split safe.** A snapshot is a frozen
+*past* truth and is **read-only**: there are no `terminate:` / `stop` /
+`supervise` methods on `SupervisionNode`. To *act* on something you discovered
+by walking, cross back to the live object:
+
+```beamtalk
+sup := node asSupervisor                    // live handle, or nil for foreign/dead
+sup ifNotNil: [:s | s terminate: Worker]    // control goes through the live object
+
+// foreign OTP nodes have no Beamtalk Supervisor — re-root the navigator instead:
+deeper := (ProcessNavigation from: node pid) unwrap tree
+```
+
+`node asSupervisor` returns the registered live `Supervisor` for a
+`#beamtalkSupervisor` node (looked up by `registeredName` via
+`Supervisor current`), and `nil` for foreign processes, dead pids, or
+`#restarting` nodes. This is the only node→live bridge; all mutation stays on
+the live object (ADR 0080 family), all discovery stays on the navigator, all
+frozen facts stay on the node.
 
 ### 4. Snapshot semantics
 

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -191,12 +191,19 @@ per-instance announcers keep the lean ETS model BT-2193 specced.
 Three classes in the **core image** (so the system can publish):
 
 ```beamtalk
-// Base event type — apps subclass it; carries typed state.
-abstract Object subclass: Announcement
+// Base event — an immutable typed payload. Apps subclass it and add `field:`
+// slots; an announcement is a *fact*, so it is a Value (never mutable). Value
+// inheritance with an abstract base mirrors `abstract Value subclass: Number`.
+abstract Value subclass: Announcement
 
-// A dispatcher instance. Apps spawn their own; the system has a singleton.
-Object subclass: Announcer
-  class spawn -> Announcer => (Erlang beamtalk_announcements) newAnnouncer
+// A dispatcher handle — an immutable Value wrapping a runtime subscription ref.
+// NOT an Actor: there is deliberately no per-announcer process (that would
+// reintroduce the central mailbox rejected in §4). The subscriber set lives in
+// the runtime ETS table keyed by `ref`; dispatch runs caller-side. `class new`
+// mints a fresh ref via FFI — the same pattern as `Random class new`.
+Value subclass: Announcer
+  field: ref :: Any = nil
+  class new -> Announcer => (Erlang beamtalk_announcements) newAnnouncer
   when: aClass :: Class do: aBlock :: Block -> Subscription => ...
   when: aClass :: Class send: sel :: Symbol to: receiver -> Subscription => ...
   when: aClass :: Class doOnce: aBlock :: Block -> Subscription => ...
@@ -293,16 +300,16 @@ the other, without coupling the two buses.
 
 ```beamtalk
 bt> Announcement subclass: PriceChanged
-...>   state: newPrice :: Money = nil
+...>   field: newPrice :: Money = nil
 PriceChanged
 
-bt> a := Announcer spawn
-#Announcer<<0.421.0>>
+bt> a := Announcer new
+an Announcer
 
 bt> a when: PriceChanged do: [:e | Transcript showLine: "now " ++ e newPrice printString]
 #Subscription<...>
 
-bt> a announce: (PriceChanged new: #{ #newPrice => 42 })
+bt> a announce: (PriceChanged newPrice: 42)
 now 42
 
 bt> "Subscribe to the system bus — one feed for everything the system emits:"
@@ -341,7 +348,7 @@ bt> "dead subscriber process is auto-removed via monitor — no manual cleanup"
 ## User Impact
 
 - **Newcomer.** `when: X do: [...]` reads like every other block-taking message
-  they already use; `Announcer spawn` mirrors `Counter spawn`. They can watch
+  they already use; `Announcer new` is an ordinary value constructor. They can watch
   the system live (`SystemAnnouncer current when: ActorSpawned do: …`) — a
   tangible way to *see* what the runtime is doing.
 - **Smalltalk developer.** It *is* Pharo Announcements, including
@@ -461,7 +468,7 @@ Downstream of acceptance (the `/plan-adr` step owns the epic + the BT-2193
 re-scope):
 
 0. **Phase 0 (napkin):** `beamtalk_announcements` with one `Announcement`
-   class, `Announcer spawn`, `when:do:`, `announce:` (async) over a single `pg`
+   class, `Announcer new`, `when:do:`, `announce:` (async) over a single `pg`
    group + monitor cleanup. Prove typed dispatch end-to-end from the REPL.
 1. **Runtime bus (full):** MRO match, `announceAndWait:` (sync), `when:send:to:`,
    `when:doOnce:`, fault isolation, sup wiring. EUnit.

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -346,6 +346,23 @@ treats as fully privileged, so no boundary is bypassed. The ADR-0091
 implementation issue owns adding `subscribe`/`unsubscribe` to the authoritative
 op list; this ADR fixes the requirement.
 
+**Publish authority (who may *announce*, not just subscribe).** Unlike C#'s
+`event` — where only the declaring type can *raise* — Beamtalk's "an announcer
+is just an object" model does not language-enforce who may publish (nor does
+Pharo's `SystemAnnouncer`). Two boundaries matter:
+
+- **Remote front (the one that matters):** the ADR-0091 push facade is
+  **subscribe-only and must never expose a publish capability**. A remote
+  Observer can listen to curated system events but can never `announce:` onto
+  `SystemAnnouncer` — otherwise it could forge `ActorSpawned`/`ClassRemoved` and
+  mislead other subscribers. Same owner as the subscribe op list above.
+- **In-image:** publishing on `SystemAnnouncer` is unrestricted, but that again
+  implies an Owner/`eval` session — a forger with `eval` doesn't need to forge,
+  so no real boundary is crossed. For *app-level* encapsulation (C#'s "only the
+  owner raises"), the idiomatic answer is an **object-capability split** — the
+  owner privately holds the `Announcer` and hands out a subscribe-only view —
+  not a language keyword. No publish-side enforcement is added in v1.
+
 ### 7. Introspection & navigation — the third navigation sibling
 
 A pub/sub bus that can't be inspected is a black box, which would contradict the
@@ -402,6 +419,21 @@ handles (`Announcer`, `Subscription`) are `Object`; snapshot records
 default subscribersOf: …` grouped by `announcementClass`. The navigator reads
 are gated as a `system`-scope read under ADR 0091, like the supervision
 navigator (§6).
+
+**Future work (not in scope): declarative `event:` emission manifest.** The
+navigator above makes *subscriptions* (who listens) discoverable — a runtime
+fact. The symmetric half — *emissions* (which `Announcement` subclasses a class
+publishes) — is today invisible, buried in `announce:` calls in method bodies.
+A declarative `event:` member (alongside `state:` / `field:` / `classState:`,
+ADR 0067) would make emissions part of a class's published contract, enable
+`announce:` type-checking, and complete the event graph (publishers *and*
+subscribers). It is **deliberately deferred to its own ADR**: it is a new
+declarative member kind touching parser / semantic analysis / reflection /
+codegen, which would break this ADR's "no parser/codegen changes" property, and
+it is a different shape from C#'s `event` (a *manifest* of emitted types, not a
+per-object channel — the channel here is the `Announcer`). A pure-stdlib interim
+(`class emittedEvents -> List(Class)`, hand-declared, no new syntax) can deliver
+the discoverability win first if wanted.
 
 ### REPL session
 

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -145,13 +145,20 @@ gen_server is not in the dispatch path.**
 - **`pg`'s role is *subscriber-group registry for `SystemAnnouncer`*, not a
   message transport.** `pg` has no send primitive — you `pg:get_members/1` and
   send yourself. For the singleton system bus we register subscribers in a `pg`
-  group so that *membership is cluster-wide for free*; v1 still delivers
-  **locally only** (the announcing node sends to local members). Genuine
-  cross-node *delivery* (ordering, partition handling, remote handler
-  execution) is the package's job (Layer 3) — not "free." Per-instance
-  `Announcer`s use the ETS table directly (no `pg` group), so there is no
-  dynamic-atom pressure; where a `pg` group is needed it is keyed by a
-  `{beamtalk_announcer, Ref}` tuple, never a minted atom.
+  group so that *membership is cluster-wide for free*. **Delivery to any
+  connected node is also free, and is in scope for v1** — `pg` membership spans
+  connected nodes, `erlang:monitor/2` works cross-node, and `Pid ! Msg` is
+  location-transparent, so a subscriber on another node (e.g. an ADR-0091
+  LiveView IDE process on the Phoenix node, which is connected to the workspace
+  node over Erlang distribution) subscribes, is monitored, and receives events
+  with no extra mechanism. What is *not* free — and is deferred to the package
+  (Layer 3) — is delivery across the **absence** of a connection: netsplit /
+  partition tolerance, buffering and replay for a reconnecting subscriber, and
+  multi-node *workspace clusters*. Single-cluster cross-node delivery to live,
+  connected nodes needs none of that. Per-instance `Announcer`s use the ETS
+  table directly (no `pg` group), so there is no dynamic-atom pressure; where a
+  `pg` group is needed it is keyed by a `{beamtalk_announcer, Ref}` tuple, never
+  a minted atom.
 - **Typed dispatch with MRO matching.** On `announce: anEvent` the matcher
   walks the event's superclass chain (ETS metadata reads) and delivers to
   subscribers of the event class *or any ancestor* (subscribe to `UIEvent`,
@@ -257,7 +264,11 @@ op list; this ADR fixes the requirement.
 
 `beamtalk-announcements` shrinks to the genuinely-optional:
 
-- **Distributed cross-node delivery** beyond what single-node `pg` gives.
+- **Hardened distributed delivery** beyond live connected nodes: netsplit /
+  partition tolerance, buffering + replay for reconnecting subscribers, and
+  multi-node *workspace clusters*. (Plain cross-node delivery to a *connected*
+  node — including the ADR-0091 LiveView front — is already handled by the core
+  bus over Erlang distribution; see Layer 1.)
 - **`RecordingAnnouncer`** — the test double that records `announce:` calls
   without dispatching.
 - **`telemetry` / OpenTelemetry bridge** — re-emit announcements as telemetry
@@ -363,7 +374,7 @@ bt> "dead subscriber process is auto-removed via monitor — no manual cleanup"
 
 **(c) Layered — runtime bus + stdlib veneer + package extras (chosen).**
 - 🎩 **Smalltalk purist:** "Typed Observer + `SystemAnnouncer` are in the image where they belong."
-- ⚙️ **BEAM veteran:** "Built on `pg`, no new bottleneck, distribution is free later; the heavy/optional parts stay out of the kernel."
+- ⚙️ **BEAM veteran:** "Built on `pg`, no new bottleneck; connected-node delivery is free now (the LiveView front is just another node on the dist mesh), and the heavy partition/replay parts stay out of the kernel."
 - 🏭 **Operator:** "Monitored, isolated, inspectable; ops bridge is opt-in."
 - 🎨 **Language designer:** "Each concern at the right altitude; the package line falls exactly on what's optional."
 - *Tension:* three layers is more moving parts than 'one package' — justified only because the system-publisher requirement is real (five consumers).
@@ -375,10 +386,13 @@ bt> "dead subscriber process is auto-removed via monitor — no manual cleanup"
   announcing process off `read_concurrency` ETS, so there is no central
   dispatch mailbox to deadlock (`announceAndWait:` reentrancy) or bottleneck.
   This is the `beamtalk_xref` / `beamtalk_trace_store` pattern.
-- **`pg` for `SystemAnnouncer` membership only:** gives cluster-wide
-  *membership* for the shared bus at no extra cost — but `pg` has no send
-  primitive, so it is a registry, not a transport, and v1 delivery is local.
-  Per-instance announcers don't use `pg`.
+- **`pg` for `SystemAnnouncer` membership:** gives cluster-wide *membership* for
+  the shared bus at no extra cost — `pg` has no send primitive, so it is a
+  registry, not a transport, but combined with location-transparent `Pid ! Msg`
+  and cross-node monitors it delivers to any *connected* node in v1 (the
+  ADR-0091 LiveView front gets live updates for free over the existing dist
+  link). Only partition tolerance / replay / multi-workspace-cluster fall to the
+  package. Per-instance announcers don't use `pg`.
 - **Central dispatch gen_server (rejected):** the obvious "announce → call the
   bus → it sends to everyone" design self-deadlocks on reentrant
   `announceAndWait:` and serialises all events through one mailbox.
@@ -410,8 +424,11 @@ exists to stop.
   to deadlock or bottleneck; crash-survivable via ETS heir; monitored + isolated
   by construction; hot-reload-safe (process-rooted subs). Clean `telemetry`
   boundary preserved (§4).
-- `pg` gives `SystemAnnouncer` cluster-wide *membership* for free, leaving only
-  cross-node *delivery* (the genuinely hard part) to the package.
+- `pg` membership + location-transparent send + cross-node monitors give
+  `SystemAnnouncer` free delivery to any *connected* node in v1 — the ADR-0091
+  LiveView front (a separate node over Erlang distribution) gets live updates
+  with no package. Only partition tolerance / replay / multi-workspace-cluster
+  fall to the package.
 
 ### Negative
 - Three layers to build and document vs BT-2193's single package.

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -196,13 +196,18 @@ Three classes in the **core image** (so the system can publish):
 // inheritance with an abstract base mirrors `abstract Value subclass: Number`.
 abstract Value subclass: Announcement
 
-// A dispatcher handle — an immutable Value wrapping a runtime subscription ref.
-// NOT an Actor: there is deliberately no per-announcer process (that would
-// reintroduce the central mailbox rejected in §4). The subscriber set lives in
-// the runtime ETS table keyed by `ref`; dispatch runs caller-side. `class new`
-// mints a fresh ref via FFI — the same pattern as `Random class new`.
-Value subclass: Announcer
-  field: ref :: Any = nil
+// A dispatcher handle — an opaque reflection of runtime state, exactly like
+// `Pid` / `Port` / `Reference` (ADR 0067, "Object's Three Roles"): an `Object
+// subclass:` with no declared data. The underlying announcer is an Erlang
+// `reference()` carried as the object's native boxing and reached via FFI;
+// equality is by identity (`=:=`), like `Pid`.
+//   - NOT a Value: we don't want `with*:` setters, structural equality,
+//     `new:`-map construction, or `fieldAt:` reflection on a capability handle.
+//   - NOT an Actor: there is deliberately no per-announcer process (that would
+//     reintroduce the central mailbox rejected in §4). The subscriber set lives
+//     in the shared runtime ETS table keyed by the ref; dispatch runs
+//     caller-side. `class new` mints a fresh announcer via FFI.
+typed Object subclass: Announcer
   class new -> Announcer => (Erlang beamtalk_announcements) newAnnouncer
   when: aClass :: Class do: aBlock :: Block -> Subscription => ...
   when: aClass :: Class send: sel :: Symbol to: receiver -> Subscription => ...
@@ -304,7 +309,7 @@ bt> Announcement subclass: PriceChanged
 PriceChanged
 
 bt> a := Announcer new
-an Announcer
+#Announcer<0.521.0>
 
 bt> a when: PriceChanged do: [:e | Transcript showLine: "now " ++ e newPrice printString]
 #Subscription<...>
@@ -348,7 +353,7 @@ bt> "dead subscriber process is auto-removed via monitor — no manual cleanup"
 ## User Impact
 
 - **Newcomer.** `when: X do: [...]` reads like every other block-taking message
-  they already use; `Announcer new` is an ordinary value constructor. They can watch
+  they already use; `Announcer new` hands back a plain handle. They can watch
   the system live (`SystemAnnouncer current when: ActorSpawned do: …`) — a
   tangible way to *see* what the runtime is doing.
 - **Smalltalk developer.** It *is* Pharo Announcements, including

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -129,12 +129,19 @@ hot-path discipline as `beamtalk_xref` and `beamtalk_trace_store`: **the
 gen_server is not in the dispatch path.**
 
 - **Subscription table = ETS, gen_server owns writes only.** Subscriptions
-  `{AnnouncementClass, SubscriberPid, Handler, OnceFlag}` live in an ETS table.
-  `when:…` / `unsubscribe:` go through the gen_server (serialised writes, and
-  it arms `erlang:monitor/2` per subscriber). The ETS table is created with
-  `{heir, SupervisorPid, …}` so it **survives a bus crash** (the
-  `beamtalk_trace_store` pattern); on restart the gen_server re-arms monitors
-  from the table, so subscriptions are not silently lost.
+  `{AnnouncementClass, SubscriberPid, Handler, OnceFlag}` live in an ETS
+  **`set` keyed by `{AnnouncementClass, SubscriberPid}`** — one row per
+  subscriber per class, never a `bag`. (The unique key is what makes the
+  `doOnce:` `ets:take/2` below remove exactly one subscriber's row; a `bag`
+  would take *all* rows for the key.) `when:…` / `unsubscribe:` go through the
+  gen_server (serialised writes, and it arms `erlang:monitor/2` per subscriber).
+  The ETS table is created with `{heir, SupervisorPid, …}` so it **survives a
+  bus crash** (the `beamtalk_trace_store` pattern). On restart the gen_server
+  re-arms monitors from the table — and because a subscriber may have **died
+  during the crash→restart gap** (its `DOWN` went to the dead bus and is lost),
+  re-arm does an `is_process_alive/1` check per row and prunes the dead ones, so
+  the table cannot accumulate stale pids. (This is new exposure vs
+  `beamtalk_trace_store`, which monitors nothing.)
 - **Dispatch runs in the announcing process, off concurrent ETS reads** — not
   in the gen_server. `announce:` / `announceAndWait:` do a `read_concurrency`
   ETS lookup of matching subscribers and fan out with direct `Pid ! Msg`
@@ -144,22 +151,25 @@ gen_server is not in the dispatch path.**
   `announceAndWait:` and (b) serialise every event through one mailbox. Keeping
   dispatch caller-side eliminates both.
 - **`pg`'s role is *subscriber-group registry for `SystemAnnouncer`*, not a
-  message transport.** `pg` has no send primitive — you `pg:get_members/1` and
-  send yourself. For the singleton system bus we register subscribers in a `pg`
-  group so that *membership is cluster-wide for free*. **Delivery to any
-  connected node is also free, and is in scope for v1** — `pg` membership spans
-  connected nodes, `erlang:monitor/2` works cross-node, and `Pid ! Msg` is
-  location-transparent, so a subscriber on another node (e.g. an ADR-0091
-  LiveView IDE process on the Phoenix node, which is connected to the workspace
-  node over Erlang distribution) subscribes, is monitored, and receives events
-  with no extra mechanism. What is *not* free — and is deferred to the package
-  (Layer 3) — is delivery across the **absence** of a connection: netsplit /
-  partition tolerance, buffering and replay for a reconnecting subscriber, and
-  multi-node *workspace clusters*. Single-cluster cross-node delivery to live,
-  connected nodes needs none of that. Per-instance `Announcer`s use the ETS
-  table directly (no `pg` group), so there is no dynamic-atom pressure; where a
-  `pg` group is needed it is keyed by a `{beamtalk_announcer, Ref}` tuple, never
-  a minted atom.
+  message transport.** `pg` has no send primitive — you `pg:get_members/2` and
+  send yourself. Use a **dedicated Beamtalk scope** (`pg:start_link(beamtalk_pg)`),
+  not the default `pg` scope — both to keep announcer groups separate from the
+  existing `beamtalk_classes` membership use, and to avoid colliding with any
+  `pg` use on a connected non-Beamtalk node. For the singleton system bus we
+  register subscribers in a `beamtalk_pg` group so that *membership is
+  cluster-wide for free*. Cross-node **delivery to a connected node works in v1**
+  with no extra machinery — `pg` membership spans connected nodes, `monitor`
+  works cross-node, `Pid ! Msg` is location-transparent — **on two conditions
+  that ADR-0091 Phase-3 integration must confirm:** (1) both nodes run `pg`
+  under the `beamtalk_pg` scope; (2) the 0091 front subscribes directly (it may
+  instead front the bus with its own push facade, in which case this path is not
+  exercised — see Consequences for the failure-semantics caveat). What is
+  genuinely *out of scope* and deferred to the package (Layer 3) is delivery
+  across the **absence** of a connection: netsplit / partition tolerance,
+  buffering and replay for a reconnecting subscriber, and multi-node *workspace
+  clusters*. Per-instance `Announcer`s use the ETS table directly (no `pg`
+  group), so there is no dynamic-atom pressure; where a `pg` group is needed it
+  is keyed by a `{beamtalk_announcer, Ref}` tuple, never a minted atom.
 - **Typed dispatch with MRO matching.** On `announce: anEvent` the matcher
   walks the event's superclass chain (ETS metadata reads) and delivers to
   subscribers of the event class *or any ancestor* (subscribe to `UIEvent`,
@@ -173,15 +183,27 @@ gen_server is not in the dispatch path.**
 - **Sync + async, fault-isolated.** `announce:` is async (direct sends, no
   wait). `announceAndWait:` gathers replies in the caller via
   `spawn_monitor`-per-handler + `receive` with a timeout, so a slow/blocked
-  handler cannot wedge the bus and a crashing handler is isolated (caught,
-  logged `domain => [beamtalk, announcements]`, never propagated to siblings or
-  the announcer). `announceAndWait:` from inside a handler is therefore safe —
-  there is no shared gen_server to deadlock on.
+  handler cannot wedge the bus and a crashing handler is isolated. The reply
+  protocol is explicit: each spawned handler process sends `{Ref, ok}` on
+  success; the caller's `receive` loop *also* matches
+  `{'DOWN', Ref, process, _, Reason}` as the handler-crashed signal (logged
+  `domain => [beamtalk, announcements]`, never propagated to siblings or the
+  announcer) and the per-handler timeout ejects the loop — so a crashed handler
+  can never leave the caller blocked on a reply that never comes.
+  `announceAndWait:` from inside a handler is therefore safe — there is no shared
+  gen_server to deadlock on. **`announceAndWait:` is *not* available on
+  `SystemAnnouncer`** (it is sealed async-only): the system bus can have many
+  subscribers, and `spawn_monitor`-per-handler there would be an unbounded
+  process storm under rapid system events (startup actor spawns). Sync gather is
+  for per-instance announcers with a known, small subscriber set.
 - **`doOnce:` is claimed atomically.** Since dispatch is caller-side and two
-  `announce:` can run concurrently, a `doOnce` subscription is taken with an
-  atomic `ets:take/2` (or gen_server compare-and-delete) — whichever announce
-  wins delivers, the loser sees it gone, so it fires at most once. (Single-node
-  guarantee; weakens under the package's distributed path, noted there.)
+  `announce:` can run concurrently, a `doOnce` subscription is consumed with an
+  atomic `ets:take/2` on its unique `{AnnouncementClass, SubscriberPid}` key —
+  whichever announce wins the `take` delivers, the loser gets `[]` and skips it,
+  so it fires at most once. (A concurrent announcer may waste its MRO walk on a
+  row that's already taken — harmless; correctness rests on the single atomic
+  `take`, not the walk.) Single-node guarantee; weakens under the package's
+  distributed path, noted there.
 
 This reverses BT-2193's "no pg / ETS-per-announcer" choice *only* for the
 shared `SystemAnnouncer` (where cluster-wide membership is worth having);
@@ -195,6 +217,11 @@ Three classes in the **core image** (so the system can publish):
 // Base event — an immutable typed payload. Apps subclass it and add `field:`
 // slots; an announcement is a *fact*, so it is a Value (never mutable). Value
 // inheritance with an abstract base mirrors `abstract Value subclass: Number`.
+// NOTE: as a Value, two announcements with equal fields compare `==`
+// (structural). That is fine here — the dispatch path keys on event *class* +
+// subscription, never on event equality, so distinct-occurrence identity is
+// never needed. (Pharo's Announcement uses identity; we accept structural
+// equality as the price of Value's `field:`/keyword-ctor ergonomics.)
 abstract Value subclass: Announcement
 
 // A dispatcher handle — an opaque reflection of runtime state, exactly like
@@ -238,6 +265,13 @@ subclasses (stdlib-provided): `ActorSpawned` / `ActorStopped`, `ClassLoaded` /
 `ClassRemoved`, `BindingChanged`, and (ADR 0092) `SupervisionChildAdded` /
 `SupervisionChildCrashed`. A tool subscribes once and filters by event class
 instead of wiring four bespoke transports.
+
+**System events are announced only *after* the triggering action's metadata
+writes commit** — e.g. `ClassLoaded` fires from `beamtalk_object_class`'s
+`handle_call` reply path *after* the class's `beamtalk_class_metadata` row is
+written, so the MRO walk for the event (which reads that metadata) sees a
+consistent hierarchy. The trade is a small observable gap (class live before its
+announcement) over an inconsistent-read risk; the gap is the safe choice.
 
 ### 3. Layer 3 — the package (re-scoped BT-2193)
 
@@ -322,6 +356,10 @@ already exposes runtime *wiring* along two axes that share one shape — a
 `ProcessNavigation` walks the live supervision tree (`SupervisionNode`).
 Subscriptions are wiring of the same kind, so the substrate ships the **third
 sibling** in v1 — the pattern is settled, so there is no reason to defer it.
+(Risk, accepted: `ProcessNavigation` is Planned, not yet Implemented (ADR 0092
+BT-2427…2433); if its shape shifts during build, `AnnouncementNavigation` —
+deliberately the *same* shape — co-evolves with it. The `Announcer`
+self-inspection half costs nothing extra and is independent of that risk.)
 
 Two levels, mirroring ADR 0092's *object-knows-itself / navigator-discovers-
 system* split:
@@ -506,11 +544,11 @@ exists to stop.
   to deadlock or bottleneck; crash-survivable via ETS heir; monitored + isolated
   by construction; hot-reload-safe (process-rooted subs). Clean `telemetry`
   boundary preserved (§4).
-- `pg` membership + location-transparent send + cross-node monitors give
-  `SystemAnnouncer` free delivery to any *connected* node in v1 — the ADR-0091
-  LiveView front (a separate node over Erlang distribution) gets live updates
-  with no package. Only partition tolerance / replay / multi-workspace-cluster
-  fall to the package.
+- `pg` membership + location-transparent send + cross-node monitors let
+  `SystemAnnouncer` deliver to a *connected* node in v1 with no package — useful
+  for the ADR-0091 LiveView front — subject to the two integration conditions in
+  Layer 1 (shared `beamtalk_pg` scope; front subscribes directly). Only
+  partition tolerance / replay / multi-workspace-cluster fall to the package.
 - The bus is **navigable in v1** (§7): `AnnouncementNavigation` + the
   `Announcer` self-inspection methods make subscriptions a first-class,
   walkable part of the runtime — the third sibling of `SystemNavigation` /
@@ -530,8 +568,26 @@ exists to stop.
   per-subscription. Consumers needing causal order (e.g. `ActorSpawned` before a
   dependent event) must not assume it — documented, not engineered, in v1.
 - MRO matching costs an ETS-metadata walk per announce (~ depth × ~150 ns + fan-
-  out send cost). Fine for discrete events at human/IDE rates; **not** fine for
-  line-rate streams — which is precisely why Transcript is excluded (§5).
+  out send cost — the ns figure is an order-of-magnitude estimate, to be
+  confirmed by the Phase-1 EUnit benchmark). Fine for discrete events at
+  human/IDE rates; **not** fine for line-rate streams — which is precisely why
+  Transcript is excluded (§5).
+- **At-most-one in-flight delivery after `unsubscribe:`.** Because dispatch is
+  caller-side, a subscriber can receive a message for an `announce:` that was
+  already fanning out when its `unsubscribe:` completed. Handlers must be
+  idempotent / tolerate one spurious post-unsubscribe delivery — a real
+  behavioural difference from a centralised bus, and a documented contract, not
+  a bug.
+- **MRO walk truncates if a class is removed mid-announce.** A concurrent
+  `ClassRemoved` can make the superclass walk hit `not_found` and stop, so
+  subscribers of ancestors above the removed class miss that one event. Accepted
+  for the intended interactive/IDE use; documented, not engineered around.
+- **Cross-node sends absorb up to `net_ticktime` on unreachability short of a
+  full netsplit.** If a connected subscriber's node becomes unreachable
+  (port congestion, half-open TCP) the announcer keeps sending to it until the
+  cross-node monitor fires (default ~60 s). This is normal distribution jitter,
+  not partition handling (deferred to the package); cross-node consumers accept
+  it as v1 behaviour.
 
 ### Neutral
 - Adds a runtime worker (`beamtalk_announcements`) under `beamtalk_runtime_sup`
@@ -552,7 +608,14 @@ re-scope):
    class, `Announcer new`, `when:do:`, `announce:` (async) over a single `pg`
    group + monitor cleanup. Prove typed dispatch end-to-end from the REPL.
 1. **Runtime bus (full):** MRO match, `announceAndWait:` (sync), `when:send:to:`,
-   `when:doOnce:`, fault isolation, sup wiring. EUnit.
+   `when:doOnce:`, fault isolation, sup wiring. **EUnit must prove the
+   concurrency properties a REPL demo cannot** (the hardest-to-get-right parts):
+   (a) concurrent `announce:` from N processes against one `doOnce` subscription
+   → *exactly one* delivery; (b) subscriber dies before dispatch → no delivery,
+   no announcer crash; (c) bus crashes + restarts → subscriptions survive (heir)
+   and pids that died in the gap are pruned; (d) handler crash under
+   `announceAndWait:` → caller still returns (DOWN handled), siblings unaffected;
+   plus the MRO-walk microbenchmark backing the cost estimate.
 2. **stdlib veneer + introspection:** `Announcement` / `Announcer` /
    `SystemAnnouncer`, the `Announcer` self-inspection methods, and the
    `AnnouncementNavigation` navigator + `SubscriptionNode` value class (§7) —

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -677,6 +677,26 @@ re-scope):
 Affected components: **runtime** (new worker), **stdlib** (veneer + system
 events), **package** (re-scoped), **docs/tests**. No parser/codegen changes.
 
+## Implementation Tracking
+
+**Epic:** [BT-2438](https://linear.app/beamtalk/issue/BT-2438) — Announcements: Typed Event Substrate (ADR 0093)
+**Status:** Planned
+
+| Phase | Issue | Scope |
+|---|---|---|
+| 1 | BT-2439 | Runtime bus skeleton + ETS sub table + subscribe + async `announce:` |
+| 1 | BT-2440 | MRO subclass matching + per-subscription de-dup |
+| 1 | BT-2441 | `announceAndWait:` (sync) + `doOnce:` + `when:send:to:` + fault isolation |
+| 1 | BT-2442 | ETS heir crash-survival re-arm + dead-pid prune |
+| 2 | BT-2443 | stdlib veneer — `Announcement`/`Announcer`/`SystemAnnouncer`/`Subscription` |
+| 2 | BT-2444 | Introspection — self-inspection + `AnnouncementNavigation` + `SubscriptionNode` |
+| 3 | BT-2445 | System `Announcement` subclasses + runtime emit points |
+| 3 | BT-2446 | Point consumer ADRs (0017/0046/0054/0091/0092) at `SystemAnnouncer` |
+| 4 | BT-2193 | Package re-scope — distributed/`RecordingAnnouncer`/telemetry bridge |
+| 5 | BT-2447 | Language docs + surface-parity + e2e btscript; flip ADR → Implemented |
+
+Related: BT-2437 (`event:` emission manifest — separate track, §7). ADR-authoring issue BT-2396 is Done.
+
 ## Migration Path
 
 - **BT-2193** is re-scoped from "whole framework as a package" to "optional

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -1,7 +1,7 @@
 # ADR 0093: Announcements — Typed Event Substrate (Runtime Bus + stdlib Veneer)
 
 ## Status
-Proposed (2026-06-06)
+Accepted (2026-06-07)
 
 ## Context
 

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -110,8 +110,10 @@ substrate and `telemetry`'s measurement role.
 │   SystemAnnouncer (singleton) · when:do: / announce: / …       │
 ├──────────────────────────────────────────────────────────────┤
 │ runtime (Erlang)  beamtalk_announcements                       │
-│   typed dispatch over pg topic-groups + monitor-based liveness │
-│   MRO match · sync(call) + async(cast) · fault isolation       │
+│   ETS subscription table (gen_server owns writes + monitors);  │
+│   dispatch runs caller-side off concurrent ETS reads.          │
+│   MRO match (deduped) · async + isolated sync · pg = system    │
+│   subscriber-group registry (membership, not transport)        │
 ├──────────────────────────────────────────────────────────────┤
 │ existing: pg (membership)   ·   telemetry (measurement, 0069)  │
 └──────────────────────────────────────────────────────────────┘
@@ -120,31 +122,62 @@ substrate and `telemetry`'s measurement role.
 ### 1. Layer 1 — runtime bus (`beamtalk_announcements`)
 
 A runtime module providing typed publish/subscribe, slotted into
-`beamtalk_runtime_sup` as a worker (template: `beamtalk_xref`, ADR 0087).
-**It reuses `pg` as the transport** — one `pg` group per *announcer identity*
-— and layers the typed concerns on top that `pg` lacks:
+`beamtalk_runtime_sup` as a worker **after `beamtalk_bootstrap`** (which starts
+`pg`) — template: `beamtalk_xref` (ADR 0087). The design follows the same
+hot-path discipline as `beamtalk_xref` and `beamtalk_trace_store`: **the
+gen_server is not in the dispatch path.**
 
-- **Typed dispatch with MRO matching.** Subscriptions are keyed by
-  `Announcement` class. On `announce: anEvent`, the bus walks the event's
-  superclass chain and delivers to subscribers of the event class *or any
-  ancestor* (subscribe to `UIEvent`, receive `ButtonClicked`). The MRO walk
-  happens at announce time, so live class-hierarchy changes are respected.
-- **Liveness.** `erlang:monitor/2` on each subscriber; a `DOWN` removes its
-  subscriptions (the `pg` group membership *is* the liveness for the broadcast
-  fan-out; monitors handle the typed-subscription table).
-- **Sync + async.** `announce:` → `cast` (fire-and-forget); `announceAndWait:`
-  → `call` (blocks until every subscriber's handler returns).
-- **Fault isolation.** Each handler runs guarded; a crash is caught, logged
-  (`domain => [beamtalk, announcements]`), and does not affect siblings or the
-  publisher.
+- **Subscription table = ETS, gen_server owns writes only.** Subscriptions
+  `{AnnouncementClass, SubscriberPid, Handler, OnceFlag}` live in an ETS table.
+  `when:…` / `unsubscribe:` go through the gen_server (serialised writes, and
+  it arms `erlang:monitor/2` per subscriber). The ETS table is created with
+  `{heir, SupervisorPid, …}` so it **survives a bus crash** (the
+  `beamtalk_trace_store` pattern); on restart the gen_server re-arms monitors
+  from the table, so subscriptions are not silently lost.
+- **Dispatch runs in the announcing process, off concurrent ETS reads** — not
+  in the gen_server. `announce:` / `announceAndWait:` do a `read_concurrency`
+  ETS lookup of matching subscribers and fan out with direct `Pid ! Msg`
+  (async) or a gathered request/response (sync) **from the caller's own
+  process**. This is the ADR-0087/0092 lesson: routing dispatch through a
+  central gen_server would (a) self-deadlock when a handler re-announces under
+  `announceAndWait:` and (b) serialise every event through one mailbox. Keeping
+  dispatch caller-side eliminates both.
+- **`pg`'s role is *subscriber-group registry for `SystemAnnouncer`*, not a
+  message transport.** `pg` has no send primitive — you `pg:get_members/1` and
+  send yourself. For the singleton system bus we register subscribers in a `pg`
+  group so that *membership is cluster-wide for free*; v1 still delivers
+  **locally only** (the announcing node sends to local members). Genuine
+  cross-node *delivery* (ordering, partition handling, remote handler
+  execution) is the package's job (Layer 3) — not "free." Per-instance
+  `Announcer`s use the ETS table directly (no `pg` group), so there is no
+  dynamic-atom pressure; where a `pg` group is needed it is keyed by a
+  `{beamtalk_announcer, Ref}` tuple, never a minted atom.
+- **Typed dispatch with MRO matching.** On `announce: anEvent` the matcher
+  walks the event's superclass chain (ETS metadata reads) and delivers to
+  subscribers of the event class *or any ancestor* (subscribe to `UIEvent`,
+  receive `ButtonClicked`); the walk is at announce time so live hierarchy
+  changes are respected. **Delivery is de-duplicated per subscriber process**
+  across the MRO walk — a process that subscribed to *both* `UIEvent` and
+  `ButtonClicked` receives one delivery per *subscription* it registered
+  (Pharo's rule), and the matcher never double-sends for a single ancestor
+  walk. (See cost note below; this is why high-volume streaming is *excluded* —
+  §5.)
+- **Sync + async, fault-isolated.** `announce:` is async (direct sends, no
+  wait). `announceAndWait:` gathers replies in the caller via
+  `spawn_monitor`-per-handler + `receive` with a timeout, so a slow/blocked
+  handler cannot wedge the bus and a crashing handler is isolated (caught,
+  logged `domain => [beamtalk, announcements]`, never propagated to siblings or
+  the announcer). `announceAndWait:` from inside a handler is therefore safe —
+  there is no shared gen_server to deadlock on.
+- **`doOnce:` is claimed atomically.** Since dispatch is caller-side and two
+  `announce:` can run concurrently, a `doOnce` subscription is taken with an
+  atomic `ets:take/2` (or gen_server compare-and-delete) — whichever announce
+  wins delivers, the loser sees it gone, so it fires at most once. (Single-node
+  guarantee; weakens under the package's distributed path, noted there.)
 
-Why `pg` rather than BT-2193's ETS-per-announcer or a brand-new bus: `pg` is
-already started, already the project's broadcast primitive, cluster-ready
-(the v2 distributed path is then *free* — same code, `pg` spans nodes on OTP
-23+), and avoids standing up bespoke ETS ownership/heir machinery. The typed
-table (class → subscribers, monitors) is small per-announcer state the module
-owns; `pg` carries the fan-out. (BT-2193's "no pg" note predates this
-consolidation goal — it optimised a single package in isolation.)
+This reverses BT-2193's "no pg / ETS-per-announcer" choice *only* for the
+shared `SystemAnnouncer` (where cluster-wide membership is worth having);
+per-instance announcers keep the lean ETS model BT-2193 specced.
 
 ### 2. Layer 2 — stdlib typed veneer
 
@@ -170,12 +203,55 @@ sealed Announcer subclass: SystemAnnouncer
 ```
 
 `SystemAnnouncer current` is the shared bus the runtime emits onto and tools
-subscribe to. System facilities publish well-known `Announcement` subclasses
-(stdlib-provided): `TranscriptChanged`, `ActorSpawned` / `ActorStopped`,
-`ClassLoaded` / `ClassRemoved`, `BindingChanged`, and (ADR 0092)
-`SupervisionChildAdded` / `SupervisionChildCrashed`. These are the **five
-consuming ADRs' channels, unified** — a tool subscribes once and filters by
-event class instead of wiring five bespoke transports.
+subscribe to. System facilities publish well-known **discrete** `Announcement`
+subclasses (stdlib-provided): `ActorSpawned` / `ActorStopped`, `ClassLoaded` /
+`ClassRemoved`, `BindingChanged`, and (ADR 0092) `SupervisionChildAdded` /
+`SupervisionChildCrashed`. A tool subscribes once and filters by event class
+instead of wiring four bespoke transports.
+
+### 5. What does *not* belong on this bus (scope boundary)
+
+Two of the "five consumers" are **not** discrete domain events and must stay
+off `SystemAnnouncer`:
+
+- **Transcript line streaming (ADR 0017/0054).** This is a high-volume,
+  ordered byte/line stream, not a typed domain event. Routing it through the
+  typed bus would add a hop, force per-line MRO matching, and make the
+  announcements path a throughput bottleneck shared with discrete events.
+  Transcript keeps its **own dedicated direct-push channel**
+  (`beamtalk_transcript_stream` with `subscribe/1`/`unsubscribe/1`, sending
+  `Pid ! {transcript_output, …}` straight from the Transcript process). It is
+  a *stream*, governed by ADR 0017/0054, not this ADR.
+- **`telemetry` measurement events** (spans/counters) — §4; the measurement
+  bus, bridged from, not merged.
+
+Per-consumer placement:
+
+| Consumer (ADR) | Needs typed MRO events? | Mechanism |
+|---|---|---|
+| actor spawn/stop (0017/0046) | discrete, typed | `SystemAnnouncer` (`ActorSpawned`/`Stopped`) — *or* a `telemetry` attach if the consumer only needs a counter (§4) |
+| class load/remove (0046) | discrete, typed | `SystemAnnouncer` (`ClassLoaded`/`Removed`) |
+| bindings changed (0091) | discrete, typed | `SystemAnnouncer` (`BindingChanged`) |
+| supervision deltas (0092) | discrete, typed | `SystemAnnouncer` (`SupervisionChild…`) |
+| **Transcript lines (0017/0054)** | **no — a stream** | **dedicated `beamtalk_transcript_stream`, NOT this bus** |
+
+So this substrate consolidates the **discrete** push channels; it deliberately
+does not swallow the Transcript *stream*. That is the honest line, and it keeps
+the bus from becoming a throughput chokepoint.
+
+### 6. Security — subscription is a read capability (ties to ADR 0091)
+
+Subscribing to `SystemAnnouncer` observes everything the system emits, so it is
+a **read** operation under ADR 0091's role model. The remote front's
+push-subscription facade (ADR 0091) is the gate: it wraps `SystemAnnouncer`
+subscription as a named, RBAC-checked op (Observer role may subscribe to the
+curated system events; subscribing to *all* events, or to internal/infra
+announcements, is gated like ADR 0092's `system` scope). Direct
+`SystemAnnouncer current` access from in-image Beamtalk code is unrestricted —
+but that already implies an `eval`-capable (Owner) session, which ADR 0091
+treats as fully privileged, so no boundary is bypassed. The ADR-0091
+implementation issue owns adding `subscribe`/`unsubscribe` to the authoritative
+op list; this ADR fixes the requirement.
 
 ### 3. Layer 3 — the package (re-scoped BT-2193)
 
@@ -266,7 +342,8 @@ bt> "dead subscriber process is auto-removed via monitor — no manual cleanup"
 - **Operator.** Subscriptions are monitored (no leak), handlers are isolated
   (no cascade), and the bus is `pg` (inspectable with standard tools). The
   package bridge exports to existing observability without coupling.
-- **Tooling developer.** One typed feed replaces five bespoke transports;
+- **Tooling developer.** One typed feed replaces the discrete bespoke
+  transports (Transcript streaming stays its own channel, §5);
   filtering by `Announcement` subclass is a clean, evolvable contract for the
   LiveView/VSCode panes (ADRs 0017/0046/0085/0091).
 
@@ -293,10 +370,22 @@ bt> "dead subscriber process is auto-removed via monitor — no manual cleanup"
 
 ### Substrate fork
 
-- **`pg` (chosen):** already started, already our broadcast primitive, cluster-ready, no new ownership machinery. *Con:* typed/MRO/liveness must be layered on top (we do).
-- **ETS-per-announcer + monitors (BT-2193's original):** fine for isolated app announcers; but doesn't give cluster distribution for free and re-introduces bespoke ETS heir/ownership handling the runtime already solved with `pg`.
-- **`gen_event`:** rejected — serialised single-process dispatch, shared failure domain.
-- **`telemetry` as the substrate:** rejected — untyped, no liveness/MRO, and it would overload ADR 0069's measurement bus with reactive domain logic.
+- **ETS subscription table + caller-side dispatch (chosen):** gen_server owns
+  writes + monitors + ETS heir (crash-survivable); dispatch runs in the
+  announcing process off `read_concurrency` ETS, so there is no central
+  dispatch mailbox to deadlock (`announceAndWait:` reentrancy) or bottleneck.
+  This is the `beamtalk_xref` / `beamtalk_trace_store` pattern.
+- **`pg` for `SystemAnnouncer` membership only:** gives cluster-wide
+  *membership* for the shared bus at no extra cost — but `pg` has no send
+  primitive, so it is a registry, not a transport, and v1 delivery is local.
+  Per-instance announcers don't use `pg`.
+- **Central dispatch gen_server (rejected):** the obvious "announce → call the
+  bus → it sends to everyone" design self-deadlocks on reentrant
+  `announceAndWait:` and serialises all events through one mailbox.
+- **`gen_event` (rejected):** serialised single-process dispatch, shared
+  failure domain.
+- **`telemetry` as the substrate (rejected):** untyped, no liveness/MRO, and it
+  would overload ADR 0069's measurement bus with reactive domain logic.
 
 ### Tension points
 - Designers split (a)↔(b) on "lean core"; the dependency-direction fact breaks the tie toward (b)/(c).
@@ -313,25 +402,41 @@ exists to stop.
 ## Consequences
 
 ### Positive
-- One typed substrate replaces five bespoke push channels before they are built.
+- One typed substrate replaces the **discrete** bespoke push channels before
+  they are built (Transcript streaming stays on its own channel — §5).
 - System facilities and app code share one mechanism (`SystemAnnouncer` is the
   Pharo-correct home).
-- Free single-node→cluster path via `pg`; clean `telemetry` boundary preserved.
-- Monitored + isolated by construction; hot-reload-safe (process-rooted subs).
+- Dispatch off the hot path (caller-side, concurrent ETS) → no central mailbox
+  to deadlock or bottleneck; crash-survivable via ETS heir; monitored + isolated
+  by construction; hot-reload-safe (process-rooted subs). Clean `telemetry`
+  boundary preserved (§4).
+- `pg` gives `SystemAnnouncer` cluster-wide *membership* for free, leaving only
+  cross-node *delivery* (the genuinely hard part) to the package.
 
 ### Negative
 - Three layers to build and document vs BT-2193's single package.
-- Re-scopes BT-2193 and requires follow-up edits to five ADRs (0017/0046/0054/
-  0091/0092) to point at the shared substrate.
+- Re-scopes BT-2193 and requires follow-up edits to four ADRs (0046/0054/0091/
+  0092) to point at the shared substrate, plus confirming Transcript stays on
+  ADR 0017/0054's stream.
 - Two buses coexist (`telemetry` + Announcements); the "measure vs react" line
-  must be taught or people will reach for the wrong one. (Mitigated by the
-  package bridge for the overlap cases.)
+  must be taught or people will reach for the wrong one. (Mitigated by §4 + the
+  package bridge.)
+- **No cross-event ordering guarantee** across different announcing processes
+  (each fans out from its own process); within a single `announce:` order is
+  per-subscription. Consumers needing causal order (e.g. `ActorSpawned` before a
+  dependent event) must not assume it — documented, not engineered, in v1.
+- MRO matching costs an ETS-metadata walk per announce (~ depth × ~150 ns + fan-
+  out send cost). Fine for discrete events at human/IDE rates; **not** fine for
+  line-rate streams — which is precisely why Transcript is excluded (§5).
 
 ### Neutral
 - Adds a runtime worker (`beamtalk_announcements`) under `beamtalk_runtime_sup`
-  and 3–4 stdlib classes + a handful of system `Announcement` subclasses.
-- `pg` gains a second role (membership *and* announcement transport); both are
-  standard `pg` usage.
+  (after `beamtalk_bootstrap`) and 3–4 stdlib classes + a handful of system
+  `Announcement` subclasses.
+- `pg` gains a second use (class-registry membership *and* `SystemAnnouncer`
+  subscriber membership); both are ordinary `pg` group usage.
+- `announceAndWait:` is `spawn_monitor`-per-handler — N transient processes per
+  sync announce; acceptable for the low-frequency sync path, not the async one.
 
 ## Implementation
 
@@ -369,7 +474,7 @@ events), **package** (re-scoped), **docs/tests**. No parser/codegen changes.
 - Related issues: BT-2396 (this ADR), BT-2193 (package — to be re-scoped),
   BT-567 (original stdlib spec, superseded), BT-1242 (`class_removed` via pg)
 - Related ADRs: ADR 0069 (Tracing / `telemetry` measurement bus — the boundary),
-  ADR 0092 (Supervision Introspection — consumer; §8 points here), ADR 0017
+  ADR 0092 (Supervision Introspection — consumer; §8 updated to point here), ADR 0017
   (browser), ADR 0046 (VSCode sidebar), ADR 0054 (protocols), ADR 0091 (remote
   front), ADR 0070/0073 (package namespaces/distribution)
 - Code: `runtime/apps/beamtalk_runtime/src/beamtalk_runtime_sup.erl`,

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -224,6 +224,12 @@ typed Object subclass: Announcer
 // The one the *system* publishes through — Pharo's SystemAnnouncer.
 sealed Announcer subclass: SystemAnnouncer
   class current -> SystemAnnouncer => (Erlang beamtalk_announcements) system
+
+// The unsubscribe token returned by when:… — another opaque runtime handle
+// (Object, like Announcer), not data. `unsubscribe` removes exactly this row.
+sealed typed Object subclass: Subscription
+  unsubscribe -> Nil => ...
+  isActive    -> Boolean => ...
 ```
 
 `SystemAnnouncer current` is the shared bus the runtime emits onto and tools
@@ -232,6 +238,35 @@ subclasses (stdlib-provided): `ActorSpawned` / `ActorStopped`, `ClassLoaded` /
 `ClassRemoved`, `BindingChanged`, and (ADR 0092) `SupervisionChildAdded` /
 `SupervisionChildCrashed`. A tool subscribes once and filters by event class
 instead of wiring four bespoke transports.
+
+### 3. Layer 3 — the package (re-scoped BT-2193)
+
+`beamtalk-announcements` shrinks to the genuinely-optional:
+
+- **Hardened distributed delivery** beyond live connected nodes: netsplit /
+  partition tolerance, buffering + replay for reconnecting subscribers, and
+  multi-node *workspace clusters*. (Plain cross-node delivery to a *connected*
+  node — including the ADR-0091 LiveView front — is already handled by the core
+  bus over Erlang distribution; see Layer 1.)
+- **`RecordingAnnouncer`** — the test double that records `announce:` calls
+  without dispatching.
+- **`telemetry` / OpenTelemetry bridge** — re-emit announcements as telemetry
+  spans for ops pipelines (the bridge direction ADR 0069 anticipated).
+
+### 4. The line vs `telemetry` (ADR 0069)
+
+| | `telemetry` (ADR 0069) | Announcements (this ADR) |
+|---|---|---|
+| Purpose | **Measurement** — spans, counters, durations | **Typed domain events** you react to |
+| Event identity | string list `[beamtalk, actor, dispatch]` | `Announcement` subclass (typed, MRO) |
+| Delivery | sync, in caller process, fire-and-forget | async or sync; isolated; monitored |
+| Subscriber | metrics handler (export to StatsD/OTel) | app logic / IDE pane reacting |
+| Liveness | none (handlers are module funs) | `monitor`-based per subscriber |
+
+Rule of thumb: *measure* with `telemetry`, *react* with Announcements. Actor
+spawn/stop can legitimately produce **both** (a telemetry counter for ops, a
+`SystemAnnouncer` event for the IDE) — the package's bridge is how one becomes
+the other, without coupling the two buses.
 
 ### 5. What does *not* belong on this bus (scope boundary)
 
@@ -330,35 +365,6 @@ default subscribersOf: …` grouped by `announcementClass`. The navigator reads
 are gated as a `system`-scope read under ADR 0091, like the supervision
 navigator (§6).
 
-### 3. Layer 3 — the package (re-scoped BT-2193)
-
-`beamtalk-announcements` shrinks to the genuinely-optional:
-
-- **Hardened distributed delivery** beyond live connected nodes: netsplit /
-  partition tolerance, buffering + replay for reconnecting subscribers, and
-  multi-node *workspace clusters*. (Plain cross-node delivery to a *connected*
-  node — including the ADR-0091 LiveView front — is already handled by the core
-  bus over Erlang distribution; see Layer 1.)
-- **`RecordingAnnouncer`** — the test double that records `announce:` calls
-  without dispatching.
-- **`telemetry` / OpenTelemetry bridge** — re-emit announcements as telemetry
-  spans for ops pipelines (the bridge direction ADR 0069 anticipated).
-
-### 4. The line vs `telemetry` (ADR 0069)
-
-| | `telemetry` (ADR 0069) | Announcements (this ADR) |
-|---|---|---|
-| Purpose | **Measurement** — spans, counters, durations | **Typed domain events** you react to |
-| Event identity | string list `[beamtalk, actor, dispatch]` | `Announcement` subclass (typed, MRO) |
-| Delivery | sync, in caller process, fire-and-forget | async or sync; isolated; monitored |
-| Subscriber | metrics handler (export to StatsD/OTel) | app logic / IDE pane reacting |
-| Liveness | none (handlers are module funs) | `monitor`-based per subscriber |
-
-Rule of thumb: *measure* with `telemetry`, *react* with Announcements. Actor
-spawn/stop can legitimately produce **both** (a telemetry counter for ops, a
-`SystemAnnouncer` event for the IDE) — the package's bridge is how one becomes
-the other, without coupling the two buses.
-
 ### REPL session
 
 ```beamtalk
@@ -409,7 +415,7 @@ bt> "dead subscriber process is auto-removed via monitor — no manual cleanup"
 |---|---|---|
 | **Pharo Announcements + `SystemAnnouncer`** | Typed `Announcement` subclasses, `when:do:` / `when:send:to:`, subclass dispatch; `SystemAnnouncer uniqueInstance` is **core image**, the system publishes class/method change events through it. | **Take:** the whole typed-Observer protocol *and the it-lives-in-the-core decision*. This ADR's central move is recognising Beamtalk is in the same position. **Adapt:** weak refs → BEAM `monitor`. |
 | **GemStone Announcements** | Same family, server-side. | Confirms the model scales to a shared multi-client image — our exact LiveView situation. |
-| **Phoenix.PubSub** | topic-string + cluster broadcast over `pg2`/`pg`. | **Take:** `pg` as the cluster-ready transport (free v2 distribution). **Leave:** topic *strings* — we want typed events + MRO, not stringly-typed topics. |
+| **Phoenix.PubSub** | topic-string + cluster broadcast over `pg2`/`pg`. | **Take:** `pg` for cluster-wide membership (free connected-node delivery in v1; partition tolerance to the package — Layer 1/3). **Leave:** topic *strings* — we want typed events + MRO, not stringly-typed topics. |
 | **Erlang `gen_event`** | Serialised handler dispatch in one process. | **Leave:** single-process serialisation is a bottleneck and a shared failure domain; `pg` fan-out + isolated handlers is more BEAM-idiomatic. |
 | **Erlang `telemetry`** (ADR 0069) | Untyped measurement bus. | **Leave** as the measurement layer; **bridge** to it from the package. Explicitly *not* the typed Observer. |
 | **ROS typed topics / Akka EventStream** | Typed publish/subscribe by message class. | Confirms type-keyed (not string-keyed) subscription is the ergonomic choice for domain events. |
@@ -529,8 +535,9 @@ exists to stop.
 
 ### Neutral
 - Adds a runtime worker (`beamtalk_announcements`) under `beamtalk_runtime_sup`
-  (after `beamtalk_bootstrap`) and 3–4 stdlib classes + a handful of system
-  `Announcement` subclasses.
+  (after `beamtalk_bootstrap`) and ~6 stdlib classes (`Announcement`,
+  `Announcer`, `SystemAnnouncer`, `Subscription`, `AnnouncementNavigation`,
+  `SubscriptionNode`) + a handful of system `Announcement` subclasses.
 - `pg` gains a second use (class-registry membership *and* `SystemAnnouncer`
   subscriber membership); both are ordinary `pg` group usage.
 - `announceAndWait:` is `spawn_monitor`-per-handler — N transient processes per

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -128,20 +128,24 @@ A runtime module providing typed publish/subscribe, slotted into
 hot-path discipline as `beamtalk_xref` and `beamtalk_trace_store`: **the
 gen_server is not in the dispatch path.**
 
-- **Subscription table = ETS, gen_server owns writes only.** Subscriptions
-  `{AnnouncementClass, SubscriberPid, Handler, OnceFlag}` live in an ETS
-  **`set` keyed by `{AnnouncementClass, SubscriberPid}`** — one row per
-  subscriber per class, never a `bag`. (The unique key is what makes the
-  `doOnce:` `ets:take/2` below remove exactly one subscriber's row; a `bag`
-  would take *all* rows for the key.) `when:…` / `unsubscribe:` go through the
-  gen_server (serialised writes, and it arms `erlang:monitor/2` per subscriber).
-  The ETS table is created with `{heir, SupervisorPid, …}` so it **survives a
-  bus crash** (the `beamtalk_trace_store` pattern). On restart the gen_server
-  re-arms monitors from the table — and because a subscriber may have **died
-  during the crash→restart gap** (its `DOWN` went to the dead bus and is lost),
-  re-arm does an `is_process_alive/1` check per row and prunes the dead ones, so
-  the table cannot accumulate stale pids. (This is new exposure vs
-  `beamtalk_trace_store`, which monitors nothing.)
+- **Subscription table = ETS, gen_server owns writes only.** Each subscription
+  is a row `{SubRef, AnnouncementClass, SubscriberPid, Handler, OnceFlag}` in an
+  ETS **`set` keyed by a unique `SubRef`** (the ref the returned `Subscription`
+  wraps), with a secondary by-class index (`ordered_set` on
+  `{AnnouncementClass, SubRef}`) for the MRO lookup. Keying by `SubRef` — *not*
+  by `{Class, Pid}` — means a process may hold **multiple distinct subscriptions
+  to the same class** (Pharo's rule, and what the per-*subscription* de-dup below
+  assumes): a second `when: C do: […]` adds a row, it never silently replaces the
+  first. `doOnce:`'s `ets:take(SubRef)` stays atomic and selective on the unique
+  key. `when:…` / `unsubscribe:` go through the gen_server (serialised writes,
+  and it arms `erlang:monitor/2` per subscriber). The ETS table is created with
+  `{heir, SupervisorPid, …}` so it **survives a bus crash** (the
+  `beamtalk_trace_store` pattern). On restart the gen_server re-arms monitors
+  from the table — and because a subscriber may have **died during the
+  crash→restart gap** (its `DOWN` went to the dead bus and is lost), re-arm does
+  an `is_process_alive/1` check per row and prunes the dead ones, so the table
+  cannot accumulate stale pids. (New exposure vs `beamtalk_trace_store`, which
+  monitors nothing.)
 - **Dispatch runs in the announcing process, off concurrent ETS reads** — not
   in the gen_server. `announce:` / `announceAndWait:` do a `read_concurrency`
   ETS lookup of matching subscribers and fan out with direct `Pid ! Msg`
@@ -189,16 +193,21 @@ gen_server is not in the dispatch path.**
   `{'DOWN', Ref, process, _, Reason}` as the handler-crashed signal (logged
   `domain => [beamtalk, announcements]`, never propagated to siblings or the
   announcer) and the per-handler timeout ejects the loop — so a crashed handler
-  can never leave the caller blocked on a reply that never comes.
+  can never leave the caller blocked on a reply that never comes. The timeout
+  **defaults to 5 s** and is configurable via `announceAndWait:timeout:` (ms).
   `announceAndWait:` from inside a handler is therefore safe — there is no shared
   gen_server to deadlock on. **`announceAndWait:` is *not* available on
   `SystemAnnouncer`** (it is sealed async-only): the system bus can have many
   subscribers, and `spawn_monitor`-per-handler there would be an unbounded
   process storm under rapid system events (startup actor spawns). Sync gather is
-  for per-instance announcers with a known, small subscriber set.
+  for per-instance announcers with a known, small subscriber set. **Enforcement
+  is at runtime** — `SystemAnnouncer` overrides `announceAndWait:` to raise
+  `(UnsupportedOperation announceAndWait:)`, *not* a type-only prohibition,
+  because a value statically typed `Announcer` may dynamically be the system bus,
+  so the guard must hold at the call, not just the declared type.
 - **`doOnce:` is claimed atomically.** Since dispatch is caller-side and two
   `announce:` can run concurrently, a `doOnce` subscription is consumed with an
-  atomic `ets:take/2` on its unique `{AnnouncementClass, SubscriberPid}` key —
+  atomic `ets:take(SubRef)` on its unique key —
   whichever announce wins the `take` delivers, the loser gets `[]` and skips it,
   so it fires at most once. (A concurrent announcer may waste its MRO walk on a
   row that's already taken — harmless; correctness rests on the single atomic
@@ -241,7 +250,8 @@ typed Object subclass: Announcer
   when: aClass :: Class send: sel :: Symbol to: receiver -> Subscription => ...
   when: aClass :: Class doOnce: aBlock :: Block -> Subscription => ...
   announce: anEvent :: Announcement -> Nil => ...           // async (cast)
-  announceAndWait: anEvent :: Announcement -> Nil => ...     // sync (call)
+  announceAndWait: anEvent :: Announcement -> Nil => ...     // sync (call), 5s default timeout
+  announceAndWait: anEvent :: Announcement timeout: ms :: Integer -> Nil => ...
   unsubscribe: receiver -> Nil => ...
   // self-inspection (object-knows-itself; reads its own ETS rows by ref) — §7
   subscriptions -> List(SubscriptionNode) => ...
@@ -253,10 +263,12 @@ sealed Announcer subclass: SystemAnnouncer
   class current -> SystemAnnouncer => (Erlang beamtalk_announcements) system
 
 // The unsubscribe token returned by when:… — another opaque runtime handle
-// (Object, like Announcer), not data. `unsubscribe` removes exactly this row.
+// (Object, like Announcer), wrapping the subscription's unique SubRef. Each
+// when:… returns a *distinct* Subscription (a process may hold several to the
+// same class — Pharo's rule), so re-subscribing never silently replaces.
 sealed typed Object subclass: Subscription
-  unsubscribe -> Nil => ...
-  isActive    -> Boolean => ...
+  unsubscribe -> Nil => ...        // removes exactly this SubRef's row
+  isActive    -> Boolean => ...    // ets:member on the SubRef; false after unsubscribe
 ```
 
 `SystemAnnouncer current` is the shared bus the runtime emits onto and tools
@@ -439,7 +451,7 @@ the discoverability win first if wanted.
 
 ```beamtalk
 bt> Announcement subclass: PriceChanged
-...>   field: newPrice :: Money = nil
+...>   field: newPrice :: Number = nil
 PriceChanged
 
 bt> a := Announcer new

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -99,7 +99,7 @@ veneer (the part that was going to be a package), and a thin package for the
 genuinely-optional extras.** Draw a firm line between this typed-domain-event
 substrate and `telemetry`'s measurement role.
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────┐
 │ package: beamtalk-announcements (OPTIONAL)                     │
 │   distributed cross-node delivery · RecordingAnnouncer ·       │

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -1,0 +1,380 @@
+# ADR 0093: Announcements — Typed Event Substrate (Runtime Bus + stdlib Veneer)
+
+## Status
+Proposed (2026-06-06)
+
+## Context
+
+### The problem
+
+Beamtalk has no first-class way for one part of the system to say "X happened"
+and another part to react. Application code wants a typed Observer
+(`when: SomethingChanged do: [...]`). And the *system itself* increasingly
+wants to publish: a LiveView IDE pane needs Transcript lines, actor
+spawn/stop, class loads, binding changes, and supervision-tree deltas pushed
+to it as they happen.
+
+This ADR decides **what the pub/sub mechanism is, and — critically — where it
+lives** (runtime / stdlib / package), so the rest of the system has one
+substrate to build on instead of many.
+
+### Why now: five ADRs are each about to reinvent this
+
+Investigating ADR 0092 (supervision-tree introspection) surfaced that **five
+separate accepted/proposed ADRs each independently plan their own bespoke
+"subscribe / broadcast" channel** — and none is built yet:
+
+| ADR | Bespoke notification it plans |
+|---|---|
+| 0017 (browser connectivity) | `beamtalk_transcript_stream:subscribe/unsubscribe`; "actor-spawned/stopped … *requires new registry notification infrastructure*" |
+| 0046 (VSCode sidebar) | new `class-loaded` push event + `actors` spawned/stopped channel |
+| 0054 (communication protocols) | WebSocket push for Transcript + actor lifecycle; future `{future_resolved}` notifications |
+| 0091 (remote workspace front) | push-subscription facade for transcript / actors / classes / bindings |
+| 0092 (supervision introspection) | supervision-tree deltas (deferred to "the Announcements package") |
+
+That is five teams about to build five slightly-different subscribe/broadcast
+mechanisms. Deciding the substrate now **prevents** the fragmentation rather
+than forcing a later consolidation.
+
+### What already exists (and what it is *not*)
+
+The runtime already has two event-ish mechanisms — neither is a typed Observer:
+
+1. **`pg` process groups** — started at boot (`pg:start_link/0` in
+   `beamtalk_bootstrap`) and used today as a **membership registry**:
+   `beamtalk_object_class` joins the `beamtalk_classes` group so
+   `beamtalk_class_registry` can enumerate live class processes. `pg` is
+   untyped, stateless broadcast — no event types, no per-subscriber liveness
+   beyond group membership, no subclass matching.
+2. **`telemetry`** — adopted by **ADR 0069** as the *measurement* bus
+   (`telemetry:span/3` around actor dispatch, lock-free counters, ETS trace
+   store). It is deliberately fire-and-forget, untyped (string-list event
+   names), with handlers run synchronously in the caller process. It is the
+   right tool for spans/metrics and the wrong tool for "subscribe to a typed
+   domain event and react in app logic."
+
+So Beamtalk has a **membership primitive** and a **measurement bus** — but no
+**typed domain-event** layer. That gap is what every one of the five ADRs is
+working around.
+
+### Prior history of this decision
+
+- **BT-567** originally specced an Announcements framework *in stdlib*.
+- **BT-2193** re-scoped it to a standalone **package** (`beamtalk-announcements`),
+  after ADRs 0070/0073 made packages first-class — on the reasoning that it is
+  "self-contained, optional, decoupled from runtime bootstrap."
+- **BT-2396** (this ADR) was filed to formalise the design before the package
+  is built.
+
+The package framing assumed Announcements is a *leaf* capability that apps opt
+into. The five-consumer finding challenges that: if the **system** publishes
+through it, it cannot live in an optional package, because **stdlib and the
+runtime cannot depend on a package** (CLAUDE.md / architecture: "dependencies
+flow down only"). This is exactly why Pharo keeps Announcements (and
+`SystemAnnouncer`) in the **core image**, not a loadable package.
+
+### Constraints
+
+1. **Dependency direction is the hard constraint.** stdlib/runtime → may be
+   depended on; a package → depends on them, never the reverse. Any system
+   publisher forces the typed core *below* the package line.
+2. **Do not add a third ad-hoc mechanism.** We already have `pg` (membership)
+   and `telemetry` (measurement). A typed Observer must either reuse one or
+   justify why neither fits — and must not blur the line with `telemetry`'s
+   measurement role (ADR 0069).
+3. **BEAM-native liveness.** Subscribers are processes that can die. Cleanup
+   must be `erlang:monitor/2`-driven (the BEAM analogue of Pharo's weak
+   subscriptions), not manual.
+4. **Fault isolation.** A crashing subscriber handler must not take down the
+   publisher or other subscribers (let-it-crash, Principle 10).
+5. **Hot-code-reload safe.** Subscriptions are process-rooted, not
+   module-rooted, so they survive method/class reload.
+6. **Structured errors & logging** (CLAUDE.md): `#beamtalk_error{}`, `?LOG_*`
+   with `domain => [beamtalk, announcements]`.
+
+## Decision
+
+**Adopt a three-layer design: a runtime event bus, a stdlib typed-Observer
+veneer (the part that was going to be a package), and a thin package for the
+genuinely-optional extras.** Draw a firm line between this typed-domain-event
+substrate and `telemetry`'s measurement role.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ package: beamtalk-announcements (OPTIONAL)                     │
+│   distributed cross-node delivery · RecordingAnnouncer ·       │
+│   telemetry/OTel bridge                                        │
+├──────────────────────────────────────────────────────────────┤
+│ stdlib (CORE IMAGE)                                            │
+│   Announcement (base event) · Announcer (per-instance) ·       │
+│   SystemAnnouncer (singleton) · when:do: / announce: / …       │
+├──────────────────────────────────────────────────────────────┤
+│ runtime (Erlang)  beamtalk_announcements                       │
+│   typed dispatch over pg topic-groups + monitor-based liveness │
+│   MRO match · sync(call) + async(cast) · fault isolation       │
+├──────────────────────────────────────────────────────────────┤
+│ existing: pg (membership)   ·   telemetry (measurement, 0069)  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 1. Layer 1 — runtime bus (`beamtalk_announcements`)
+
+A runtime module providing typed publish/subscribe, slotted into
+`beamtalk_runtime_sup` as a worker (template: `beamtalk_xref`, ADR 0087).
+**It reuses `pg` as the transport** — one `pg` group per *announcer identity*
+— and layers the typed concerns on top that `pg` lacks:
+
+- **Typed dispatch with MRO matching.** Subscriptions are keyed by
+  `Announcement` class. On `announce: anEvent`, the bus walks the event's
+  superclass chain and delivers to subscribers of the event class *or any
+  ancestor* (subscribe to `UIEvent`, receive `ButtonClicked`). The MRO walk
+  happens at announce time, so live class-hierarchy changes are respected.
+- **Liveness.** `erlang:monitor/2` on each subscriber; a `DOWN` removes its
+  subscriptions (the `pg` group membership *is* the liveness for the broadcast
+  fan-out; monitors handle the typed-subscription table).
+- **Sync + async.** `announce:` → `cast` (fire-and-forget); `announceAndWait:`
+  → `call` (blocks until every subscriber's handler returns).
+- **Fault isolation.** Each handler runs guarded; a crash is caught, logged
+  (`domain => [beamtalk, announcements]`), and does not affect siblings or the
+  publisher.
+
+Why `pg` rather than BT-2193's ETS-per-announcer or a brand-new bus: `pg` is
+already started, already the project's broadcast primitive, cluster-ready
+(the v2 distributed path is then *free* — same code, `pg` spans nodes on OTP
+23+), and avoids standing up bespoke ETS ownership/heir machinery. The typed
+table (class → subscribers, monitors) is small per-announcer state the module
+owns; `pg` carries the fan-out. (BT-2193's "no pg" note predates this
+consolidation goal — it optimised a single package in isolation.)
+
+### 2. Layer 2 — stdlib typed veneer
+
+Three classes in the **core image** (so the system can publish):
+
+```beamtalk
+// Base event type — apps subclass it; carries typed state.
+abstract Object subclass: Announcement
+
+// A dispatcher instance. Apps spawn their own; the system has a singleton.
+Object subclass: Announcer
+  class spawn -> Announcer => (Erlang beamtalk_announcements) newAnnouncer
+  when: aClass :: Class do: aBlock :: Block -> Subscription => ...
+  when: aClass :: Class send: sel :: Symbol to: receiver -> Subscription => ...
+  when: aClass :: Class doOnce: aBlock :: Block -> Subscription => ...
+  announce: anEvent :: Announcement -> Nil => ...           // async (cast)
+  announceAndWait: anEvent :: Announcement -> Nil => ...     // sync (call)
+  unsubscribe: receiver -> Nil => ...
+
+// The one the *system* publishes through — Pharo's SystemAnnouncer.
+sealed Announcer subclass: SystemAnnouncer
+  class current -> SystemAnnouncer => (Erlang beamtalk_announcements) system
+```
+
+`SystemAnnouncer current` is the shared bus the runtime emits onto and tools
+subscribe to. System facilities publish well-known `Announcement` subclasses
+(stdlib-provided): `TranscriptChanged`, `ActorSpawned` / `ActorStopped`,
+`ClassLoaded` / `ClassRemoved`, `BindingChanged`, and (ADR 0092)
+`SupervisionChildAdded` / `SupervisionChildCrashed`. These are the **five
+consuming ADRs' channels, unified** — a tool subscribes once and filters by
+event class instead of wiring five bespoke transports.
+
+### 3. Layer 3 — the package (re-scoped BT-2193)
+
+`beamtalk-announcements` shrinks to the genuinely-optional:
+
+- **Distributed cross-node delivery** beyond what single-node `pg` gives.
+- **`RecordingAnnouncer`** — the test double that records `announce:` calls
+  without dispatching.
+- **`telemetry` / OpenTelemetry bridge** — re-emit announcements as telemetry
+  spans for ops pipelines (the bridge direction ADR 0069 anticipated).
+
+### 4. The line vs `telemetry` (ADR 0069)
+
+| | `telemetry` (ADR 0069) | Announcements (this ADR) |
+|---|---|---|
+| Purpose | **Measurement** — spans, counters, durations | **Typed domain events** you react to |
+| Event identity | string list `[beamtalk, actor, dispatch]` | `Announcement` subclass (typed, MRO) |
+| Delivery | sync, in caller process, fire-and-forget | async or sync; isolated; monitored |
+| Subscriber | metrics handler (export to StatsD/OTel) | app logic / IDE pane reacting |
+| Liveness | none (handlers are module funs) | `monitor`-based per subscriber |
+
+Rule of thumb: *measure* with `telemetry`, *react* with Announcements. Actor
+spawn/stop can legitimately produce **both** (a telemetry counter for ops, a
+`SystemAnnouncer` event for the IDE) — the package's bridge is how one becomes
+the other, without coupling the two buses.
+
+### REPL session
+
+```beamtalk
+bt> Announcement subclass: PriceChanged
+...>   state: newPrice :: Money = nil
+PriceChanged
+
+bt> a := Announcer spawn
+#Announcer<<0.421.0>>
+
+bt> a when: PriceChanged do: [:e | Transcript showLine: "now " ++ e newPrice printString]
+#Subscription<...>
+
+bt> a announce: (PriceChanged new: #{ #newPrice => 42 })
+now 42
+
+bt> "Subscribe to the system bus — one feed for everything the system emits:"
+bt> SystemAnnouncer current when: ActorSpawned do: [:e | Transcript showLine: e actorClass name]
+#Subscription<...>
+
+bt> Counter spawn
+Counter        "← the subscription above fires"
+```
+
+### Error / edge behaviour
+
+```beamtalk
+bt> a when: 42 do: [:e | e]
+// type error: when:do: expects a Class, got Integer (42)
+
+bt> a when: PriceChanged do: [:e | e boom]   // handler crashes on announce
+bt> a announce: (PriceChanged new: #{...})
+// other subscribers still run; the crash is logged
+// (domain => [beamtalk, announcements]), not propagated to the announcer
+
+bt> "dead subscriber process is auto-removed via monitor — no manual cleanup"
+```
+
+## Prior Art
+
+| Source | Model | What we take / leave |
+|---|---|---|
+| **Pharo Announcements + `SystemAnnouncer`** | Typed `Announcement` subclasses, `when:do:` / `when:send:to:`, subclass dispatch; `SystemAnnouncer uniqueInstance` is **core image**, the system publishes class/method change events through it. | **Take:** the whole typed-Observer protocol *and the it-lives-in-the-core decision*. This ADR's central move is recognising Beamtalk is in the same position. **Adapt:** weak refs → BEAM `monitor`. |
+| **GemStone Announcements** | Same family, server-side. | Confirms the model scales to a shared multi-client image — our exact LiveView situation. |
+| **Phoenix.PubSub** | topic-string + cluster broadcast over `pg2`/`pg`. | **Take:** `pg` as the cluster-ready transport (free v2 distribution). **Leave:** topic *strings* — we want typed events + MRO, not stringly-typed topics. |
+| **Erlang `gen_event`** | Serialised handler dispatch in one process. | **Leave:** single-process serialisation is a bottleneck and a shared failure domain; `pg` fan-out + isolated handlers is more BEAM-idiomatic. |
+| **Erlang `telemetry`** (ADR 0069) | Untyped measurement bus. | **Leave** as the measurement layer; **bridge** to it from the package. Explicitly *not* the typed Observer. |
+| **ROS typed topics / Akka EventStream** | Typed publish/subscribe by message class. | Confirms type-keyed (not string-keyed) subscription is the ergonomic choice for domain events. |
+
+## User Impact
+
+- **Newcomer.** `when: X do: [...]` reads like every other block-taking message
+  they already use; `Announcer spawn` mirrors `Counter spawn`. They can watch
+  the system live (`SystemAnnouncer current when: ActorSpawned do: …`) — a
+  tangible way to *see* what the runtime is doing.
+- **Smalltalk developer.** It *is* Pharo Announcements, including
+  `SystemAnnouncer` in the image — instant familiarity, and the right answer to
+  "where's the system's announcer?"
+- **Erlang/BEAM developer.** It's `pg` + `monitor` underneath — no magic, no
+  new bottleneck process, cluster-ready. They can also attach in Erlang. The
+  `telemetry` boundary means their metrics pipeline is untouched.
+- **Operator.** Subscriptions are monitored (no leak), handlers are isolated
+  (no cascade), and the bus is `pg` (inspectable with standard tools). The
+  package bridge exports to existing observability without coupling.
+- **Tooling developer.** One typed feed replaces five bespoke transports;
+  filtering by `Announcement` subclass is a clean, evolvable contract for the
+  LiveView/VSCode panes (ADRs 0017/0046/0085/0091).
+
+## Steelman Analysis
+
+### Location fork — the core decision
+
+**(a) Pure package (status-quo BT-2193).**
+- 🎨 **Language designer:** "Smallest core; pub/sub is a library, like `http`/`json`. Apps that don't need it don't pay."
+- ⚙️ **BEAM veteran:** "Optional deps are the OTP way; don't bloat the kernel."
+- *Fatal tension:* the **system** can't publish through a package (dependency direction). Every one of the five consumers lives in runtime/stdlib, so (a) forces them to keep their bespoke channels — it doesn't solve the actual problem. Only viable if we commit that the system *never* announces, which contradicts ADRs 0017/0046/0091/0092.
+
+**(b) All in stdlib.**
+- 🎩 **Smalltalk purist:** "Pharo puts it in the image. Done. One mechanism, always present, `SystemAnnouncer` included."
+- 🧑‍💻 **Newcomer:** "It's just there in the REPL, no dependency to add."
+- *Tension:* bundles genuinely-optional weight (cross-node distribution, telemetry bridge, test doubles) into the core that most programs never use.
+
+**(c) Layered — runtime bus + stdlib veneer + package extras (chosen).**
+- 🎩 **Smalltalk purist:** "Typed Observer + `SystemAnnouncer` are in the image where they belong."
+- ⚙️ **BEAM veteran:** "Built on `pg`, no new bottleneck, distribution is free later; the heavy/optional parts stay out of the kernel."
+- 🏭 **Operator:** "Monitored, isolated, inspectable; ops bridge is opt-in."
+- 🎨 **Language designer:** "Each concern at the right altitude; the package line falls exactly on what's optional."
+- *Tension:* three layers is more moving parts than 'one package' — justified only because the system-publisher requirement is real (five consumers).
+
+### Substrate fork
+
+- **`pg` (chosen):** already started, already our broadcast primitive, cluster-ready, no new ownership machinery. *Con:* typed/MRO/liveness must be layered on top (we do).
+- **ETS-per-announcer + monitors (BT-2193's original):** fine for isolated app announcers; but doesn't give cluster distribution for free and re-introduces bespoke ETS heir/ownership handling the runtime already solved with `pg`.
+- **`gen_event`:** rejected — serialised single-process dispatch, shared failure domain.
+- **`telemetry` as the substrate:** rejected — untyped, no liveness/MRO, and it would overload ADR 0069's measurement bus with reactive domain logic.
+
+### Tension points
+- Designers split (a)↔(b) on "lean core"; the dependency-direction fact breaks the tie toward (b)/(c).
+- BEAM veterans like `pg`; the original package author chose ETS to keep the package self-contained — consolidation flips that trade.
+
+## Alternatives Considered
+
+Covered in the steelman: **(a) pure package**, **(b) all-stdlib**, **(c) layered**
+(chosen); substrate alternatives **ETS-per-announcer**, **gen_event**,
+**telemetry-as-substrate**. Also considered and rejected: **"do nothing, let
+each ADR build its own channel"** — explicitly the fragmentation this ADR
+exists to stop.
+
+## Consequences
+
+### Positive
+- One typed substrate replaces five bespoke push channels before they are built.
+- System facilities and app code share one mechanism (`SystemAnnouncer` is the
+  Pharo-correct home).
+- Free single-node→cluster path via `pg`; clean `telemetry` boundary preserved.
+- Monitored + isolated by construction; hot-reload-safe (process-rooted subs).
+
+### Negative
+- Three layers to build and document vs BT-2193's single package.
+- Re-scopes BT-2193 and requires follow-up edits to five ADRs (0017/0046/0054/
+  0091/0092) to point at the shared substrate.
+- Two buses coexist (`telemetry` + Announcements); the "measure vs react" line
+  must be taught or people will reach for the wrong one. (Mitigated by the
+  package bridge for the overlap cases.)
+
+### Neutral
+- Adds a runtime worker (`beamtalk_announcements`) under `beamtalk_runtime_sup`
+  and 3–4 stdlib classes + a handful of system `Announcement` subclasses.
+- `pg` gains a second role (membership *and* announcement transport); both are
+  standard `pg` usage.
+
+## Implementation
+
+Downstream of acceptance (the `/plan-adr` step owns the epic + the BT-2193
+re-scope):
+
+0. **Phase 0 (napkin):** `beamtalk_announcements` with one `Announcement`
+   class, `Announcer spawn`, `when:do:`, `announce:` (async) over a single `pg`
+   group + monitor cleanup. Prove typed dispatch end-to-end from the REPL.
+1. **Runtime bus (full):** MRO match, `announceAndWait:` (sync), `when:send:to:`,
+   `when:doOnce:`, fault isolation, sup wiring. EUnit.
+2. **stdlib veneer:** `Announcement` / `Announcer` / `SystemAnnouncer` +
+   registration (`generated_builtins.rs`, `build_stdlib.rs`); typed signatures.
+   BUnit.
+3. **System events + consumer consolidation:** define the system `Announcement`
+   subclasses; migrate the runtime emit points; update ADRs 0017/0046/0054/0091/
+   0092 to subscribe via `SystemAnnouncer` (and ADR 0092 §8 to point here).
+4. **Package re-scope (BT-2193):** distributed delivery, `RecordingAnnouncer`,
+   telemetry bridge; cross-repo CI.
+5. **Docs + e2e:** language-features chapter, surface-parity, e2e btscript;
+   flip this ADR to Implemented.
+
+Affected components: **runtime** (new worker), **stdlib** (veneer + system
+events), **package** (re-scoped), **docs/tests**. No parser/codegen changes.
+
+## Migration Path
+
+- **BT-2193** is re-scoped from "whole framework as a package" to "optional
+  extras as a package," with a new stdlib/runtime epic for Layers 1–2.
+- The five consuming ADRs migrate their planned bespoke channels to
+  `SystemAnnouncer` subscriptions as part of Phase 3; until then nothing
+  regresses (none of those channels is built yet).
+
+## References
+- Related issues: BT-2396 (this ADR), BT-2193 (package — to be re-scoped),
+  BT-567 (original stdlib spec, superseded), BT-1242 (`class_removed` via pg)
+- Related ADRs: ADR 0069 (Tracing / `telemetry` measurement bus — the boundary),
+  ADR 0092 (Supervision Introspection — consumer; §8 points here), ADR 0017
+  (browser), ADR 0046 (VSCode sidebar), ADR 0054 (protocols), ADR 0091 (remote
+  front), ADR 0070/0073 (package namespaces/distribution)
+- Code: `runtime/apps/beamtalk_runtime/src/beamtalk_runtime_sup.erl`,
+  `beamtalk_xref.erl` (gen_server template), `beamtalk_object_class.erl` /
+  `beamtalk_class_registry.erl` (existing `pg` membership use),
+  `beamtalk_bootstrap.erl` (`pg:start_link`)
+- External: Pharo Announcements + `SystemAnnouncer`; Phoenix.PubSub; Erlang
+  `gen_event`; Erlang `telemetry`; GemStone Announcements

--- a/docs/ADR/0093-announcements-event-substrate.md
+++ b/docs/ADR/0093-announcements-event-substrate.md
@@ -108,6 +108,7 @@ substrate and `telemetry`'s measurement role.
 │ stdlib (CORE IMAGE)                                            │
 │   Announcement (base event) · Announcer (per-instance) ·       │
 │   SystemAnnouncer (singleton) · when:do: / announce: / …       │
+│   AnnouncementNavigation + SubscriptionNode (introspection)    │
 ├──────────────────────────────────────────────────────────────┤
 │ runtime (Erlang)  beamtalk_announcements                       │
 │   ETS subscription table (gen_server owns writes + monitors);  │
@@ -215,6 +216,10 @@ typed Object subclass: Announcer
   announce: anEvent :: Announcement -> Nil => ...           // async (cast)
   announceAndWait: anEvent :: Announcement -> Nil => ...     // sync (call)
   unsubscribe: receiver -> Nil => ...
+  // self-inspection (object-knows-itself; reads its own ETS rows by ref) — §7
+  subscriptions -> List(SubscriptionNode) => ...
+  subscribersOf: aClass :: Class -> List(SubscriptionNode) => ...
+  subscriptionCount -> Integer => ...
 
 // The one the *system* publishes through — Pharo's SystemAnnouncer.
 sealed Announcer subclass: SystemAnnouncer
@@ -272,6 +277,59 @@ treats as fully privileged, so no boundary is bypassed. The ADR-0091
 implementation issue owns adding `subscribe`/`unsubscribe` to the authoritative
 op list; this ADR fixes the requirement.
 
+### 7. Introspection & navigation — the third navigation sibling
+
+A pub/sub bus that can't be inspected is a black box, which would contradict the
+very reason this lives in the core (observability/tooling, §"Why now"). Beamtalk
+already exposes runtime *wiring* along two axes that share one shape — a
+**navigator** (`Object`) returning **snapshot records** (`Value`):
+`SystemNavigation` walks static structure (classes, `sendersOf:`); ADR 0092's
+`ProcessNavigation` walks the live supervision tree (`SupervisionNode`).
+Subscriptions are wiring of the same kind, so the substrate ships the **third
+sibling** in v1 — the pattern is settled, so there is no reason to defer it.
+
+Two levels, mirroring ADR 0092's *object-knows-itself / navigator-discovers-
+system* split:
+
+- **Object-knows-itself.** A live `Announcer` / `SystemAnnouncer` inspects its
+  own subscriptions (`subscriptions`, `subscribersOf:`, `subscriptionCount`
+  above) by reading its own ETS rows — cheap, caller-side.
+- **Navigator-discovers-system.** `AnnouncementNavigation` is the dynamic twin
+  of `SystemNavigation`, a `sealed typed Object subclass` (a query handle, not
+  an actor — exactly like `SystemNavigation`/`ProcessNavigation`):
+
+```beamtalk
+class default                          -> AnnouncementNavigation   // the system bus
+class of: anAnnouncer :: Announcer     -> AnnouncementNavigation   // one announcer
+  subscriptions                        -> List(SubscriptionNode)   // snapshot
+  subscribersOf: aClass :: Class       -> List(SubscriptionNode)
+  announcedClasses                     -> List(Class)              // distinct event types in use
+```
+
+It returns a **read-only snapshot** of the subscription graph as immutable
+`Value` records:
+
+```beamtalk
+sealed typed Value subclass: SubscriptionNode
+  field: announcementClass :: Class      = nil   // the subscribed-to event type
+  field: announcer         :: Announcer  = nil   // which bus
+  field: subscriber        :: Pid        = nil   // the live handler process
+  field: handlerKind       :: Symbol     = nil   // #do | #send | #doOnce
+  field: once              :: Boolean    = false
+```
+
+The **read-vs-mutate rule** is ADR 0092 §3a's, applied identically: a
+`SubscriptionNode` is a frozen fact and read-only; to *act* you cross back to
+the live `Subscription` token (`unsubscribe`) or the `Announcer`. This keeps the
+Object/Value split consistent across all three navigators — navigators
+(`SystemNavigation`, `ProcessNavigation`, `AnnouncementNavigation`) and live
+handles (`Announcer`, `Subscription`) are `Object`; snapshot records
+(`SupervisionNode`, `SubscriptionNode`) and domain events (`Announcement`) are
+`Value`. The IDE's "event wiring" pane (ADR 0017/0091) is `AnnouncementNavigation
+default subscribersOf: …` grouped by `announcementClass`. The navigator reads
+are gated as a `system`-scope read under ADR 0091, like the supervision
+navigator (§6).
+
 ### 3. Layer 3 — the package (re-scoped BT-2193)
 
 `beamtalk-announcements` shrinks to the genuinely-optional:
@@ -323,6 +381,12 @@ bt> SystemAnnouncer current when: ActorSpawned do: [:e | Transcript showLine: e 
 
 bt> Counter spawn
 Counter        "← the subscription above fires"
+
+bt> "Introspect the wiring — the third navigation sibling (§7):"
+bt> a subscriptions size
+1
+bt> (AnnouncementNavigation default subscribersOf: ActorSpawned) first handlerKind
+#do
 ```
 
 ### Error / edge behaviour
@@ -441,6 +505,11 @@ exists to stop.
   LiveView front (a separate node over Erlang distribution) gets live updates
   with no package. Only partition tolerance / replay / multi-workspace-cluster
   fall to the package.
+- The bus is **navigable in v1** (§7): `AnnouncementNavigation` + the
+  `Announcer` self-inspection methods make subscriptions a first-class,
+  walkable part of the runtime — the third sibling of `SystemNavigation` /
+  `ProcessNavigation`, with the same `Object`-navigator / `Value`-snapshot shape.
+  Pub/sub is not a black box.
 
 ### Negative
 - Three layers to build and document vs BT-2193's single package.
@@ -477,9 +546,12 @@ re-scope):
    group + monitor cleanup. Prove typed dispatch end-to-end from the REPL.
 1. **Runtime bus (full):** MRO match, `announceAndWait:` (sync), `when:send:to:`,
    `when:doOnce:`, fault isolation, sup wiring. EUnit.
-2. **stdlib veneer:** `Announcement` / `Announcer` / `SystemAnnouncer` +
-   registration (`generated_builtins.rs`, `build_stdlib.rs`); typed signatures.
-   BUnit.
+2. **stdlib veneer + introspection:** `Announcement` / `Announcer` /
+   `SystemAnnouncer`, the `Announcer` self-inspection methods, and the
+   `AnnouncementNavigation` navigator + `SubscriptionNode` value class (§7) —
+   the navigation pattern is settled by `SystemNavigation`/`ProcessNavigation`,
+   so it ships in v1, not later. Registration (`generated_builtins.rs`,
+   `build_stdlib.rs`); typed signatures. BUnit.
 3. **System events + consumer consolidation:** define the system `Announcement`
    subclasses; migrate the runtime emit points; update ADRs 0017/0046/0054/0091/
    0092 to subscribe via `SystemAnnouncer` (and ADR 0092 §8 to point here).

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -119,6 +119,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0090](0090-array-canonical-representation.md) | Canonical Array Representation for O(log n) `at:put:` | Accepted | 2026-06-02 |
 | [0091](0091-remote-workspace-access-phoenix-authenticated-front.md) | Connection Security for Remote Workspace Access — Phoenix as Authenticated Front | Accepted | 2026-06-06 |
 | [0092](0092-supervision-tree-introspection.md) | Supervision Tree Introspection API (Runtime Query Surface) | Accepted | 2026-06-06 |
+| [0093](0093-announcements-event-substrate.md) | Announcements — Typed Event Substrate (Runtime Bus + stdlib Veneer) | Proposed | 2026-06-06 |
 
 > ADR 0086 was originally numbered 0069 (a collision with *Actor Observability and Tracing*) and was renumbered on 2026-05-25.
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -119,7 +119,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0090](0090-array-canonical-representation.md) | Canonical Array Representation for O(log n) `at:put:` | Accepted | 2026-06-02 |
 | [0091](0091-remote-workspace-access-phoenix-authenticated-front.md) | Connection Security for Remote Workspace Access — Phoenix as Authenticated Front | Accepted | 2026-06-06 |
 | [0092](0092-supervision-tree-introspection.md) | Supervision Tree Introspection API (Runtime Query Surface) | Accepted | 2026-06-06 |
-| [0093](0093-announcements-event-substrate.md) | Announcements — Typed Event Substrate (Runtime Bus + stdlib Veneer) | Proposed | 2026-06-06 |
+| [0093](0093-announcements-event-substrate.md) | Announcements — Typed Event Substrate (Runtime Bus + stdlib Veneer) | Accepted | 2026-06-07 |
 
 > ADR 0086 was originally numbered 0069 (a collision with *Actor Observability and Tracing*) and was renumbered on 2026-05-25.
 


### PR DESCRIPTION
## Summary

1. **Drafts ADR 0093 — Announcements: Typed Event Substrate (Runtime Bus + stdlib Veneer)** for BT-2396.
2. **Amends ADR 0092** — points its push/event story at ADR 0093, and (new) **aligns the `SupervisionNode` snapshot API with the live `Supervisor`** so the two read identically.

### ADR 0093 (new)

Driving finding: **five separate ADRs (0017/0046/0054/0091/0092) each independently plan their own bespoke "subscribe/broadcast" channel, and none is built yet.** Deciding the substrate now *prevents* the fragmentation. The runtime already has `pg` (membership registry) and `telemetry` (measurement bus, ADR 0069) — but **no typed domain-event layer**, which is the gap each of those ADRs works around.

**Decision (Proposed):** a three-layer design, with location/layering as the central question (dependency-direction: stdlib/runtime can't depend on a package, and the system itself must publish — Pharo's `SystemAnnouncer`-is-core precedent):

1. **Runtime bus** (`beamtalk_announcements`) — gen_server owns only the ETS subscription table + monitors (ETS `heir` for crash survival); **dispatch runs caller-side off concurrent ETS reads**, so no central mailbox to deadlock (`announceAndWait:` reentrancy) or bottleneck. `pg` is the `SystemAnnouncer` subscriber-group registry (membership free; v1 delivery local).
2. **stdlib veneer** (core image) — `Announcement` / `Announcer` / `SystemAnnouncer`.
3. **package** (re-scoped BT-2193) — optional extras only: distributed delivery, `RecordingAnnouncer`, telemetry/OTel bridge.

Explicit boundaries: *measure* with telemetry / *react* with Announcements; **Transcript line streaming is carved out** (high-volume stream, stays on `beamtalk_transcript_stream`). An adversarial-review pass (separate model) caught and fixed real errors in the first draft (pg "transport" category error, deadlock/bottleneck of central dispatch, crash-survival, dedup, security/RBAC).

### ADR 0092 amendment (supervisor/navigation API consistency)

The split is correct — *object knows itself; navigator discovers the system* (mirrors `SystemNavigation`). But the live `Supervisor` and the snapshot `SupervisionNode` described the same domain with divergent names/shapes. Now aligned (cheap — `SupervisionNode` is unimplemented, BT-2427 Planned):

- `SupervisionNode`: `children` → **`childNodes`** (frees `children` from meaning ids/classes/nodes across three receivers); add **`maxRestarts`/`restartWindow`** to mirror the live class methods (`restartIntensity` kept as a convenience dict); add **`asSupervisor`** node→live bridge.
- Live `Supervisor`: **rename `count` → `childCount`** outright (no deprecated alias — pre-1.0 clean rename, call sites/tests updated in the same change).
- New **read-vs-mutate rule**: snapshot is read-only; control goes through the live `Supervisor` (or `ProcessNavigation from: node pid`).
- New §3a table making the live/snapshot vocabulary identical.

## Changes
- `docs/ADR/0093-announcements-event-substrate.md` (new) — Status: **Proposed**
- `docs/ADR/README.md` — index entry
- `docs/ADR/0092-supervision-tree-introspection.md` — §8 repointed at ADR 0093; new §3a API-consistency section + aligned `SupervisionNode` record

## Follow-ups (not in this PR)
- `/plan-adr BT-2396` → runtime/stdlib/package epic + **re-scope BT-2193**
- The `Supervisor.bt` `count`→`childCount` rename + `asSupervisor` land under BT-2427 during ADR 0092 implementation

Docs-only; no code/parser/codegen changes.

Linear: BT-2396

https://claude.ai/code/session_015pkNg92sf2LrMiDzXVn8q6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADR for a typed “Announcements” event substrate with architecture, usage examples, error behaviors, migration guidance, and rollout plan.
  * Updated supervisor snapshot ADR: renamed children accessor, clarified snapshots are read-only and how to act via the live supervisor, and expanded/reworked supervisor restart settings.
  * Added ADR index entry for the new Announcements ADR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->