### PR TITLE
Inspector: language docs, e2e drill/refresh btscript; flip ADR 0095 → Implemented (BT-2505)

### DIFF
--- a/docs/ADR/0095-rich-navigable-inspector.md
+++ b/docs/ADR/0095-rich-navigable-inspector.md
@@ -1,24 +1,24 @@
 # ADR 0095: Rich Navigable Inspector — Drillable, Live-Refreshing Object Views
 
 ## Status
-Accepted (2026-06-11)
+Implemented (2026-06-11)
 
 ## Implementation Tracking
 
 **Epic:** [BT-2501](https://linear.app/beamtalk/issue/BT-2501) — Rich Navigable Inspector v1 (ADR 0095)
 **Design issue:** [BT-2397](https://linear.app/beamtalk/issue/BT-2397)
-**Status:** Planned
+**Status:** Implemented (2026-06-11)
 
 | Phase | Issue | Title | Size | Status |
 |---|---|---|---|---|
-| 1 | [BT-2502](https://linear.app/beamtalk/issue/BT-2502) | Inspector core — `Inspector`/`InspectorField` classes + navigation (`#value`/`#actor`, drill, cycle guard, render) | L | Backlog |
-| 2 | [BT-2503](https://linear.app/beamtalk/issue/BT-2503) | Collection + foreign kinds, windowing, value `evaluate:` | M | Backlog |
-| 3 | [BT-2504](https://linear.app/beamtalk/issue/BT-2504) | Repurpose `inspect` → `Inspector` — migration, lint, MCP/REPL surfaces | L | Backlog |
-| 4 | [BT-2505](https://linear.app/beamtalk/issue/BT-2505) | Language docs, BUnit, REPL e2e btscript; flip ADR → Implemented | M | Backlog |
+| 1 | [BT-2502](https://linear.app/beamtalk/issue/BT-2502) | Inspector core — `Inspector`/`InspectorField` classes + navigation (`#value`/`#actor`, drill, cycle guard, render) | L | Done (#2520) |
+| 2 | [BT-2503](https://linear.app/beamtalk/issue/BT-2503) | Collection + foreign kinds, windowing, value `evaluate:` | M | Done (#2521) |
+| 3 | [BT-2504](https://linear.app/beamtalk/issue/BT-2504) | Repurpose `inspect` → `Inspector` — migration, lint, MCP/REPL surfaces | L | Done (#2522) |
+| 4 | [BT-2505](https://linear.app/beamtalk/issue/BT-2505) | Language docs, BUnit, REPL e2e btscript; flip ADR → Implemented | M | Done |
 
 ```text
-Wave 1: BT-2502
-Wave 2: BT-2503  BT-2504          (parallel — both need only BT-2502)
+Wave 1: BT-2502  (#2520, merged)
+Wave 2: BT-2503  (#2521, merged) → BT-2504 (#2522, merged)   (serialised — both touch the Inspector class)
 Wave 3: BT-2505                   (epic closer → flips Status to Implemented)
 ```
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -1462,6 +1462,55 @@ Transcript show: "Hello"; cr; show: "World"
 
 `TranscriptStream >> show:` accepts any `Printable` value, so custom classes that conform to `Printable` work directly with `Transcript show:` without manual `asString` conversion.
 
+### Navigable Inspector (ADR 0095)
+
+`printString` renders an object to *one* string. The **Inspector** lets you *navigate into* it — drill through fields, render across surfaces (REPL text tree, MCP/browser wire form), and re-snapshot live actor state. `anObject inspect` is the shorthand for `Inspector on: anObject`; it returns a cursor, **not** a string.
+
+```beamtalk
+i := (Point x: 3 y: 4) inspect      // an Inspector cursor (#value kind)
+i fields                            // the drillable InspectorField records (x, y)
+i at: #x                            // Result(Inspector) — a child cursor on the value 3
+(i at: #x) unwrap subject           // => 3
+i printString                       // an indented text tree (Inspector(Point) + fields)
+```
+
+**One polymorphic class, four `kind`s.** A single `Inspector` carries a `kind` tag rather than a subclass per kind — classification lives in the runtime shim:
+
+| `kind` | Subject | Fields are… |
+|--------|---------|-------------|
+| `#value` | an immutable `Value` (or scalar) | its slots, in ADR 0094 sort order (`#slot`) |
+| `#actor` | a live actor | a lazy, timeout-guarded `sys:get_state` snapshot of its state |
+| `#collection` | `List`/`Array`/`Set`/`Dictionary`/`Bag` | a **window** (page size 50) of `#element` / `#association` fields |
+| `#foreign` | a non-Beamtalk OTP process | best-effort `process_info` + a guarded state snapshot (`#processInfo`) |
+
+A wedged, dead, or non-`sys` actor degrades to a single `#status: #unavailable` field — it never crashes.
+
+**Navigation is immutable.** Every navigation message returns a *new* cursor, so a UI can hold several at once:
+
+| Message | Returns |
+|---------|---------|
+| `fields` | `List(InspectorField)` — the current window of drillable fields |
+| `at: key` | `Result(Inspector)` — a child cursor on that field's value (`#no_such_field` on a miss) |
+| `parent` / `root` | the parent cursor / the top of the drill path (`nil` parent at the root) |
+| `path` | the breadcrumb of drilled keys from the root |
+| `refresh` | a fresh cursor on a newly-captured snapshot (the original is unchanged) |
+| `size` | the cheap full element count (for `#collection`), else the field count |
+| `page: n` | a new cursor on the `n`-th window (1-based) of a large collection |
+| `printString` / `printStringExpanded: depth` | the indented text tree (depth 1 = immediate fields) |
+| `asDictionaries` / `asDictionary` | the typed cross-surface wire form (one dict per field / the cursor envelope) |
+
+Each `InspectorField` is an immutable `Value` record with `name` (the navigation key), `label`, `value`, `kind`, and `drillable` (`isLeaf` is its negation).
+
+**`evaluate:` is values-only.** On a `#value` cursor, `i evaluate: "self x + self y"` compiles and runs the expression with `self` bound to the inspected value, returning a `Result` — never raising. On an `#actor` cursor it returns `Result error:` with kind `#actor_eval_unsupported` (actor evaluate-in-context is a deferred §7 follow-up). Live updates are **poll-only**: re-issue `refresh`.
+
+```beamtalk
+i := (Point x: 3 y: 4) inspect
+(i evaluate: "self x * 10") unwrap        // => 30
+(i evaluate: "self nonesuch") isError     // => true  (a Result error:, not a crash)
+```
+
+**Deferred §7 seams** (not in v1): actor evaluate-in-context (live routing), per-class `inspectorFields` custom views, `sealedFromInspection`, and push live updates (poll-only for now).
+
 ---
 
 ## Union Types and Narrowing (ADR 0068)

--- a/tests/repl-protocol/cases/inspector_evaluate.btscript
+++ b/tests/repl-protocol/cases/inspector_evaluate.btscript
@@ -11,6 +11,7 @@
 // here end-to-end alongside it.
 
 // @load tests/repl-protocol/fixtures/point.bt
+// @load tests/repl-protocol/fixtures/counter.bt
 
 // ===========================================================================
 // VALUE evaluate: — `self` bound to the inspected value (ADR 0095 §1, §7)
@@ -91,3 +92,65 @@ big fields size
 
 ((((1 to: 1000) asList inspect) asDictionary) at: #fields) size
 // => 50
+
+// ===========================================================================
+// inspect → drill → refresh, end-to-end against a VALUE and a live ACTOR
+// (ADR 0095 Phase 4, BT-2505)
+// ===========================================================================
+
+// --- VALUE: inspect → render → drill ---
+p := (Point x: 3 y: 4) inspect
+// => _
+
+p kind
+// => value
+
+// printString renders the class-headed text tree with immediate fields.
+p printString includesSubstring: "Inspector(Point)"
+// => true
+
+p printString includesSubstring: "x: 3"
+// => true
+
+// Drill into a field → a child cursor on that value; the root path stays empty.
+(p at: #x) unwrap subject
+// => 3
+
+p path
+// => []
+
+// --- ACTOR: inspect captures a live snapshot; refresh re-snapshots ---
+c := Counter spawn
+// => _
+
+c increment
+// => _
+
+c increment
+// => _
+
+// `c inspect` runs inside the actor and seeds the cursor from its in-hand state
+// (no self-`sys:get_state` deadlock) — the snapshot shows value 2.
+ci := c inspect
+// => _
+
+ci kind
+// => actor
+
+ci printString includesSubstring: "value: 2"
+// => true
+
+// The snapshot is frozen at inspect-time: mutating the actor does not change it.
+c increment
+// => _
+
+ci printString includesSubstring: "value: 2"
+// => true
+
+// refresh re-issues the guarded snapshot from outside the actor — now value 3.
+ci refresh printString includesSubstring: "value: 3"
+// => true
+
+// asDictionary envelope reports the cursor kind for the MCP/browser surfaces.
+(c inspect asDictionary) at: #kind
+// => actor


### PR DESCRIPTION
Final phase (4) of **ADR 0095 — Rich Navigable Inspector** ([BT-2505](https://linear.app/beamtalk/issue/BT-2505)), the epic closer.

## What's in this PR
- **Language docs** — a dedicated *Navigable Inspector* section in `docs/beamtalk-language-features.md`: `anObject inspect` opens a cursor (not a string); the four `#kind`s (`#value`/`#actor`/`#collection`/`#foreign`); immutable navigation (`fields`/`at:`/`parent`/`root`/`path`/`refresh`); `size`/`page:` windowing; the `printString` text tree; the `asDictionaries`/`asDictionary` wire form; values-only `evaluate:` (with `#actor_eval_unsupported`); and the deferred §7 seams.
- **REPL e2e** — `inspector_evaluate.btscript` now drives the full loop end-to-end: `inspect → render → drill` on a `#value`, and `inspect → snapshot → refresh` on a **live actor** (asserting the snapshot is frozen at inspect-time and `refresh` re-captures), plus the `asDictionary` kind envelope.
- **ADR 0095** — Status `Accepted` → **Implemented**; phase table marked Done with PR refs (#2520, #2521, #2522).

## Coverage note
The "comprehensive BUnit consolidating the protocol" acceptance criterion is already satisfied by `stdlib/test/inspector_test.bt` (built up across BT-2502..2504): value/actor/collection/foreign drill, cycle back-reference, window pagination + `page:` + direct-index `at:`, dead-actor `#unavailable`, and `evaluate:` + `actor_eval_unsupported`. No redundant tests added.

Local `just ci` is green except one pre-existing, unrelated flake (`beamtalk_repl_loader_tests:t_new_class_target_exists` — a local working-directory `enoent`, not touched by this PR); the new e2e btscript and all other suites pass.

https://claude.ai/code/session_019WgxJuqbkQDvwYW8L8TrAM