### PR TITLE
Fix flaky macOS nightly: normalize trailing slash in subprocess dir test

### DIFF
--- a/stdlib/test/reactive_subprocess_test.bt
+++ b/stdlib/test/reactive_subprocess_test.bt
@@ -174,8 +174,13 @@ TestCase subclass: ReactiveSubprocessTest
       notify: delegate) unwrap
     self waitForExit: delegate from: proc
     self assert: (delegate stdoutLines includes: "hello1187")
-    // On Windows, cd prints path with drive letter; on Unix, pwd prints /tmp
-    dir := self envDir
+    // On Windows, cd prints path with drive letter; on Unix, pwd prints the dir.
+    // macOS TMPDIR ends with a trailing slash (e.g. "/var/folders/.../T/") and is
+    // reached through the /private symlink, but the subprocess reports its
+    // canonical working directory without the trailing slash
+    // (e.g. "/private/var/folders/.../T"). Strip a trailing "/" so the substring
+    // check matches the canonical path the shell prints.
+    dir := self envDir replaceRegex: "/$" with: ""
     self assert: (delegate stdoutLines anySatisfy: [:line |
       line includesSubstring: dir
     ])


### PR DESCRIPTION
## Problem

The Nightly workflow's macOS ARM64 job has been failing on its `Test BUnit` step. The single failing test is `ReactiveSubprocessTest>>testOpenWithEnvAndDir`:

```
FAIL ReactiveSubprocessTest testOpenWithEnvAndDir: Assertion failed: expected true, got false
  at ReactiveSubprocessTest>>testOpenWithEnvAndDir (test/reactive_subprocess_test.bt:179)
```

## Root cause

The test launches a subprocess with `dir: File tempDirectory`, has the shell print its working directory via `pwd`, and asserts that an output line contains the expected dir string.

On macOS this comparison is fragile:
- `TMPDIR` (what `File tempDirectory` returns) ends with a **trailing slash**, e.g. `/var/folders/.../T/`.
- The temp dir is reached through the `/private` symlink, so the shell reports its **canonical** working directory without the trailing slash, e.g. `/private/var/folders/.../T`.

The `/private` prefix is harmless (the substring check still matches the tail), but the **trailing slash** breaks the match — `…/T/` is not a substring of `…/T`. Linux/Windows temp paths have no trailing slash, so the test passes there, which is why this only showed up in the nightly macOS job.

## Fix

Strip a trailing `/` from the expected dir before the substring check. No-op on Linux/Windows.

## Verification

- Reproduced the exact nightly failure locally by pointing `TMPDIR` at a trailing-slash path (which makes Linux `pwd` print the path without the slash, the same mismatch macOS hits): fails at line 179 without the fix, passes with it.
- Full BUnit suite green: `2496 tests, 2494 passed, 0 failed` (2 Windows-only tests skipped on Linux).
- `erlfmt`/lint clean.

https://claude.ai/code/session_01398i5uUACc4BkwnsPAwrLX

---
_Generated by [Claude Code](https://claude.ai/code/session_01398i5uUACc4BkwnsPAwrLX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness for subprocess working directory handling across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->