### PR TITLE
Shared structural renderer runtime primitive for ClassName(field: value, ...) (BT-2459)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_printer.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_printer.erl
@@ -125,7 +125,8 @@ render_structural(ClassName, _Fields, 0, _Width, _Length, Seen) ->
 render_structural(ClassName, Fields, Depth, Width, Length, Seen) ->
     ClassBin = atom_to_binary(ClassName, utf8),
     SortedFields = lists:sort(Fields),
-    {FieldIoList, Seen2} = render_fields(SortedFields, Depth - 1, Width, Length, Seen, []),
+    %% Each nested level gets a fresh width budget (Width is the per-level cap).
+    {FieldIoList, Seen2} = render_fields(SortedFields, Depth - 1, Width, Width, Length, Seen, []),
     Result = iolist_to_binary([ClassBin, <<"(">>, FieldIoList, <<")">>]),
     {maybe_truncate(Result, Length), Seen2}.
 
@@ -134,20 +135,22 @@ render_structural(ClassName, Fields, Depth, Width, Length, Seen) ->
     non_neg_integer(),
     non_neg_integer(),
     non_neg_integer(),
+    non_neg_integer(),
     map(),
     list()
 ) ->
     {iolist(), map()}.
-render_fields([], _Depth, _Width, _Length, Seen, Acc) ->
+render_fields([], _Depth, _MaxWidth, _Remaining, _Length, Seen, Acc) ->
     {lists:join(<<", ">>, lists:reverse(Acc)), Seen};
-render_fields(_Fields, _Depth, 0, _Length, Seen, Acc) ->
+render_fields(_Fields, _Depth, _MaxWidth, 0, _Length, Seen, Acc) ->
     %% Width exhausted: append elision marker.
     {lists:join(<<", ">>, lists:reverse([?ELISION | Acc])), Seen};
-render_fields([{Name, Value} | Rest], Depth, Width, Length, Seen, Acc) ->
+render_fields([{Name, Value} | Rest], Depth, MaxWidth, Remaining, Length, Seen, Acc) ->
     NameBin = atom_to_binary(Name, utf8),
-    {ValueBin, Seen2} = render_value(Value, Depth, Width, Length, Seen),
+    %% Nested values get the full MaxWidth budget, not the parent's remaining count.
+    {ValueBin, Seen2} = render_value(Value, Depth, MaxWidth, Length, Seen),
     FieldBin = iolist_to_binary([NameBin, <<": ">>, ValueBin]),
-    render_fields(Rest, Depth, Width - 1, Length, Seen2, [FieldBin | Acc]).
+    render_fields(Rest, Depth, MaxWidth, Remaining - 1, Length, Seen2, [FieldBin | Acc]).
 
 -spec render_value(
     term(),
@@ -163,7 +166,12 @@ render_value(Value, Depth, Width, Length, Seen) when is_map(Value) ->
             %% Plain map — use printString.
             {beamtalk_primitive:print_string(Value), Seen};
         ClassName ->
-            %% Check cycle guard: use identity of the map reference.
+            %% Cycle guard: phash2 hashes by *value* (structural equality).
+            %% For immutable Values, structurally equal maps produce identical
+            %% output, so eliding a duplicate is correct. Hash collisions between
+            %% genuinely different maps are possible (~1 in 2^27) but benign —
+            %% the worst case is eliding a field that would have rendered differently.
+            %% True cycles cannot occur with immutable Values (ADR 0042).
             Id = erlang:phash2(Value),
             case maps:is_key(Id, Seen) of
                 true ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_printer.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_printer.erl
@@ -1,0 +1,190 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_object_printer).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+Canonical structural renderer for Beamtalk objects.
+
+This module is the **single source of truth** for the structural
+`ClassName(field: value, ...)` representation (ADR 0094, Phase 1).
+Both the compiled stdlib (`Value.bt`) and the runtime fallback
+(`beamtalk_object_ops`, `beamtalk_primitive`, `beamtalk_reflection`)
+must call through this module to guarantee byte-identical output.
+
+## Format
+
+    ClassName(field1: value1, field2: value2)
+
+- Fields are rendered in **sorted** order (deterministic output).
+- Each field value is rendered via its own `printString` (Debug form).
+- A class with no fields renders as `ClassName()`.
+
+## Bounded recursion
+
+Nested values expand recursively, bounded by:
+- **depth cap** (default `?DEFAULT_DEPTH_CAP`): guards pathological nesting
+- **width cap** (default `?DEFAULT_WIDTH_CAP`): max fields per level
+- **total-length cap** (default `?DEFAULT_LENGTH_CAP`): guards wide-and-shallow
+- **cycle guard**: emits `...` instead of looping
+
+When any bound is hit, the truncated position renders as `...`.
+
+## Usage
+
+    beamtalk_object_printer:structural(ClassName, Fields)
+    beamtalk_object_printer:structural(ClassName, Fields, Opts)
+
+Where `Fields` is a list of `{atom(), term()}` pairs (already extracted
+from the object's state map by the caller).
+
+See also: ADR 0094 sections 3, 4, 6; Critical Risks #1, #4
+""".
+
+-export([
+    structural/2,
+    structural/3
+]).
+
+-include("beamtalk.hrl").
+
+%%% ============================================================================
+%%% Tunable constants
+%%% ============================================================================
+
+%% Maximum nesting depth before elision.
+-define(DEFAULT_DEPTH_CAP, 5).
+
+%% Maximum number of fields/elements rendered per collection level.
+-define(DEFAULT_WIDTH_CAP, 50).
+
+%% Maximum total byte length of the rendered output.
+-define(DEFAULT_LENGTH_CAP, 10000).
+
+%% Elision marker emitted when a bound is exceeded.
+-define(ELISION, <<"...">>).
+
+%%% ============================================================================
+%%% Public API
+%%% ============================================================================
+
+-doc """
+Render `ClassName(field: value, ...)` with default bounds.
+
+`ClassName` is an atom. `Fields` is a list of `{Name :: atom(), Value :: term()}`
+pairs. Fields are sorted by name for deterministic output.
+""".
+-spec structural(atom(), [{atom(), term()}]) -> binary().
+structural(ClassName, Fields) ->
+    structural(ClassName, Fields, #{}).
+
+-doc """
+Render `ClassName(field: value, ...)` with caller-supplied options.
+
+Supported options:
+- `depth` — maximum nesting depth (default 5)
+- `width` — maximum fields per level (default 50)
+- `length` — maximum total output bytes (default 10000)
+
+All options are optional; missing keys use defaults.
+""".
+-spec structural(atom(), [{atom(), term()}], map()) -> binary().
+structural(ClassName, Fields, Opts) ->
+    Depth = maps:get(depth, Opts, ?DEFAULT_DEPTH_CAP),
+    Width = maps:get(width, Opts, ?DEFAULT_WIDTH_CAP),
+    Length = maps:get(length, Opts, ?DEFAULT_LENGTH_CAP),
+    Seen = #{},
+    {Result, _SeenOut} = render_structural(ClassName, Fields, Depth, Width, Length, Seen),
+    Result.
+
+%%% ============================================================================
+%%% Internal rendering
+%%% ============================================================================
+
+%% All internal render functions return `{binary(), Seen}` so the cycle-guard
+%% set propagates across sibling fields (not just down the recursion).
+
+-spec render_structural(
+    atom(),
+    [{atom(), term()}],
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    map()
+) ->
+    {binary(), map()}.
+render_structural(ClassName, _Fields, 0, _Width, _Length, Seen) ->
+    %% Depth exhausted: emit elided form.
+    Bin = iolist_to_binary([
+        atom_to_binary(ClassName, utf8),
+        <<"(", ?ELISION/binary, ")">>
+    ]),
+    {Bin, Seen};
+render_structural(ClassName, Fields, Depth, Width, Length, Seen) ->
+    ClassBin = atom_to_binary(ClassName, utf8),
+    SortedFields = lists:sort(Fields),
+    {FieldIoList, Seen2} = render_fields(SortedFields, Depth - 1, Width, Length, Seen, []),
+    Result = iolist_to_binary([ClassBin, <<"(">>, FieldIoList, <<")">>]),
+    {maybe_truncate(Result, Length), Seen2}.
+
+-spec render_fields(
+    [{atom(), term()}],
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    map(),
+    list()
+) ->
+    {iolist(), map()}.
+render_fields([], _Depth, _Width, _Length, Seen, Acc) ->
+    {lists:join(<<", ">>, lists:reverse(Acc)), Seen};
+render_fields(_Fields, _Depth, 0, _Length, Seen, Acc) ->
+    %% Width exhausted: append elision marker.
+    {lists:join(<<", ">>, lists:reverse([?ELISION | Acc])), Seen};
+render_fields([{Name, Value} | Rest], Depth, Width, Length, Seen, Acc) ->
+    NameBin = atom_to_binary(Name, utf8),
+    {ValueBin, Seen2} = render_value(Value, Depth, Width, Length, Seen),
+    FieldBin = iolist_to_binary([NameBin, <<": ">>, ValueBin]),
+    render_fields(Rest, Depth, Width - 1, Length, Seen2, [FieldBin | Acc]).
+
+-spec render_value(
+    term(),
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    map()
+) -> {binary(), map()}.
+render_value(Value, Depth, Width, Length, Seen) when is_map(Value) ->
+    %% Tagged map (Value instance): recurse structurally if it has user fields.
+    case beamtalk_tagged_map:class_of(Value) of
+        undefined ->
+            %% Plain map — use printString.
+            {beamtalk_primitive:print_string(Value), Seen};
+        ClassName ->
+            %% Check cycle guard: use identity of the map reference.
+            Id = erlang:phash2(Value),
+            case maps:is_key(Id, Seen) of
+                true ->
+                    {?ELISION, Seen};
+                false ->
+                    NewSeen = Seen#{Id => true},
+                    UserKeys = beamtalk_tagged_map:user_field_keys(Value),
+                    Fields = [{K, maps:get(K, Value)} || K <- UserKeys],
+                    render_structural(ClassName, Fields, Depth, Width, Length, NewSeen)
+            end
+    end;
+render_value(#beamtalk_object{} = Value, _Depth, _Width, _Length, Seen) ->
+    %% Actor/object references: use printString (opaque — no field access).
+    {beamtalk_primitive:print_string(Value), Seen};
+render_value(Value, _Depth, _Width, _Length, Seen) ->
+    %% Primitives (integers, strings, booleans, symbols, etc.): use printString.
+    {beamtalk_primitive:print_string(Value), Seen}.
+
+-spec maybe_truncate(binary(), non_neg_integer()) -> binary().
+maybe_truncate(Bin, MaxLength) when byte_size(Bin) > MaxLength ->
+    Prefix = binary:part(Bin, 0, MaxLength),
+    <<Prefix/binary, ?ELISION/binary>>;
+maybe_truncate(Bin, _MaxLength) ->
+    Bin.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_object_printer_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_object_printer_tests.erl
@@ -1,0 +1,227 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_object_printer_tests).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+EUnit tests for beamtalk_object_printer — the canonical structural renderer.
+
+Covers: flat value, nested value, empty-field value, depth-cap elision,
+width-cap elision, total-length-cap elision, and cycle-guard elision.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include("beamtalk.hrl").
+
+%%% ============================================================================
+%%% Flat value tests
+%%% ============================================================================
+
+flat_integer_fields_test() ->
+    Fields = [{x, 3}, {y, 4}],
+    ?assertEqual(
+        <<"Point(x: 3, y: 4)">>,
+        beamtalk_object_printer:structural('Point', Fields)
+    ).
+
+flat_string_fields_test() ->
+    %% Strings should be quoted (Debug/printString form).
+    Fields = [{sender, <<"Alice">>}, {text, <<"Hi">>}],
+    ?assertEqual(
+        <<"Message(sender: \"Alice\", text: \"Hi\")">>,
+        beamtalk_object_printer:structural('Message', Fields)
+    ).
+
+flat_mixed_fields_test() ->
+    Fields = [{active, true}, {count, 42}, {name, <<"Bob">>}],
+    ?assertEqual(
+        <<"Config(active: true, count: 42, name: \"Bob\")">>,
+        beamtalk_object_printer:structural('Config', Fields)
+    ).
+
+flat_symbol_field_test() ->
+    Fields = [{mode, fast}],
+    ?assertEqual(
+        <<"Setting(mode: #fast)">>,
+        beamtalk_object_printer:structural('Setting', Fields)
+    ).
+
+%%% ============================================================================
+%%% Sorted field order
+%%% ============================================================================
+
+fields_are_sorted_test() ->
+    %% Provide fields out of order; output must be sorted.
+    Fields = [{z, 3}, {a, 1}, {m, 2}],
+    ?assertEqual(
+        <<"Triple(a: 1, m: 2, z: 3)">>,
+        beamtalk_object_printer:structural('Triple', Fields)
+    ).
+
+%%% ============================================================================
+%%% Empty-field (no fields) test
+%%% ============================================================================
+
+empty_fields_test() ->
+    ?assertEqual(
+        <<"Unit()">>,
+        beamtalk_object_printer:structural('Unit', [])
+    ).
+
+%%% ============================================================================
+%%% Nested value test
+%%% ============================================================================
+
+nested_value_test() ->
+    %% Simulate Line(from: Point(x: 0, y: 0), to: Point(x: 3, y: 4))
+    %% using tagged maps (Value instances).
+    Point1 = #{'$beamtalk_class' => 'Point', x => 0, y => 0},
+    Point2 = #{'$beamtalk_class' => 'Point', x => 3, y => 4},
+    Fields = [{from, Point1}, {to, Point2}],
+    ?assertEqual(
+        <<"Line(from: Point(x: 0, y: 0), to: Point(x: 3, y: 4))">>,
+        beamtalk_object_printer:structural('Line', Fields)
+    ).
+
+double_nested_value_test() ->
+    %% Inner → middle → outer nesting.
+    Inner = #{'$beamtalk_class' => 'Point', x => 1, y => 2},
+    Middle = #{'$beamtalk_class' => 'Wrapper', value => Inner},
+    Fields = [{wrapped, Middle}],
+    ?assertEqual(
+        <<"Box(wrapped: Wrapper(value: Point(x: 1, y: 2)))">>,
+        beamtalk_object_printer:structural('Box', Fields)
+    ).
+
+%%% ============================================================================
+%%% Depth-cap elision
+%%% ============================================================================
+
+depth_cap_elision_test() ->
+    %% With depth=1, nested tagged maps should be elided.
+    Inner = #{'$beamtalk_class' => 'Point', x => 1, y => 2},
+    Fields = [{value, Inner}],
+    %% depth=1 means we can render the outer level but inner is at depth 0 → elided.
+    ?assertEqual(
+        <<"Wrapper(value: Point(...))">>,
+        beamtalk_object_printer:structural('Wrapper', Fields, #{depth => 1})
+    ).
+
+depth_cap_at_zero_test() ->
+    %% depth=0 should elide even the top-level fields.
+    Fields = [{x, 1}],
+    ?assertEqual(
+        <<"Point(...)">>,
+        beamtalk_object_printer:structural('Point', Fields, #{depth => 0})
+    ).
+
+%%% ============================================================================
+%%% Width-cap elision
+%%% ============================================================================
+
+width_cap_elision_test() ->
+    %% width=2 with 4 fields: first 2 shown, then elision.
+    Fields = [{a, 1}, {b, 2}, {c, 3}, {d, 4}],
+    ?assertEqual(
+        <<"Wide(a: 1, b: 2, ...)">>,
+        beamtalk_object_printer:structural('Wide', Fields, #{width => 2})
+    ).
+
+width_cap_exact_test() ->
+    %% width=3 with exactly 3 fields: no elision.
+    Fields = [{a, 1}, {b, 2}, {c, 3}],
+    ?assertEqual(
+        <<"Exact(a: 1, b: 2, c: 3)">>,
+        beamtalk_object_printer:structural('Exact', Fields, #{width => 3})
+    ).
+
+%%% ============================================================================
+%%% Total-length-cap elision
+%%% ============================================================================
+
+length_cap_elision_test() ->
+    %% Very short length cap forces truncation.
+    Fields = [{name, <<"a very long string value that should be truncated">>}],
+    Result = beamtalk_object_printer:structural('Big', Fields, #{length => 20}),
+    %% Result should be at most 20 bytes + "..." suffix.
+    ?assert(byte_size(Result) =< 23),
+    %% Should end with "..."
+    Len = byte_size(Result),
+    Suffix = binary:part(Result, Len - 3, 3),
+    ?assertEqual(<<"...">>, Suffix).
+
+%%% ============================================================================
+%%% Cycle-guard elision
+%%% ============================================================================
+
+cycle_guard_self_referencing_map_test() ->
+    %% Simulate a "cycle" by having two tagged maps with the same phash2.
+    %% In practice, a Value referencing itself (impossible with immutable Values,
+    %% but the guard protects against it). We test by nesting the same map twice.
+    Shared = #{'$beamtalk_class' => 'Node', value => 42},
+    %% Nesting the same map at two positions — phash2 is identical, so the second
+    %% occurrence triggers the cycle guard.
+    Fields = [{left, Shared}, {right, Shared}],
+    Result = beamtalk_object_printer:structural('Tree', Fields),
+    %% One of them will render fully, the other will be elided as "...".
+    %% Since fields are sorted (left, right), left renders first.
+    ?assertEqual(
+        <<"Tree(left: Node(value: 42), right: ...)">>,
+        Result
+    ).
+
+%%% ============================================================================
+%%% Actor/object reference rendering
+%%% ============================================================================
+
+actor_reference_in_field_test() ->
+    %% Actor references use printString (opaque).
+    Obj = #beamtalk_object{class = 'Counter', class_mod = counter, pid = self()},
+    Fields = [{target, Obj}],
+    Result = beamtalk_object_printer:structural('Holder', Fields),
+    %% Should contain "a Counter" (current printString for non-class objects).
+    ?assertMatch(<<"Holder(target: a Counter)">>, Result).
+
+%%% ============================================================================
+%%% Nil and boolean field values
+%%% ============================================================================
+
+nil_field_test() ->
+    Fields = [{value, nil}],
+    ?assertEqual(
+        <<"Box(value: nil)">>,
+        beamtalk_object_printer:structural('Box', Fields)
+    ).
+
+boolean_fields_test() ->
+    Fields = [{enabled, true}, {visible, false}],
+    ?assertEqual(
+        <<"Flags(enabled: true, visible: false)">>,
+        beamtalk_object_printer:structural('Flags', Fields)
+    ).
+
+%%% ============================================================================
+%%% Float field value
+%%% ============================================================================
+
+float_field_test() ->
+    Fields = [{x, 3.14}],
+    Result = beamtalk_object_printer:structural('Measure', Fields),
+    %% Float rendering varies slightly; just check the structure.
+    ?assertMatch(<<"Measure(x: ", _/binary>>, Result).
+
+%%% ============================================================================
+%%% Options passthrough
+%%% ============================================================================
+
+custom_depth_and_width_test() ->
+    %% Deep nesting with custom depth=2, width=1.
+    Inner = #{'$beamtalk_class' => 'Point', x => 0, y => 0},
+    Middle = #{'$beamtalk_class' => 'Wrapper', value => Inner},
+    Fields = [{a, Middle}, {b, 42}],
+    %% width=1 → only first field (a) shown, b elided.
+    %% depth=2 → Middle renders but Inner (at depth 0) is elided.
+    Result = beamtalk_object_printer:structural('Outer', Fields, #{depth => 2, width => 1}),
+    ?assertEqual(<<"Outer(a: Wrapper(value: Point(...)), ...)">>, Result).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_object_printer_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_object_printer_tests.erl
@@ -225,3 +225,14 @@ custom_depth_and_width_test() ->
     %% depth=2 → Middle renders but Inner (at depth 0) is elided.
     Result = beamtalk_object_printer:structural('Outer', Fields, #{depth => 2, width => 1}),
     ?assertEqual(<<"Outer(a: Wrapper(value: Point(...)), ...)">>, Result).
+
+width_resets_per_nesting_level_test() ->
+    %% Verify that nested objects get a fresh width budget, not the parent's
+    %% remaining count. With width=2, the outer has 3 fields (a, b, c) but
+    %% the nested object should still be able to render its own 2 fields.
+    Inner = #{'$beamtalk_class' => 'Point', x => 1, y => 2},
+    Fields = [{a, Inner}, {b, 42}, {c, 99}],
+    Result = beamtalk_object_printer:structural('Outer', Fields, #{width => 2}),
+    %% Outer shows a + b, then elides c. But Inner gets its own budget of 2,
+    %% so Point shows both x and y.
+    ?assertEqual(<<"Outer(a: Point(x: 1, y: 2), b: 42, ...)">>, Result).


### PR DESCRIPTION
## Summary

Implements Phase 1 of ADR 0094 — the single canonical structural renderer for Beamtalk objects.

- Adds `beamtalk_object_printer` module with `structural/2,3` API producing `ClassName(field: value, ...)` format
- Implements bounded recursion: depth cap (5), width cap (50 per level), total-length cap (10000), and cycle guard via phash2-based Seen set
- Fields rendered in sorted order; each field value rendered via `printString` (not `inspect`), decoupling from the deferred inspect redesign
- Width budget correctly resets per nesting level so nested objects get their full field allowance
- 20 EUnit tests covering: flat values, nested values, empty fields, depth-cap elision, width-cap elision, length-cap elision, cycle-guard elision, actor references, and combined options

**This is a standalone foundation module** — no existing display paths are changed. Callers will be repointed in Phase 2 (BT-2460).

Resolves [BT-2459](https://linear.app/beamtalk/issue/BT-2459)

## Test plan

- [x] All 20 EUnit tests pass (`rebar3 eunit --module=beamtalk_object_printer_tests`)
- [x] Full `just test` suite passes (1 pre-existing unrelated failure in SystemNavigationPackageQueriesTest)
- [x] `just clippy` clean
- [x] `just fmt` clean
- [x] `rebar3 fmt --check` clean
- [x] `just dialyzer` clean
- [x] No changes to existing REPL/printString output (existing tests pass unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added object printing capability to render Beamtalk objects in a canonical structural format with support for customizable depth, width, and length bounds.

* **Tests**
  * Added comprehensive test coverage for object printing across nested structures, constraint handling, cycle detection, and various data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->