### PR TITLE
Announcements: announceAndWait: (sync) + doOnce: + when:send:to: + fault isolation (BT-2441)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_announcements.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_announcements.erl
@@ -19,6 +19,36 @@ BT-2439 delivered the foundation with exact-class matching; BT-2440 adds the MRO
 its class *or any ancestor*, with the walk performed at announce time (live
 hierarchy changes respected) and delivery de-duplicated per subscription.
 
+BT-2441 adds the synchronous, fault-isolated path and the once-only consume:
+
+- **`announceAndWait/2,3` — synchronous gather, caller-side.** Walks the same MRO
+  chain as `announce/2` to collect matching subscriptions, then `spawn_monitor`s
+  one transient process *per matching subscription* to run that subscription's
+  handler. The caller's `receive` loop gathers `{Ref, ok}` acks and treats a
+  `{'DOWN', Ref, process, _, Reason}` as the handler-crashed signal — logged
+  `domain => [beamtalk, announcements]`, never re-raised into the caller or a
+  sibling handler. A per-handler timeout (5s default, configurable in ms via
+  `announceAndWait/3`) ejects the loop so a slow or wedged handler can never leave
+  the caller blocked forever. Because the gather runs entirely in the *caller's*
+  process — there is no shared gen_server in the path — an `announceAndWait/2`
+  issued from inside a handler is reentrant-safe and cannot deadlock.
+
+- **Handler invocation (`run_handler/2`).** The transient process runs the stored
+  handler: a `fun/1` (block) is applied to the event, a `fun/0` is applied with no
+  args, and a `{send, Selector, Receiver}` handler (the `when:send:to:` form) is
+  dispatched via `beamtalk_message_dispatch:send/3` with the event as the sole
+  argument. Any other opaque term is a no-op success (the async path delivers it
+  as a message to the subscriber instead — see `deliver/3`).
+
+- **`doOnce` consumed atomically.** A subscription registered with `OnceFlag =
+  true` is consumed with an atomic `ets:take/2` on its unique `SubRef` at delivery
+  time, on both the async (`announce/2`) and sync (`announceAndWait/2,3`) paths.
+  With caller-side dispatch two announces may race for the same once-only row;
+  whichever wins the `take` delivers and the loser gets `[]` and skips it, so a
+  `doOnce` subscription fires **at most once** even under concurrent announcers.
+  The by-class index row is removed alongside the primary row so the consumed
+  subscription leaves no stale index entry.
+
 Design (the `beamtalk_xref` / `beamtalk_trace_store` discipline — the gen_server
 is NOT in the dispatch path):
 
@@ -52,9 +82,9 @@ is NOT in the dispatch path):
   from the surviving rows. The full crash→restart dead-pid prune is BT-2442;
   Phase 1 re-arms and keeps the data.
 
-Out of scope here (later issues): the sync `announceAndWait:` path / `doOnce:` /
-`when:send:to:` / handler fault isolation (BT-2441), and the heir crash re-arm
-dead-pid prune (BT-2442).
+Out of scope here (later issues): the heir crash re-arm dead-pid prune (BT-2442)
+and the stdlib typed veneer classes — `Announcer` / `Announcement` /
+`Subscription` (BT-2444).
 
 See also: docs/ADR/0093-announcements-event-substrate.md §1
 """.
@@ -74,7 +104,9 @@ See also: docs/ADR/0093-announcements-event-substrate.md §1
 
 %% API — dispatch (caller-side, off concurrent ETS reads)
 -export([
-    announce/2
+    announce/2,
+    announceAndWait/2,
+    announceAndWait/3
 ]).
 
 %% API — introspection (direct ETS reads)
@@ -99,6 +131,10 @@ See also: docs/ADR/0093-announcements-event-substrate.md §1
 
 %% Dedicated pg scope (ADR 0093 §1 — NOT the default scope).
 -define(PG_SCOPE, beamtalk_pg).
+
+%% Per-handler timeout for the synchronous `announceAndWait/2` gather (ADR 0093
+%% §1 — "defaults to 5 s", configurable in ms via `announceAndWait/3`).
+-define(DEFAULT_ANNOUNCE_TIMEOUT, 5000).
 
 %%====================================================================
 %% Types
@@ -230,28 +266,110 @@ announce(EventClass, Event) when is_atom(EventClass) ->
         undefined ->
             ok;
         _ ->
-            _ = walk_and_deliver(EventClass, EventClass, Event, sets:new([{version, 2}]), 0),
-            ok
+            lists:foreach(
+                fun(SubRef) -> deliver(SubRef, EventClass, Event) end,
+                collect_matching(EventClass)
+            )
     end.
 
 -doc """
-Walk the superclass chain from `CurrentClass` and deliver `Event` (announced as
-`EventClass`) to every subscription matching a class on the walk, de-duplicated
-per `SubRef` via the `Delivered` set. Returns the updated `Delivered` set.
-
-Terminates when the chain reaches the root (`{ok, none}`), a class with no
-metadata row (`not_found` — truncation), or the `?MAX_HIERARCHY_DEPTH` cap (a
-corrupted cyclic hierarchy). Caller-side; no bus call.
+Announce `Event` synchronously: deliver to every matching subscriber *and wait*
+for each handler to complete, with per-handler fault isolation and a default 5 s
+timeout. Equivalent to `announceAndWait(EventClass, Event,
+?DEFAULT_ANNOUNCE_TIMEOUT)`. See `announceAndWait/3`.
 """.
--spec walk_and_deliver(
-    announcement_class(), announcement_class(), term(), sets:set(sub_ref()), non_neg_integer()
-) -> sets:set(sub_ref()).
-walk_and_deliver(_CurrentClass, EventClass, _Event, Delivered, Depth) when
+-spec announceAndWait(announcement_class(), term()) -> ok.
+announceAndWait(EventClass, Event) when is_atom(EventClass) ->
+    announceAndWait(EventClass, Event, ?DEFAULT_ANNOUNCE_TIMEOUT).
+
+-doc """
+Announce `Event` synchronously to every subscriber of `EventClass` *or any of its
+ancestors* and gather each handler's completion before returning. Runs entirely
+in the *calling* process — there is no shared gen_server in the path, so an
+`announceAndWait/2,3` issued from inside a handler is reentrant-safe and cannot
+deadlock.
+
+Matching uses the same MRO walk and per-subscription de-duplication as
+`announce/2`. For each matching subscription the bus `spawn_monitor`s one
+transient process that runs the subscription's handler (see `run_handler/2`) and
+sends a `{handler_ack, ReplyRef}` ack to the caller on success. The caller's
+`receive` loop gathers those acks; a `{'DOWN', MonRef, process, _, Reason}` with
+an abnormal `Reason` is the handler-crashed signal — caught, logged
+`domain => [beamtalk, announcements]`, and **never** re-raised into the caller or
+propagated to sibling handlers (each runs in its own process). A per-handler
+`Timeout` (ms) ejects the wait so a slow or wedged handler cannot block the caller
+forever; on timeout every still-pending handler is demonitored (a final
+`DOWN`/ack flushed) and logged, and the call returns — the lingering handler
+process is left to finish or die on its own (it is unlinked, so it cannot harm the
+caller).
+
+`doOnce` subscriptions are consumed with the same atomic `ets:take/2` as the async
+path, so a once-only subscription fires at most once across concurrent
+`announce`/`announceAndWait` callers. Returns `ok` once every spawned handler has
+acked, crashed, or timed out.
+""".
+-spec announceAndWait(announcement_class(), term(), timeout()) -> ok.
+announceAndWait(EventClass, Event, Timeout) when is_atom(EventClass) ->
+    case ets:whereis(?BY_CLASS_TABLE) of
+        undefined ->
+            ok;
+        _ ->
+            %% Spawn one monitored handler process per matching subscription that
+            %% survives the atomic claim (doOnce consume happens here, so the
+            %% concurrent-race guarantee holds). A subscription whose subscriber
+            %% process has already died is skipped — its handler is not run — for
+            %% parity with the async `deliver/3` guard (a doOnce row is still
+            %% consumed by the claim, matching the async path). Then gather every
+            %% reply.
+            Pending = lists:foldl(
+                fun(SubRef, Acc) ->
+                    case claim_row(SubRef) of
+                        {ok, _Class, SubscriberPid, Handler, _Once} ->
+                            case is_process_alive(SubscriberPid) of
+                                true ->
+                                    spawn_handler(
+                                        EventClass, Event, Handler, SubscriberPid, Acc
+                                    );
+                                false ->
+                                    Acc
+                            end;
+                        not_found ->
+                            Acc
+                    end
+                end,
+                #{},
+                collect_matching(EventClass)
+            ),
+            gather_replies(Pending, EventClass, Timeout)
+    end.
+
+-doc """
+Collect the `SubRef`s of every subscription matching `EventClass` *or any of its
+ancestors*, de-duplicated per `SubRef`, by walking the event class's superclass
+chain (`beamtalk_class_metadata:lookup_superclass/1`) and reading the by-class
+index at each level. Caller-side; no bus call. Used by both `announce/2` (async)
+and `announceAndWait/3` (sync), which then deliver to / spawn handlers for the
+returned refs — the actual subscription row (handler, once flag, liveness) is read
+at delivery time, so this list is purely a matching set.
+
+The walk stops gracefully at the root (`{ok, none}`), at a class whose metadata
+row is absent (`not_found` — e.g. a class removed mid-walk), and at the
+`?MAX_HIERARCHY_DEPTH` cap that bounds a corrupted cyclic hierarchy.
+""".
+-spec collect_matching(announcement_class()) -> [sub_ref()].
+collect_matching(EventClass) ->
+    Refs = walk_collect(EventClass, EventClass, sets:new([{version, 2}]), [], 0),
+    lists:reverse(Refs).
+
+-spec walk_collect(
+    announcement_class(), announcement_class(), sets:set(sub_ref()), [sub_ref()], non_neg_integer()
+) -> [sub_ref()].
+walk_collect(_CurrentClass, EventClass, _Seen, Acc, Depth) when
     Depth > ?MAX_HIERARCHY_DEPTH
 ->
-    %% Runs in the *announcing* caller's process (announce/2 is caller-side), not
-    %% the bus process, so the `domain` metadata set in init/1 does not apply —
-    %% set it explicitly, matching bad_subscribe_args/3.
+    %% Runs in the *announcing* caller's process (dispatch is caller-side), not the
+    %% bus process, so the `domain` metadata set in init/1 does not apply — set it
+    %% explicitly, matching bad_subscribe_args/3.
     ?LOG_WARNING(#{
         event => announcement_mro_walk_truncated,
         reason => max_depth_exceeded,
@@ -259,22 +377,19 @@ walk_and_deliver(_CurrentClass, EventClass, _Event, Delivered, Depth) when
         max_depth => ?MAX_HIERARCHY_DEPTH,
         domain => [beamtalk, announcements]
     }),
-    Delivered;
-walk_and_deliver(CurrentClass, EventClass, Event, Delivered, Depth) ->
-    %% Deliver to every subscription registered against `CurrentClass`, skipping
-    %% any SubRef already delivered to on this walk (per-subscription de-dup).
+    Acc;
+walk_collect(CurrentClass, EventClass, Seen, Acc, Depth) ->
+    %% Gather every subscription registered against `CurrentClass`, skipping any
+    %% SubRef already seen on this walk (per-subscription de-dup).
     IndexRows = ets:match_object(?BY_CLASS_TABLE, {{CurrentClass, '_'}}),
-    Delivered1 = lists:foldl(
-        fun({{_Class, SubRef}}, Acc) ->
-            case sets:is_element(SubRef, Acc) of
-                true ->
-                    Acc;
-                false ->
-                    deliver(SubRef, EventClass, Event),
-                    sets:add_element(SubRef, Acc)
+    {Seen1, Acc1} = lists:foldl(
+        fun({{_Class, SubRef}}, {SeenAcc, RefAcc}) ->
+            case sets:is_element(SubRef, SeenAcc) of
+                true -> {SeenAcc, RefAcc};
+                false -> {sets:add_element(SubRef, SeenAcc), [SubRef | RefAcc]}
             end
         end,
-        Delivered,
+        {Seen, Acc},
         IndexRows
     ),
     %% Walk to the superclass, reading the live metadata at announce time. A
@@ -282,23 +397,26 @@ walk_and_deliver(CurrentClass, EventClass, Event, Delivered, Depth) ->
     %% mid-walk); the root (`{ok, none}`) ends it normally.
     case beamtalk_class_metadata:lookup_superclass(CurrentClass) of
         {ok, none} ->
-            Delivered1;
+            Acc1;
         {ok, Super} ->
-            walk_and_deliver(Super, EventClass, Event, Delivered1, Depth + 1);
+            walk_collect(Super, EventClass, Seen1, Acc1, Depth + 1);
         not_found ->
-            Delivered1
+            Acc1
     end.
 
 -doc """
-Deliver `Event` to one subscription if it is still live and its subscriber
-process is alive. Skips silently otherwise (the row may have been unsubscribed
-or the subscriber may have died between the index read and here — a race that is
-harmless: a missed delivery to a process that is gone). Caller-side; no bus call.
+Deliver `Event` to one subscription (async path) if it is still live and its
+subscriber process is alive. A `doOnce` subscription is consumed atomically via
+`claim_row/1` so it fires at most once even under concurrent announcers; a
+non-once subscription is read without removal. Skips silently when the row is
+gone (unsubscribed, already consumed by a racing once-only delivery, or the
+subscriber died between the index read and here — all harmless). Caller-side; no
+bus call.
 """.
 -spec deliver(sub_ref(), announcement_class(), term()) -> ok.
 deliver(SubRef, EventClass, Event) ->
-    case ets:lookup(?SUBS_TABLE, SubRef) of
-        [{SubRef, _Class, SubscriberPid, Handler, _Once}] ->
+    case claim_row(SubRef) of
+        {ok, _Class, SubscriberPid, Handler, _Once} ->
             case is_process_alive(SubscriberPid) of
                 true ->
                     SubscriberPid ! {beamtalk_announcement, SubRef, EventClass, Handler, Event},
@@ -306,9 +424,208 @@ deliver(SubRef, EventClass, Event) ->
                 false ->
                     ok
             end;
-        [] ->
+        not_found ->
             ok
     end.
+
+-doc """
+Read a subscription row for delivery, consuming it if it is a `doOnce`
+subscription. For a once-only row (`OnceFlag = true`) the read is an atomic
+`ets:take/2` on the unique `SubRef`: exactly one concurrent caller gets the row
+and delivers, every other gets `not_found` and skips — so the subscription fires
+at most once. The by-class index entry is removed alongside the consumed row so no
+stale index entry lingers. A non-once row is read with `ets:lookup/2` (left in
+place). Returns `not_found` for an unknown / already-consumed / unsubscribed ref.
+""".
+-spec claim_row(sub_ref()) ->
+    {ok, announcement_class(), pid(), handler(), boolean()} | not_found.
+claim_row(SubRef) ->
+    case ets:lookup(?SUBS_TABLE, SubRef) of
+        [{SubRef, Class, Pid, Handler, false}] ->
+            {ok, Class, Pid, Handler, false};
+        [{SubRef, _Class, _Pid, _Handler, true}] ->
+            %% doOnce — atomically consume on the unique key. Whichever concurrent
+            %% caller wins the `take` delivers; the rest get `[]` and skip.
+            case ets:take(?SUBS_TABLE, SubRef) of
+                [{SubRef, Class, Pid, Handler, true}] ->
+                    true = ets:delete(?BY_CLASS_TABLE, {Class, SubRef}),
+                    {ok, Class, Pid, Handler, true};
+                [] ->
+                    not_found
+            end;
+        [] ->
+            not_found
+    end.
+
+%%====================================================================
+%% Internal: synchronous gather (announceAndWait)
+%%====================================================================
+
+-doc """
+Spawn one monitored transient process to run `Handler` for the synchronous path,
+recording it in the `Pending` map keyed by its monitor `Ref`. The value is
+`{ReplyRef, HandlerPid, SubscriberPid}`: `ReplyRef` is a fresh reference minted in
+the caller and closed over by the spawned process, which — on a clean run of
+`run_handler/2` — sends `{handler_ack, ReplyRef}` back to the caller. If the
+handler raises, the process exits abnormally and no ack is sent; the monitor
+`DOWN` (keyed by the same `MonRef`) carries the reason and `gather_replies/3`
+treats it as the isolated-crash signal. Two refs are needed because the child
+cannot know its own monitor ref; `gather_replies/3` correlates the ack's
+`ReplyRef` back to the monitor `Ref`. `HandlerPid` is kept so a timed-out handler
+can be killed; `SubscriberPid` for the crash/timeout diagnostic log. The handler
+runs under `spawn_monitor` (monitored, **not** linked), so neither its crash nor a
+kill signal can reach the caller.
+""".
+-spec spawn_handler(announcement_class(), term(), handler(), pid(), Pending) -> Pending when
+    Pending :: #{reference() => {reference(), pid(), pid()}}.
+spawn_handler(_EventClass, Event, Handler, SubscriberPid, Pending) ->
+    Caller = self(),
+    ReplyRef = make_ref(),
+    {HandlerPid, MonRef} = spawn_monitor(fun() ->
+        ok = run_handler(Handler, Event),
+        Caller ! {handler_ack, ReplyRef},
+        ok
+    end),
+    Pending#{MonRef => {ReplyRef, HandlerPid, SubscriberPid}}.
+
+-doc """
+Run one subscription's stored handler for the synchronous path, returning `ok` on
+completion. Handler forms:
+
+- a `fun/1` (a block taking the event) is applied to `Event`;
+- a `fun/0` (a no-arg block) is applied with no args;
+- `{send, Selector, Receiver}` (the `when:send:to:` form) is dispatched via
+  `beamtalk_message_dispatch:send(Receiver, Selector, [Event])`;
+- any other opaque term is a no-op success — the runtime layer does not interpret
+  arbitrary stdlib handler terms in the sync path (the async path delivers them as
+  a message to the subscriber instead).
+
+Runs inside the transient `spawn_monitor` process; any exception it raises exits
+that process and surfaces to the caller as a monitor `DOWN`, isolated from siblings
+and the announcer (`gather_replies/3`).
+""".
+-spec run_handler(handler(), term()) -> ok.
+run_handler(Handler, Event) when is_function(Handler, 1) ->
+    _ = Handler(Event),
+    ok;
+run_handler(Handler, _Event) when is_function(Handler, 0) ->
+    _ = Handler(),
+    ok;
+run_handler({send, Selector, Receiver}, Event) when is_atom(Selector) ->
+    _ = beamtalk_message_dispatch:send(Receiver, Selector, [Event]),
+    ok;
+run_handler(_Handler, _Event) ->
+    ok.
+
+-doc """
+Gather replies from every spawned handler, returning `ok` once each has acked,
+crashed, or timed out. `Pending` maps each handler's monitor `MonRef` to its
+`{ReplyRef, HandlerPid, SubscriberPid}`. The loop blocks on `Timeout`; on timeout
+every still-pending handler is killed (it ran longer than allowed), demonitored,
+and logged, then the call returns — so a slow handler can never wedge the caller. A
+handler crash (an abnormal monitor `DOWN`) is logged and dropped — never re-raised
+— so siblings and the announcer are unaffected.
+""".
+-spec gather_replies(
+    #{reference() => {reference(), pid(), pid()}}, announcement_class(), timeout()
+) -> ok.
+gather_replies(Pending, _EventClass, _Timeout) when map_size(Pending) =:= 0 ->
+    ok;
+gather_replies(Pending, EventClass, Timeout) ->
+    receive
+        {handler_ack, ReplyRef} ->
+            %% Correlate the ack's ReplyRef back to its monitor ref. An ack from a
+            %% no-longer-pending handler (e.g. one already counted as timed out) is
+            %% ignored.
+            case find_by_reply_ref(ReplyRef, Pending) of
+                {ok, MonRef} ->
+                    erlang:demonitor(MonRef, [flush]),
+                    gather_replies(maps:remove(MonRef, Pending), EventClass, Timeout);
+                error ->
+                    gather_replies(Pending, EventClass, Timeout)
+            end;
+        {'DOWN', MonRef, process, _Pid, Reason} when is_map_key(MonRef, Pending) ->
+            #{MonRef := {_ReplyRef, _HandlerPid, SubscriberPid}} = Pending,
+            %% `normal` is a clean exit that lost the race with its own ack (or a
+            %% handler that returned without our ack ever mattering); only abnormal
+            %% reasons are an isolated crash worth logging.
+            case Reason of
+                normal -> ok;
+                _ -> log_handler_crash(EventClass, SubscriberPid, Reason)
+            end,
+            gather_replies(maps:remove(MonRef, Pending), EventClass, Timeout)
+    after Timeout ->
+        %% Per-handler timeout: eject every still-pending handler so a slow or
+        %% wedged handler cannot block the caller forever. Kill the lingering
+        %% handler process (it is monitored, not linked, so the kill cannot reach
+        %% the caller), demonitor (flushing its `DOWN`), and flush any
+        %% already-queued `{handler_ack, ReplyRef}` so a handler that completed
+        %% just as the timeout fired leaves no stale message in the caller's
+        %% mailbox.
+        maps:foreach(
+            fun(MonRef, {ReplyRef, HandlerPid, SubscriberPid}) ->
+                exit(HandlerPid, kill),
+                _ = erlang:demonitor(MonRef, [flush]),
+                flush_ack(ReplyRef),
+                log_handler_timeout(EventClass, SubscriberPid, Timeout)
+            end,
+            Pending
+        ),
+        ok
+    end.
+
+-doc """
+Remove a single already-queued `{handler_ack, ReplyRef}` from the caller's
+mailbox if present (non-blocking). Called when a handler times out, so a handler
+that acked just as the timeout fired does not leave a stale message behind.
+`ReplyRef` is unique per spawned handler, so this is selective.
+""".
+-spec flush_ack(reference()) -> ok.
+flush_ack(ReplyRef) ->
+    receive
+        {handler_ack, ReplyRef} -> ok
+    after 0 -> ok
+    end.
+
+-doc "Find the monitor ref in `Pending` whose value carries `ReplyRef`.".
+-spec find_by_reply_ref(reference(), #{reference() => {reference(), pid(), pid()}}) ->
+    {ok, reference()} | error.
+find_by_reply_ref(ReplyRef, Pending) ->
+    maps:fold(
+        fun
+            (MonRef, {RR, _HandlerPid, _SubscriberPid}, error) when RR =:= ReplyRef ->
+                {ok, MonRef};
+            (_MonRef, _V, Acc) ->
+                Acc
+        end,
+        error,
+        Pending
+    ).
+
+-doc "Log an isolated handler crash on the synchronous path (never re-raised).".
+-spec log_handler_crash(announcement_class(), pid(), term()) -> ok.
+log_handler_crash(EventClass, SubscriberPid, Reason) ->
+    %% Caller-side process, not the bus — set `domain` explicitly (ADR 0093 §1).
+    ?LOG_ERROR(#{
+        event => announcement_handler_crashed,
+        event_class => EventClass,
+        subscriber => SubscriberPid,
+        reason => Reason,
+        domain => [beamtalk, announcements]
+    }),
+    ok.
+
+-doc "Log a handler that exceeded the per-handler timeout on the synchronous path.".
+-spec log_handler_timeout(announcement_class(), pid(), timeout()) -> ok.
+log_handler_timeout(EventClass, SubscriberPid, Timeout) ->
+    ?LOG_WARNING(#{
+        event => announcement_handler_timeout,
+        event_class => EventClass,
+        subscriber => SubscriberPid,
+        timeout_ms => Timeout,
+        domain => [beamtalk, announcements]
+    }),
+    ok.
 
 %%====================================================================
 %% API — introspection

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
@@ -14,6 +14,14 @@ multi-subscription rule), idempotent unsubscribe, and the introspection reads.
 BT-2440 adds the MRO (superclass-chain) matching: delivery to subscribers of an
 ancestor class, per-subscription de-duplication across the walk, and graceful
 truncation when a class's metadata row is removed mid-hierarchy.
+
+BT-2441 adds the synchronous + once-only + message-send forms with fault
+isolation: `announceAndWait/2,3` running each handler in its own monitored
+process; a `doOnce` subscription consumed atomically (exactly-once under N
+concurrent announcers); the `{send, Sel, Receiver}` (`when:send:to:`) handler
+form; per-handler fault isolation (a crashing handler is caught and the caller
+still returns, siblings unaffected); a per-handler timeout that ejects a wedged
+handler; and reentrant `announceAndWait/2` from inside a handler (no deadlock).
 """.
 
 -include_lib("eunit/include/eunit.hrl").
@@ -500,6 +508,377 @@ mro_cyclic_hierarchy_test_() ->
     end}.
 
 %%====================================================================
+%% announceAndWait — synchronous gather runs each handler and returns
+%%====================================================================
+
+%% A subscriber with a block handler that records the event into the test
+%% process's mailbox; the sync gather runs the handler in its own process and
+%% returns only once it has acked.
+announce_and_wait_runs_handler_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Collector = self(),
+                Sub = spawn_idle(),
+                try
+                    Handler = fun(Event) -> Collector ! {ran, Event} end,
+                    {ok, _SubRef} = beamtalk_announcements:subscribe(
+                        'SyncEvent', Sub, Handler, false
+                    ),
+                    ok = beamtalk_announcements:announceAndWait('SyncEvent', {payload, 1}),
+                    %% The handler ran (the sync gather waited for it).
+                    receive
+                        {ran, Got} -> ?assertEqual({payload, 1}, Got)
+                    after 1000 -> ?assert(false)
+                    end
+                after
+                    stop_idle(Sub)
+                end
+            end),
+            ?_test(begin
+                %% No subscribers — a harmless no-op that returns ok.
+                ?assertEqual(ok, beamtalk_announcements:announceAndWait('Nobody', x))
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% announceAndWait — MRO matching (ancestor subscriber runs its handler)
+%%====================================================================
+
+announce_and_wait_mro_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                build_hierarchy(),
+                Collector = self(),
+                Sub = spawn_idle(),
+                try
+                    Handler = fun(E) -> Collector ! {anc_ran, E} end,
+                    {ok, _} = beamtalk_announcements:subscribe('UIEvent', Sub, Handler, false),
+                    %% Announce the subclass synchronously; the ancestor handler runs.
+                    ok = beamtalk_announcements:announceAndWait('ButtonClicked', click),
+                    receive
+                        {anc_ran, Got} -> ?assertEqual(click, Got)
+                    after 1000 -> ?assert(false)
+                    end
+                after
+                    stop_idle(Sub)
+                end
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% when:send:to: — a {send, Selector, Receiver} handler dispatches a message
+%%====================================================================
+
+%% The handler form for `when:send:to:` is `{send, Selector, Receiver}`. On the
+%% sync path the runtime dispatches `Receiver perform: Selector with: Event` via
+%% `beamtalk_message_dispatch:send/3`. We exercise it against a real Beamtalk
+%% value (an Integer) so the dispatch goes through the genuine runtime path; the
+%% full runtime app is started so value dispatch (the extensions table) is live.
+when_send_to_dispatches_message_test_() ->
+    {setup, fun setup_with_dispatch/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Sub = spawn_idle(),
+                try
+                    %% {send, Selector, Receiver}: dispatch `printString` to the
+                    %% Integer 42 — a real value method. The sync gather runs the
+                    %% handler via beamtalk_message_dispatch and the dispatch
+                    %% succeeds, so the call returns ok.
+                    {ok, _} = beamtalk_announcements:subscribe(
+                        'PrintCmd', Sub, {send, 'printString', 42}, false
+                    ),
+                    ?assertEqual(
+                        ok, beamtalk_announcements:announceAndWait('PrintCmd', ignored)
+                    )
+                after
+                    stop_idle(Sub)
+                end
+            end),
+            ?_test(begin
+                %% A {send,...} to a selector the receiver does not understand
+                %% raises in the handler process — proving the {send,...} form is
+                %% genuinely dispatched (an opaque no-op would never crash). The
+                %% crash is isolated: the caller still returns ok.
+                Sub = spawn_idle(),
+                try
+                    {ok, _} = beamtalk_announcements:subscribe(
+                        'BogusCmd', Sub, {send, bogusSelectorXyz, 7}, false
+                    ),
+                    ?assertEqual(
+                        ok, beamtalk_announcements:announceAndWait('BogusCmd', ignored)
+                    )
+                after
+                    stop_idle(Sub)
+                end
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% Fault isolation — a crashing handler is caught, caller returns, siblings ok
+%%====================================================================
+
+announce_and_wait_handler_crash_isolated_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            {timeout, 10,
+                ?_test(begin
+                    Collector = self(),
+                    Sub = spawn_idle(),
+                    try
+                        Crashing = fun(_E) -> error(boom) end,
+                        Healthy = fun(E) -> Collector ! {healthy_ran, E} end,
+                        {ok, _} = beamtalk_announcements:subscribe(
+                            'FaultEvent', Sub, Crashing, false
+                        ),
+                        {ok, _} = beamtalk_announcements:subscribe(
+                            'FaultEvent', Sub, Healthy, false
+                        ),
+                        %% The caller returns ok despite the crashing handler, and the
+                        %% sibling handler still ran (isolation).
+                        ?assertEqual(
+                            ok, beamtalk_announcements:announceAndWait('FaultEvent', e)
+                        ),
+                        receive
+                            {healthy_ran, Got} -> ?assertEqual(e, Got)
+                        after 1000 -> ?assert(false)
+                        end,
+                        %% The announcer process (this test process) survived intact.
+                        ?assert(is_integer(beamtalk_announcements:subscription_count()))
+                    after
+                        stop_idle(Sub)
+                    end
+                end)}
+        ]
+    end}.
+
+%%====================================================================
+%% Per-handler timeout — a wedged handler does not block the caller forever
+%%====================================================================
+
+announce_and_wait_timeout_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            {timeout, 10,
+                ?_test(begin
+                    Sub = spawn_idle(),
+                    try
+                        %% A handler that sleeps far longer than the timeout.
+                        Wedged = fun(_E) -> timer:sleep(60000) end,
+                        {ok, _} = beamtalk_announcements:subscribe('SlowEvent', Sub, Wedged, false),
+                        Start = erlang:monotonic_time(millisecond),
+                        %% A short per-handler timeout ejects the wedged handler.
+                        ?assertEqual(
+                            ok, beamtalk_announcements:announceAndWait('SlowEvent', e, 100)
+                        ),
+                        Elapsed = erlang:monotonic_time(millisecond) - Start,
+                        %% Returned promptly (well under the wedged 60s sleep).
+                        ?assert(Elapsed < 5000)
+                    after
+                        stop_idle(Sub)
+                    end
+                end)},
+            {timeout, 10,
+                ?_test(begin
+                    %% A handler that finishes just *after* a tight timeout: it acks,
+                    %% but the call has already timed out and returned. The stale
+                    %% `{handler_ack, _}` must NOT linger in the caller's mailbox (the
+                    %% timeout path flushes it).
+                    Sub = spawn_idle(),
+                    try
+                        %% Sleeps past the 50ms timeout, then completes (sends its ack).
+                        Lagging = fun(_E) -> timer:sleep(150) end,
+                        {ok, _} = beamtalk_announcements:subscribe('LagEvent', Sub, Lagging, false),
+                        ?assertEqual(
+                            ok, beamtalk_announcements:announceAndWait('LagEvent', e, 50)
+                        ),
+                        %% Give the lagging handler time to finish and (try to) ack.
+                        timer:sleep(300),
+                        %% No stale ack message of any shape lingers in this mailbox.
+                        receive
+                            {handler_ack, _} -> ?assert(false)
+                        after 50 -> ok
+                        end
+                    after
+                        stop_idle(Sub)
+                    end
+                end)}
+        ]
+    end}.
+
+%%====================================================================
+%% Reentrant announceAndWait — from inside a handler, no deadlock
+%%====================================================================
+
+announce_and_wait_reentrant_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            {timeout, 10,
+                ?_test(begin
+                    Collector = self(),
+                    Sub = spawn_idle(),
+                    try
+                        %% Inner subscription whose handler records the inner event.
+                        InnerHandler = fun(E) -> Collector ! {inner, E} end,
+                        {ok, _} = beamtalk_announcements:subscribe(
+                            'InnerEvent', Sub, InnerHandler, false
+                        ),
+                        %% Outer handler re-announces synchronously from inside itself.
+                        OuterHandler = fun(_E) ->
+                            ok = beamtalk_announcements:announceAndWait('InnerEvent', nested),
+                            Collector ! {outer_done}
+                        end,
+                        {ok, _} = beamtalk_announcements:subscribe(
+                            'OuterEvent', Sub, OuterHandler, false
+                        ),
+                        %% No shared gen_server in the path, so the reentrant sync
+                        %% announce does not deadlock; both fire and the call returns.
+                        ?assertEqual(
+                            ok, beamtalk_announcements:announceAndWait('OuterEvent', start)
+                        ),
+                        receive
+                            {inner, Got} -> ?assertEqual(nested, Got)
+                        after 1000 -> ?assert(false)
+                        end,
+                        receive
+                            {outer_done} -> ok
+                        after 1000 -> ?assert(false)
+                        end
+                    after
+                        stop_idle(Sub)
+                    end
+                end)}
+        ]
+    end}.
+
+%%====================================================================
+%% doOnce — fires at most once for a single announcer
+%%====================================================================
+
+do_once_single_announcer_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Collector = self(),
+                Sub = spawn_subscriber(Collector),
+                try
+                    {ok, SubRef} = beamtalk_announcements:subscribe(
+                        'OnceEvent', Sub, h, true
+                    ),
+                    ?assert(beamtalk_announcements:is_active(SubRef)),
+                    %% First announce delivers and consumes the subscription.
+                    ok = beamtalk_announcements:announce('OnceEvent', first),
+                    {GotRef, 'OnceEvent', h, first} = expect_received(),
+                    ?assertEqual(SubRef, GotRef),
+                    %% The subscription is gone (consumed atomically).
+                    ok = wait_until(fun() ->
+                        not beamtalk_announcements:is_active(SubRef)
+                    end),
+                    ?assertEqual([], beamtalk_announcements:subscribers_of('OnceEvent')),
+                    %% A second announce delivers nothing.
+                    ok = beamtalk_announcements:announce('OnceEvent', second),
+                    refute_received()
+                after
+                    stop_subscriber(Sub)
+                end
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% doOnce — exactly-one delivery under N concurrent announcers
+%%====================================================================
+
+%% N processes race to announce the same once-only subscription concurrently.
+%% Exactly one delivery must occur — the atomic ets:take guarantees a single
+%% winner regardless of how the announces interleave.
+do_once_concurrent_announcers_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            {timeout, 30,
+                ?_test(begin
+                    Collector = self(),
+                    Sub = spawn_subscriber(Collector),
+                    try
+                        {ok, _SubRef} = beamtalk_announcements:subscribe(
+                            'RaceEvent', Sub, once_h, true
+                        ),
+                        %% Fan out N concurrent announcers.
+                        N = 50,
+                        Parent = self(),
+                        Barrier = make_ref(),
+                        Pids = [
+                            spawn(fun() ->
+                                %% Wait for the go signal so they fire as simultaneously
+                                %% as the scheduler allows.
+                                receive
+                                    {go, Barrier} -> ok
+                                end,
+                                beamtalk_announcements:announce('RaceEvent', payload),
+                                Parent ! {announced, self()}
+                            end)
+                         || _ <- lists:seq(1, N)
+                        ],
+                        [P ! {go, Barrier} || P <- Pids],
+                        %% Wait for all announcers to finish.
+                        [
+                            receive
+                                {announced, P} -> ok
+                            after 5000 -> ?assert(false)
+                            end
+                         || P <- Pids
+                        ],
+                        %% Exactly one delivery total, despite N concurrent announces.
+                        {_R, 'RaceEvent', once_h, payload} = expect_received(),
+                        refute_received(),
+                        ?assertEqual([], beamtalk_announcements:subscribers_of('RaceEvent'))
+                    after
+                        stop_subscriber(Sub)
+                    end
+                end)}
+        ]
+    end}.
+
+%%====================================================================
+%% doOnce — consumed on the synchronous path too
+%%====================================================================
+
+do_once_sync_path_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Collector = self(),
+                Sub = spawn_idle(),
+                try
+                    Handler = fun(E) -> Collector ! {once_sync, E} end,
+                    {ok, SubRef} = beamtalk_announcements:subscribe(
+                        'OnceSyncEvent', Sub, Handler, true
+                    ),
+                    ok = beamtalk_announcements:announceAndWait('OnceSyncEvent', a),
+                    receive
+                        {once_sync, GotA} -> ?assertEqual(a, GotA)
+                    after 1000 -> ?assert(false)
+                    end,
+                    %% Consumed — the subscription is gone.
+                    ?assertNot(beamtalk_announcements:is_active(SubRef)),
+                    %% A second sync announce delivers nothing (no handler runs).
+                    ok = beamtalk_announcements:announceAndWait('OnceSyncEvent', b),
+                    receive
+                        {once_sync, _} -> ?assert(false)
+                    after 200 -> ok
+                    end
+                after
+                    stop_idle(Sub)
+                end
+            end)
+        ]
+    end}.
+
+%%====================================================================
 %% Helpers
 %%====================================================================
 
@@ -512,6 +891,41 @@ build_hierarchy() ->
     beamtalk_class_metadata:insert('UIEvent', undefined, undefined, 'DomainEvent'),
     beamtalk_class_metadata:insert('ButtonClicked', undefined, undefined, 'UIEvent'),
     ok.
+
+%% Set up for the `when:send:to:` test: the standalone bus (via `setup/0`) plus
+%% the `beamtalk_extensions` table that real value dispatch reads. Initialising
+%% that table is all the `{send, Selector, Receiver}` path needs to dispatch a
+%% genuine value method (e.g. `Integer printString`) — no need to start the whole
+%% runtime application (which would clash with the standalone bus other tests in
+%% this module leave registered). `init/0` is idempotent if the app already
+%% created the table.
+setup_with_dispatch() ->
+    Pid = setup(),
+    catch beamtalk_extensions:init(),
+    Pid.
+
+%% Spawn an idle process to act as the subscriber pid for synchronous-path tests.
+%% On the sync path the subscriber pid is used only to arm the bus monitor and for
+%% crash/timeout diagnostics — the handler runs in a transient process the bus
+%% spawns, not in this pid — so an inert process that just waits to be stopped is
+%% all that is needed (and keeping it alive prevents the bus pruning its rows).
+spawn_idle() ->
+    spawn(fun idle_loop/0).
+
+idle_loop() ->
+    receive
+        {stop, From} -> From ! {stopped, self()};
+        _ -> idle_loop()
+    end.
+
+stop_idle(Pid) ->
+    Pid ! {stop, self()},
+    receive
+        {stopped, Pid} -> ok
+    after 500 ->
+        exit(Pid, kill),
+        ok
+    end.
 
 %% Poll `Pred` until it returns true, or fail after ~2s.
 wait_until(Pred) ->


### PR DESCRIPTION
## Summary

Implements ADR 0093 §1, Phase 1: the synchronous + once-only + message-send subscription forms with fault isolation, building on the `beamtalk_announcements` gen_server, ETS subscription tables, and MRO-walking async `announce/2` delivered in BT-2439 + BT-2440.

Linear: https://linear.app/beamtalk/issue/BT-2441

## Key changes (`runtime/apps/beamtalk_runtime/src/beamtalk_announcements.erl`)

- **`announceAndWait/2,3` (sync gather, caller-side).** Walks the same MRO chain as `announce/2`, then `spawn_monitor`s one transient process per matching subscription to run its handler. The caller's `receive` loop gathers `{handler_ack, ReplyRef}` acks; a monitor `DOWN` with an abnormal reason is the handler-crashed signal. Per-handler timeout defaults to 5s, configurable in ms via `announceAndWait/3`. No shared gen_server in the path, so a reentrant `announceAndWait:` from inside a handler is deadlock-free.
- **Per-handler fault isolation.** A crashing handler is caught, logged `domain => [beamtalk, announcements]`, and never propagated to siblings or the announcer. A timed-out handler is killed and any already-queued stale ack is flushed from the caller's mailbox.
- **`doOnce` consumed atomically** via `ets:take/2` on the unique `SubRef` (both async and sync paths) — fires at most once even under N concurrent announcers; the by-class index row is removed alongside.
- **`when:send:to:`** handler form `{send, Selector, Receiver}` dispatched via `beamtalk_message_dispatch:send/3`; block funs (`/0`, `/1`) are invoked directly.
- Shared MRO collection walk (`collect_matching/1`) feeds both paths; the sync path skips dead subscribers for parity with the async `deliver/3` guard.

## Tests (`beamtalk_announcements_tests.erl`)

New EUnit cases: exactly-one `doOnce` delivery under 50 concurrent announcers; handler-crash isolation (caller still returns, sibling handler runs); reentrant sync (no deadlock); per-handler timeout (prompt return on a wedged handler); no stale `{handler_ack, _}` left in the caller mailbox after a timeout; `when:send:to:` dispatch (positive + isolated bogus-selector). All 25 module tests pass.

## Verification

- `beamtalk_announcements_tests`: 25 tests, 0 failures
- Full runtime EUnit: only the 4 pre-existing flaky failures (`beamtalk_binary_tests`, `beamtalk_stream_tests`, `beamtalk_test_case_tests`), identical to clean `origin/main` — no regressions
- `just clippy`, `just dialyzer`, `just fmt-check`: clean

No runtime supervisor child-list change (the bus was already a supervised child from BT-2439), so `beamtalk_runtime_sup_tests.erl` is unaffected.

https://claude.ai/code/session_01T17Psn5v3wvyPbbwpREMqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01T17Psn5v3wvyPbbwpREMqw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronous announcement API with configurable per-handler timeout (default 5000ms) and fault isolation—handlers execute in isolated processes while the caller waits for completion or timeout.
  * Ensures one-time subscriptions are consumed atomically across concurrent announcers.

* **Tests**
  * Added comprehensive test coverage for synchronous announcement behavior, including timeout handling, handler isolation, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->