### PR TITLE
Inspector core: Inspector/InspectorField classes + navigation (BT-2502)

### DIFF
--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -1011,6 +1011,7 @@ fn generate_builtins_rs(class_metadata: &[ClassMeta]) -> Result<()> {
         "/// Returns true if the given class name is a stdlib built-in class.\n\
          ///\n\
          /// Auto-generated from `lib/*.bt` file names.\n\
+         #[allow(clippy::too_many_lines)] // auto-generated: one match arm per stdlib class\n\
          pub(super) fn is_generated_builtin_class(name: &str) -> bool {\n\
          \x20   matches!(\n\
          \x20       name,\n",

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 /// Returns true if the given class name is a stdlib built-in class.
 ///
 /// Auto-generated from `lib/*.bt` file names.
+#[allow(clippy::too_many_lines)] // auto-generated: one match arm per stdlib class
 pub(super) fn is_generated_builtin_class(name: &str) -> bool {
     matches!(
         name,
@@ -57,6 +58,8 @@ pub(super) fn is_generated_builtin_class(name: &str) -> bool {
             | "File"
             | "FileHandle"
             | "Float"
+            | "Inspector"
+            | "InspectorField"
             | "InstantiationError"
             | "Integer"
             | "Interval"
@@ -1548,6 +1551,82 @@ pub(super) fn generated_builtin_classes() -> HashMap<EcoString, ClassInfo> {
     );
 
     classes.insert(
+        "Inspector".into(),
+        ClassInfo {
+            name: "Inspector".into(),
+            superclass: Some("Object".into()),
+            is_sealed: true,
+            is_abstract: false,
+            is_typed: true,
+            is_internal: false,
+            package: Some("stdlib".into()),
+            is_value: false,
+            is_native: false,
+            state: vec![],
+            state_types: HashMap::new(),
+            state_has_default: HashMap::new(),
+            methods: vec![
+                MethodInfo { selector: "subject".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Object".into()), param_types: vec![], doc: Some("The inspected object — the value itself, or, for an actor, the captured\nstate snapshot.\n\n## Examples\n```beamtalk\n(Inspector on: (Point x: 3 y: 4)) subject   // => Point(x: 3, y: 4)\n```".into()) },
+                MethodInfo { selector: "kind".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Symbol".into()), param_types: vec![], doc: Some("The subject kind: `#value` (structural) or `#actor` (snapshot) in v1.\n\n## Examples\n```beamtalk\n(Inspector on: (Point x: 3 y: 4)) kind   // => #value\n(Inspector on: aCounter) kind            // => #actor\n```".into()) },
+                MethodInfo { selector: "fields".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("List(InspectorField)".into()), param_types: vec![], doc: Some("The drillable fields of the inspected object, as immutable\n`InspectorField` records (ADR 0095 §2–§3).\n\nFor a `#value`, these are its `field:` slots in ADR-0094 sort order. For an\n`#actor`, they are its user state slots from a lazy, timeout-guarded\nsnapshot — or, if the actor is busy/dead/non-`sys`, the single diagnostic\n`InspectorField name: #status value: #unavailable` (never a crash).\n\n## Examples\n```beamtalk\n(Inspector on: (Point x: 3 y: 4)) fields size   // => 2\n```".into()) },
+                MethodInfo { selector: "at:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Result(Inspector, Error)".into()), param_types: vec![Some("Object".into())], doc: Some("Drill into one field by name, returning a child `Inspector` cursor on that\nfield's value (ADR 0095 §1).\n\nReturns a `Result`: `Result error: (beamtalk_error no_such_field)` when no\nfield has that name. The child cursor's `parent` is this cursor, and its\n`path` extends this one's by the drilled name.\n\n## Examples\n```beamtalk\n(Inspector on: (Point x: 3 y: 4)) at: #x     // => Result ok: (an Inspector on 3)\n(Inspector on: (Point x: 3 y: 4)) at: #zzz   // => Result error: no_such_field\n```".into()) },
+                MethodInfo { selector: "parent".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Inspector | Nil".into()), param_types: vec![], doc: Some("The cursor this one was drilled from, or `nil` at the root.\n\n## Examples\n```beamtalk\nchild := ((Inspector on: (Point x: 3 y: 4)) at: #x) unwrap\nchild parent kind   // => #value\n```".into()) },
+                MethodInfo { selector: "root".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Inspector".into()), param_types: vec![], doc: Some("The top of this drill chain — the cursor with no `parent`.\n\n## Examples\n```beamtalk\nchild := ((Inspector on: (Point x: 3 y: 4)) at: #x) unwrap\nchild root kind   // => #value\n```".into()) },
+                MethodInfo { selector: "path".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("List".into()), param_types: vec![], doc: Some("The breadcrumb of drilled names from the root to this cursor (for UI).\n`#()` at the root.\n\n## Examples\n```beamtalk\nchild := ((Inspector on: (Point x: 3 y: 4)) at: #x) unwrap\nchild path   // => #(#x)\n```".into()) },
+                MethodInfo { selector: "refresh".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Inspector".into()), param_types: vec![], doc: Some("A cursor on a freshly-captured snapshot of the *same* subject (ADR 0095\n§5). The original cursor is unchanged (immutable).\n\n`refresh` re-snapshots **this cursor's own subject**, which differs by how\nthe cursor was reached:\n- A **root `#actor`** cursor re-issues the guarded `sys:get_state`, picking\n  up state change since the previous snapshot.\n- A **`#value`** cursor (including one drilled into an actor's slot with\n  `at:`) re-freezes its already-captured value — structurally identical,\n  since per ADR 0095 §4 drilling never re-contacts the live actor (the\n  sub-tree is a consistent point-in-time view). To see a drilled actor\n  field move, `refresh` the **root** actor cursor and drill again.\n\n## Examples\n```beamtalk\nci := Inspector on: aCounter   // snapshot at T0\naCounter increment             // state moves on\nci refresh fields              // a fresh cursor at T1 (root actor re-fetched)\n```".into()) },
+                MethodInfo { selector: "printString".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("String".into()), param_types: vec![], doc: Some("An indented text tree of the cursor and its immediate fields, one level\ndeep (ADR 0095 §7). The REPL default.\n\n## Examples\n```beamtalk\n(Inspector on: (Point x: 3 y: 4)) printString\n  // => \"Inspector(Point)\\n  x: 3\\n  y: 4\"\n```".into()) },
+                MethodInfo { selector: "printStringExpanded:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("String".into()), param_types: vec![Some("Integer".into())], doc: Some("An indented text tree of the cursor to `depth` levels (ADR 0095 §7).\n`depth: 1` is the immediate fields; deeper expands drillable children.\n\n## Examples\n```beamtalk\n(Inspector on: (Point x: 3 y: 4)) printStringExpanded: 1\n```".into()) },
+            ],
+            class_methods: vec![
+                MethodInfo { selector: "on:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "Inspector".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Inspector".into()), param_types: vec![Some("Object".into())], doc: Some("Open an inspector cursor on `anObject` (ADR 0095 §1).\n\nFor an actor, the timeout-guarded `sys:get_state` snapshot is captured\nhere, at construction; for a value the subject is taken structurally with no\nprocess contact. This is the Phase-1 entry point (`anObject inspect`\nshorthand is Phase 3).\n\n## Examples\n```beamtalk\nInspector on: (Point x: 3 y: 4)   // => an Inspector\nInspector on: aCounter            // => an Inspector (#actor)\n```".into()) },
+            ],
+            class_variables: vec![],
+            type_params: vec![],
+            type_param_bounds: vec![],
+            superclass_type_args: vec![],
+        },
+    );
+
+    classes.insert(
+        "InspectorField".into(),
+        ClassInfo {
+            name: "InspectorField".into(),
+            superclass: Some("Value".into()),
+            is_sealed: true,
+            is_abstract: false,
+            is_typed: true,
+            is_internal: false,
+            package: Some("stdlib".into()),
+            is_value: true,
+            is_native: false,
+            state: vec!["name".into(), "label".into(), "value".into(), "kind".into(), "drillable".into()],
+            state_types: HashMap::from([("name".into(), "Object".into()), ("label".into(), "String".into()), ("value".into(), "Object".into()), ("kind".into(), "Symbol".into()), ("drillable".into(), "Boolean".into())]),
+            state_has_default: HashMap::from([("name".into(), true), ("label".into(), true), ("value".into(), true), ("kind".into(), true), ("drillable".into(), true)]),
+            methods: vec![
+                MethodInfo { selector: "isLeaf".into(), arity: 0, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Boolean".into()), param_types: vec![], doc: Some("Whether this field is a leaf scalar (the negation of `drillable`).\n\n## Examples\n```beamtalk\nfield isLeaf   // => false\n```".into()) },
+                MethodInfo { selector: "printString".into(), arity: 0, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("String".into()), param_types: vec![], doc: Some("Human-readable one-line description, e.g.\n`#InspectorField<x: 3>` or `#InspectorField<status: #unavailable>`.\n\n## Examples\n```beamtalk\nfield printString   // => \"#InspectorField<x: 3>\"\n```".into()) },
+                MethodInfo { selector: "name".into(), arity: 0, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Object".into()), param_types: vec![], doc: Some("Returns the `name` field value. Default: `nil`.\n\n*(compiler-generated)*".into()) },
+                MethodInfo { selector: "withName:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("InspectorField".into()), param_types: vec![Some("Object".into())], doc: Some("Returns a new `InspectorField` with `name` set to the given value.\n\n*(compiler-generated)*".into()) },
+                MethodInfo { selector: "label".into(), arity: 0, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("String".into()), param_types: vec![], doc: Some("Returns the `label` field value. Default: `\"\"`.\n\n*(compiler-generated)*".into()) },
+                MethodInfo { selector: "withLabel:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("InspectorField".into()), param_types: vec![Some("String".into())], doc: Some("Returns a new `InspectorField` with `label` set to the given value.\n\n*(compiler-generated)*".into()) },
+                MethodInfo { selector: "value".into(), arity: 0, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Object".into()), param_types: vec![], doc: Some("Returns the `value` field value. Default: `nil`.\n\n*(compiler-generated)*".into()) },
+                MethodInfo { selector: "withValue:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("InspectorField".into()), param_types: vec![Some("Object".into())], doc: Some("Returns a new `InspectorField` with `value` set to the given value.\n\n*(compiler-generated)*".into()) },
+                MethodInfo { selector: "kind".into(), arity: 0, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Symbol".into()), param_types: vec![], doc: Some("Returns the `kind` field value. Default: `#slot`.\n\n*(compiler-generated)*".into()) },
+                MethodInfo { selector: "withKind:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("InspectorField".into()), param_types: vec![Some("Symbol".into())], doc: Some("Returns a new `InspectorField` with `kind` set to the given value.\n\n*(compiler-generated)*".into()) },
+                MethodInfo { selector: "drillable".into(), arity: 0, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Boolean".into()), param_types: vec![], doc: Some("Returns the `drillable` field value. Default: `true`.\n\n*(compiler-generated)*".into()) },
+                MethodInfo { selector: "withDrillable:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("InspectorField".into()), param_types: vec![Some("Boolean".into())], doc: Some("Returns a new `InspectorField` with `drillable` set to the given value.\n\n*(compiler-generated)*".into()) },
+            ],
+            class_methods: vec![
+                MethodInfo { selector: "name:label:value:kind:drillable:".into(), arity: 5, kind: MethodKind::Primary, defined_in: "InspectorField".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("InspectorField".into()), param_types: vec![Some("Object".into()), Some("String".into()), Some("Object".into()), Some("Symbol".into()), Some("Boolean".into())], doc: Some("Creates a new `InspectorField`. Args: name (default: nil), label (default: \"\"), value (default: nil), kind (default: #slot), drillable (default: true).\n\n*(compiler-generated)*".into()) },
+            ],
+            class_variables: vec![],
+            type_params: vec![],
+            type_param_bounds: vec![],
+            superclass_type_args: vec![],
+        },
+    );
+
+    classes.insert(
         "InstantiationError".into(),
         ClassInfo {
             name: "InstantiationError".into(),
@@ -1941,7 +2020,7 @@ pub(super) fn generated_builtin_classes() -> HashMap<EcoString, ClassInfo> {
                 MethodInfo { selector: "ifNotNil:ifNil:".into(), arity: 2, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: None, param_types: vec![Some("Block".into()), Some("Block".into())], doc: Some("If not nil, evaluate `notNilBlock` with self; otherwise evaluate `nilBlock`.\n\n## Examples\n```beamtalk\n42 ifNotNil: [:v | v + 1] ifNil: [0]    // => 43\nnil ifNotNil: [:v | v + 1] ifNil: [0]   // => 0\n```".into()) },
                 MethodInfo { selector: "printString".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("String".into()), param_types: vec![], doc: Some("Return the developer-readable (Debug) string representation.\n\n`printString` is the **Debug** protocol (ADR 0094): the self-describing,\nstructural form used by the REPL, logs, and by any *other* `printString`\nthat nests this object. It is the REPL default — evaluating an expression\nshows its `printString`.\n\nThis default returns the **bare class name** (no `a`/`an` article — the\nold `\"a ClassName\"` form was dropped in ADR 0094). `Value` overrides it\nwith the structural `ClassName(field: value, ...)` form, actors render as\n`Actor(ClassName, pid)`, supervisors as `Supervisor(ClassName, pid)` /\n`DynamicSupervisor(ClassName, pid)`, and primitive types (Integer, String,\nList, …) override it with their own richer output. Authors rarely override\n`printString` directly — the default is derived.\n\n## Examples\n```beamtalk\n42 printString            // => \"42\"\n```".into()) },
                 MethodInfo { selector: "displayString".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("String".into()), param_types: vec![], doc: Some("Return the user-facing (Display) string representation.\n\n`displayString` is the **Display** protocol (ADR 0094): the human-facing\nform. It is the hook the **language** pulls during string interpolation —\nevery `{...}` segment renders via the value's `displayString`. Developers\nrarely call it directly; they **override** it when a value has a natural\nhuman rendering (e.g. `Money` → `$10.50`, where `printString` would still\nshow the Debug form).\n\nIt **defaults to `printString`**, so most types need no override. `String`\nand `Symbol` demonstrate the split: `\"hi\" printString` → `\"\\\"hi\\\"\"`\n(quoted, Debug) while `\"hi\" displayString` → `\"hi\"` (plain, Display);\nlikewise `#foo` drops its `#` prefix under `displayString`.\n\n`displayString` is **not** part of the `Printable` protocol (deferred per\nADR 0094 §5).\n\n## Examples\n```beamtalk\n42 displayString             // => \"42\"\n```".into()) },
-                MethodInfo { selector: "inspect".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("String".into()), param_types: vec![], doc: Some("Inspect the receiver.\n\nUnchanged by ADR 0094: `inspect` still returns a `String` and delegates to\n`printString`, so it shares the structural Debug form with a single source\nof truth. Its planned redesign into a rich, navigable tooling/action verb\nis deferred to a follow-up ADR designed against the LiveView surface\n(BT-2397).\n\n## Examples\n```beamtalk\n42 inspect             // => \"42\"\n```".into()) },
+                MethodInfo { selector: "inspect".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("String".into()), param_types: vec![], doc: Some("Inspect the receiver.\n\nUnchanged by ADR 0094: `inspect` still returns a `String` and delegates to\n`printString`, so it shares the structural Debug form with a single source\nof truth.\n\n**ADR 0095 Phase 1 (BT-2502).** The rich, navigable inspector now exists as\nthe `Inspector` class — use `Inspector on: anObject` to open a drillable,\nrefreshable cursor. The *repurpose* of `inspect` itself (`inspect ->\nInspector`, removing the 14 `inspect -> String` overrides, and the\ngradual-typing crash audit) is the breaking change deferred to Phase 3\n(BT-2504); `inspect` keeps returning a `String` until then.\n\n## Examples\n```beamtalk\n42 inspect             // => \"42\"\n(Point x: 3 y: 4) inspect    // => \"Point(x: 3, y: 4)\"  (String, until Phase 3)\n```".into()) },
                 MethodInfo { selector: "yourself".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: true, is_internal: false, spawns_block: false, return_type: Some("Self".into()), param_types: vec![], doc: Some("Return the receiver itself. Useful for cascading side effects.\n\n## Examples\n```beamtalk\n42 yourself            // => 42\n```".into()) },
                 MethodInfo { selector: "hash".into(), arity: 0, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: false, is_internal: false, spawns_block: false, return_type: Some("Integer".into()), param_types: vec![], doc: Some("Return a hash value for the receiver.\n\n## Examples\n```beamtalk\n42 hash\n```".into()) },
                 MethodInfo { selector: "respondsTo:".into(), arity: 1, kind: MethodKind::Primary, defined_in: "Object".into(), is_sealed: true, is_internal: false, spawns_block: false, return_type: Some("Boolean".into()), param_types: vec![Some("Symbol".into())], doc: Some("Test if the receiver responds to the given selector.\n\n## Examples\n```beamtalk\n42 respondsTo: #abs    // => true\n```".into()) },

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -242,9 +242,19 @@ text across surfaces:
   `beamtalk_primitive`, `beamtalk_reflection`) — both delegating to one shared
   structural renderer so output is byte-identical regardless of dispatch path.
 
-`inspect` is unchanged (returns a `String`, delegates to `printString`); the
-richer navigable-inspector surface is deferred to
-[BT-2397](https://linear.app/beamtalk/issue/BT-2397).
+`inspect` (the language method) is **unchanged in Phase 1** — it still returns a
+`String`, delegating to `printString`. ADR 0095 Phase 1
+([BT-2502](https://linear.app/beamtalk/issue/BT-2502)) adds the navigable
+`Inspector` / `InspectorField` classes and the `Inspector on: anObject` entry
+point — a drillable cursor with `at:`, structural/snapshot `fields`, `refresh`,
+and a depth-1 `printString` tree. The breaking *repurpose* of `inspect`
+(`inspect -> Inspector`, removing the 14 `inspect -> String` overrides, the
+gradual-typing crash audit) is Phase 3
+([BT-2504](https://linear.app/beamtalk/issue/BT-2504)); the `"op": "inspect"`
+REPL/MCP **wire op** stays the agent-only flat JSON (line 86) until its
+`asDictionaries` migration in Phase 5. Epic:
+[BT-2501](https://linear.app/beamtalk/issue/BT-2501) (design
+[BT-2397](https://linear.app/beamtalk/issue/BT-2397)).
 
 ## Drift Check (CI)
 

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_inspector.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_inspector.erl
@@ -1,0 +1,470 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%%% **DDD Context:** Runtime Context
+
+-module(beamtalk_inspector).
+
+-moduledoc """
+Runtime shim backing the `Inspector` / `InspectorField` stdlib classes (ADR 0095).
+
+An `Inspector` is an immutable cursor over one object. This module mints the
+cursor handle, classifies the subject `kind`, derives its drillable
+`InspectorField` records, drills (`at:`), and re-captures snapshots (`refresh`).
+It is the runtime half of the design; the navigation API and rendering live in
+`stdlib/src/Inspector.bt`.
+
+## The cursor handle
+
+`on/1` mints a tagged map:
+
+```erlang
+#{
+  '$beamtalk_class' => 'Inspector',
+  kind    => value | actor,    %% #value (structural) | #actor (snapshot)
+  pid     => pid() | nil,       %% the live actor pid, for refresh (nil for values)
+  subject => term(),            %% the value itself, or the captured snapshot (actors)
+  parent  => inspector() | nil, %% the cursor drilled from (nil at root)
+  path    => [term()]           %% breadcrumb of drilled names from root
+}
+```
+
+The handle is immutable: `at:` and `refresh` return *new* handles.
+
+## Kind & state capture (ADR 0095 §3–§4)
+
+- `#value` — a tagged `Value` map. Fields are its user `field:` slots in ADR-0094
+  sort order, read purely (no process contact).
+- `#actor` — a live pid. State is captured **at `on:`** via the shared
+  timeout-guarded `sys:get_state` (`beamtalk_process_navigation:guarded_state/1`);
+  the frozen snapshot is the cursor's `subject`, reused for all drilling and
+  reset only by `refresh`. A busy/dead/non-`sys` actor degrades to a single
+  `InspectorField name: #status value: #unavailable` — never a crash.
+
+`#collection` / `#foreign` kinds, value `evaluate:`, windowing, and the pid-keyed
+cycle guard for deep actor graphs are later phases (ADR 0095 §6–§7).
+""".
+
+%% Selector→function mapping (beamtalk_erlang_proxy): a single-keyword selector
+%% strips its trailing colon (`on:` → `on`, `fieldsOf:` → `fieldsOf`); a
+%% multi-keyword selector uses its *first* keyword as the function name with all
+%% arguments positional (`inspector:at:` → `inspector/2`, `printString:depth:` →
+%% `printString/2`).
+-export([
+    on/1,
+    subjectOf/1,
+    kindOf/1,
+    fieldsOf/1,
+    inspector/2,
+    parentOf/1,
+    pathOf/1,
+    refresh/1,
+    printString/2
+]).
+
+-include("beamtalk.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+%% The `Inspector` cursor handle. The `'$beamtalk_class'` tag lets the spec
+%% reader map FFI returns of this shape to the Beamtalk `Inspector` type.
+-type inspector() :: #{
+    '$beamtalk_class' := 'Inspector',
+    kind := value | actor,
+    pid := pid() | nil,
+    available := boolean(),
+    subject := term(),
+    parent := inspector() | nil,
+    path := [term()]
+}.
+
+%% An `InspectorField` Value record. The `'$beamtalk_class'` tag maps it to the
+%% Beamtalk `InspectorField` type for `fieldsOf/1`'s `List(InspectorField)`.
+-type field_map() :: #{
+    '$beamtalk_class' := 'InspectorField',
+    name := term(),
+    label := binary(),
+    value := term(),
+    kind := atom(),
+    drillable := boolean()
+}.
+
+%%====================================================================
+%% Construction
+%%====================================================================
+
+-doc """
+Mint an `Inspector` cursor on `Subject` (`Inspector on:` / `anObject inspect`).
+
+Classifies the subject kind and, for an actor, captures its timeout-guarded
+state snapshot. The minted cursor is a root (`parent => nil`, `path => []`).
+""".
+-spec on(term()) -> inspector().
+on(Subject) ->
+    root_cursor(Subject, []).
+
+%% Build a root cursor (no parent) for a subject, classifying kind and capturing
+%% actor state. `Path` is the breadcrumb a drilled child inherits.
+-spec root_cursor(term(), [term()]) -> inspector().
+root_cursor(Subject, Path) ->
+    cursor(Subject, nil, Path).
+
+%% Build a cursor with an explicit parent. An actor subject arrives either as a
+%% bare pid or — the usual Beamtalk handle — a `#beamtalk_object{}` wrapping the
+%% pid (resolving a `{registered, Name}` ref to the live pid). Everything else is
+%% a `#value`.
+-spec cursor(term(), inspector() | nil, [term()]) -> inspector().
+cursor(#beamtalk_object{pid = Pid}, Parent, Path) when is_pid(Pid) ->
+    actor_cursor(Pid, Parent, Path);
+cursor(#beamtalk_object{pid = {registered, Name}}, Parent, Path) ->
+    case erlang:whereis(Name) of
+        Pid when is_pid(Pid) -> actor_cursor(Pid, Parent, Path);
+        _ -> value_cursor(unavailable, Parent, Path)
+    end;
+cursor(Subject, Parent, Path) when is_pid(Subject) ->
+    actor_cursor(Subject, Parent, Path);
+cursor(Subject, Parent, Path) ->
+    value_cursor(Subject, Parent, Path).
+
+%% Mint an `#actor` cursor over a live pid: capture the guarded snapshot now
+%% (ADR 0095 §4). The pid is retained for refresh. `available` records whether
+%% the guarded read succeeded — a *distinct* flag, never a sentinel value in
+%% `subject`, so an actor whose real state happens to be the atom `unavailable`
+%% is not mistaken for a failed snapshot (the spaces never overlap).
+-spec actor_cursor(pid(), inspector() | nil, [term()]) -> inspector().
+actor_cursor(Pid, Parent, Path) ->
+    {Available, Snapshot} =
+        case beamtalk_process_navigation:guarded_state(Pid) of
+            {ok, State} -> {true, State};
+            unavailable -> {false, nil}
+        end,
+    #{
+        '$beamtalk_class' => 'Inspector',
+        kind => actor,
+        pid => Pid,
+        available => Available,
+        subject => Snapshot,
+        parent => Parent,
+        path => Path
+    }.
+
+%% Mint a `#value` cursor: pure structural subject, no process contact (always
+%% available).
+-spec value_cursor(term(), inspector() | nil, [term()]) -> inspector().
+value_cursor(Subject, Parent, Path) ->
+    #{
+        '$beamtalk_class' => 'Inspector',
+        kind => value,
+        pid => nil,
+        available => true,
+        subject => Subject,
+        parent => Parent,
+        path => Path
+    }.
+
+%%====================================================================
+%% Identity accessors
+%%====================================================================
+
+-spec subjectOf(inspector()) -> term().
+subjectOf(#{subject := Subject}) -> Subject.
+
+-spec kindOf(inspector()) -> atom().
+kindOf(#{kind := Kind}) -> Kind.
+
+-spec parentOf(inspector()) -> inspector() | nil.
+parentOf(#{parent := Parent}) -> Parent.
+
+-spec pathOf(inspector()) -> [term()].
+pathOf(#{path := Path}) -> Path.
+
+%%====================================================================
+%% Field derivation (ADR 0095 §3)
+%%====================================================================
+
+-doc """
+Derive the drillable `InspectorField` records for a cursor.
+
+`#value` → its user `field:` slots in ADR-0094 sort order. `#actor` → its state
+slots from the frozen snapshot, or the single `#status => #unavailable`
+diagnostic field when the snapshot could not be captured.
+""".
+-spec fieldsOf(inspector()) -> [field_map()].
+fieldsOf(#{kind := actor, available := false}) ->
+    [unavailable_field()];
+fieldsOf(#{subject := Subject}) ->
+    case beamtalk_tagged_map:is_tagged(Subject) of
+        true -> slot_fields(Subject);
+        false -> []
+    end.
+
+%% Build a sorted list of `InspectorField` records from a tagged map's user
+%% slots (ADR-0094 sort order — `user_field_keys/1` is unsorted, so we sort).
+-spec slot_fields(map()) -> [field_map()].
+slot_fields(State) ->
+    Keys = lists:sort(beamtalk_tagged_map:user_field_keys(State)),
+    [field_record(K, maps:get(K, State, nil)) || K <- Keys].
+
+%% A `#slot` InspectorField for one field key/value pair.
+-spec field_record(term(), term()) -> field_map().
+field_record(Key, Value) ->
+    inspector_field(Key, label_for(Key), Value, slot, is_drillable(Value)).
+
+%% The diagnostic field for an actor whose state could not be captured
+%% (busy/dead/non-`sys`): `InspectorField name: #status value: #unavailable`.
+-spec unavailable_field() -> field_map().
+unavailable_field() ->
+    inspector_field(status, <<"status">>, unavailable, slot, false).
+
+%% Mint an `InspectorField` Value record (tagged map). Field order mirrors the
+%% stdlib `field:` declarations: name, label, value, kind, drillable.
+-spec inspector_field(term(), binary(), term(), atom(), boolean()) -> field_map().
+inspector_field(Name, Label, Value, Kind, Drillable) ->
+    #{
+        '$beamtalk_class' => 'InspectorField',
+        name => Name,
+        label => Label,
+        value => Value,
+        kind => Kind,
+        drillable => Drillable
+    }.
+
+%% A field is drillable when its value is a tagged Beamtalk object (a Value with
+%% slots, or an actor pid) — i.e. there is something to drill into. Bare scalars
+%% (numbers, atoms/symbols, booleans, nil, strings) are leaves.
+-spec is_drillable(term()) -> boolean().
+is_drillable(Value) ->
+    actor_pid(Value) =/= not_actor orelse beamtalk_tagged_map:is_tagged(Value).
+
+%% Extract the live pid from an actor subject — a bare pid or a
+%% `#beamtalk_object{}` handle (resolving a `{registered, Name}` ref). Returns
+%% `not_actor` for anything that is not a live actor reference.
+-spec actor_pid(term()) -> {ok, pid()} | not_actor.
+actor_pid(Pid) when is_pid(Pid) ->
+    {ok, Pid};
+actor_pid(#beamtalk_object{pid = Pid}) when is_pid(Pid) ->
+    {ok, Pid};
+actor_pid(#beamtalk_object{pid = {registered, Name}}) ->
+    case erlang:whereis(Name) of
+        Pid when is_pid(Pid) -> {ok, Pid};
+        _ -> not_actor
+    end;
+actor_pid(_) ->
+    not_actor.
+
+%% The display label for a slot key — the field name as a binary.
+-spec label_for(term()) -> binary().
+label_for(Key) when is_atom(Key) -> atom_to_binary(Key, utf8);
+label_for(Key) when is_binary(Key) -> Key;
+label_for(Key) -> iolist_to_binary(io_lib:format("~p", [Key])).
+
+%%====================================================================
+%% Navigation (ADR 0095 §1)
+%%====================================================================
+
+-doc """
+Drill into the field named `Name` (the `Inspector >> at:` shim).
+
+Returns the raw `{ok, ChildCursor} | {error, #beamtalk_error{}}` tuple — the FFI
+boundary (`beamtalk_erlang_proxy:coerce_result/1`) lifts it to a Beamtalk
+`Result`, so the stdlib signature is `Result(Inspector, Error)` (the same shape
+`beamtalk_process_navigation:from/1` uses). The child cursor's `parent` is
+`Cursor` and its `path` extends this one's by `Name`; a miss yields a
+`no_such_field` error.
+""".
+-spec inspector(inspector(), term()) -> {ok, inspector()} | {error, #beamtalk_error{}}.
+inspector(Cursor, Name) ->
+    Fields = fieldsOf(Cursor),
+    case find_field(Name, Fields) of
+        {ok, Value} ->
+            ChildPath = pathOf(Cursor) ++ [Name],
+            Child = cursor(Value, Cursor, ChildPath),
+            {ok, Child};
+        error ->
+            {error, no_such_field_error(Name)}
+    end.
+
+%% Look up a field's value by its navigation name in a derived field list.
+-spec find_field(term(), [field_map()]) -> {ok, term()} | error.
+find_field(_Name, []) ->
+    error;
+find_field(Name, [#{name := Name, value := Value} | _]) ->
+    {ok, Value};
+find_field(Name, [_ | Rest]) ->
+    find_field(Name, Rest).
+
+-doc """
+Return a cursor on a freshly-captured snapshot of the same subject (`refresh`).
+
+For a `#value` the subject is structurally identical; for an `#actor` the shared
+guarded `sys:get_state` is re-issued, picking up state change since the previous
+snapshot. The new cursor preserves `parent` and `path`; the original is
+unchanged (immutable).
+""".
+-spec refresh(inspector()) -> inspector().
+refresh(#{kind := actor, pid := Pid, parent := Parent, path := Path}) ->
+    cursor(Pid, Parent, Path);
+refresh(#{subject := Subject, parent := Parent, path := Path}) ->
+    cursor(Subject, Parent, Path).
+
+%%====================================================================
+%% Rendering (ADR 0095 §7)
+%%====================================================================
+
+-doc """
+Render the cursor as an indented text tree to `Depth` levels.
+
+Depth 1 is the header line plus the immediate fields; deeper levels expand each
+drillable field's own fields recursively. A **pid-keyed seen-set** guards actor
+descents: revisiting an already-expanded actor pid emits a back-reference marker
+(`↩ Actor(...)`) instead of recursing (ADR 0095 Cycle handling). Pure value
+sub-trees cannot cycle (ADR 0042) and are bounded by `Depth`.
+""".
+-spec printString(inspector(), integer()) -> binary().
+printString(Cursor, Depth) ->
+    iolist_to_binary(render(Cursor, Depth, 0, #{})).
+
+%% Render a cursor's tree. `Indent` is the nesting level (2 spaces each); `Seen`
+%% is the set of actor pids on the **current ancestor path** (the cycle guard).
+%% `Seen` is passed *down* into children but never propagated back to siblings —
+%% so it tracks true ancestry (a cycle) and not mere prior visitation (a shared
+%% diamond reference, which must still expand, not back-reference).
+-spec render(inspector(), integer(), non_neg_integer(), map()) -> iolist().
+render(Cursor, Depth, Indent, Seen0) ->
+    Header = header_line(Cursor),
+    %% Add this cursor's pid to the ancestor set for the descent below it.
+    Seen = mark_seen(Cursor, Seen0),
+    case Depth =< 0 of
+        true ->
+            [pad(Indent), Header];
+        false ->
+            FieldLines = [
+                render_field(F, Depth, Indent + 1, Seen)
+             || F <- fieldsOf(Cursor)
+            ],
+            [pad(Indent), Header, FieldLines]
+    end.
+
+%% Add the cursor's actor pid (if any) to the ancestor seen-set.
+-spec mark_seen(inspector(), map()) -> map().
+mark_seen(#{kind := actor, pid := Pid}, Seen) when is_pid(Pid) ->
+    Seen#{Pid => true};
+mark_seen(_, Seen) ->
+    Seen.
+
+%% Render one field line, expanding drillable children when depth remains. A
+%% drilled value that is an actor pid already on the ancestor path yields a
+%% back-reference marker rather than recursing (the pid-keyed cycle guard).
+-spec render_field(map(), integer(), non_neg_integer(), map()) -> iolist().
+render_field(#{label := Label, value := Value, drillable := true}, Depth, Indent, Seen) when
+    Depth > 1
+->
+    case actor_pid(Value) of
+        {ok, Pid} ->
+            case maps:is_key(Pid, Seen) of
+                true ->
+                    [$\n, pad(Indent), Label, <<": ">>, back_reference(Pid)];
+                false ->
+                    expand_field(Label, Value, Depth, Indent, Seen)
+            end;
+        not_actor ->
+            expand_field(Label, Value, Depth, Indent, Seen)
+    end;
+render_field(#{label := Label, value := Value}, _Depth, Indent, _Seen) ->
+    scalar_field_line(Label, Value, Indent).
+
+%% Expand a drillable field into its own (depth-1) sub-tree, or fall back to a
+%% scalar line for a non-navigable leaf. The ancestor `Seen` set is passed down
+%% unchanged; the child adds itself for its own descent only.
+-spec expand_field(binary(), term(), integer(), non_neg_integer(), map()) -> iolist().
+expand_field(Label, Value, Depth, Indent, Seen) ->
+    case beamtalk_tagged_map:is_tagged(Value) orelse actor_pid(Value) =/= not_actor of
+        true ->
+            Child = root_cursor(Value, []),
+            ChildIo = render(Child, Depth - 1, 0, Seen),
+            [
+                $\n,
+                pad(Indent),
+                Label,
+                <<": ">>,
+                string:trim(iolist_to_binary(ChildIo), leading)
+            ];
+        false ->
+            scalar_field_line(Label, Value, Indent)
+    end.
+
+%% The cycle back-reference marker for a revisited actor pid, e.g.
+%% `↩ Actor(Counter, <0.123.0>)` — informative class + pid, never re-expanded.
+-spec back_reference(pid()) -> iolist().
+back_reference(Pid) ->
+    [
+        <<"↩ Actor("/utf8>>,
+        actor_class_label(Pid),
+        <<", ">>,
+        beamtalk_opaque_ops:pid_to_string(Pid),
+        <<")">>
+    ].
+
+-spec scalar_field_line(binary(), term(), non_neg_integer()) -> iolist().
+scalar_field_line(Label, Value, Indent) ->
+    [$\n, pad(Indent), Label, <<": ">>, value_string(Value)].
+
+%% The header line for a cursor, e.g. `Inspector(Point)` or
+%% `Inspector(Counter)` / `Inspector(Integer = 3)` for a scalar leaf.
+-spec header_line(inspector()) -> iolist().
+header_line(#{kind := actor, available := false, pid := Pid}) ->
+    [<<"Inspector(">>, actor_class_label(Pid), <<" = #unavailable)">>];
+header_line(#{kind := actor, pid := Pid}) ->
+    [<<"Inspector(">>, actor_class_label(Pid), <<")">>];
+header_line(#{subject := Subject}) ->
+    case beamtalk_tagged_map:is_tagged(Subject) of
+        true ->
+            ClassName = beamtalk_tagged_map:class_of(Subject, 'Object'),
+            [<<"Inspector(">>, atom_to_binary(ClassName, utf8), <<")">>];
+        false ->
+            [<<"Inspector(">>, value_string(Subject), <<")">>]
+    end.
+
+%% A best-effort class label for an actor pid (the behaviour class name, or the
+%% pid string if unknown).
+-spec actor_class_label(pid()) -> binary().
+actor_class_label(Pid) when is_pid(Pid) ->
+    case actor_class(Pid) of
+        nil -> value_string(Pid);
+        Class -> atom_to_binary(Class, utf8)
+    end.
+
+%% The actor's behaviour class atom from its process dictionary, or nil.
+-spec actor_class(pid()) -> atom() | nil.
+actor_class(Pid) ->
+    case erlang:process_info(Pid, dictionary) of
+        {dictionary, Dict} when is_list(Dict) ->
+            case lists:keyfind('$beamtalk_actor', 1, Dict) of
+                {'$beamtalk_actor', Class} when is_atom(Class) -> Class;
+                _ -> nil
+            end;
+        _ ->
+            nil
+    end.
+
+%% Indent padding: two spaces per level.
+-spec pad(non_neg_integer()) -> binary().
+pad(N) ->
+    list_to_binary(lists:duplicate(N * 2, $\s)).
+
+%% A short display string for a leaf value (re-using the primitive renderer).
+-spec value_string(term()) -> binary().
+value_string(Value) ->
+    beamtalk_primitive:print_string(Value).
+
+%%====================================================================
+%% Errors
+%%====================================================================
+
+-spec no_such_field_error(term()) -> #beamtalk_error{}.
+no_such_field_error(Name) ->
+    beamtalk_error:new(
+        no_such_field,
+        'Inspector',
+        'at:',
+        iolist_to_binary([<<"no field named ">>, label_for(Name)])
+    ).

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_process_navigation.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_process_navigation.erl
@@ -82,6 +82,8 @@ timeout-guarded `sys:get_status/1` fetch — never called during snapshotting.
     from/1,
     from/2,
     status/1,
+    guarded_state/1,
+    guarded_state/2,
     infra_deny_list/0,
     is_infra/1,
     %% Node / tree accessors consumed by the SupervisionNode & SupervisionTree
@@ -109,6 +111,11 @@ timeout-guarded `sys:get_status/1` fetch — never called during snapshotting.
 %% non-`sys`-compliant process must yield `nil`, never block the caller
 %% (ADR 0092 §5).
 -define(STATUS_TIMEOUT, 2000).
+
+%% Bounded timeout (ms) for the guarded `sys:get_state/1` fetch shared with the
+%% Inspector (ADR 0095 §4). Same discipline as `status/1`: a busy, wedged, dead,
+%% or non-`sys`-compliant process yields `unavailable`, never blocks the caller.
+-define(GET_STATE_TIMEOUT, 2000).
 
 %% Per-supervisor child-expansion cap (ADR 0092 §Constraints 1). A supervisor
 %% with more than this many live children — typically a `simple_one_for_one`
@@ -266,6 +273,38 @@ status(_) ->
 -spec sys_state([term()]) -> atom().
 sys_state([_ProcDict, SysState | _]) when is_atom(SysState) -> SysState;
 sys_state(_) -> running.
+
+-doc """
+Timeout-guarded `sys:get_state/1` — the shared safe live-state read (ADR 0095 §4).
+
+Returns `{ok, State}` for an alive, `sys`-compliant process; `unavailable` —
+logged at debug, never raised — for a process that is dead, busy past the
+timeout, or not `sys`-compliant. This is the one place that knows how to safely
+read a live process's state; the Inspector (`beamtalk_inspector`) shares it so
+there is a single guarded-read discipline across the runtime (the same intent
+`status/1` serves for `sys:get_status/1`).
+""".
+-spec guarded_state(term()) -> {ok, term()} | unavailable.
+guarded_state(Pid) ->
+    guarded_state(Pid, ?GET_STATE_TIMEOUT).
+
+-spec guarded_state(term(), timeout()) -> {ok, term()} | unavailable.
+guarded_state(Pid, Timeout) when is_pid(Pid) ->
+    try sys:get_state(Pid, Timeout) of
+        State ->
+            {ok, State}
+    catch
+        Class:Reason ->
+            ?LOG_DEBUG("guarded state fetch failed", #{
+                pid => Pid,
+                error_class => Class,
+                reason => Reason,
+                domain => [beamtalk, runtime]
+            }),
+            unavailable
+    end;
+guarded_state(_, _) ->
+    unavailable.
 
 %%% ============================================================================
 %%% Node / tree accessors (BT-2429)

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_inspector_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_inspector_tests.erl
@@ -1,0 +1,169 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%%% **DDD Context:** Runtime Context
+
+-module(beamtalk_inspector_tests).
+
+-moduledoc """
+Unit tests for `beamtalk_inspector` — the ADR 0095 Phase 1 inspector shim.
+
+Coverage:
+- kind classification (`#value` for a tagged Value map, `#actor` for a pid)
+- `#value` field derivation in ADR-0094 sort order, with drillability
+- `at:` drilling into a child cursor (parent/path wired) and the
+  `no_such_field` error Result on a miss
+- `refresh` returning a fresh cursor (immutable original)
+- the shared `beamtalk_process_navigation:guarded_state/1` guard: a live
+  `sys`-compliant process yields `{ok, State}`; a dead pid yields `unavailable`
+- an `#actor` over a live gen_server snapshots its state; a dead actor degrades
+  to the single `#status => #unavailable` diagnostic field (never a crash)
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+%% A minimal sys-compliant gen_server whose state is a tagged Value-shaped map,
+%% so the inspector's actor snapshot path can read user fields.
+-export([init/1, handle_call/3, handle_cast/2]).
+
+%%====================================================================
+%% Test gen_server
+%%====================================================================
+
+init(State) -> {ok, State}.
+handle_call(_Req, _From, State) -> {reply, ok, State}.
+handle_cast(_Msg, State) -> {noreply, State}.
+
+%% Start a sys-compliant process whose state is the given tagged map.
+start_actor(State) ->
+    {ok, Pid} = gen_server:start_link(?MODULE, State, []),
+    Pid.
+
+%% A Value-shaped tagged map (Point with x/y).
+point(X, Y) ->
+    #{'$beamtalk_class' => 'Point', x => X, y => Y}.
+
+%%====================================================================
+%% Kind classification
+%%====================================================================
+
+value_kind_test() ->
+    I = beamtalk_inspector:on(point(3, 4)),
+    ?assertEqual(value, beamtalk_inspector:kindOf(I)).
+
+actor_kind_test() ->
+    Pid = start_actor(point(1, 2)),
+    I = beamtalk_inspector:on(Pid),
+    ?assertEqual(actor, beamtalk_inspector:kindOf(I)),
+    gen_server:stop(Pid).
+
+root_cursor_has_no_parent_test() ->
+    I = beamtalk_inspector:on(point(3, 4)),
+    ?assertEqual(nil, beamtalk_inspector:parentOf(I)),
+    ?assertEqual([], beamtalk_inspector:pathOf(I)).
+
+%%====================================================================
+%% #value field derivation (ADR 0094 sort order)
+%%====================================================================
+
+value_fields_sorted_test() ->
+    I = beamtalk_inspector:on(point(3, 4)),
+    Fields = beamtalk_inspector:fieldsOf(I),
+    Names = [maps:get(name, F) || F <- Fields],
+    ?assertEqual([x, y], Names).
+
+value_field_values_test() ->
+    I = beamtalk_inspector:on(point(3, 4)),
+    [XF, YF] = beamtalk_inspector:fieldsOf(I),
+    ?assertEqual(3, maps:get(value, XF)),
+    ?assertEqual(4, maps:get(value, YF)).
+
+scalar_field_not_drillable_test() ->
+    I = beamtalk_inspector:on(point(3, 4)),
+    [XF | _] = beamtalk_inspector:fieldsOf(I),
+    ?assertEqual(false, maps:get(drillable, XF)).
+
+nested_value_field_drillable_test() ->
+    Nested = #{'$beamtalk_class' => 'Pair', a => point(1, 2), b => 9},
+    I = beamtalk_inspector:on(Nested),
+    Fields = beamtalk_inspector:fieldsOf(I),
+    [AF] = [F || F <- Fields, maps:get(name, F) =:= a],
+    ?assertEqual(true, maps:get(drillable, AF)).
+
+field_records_tagged_inspectorfield_test() ->
+    I = beamtalk_inspector:on(point(3, 4)),
+    [XF | _] = beamtalk_inspector:fieldsOf(I),
+    ?assertEqual('InspectorField', maps:get('$beamtalk_class', XF)),
+    ?assertEqual(slot, maps:get(kind, XF)).
+
+%%====================================================================
+%% Navigation: at: / parent / path
+%%====================================================================
+
+%% `inspector/2` returns the raw `{ok, Child} | {error, Err}` tuple; the FFI
+%% boundary (`coerce_result/1`) lifts it to a Beamtalk `Result` at the call site.
+at_drills_into_child_test() ->
+    I = beamtalk_inspector:on(point(3, 4)),
+    {ok, Child} = beamtalk_inspector:inspector(I, x),
+    ?assertEqual(3, beamtalk_inspector:subjectOf(Child)),
+    ?assertEqual([x], beamtalk_inspector:pathOf(Child)).
+
+at_child_parent_is_cursor_test() ->
+    I = beamtalk_inspector:on(point(3, 4)),
+    {ok, Child} = beamtalk_inspector:inspector(I, x),
+    ?assertEqual(I, beamtalk_inspector:parentOf(Child)).
+
+at_miss_returns_no_such_field_test() ->
+    I = beamtalk_inspector:on(point(3, 4)),
+    {error, Err} = beamtalk_inspector:inspector(I, nonesuch),
+    ?assertEqual(no_such_field, Err#beamtalk_error.kind).
+
+%%====================================================================
+%% Refresh
+%%====================================================================
+
+refresh_value_returns_cursor_test() ->
+    I = beamtalk_inspector:on(point(3, 4)),
+    R = beamtalk_inspector:refresh(I),
+    ?assertEqual(value, beamtalk_inspector:kindOf(R)),
+    ?assertEqual(point(3, 4), beamtalk_inspector:subjectOf(R)).
+
+%%====================================================================
+%% Shared guarded_state/1 (ADR 0095 §4)
+%%====================================================================
+
+guarded_state_live_test() ->
+    Pid = start_actor(point(5, 6)),
+    ?assertEqual({ok, point(5, 6)}, beamtalk_process_navigation:guarded_state(Pid)),
+    gen_server:stop(Pid).
+
+guarded_state_dead_test() ->
+    Pid = start_actor(point(5, 6)),
+    gen_server:stop(Pid),
+    ?assertEqual(unavailable, beamtalk_process_navigation:guarded_state(Pid)).
+
+guarded_state_non_pid_test() ->
+    ?assertEqual(unavailable, beamtalk_process_navigation:guarded_state(not_a_pid)).
+
+%%====================================================================
+%% #actor snapshot + unavailable degradation
+%%====================================================================
+
+actor_fields_from_snapshot_test() ->
+    Pid = start_actor(point(7, 8)),
+    I = beamtalk_inspector:on(Pid),
+    Fields = beamtalk_inspector:fieldsOf(I),
+    Names = lists:sort([maps:get(name, F) || F <- Fields]),
+    ?assertEqual([x, y], Names),
+    gen_server:stop(Pid).
+
+dead_actor_fields_unavailable_test() ->
+    Pid = start_actor(point(7, 8)),
+    gen_server:stop(Pid),
+    %% Inspecting a dead actor must not crash — single status field.
+    I = beamtalk_inspector:on(Pid),
+    [StatusF] = beamtalk_inspector:fieldsOf(I),
+    ?assertEqual(status, maps:get(name, StatusF)),
+    ?assertEqual(unavailable, maps:get(value, StatusF)),
+    ?assertEqual(false, maps:get(drillable, StatusF)).

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_stdlib.app.src
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_stdlib.app.src
@@ -45,6 +45,8 @@
             #{name => 'File', module => 'bt@stdlib@file', parent => 'Object', package => 'stdlib', kind => object, type_params => []},
             #{name => 'FileHandle', module => 'bt@stdlib@file_handle', parent => 'Object', package => 'stdlib', kind => object, type_params => []},
             #{name => 'Float', module => 'bt@stdlib@float', parent => 'Number', package => 'stdlib', kind => object, type_params => []},
+            #{name => 'Inspector', module => 'bt@stdlib@inspector', parent => 'Object', package => 'stdlib', kind => object, type_params => []},
+            #{name => 'InspectorField', module => 'bt@stdlib@inspector_field', parent => 'Value', package => 'stdlib', kind => value, type_params => []},
             #{name => 'InstantiationError', module => 'bt@stdlib@instantiation_error', parent => 'Error', package => 'stdlib', kind => object, type_params => []},
             #{name => 'Integer', module => 'bt@stdlib@integer', parent => 'Number', package => 'stdlib', kind => object, type_params => []},
             #{name => 'Interval', module => 'bt@stdlib@interval', parent => 'Collection', package => 'stdlib', kind => object, type_params => []},

--- a/stdlib/src/Inspector.bt
+++ b/stdlib/src/Inspector.bt
@@ -1,0 +1,182 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+/// Inspector — a live, immutable cursor for navigating into a single object
+/// (ADR 0095).
+///
+/// Where the three navigators (`SystemNavigation`, `ProcessNavigation`,
+/// `AnnouncementNavigation`) each enumerate a *system-wide collection*, an
+/// `Inspector` is a **cursor over one object** that drills *into* it — the
+/// Beamtalk equivalent of a Pharo Inspector. `Inspector on: anObject` returns a
+/// cursor; `fields` lists its drillable `InspectorField` records; `at:` drills
+/// into one field, returning a new child cursor; `parent`/`root`/`path` walk the
+/// drill chain; `refresh` re-captures a fresh snapshot of the same subject.
+///
+/// (`Inspector on:` is the Phase-1 entry point. The `anObject inspect` shorthand
+/// — repurposing `inspect` from `String` to `Inspector` — is the breaking change
+/// deferred to ADR 0095 Phase 3, BT-2504; in Phase 1 `inspect` still returns a
+/// structural `String`.)
+///
+/// **The cursor is immutable.** Every navigation message returns a *new*
+/// `Inspector` — `at:` returns a child cursor (with `parent` set), `refresh`
+/// returns a cursor on a freshly-captured snapshot. Nothing mutates in place, so
+/// a UI can hold several cursors at once.
+///
+/// **`kind`-polymorphic, one class.** A single `Inspector` carries a `kind` tag
+/// (`#value` structural, `#actor` snapshot) rather than a subclass per kind —
+/// the same fork ADR 0092's `SupervisionNode` settled. v1 covers `#value` (pure
+/// structural traversal of a `Value`'s `field:` slots, ADR 0094 sort order) and
+/// `#actor` (a lazy, timeout-guarded `sys:get_state` snapshot of an `Actor`'s
+/// state). A wedged, dead, or non-`sys` actor degrades to a single
+/// `InspectorField name: #status value: #unavailable` — never a crash.
+/// (`#collection`/`#foreign` and value `evaluate:` are later phases, ADR 0095
+/// §6–§7.)
+///
+/// `Inspector` is a `sealed typed Object subclass`: a live cursor handle, like
+/// the navigators. Its carried state (subject, kind, snapshot, parent, path)
+/// lives in a runtime-minted handle — not in declarable `field:` slots (an
+/// Object subclass has none, ADR 0067) — and is read back through the
+/// `beamtalk_inspector` shim. The *records* it returns (`InspectorField`) are
+/// the `Value`s.
+///
+/// ## Examples
+/// ```beamtalk
+/// i := Inspector on: (Point x: 3 y: 4)
+/// i kind            // => #value
+/// i fields size     // => 2
+/// (i at: #x) unwrap subject   // => 3
+/// i path            // => #()
+/// ```
+sealed typed Object subclass: Inspector
+
+  /// Open an inspector cursor on `anObject` (ADR 0095 §1).
+  ///
+  /// For an actor, the timeout-guarded `sys:get_state` snapshot is captured
+  /// here, at construction; for a value the subject is taken structurally with no
+  /// process contact. This is the Phase-1 entry point (`anObject inspect`
+  /// shorthand is Phase 3).
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// Inspector on: (Point x: 3 y: 4)   // => an Inspector
+  /// Inspector on: aCounter            // => an Inspector (#actor)
+  /// ```
+  class on: anObject :: Object -> Inspector =>
+    (Erlang beamtalk_inspector) on: anObject
+
+  /// The inspected object — the value itself, or, for an actor, the captured
+  /// state snapshot.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// (Inspector on: (Point x: 3 y: 4)) subject   // => Point(x: 3, y: 4)
+  /// ```
+  subject -> Object => (Erlang beamtalk_inspector) subjectOf: self
+
+  /// The subject kind: `#value` (structural) or `#actor` (snapshot) in v1.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// (Inspector on: (Point x: 3 y: 4)) kind   // => #value
+  /// (Inspector on: aCounter) kind            // => #actor
+  /// ```
+  kind -> Symbol => (Erlang beamtalk_inspector) kindOf: self
+
+  /// The drillable fields of the inspected object, as immutable
+  /// `InspectorField` records (ADR 0095 §2–§3).
+  ///
+  /// For a `#value`, these are its `field:` slots in ADR-0094 sort order. For an
+  /// `#actor`, they are its user state slots from a lazy, timeout-guarded
+  /// snapshot — or, if the actor is busy/dead/non-`sys`, the single diagnostic
+  /// `InspectorField name: #status value: #unavailable` (never a crash).
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// (Inspector on: (Point x: 3 y: 4)) fields size   // => 2
+  /// ```
+  fields -> List(InspectorField) => (Erlang beamtalk_inspector) fieldsOf: self
+
+  /// Drill into one field by name, returning a child `Inspector` cursor on that
+  /// field's value (ADR 0095 §1).
+  ///
+  /// Returns a `Result`: `Result error: (beamtalk_error no_such_field)` when no
+  /// field has that name. The child cursor's `parent` is this cursor, and its
+  /// `path` extends this one's by the drilled name.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// (Inspector on: (Point x: 3 y: 4)) at: #x     // => Result ok: (an Inspector on 3)
+  /// (Inspector on: (Point x: 3 y: 4)) at: #zzz   // => Result error: no_such_field
+  /// ```
+  at: aName :: Object -> Result(Inspector, Error) =>
+    (Erlang beamtalk_inspector) inspector: self at: aName
+
+  /// The cursor this one was drilled from, or `nil` at the root.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// child := ((Inspector on: (Point x: 3 y: 4)) at: #x) unwrap
+  /// child parent kind   // => #value
+  /// ```
+  parent -> Inspector | Nil => (Erlang beamtalk_inspector) parentOf: self
+
+  /// The top of this drill chain — the cursor with no `parent`.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// child := ((Inspector on: (Point x: 3 y: 4)) at: #x) unwrap
+  /// child root kind   // => #value
+  /// ```
+  root -> Inspector =>
+    self parent isNil ifTrue: [self] ifFalse: [self parent root]
+
+  /// The breadcrumb of drilled names from the root to this cursor (for UI).
+  /// `#()` at the root.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// child := ((Inspector on: (Point x: 3 y: 4)) at: #x) unwrap
+  /// child path   // => #(#x)
+  /// ```
+  path -> List => (Erlang beamtalk_inspector) pathOf: self
+
+  /// A cursor on a freshly-captured snapshot of the *same* subject (ADR 0095
+  /// §5). The original cursor is unchanged (immutable).
+  ///
+  /// `refresh` re-snapshots **this cursor's own subject**, which differs by how
+  /// the cursor was reached:
+  /// - A **root `#actor`** cursor re-issues the guarded `sys:get_state`, picking
+  ///   up state change since the previous snapshot.
+  /// - A **`#value`** cursor (including one drilled into an actor's slot with
+  ///   `at:`) re-freezes its already-captured value — structurally identical,
+  ///   since per ADR 0095 §4 drilling never re-contacts the live actor (the
+  ///   sub-tree is a consistent point-in-time view). To see a drilled actor
+  ///   field move, `refresh` the **root** actor cursor and drill again.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// ci := Inspector on: aCounter   // snapshot at T0
+  /// aCounter increment             // state moves on
+  /// ci refresh fields              // a fresh cursor at T1 (root actor re-fetched)
+  /// ```
+  refresh -> Inspector => (Erlang beamtalk_inspector) refresh: self
+
+  /// An indented text tree of the cursor and its immediate fields, one level
+  /// deep (ADR 0095 §7). The REPL default.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// (Inspector on: (Point x: 3 y: 4)) printString
+  ///   // => "Inspector(Point)\n  x: 3\n  y: 4"
+  /// ```
+  printString -> String => self printStringExpanded: 1
+
+  /// An indented text tree of the cursor to `depth` levels (ADR 0095 §7).
+  /// `depth: 1` is the immediate fields; deeper expands drillable children.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// (Inspector on: (Point x: 3 y: 4)) printStringExpanded: 1
+  /// ```
+  printStringExpanded: depth :: Integer -> String =>
+    (Erlang beamtalk_inspector) printString: self depth: depth

--- a/stdlib/src/InspectorField.bt
+++ b/stdlib/src/InspectorField.bt
@@ -1,0 +1,62 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+/// InspectorField — an immutable record for one drillable field of an inspected
+/// object (ADR 0095 §2).
+///
+/// An `InspectorField` is a frozen, point-in-time fact about a single slot,
+/// element, or association of the object an `Inspector` is focused on: its name
+/// (the navigation key), a display `label`, the field's `value`, the field
+/// `kind`, and whether the value is itself drillable. Fields are minted by the
+/// runtime shim (`beamtalk_inspector`) when an `Inspector` derives its fields,
+/// and never mutate — to observe change, `refresh` the cursor for a new snapshot.
+///
+/// The **read-vs-mutate rule** (ADR 0092 §3a, applied identically): an
+/// `InspectorField` is a frozen fact and read-only. To *change* something you
+/// discovered, cross back to the live object and send it a message. This keeps
+/// the Object/Value split consistent with the three navigators — cursors
+/// (`Inspector`, `SystemNavigation`, …) are `Object`; snapshot records
+/// (`InspectorField`, `SupervisionNode`, `SubscriptionNode`) are `Value`.
+///
+/// ## Examples
+/// ```beamtalk
+/// field := (Inspector on: (Point x: 3 y: 4)) fields first
+/// field name        // => #x
+/// field label       // => "x"
+/// field value       // => 3
+/// field kind        // => #slot
+/// field drillable   // => true
+/// ```
+sealed typed Value subclass: InspectorField
+  /// The navigation key: a Symbol (slot name), Integer (element index), or key
+  /// (association key). Passed to `Inspector at:` to drill into this field.
+  field: name :: Object = nil
+  /// The display label for this field, e.g. `"x"`, `"[0]"`, `"#key →"`.
+  field: label :: String = ""
+  /// The field's value — the object reached by drilling here.
+  field: value :: Object = nil
+  /// The field kind: one of `#slot` (Value/actor slot), `#element` (collection
+  /// element), `#association` (dictionary entry), or `#processInfo` (foreign
+  /// process datum).
+  field: kind :: Symbol = #slot
+  /// Whether the value is itself drillable (`false` for leaf scalars — numbers,
+  /// atoms, booleans, nil).
+  field: drillable :: Boolean = true
+
+  /// Whether this field is a leaf scalar (the negation of `drillable`).
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// field isLeaf   // => false
+  /// ```
+  isLeaf -> Boolean => self drillable not
+
+  /// Human-readable one-line description, e.g.
+  /// `#InspectorField<x: 3>` or `#InspectorField<status: #unavailable>`.
+  ///
+  /// ## Examples
+  /// ```beamtalk
+  /// field printString   // => "#InspectorField<x: 3>"
+  /// ```
+  printString -> String =>
+    "#InspectorField<" ++ self label ++ ": " ++ self value printString ++ ">"

--- a/stdlib/src/Object.bt
+++ b/stdlib/src/Object.bt
@@ -128,13 +128,19 @@ ProtoObject subclass: Object
   ///
   /// Unchanged by ADR 0094: `inspect` still returns a `String` and delegates to
   /// `printString`, so it shares the structural Debug form with a single source
-  /// of truth. Its planned redesign into a rich, navigable tooling/action verb
-  /// is deferred to a follow-up ADR designed against the LiveView surface
-  /// (BT-2397).
+  /// of truth.
+  ///
+  /// **ADR 0095 Phase 1 (BT-2502).** The rich, navigable inspector now exists as
+  /// the `Inspector` class — use `Inspector on: anObject` to open a drillable,
+  /// refreshable cursor. The *repurpose* of `inspect` itself (`inspect ->
+  /// Inspector`, removing the 14 `inspect -> String` overrides, and the
+  /// gradual-typing crash audit) is the breaking change deferred to Phase 3
+  /// (BT-2504); `inspect` keeps returning a `String` until then.
   ///
   /// ## Examples
   /// ```beamtalk
   /// 42 inspect             // => "42"
+  /// (Point x: 3 y: 4) inspect    // => "Point(x: 3, y: 4)"  (String, until Phase 3)
   /// ```
   inspect -> String => self printString
 

--- a/stdlib/test/inspector_test.bt
+++ b/stdlib/test/inspector_test.bt
@@ -1,0 +1,285 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2502: Tests for the Inspector / InspectorField classes (ADR 0095 Phase 1).
+//
+// Covers value drill (#value structural traversal), actor snapshot (#actor lazy
+// guarded sys:get_state), the no_such_field error on `at:`, immutable
+// parent/root/path navigation, refresh re-snapshotting, and printString.
+//
+// Fixtures:
+//   fixtures/value_point.bt — Value subclass with x, y integer fields
+//   fixtures/counter.bt     — Actor subclass with a `value` integer field
+//   fixtures/inspect_pair.bt — Value subclass with left/right fields (nesting)
+
+TestCase subclass: InspectorTest
+
+  // === InspectorField value record ===
+  testInspectorFieldAccessors =>
+    f := InspectorField
+      name: #x
+      label: "x"
+      value: 3
+      kind: #slot
+      drillable: true
+    self assert: f name equals: #x
+    self assert: f label equals: "x"
+    self assert: f value equals: 3
+    self assert: f kind equals: #slot
+    self assert: f drillable equals: true
+
+  testInspectorFieldIsLeafIsNegationOfDrillable =>
+    leaf := InspectorField
+      name: #n
+      label: "n"
+      value: 7
+      kind: #slot
+      drillable: false
+    self assert: leaf isLeaf equals: true
+    drillable := InspectorField
+      name: #n
+      label: "n"
+      value: 7
+      kind: #slot
+      drillable: true
+    self assert: drillable isLeaf equals: false
+
+  testInspectorFieldPrintStringShape =>
+    f := InspectorField
+      name: #x
+      label: "x"
+      value: 3
+      kind: #slot
+      drillable: false
+    self assert: (f printString startsWith: "#InspectorField<") equals: true
+    self assert: (f printString includesSubstring: "x: 3") equals: true
+
+  // === Construction: Inspector on: / inspect shorthand ===
+  testInspectorOnReturnsInspector =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    self assert: (i isKindOf: Inspector) equals: true
+
+  testValueKindClassifiedAsValue =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    self assert: i kind equals: #value
+
+  testActorKindClassifiedAsActor =>
+    c := Counter spawn
+    i := Inspector on: c
+    self assert: i kind equals: #actor
+
+  // === #value: structural field derivation (ADR 0094 sort order) ===
+  testValueFieldsAreSlots =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    self assert: i fields size equals: 2
+
+  testValueFieldsSortedByName =>
+    // ADR 0094 sort order: fields come back sorted by name (x before y).
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    names := i fields collect: [:f | f name]
+    self assert: names equals: #(#x, #y)
+
+  testValueFieldValuesMatch =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    xField := i fields detect: [:f | f name == #x]
+    self assert: xField value equals: 3
+
+  testScalarFieldIsNotDrillable =>
+    // An Integer slot value is a leaf — not drillable.
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    xField := i fields detect: [:f | f name == #x]
+    self assert: xField drillable equals: false
+
+  testNestedValueFieldIsDrillable =>
+    // A field holding another Value is drillable.
+    inner := ValuePoint x: 1 y: 2
+    pair := InspectPair new: #{#left => inner, #right => 42}
+    i := Inspector on: pair
+    leftField := i fields detect: [:f | f name == #left]
+    self assert: leftField drillable equals: true
+
+  // === Navigation: at: drills into a child cursor ===
+  testAtDrillsIntoChildValue =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    child := (i at: #x) unwrap
+    self assert: child subject equals: 3
+
+  testAtChildParentIsTheCursor =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    child := (i at: #x) unwrap
+    self assert: child parent kind equals: #value
+
+  testAtMissReturnsNoSuchField =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    result := i at: #nonesuch
+    self assert: result isError equals: true
+
+  testAtMissErrorKindIsNoSuchField =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    result := i at: #nonesuch
+    self assert: result error kind equals: #no_such_field
+
+  // === Immutable cursor: parent / root / path ===
+  testRootCursorParentIsNil =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    self assert: i parent equals: nil
+
+  testRootCursorPathIsEmpty =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    self assert: i path equals: #()
+
+  testChildPathExtendsByDrilledName =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    child := (i at: #x) unwrap
+    self assert: child path equals: #(#x)
+
+  testRootWalksBackToTop =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    child := (i at: #x) unwrap
+    self assert: child root kind equals: #value
+
+  testNavigationDoesNotMutateOriginalCursor =>
+    // Drilling returns a new cursor; the original is unchanged (immutable).
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    _ := (i at: #x) unwrap
+    self assert: i path equals: #()
+    self assert: i parent equals: nil
+
+  // === #actor: lazy guarded snapshot ===
+  testActorFieldsFromSnapshot =>
+    c := Counter spawn
+    c increment
+    c increment
+    i := Inspector on: c
+    valueField := i fields detect: [:f | f name == #value]
+    self assert: valueField value equals: 2
+
+  testActorSnapshotIsFrozen =>
+    // The snapshot is captured at `on:`; later mutation is not seen until refresh.
+    c := Counter spawn
+    i := Inspector on: c
+    c increment
+    valueField := i fields detect: [:f | f name == #value]
+    self assert: valueField value equals: 0
+
+  testRefreshReSnapshotsActor =>
+    c := Counter spawn
+    i := Inspector on: c
+    c increment
+    refreshed := i refresh
+    valueField := refreshed fields detect: [:f | f name == #value]
+    self assert: valueField value equals: 1
+
+  testRefreshReturnsNewCursorOriginalUnchanged =>
+    c := Counter spawn
+    i := Inspector on: c
+    c increment
+    _ := i refresh
+    // Original cursor still shows the T0 snapshot.
+    valueField := i fields detect: [:f | f name == #value]
+    self assert: valueField value equals: 0
+
+  // === Busy / dead actor degrades to #unavailable, never crashes ===
+  testDeadActorFieldsAreUnavailable =>
+    c := Counter spawn
+    c stop
+    // Inspecting a dead actor must not crash — it yields a single status field.
+    i := Inspector on: c
+    statusField := i fields detect: [:f | f name == #status]
+    self assert: statusField value equals: #unavailable
+
+  testDeadActorStatusFieldIsNotDrillable =>
+    c := Counter spawn
+    c stop
+    i := Inspector on: c
+    statusField := i fields detect: [:f | f name == #status]
+    self assert: statusField drillable equals: false
+
+  // === Rendering: printString depth-1 tree ===
+  testPrintStringHeaderNamesClass =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    self assert: (i printString includesSubstring: "Inspector(ValuePoint)") equals: true
+
+  testPrintStringIncludesImmediateFields =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    str := i printString
+    self assert: (str includesSubstring: "x: 3") equals: true
+    self assert: (str includesSubstring: "y: 4") equals: true
+
+  testPrintStringExpandedDepthAcceptsDepth =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    self assert: (i printStringExpanded: 1) equals: i printString
+
+  // === Cycle guard: pid-keyed seen-set with back-reference marker ===
+  testActorCycleEmitsBackReference =>
+    // A's state holds B, B's state holds A (a pid cycle). Expanding deeply must
+    // not recurse forever — the revisited actor pid yields a `↩ Actor(...)`
+    // back-reference marker instead (ADR 0095 Cycle handling).
+    a := CycleActorA spawn
+    b := CycleActorB spawn
+    a setPeer: b
+    b setPeer: a
+    str := (Inspector on: a) printStringExpanded: 5
+    self assert: (str includesSubstring: "↩ Actor") equals: true
+
+  testActorCycleRenderTerminates =>
+    // The expansion completes (does not hang) and names both actors once.
+    a := CycleActorA spawn
+    b := CycleActorB spawn
+    a setPeer: b
+    b setPeer: a
+    str := (Inspector on: a) printStringExpanded: 5
+    self assert: (str includesSubstring: "Inspector(CycleActorA)") equals: true
+
+  testSharedActorReferenceIsNotMistakenForCycle =>
+    // A diamond (shared, non-cyclic) reference: a value whose two fields both
+    // hold the SAME actor. Neither is an ancestor of the other, so BOTH must
+    // expand — the cycle guard tracks ancestry, not mere prior visitation, so
+    // there is no spurious back-reference (ADR 0095 Cycle handling).
+    c := Counter spawn
+    pair := InspectPair new: #{#left => c, #right => c}
+    str := (Inspector on: pair) printStringExpanded: 3
+    self deny: (str includesSubstring: "↩ Actor")
+
+  // === Depth bound: deeper expansion shows nested fields ===
+  testDepthOneRendersNestedValueInline =>
+    // At depth 1 a nested Value renders as its one-line structural string on the
+    // field line — not expanded into its own indented sub-tree.
+    inner := ValuePoint x: 1 y: 2
+    pair := InspectPair new: #{#left => inner, #right => 42}
+    str := (Inspector on: pair) printStringExpanded: 1
+    self assert: (str includesSubstring: "left: ValuePoint(x: 1, y: 2)") equals: true
+
+  testDepthTwoExpandsNestedValueSubTree =>
+    // At depth 2 the nested ValuePoint expands into its own header + fields, so a
+    // child header line `Inspector(ValuePoint)` appears that depth 1 omits.
+    inner := ValuePoint x: 1 y: 2
+    pair := InspectPair new: #{#left => inner, #right => 42}
+    shallow := (Inspector on: pair) printStringExpanded: 1
+    deep := (Inspector on: pair) printStringExpanded: 2
+    self deny: (shallow includesSubstring: "Inspector(ValuePoint)")
+    self assert: (deep includesSubstring: "Inspector(ValuePoint)") equals: true
+
+  // === Edge case: a Value with no fields ===
+  testEmptyValueHasNoFields =>
+    i := Inspector on: EmptyValue new
+    self assert: i fields size equals: 0
+
+  testEmptyValuePrintStringHasHeaderOnly =>
+    i := Inspector on: EmptyValue new
+    self assert: (i printString includesSubstring: "Inspector(EmptyValue)") equals: true
+
+  // === Edge case: drilling into a scalar yields a leaf cursor with no fields ===
+  testDrilledScalarHasNoFields =>
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    child := (i at: #x) unwrap
+    self assert: child fields size equals: 0
+    self assert: child kind equals: #value
+
+  // === `Inspector on:` is the Phase-1 entry point (inspect repurpose is Phase 3) ===
+  testInspectorOnIsTheEntryPoint =>
+    // ADR 0095 Phase 1 ships `Inspector on:`; `Object >> inspect` still returns a
+    // String (the breaking repurpose is Phase 3, BT-2504). `Inspector on:` is the
+    // unambiguous way to open a cursor on any receiver.
+    i := Inspector on: (ValuePoint x: 3 y: 4)
+    self assert: i kind equals: #value


### PR DESCRIPTION
Implements **Phase 1** of [ADR 0095 — Rich Navigable Inspector](docs/ADR/0095-rich-navigable-inspector.md) (epic [BT-2501](https://linear.app/beamtalk/issue/BT-2501)).

Linear: https://linear.app/beamtalk/issue/BT-2502

## Summary

The foundation for a Pharo-style, drillable object inspector: an immutable `Inspector` cursor over a single object plus an `InspectorField` record, covering the two no-extra-machinery kinds — `#value` (pure structural traversal of `field:` slots in ADR-0094 sort order) and `#actor` (a lazy, timeout-guarded `sys:get_state` snapshot). A busy/dead/non-`sys` actor degrades to a single `InspectorField name: #status value: #unavailable` — never a crash.

## Key changes

- **`stdlib/src/Inspector.bt`** — `sealed typed Object subclass`, a `kind`-tagged immutable cursor: `on:`, `subject`, `kind`, `fields`, `at:` (→ child cursor, `Result error: no_such_field` on miss), `parent`/`root`/`path`, `refresh`, `printString`/`printStringExpanded:`. Carried state lives in a runtime-minted handle (Object subclasses have no `field:` slots, ADR 0067).
- **`stdlib/src/InspectorField.bt`** — `sealed typed Value subclass` (`name`/`label`/`value`/`kind`/`drillable`), mirroring `SupervisionNode`/`SubscriptionNode`.
- **`runtime/.../beamtalk_inspector.erl`** — the shim: kind classification (a Beamtalk actor handle `#beamtalk_object{}` or bare pid → `#actor`), ADR-0094-sorted slot derivation, `at:` drill, `refresh` re-snapshot, and a depth-bounded `printString` tree with an **ancestor-scoped pid cycle guard** (back-reference marker on a true cycle; shared references still expand).
- **`runtime/.../beamtalk_process_navigation.erl`** — shared timeout-guarded `guarded_state/1,2` (ADR 0095 §4): the single safe live-state read, reused by the Inspector.
- **`stdlib/src/Object.bt`** — `inspect` doc now points to `Inspector on:`; the *repurpose* of `inspect` itself (`String → Inspector`, removing the 14 `inspect -> String` overrides, the gradual-typing audit) remains the breaking change deferred to Phase 3 (BT-2504). `inspect` still returns `String` here.

## Tests

- **`stdlib/test/inspector_test.bt`** (BUnit): value drill, actor snapshot + frozen-snapshot + refresh, dead-actor `#unavailable`, `no_such_field`, immutable `parent`/`root`/`path`, cycle back-reference, diamond (shared, non-cyclic) reference, depth bound, empty value, scalar leaf.
- **`runtime/.../beamtalk_inspector_tests.erl`** (EUnit): classification, sorted field derivation, drillability, `at:` + `no_such_field`, refresh, shared `guarded_state` (live / dead / non-pid), actor snapshot + `#unavailable` degradation.

CI: `just ci` green (clippy, fmt-check, dialyzer, stdlib 250, BUnit 2532, runtime EUnit 4838+1526, parity).

## Out of scope (later phases)

`#collection`/`#foreign` kinds, value `evaluate:`, windowing, `asDictionaries`, and the breaking `inspect` migration.

https://claude.ai/code/session_019WgxJuqbkQDvwYW8L8TrAM

---
_Generated by [Claude Code](https://claude.ai/code/session_019WgxJuqbkQDvwYW8L8TrAM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `Inspector` class for exploring and navigating object structure, supporting both values and live actor snapshots with refresh capability.
  * Added `InspectorField` value type representing drillable field details (name, label, value, kind, and drillability status).
  * Enhanced `Object>>inspect` documentation to clarify current behavior and introduce the rich inspection workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->