### PR TITLE
Announcements: MRO subclass matching + per-subscription de-dup (BT-2440)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_announcements.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_announcements.erl
@@ -9,11 +9,15 @@
 -moduledoc """
 Runtime event bus for the typed Announcements substrate (ADR 0093 Layer 1).
 
-Phase 1 (BT-2439) — the runtime foundation + napkin proof. Stands up the
-`beamtalk_announcements` gen_server, a dedicated `beamtalk_pg` scope, and the
-ETS subscription table, and proves typed dispatch end-to-end: `subscribe/4`,
-`unsubscribe/1`, and an async `announce/2` that delivers to subscribers of one
-exact `Announcement` class (no MRO walk yet — that lands in BT-2440).
+Phase 1 — the runtime foundation. Stands up the `beamtalk_announcements`
+gen_server, a dedicated `beamtalk_pg` scope, and the ETS subscription table, and
+proves typed dispatch end-to-end: `subscribe/4`, `unsubscribe/1`, and an async
+`announce/2`.
+
+BT-2439 delivered the foundation with exact-class matching; BT-2440 adds the MRO
+(superclass-chain) walk to `announce/2`: an event is delivered to subscribers of
+its class *or any ancestor*, with the walk performed at announce time (live
+hierarchy changes respected) and delivery de-duplicated per subscription.
 
 Design (the `beamtalk_xref` / `beamtalk_trace_store` discipline — the gen_server
 is NOT in the dispatch path):
@@ -25,7 +29,8 @@ is NOT in the dispatch path):
   subscriptions to the same class (Pharo's rule): a second `subscribe` adds a
   row, it never replaces the first. A secondary by-class index
   (`ordered_set` on `{AnnouncementClass, SubRef}`) lets `announce/2` fetch the
-  matching subscribers for one class without scanning the whole table.
+  matching subscribers for one class without scanning the whole table, and the
+  MRO walk fetches it once per class on the event's superclass chain.
 
 - **Writes serialise through the gen_server.** `subscribe/4` / `unsubscribe/1`
   are `gen_server:call`s so the table writes are serialised and the bus can arm
@@ -47,8 +52,7 @@ is NOT in the dispatch path):
   from the surviving rows. The full crash→restart dead-pid prune is BT-2442;
   Phase 1 re-arms and keeps the data.
 
-Out of scope for this phase (later issues): MRO subclass matching + per-
-subscription de-dup (BT-2440), the sync `announceAndWait:` path / `doOnce:` /
+Out of scope here (later issues): the sync `announceAndWait:` path / `doOnce:` /
 `when:send:to:` / handler fault isolation (BT-2441), and the heir crash re-arm
 dead-pid prune (BT-2442).
 
@@ -191,14 +195,30 @@ is_active(_SubRef) ->
 %%====================================================================
 
 -doc """
-Announce `Event` (an announcement payload) to every subscriber of `EventClass`,
-asynchronously. Runs entirely in the *calling* process: a concurrent ETS read of
-the by-class index followed by a direct `Pid ! {beamtalk_announcement, SubRef,
-EventClass, Handler, Event}` to each live subscriber. Returns `ok` immediately
-(fire-and-forget).
+Announce `Event` (an announcement payload) to every subscriber of `EventClass`
+*or any of its ancestors*, asynchronously. Runs entirely in the *calling*
+process: it walks the event class's superclass chain via `read_concurrency` ETS
+metadata reads (`beamtalk_class_metadata:lookup_superclass/1`), gathers the
+matching subscriptions from the by-class index at each level, and sends a direct
+`Pid ! {beamtalk_announcement, SubRef, EventClass, Handler, Event}` to each live
+subscriber. Returns `ok` immediately (fire-and-forget).
 
-Phase 1 matches a single exact class — no superclass (MRO) walk, no per-
-subscription de-dup. MRO matching lands in BT-2440.
+MRO matching (BT-2440): subscribe to `UIEvent` and you receive `ButtonClicked`.
+The walk happens at announce time, so live hierarchy changes are respected. Each
+delivered message carries `EventClass` — the *announced* class — not the ancestor
+the subscription matched on.
+
+De-duplication is **per subscription**: a `SubRef` is delivered to at most once
+per `announce`, even though the MRO walk visits several classes. Because a
+subscription is registered against exactly one class, the dedup set guards the
+pathological cases — a corrupted hierarchy that revisits a class, or a future
+many-class subscription — rather than the common path. A process that holds two
+distinct subscriptions matching the event still receives two messages (one per
+`SubRef`, Pharo's rule).
+
+The walk stops gracefully at the root (`{ok, none}`), at a class whose metadata
+row is absent (`not_found` — e.g. a class removed mid-walk), and at a depth cap
+(`?MAX_HIERARCHY_DEPTH`) that bounds a corrupted cyclic hierarchy.
 
 A subscriber whose process has already died (its `DOWN` not yet processed by the
 bus) is skipped via an `is_process_alive/1` guard, so a stale row never produces
@@ -210,15 +230,63 @@ announce(EventClass, Event) when is_atom(EventClass) ->
         undefined ->
             ok;
         _ ->
-            %% Caller-side fan-out off the concurrent by-class index. Each index
-            %% row is `{{EventClass, SubRef}}`; the SubRef resolves the full
-            %% subscription row in the primary table.
-            IndexRows = ets:match_object(?BY_CLASS_TABLE, {{EventClass, '_'}}),
-            lists:foreach(
-                fun({{_Class, SubRef}}) -> deliver(SubRef, EventClass, Event) end,
-                IndexRows
-            ),
+            _ = walk_and_deliver(EventClass, EventClass, Event, sets:new([{version, 2}]), 0),
             ok
+    end.
+
+-doc """
+Walk the superclass chain from `CurrentClass` and deliver `Event` (announced as
+`EventClass`) to every subscription matching a class on the walk, de-duplicated
+per `SubRef` via the `Delivered` set. Returns the updated `Delivered` set.
+
+Terminates when the chain reaches the root (`{ok, none}`), a class with no
+metadata row (`not_found` — truncation), or the `?MAX_HIERARCHY_DEPTH` cap (a
+corrupted cyclic hierarchy). Caller-side; no bus call.
+""".
+-spec walk_and_deliver(
+    announcement_class(), announcement_class(), term(), sets:set(sub_ref()), non_neg_integer()
+) -> sets:set(sub_ref()).
+walk_and_deliver(_CurrentClass, EventClass, _Event, Delivered, Depth) when
+    Depth > ?MAX_HIERARCHY_DEPTH
+->
+    %% Runs in the *announcing* caller's process (announce/2 is caller-side), not
+    %% the bus process, so the `domain` metadata set in init/1 does not apply —
+    %% set it explicitly, matching bad_subscribe_args/3.
+    ?LOG_WARNING(#{
+        event => announcement_mro_walk_truncated,
+        reason => max_depth_exceeded,
+        event_class => EventClass,
+        max_depth => ?MAX_HIERARCHY_DEPTH,
+        domain => [beamtalk, announcements]
+    }),
+    Delivered;
+walk_and_deliver(CurrentClass, EventClass, Event, Delivered, Depth) ->
+    %% Deliver to every subscription registered against `CurrentClass`, skipping
+    %% any SubRef already delivered to on this walk (per-subscription de-dup).
+    IndexRows = ets:match_object(?BY_CLASS_TABLE, {{CurrentClass, '_'}}),
+    Delivered1 = lists:foldl(
+        fun({{_Class, SubRef}}, Acc) ->
+            case sets:is_element(SubRef, Acc) of
+                true ->
+                    Acc;
+                false ->
+                    deliver(SubRef, EventClass, Event),
+                    sets:add_element(SubRef, Acc)
+            end
+        end,
+        Delivered,
+        IndexRows
+    ),
+    %% Walk to the superclass, reading the live metadata at announce time. A
+    %% missing row (`not_found`) truncates the walk gracefully (class removed
+    %% mid-walk); the root (`{ok, none}`) ends it normally.
+    case beamtalk_class_metadata:lookup_superclass(CurrentClass) of
+        {ok, none} ->
+            Delivered1;
+        {ok, Super} ->
+            walk_and_deliver(Super, EventClass, Event, Delivered1, Depth + 1);
+        not_found ->
+            Delivered1
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
@@ -4,12 +4,16 @@
 -module(beamtalk_announcements_tests).
 
 -moduledoc """
-EUnit tests for `beamtalk_announcements` (BT-2439 / ADR 0093 Phase 1).
+EUnit tests for `beamtalk_announcements` (BT-2439 / BT-2440 / ADR 0093 Phase 1).
 
 Covers the Phase-1 acceptance criteria: deliver to a subscriber of the exact
-class, a dead subscriber pruned automatically via monitor `DOWN`, single-class
-match (no MRO walk yet), distinct subscriptions to the same class (Pharo's
+class, a dead subscriber pruned automatically via monitor `DOWN`, an unrelated
+class delivering nothing, distinct subscriptions to the same class (Pharo's
 multi-subscription rule), idempotent unsubscribe, and the introspection reads.
+
+BT-2440 adds the MRO (superclass-chain) matching: delivery to subscribers of an
+ancestor class, per-subscription de-duplication across the walk, and graceful
+truncation when a class's metadata row is removed mid-hierarchy.
 """.
 
 -include_lib("eunit/include/eunit.hrl").
@@ -53,6 +57,14 @@ clear_all_subscriptions() ->
     catch
         _:_ -> ok
     end,
+    %% Drop any class-hierarchy rows the MRO tests insert, so a stale superclass
+    %% link cannot leak into a later test's announce walk.
+    lists:foreach(
+        fun(C) ->
+            catch beamtalk_class_metadata:delete(C)
+        end,
+        ['ButtonClicked', 'UIEvent', 'DomainEvent', 'PriceChanged', 'OtherEvent']
+    ),
     ok.
 
 %%====================================================================
@@ -136,7 +148,7 @@ deliver_to_subscriber_test_() ->
     end}.
 
 %%====================================================================
-%% Single-class match — no MRO walk (Phase 1)
+%% An unrelated class delivers nothing (no spurious cross-class match)
 %%====================================================================
 
 single_class_match_test_() ->
@@ -149,8 +161,9 @@ single_class_match_test_() ->
                     {ok, _SubRef} = beamtalk_announcements:subscribe(
                         'PriceChanged', Sub, h, false
                     ),
-                    %% Announcing a *different* class delivers nothing — no
-                    %% MRO/match across class names in Phase 1.
+                    %% Announcing an *unrelated* class delivers nothing — with
+                    %% no metadata rows the MRO walk truncates immediately and
+                    %% 'OtherEvent' is not an ancestor of 'PriceChanged'.
                     ok = beamtalk_announcements:announce('OtherEvent', {x, 1}),
                     refute_received(),
                     %% The matching class still delivers.
@@ -302,8 +315,203 @@ invalid_subscribe_args_test_() ->
     end}.
 
 %%====================================================================
+%% MRO ancestor delivery — subscribe to an ancestor, receive a subclass event
+%%====================================================================
+
+%% Hierarchy: ButtonClicked -> UIEvent -> DomainEvent (root). A subscriber of any
+%% ancestor receives an announce of the subclass; the delivered EventClass is the
+%% *announced* class, not the matched ancestor.
+mro_ancestor_delivery_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                build_hierarchy(),
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                try
+                    %% Subscribe to the *ancestor*, announce the *subclass*.
+                    {ok, SubRef} = beamtalk_announcements:subscribe(
+                        'UIEvent', Sub, h, false
+                    ),
+                    ok = beamtalk_announcements:announce('ButtonClicked', {click, 1}),
+                    {GotRef, GotClass, GotHandler, GotEvent} = expect_received(),
+                    ?assertEqual(SubRef, GotRef),
+                    %% Carries the announced class, not the matched ancestor.
+                    ?assertEqual('ButtonClicked', GotClass),
+                    ?assertEqual(h, GotHandler),
+                    ?assertEqual({click, 1}, GotEvent),
+                    %% No second delivery from a higher ancestor for this one sub.
+                    refute_received()
+                after
+                    stop_subscriber(Sub)
+                end
+            end),
+            ?_test(begin
+                %% Root-class subscriber also receives a deep subclass event.
+                build_hierarchy(),
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                try
+                    {ok, _} = beamtalk_announcements:subscribe('DomainEvent', Sub, root_h, false),
+                    ok = beamtalk_announcements:announce('ButtonClicked', deep),
+                    {_R, 'ButtonClicked', root_h, deep} = expect_received(),
+                    refute_received()
+                after
+                    stop_subscriber(Sub)
+                end
+            end),
+            ?_test(begin
+                %% A sibling-class subscriber is NOT matched (not on the chain).
+                build_hierarchy(),
+                beamtalk_class_metadata:insert('OtherEvent', undefined, undefined, 'DomainEvent'),
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                try
+                    {ok, _} = beamtalk_announcements:subscribe('OtherEvent', Sub, sib, false),
+                    ok = beamtalk_announcements:announce('ButtonClicked', x),
+                    refute_received()
+                after
+                    stop_subscriber(Sub)
+                end
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Per-subscription de-dup across the MRO walk
+%%====================================================================
+
+%% A process holding two subscriptions that both match the event (one on the
+%% subclass, one on an ancestor) receives TWO messages — one per subscription
+%% (Pharo's rule) — and the matcher never double-sends a single subscription even
+%% though the walk visits several ancestor classes.
+mro_per_subscription_dedup_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                build_hierarchy(),
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                try
+                    %% Two distinct subscriptions on the same pid: one on the
+                    %% exact class, one on an ancestor. Both match 'ButtonClicked'.
+                    {ok, SubRefSub} = beamtalk_announcements:subscribe(
+                        'ButtonClicked', Sub, on_sub, false
+                    ),
+                    {ok, SubRefAnc} = beamtalk_announcements:subscribe(
+                        'UIEvent', Sub, on_anc, false
+                    ),
+                    ?assertNotEqual(SubRefSub, SubRefAnc),
+
+                    ok = beamtalk_announcements:announce('ButtonClicked', e),
+                    %% Exactly two deliveries — one per subscription.
+                    R1 = expect_received(),
+                    R2 = expect_received(),
+                    refute_received(),
+                    Handlers = lists:sort([element(3, R1), element(3, R2)]),
+                    ?assertEqual([on_anc, on_sub], Handlers),
+                    %% Each subscription delivered exactly once (distinct refs).
+                    Refs = lists:sort([element(1, R1), element(1, R2)]),
+                    ?assertEqual(lists:sort([SubRefSub, SubRefAnc]), Refs)
+                after
+                    stop_subscriber(Sub)
+                end
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Class removed mid-walk — truncation handled gracefully (no crash)
+%%====================================================================
+
+%% If an intermediate class's metadata row is gone, the walk stops at that point
+%% with no crash: subscribers below the gap still receive the event, ancestors
+%% above it do not.
+mro_truncation_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                build_hierarchy(),
+                Collector = self(),
+                SubMid = spawn_subscriber(Collector),
+                SubTop = spawn_subscriber(Collector),
+                try
+                    {ok, RefMid} = beamtalk_announcements:subscribe(
+                        'UIEvent', SubMid, mid, false
+                    ),
+                    {ok, _RefTop} = beamtalk_announcements:subscribe(
+                        'DomainEvent', SubTop, top, false
+                    ),
+                    %% Remove the 'UIEvent' metadata row: the walk from
+                    %% 'ButtonClicked' reads superclass = 'UIEvent', delivers to
+                    %% RefMid, then lookup_superclass('UIEvent') is not_found and
+                    %% the walk truncates before reaching 'DomainEvent'.
+                    beamtalk_class_metadata:delete('UIEvent'),
+
+                    ok = beamtalk_announcements:announce('ButtonClicked', t),
+                    %% The mid-level subscriber still got it (delivered before the
+                    %% gap); a single, well-formed delivery, no crash.
+                    {GotRef, 'ButtonClicked', mid, t} = expect_received(),
+                    ?assertEqual(RefMid, GotRef),
+                    %% The above-the-gap root subscriber gets nothing.
+                    refute_received(),
+                    %% The bus survived (still answers calls).
+                    ?assert(is_integer(beamtalk_announcements:subscription_count()))
+                after
+                    stop_subscriber(SubMid),
+                    stop_subscriber(SubTop)
+                end
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Corrupted cyclic hierarchy — depth cap bounds the walk, no crash, dedup holds
+%%====================================================================
+
+%% A metadata cycle (A -> B -> A) cannot loop forever: the depth cap truncates
+%% the walk, the bus does not crash, and a subscriber on a class in the cycle
+%% still receives exactly one delivery (per-subscription de-dup spans revisits).
+mro_cyclic_hierarchy_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                %% Cycle: 'CycA' -> 'CycB' -> 'CycA' -> ...
+                beamtalk_class_metadata:insert('CycA', undefined, undefined, 'CycB'),
+                beamtalk_class_metadata:insert('CycB', undefined, undefined, 'CycA'),
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                try
+                    {ok, SubRef} = beamtalk_announcements:subscribe('CycA', Sub, cyc, false),
+                    ok = beamtalk_announcements:announce('CycA', boom),
+                    %% Exactly one delivery despite the walk revisiting 'CycA'.
+                    {GotRef, 'CycA', cyc, boom} = expect_received(),
+                    ?assertEqual(SubRef, GotRef),
+                    refute_received(),
+                    %% Bus survived the bounded walk.
+                    ?assert(is_integer(beamtalk_announcements:subscription_count()))
+                after
+                    stop_subscriber(Sub),
+                    catch beamtalk_class_metadata:delete('CycA'),
+                    catch beamtalk_class_metadata:delete('CycB')
+                end
+            end)
+        ]
+    end}.
+
+%%====================================================================
 %% Helpers
 %%====================================================================
+
+%% Stand up a 3-level class hierarchy in the metadata table for the MRO tests:
+%% ButtonClicked -> UIEvent -> DomainEvent (root, superclass = none).
+%% Rows carry only the superclass link (module/selectors undefined — the MRO walk
+%% reads only superclass). cleanup/1 drops these rows after each test.
+build_hierarchy() ->
+    beamtalk_class_metadata:insert('DomainEvent', undefined, undefined, none),
+    beamtalk_class_metadata:insert('UIEvent', undefined, undefined, 'DomainEvent'),
+    beamtalk_class_metadata:insert('ButtonClicked', undefined, undefined, 'UIEvent'),
+    ok.
 
 %% Poll `Pred` until it returns true, or fail after ~2s.
 wait_until(Pred) ->


### PR DESCRIPTION
Part of ADR 0093 (Announcements), Layer 1. Builds on BT-2439 (the runtime bus). Adds the MRO (superclass-chain) walk to `announce/2`.

Linear issue: https://linear.app/beamtalk/issue/BT-2440

## What was implemented

- **MRO matching in `announce/2`**: the event class's superclass chain is walked at announce time via `beamtalk_class_metadata:lookup_superclass/1`, gathering matching subscriptions from the by-class index at each level. Subscribe to `UIEvent` and you receive `ButtonClicked`. The walk happens at announce time, so live hierarchy changes are respected.
- **Per-subscription de-dup**: a `SubRef` is delivered to at most once per `announce`, even though the walk visits several classes. A process holding two distinct subscriptions still receives two messages (one per `SubRef`, Pharo's rule).
- **Announced class preserved**: each delivered message carries the *announced* `EventClass`, not the ancestor the subscription matched on.
- **Graceful termination**: the walk stops at the root (`{ok, none}`), a class whose metadata row is absent (`not_found` — class removed mid-walk), and a depth cap (`?MAX_HIERARCHY_DEPTH`) that bounds a corrupted cyclic hierarchy (logged at WARNING).

## Out of scope (later phases)

Sync `announceAndWait:` / `doOnce:` / `when:send:to:` + fault isolation (BT-2441), heir crash re-arm dead-pid prune (BT-2442), stdlib veneer (BT-2443).

## Verification

- `just build`, `rebar3 fmt --check`, `just dialyzer` all clean.
- 13 EUnit tests pass (6 new): ancestor delivery, multi-level chain, per-`SubRef` dedup, distinct-subscription double delivery, truncation on missing metadata, exact-class still matching.

https://claude.ai/code/session_01T17Psn5v3wvyPbbwpREMqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01T17Psn5v3wvyPbbwpREMqw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Event delivery now includes ancestor-class subscribers through method resolution order hierarchy matching.
  * Per-subscription de-duplication prevents duplicate messages when events traverse multiple class hierarchies.

* **Improvements**
  * Added safeguards against corrupted or incomplete class hierarchies with automatic truncation and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->