### PR TITLE
Announcements: point consumer ADRs (0017/0046/0054/0091/0092) at SystemAnnouncer (BT-2446)

### DIFF
--- a/docs/ADR/0017-browser-connectivity-to-running-workspaces.md
+++ b/docs/ADR/0017-browser-connectivity-to-running-workspaces.md
@@ -134,8 +134,21 @@ The WebSocket handler subscribes to the workspace's `Transcript` actor on connec
 | Push type | Payload | When | Phase |
 |-----------|---------|------|-------|
 | `transcript` | `{"push": "transcript", "text": "..."}` | Any `Transcript show:` in any session | 1 |
-| `actor-spawned` | `{"push": "actor-spawned", "class": "Counter", "pid": "..."}` | Actor spawned in workspace | 2 (requires new registry notification infrastructure) |
-| `actor-stopped` | `{"push": "actor-stopped", "pid": "..."}` | Actor stopped/crashed | 2 (requires new registry notification infrastructure) |
+| `actor-spawned` | `{"push": "actor-spawned", "class": "Counter", "pid": "..."}` | Actor spawned in workspace | 2 (via `SystemAnnouncer` — see below) |
+| `actor-stopped` | `{"push": "actor-stopped", "pid": "..."}` | Actor stopped/crashed | 2 (via `SystemAnnouncer` — see below) |
+
+**Source of the actor lifecycle pushes — `SystemAnnouncer` (ADR 0093).** The
+`actor-spawned`/`actor-stopped` pushes do **not** require a bespoke registry
+notification channel. They are produced by subscribing the WebSocket handler to
+the shared typed event bus from ADR 0093: `SystemAnnouncer current` emits the
+discrete `ActorSpawned` / `ActorStopped` `Announcement` subclasses, and the
+handler translates those into the JSON pushes above. Per ADR 0093 §5, the
+**Transcript line stream stays on its own dedicated `beamtalk_transcript_stream`
+channel** — it is a high-volume ordered byte/line stream, not a discrete typed
+domain event, and deliberately does **not** route through the announcements bus.
+So this ADR uses two mechanisms: `beamtalk_transcript_stream` for the
+`transcript` push, and `SystemAnnouncer` for the discrete
+`actor-spawned`/`actor-stopped` pushes.
 
 **Message ordering:** Push messages (Transcript) and request responses (`eval` result) are independent streams. A Transcript push from another session may arrive between an eval request and its response. The browser frontend must handle messages by type (`push` vs `id`-correlated response), not by arrival order.
 
@@ -199,7 +212,8 @@ websocket_info({transcript_output, Text}, State) ->
                         <<"text">> => Text}),
     {[{text, Push}], State};
 
-%% Actor lifecycle push (future: from actor registry)
+%% Actor lifecycle push (delivered via SystemAnnouncer subscription, ADR 0093 —
+%% the handler subscribes to ActorSpawned/ActorStopped, not a bespoke registry)
 websocket_info({actor_spawned, Class, Pid}, State) ->
     Push = jsx:encode(#{<<"push">> => <<"actor-spawned">>,
                         <<"class">> => atom_to_binary(Class, utf8),
@@ -588,7 +602,9 @@ Build the workspace experience on Phase 0's validated transport. The browser mus
 
 ### Phase 2: Live Updates (Size: M)
 
-- Actor registry notification infrastructure (new: subscribe to spawn/stop events)
+- Subscribe the WebSocket handler to `SystemAnnouncer` (ADR 0093) for
+  `ActorSpawned` / `ActorStopped` events — no bespoke registry notification
+  infrastructure is built; the shared typed event bus is the source
 - `actor-spawned` and `actor-stopped` push messages
 
 ### Phase 3: Phoenix LiveView IDE (Size: XL)
@@ -626,6 +642,6 @@ Build the workspace experience on Phase 0's validated transport. The browser mus
 No migration needed — this is purely additive. The WebSocket REPL transport (ADR 0020/BT-683) is already in place. The `load-source` op is a new operation alongside the existing `load-file` op.
 
 ## References
-- Related ADRs: [ADR 0004 — Persistent Workspace Management](0004-persistent-workspace-management.md), [ADR 0009 — OTP Application Structure](0009-otp-application-structure.md), [ADR 0010 — Global Objects and Singleton Dispatch](0010-global-objects-and-singleton-dispatch.md), [ADR 0020 — Connection Security](0020-connection-security.md), [ADR 0022 — Embedded Compiler via OTP Port](0022-embedded-compiler-via-otp-port.md), [ADR 0027 — Cross-Platform Support](0027-cross-platform-support.md)
+- Related ADRs: [ADR 0004 — Persistent Workspace Management](0004-persistent-workspace-management.md), [ADR 0009 — OTP Application Structure](0009-otp-application-structure.md), [ADR 0010 — Global Objects and Singleton Dispatch](0010-global-objects-and-singleton-dispatch.md), [ADR 0020 — Connection Security](0020-connection-security.md), [ADR 0022 — Embedded Compiler via OTP Port](0022-embedded-compiler-via-otp-port.md), [ADR 0027 — Cross-Platform Support](0027-cross-platform-support.md), [ADR 0093 — Announcements (Typed Event Substrate)](0093-announcements-event-substrate.md) — source of the `actor-spawned`/`actor-stopped` pushes (`SystemAnnouncer`); Transcript line streaming stays on `beamtalk_transcript_stream` per §5
 - Documentation: [REPL Protocol](../repl-protocol.md), [IDE Vision](../beamtalk-ide.md), [Design Principles](../beamtalk-principles.md)
 - Prior art: [Livebook](https://livebook.dev/), [Jupyter Kernel Gateway](https://jupyter-kernel-gateway.readthedocs.io/), [Cowboy WebSocket](https://ninenines.eu/docs/en/cowboy/2.9/manual/cowboy_websocket/)

--- a/docs/ADR/0017-browser-connectivity-to-running-workspaces.md
+++ b/docs/ADR/0017-browser-connectivity-to-running-workspaces.md
@@ -220,6 +220,12 @@ websocket_info({actor_spawned, Class, Pid}, State) ->
                         <<"pid">> => list_to_binary(pid_to_list(Pid))}),
     {[{text, Push}], State};
 
+websocket_info({actor_stopped, Class, Pid}, State) ->
+    Push = jsx:encode(#{<<"push">> => <<"actor-stopped">>,
+                        <<"class">> => atom_to_binary(Class, utf8),
+                        <<"pid">> => list_to_binary(pid_to_list(Pid))}),
+    {[{text, Push}], State};
+
 websocket_info(_Info, State) ->
     {[], State}.
 

--- a/docs/ADR/0046-vscode-live-workspace-sidebar.md
+++ b/docs/ADR/0046-vscode-live-workspace-sidebar.md
@@ -138,11 +138,23 @@ The LSP's connection is read-only and minimal — it subscribes to `class-loaded
 
 Most updates are event-driven via existing push channels. The extension owns the REPL terminal, so it can observe eval completion directly (terminal output parsing or `eval` op response). The only missing push event is `class-loaded` — see Protocol Changes below.
 
+**Source of the discrete push events — `SystemAnnouncer` (ADR 0093).** The
+discrete `actors` (spawned/stopped) and `classes` (`class-loaded`) push channels
+are **not** bespoke notification infrastructure. The workspace's WebSocket
+handler subscribes to the shared typed event bus from ADR 0093:
+`SystemAnnouncer current` emits the `ActorSpawned` / `ActorStopped` and
+`ClassLoaded` / `ClassRemoved` `Announcement` subclasses, and the handler
+forwards them to WebSocket subscribers as the channel pushes below. The `class`
+push is therefore not a new ad-hoc mechanism — it is one more subscription on
+the same bus. Per ADR 0093 §5, the **`transcript` push stays on the dedicated
+`beamtalk_transcript_stream` channel** (a high-volume line stream, not a discrete
+typed event) and does **not** route through the announcements bus.
+
 ### Protocol Changes Required
 
 One small addition to the existing protocol:
 
-**`class-loaded` push event**: When any session loads, reloads, or eval-defines a class, the workspace broadcasts a push event to all WebSocket subscribers — analogous to the existing `actors` channel `spawned`/`stopped` events. This lets the sidebar refresh the Classes section without polling.
+**`class-loaded` push event**: When any session loads, reloads, or eval-defines a class, the workspace broadcasts a push event to all WebSocket subscribers — analogous to the existing `actors` channel `spawned`/`stopped` events. Both are sourced from `SystemAnnouncer` (`ClassLoaded` / `ActorSpawned` / `ActorStopped`, ADR 0093) — the handler subscribes once to the typed bus rather than wiring a bespoke per-event channel. This lets the sidebar refresh the Classes section without polling.
 
 No `bindings` session param is needed: the extension owns the REPL session and queries its own session's bindings directly. The `complete` op's session param pattern already exists and works the same way.
 
@@ -327,6 +339,7 @@ Rely on the terminal REPL for all workspace inspection. The REPL already support
 One runtime-side change:
 
 1. **`class-loaded` push event** (`beamtalk_repl_server.erl`, `beamtalk_ws_handler.erl`)
+   - The WebSocket handler subscribes to `SystemAnnouncer` (ADR 0093) for `ClassLoaded` (and `ActorSpawned`/`ActorStopped`) events and forwards them as pushes — no bespoke broadcast channel is built
    - Broadcast `{"type":"push","channel":"classes","event":"loaded","data":{"class":"Counter"}}` to all WebSocket subscribers when any session loads, reloads, or eval-defines a class — same structured format as the existing `actors` channel push events
 
 2. **Session ID on REPL startup** (`beamtalk-cli/src/commands/repl.rs`)
@@ -392,6 +405,7 @@ One runtime-side change:
   - [ADR 0004: Persistent Workspace Management](0004-persistent-workspace-management.md) — workspace lifecycle, session model
   - [ADR 0017: Browser Connectivity to Running Workspaces](0017-browser-connectivity-to-running-workspaces.md) — WebSocket protocol, push channels, Phase 3 browser UI
   - [ADR 0024: Static-First, Live-Augmented IDE Tooling](0024-static-first-live-augmented-ide-tooling.md) — Tier 3 live augmentation (uses an independent LSP-owned workspace connection)
+  - [ADR 0093: Announcements (Typed Event Substrate)](0093-announcements-event-substrate.md) — source of the discrete `actors`/`classes` push events (`SystemAnnouncer`: `ActorSpawned`/`ActorStopped`/`ClassLoaded`/`ClassRemoved`); `transcript` push stays on `beamtalk_transcript_stream` per §5
 - Protocol documentation: `docs/repl-protocol.md`
 - VSCode API references:
   - [TreeView API](https://code.visualstudio.com/api/extension-guides/tree-view)

--- a/docs/ADR/0054-communication-protocols.md
+++ b/docs/ADR/0054-communication-protocols.md
@@ -63,6 +63,24 @@ Response:
 - Capability discovery via `describe` operation
 - Legacy format auto-detection for backward compatibility
 
+**Source of the server-initiated pushes — two mechanisms (ADR 0093 §5).** This
+WebSocket boundary carries two kinds of server-initiated push, and they have
+**different** sources:
+
+- **Discrete, typed lifecycle events** (actor spawned/stopped, class
+  loaded/removed, and any future `{future_resolved}`-style notification a tool
+  wants to observe) are produced by the workspace handler subscribing to the
+  shared typed event bus from **ADR 0093** — `SystemAnnouncer current` emits
+  `ActorSpawned` / `ActorStopped` / `ClassLoaded` / `ClassRemoved` `Announcement`
+  subclasses, which the handler forwards as WebSocket pushes. The workspace does
+  **not** build a bespoke per-event subscribe/broadcast channel for these.
+- **Transcript line output** stays on its **own dedicated direct-push channel**
+  (`beamtalk_transcript_stream`, governed by this ADR and ADR 0017). Per ADR 0093
+  §5 it is a high-volume ordered byte/line *stream*, not a discrete typed domain
+  event, so it deliberately does **not** route through the announcements bus —
+  routing it there would add a hop, force per-line MRO matching, and make the
+  typed bus a throughput bottleneck.
+
 **Evolution:** The REPL protocol originally used raw TCP with newline-delimited JSON. ADR 0020 migrated to WebSocket for browser compatibility and cookie authentication. The operation semantics are unchanged.
 
 ### 2. Workspace ↔ Compiler: OTP Port + ETF
@@ -116,7 +134,7 @@ gen_server:cast(ActorPid, {increment, [], FuturePid}).
 - Location transparency — the same message protocol works for local and distributed (cross-node) actor communication
 - `doesNotUnderstand:args:` handler enables proxy and delegation patterns (Smalltalk DNU)
 
-**Future resolution** is a sub-protocol within this boundary. Futures are lightweight BEAM processes that transition through `pending → resolved | rejected` states. Waiters register via `{await, Pid}` messages and receive `{future_resolved, FuturePid, Value}` or `{future_rejected, FuturePid, Reason}` notifications. Futures self-terminate after 5 minutes of inactivity.
+**Future resolution** is a sub-protocol within this boundary. Futures are lightweight BEAM processes that transition through `pending → resolved | rejected` states. Waiters register via `{await, Pid}` messages and receive `{future_resolved, FuturePid, Value}` or `{future_rejected, FuturePid, Reason}` notifications. Futures self-terminate after 5 minutes of inactivity. This direct waiter-registration protocol is point-to-point and stays as-is; a *tool* that instead wants to **observe** future resolutions as discrete events (e.g. an IDE timeline pane) does so by subscribing to `SystemAnnouncer` (ADR 0093), not by adding another bespoke broadcast channel here.
 
 ## Prior Art
 
@@ -246,6 +264,7 @@ No code changes are required.
   - [ADR 0022](0022-embedded-compiler-via-otp-port.md) — Embedded Compiler via OTP Port
   - [ADR 0029](0029-streaming-eval-output.md) — Streaming Eval Output
   - [ADR 0043](0043-sync-by-default-actor-messaging.md) — Sync-by-Default Actor Messaging
+  - [ADR 0093](0093-announcements-event-substrate.md) — Announcements (Typed Event Substrate): source of the discrete actor/class/future lifecycle pushes (`SystemAnnouncer`); Transcript line streaming stays on `beamtalk_transcript_stream` per §5
 - Documentation:
   - `docs/repl-protocol.md` — REPL protocol specification
   - `docs/internal/beamtalk-protocols.md` — Internal protocol details (actor messaging, future resolution)

--- a/docs/ADR/0091-remote-workspace-access-phoenix-authenticated-front.md
+++ b/docs/ADR/0091-remote-workspace-access-phoenix-authenticated-front.md
@@ -209,12 +209,32 @@ op set (the implementation issue owns the authoritative list):
 - **Execute** (RCE-bearing): `eval`, `load-source`, method `save`/`flush`
   (write-surface, ADR 0082), `reload`.
 - **Read** (no code injection): `info`, `inspect`, `bindings`, `actors`,
-  `sessions`, `complete`, plus the push-subscription facade
-  (transcript / actors / classes / bindings).
+  `sessions`, `complete`, plus the **subscribe-only** push facade
+  (transcript / actors / classes / bindings — see below).
 - **Admin:** `kill`, `rotate-cookie`.
 
 Note `complete` is **inference-only — it does not evaluate** (ADR 0045: "inference
 without evaluation"), so it is safe to grant a non-executing role.
+
+**The push facade is subscribe-only over `SystemAnnouncer` (ADR 0093) — it has no
+publish capability.** The three discrete push channels (actors / classes /
+bindings) are **not** bespoke subscribe/broadcast infrastructure built by this
+ADR: they are subscriptions on the shared typed event bus from ADR 0093 —
+`SystemAnnouncer current` emits `ActorSpawned` / `ActorStopped` / `ClassLoaded` /
+`ClassRemoved` / `BindingChanged` `Announcement` subclasses, and the facade
+forwards the curated subset to the authenticated browser. (Transcript line
+streaming stays on its own dedicated `beamtalk_transcript_stream` channel — a
+high-volume stream, not a discrete typed event — per ADR 0093 §5.) Per ADR 0093
+§6, **subscribing to `SystemAnnouncer` is a read capability**, so the facade
+exposes it as a named, RBAC-checked *subscribe* op available to the Observer
+role; subscribing to *all* events or to internal/infra announcements is gated
+like ADR 0092's `system` scope. **Critically, the facade must never expose a
+publish capability** (`announce:`): a remote Observer can listen to the curated
+system events but can never emit onto `SystemAnnouncer`, otherwise it could forge
+`ActorSpawned` / `ClassRemoved` events and mislead other subscribers. This ADR's
+implementation issue owns adding the `subscribe` / `unsubscribe` ops (subscribe-
+only) to the authoritative facade op list; there is deliberately no `announce` /
+`publish` op in the facade.
 
 The facade is the substrate RBAC hangs off: per-op authorization is only
 meaningful against a finite, named vocabulary of ops. It is also the natural
@@ -729,7 +749,10 @@ middle "Collaborator" RBAC rung; reintroducing `inet_tls_dist` (removed PR #1401
   (amends Principle 6), [ADR 0017 — Browser Connectivity](0017-browser-connectivity-to-running-workspaces.md)
   (Phase 3), [ADR 0085 — Editor Live-Image Representation](0085-editor-live-image-representation.md)
   (read-surface), [ADR 0082 — Method-Level Edit and Save](0082-method-level-edit-save-and-changelog.md)
-  (write-surface)
+  (write-surface), [ADR 0093 — Announcements (Typed Event Substrate)](0093-announcements-event-substrate.md)
+  (the push facade is a **subscribe-only** view of `SystemAnnouncer`; this ADR's
+  facade op list owns the `subscribe`/`unsubscribe` ops and exposes **no** publish
+  capability — ADR 0093 §6)
 - Documentation: `docs/research/phoenix-topology-spike.md` ("Auth implications"),
   [REPL Protocol](../repl-protocol.md)
 - Erlang `ssl_dist`: https://www.erlang.org/doc/apps/ssl/ssl_distribution.html

--- a/docs/ADR/0092-supervision-tree-introspection.md
+++ b/docs/ADR/0092-supervision-tree-introspection.md
@@ -161,7 +161,8 @@ high-level navigable object (collection protocol + parent/child/walk) backed by
 flat, inspectable node records. State capture (`sys:get_status`) is lazy and
 timeout-guarded. Foreign OTP processes appear as first-class nodes with a
 distinct `kind`. Change-event streaming is explicitly **out of scope** and
-deferred to the Announcements substrate (BT-2193).
+deferred to the Announcements substrate (ADR 0093 — `SupervisionChildAdded` /
+`SupervisionChildCrashed` on `SystemAnnouncer`; see §8).
 
 ### 1. Receiver — a dedicated `ProcessNavigation` value class
 
@@ -672,7 +673,7 @@ coverage. The full design is preferred because the foreign-process and
 The decision is **tree-object-backed-by-flat-records on a dedicated
 `ProcessNavigation` class with a `Workspace processes` alias**, snapshot
 semantics, lazy guarded state, foreign processes tagged by `kind`, and
-change-events deferred to BT-2193.
+change-events deferred to the Announcements substrate (ADR 0093 / `SystemAnnouncer`, §8).
 
 ## Consequences
 
@@ -690,7 +691,8 @@ change-events deferred to BT-2193.
   inspect it. Mitigated by lazy `status` returning `nil`, but users must
   understand "snapshot, not live."
 - No push events in v1; a "live" IDE pane must poll. Acceptable (LiveDashboard
-  does the same) but is a known follow-up dependency on BT-2193.
+  does the same) but is a known follow-up dependency on the Announcements
+  substrate (ADR 0093 — `SupervisionChild…` on `SystemAnnouncer`, §8).
 - `kind` classification leans on the `'$beamtalk_actor'` process-dictionary
   marker and OTP behaviour metadata; an exotic foreign process could be
   mis-tagged `#otpProcess`. Low impact (it still appears, just generically).
@@ -779,13 +781,16 @@ two more later + facade method), **docs/tests**. No parser or codegen changes.
 ## References
 - Related issues: BT-2395 (this ADR), BT-448 (supervision syntax, shipped),
   BT-1387 (OTP supervision tree runtime), BT-1191 (`Workspace startSupervisor:`),
-  BT-2193 (Announcements — deferred push-event substrate),
+  BT-2438 (Announcements epic, ADR 0093 — the deferred push-event substrate; §8 points here),
+  BT-2193 (Announcements package — re-scoped to optional extras by ADR 0093),
   BT-2228 (SystemNavigation xref epic — parallel pattern),
   BT-2189/BT-2190 (moved navigation off the `Beamtalk` facade)
 - Related ADRs: ADR 0059 (Supervision Tree Syntax), ADR 0080 (Supervisor
   Lifecycle Result), ADR 0085 (Editor Live-Image Representation — primary
   consumer), ADR 0087 (Maintained Xref Index for SystemNavigation — static
-  counterpart), ADR 0091 (Remote Workspace Access)
+  counterpart), ADR 0091 (Remote Workspace Access), ADR 0093 (Announcements —
+  Typed Event Substrate: supervision deltas are published on `SystemAnnouncer`;
+  §8 is the seam)
 - Documentation: `stdlib/src/WorkspaceInterface.bt`,
   `stdlib/src/SystemNavigation.bt`, `stdlib/src/Supervisor.bt`,
   `runtime/apps/beamtalk_runtime/src/beamtalk_supervisor.erl`


### PR DESCRIPTION
Phase 3 of ADR 0093 (Announcements — Typed Event Substrate). Repoints the five consumer ADRs that each independently planned a bespoke subscribe/broadcast channel at the shared `SystemAnnouncer` typed event bus.

Linear issue: https://linear.app/beamtalk/issue/BT-2446

## What changed

Each ADR's bespoke discrete push channel now documents `SystemAnnouncer` (ADR 0093) as its source, while the high-volume **Transcript line stream stays on its dedicated `beamtalk_transcript_stream` channel** per ADR 0093 §5 (a stream, not a discrete typed event).

- **0017 (browser connectivity):** `actor-spawned`/`actor-stopped` pushes sourced from `SystemAnnouncer` (`ActorSpawned`/`ActorStopped`) instead of "new registry notification infrastructure"; WebSocket handler sketch comment, Phase 2 plan, and References updated. Transcript stays on `beamtalk_transcript_stream`.
- **0046 (VSCode sidebar):** discrete `actors`/`classes` (`class-loaded`) push events sourced from `SystemAnnouncer` (`ActorSpawned`/`ActorStopped`/`ClassLoaded`/`ClassRemoved`); `transcript` push stays on the dedicated stream.
- **0054 (communication protocols):** discrete lifecycle pushes (actor/class, and any future `{future_resolved}` observation) via `SystemAnnouncer`; the point-to-point future-resolution waiter protocol stays as-is; Transcript line streaming stays on its own channel.
- **0091 (remote front):** push facade documented as **subscribe-only over `SystemAnnouncer` with no publish capability** (ADR 0093 §6) — a remote Observer can subscribe (a read capability) but can never `announce:`/forge events.
- **0092 (supervision introspection):** §8 already pointed at ADR 0093; the remaining stale change-event deferrals (Decision summary, Negative consequences, References) repointed from the re-scoped BT-2193 package at ADR 0093 / `SystemAnnouncer`.

## Acceptance criteria

- [x] ADRs 0017, 0046, 0054, 0091, 0092 updated to consume `SystemAnnouncer` subscriptions instead of bespoke subscribe/broadcast channels (Transcript line streaming stays on `beamtalk_transcript_stream` per §5)
- [x] ADR 0092 §8 points here
- [x] ADR 0091 push facade documented as subscribe-only (no publish capability)

Docs-only change; no code or tests affected.

https://claude.ai/code/session_01SDNxr97y1Z7sJ2sAgh6bfP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDNxr97y1Z7sJ2sAgh6bfP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that lifecycle and class/actor updates are delivered via a centralized announcements subscription.
  * Confirmed transcript output continues to stream on a separate, dedicated channel (not via announcements).
  * Made the remote access push facade explicitly subscribe-only (no publish capability).
  * Updated cross-references and implementation notes to reflect these protocol clarifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->