### PR TITLE
Tighten class object printString/inspect assertions (BT-2457)

### DIFF
--- a/stdlib/test/class_object_dispatch_test.bt
+++ b/stdlib/test/class_object_dispatch_test.bt
@@ -22,11 +22,11 @@ TestCase subclass: ClassObjectDispatchTest
 
   testClassObjectPrintString =>
     ps := Counter printString
-    self deny: ps isEmpty
+    self assert: ps equals: "Counter"
 
   testClassObjectInspect =>
     i := Counter inspect
-    self deny: i isEmpty
+    self assert: i equals: "a Counter"
 
   testClassObjectPerform =>
     self assert: (Counter perform: #name) equals: #Counter


### PR DESCRIPTION
## Summary

Replaces two loose `deny: isEmpty` checks in `ClassObjectDispatchTest` with exact equality assertions, pinning the known deterministic output.

- `testClassObjectPrintString`: `deny: ps isEmpty` → `assert: ps equals: "Counter"`
- `testClassObjectInspect`: `deny: i isEmpty` → `assert: i equals: "a Counter"`

## Why these values

**`Counter printString → "Counter"`** — `Class>>printString` is defined as `sealed printString -> String => self name asString` (stdlib/src/Class.bt:27). Consistent with `object_protocol_test.bt` lines 33–36 which pin `42 class printString → "Integer"`, `"hello" class printString → "String"`, etc.

**`Counter inspect → "a Counter"`** — `Object>>inspect` delegates to `self printString`; inside that compiled method, dispatch finds `Object>>printString => "a " ++ self class printString` rather than `Class>>printString`. The value `"a Counter"` was confirmed by the failing test run during development (first attempt used `"Counter"`, caught the real value).

## Safety

Both replacements are strictly stronger — they catch wrong class names, inverted case, or any non-empty garbage that `deny: isEmpty` would silently accept. The test intent (class objects dispatch Object base class methods correctly) is preserved and sharpened.

All 2447 BUnit tests pass.

Linear: https://linear.app/beamtalk/issue/BT-2457/tighten-loose-assertions-in-class-object-dispatch-testbt

---
_Generated by [Claude Code](https://claude.ai/code/session_012HpbS7EXCGbwM5oTifjUKX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation of class object string representation and inspection functionality to ensure correct behavior and accurate output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->