### PR TITLE
Tighten placeholder assertion in class_var_subexpr_test.bt (BT-2474)

### DIFF
--- a/stdlib/test/class_var_subexpr_test.bt
+++ b/stdlib/test/class_var_subexpr_test.bt
@@ -188,12 +188,13 @@ TestCase subclass: ClassVarSubExprTest
   // receiver from BT-1937's binary op hoisting. Before this fix the
   // generated Core Erlang was malformed (the open let-chain was embedded
   // inside `let _Cond = ... in case`); the test runs the method to
-  // confirm compilation + execution succeed. The class var mutation
+  // confirm compilation + execution succeed. The loop runs once (1 to: 1),
+  // tick > 0 is true, so hits increments to 1. The class var mutation
   // observed by the enclosing method is a separate concern (class vars
   // don't thread through `to:do:` loops — pre-existing limitation, BT-2308).
   testTickInLoopConditionalCompilesAndRuns =>
     result := ClassVarSubExpr tickInLoopConditional
-    self assert: result notNil
+    self assert: result equals: 1
 
   // BT-1942: Explicit `^` return with an open-scope receiver.
   // `generate_class_method_return` must hoist the open let-chain so


### PR DESCRIPTION
## Summary

- Replace `self assert: result notNil` with `self assert: result equals: 1` in `testTickInLoopConditionalCompilesAndRuns`
- Update the inline comment to explain why the result is 1 (loop runs once, tick > 0 is true, hits increments to 1)

The method `ClassVarSubExpr tickInLoopConditional` deterministically returns `1`: `1 to: 1` runs exactly once, `self tick` makes the counter 1 (which is > 0), so `hits` is incremented from 0 to 1 and returned. The previous `notNil` guard only confirmed "didn't crash"; the new assertion also verifies the correct return value.

Test intent is unchanged — the test still confirms compilation and execution succeed. The known pre-existing limitation (class vars don't thread through `to:do:` loops, BT-2308) is preserved in the comment.

## Test plan

- [x] `just test-bunit` passes — 2479 tests, 0 failures

https://linear.app/beamtalk/issue/BT-2474/tighten-placeholder-assertion-in-class-var-subexpr-testbt

---
_Generated by [Claude Code](https://claude.ai/code/session_019ULT5Tet3muYTmcNZU4X5G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced a regression test with more precise assertions and improved documentation to ensure expected behavior is properly validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->