### PR TITLE
Dispatch repository_dispatch from beamtalk release.yml to beamtalk-uat (BT-2449)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,6 +337,49 @@ jobs:
             ${{ steps.package.outputs.archive }}.sha256
           retention-days: 7
 
+  # ─── Notify beamtalk-uat acceptance gate (BT-2449) ──────────────────────
+  # After every platform's release archive is built and uploaded, fire a
+  # repository_dispatch into jamesc/beamtalk-uat so the UAT gate (BT-2253)
+  # runs against this exact published version. The consumer (BT-2451) listens
+  # for the event-type `beamtalk-release` and reads `version` + `tag` from the
+  # client-payload.
+  #
+  # Guarded by `github.event_name == 'release'` — the same condition that gates
+  # the real "Upload release asset" steps above — so dry-run / artifact-only
+  # invocations (workflow_dispatch) no-op cleanly and never dispatch.
+  notify-uat:
+    needs: [linux-x86_64, macos-x86_64, macos-arm64, windows-x86_64]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # Re-resolve version/tag here (each build job computes these in its own
+      # runner; this is a separate job, so derive them the same way).
+      - name: Determine version
+        id: version
+        run: scripts/ci/determine-version.sh "${{ github.event_name }}" "${{ github.event.release.tag_name }}" "${{ inputs.tag }}"
+
+      - name: Dispatch UAT gate
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          # UAT_DISPATCH_TOKEN: a PAT / fine-grained token with
+          # `contents: write` (i.e. repository_dispatch) scope on
+          # jamesc/beamtalk-uat. It must be provisioned separately as a repo
+          # secret in this repo's settings — it is NOT GITHUB_TOKEN, which
+          # cannot dispatch across repositories.
+          token: ${{ secrets.UAT_DISPATCH_TOKEN }}
+          repository: jamesc/beamtalk-uat
+          event-type: beamtalk-release
+          client-payload: |
+            {
+              "version": "${{ steps.version.outputs.version }}",
+              "tag": "${{ steps.version.outputs.tag }}"
+            }
+
   # ─── VS Code extension (delegated to release-vscode.yml) ────────────────
   vscode-extension:
     uses: ./.github/workflows/release-vscode.yml


### PR DESCRIPTION
## Summary

Wires the cross-repo coordination for the BT-2253 UAT acceptance gate: when `beamtalk` publishes a release, `release.yml` now notifies `jamesc/beamtalk-uat` to run the gate against that exact version.

Linear: https://linear.app/beamtalk/issue/BT-2449

## Consumer contract (for BT-2451 / beamtalk-uat side)

The beamtalk-uat workflow should listen for:

- **event-type:** `beamtalk-release`
- **client-payload shape:**
  ```json
  { "version": "0.4.0", "tag": "v0.4.0" }
  ```
  (`version` is the tag with the leading `v` stripped, matching `determine-version.sh`.)

## Key changes

- New `notify-uat` job in `.github/workflows/release.yml`:
  - `needs: [linux-x86_64, macos-x86_64, macos-arm64, windows-x86_64]` — fires once, only after every platform's archive is built and uploaded.
  - `if: github.event_name == 'release'` — the same condition that gates the real "Upload release asset" steps, so dry-run / `workflow_dispatch` invocations no-op cleanly and never dispatch.
  - Uses `peter-evans/repository-dispatch@v3` to dispatch into `jamesc/beamtalk-uat`.
  - Reuses `scripts/ci/determine-version.sh` for `version`/`tag` resolution (re-run here because each job has its own runner).

## Secret requirement (provisioned separately)

References `secrets.UAT_DISPATCH_TOKEN` — a PAT / fine-grained token with `contents: write` (repository_dispatch) scope on `jamesc/beamtalk-uat`. This must be added as a repo secret in settings; `GITHUB_TOKEN` cannot dispatch across repositories. Documented inline in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to automatically notify UAT environments when releases are published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->