### PR TITLE
Runtime bus: beamtalk_announcements + ETS subscription table + subscribe/async announce (BT-2439)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_announcements.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_announcements.erl
@@ -1,0 +1,544 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_announcements).
+-behaviour(gen_server).
+
+%%% **DDD Context:** Runtime Context
+
+-moduledoc """
+Runtime event bus for the typed Announcements substrate (ADR 0093 Layer 1).
+
+Phase 1 (BT-2439) — the runtime foundation + napkin proof. Stands up the
+`beamtalk_announcements` gen_server, a dedicated `beamtalk_pg` scope, and the
+ETS subscription table, and proves typed dispatch end-to-end: `subscribe/4`,
+`unsubscribe/1`, and an async `announce/2` that delivers to subscribers of one
+exact `Announcement` class (no MRO walk yet — that lands in BT-2440).
+
+Design (the `beamtalk_xref` / `beamtalk_trace_store` discipline — the gen_server
+is NOT in the dispatch path):
+
+- **Subscription table = ETS, gen_server owns writes only.** Each subscription
+  is a row `{SubRef, AnnouncementClass, SubscriberPid, Handler, OnceFlag}` in a
+  `set` keyed by the unique `SubRef` the returned `Subscription` wraps. Keying by
+  `SubRef` — not `{Class, Pid}` — means a process may hold multiple distinct
+  subscriptions to the same class (Pharo's rule): a second `subscribe` adds a
+  row, it never replaces the first. A secondary by-class index
+  (`ordered_set` on `{AnnouncementClass, SubRef}`) lets `announce/2` fetch the
+  matching subscribers for one class without scanning the whole table.
+
+- **Writes serialise through the gen_server.** `subscribe/4` / `unsubscribe/1`
+  are `gen_server:call`s so the table writes are serialised and the bus can arm
+  one `erlang:monitor/2` per distinct subscriber pid (ref-counted across that
+  pid's subscriptions, so the monitor is only dropped when its last subscription
+  goes). A dead subscriber is pruned automatically on the `DOWN` message —
+  no manual cleanup.
+
+- **Dispatch runs caller-side, off concurrent ETS reads.** `announce/2` does a
+  `read_concurrency` ETS lookup of the by-class index in the *announcing*
+  process and fans out with direct `Pid ! Msg`. Routing dispatch through the
+  gen_server would serialise every event through one mailbox (and, once the sync
+  path lands, self-deadlock on re-entrant announce) — keeping it caller-side
+  eliminates both.
+
+- **Crash-survivable tables.** Both ETS tables are created with
+  `{heir, SupervisorPid, ...}` so they survive a bus crash (the
+  `beamtalk_trace_store` pattern). On restart the gen_server re-arms monitors
+  from the surviving rows. The full crash→restart dead-pid prune is BT-2442;
+  Phase 1 re-arms and keeps the data.
+
+Out of scope for this phase (later issues): MRO subclass matching + per-
+subscription de-dup (BT-2440), the sync `announceAndWait:` path / `doOnce:` /
+`when:send:to:` / handler fault isolation (BT-2441), and the heir crash re-arm
+dead-pid prune (BT-2442).
+
+See also: docs/ADR/0093-announcements-event-substrate.md §1
+""".
+
+-include_lib("kernel/include/logger.hrl").
+-include("beamtalk.hrl").
+
+%% API — lifecycle
+-export([start_link/0]).
+
+%% API — write path (through the gen_server)
+-export([
+    subscribe/4,
+    unsubscribe/1,
+    is_active/1
+]).
+
+%% API — dispatch (caller-side, off concurrent ETS reads)
+-export([
+    announce/2
+]).
+
+%% API — introspection (direct ETS reads)
+-export([
+    subscription_count/0,
+    subscribers_of/1
+]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+%% Table names
+-define(SUBS_TABLE, beamtalk_announcement_subs).
+-define(BY_CLASS_TABLE, beamtalk_announcement_by_class).
+
+%% Dedicated pg scope (ADR 0093 §1 — NOT the default scope).
+-define(PG_SCOPE, beamtalk_pg).
+
+%%====================================================================
+%% Types
+%%====================================================================
+
+-type announcement_class() :: atom().
+-type sub_ref() :: reference().
+-type handler() :: term().
+
+%% A subscription row in the primary `set` table, keyed by `SubRef`.
+-type sub_row() :: {
+    sub_ref(),
+    announcement_class(),
+    pid(),
+    handler(),
+    OnceFlag :: boolean()
+}.
+
+-export_type([announcement_class/0, sub_ref/0, handler/0, sub_row/0]).
+
+%% gen_server state: the per-subscriber monitor bookkeeping. `monitors` maps a
+%% subscriber pid to `{MonitorRef, RefCount}` so a pid with several
+%% subscriptions is monitored exactly once and the monitor is demonitored only
+%% when its last subscription is removed.
+-record(state, {
+    monitors = #{} :: #{pid() => {reference(), pos_integer()}}
+}).
+
+%%====================================================================
+%% API — lifecycle
+%%====================================================================
+
+-doc "Start the announcements bus gen_server.".
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%%====================================================================
+%% API — write path
+%%====================================================================
+
+-doc """
+Register a subscription: deliver announcements of exactly `AnnouncementClass`
+to `SubscriberPid`, carrying `Handler` (an opaque term the stdlib veneer
+interprets — a block ref, `{send, Sel, Receiver}`, etc.). `OnceFlag` marks a
+`doOnce` subscription (consumed atomically on first delivery — the consume path
+lands in BT-2441; Phase 1 stores the flag).
+
+Returns `{ok, SubRef}` where `SubRef` is the unique reference the stdlib
+`Subscription` object wraps. Each call mints a *distinct* `SubRef`, so a process
+may hold several subscriptions to the same class — re-subscribing never silently
+replaces (Pharo's rule).
+
+Synchronous (serialised write). The bus arms one `erlang:monitor/2` per distinct
+subscriber pid so a dead subscriber's rows are pruned automatically.
+""".
+-spec subscribe(announcement_class(), pid(), handler(), boolean()) ->
+    {ok, sub_ref()} | {error, #beamtalk_error{}}.
+subscribe(AnnouncementClass, SubscriberPid, Handler, OnceFlag) when
+    is_atom(AnnouncementClass), is_pid(SubscriberPid), is_boolean(OnceFlag)
+->
+    gen_server:call(?MODULE, {subscribe, AnnouncementClass, SubscriberPid, Handler, OnceFlag});
+subscribe(AnnouncementClass, SubscriberPid, _Handler, OnceFlag) ->
+    {error, bad_subscribe_args(AnnouncementClass, SubscriberPid, OnceFlag)}.
+
+-doc """
+Remove the subscription identified by `SubRef`. Idempotent — unsubscribing an
+unknown or already-removed `SubRef` is a no-op that returns `ok`. Synchronous
+(serialised write); demonitors the subscriber pid when this was its last
+subscription.
+""".
+-spec unsubscribe(sub_ref()) -> ok.
+unsubscribe(SubRef) when is_reference(SubRef) ->
+    gen_server:call(?MODULE, {unsubscribe, SubRef});
+unsubscribe(_SubRef) ->
+    ok.
+
+-doc """
+Whether `SubRef` still names a live subscription. Direct ETS membership read —
+does not go through the gen_server. `false` after `unsubscribe/1` or after the
+subscriber process died.
+""".
+-spec is_active(sub_ref()) -> boolean().
+is_active(SubRef) when is_reference(SubRef) ->
+    case ets:whereis(?SUBS_TABLE) of
+        undefined -> false;
+        _ -> ets:member(?SUBS_TABLE, SubRef)
+    end;
+is_active(_SubRef) ->
+    false.
+
+%%====================================================================
+%% API — dispatch (caller-side)
+%%====================================================================
+
+-doc """
+Announce `Event` (an announcement payload) to every subscriber of `EventClass`,
+asynchronously. Runs entirely in the *calling* process: a concurrent ETS read of
+the by-class index followed by a direct `Pid ! {beamtalk_announcement, SubRef,
+EventClass, Handler, Event}` to each live subscriber. Returns `ok` immediately
+(fire-and-forget).
+
+Phase 1 matches a single exact class — no superclass (MRO) walk, no per-
+subscription de-dup. MRO matching lands in BT-2440.
+
+A subscriber whose process has already died (its `DOWN` not yet processed by the
+bus) is skipped via an `is_process_alive/1` guard, so a stale row never produces
+a send to a dead pid.
+""".
+-spec announce(announcement_class(), term()) -> ok.
+announce(EventClass, Event) when is_atom(EventClass) ->
+    case ets:whereis(?BY_CLASS_TABLE) of
+        undefined ->
+            ok;
+        _ ->
+            %% Caller-side fan-out off the concurrent by-class index. Each index
+            %% row is `{{EventClass, SubRef}}`; the SubRef resolves the full
+            %% subscription row in the primary table.
+            IndexRows = ets:match_object(?BY_CLASS_TABLE, {{EventClass, '_'}}),
+            lists:foreach(
+                fun({{_Class, SubRef}}) -> deliver(SubRef, EventClass, Event) end,
+                IndexRows
+            ),
+            ok
+    end.
+
+-doc """
+Deliver `Event` to one subscription if it is still live and its subscriber
+process is alive. Skips silently otherwise (the row may have been unsubscribed
+or the subscriber may have died between the index read and here — a race that is
+harmless: a missed delivery to a process that is gone). Caller-side; no bus call.
+""".
+-spec deliver(sub_ref(), announcement_class(), term()) -> ok.
+deliver(SubRef, EventClass, Event) ->
+    case ets:lookup(?SUBS_TABLE, SubRef) of
+        [{SubRef, _Class, SubscriberPid, Handler, _Once}] ->
+            case is_process_alive(SubscriberPid) of
+                true ->
+                    SubscriberPid ! {beamtalk_announcement, SubRef, EventClass, Handler, Event},
+                    ok;
+                false ->
+                    ok
+            end;
+        [] ->
+            ok
+    end.
+
+%%====================================================================
+%% API — introspection
+%%====================================================================
+
+-doc "Total number of live subscriptions across all classes. Direct ETS read.".
+-spec subscription_count() -> non_neg_integer().
+subscription_count() ->
+    case ets:whereis(?SUBS_TABLE) of
+        undefined -> 0;
+        _ -> ets:info(?SUBS_TABLE, size)
+    end.
+
+-doc """
+The `SubRef`s currently subscribed to exactly `AnnouncementClass`. Direct ETS
+read of the by-class index — does not go through the gen_server.
+""".
+-spec subscribers_of(announcement_class()) -> [sub_ref()].
+subscribers_of(AnnouncementClass) when is_atom(AnnouncementClass) ->
+    case ets:whereis(?BY_CLASS_TABLE) of
+        undefined ->
+            [];
+        _ ->
+            [
+                SubRef
+             || {{_Class, SubRef}} <- ets:match_object(
+                    ?BY_CLASS_TABLE, {{AnnouncementClass, '_'}}
+                )
+            ]
+    end.
+
+%%====================================================================
+%% gen_server callbacks
+%%====================================================================
+
+init([]) ->
+    logger:set_process_metadata(#{domain => [beamtalk, announcements]}),
+
+    %% Dedicated Beamtalk pg scope (ADR 0093 §1) — kept separate from the
+    %% default `pg` scope used for class-registry membership, and from any pg
+    %% use on a connected non-Beamtalk node. The scope is the membership
+    %% registry for SystemAnnouncer in later phases; standing it up here means
+    %% the scope exists before any subscriber tries to join a group.
+    ensure_pg_scope(),
+
+    %% Heir is the supervisor so both tables survive a bus crash (the
+    %% beamtalk_trace_store pattern); on restart we re-arm monitors from the
+    %% inherited rows.
+    SupPid = find_supervisor(),
+    ensure_tables(SupPid),
+
+    %% Re-arm monitors for any subscriptions that survived a crash via heir.
+    Monitors = rearm_monitors(),
+
+    ?LOG_INFO(#{
+        event => announcements_started,
+        tables => [?SUBS_TABLE, ?BY_CLASS_TABLE],
+        pg_scope => ?PG_SCOPE,
+        rearmed_subscribers => maps:size(Monitors)
+    }),
+    {ok, #state{monitors = Monitors}}.
+
+handle_call({subscribe, AnnouncementClass, SubscriberPid, Handler, OnceFlag}, _From, State) ->
+    SubRef = make_ref(),
+    true = ets:insert(?SUBS_TABLE, {SubRef, AnnouncementClass, SubscriberPid, Handler, OnceFlag}),
+    true = ets:insert(?BY_CLASS_TABLE, {{AnnouncementClass, SubRef}}),
+    NewState = arm_monitor(SubscriberPid, State),
+    {reply, {ok, SubRef}, NewState};
+handle_call({unsubscribe, SubRef}, _From, State) ->
+    NewState =
+        case ets:lookup(?SUBS_TABLE, SubRef) of
+            [{SubRef, AnnouncementClass, SubscriberPid, _Handler, _Once}] ->
+                remove_subscription(SubRef, AnnouncementClass),
+                disarm_monitor(SubscriberPid, State);
+            [] ->
+                %% Idempotent — unknown / already-removed SubRef.
+                State
+        end,
+    {reply, ok, NewState};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', _MonRef, process, Pid, _Reason}, State) ->
+    %% A monitored subscriber died — prune all of its subscriptions and drop the
+    %% monitor bookkeeping. Auto-cleanup, no manual unsubscribe needed.
+    NewState = prune_subscriber(Pid, State),
+    {noreply, NewState};
+handle_info({'ETS-TRANSFER', TableName, _FromPid, _HeirData}, State) ->
+    %% Inherited a table back from the supervisor heir after a crash/restart.
+    ?LOG_INFO(#{event => announcements_table_inherited, table => TableName}),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    %% Tables are heir'd to the supervisor and survive; monitors die with this
+    %% process. The restarted bus re-arms from the surviving rows.
+    ok.
+
+code_change(OldVsn, State, Extra) ->
+    beamtalk_hot_reload:code_change(OldVsn, State, Extra).
+
+%%====================================================================
+%% Internal: setup
+%%====================================================================
+
+-doc """
+Start the dedicated `beamtalk_pg` scope if it is not already running.
+Idempotent — a scope already started (e.g. after a bus restart, since the pg
+scope process is separate from this gen_server) is left as-is. `pg:start_link/1`
+links the scope to whoever starts it; on a restart the existing scope keeps
+running under its original owner, which is fine — we only need it to exist.
+""".
+-spec ensure_pg_scope() -> ok.
+ensure_pg_scope() ->
+    case whereis(?PG_SCOPE) of
+        undefined ->
+            case pg:start_link(?PG_SCOPE) of
+                {ok, _Pid} -> ok;
+                {error, {already_started, _Pid}} -> ok
+            end;
+        _Pid ->
+            ok
+    end,
+    ok.
+
+-doc "Find the supervisor pid for the ETS heir option (self if not supervised).".
+-spec find_supervisor() -> pid().
+find_supervisor() ->
+    case whereis(beamtalk_runtime_sup) of
+        undefined -> self();
+        Pid -> Pid
+    end.
+
+-doc """
+Create both ETS tables if they do not already exist (they may already exist,
+inherited from the supervisor heir after a crash). The primary table is a `set`
+keyed by `SubRef`; the by-class index is an `ordered_set` keyed by
+`{AnnouncementClass, SubRef}`. Both are `public` so caller-side `announce/2`
+reads work regardless of which process currently owns the table after an
+inheritance, and both carry `{read_concurrency, true}` for the concurrent
+dispatch reads.
+""".
+-spec ensure_tables(pid()) -> ok.
+ensure_tables(SupPid) ->
+    ensure_table(?SUBS_TABLE, [
+        named_table,
+        public,
+        set,
+        {read_concurrency, true},
+        {heir, SupPid, ?SUBS_TABLE}
+    ]),
+    ensure_table(?BY_CLASS_TABLE, [
+        named_table,
+        public,
+        ordered_set,
+        {read_concurrency, true},
+        {heir, SupPid, ?BY_CLASS_TABLE}
+    ]),
+    ok.
+
+-spec ensure_table(atom(), [term()]) -> ok.
+ensure_table(Name, Opts) ->
+    case ets:whereis(Name) of
+        undefined ->
+            _ = ets:new(Name, Opts),
+            ok;
+        _Tid ->
+            %% Inherited via heir after a crash — public table, reads/writes
+            %% work regardless of ownership; the data is preserved.
+            ok
+    end.
+
+-doc """
+Re-arm one monitor per distinct subscriber pid found in the surviving primary
+table (after a crash→restart with heir-preserved rows). Returns the monitor
+bookkeeping map. A pid that died during the crash→restart gap is still monitored
+here; its `DOWN` fires immediately (`erlang:monitor/2` of a dead pid sends an
+instant `DOWN`), so the stale row is pruned via the normal `DOWN` path. The
+eager `is_process_alive/1` prune of such rows is BT-2442; Phase 1 relies on the
+immediate `DOWN`.
+""".
+-spec rearm_monitors() -> #{pid() => {reference(), pos_integer()}}.
+rearm_monitors() ->
+    Rows = ets:tab2list(?SUBS_TABLE),
+    lists:foldl(
+        fun({_SubRef, _Class, SubscriberPid, _Handler, _Once}, Acc) ->
+            case Acc of
+                #{SubscriberPid := {MonRef, Count}} ->
+                    Acc#{SubscriberPid => {MonRef, Count + 1}};
+                _ ->
+                    MonRef = erlang:monitor(process, SubscriberPid),
+                    Acc#{SubscriberPid => {MonRef, 1}}
+            end
+        end,
+        #{},
+        Rows
+    ).
+
+%%====================================================================
+%% Internal: monitor bookkeeping
+%%====================================================================
+
+-doc """
+Arm a monitor for `SubscriberPid` if not already monitored, otherwise bump its
+ref-count. One monitor per distinct subscriber pid, ref-counted across that
+pid's subscriptions.
+""".
+-spec arm_monitor(pid(), #state{}) -> #state{}.
+arm_monitor(SubscriberPid, #state{monitors = Monitors} = State) ->
+    NewMonitors =
+        case Monitors of
+            #{SubscriberPid := {MonRef, Count}} ->
+                Monitors#{SubscriberPid => {MonRef, Count + 1}};
+            _ ->
+                MonRef = erlang:monitor(process, SubscriberPid),
+                Monitors#{SubscriberPid => {MonRef, 1}}
+        end,
+    State#state{monitors = NewMonitors}.
+
+-doc """
+Decrement `SubscriberPid`'s monitor ref-count; demonitor and drop the entry when
+it reaches zero (the pid's last subscription was removed).
+""".
+-spec disarm_monitor(pid(), #state{}) -> #state{}.
+disarm_monitor(SubscriberPid, #state{monitors = Monitors} = State) ->
+    NewMonitors =
+        case Monitors of
+            #{SubscriberPid := {MonRef, Count}} when Count =< 1 ->
+                erlang:demonitor(MonRef, [flush]),
+                maps:remove(SubscriberPid, Monitors);
+            #{SubscriberPid := {MonRef, Count}} ->
+                Monitors#{SubscriberPid => {MonRef, Count - 1}};
+            _ ->
+                Monitors
+        end,
+    State#state{monitors = NewMonitors}.
+
+-doc """
+Prune every subscription owned by a dead `Pid` (on its `DOWN`) and drop its
+monitor entry. Removes the rows from both tables.
+""".
+-spec prune_subscriber(pid(), #state{}) -> #state{}.
+prune_subscriber(Pid, #state{monitors = Monitors} = State) ->
+    %% Find and remove all of this pid's subscription rows from both tables.
+    Rows = ets:match_object(?SUBS_TABLE, {'_', '_', Pid, '_', '_'}),
+    lists:foreach(
+        fun({SubRef, AnnouncementClass, _Pid, _Handler, _Once}) ->
+            remove_subscription(SubRef, AnnouncementClass)
+        end,
+        Rows
+    ),
+    State#state{monitors = maps:remove(Pid, Monitors)}.
+
+%%====================================================================
+%% Internal: table writes
+%%====================================================================
+
+-doc """
+Remove one subscription's rows from both the primary table and the by-class
+index. Runs inside the gen_server (serialised write).
+""".
+-spec remove_subscription(sub_ref(), announcement_class()) -> ok.
+remove_subscription(SubRef, AnnouncementClass) ->
+    true = ets:delete(?SUBS_TABLE, SubRef),
+    true = ets:delete(?BY_CLASS_TABLE, {AnnouncementClass, SubRef}),
+    ok.
+
+%%====================================================================
+%% Internal: structured errors
+%%====================================================================
+
+-doc "Build the `#beamtalk_error{}` for an invalid `subscribe/4` argument set.".
+-spec bad_subscribe_args(term(), term(), term()) -> #beamtalk_error{}.
+bad_subscribe_args(AnnouncementClass, SubscriberPid, OnceFlag) ->
+    %% This runs in the *caller's* process (validation precedes the
+    %% gen_server:call), not the bus process, so the `domain` metadata set in
+    %% init/1 does not apply — set it explicitly on this call.
+    ?LOG_ERROR(#{
+        event => invalid_subscribe_args,
+        announcement_class => AnnouncementClass,
+        subscriber => SubscriberPid,
+        once_flag => OnceFlag,
+        domain => [beamtalk, announcements]
+    }),
+    #beamtalk_error{
+        kind = invalid_argument,
+        class = 'Announcer',
+        selector = 'subscribe',
+        message =
+            <<"subscribe expects an atom class, a pid subscriber, and a boolean once flag">>,
+        hint = <<"check the announcement class and subscriber arguments">>,
+        details = #{
+            announcement_class => AnnouncementClass,
+            subscriber => SubscriberPid,
+            once_flag => OnceFlag
+        }
+    }.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_runtime_sup.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_runtime_sup.erl
@@ -53,6 +53,17 @@ init([]) ->
             type => worker,
             modules => [beamtalk_bootstrap]
         },
+        %% Typed Announcements event bus (ADR 0093 Layer 1). MUST come AFTER
+        %% beamtalk_bootstrap, which starts pg — the bus stands up a dedicated
+        %% `beamtalk_pg` scope and relies on pg being available.
+        #{
+            id => beamtalk_announcements,
+            start => {beamtalk_announcements, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [beamtalk_announcements]
+        },
         %% Then register stdlib primitive classes (Integer, String, etc.)
         #{
             id => beamtalk_stdlib,

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
@@ -65,6 +65,19 @@ clear_all_subscriptions() ->
 spawn_subscriber(Collector) ->
     spawn(fun() -> subscriber_loop(Collector) end).
 
+%% Stop a spawned subscriber deterministically so it does not linger across test
+%% cases. Sends the `{stop, self()}` message `subscriber_loop/1` handles and
+%% waits for the ack; falls back to `exit/2` if the process is wedged or already
+%% gone.
+stop_subscriber(Sub) ->
+    Sub ! {stop, self()},
+    receive
+        {stopped, Sub} -> ok
+    after 500 ->
+        exit(Sub, kill),
+        ok
+    end.
+
 subscriber_loop(Collector) ->
     receive
         {beamtalk_announcement, SubRef, EventClass, Handler, Event} ->
@@ -103,17 +116,21 @@ deliver_to_subscriber_test_() ->
             ?_test(begin
                 Collector = self(),
                 Sub = spawn_subscriber(Collector),
-                {ok, SubRef} = beamtalk_announcements:subscribe(
-                    'PriceChanged', Sub, my_handler, false
-                ),
-                ?assert(beamtalk_announcements:is_active(SubRef)),
+                try
+                    {ok, SubRef} = beamtalk_announcements:subscribe(
+                        'PriceChanged', Sub, my_handler, false
+                    ),
+                    ?assert(beamtalk_announcements:is_active(SubRef)),
 
-                ok = beamtalk_announcements:announce('PriceChanged', {price, 42}),
-                {GotRef, GotClass, GotHandler, GotEvent} = expect_received(),
-                ?assertEqual(SubRef, GotRef),
-                ?assertEqual('PriceChanged', GotClass),
-                ?assertEqual(my_handler, GotHandler),
-                ?assertEqual({price, 42}, GotEvent)
+                    ok = beamtalk_announcements:announce('PriceChanged', {price, 42}),
+                    {GotRef, GotClass, GotHandler, GotEvent} = expect_received(),
+                    ?assertEqual(SubRef, GotRef),
+                    ?assertEqual('PriceChanged', GotClass),
+                    ?assertEqual(my_handler, GotHandler),
+                    ?assertEqual({price, 42}, GotEvent)
+                after
+                    stop_subscriber(Sub)
+                end
             end)
         ]
     end}.
@@ -128,16 +145,20 @@ single_class_match_test_() ->
             ?_test(begin
                 Collector = self(),
                 Sub = spawn_subscriber(Collector),
-                {ok, _SubRef} = beamtalk_announcements:subscribe(
-                    'PriceChanged', Sub, h, false
-                ),
-                %% Announcing a *different* class delivers nothing — no MRO/match
-                %% across class names in Phase 1.
-                ok = beamtalk_announcements:announce('OtherEvent', {x, 1}),
-                refute_received(),
-                %% The matching class still delivers.
-                ok = beamtalk_announcements:announce('PriceChanged', {x, 2}),
-                {_R, 'PriceChanged', h, {x, 2}} = expect_received()
+                try
+                    {ok, _SubRef} = beamtalk_announcements:subscribe(
+                        'PriceChanged', Sub, h, false
+                    ),
+                    %% Announcing a *different* class delivers nothing — no
+                    %% MRO/match across class names in Phase 1.
+                    ok = beamtalk_announcements:announce('OtherEvent', {x, 1}),
+                    refute_received(),
+                    %% The matching class still delivers.
+                    ok = beamtalk_announcements:announce('PriceChanged', {x, 2}),
+                    {_R, 'PriceChanged', h, {x, 2}} = expect_received()
+                after
+                    stop_subscriber(Sub)
+                end
             end)
         ]
     end}.
@@ -152,21 +173,25 @@ multiple_subscriptions_same_class_test_() ->
             ?_test(begin
                 Collector = self(),
                 Sub = spawn_subscriber(Collector),
-                {ok, SubRef1} = beamtalk_announcements:subscribe('E', Sub, h1, false),
-                {ok, SubRef2} = beamtalk_announcements:subscribe('E', Sub, h2, false),
-                ?assertNotEqual(SubRef1, SubRef2),
-                ?assertEqual(2, beamtalk_announcements:subscription_count()),
-                ?assertEqual(
-                    lists:sort([SubRef1, SubRef2]),
-                    lists:sort(beamtalk_announcements:subscribers_of('E'))
-                ),
+                try
+                    {ok, SubRef1} = beamtalk_announcements:subscribe('E', Sub, h1, false),
+                    {ok, SubRef2} = beamtalk_announcements:subscribe('E', Sub, h2, false),
+                    ?assertNotEqual(SubRef1, SubRef2),
+                    ?assertEqual(2, beamtalk_announcements:subscription_count()),
+                    ?assertEqual(
+                        lists:sort([SubRef1, SubRef2]),
+                        lists:sort(beamtalk_announcements:subscribers_of('E'))
+                    ),
 
-                ok = beamtalk_announcements:announce('E', payload),
-                %% Both subscriptions deliver (one message per subscription).
-                R1 = expect_received(),
-                R2 = expect_received(),
-                Handlers = lists:sort([element(3, R1), element(3, R2)]),
-                ?assertEqual([h1, h2], Handlers)
+                    ok = beamtalk_announcements:announce('E', payload),
+                    %% Both subscriptions deliver (one message per subscription).
+                    R1 = expect_received(),
+                    R2 = expect_received(),
+                    Handlers = lists:sort([element(3, R1), element(3, R2)]),
+                    ?assertEqual([h1, h2], Handlers)
+                after
+                    stop_subscriber(Sub)
+                end
             end)
         ]
     end}.
@@ -181,23 +206,27 @@ unsubscribe_test_() ->
             ?_test(begin
                 Collector = self(),
                 Sub = spawn_subscriber(Collector),
-                {ok, SubRef1} = beamtalk_announcements:subscribe('E', Sub, h1, false),
-                {ok, SubRef2} = beamtalk_announcements:subscribe('E', Sub, h2, false),
+                try
+                    {ok, SubRef1} = beamtalk_announcements:subscribe('E', Sub, h1, false),
+                    {ok, SubRef2} = beamtalk_announcements:subscribe('E', Sub, h2, false),
 
-                ok = beamtalk_announcements:unsubscribe(SubRef1),
-                ?assertNot(beamtalk_announcements:is_active(SubRef1)),
-                ?assert(beamtalk_announcements:is_active(SubRef2)),
-                ?assertEqual([SubRef2], beamtalk_announcements:subscribers_of('E')),
+                    ok = beamtalk_announcements:unsubscribe(SubRef1),
+                    ?assertNot(beamtalk_announcements:is_active(SubRef1)),
+                    ?assert(beamtalk_announcements:is_active(SubRef2)),
+                    ?assertEqual([SubRef2], beamtalk_announcements:subscribers_of('E')),
 
-                %% Idempotent: removing the same ref again is a no-op `ok`.
-                ?assertEqual(ok, beamtalk_announcements:unsubscribe(SubRef1)),
-                %% Unknown ref is also a no-op.
-                ?assertEqual(ok, beamtalk_announcements:unsubscribe(make_ref())),
+                    %% Idempotent: removing the same ref again is a no-op `ok`.
+                    ?assertEqual(ok, beamtalk_announcements:unsubscribe(SubRef1)),
+                    %% Unknown ref is also a no-op.
+                    ?assertEqual(ok, beamtalk_announcements:unsubscribe(make_ref())),
 
-                ok = beamtalk_announcements:announce('E', payload),
-                {_R, 'E', h2, payload} = expect_received(),
-                %% Only the surviving subscription delivered.
-                refute_received()
+                    ok = beamtalk_announcements:announce('E', payload),
+                    {_R, 'E', h2, payload} = expect_received(),
+                    %% Only the surviving subscription delivered.
+                    refute_received()
+                after
+                    stop_subscriber(Sub)
+                end
             end)
         ]
     end}.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
@@ -1,0 +1,292 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_announcements_tests).
+
+-moduledoc """
+EUnit tests for `beamtalk_announcements` (BT-2439 / ADR 0093 Phase 1).
+
+Covers the Phase-1 acceptance criteria: deliver to a subscriber of the exact
+class, a dead subscriber pruned automatically via monitor `DOWN`, single-class
+match (no MRO walk yet), distinct subscriptions to the same class (Pharo's
+multi-subscription rule), idempotent unsubscribe, and the introspection reads.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include("beamtalk.hrl").
+
+%%====================================================================
+%% Setup / teardown
+%%====================================================================
+
+setup() ->
+    %% Use an already-running supervised server when one exists (the runtime app
+    %% starts the bus under the supervisor); otherwise stand a fresh one up for
+    %% tests that run outside the application.
+    Pid =
+        case whereis(beamtalk_announcements) of
+            undefined ->
+                {ok, P} = beamtalk_announcements:start_link(),
+                P;
+            P ->
+                P
+        end,
+    clear_all_subscriptions(),
+    Pid.
+
+cleanup(_Pid) ->
+    %% Don't stop the server — supervised in the runtime app. Clear all rows so
+    %% the next test starts empty even if it picks up the same gen_server.
+    clear_all_subscriptions(),
+    ok.
+
+clear_all_subscriptions() ->
+    %% Tables are `public`, so we can wipe them directly. Route the monitor-state
+    %% reset through the gen_server so its bookkeeping does not leak across tests.
+    try
+        ets:delete_all_objects(beamtalk_announcement_subs),
+        ets:delete_all_objects(beamtalk_announcement_by_class),
+        sys:replace_state(beamtalk_announcements, fun(S) ->
+            %% Clear the in-state monitor map (record field 2).
+            setelement(2, S, #{})
+        end)
+    catch
+        _:_ -> ok
+    end,
+    ok.
+
+%%====================================================================
+%% Test subscriber: echoes received announcements back to a collector.
+%%====================================================================
+
+%% Spawn a subscriber that forwards every `beamtalk_announcement` message it
+%% receives to `Collector`, so the test process can assert on delivery. Replies
+%% to a `{stop, From}` message so the test can kill it deterministically.
+spawn_subscriber(Collector) ->
+    spawn(fun() -> subscriber_loop(Collector) end).
+
+subscriber_loop(Collector) ->
+    receive
+        {beamtalk_announcement, SubRef, EventClass, Handler, Event} ->
+            Collector ! {received, self(), SubRef, EventClass, Handler, Event},
+            subscriber_loop(Collector);
+        {stop, From} ->
+            From ! {stopped, self()},
+            ok
+    end.
+
+%% Block until a `{received, ...}` arrives or fail after a timeout.
+expect_received() ->
+    receive
+        {received, _Pid, SubRef, EventClass, Handler, Event} ->
+            {SubRef, EventClass, Handler, Event}
+    after 1000 ->
+        ?assert(false)
+    end.
+
+%% Assert that NO `{received, ...}` arrives within a short window.
+refute_received() ->
+    receive
+        {received, _Pid, _SubRef, _EventClass, _Handler, _Event} ->
+            ?assert(false)
+    after 200 ->
+        ok
+    end.
+
+%%====================================================================
+%% Deliver to a subscriber of the exact class
+%%====================================================================
+
+deliver_to_subscriber_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                {ok, SubRef} = beamtalk_announcements:subscribe(
+                    'PriceChanged', Sub, my_handler, false
+                ),
+                ?assert(beamtalk_announcements:is_active(SubRef)),
+
+                ok = beamtalk_announcements:announce('PriceChanged', {price, 42}),
+                {GotRef, GotClass, GotHandler, GotEvent} = expect_received(),
+                ?assertEqual(SubRef, GotRef),
+                ?assertEqual('PriceChanged', GotClass),
+                ?assertEqual(my_handler, GotHandler),
+                ?assertEqual({price, 42}, GotEvent)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Single-class match — no MRO walk (Phase 1)
+%%====================================================================
+
+single_class_match_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                {ok, _SubRef} = beamtalk_announcements:subscribe(
+                    'PriceChanged', Sub, h, false
+                ),
+                %% Announcing a *different* class delivers nothing — no MRO/match
+                %% across class names in Phase 1.
+                ok = beamtalk_announcements:announce('OtherEvent', {x, 1}),
+                refute_received(),
+                %% The matching class still delivers.
+                ok = beamtalk_announcements:announce('PriceChanged', {x, 2}),
+                {_R, 'PriceChanged', h, {x, 2}} = expect_received()
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Distinct subscriptions to the same class (Pharo's multi-sub rule)
+%%====================================================================
+
+multiple_subscriptions_same_class_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                {ok, SubRef1} = beamtalk_announcements:subscribe('E', Sub, h1, false),
+                {ok, SubRef2} = beamtalk_announcements:subscribe('E', Sub, h2, false),
+                ?assertNotEqual(SubRef1, SubRef2),
+                ?assertEqual(2, beamtalk_announcements:subscription_count()),
+                ?assertEqual(
+                    lists:sort([SubRef1, SubRef2]),
+                    lists:sort(beamtalk_announcements:subscribers_of('E'))
+                ),
+
+                ok = beamtalk_announcements:announce('E', payload),
+                %% Both subscriptions deliver (one message per subscription).
+                R1 = expect_received(),
+                R2 = expect_received(),
+                Handlers = lists:sort([element(3, R1), element(3, R2)]),
+                ?assertEqual([h1, h2], Handlers)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Unsubscribe removes exactly one subscription, is idempotent
+%%====================================================================
+
+unsubscribe_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                {ok, SubRef1} = beamtalk_announcements:subscribe('E', Sub, h1, false),
+                {ok, SubRef2} = beamtalk_announcements:subscribe('E', Sub, h2, false),
+
+                ok = beamtalk_announcements:unsubscribe(SubRef1),
+                ?assertNot(beamtalk_announcements:is_active(SubRef1)),
+                ?assert(beamtalk_announcements:is_active(SubRef2)),
+                ?assertEqual([SubRef2], beamtalk_announcements:subscribers_of('E')),
+
+                %% Idempotent: removing the same ref again is a no-op `ok`.
+                ?assertEqual(ok, beamtalk_announcements:unsubscribe(SubRef1)),
+                %% Unknown ref is also a no-op.
+                ?assertEqual(ok, beamtalk_announcements:unsubscribe(make_ref())),
+
+                ok = beamtalk_announcements:announce('E', payload),
+                {_R, 'E', h2, payload} = expect_received(),
+                %% Only the surviving subscription delivered.
+                refute_received()
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Dead subscriber pruned automatically via monitor DOWN
+%%====================================================================
+
+dead_subscriber_pruned_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                {ok, SubRef} = beamtalk_announcements:subscribe('E', Sub, h, false),
+                ?assert(beamtalk_announcements:is_active(SubRef)),
+                ?assertEqual(1, beamtalk_announcements:subscription_count()),
+
+                %% Kill the subscriber and wait for it to be gone.
+                MRef = erlang:monitor(process, Sub),
+                exit(Sub, kill),
+                receive
+                    {'DOWN', MRef, process, Sub, _} -> ok
+                after 1000 -> ?assert(false)
+                end,
+
+                %% The bus processes the DOWN asynchronously; sync on it via a
+                %% gen_server call (subscribe of a throwaway ref forces the
+                %% mailbox to drain past the DOWN). Poll until pruned.
+                ok = wait_until(fun() ->
+                    beamtalk_announcements:subscription_count() =:= 0
+                end),
+                ?assertNot(beamtalk_announcements:is_active(SubRef)),
+                ?assertEqual([], beamtalk_announcements:subscribers_of('E'))
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% No subscribers — announce is a harmless no-op
+%%====================================================================
+
+announce_no_subscribers_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                ?assertEqual(ok, beamtalk_announcements:announce('Nobody', whatever)),
+                ?assertEqual(0, beamtalk_announcements:subscription_count())
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Invalid subscribe args return a structured #beamtalk_error{}
+%%====================================================================
+
+invalid_subscribe_args_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                %% Non-atom class.
+                {error, Err1} = beamtalk_announcements:subscribe(
+                    "NotAnAtom", self(), h, false
+                ),
+                ?assertMatch(#beamtalk_error{kind = invalid_argument, class = 'Announcer'}, Err1),
+                %% Non-pid subscriber.
+                {error, Err2} = beamtalk_announcements:subscribe(
+                    'E', not_a_pid, h, false
+                ),
+                ?assertMatch(#beamtalk_error{kind = invalid_argument}, Err2)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% Poll `Pred` until it returns true, or fail after ~2s.
+wait_until(Pred) ->
+    wait_until(Pred, 200).
+
+wait_until(_Pred, 0) ->
+    ?assert(false);
+wait_until(Pred, N) ->
+    case Pred() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(10),
+            wait_until(Pred, N - 1)
+    end.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_runtime_sup_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_runtime_sup_tests.erl
@@ -34,9 +34,9 @@ supervisor_intensity_test() ->
 children_count_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    %% Should have exactly 7 children: xref, bootstrap, stdlib, object_instances,
-    %% subprocess_sup, reactive_subprocess_sup, trace_store
-    ?assertEqual(7, length(ChildSpecs)).
+    %% Should have exactly 8 children: xref, bootstrap, announcements, stdlib,
+    %% object_instances, subprocess_sup, reactive_subprocess_sup, trace_store
+    ?assertEqual(8, length(ChildSpecs)).
 
 children_ids_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
@@ -46,6 +46,7 @@ children_ids_test() ->
     Ids = [maps:get(id, Spec) || Spec <- ChildSpecs],
     ?assert(lists:member(beamtalk_xref, Ids)),
     ?assert(lists:member(beamtalk_bootstrap, Ids)),
+    ?assert(lists:member(beamtalk_announcements, Ids)),
     ?assert(lists:member(beamtalk_stdlib, Ids)),
     ?assert(lists:member(beamtalk_object_instances, Ids)),
     ?assert(lists:member(beamtalk_subprocess_sup, Ids)),
@@ -56,11 +57,11 @@ children_ids_test() ->
 children_are_workers_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    %% xref (worker), bootstrap, stdlib, object_instances are workers; subprocess_sup
-    %% and reactive_subprocess_sup are supervisors; trace_store is worker.
+    %% xref (worker), bootstrap, announcements, stdlib, object_instances are workers;
+    %% subprocess_sup and reactive_subprocess_sup are supervisors; trace_store is worker.
     Types = [maps:get(type, Spec) || Spec <- ChildSpecs],
     ?assertEqual(
-        [worker, worker, worker, worker, supervisor, supervisor, worker],
+        [worker, worker, worker, worker, worker, supervisor, supervisor, worker],
         Types
     ).
 
@@ -70,7 +71,7 @@ children_are_permanent_test() ->
     %% All children should have permanent restart
     RestartTypes = [maps:get(restart, Spec) || Spec <- ChildSpecs],
     ?assertEqual(
-        lists:duplicate(7, permanent),
+        lists:duplicate(8, permanent),
         RestartTypes
     ).
 
@@ -82,13 +83,14 @@ children_are_permanent_test() ->
 children_ordered_correctly_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    %% Verify ordering: xref -> bootstrap -> stdlib -> instances -> subprocess_sup
-    %% -> reactive_subprocess_sup -> trace_store
+    %% Verify ordering: xref -> bootstrap -> announcements -> stdlib -> instances
+    %% -> subprocess_sup -> reactive_subprocess_sup -> trace_store
     Ids = [maps:get(id, Spec) || Spec <- ChildSpecs],
     ?assertEqual(
         [
             beamtalk_xref,
             beamtalk_bootstrap,
+            beamtalk_announcements,
             beamtalk_stdlib,
             beamtalk_object_instances,
             beamtalk_subprocess_sup,
@@ -118,6 +120,7 @@ bootstrap_child_spec_test() ->
     [
         _XrefSpec,
         BootstrapSpec,
+        _AnnouncementsSpec,
         _StdlibSpec,
         _InstancesSpec,
         _SubprocessSupSpec,
@@ -137,6 +140,7 @@ instances_child_spec_test() ->
     [
         _XrefSpec,
         _BootstrapSpec,
+        _AnnouncementsSpec,
         _StdlibSpec,
         InstancesSpec,
         _SubprocessSupSpec,
@@ -156,6 +160,7 @@ stdlib_child_spec_test() ->
     [
         _XrefSpec,
         _BootstrapSpec,
+        _AnnouncementsSpec,
         StdlibSpec,
         _InstancesSpec,
         _SubprocessSupSpec,
@@ -175,6 +180,7 @@ subprocess_sup_child_spec_test() ->
     [
         _XrefSpec,
         _BootstrapSpec,
+        _AnnouncementsSpec,
         _StdlibSpec,
         _InstancesSpec,
         SubprocessSupSpec,
@@ -194,6 +200,7 @@ reactive_subprocess_sup_child_spec_test() ->
     [
         _XrefSpec,
         _BootstrapSpec,
+        _AnnouncementsSpec,
         _StdlibSpec,
         _InstancesSpec,
         _SubprocessSupSpec,
@@ -213,7 +220,7 @@ reactive_subprocess_sup_child_spec_test() ->
 
 init_returns_proper_format_test() ->
     Result = beamtalk_runtime_sup:init([]),
-    ?assertMatch({ok, {#{strategy := one_for_one}, [_, _, _, _, _, _, _]}}, Result).
+    ?assertMatch({ok, {#{strategy := one_for_one}, [_, _, _, _, _, _, _, _]}}, Result).
 
 %%% Behavioral tests
 
@@ -247,6 +254,7 @@ all_children_alive_test() ->
         ExpectedIds = [
             beamtalk_xref,
             beamtalk_bootstrap,
+            beamtalk_announcements,
             beamtalk_stdlib,
             beamtalk_object_instances,
             beamtalk_subprocess_sup,


### PR DESCRIPTION
Part of ADR 0093 (Announcements). Phase 1 of 5 — the runtime foundation + napkin proof. Stands up `beamtalk_announcements` and proves typed dispatch end-to-end with one Announcement class.

Linear issue: https://linear.app/beamtalk/issue/BT-2439

## What was implemented

- **New `beamtalk_announcements` gen_server** (template: `beamtalk_xref`), wired into `beamtalk_runtime_sup` as a worker **after** `beamtalk_bootstrap` (which starts pg).
- **Dedicated `beamtalk_pg` scope** (`pg:start_link(beamtalk_pg)`), kept separate from the default pg scope.
- **ETS subscription table**: a `set` keyed by a unique `SubRef` (row `{SubRef, AnnouncementClass, SubscriberPid, Handler, OnceFlag}`) plus a secondary by-class index (`ordered_set` on `{AnnouncementClass, SubRef}`). Both created with `{heir, SupervisorPid, ...}` so they survive a bus crash.
- **`subscribe/4` / `unsubscribe/1` go through the gen_server** (serialised writes). The bus arms one ref-counted `erlang:monitor/2` per distinct subscriber pid; a dead subscriber's rows are pruned automatically on `DOWN` — no manual cleanup. Keying by `SubRef` (not `{Class, Pid}`) lets a process hold multiple distinct subscriptions to the same class (Pharo's rule).
- **Async `announce/2` runs caller-side** (concurrent `read_concurrency` ETS read + direct `Pid ! Msg`), single-class match (no MRO walk yet — that's BT-2440).
- **Structured `#beamtalk_error{}`** for invalid args + `?LOG_*` with `domain => [beamtalk, announcements]`.
- **EUnit** (`beamtalk_announcements_tests`): deliver-to-subscriber, dead-subscriber pruned, single-class match (no MRO), multiple distinct subscriptions to one class, idempotent unsubscribe, no-subscribers no-op, and invalid-args structured error.

## Out of scope (later phase issues)

MRO matching (BT-2440), sync `announceAndWait:` / `doOnce:` / `when:send:to:` / fault isolation (BT-2441), crash re-arm dead-pid prune (BT-2442), stdlib veneer (BT-2443).

## Verification

- `just build`, `just clippy`, `just fmt-check`, `just dialyzer` all clean.
- 7 new EUnit tests pass; `beamtalk_bootstrap_tests` (full supervision startup) passes with the new child wired in.
- The 4 pre-existing full-suite EUnit failures were verified identical on the base branch with these changes stashed — unrelated to this work.

https://claude.ai/code/session_01T17Psn5v3wvyPbbwpREMqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01T17Psn5v3wvyPbbwpREMqw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an announcement event bus for publish-subscribe messaging with subscribe/unsubscribe, class-based delivery, automatic pruning of inactive subscribers, and runtime-safe restart behavior.
  * Integrated the announcement bus into the runtime supervisor.

* **Tests**
  * Added tests covering subscriptions, delivery semantics, pruning on process termination, idempotent unsubscribe, no-op announces, and argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->