### PR TITLE
Extract sealed_fn_name helper to centralise __sealed_ naming convention (BT-2472)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/actor_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/actor_codegen.rs
@@ -14,7 +14,7 @@ use super::document::leaf::{atom, fname};
 use super::document::{Document, INDENT, join, line, nest};
 use super::selector_mangler::safe_class_method_fn_name;
 use super::spec_codegen;
-use super::util::ClassIdentity;
+use super::util::{ClassIdentity, sealed_fn_name};
 use super::{CodeGenContext, CoreErlangGenerator, Result};
 use crate::ast::{MethodKind, Module};
 use crate::docvec;
@@ -338,7 +338,7 @@ impl CoreErlangGenerator {
                     .map_or(0, |i| c.methods[i].selector.arity())
             });
             // Standalone function takes Args + Self + State params
-            parts.push(docvec![", ", fname(format!("__sealed_{sel}"), arity + 2),]);
+            parts.push(docvec![", ", fname(sealed_fn_name(&sel), arity + 2),]);
         }
         Document::Vec(parts)
     }
@@ -517,7 +517,7 @@ impl CoreErlangGenerator {
             // Generate: '__sealed_{selector}'/N = fun (Arg1, ..., Self, State) ->
             let method_entry = docvec![
                 "\n",
-                fname(format!("__sealed_{selector_name}"), arity),
+                fname(sealed_fn_name(&selector_name), arity),
                 "  = ",
                 fun_doc,
                 "\n",

--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -38,6 +38,7 @@
 
 use super::document::Document;
 use super::document::leaf;
+use super::util::sealed_fn_name;
 use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result};
 use crate::ast::{Expression, Literal, MessageSelector, WellKnownSelector};
 use crate::docvec;
@@ -1498,7 +1499,7 @@ impl CoreErlangGenerator {
                         " = case call ",
                         leaf::atom(module),
                         ":",
-                        leaf::atom(format!("__sealed_{selector_name}")),
+                        leaf::atom(sealed_fn_name(&selector_name)),
                         "(",
                         args_doc,
                         Document::Str(comma),
@@ -1670,7 +1671,7 @@ impl CoreErlangGenerator {
             "case call ",
             leaf::atom(module),
             ":",
-            leaf::atom(format!("__sealed_{selector_name}")),
+            leaf::atom(sealed_fn_name(selector_name)),
             "(",
             args_doc,
             Document::Str(comma),
@@ -3043,7 +3044,7 @@ impl CoreErlangGenerator {
                     " = case call ",
                     leaf::atom(module.to_string()),
                     ":",
-                    leaf::atom(format!("__sealed_{selector_name}")),
+                    leaf::atom(sealed_fn_name(&selector_name)),
                     "(",
                     args_doc,
                     comma,

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -73,6 +73,18 @@ pub fn escape_atom_chars(name: &str) -> String {
     result
 }
 
+/// Returns the internal function name for a sealed method with the given selector.
+///
+/// Sealed actor methods are compiled to standalone `'__sealed_{selector}'/N` functions
+/// (BT-403) instead of dispatching through the `gen_server` call machinery. Centralising
+/// the naming convention here ensures callers cannot drift from the `__sealed_` prefix.
+pub(super) fn sealed_fn_name(selector: &str) -> String {
+    let mut s = String::with_capacity("__sealed_".len() + selector.len());
+    s.push_str("__sealed_");
+    s.push_str(selector);
+    s
+}
+
 /// BT-745: Generate a `'beamtalk_class' = [{...}]` attribute fragment for the
 /// module attributes section. Returns `Document::Nil` when classes is empty.
 pub(super) fn beamtalk_class_attribute(classes: &[ClassDefinition]) -> Document<'static> {
@@ -518,6 +530,16 @@ mod tests {
             escape_core_erlang_string("C:\\Users\\foo\\bar.bt"),
             "C:\\\\Users\\\\foo\\\\bar.bt"
         );
+    }
+
+    #[test]
+    fn test_sealed_fn_name_simple() {
+        assert_eq!(sealed_fn_name("ping"), "__sealed_ping");
+    }
+
+    #[test]
+    fn test_sealed_fn_name_keyword_selector() {
+        assert_eq!(sealed_fn_name("increment:"), "__sealed_increment:");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `__sealed_{selector}` naming convention for sealed actor methods was hardcoded in five separate `format!()` calls across two files with no single source of truth.

- Add `sealed_fn_name(selector: &str) -> String` to `util.rs` alongside the existing name-conversion helpers (`versioned_var`, `escape_atom_chars`)
- Replace all 5 call sites in `actor_codegen.rs` (×2) and `dispatch_codegen.rs` (×3)
- Add two unit tests covering unary and keyword selectors

The helper uses `push_str` instead of `format!()` for consistency with BT-875's `util.rs` style, and is `pub(super)` scoped to the `core_erlang` codegen module.

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 4081 tests pass (includes 2 new `test_sealed_fn_name_*` tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `just ci` — green

Linear issue: https://linear.app/beamtalk/issue/BT-2472

https://claude.ai/code/session_01FAtNyQYWuFtgF6GYJi1zK9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAtNyQYWuFtgF6GYJi1zK9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated sealed actor method function naming logic in code generation for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->