### PR TITLE
fix(liveview): send flat op params to workspace protocol (BT-2496)

### DIFF
--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -273,7 +273,10 @@ defmodule BtAttach.Workspace do
   # term is returned verbatim — `encode/2` (JSON) is never invoked, so the
   # wire-shaped rows arrive live over distribution (BT-2399 / ADR 0096).
   defp dispatch_browse(op, params) when is_binary(op) and is_map(params) do
-    request = %{"op" => op, "params" => params}
+    # The protocol is FLAT: `decode_map/1` reads each op param as a TOP-LEVEL key
+    # (`params = maps:without([op, id, session], Map)`), not from a nested
+    # `"params"` sub-map. Merge the op's params straight in alongside `"op"`.
+    request = Map.put(params, "op", op)
 
     case rpc(:beamtalk_repl_protocol, :decode, [encode_json(request)]) do
       {:ok, msg} ->
@@ -299,7 +302,10 @@ defmodule BtAttach.Workspace do
   # dispatch through the term-returning op layer. `dispatch/4` returns the
   # `op_result()` term directly — JSON encoding (`encode/2`) is never invoked.
   defp dispatch_eval(session_pid, expression) do
-    request = %{"op" => "eval", "params" => %{"code" => expression}}
+    # Flat protocol: `code` is a top-level key, NOT nested under `"params"` (see
+    # `dispatch_browse/2`). A nested map decodes to `params = %{"params" => …}`,
+    # so the eval op never finds `code` and reports an empty expression.
+    request = %{"op" => "eval", "code" => expression}
 
     case rpc(:beamtalk_repl_protocol, :decode, [encode_json(request)]) do
       {:ok, msg} ->
@@ -696,7 +702,9 @@ defmodule BtAttach.Workspace do
   # directly — JSON encoding (`encode/2`) is never invoked, so the fields stay
   # live terms with their messageable pids intact.
   defp dispatch_inspect(pid_str) do
-    request = %{"op" => "inspect", "params" => %{"actor" => pid_str}}
+    # Flat protocol: `actor` is a top-level key, NOT nested under `"params"`
+    # (see `dispatch_browse/2`).
+    request = %{"op" => "inspect", "actor" => pid_str}
 
     case rpc(:beamtalk_repl_protocol, :decode, [encode_json(request)]) do
       {:ok, msg} ->

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -74,8 +74,14 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
 
   test "eval round-trip renders the workspace result term", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/")
-    html = view |> form("#eval-form") |> render_submit(%{expr: "3 + 4"})
-    assert html =~ "7"
+    view |> form("#eval-form") |> render_submit(%{expr: "3 + 4"})
+    # Scope the assertion to the result value element, NOT the whole page: the
+    # connected shell renders a session id (`phoenix-<integer>`) whose digits
+    # would let a bare `html =~ "7"` pass even when eval is completely broken and
+    # the result pane shows an error. The value span is the real signal — it must
+    # carry the computed `7` and there must be no error pane (BT-2496).
+    assert view |> element(".ws-result:not(.err) .val") |> render() =~ "7"
+    refute render(view) =~ "Empty expression"
   end
 
   test "eval state persists across evals within a session", %{conn: conn} do
@@ -83,8 +89,10 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
 
     # Bind a variable, then read it back in a later eval on the same session.
     view |> form("#eval-form") |> render_submit(%{expr: "x := 21 * 2"})
-    html = view |> form("#eval-form") |> render_submit(%{expr: "x"})
-    assert html =~ "42"
+    view |> form("#eval-form") |> render_submit(%{expr: "x"})
+    # Result-scoped (see "eval round-trip" above) so a session-id digit can't
+    # spuriously satisfy the assertion when eval is broken.
+    assert view |> element(".ws-result:not(.err) .val") |> render() =~ "42"
   end
 
   test "Transcript output streams live into the LiveView", %{conn: conn} do


### PR DESCRIPTION
Fixes the 3 workspace-gated LiveView e2e failures in BT-2496.

Linear: https://linear.app/beamtalk/issue/BT-2496

## Root cause — one bug behind all three failures

`BtAttach.Workspace` built every Attach-topology op request with its params nested under a `"params"` sub-map:

```elixir
%{"op" => "eval", "params" => %{"code" => expression}}   # wrong
```

…but the workspace protocol decoder is **flat**: `beamtalk_repl_protocol:decode_map/1` does `params = maps:without([op, id, session], Map)`. So the decoded params became `%{"params" => %{"code" => …}}`, the eval op never found `"code"`, and **every eval returned `empty_expression`** → no class compiled, no binding created, Inspector + System Browser dead. The same nesting bug was in `dispatch_inspect/1` (`actor`) and `dispatch_browse/2` (`class`/`side`/`selector`).

Broken since the file was first added (`7fe8358`, Epic BT-2416) — not introduced by the Cockpit UI rebuild.

## Why it went undetected

1. **No workspace-gated CI leg.** `liveview.yml` runs `mix test` with no `BT_WORKSPACE_COOKIE`, so `test_helper.exs` excludes every `:workspace` test. (Tracked: BT-2510.)
2. **Spurious green.** `eval round-trip` / `eval state persists` asserted `html =~ "7"` / `=~ "42"`, which match digits in the connected shell's `phoenix-<integer>` session id — so they passed even with eval 100% broken.

## Changes

- `dispatch_eval/1`, `dispatch_inspect/1`, `dispatch_browse/2`: build **flat** requests (`code`/`actor`/op params as top-level keys).
- Harden the two round-trip assertions to scope to the `.ws-result .val` element so a session-id digit can't satisfy them again.

## Verification (live `spike` workspace)

- All 3 target tests green: BT-2408 inspect, BT-2409 save+observe, BT-2410 session isolation.
- Full `editors/liveview` suite **134/0** with `mix test --include workspace`.
- Fix validated end-to-end via direct probes: `3 + 4 → {:ok, 7}`, `Counter spawn → {:beamtalk_object, …, #PID<…>}`, `browse_classes → 99 classes`, `browse_class_definition("Integer") → {:value, …}`.
- `mix format --check-formatted` and `mix compile --warnings-as-errors` clean.

## Follow-up
- BT-2510: add a workspace-gated CI leg so the Attach eval path can't rot silently again.

https://claude.ai/code/session_01GvkPAk5baPkCyJarjMo1p7

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvkPAk5baPkCyJarjMo1p7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced eval operation test assertions for more precise result verification and improved error detection.

* **Chores**
  * Internal protocol request structure optimization for consistency across browse, eval, and inspect operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->