### PR TITLE
Consolidate zero-param dispatch BIFs to use leaf::atom pattern (BT-2498)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/error_handling.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/error_handling.rs
@@ -22,27 +22,12 @@ pub(crate) fn generate_exception_bif(
     params: &[String],
 ) -> Option<Document<'static>> {
     match selector {
-        "message" => Some(Document::Str(
-            "call 'beamtalk_exception_handler':'dispatch'('message', [], Self)",
-        )),
-        "hint" => Some(Document::Str(
-            "call 'beamtalk_exception_handler':'dispatch'('hint', [], Self)",
-        )),
-        "kind" => Some(Document::Str(
-            "call 'beamtalk_exception_handler':'dispatch'('kind', [], Self)",
-        )),
-        "selector" => Some(Document::Str(
-            "call 'beamtalk_exception_handler':'dispatch'('selector', [], Self)",
-        )),
-        "errorClass" => Some(Document::Str(
-            "call 'beamtalk_exception_handler':'dispatch'('errorClass', [], Self)",
-        )),
-        "printString" => Some(Document::Str(
-            "call 'beamtalk_exception_handler':'dispatch'('printString', [], Self)",
-        )),
-        "signal" => Some(Document::Str(
-            "call 'beamtalk_exception_handler':'dispatch'('signal', [], Self)",
-        )),
+        "message" | "hint" | "kind" | "selector" | "errorClass" | "printString" | "signal"
+        | "stackTrace" => Some(docvec![
+            "call 'beamtalk_exception_handler':'dispatch'(",
+            leaf::atom(selector.to_owned()),
+            ", [], Self)",
+        ]),
         "signal:" => {
             let p0 = param(params, 0, "_Msg");
             Some(docvec![
@@ -51,9 +36,6 @@ pub(crate) fn generate_exception_bif(
                 "], Self)",
             ])
         }
-        "stackTrace" => Some(Document::Str(
-            "call 'beamtalk_exception_handler':'dispatch'('stackTrace', [], Self)",
-        )),
         // BT-1524: Class-side signal primitives — raise exceptions without instance allocation.
         "classSignal:" => {
             let p0 = param(params, 0, "_Msg");

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitives/reflection.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitives/reflection.rs
@@ -9,7 +9,9 @@
 //! `CompiledMethod`, `Symbol`.
 
 use super::super::document::Document;
+use super::super::document::leaf;
 use super::binary_bif;
+use crate::docvec;
 
 /// Symbol primitive implementations (BT-273).
 ///
@@ -47,24 +49,13 @@ pub(crate) fn generate_compiled_method_bif(
 ) -> Option<Document<'static>> {
     let _ = params; // all CompiledMethod selectors are zero-param instance reads
     match selector {
-        "selector" => Some(Document::Str(
-            "call 'beamtalk_compiled_method_ops':'dispatch'('selector', [], Self)",
-        )),
-        "source" => Some(Document::Str(
-            "call 'beamtalk_compiled_method_ops':'dispatch'('source', [], Self)",
-        )),
-        "doc" => Some(Document::Str(
-            "call 'beamtalk_compiled_method_ops':'dispatch'('doc', [], Self)",
-        )),
-        "argumentCount" => Some(Document::Str(
-            "call 'beamtalk_compiled_method_ops':'dispatch'('argumentCount', [], Self)",
-        )),
-        "printString" => Some(Document::Str(
-            "call 'beamtalk_compiled_method_ops':'dispatch'('printString', [], Self)",
-        )),
-        "asString" => Some(Document::Str(
-            "call 'beamtalk_compiled_method_ops':'dispatch'('asString', [], Self)",
-        )),
+        "selector" | "source" | "doc" | "argumentCount" | "printString" | "asString" => {
+            Some(docvec![
+                "call 'beamtalk_compiled_method_ops':'dispatch'(",
+                leaf::atom(selector.to_owned()),
+                ", [], Self)",
+            ])
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

Fixes a CLAUDE.md typed-leaf API violation in two codegen primitive functions.

`generate_exception_bif` and `generate_compiled_method_bif` were hardcoding per-selector `Document::Str(...)` arms for identical zero-param Erlang dispatch calls, while `generate_stack_frame_bif` in the same file already used the correct `leaf::atom(selector)` multi-arm pattern. This change makes all three functions consistent.

## Changes

- **`error_handling.rs`**: Collapse 8 individual `Document::Str` arms in `generate_exception_bif` into one `"message" | "hint" | … | "stackTrace"` arm using `docvec!` + `leaf::atom(selector.to_owned())`. Special cases (`signal:`, `classSignal:`, `classSignal`) are unchanged.
- **`reflection.rs`**: Same treatment for `generate_compiled_method_bif` — collapse 6 arms into one. Adds `leaf` and `docvec!` imports.

No behavioral change. All existing per-selector unit tests (13 in `error_handling.rs`, 7 in `primitives/mod.rs`) validate identical output.

## Linear

https://linear.app/beamtalk/issue/BT-2498/consolidate-zero-param-dispatch-bifs-to-use-leafatom-pattern

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGugmrRQ1ecj3ktQYLTTDs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code generation systems for exception handling and compiled method operations. Consolidated multiple selector field operations into unified, streamlined patterns to eliminate code duplication and enhance maintainability. These infrastructure improvements support more efficient development and long-term code quality without impacting user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->