### PR TITLE
fix: correct frame-ordering assertion in ensure_test_context test (BT-2468)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_test_case_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_test_case_tests.erl
@@ -344,7 +344,11 @@ ensure_test_context_appends_context_test() ->
         FailMsg, 'bt@user@A', testBar, Stacktrace
     ),
     ?assertNotEqual(nomatch, binary:match(Result, <<"testBar">>)),
-    %% The synthetic test context should appear after the existing "at" line
-    {HelperPos, _} = binary:match(Result, <<"helper">>),
-    {TestBarPos, _} = binary:match(Result, <<"testBar">>),
+    %% The synthetic test context should appear after the existing "at" line.
+    %% Match the full "A>>method" frame strings rather than the bare method
+    %% names: "testBar" also occurs in the leading "FAIL testBar:" message,
+    %% so matching <<"testBar">> alone would find the header, not the
+    %% appended synthetic frame.
+    {HelperPos, _} = binary:match(Result, <<"A>>helper">>),
+    {TestBarPos, _} = binary:match(Result, <<"A>>testBar">>),
     ?assert(HelperPos < TestBarPos).


### PR DESCRIPTION
## Summary

Fixes the pre-existing `ensure_test_context_appends_context_test` failure in `beamtalk_test_case_tests.erl` (BT-2468). The bug was in the **test's expectation**, not in `ensure_test_context/4`.

## Root cause

The test builds:
- `FailMsg = "FAIL testBar: some error\n  at A>>helper"`
- After `ensure_test_context/4` appends the synthetic frame: `"...at A>>helper\n  at A>>testBar"`

`ensure_test_context/4` correctly appends the test-method frame *after* the innermost-first stacktrace lines (matching its documented behavior). But the assertion used `binary:match(Result, <<"testBar">>)`, which matched the **first** `testBar` — inside the `"FAIL testBar:"` header (offset ~5) — rather than the appended frame. That made `TestBarPos < HelperPos`, failing `?assert(HelperPos < TestBarPos)`.

## Fix

Match the full `A>>helper` / `A>>testBar` frame strings so the assertion locates the rendered stacktrace frames instead of the message header. The implementation is correct and unchanged.

## Acceptance criteria

- [x] Determined the bug is in the test's expectation, not `ensure_test_context/4`
- [x] `ensure_test_context_appends_context_test` passes
- [x] Confirmed rendered stacktraces place synthetic context in the intended position (innermost-first preserved, context appended)

## Verification

- `rebar3 eunit --module=beamtalk_test_case_tests` → **35 tests, 0 failures**
- `rebar3 fmt --check` → clean

https://claude.ai/code/session_014SoNxnUYG18TGw5GJh6ZS5

---
_Generated by [Claude Code](https://claude.ai/code/session_014SoNxnUYG18TGw5GJh6ZS5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test assertions for improved reliability in frame context verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->