### PR TITLE
Replace hardcoded /tmp/ paths in erlc.rs unit tests (BT-2479)

### DIFF
--- a/crates/beamtalk-cli/src/erlc.rs
+++ b/crates/beamtalk-cli/src/erlc.rs
@@ -219,28 +219,29 @@ mod tests {
 
     #[test]
     fn test_basic_invocation() {
-        let inv = ErlcInvocation::new("/tmp/out").source_file(Utf8PathBuf::from("/tmp/foo.erl"));
+        let inv =
+            ErlcInvocation::new("/fake/out").source_file(Utf8PathBuf::from("/fake/foo.erl"));
         let cmd = inv.build();
         let args: Vec<_> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
-        assert_eq!(args, vec!["-o", "/tmp/out", "/tmp/foo.erl"]);
+        assert_eq!(args, vec!["-o", "/fake/out", "/fake/foo.erl"]);
     }
 
     #[test]
     fn test_debug_info() {
-        let inv = ErlcInvocation::new("/tmp/out")
+        let inv = ErlcInvocation::new("/fake/out")
             .debug_info()
-            .source_file(Utf8PathBuf::from("/tmp/foo.erl"));
+            .source_file(Utf8PathBuf::from("/fake/foo.erl"));
         let cmd = inv.build();
         let args: Vec<_> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
-        assert_eq!(args, vec!["+debug_info", "-o", "/tmp/out", "/tmp/foo.erl"]);
+        assert_eq!(args, vec!["+debug_info", "-o", "/fake/out", "/fake/foo.erl"]);
     }
 
     #[test]
     fn test_docs() {
-        let inv = ErlcInvocation::new("/tmp/out")
+        let inv = ErlcInvocation::new("/fake/out")
             .debug_info()
             .docs()
-            .source_file(Utf8PathBuf::from("/tmp/foo.erl"));
+            .source_file(Utf8PathBuf::from("/fake/foo.erl"));
         let cmd = inv.build();
         let args: Vec<_> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
         assert_eq!(
@@ -249,30 +250,30 @@ mod tests {
                 "+debug_info",
                 "+warn_missing_doc",
                 "-o",
-                "/tmp/out",
-                "/tmp/foo.erl"
+                "/fake/out",
+                "/fake/foo.erl"
             ]
         );
     }
 
     #[test]
     fn test_code_paths() {
-        let inv = ErlcInvocation::new("/tmp/out")
-            .code_path("/tmp/ebin1")
-            .code_path("/tmp/ebin2")
-            .source_file(Utf8PathBuf::from("/tmp/foo.erl"));
+        let inv = ErlcInvocation::new("/fake/out")
+            .code_path("/fake/ebin1")
+            .code_path("/fake/ebin2")
+            .source_file(Utf8PathBuf::from("/fake/foo.erl"));
         let cmd = inv.build();
         let args: Vec<_> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
         assert_eq!(
             args,
             vec![
                 "-o",
-                "/tmp/out",
+                "/fake/out",
                 "-pa",
-                "/tmp/ebin1",
+                "/fake/ebin1",
                 "-pa",
-                "/tmp/ebin2",
-                "/tmp/foo.erl"
+                "/fake/ebin2",
+                "/fake/foo.erl"
             ]
         );
     }

--- a/crates/beamtalk-cli/src/erlc.rs
+++ b/crates/beamtalk-cli/src/erlc.rs
@@ -219,8 +219,7 @@ mod tests {
 
     #[test]
     fn test_basic_invocation() {
-        let inv =
-            ErlcInvocation::new("/fake/out").source_file(Utf8PathBuf::from("/fake/foo.erl"));
+        let inv = ErlcInvocation::new("/fake/out").source_file(Utf8PathBuf::from("/fake/foo.erl"));
         let cmd = inv.build();
         let args: Vec<_> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
         assert_eq!(args, vec!["-o", "/fake/out", "/fake/foo.erl"]);
@@ -233,7 +232,10 @@ mod tests {
             .source_file(Utf8PathBuf::from("/fake/foo.erl"));
         let cmd = inv.build();
         let args: Vec<_> = cmd.get_args().map(|a| a.to_str().unwrap()).collect();
-        assert_eq!(args, vec!["+debug_info", "-o", "/fake/out", "/fake/foo.erl"]);
+        assert_eq!(
+            args,
+            vec!["+debug_info", "-o", "/fake/out", "/fake/foo.erl"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Removes 15 hardcoded `/tmp/` path violations from the `ErlcInvocation` unit tests in `crates/beamtalk-cli/src/erlc.rs`, replacing them with `/fake/` equivalents. Fixes a CLAUDE.md §Cross-platform temp paths violation.

- Replace `/tmp/out` → `/fake/out` in all 4 test functions
- Replace `/tmp/foo.erl` → `/fake/foo.erl`  
- Replace `/tmp/ebin1`, `/tmp/ebin2` → `/fake/ebin1`, `/fake/ebin2`
- Apply `rustfmt` formatting while touching the block

**Why this is safe:** None of these tests perform filesystem I/O. They only call `ErlcInvocation::build()` and assert `cmd.get_args()` order. The paths are purely illustrative — `/fake/…` communicates "dummy placeholder" more clearly than `/tmp/…`.

Linear: https://linear.app/beamtalk/issue/BT-2479/replace-hardcoded-tmp-paths-in-erlcrs-unit-tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcqpbAAgjQBFCnP45vLQFV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains internal test improvements with no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->