### PR TITLE
Inspector edge-case fixes: self-shadow, empty-list, dead-actor refresh, forged maps (BT-2509)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -211,25 +211,25 @@ impl CoreErlangGenerator {
                     // BT-2503 (ADR 0095 §1): at the top level of a REPL eval there is
                     // no enclosing-method receiver, so a bare `Self` would be an
                     // unbound Core Erlang variable. Resolve `self` from the bindings
-                    // map instead (the same `maps:find` → `resolve_name` path a free
-                    // identifier takes), so the Inspector's value `evaluate:` can bind
-                    // `self` to the inspected value by passing `#{self => Value}`. A
-                    // bare `self` with no such binding falls through to
-                    // `resolve_name`, yielding an `undefined_variable` error rather
-                    // than a crash.
+                    // map instead, so the Inspector's value `evaluate:` can bind
+                    // `self` to the inspected value by passing `#{self => Value}`.
+                    // BT-2509: on a miss, raise `undefined_variable` directly rather
+                    // than routing through `resolve_name`, whose `bind:as:` tier would
+                    // let a user binding named `self` silently shadow the reserved
+                    // word. A top-level `self` with no `#{self => _}` binding is
+                    // genuinely undefined.
                     let state_var = self.current_state_var();
                     let resolved_var = self.fresh_var("Resolved");
                     Ok(docvec![
                         "case call 'maps':'find'('self', ",
-                        leaf::var(state_var.clone()),
+                        leaf::var(state_var),
                         ") of ",
                         "<{'ok', ",
                         leaf::var(resolved_var.clone()),
                         "}> when 'true' -> ",
                         leaf::var(resolved_var),
-                        " <'error'> when 'true' -> call 'beamtalk_workspace':'resolve_name'(",
-                        leaf::var(state_var),
-                        ", 'self') ",
+                        " <'error'> when 'true' -> ",
+                        "call 'beamtalk_workspace':'raise_undefined_variable'('self') ",
                         "end",
                     ])
                 } else {

--- a/crates/beamtalk-core/src/repl/codegen.rs
+++ b/crates/beamtalk-core/src/repl/codegen.rs
@@ -983,6 +983,27 @@ mod tests {
     }
 
     #[test]
+    fn repl_self_miss_raises_undefined_variable_not_resolve_name() {
+        // BT-2509: a top-level `self` resolves from the bindings map, but on a
+        // miss it must raise `undefined_variable` directly — never route through
+        // `resolve_name`, whose `bind:as:` tier would let a user binding named
+        // `self` silently shadow the reserved word.
+        let result = generate_repl_expression(&ident_expr("self"), "repl_self_test").unwrap();
+        assert!(
+            result.contains("'maps':'find'('self'"),
+            "self should be resolved from the bindings map"
+        );
+        assert!(
+            result.contains("'raise_undefined_variable'('self')"),
+            "a self miss should raise undefined_variable directly"
+        );
+        assert!(
+            !result.contains("'resolve_name'"),
+            "self must not fall through to resolve_name (bind:as: shadow)"
+        );
+    }
+
+    #[test]
     fn repl_module_structure() {
         let result = generate_repl_expression(&int_expr(1), "repl_mod_struct").unwrap();
         // Verify the essential Core Erlang module structure

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_inspector.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_inspector.erl
@@ -460,6 +460,11 @@ label_for(Key) -> iolist_to_binary(io_lib:format("~p", [Key])).
 %% collection-tagged maps all qualify; a tagged `Value`/`Actor`/exception map does
 %% not.
 -spec is_collection(term()) -> boolean().
+is_collection([]) ->
+    %% The empty list `#()` is a leaf (no elements to navigate), consistent with
+    %% `is_drillable([])` — direct `Inspector on: #()` and a drilled `#()` field
+    %% agree it is not a collection (BT-2509).
+    false;
 is_collection(Subject) when is_list(Subject) ->
     %% Only *proper* (nil-terminated) lists are collections. Improper lists
     %% (e.g. `[1|2]`, routine in foreign OTP process state) would crash the
@@ -489,7 +494,7 @@ collection_size(Subject) when is_list(Subject) ->
     length(Subject);
 collection_size(Subject) when is_map(Subject) ->
     case beamtalk_tagged_map:class_of(Subject, 'Dictionary') of
-        'Array' -> array:size(maps:get(data, Subject, array:new()));
+        'Array' -> array:size(array_data(Subject));
         'Set' -> length(set_elements(Subject));
         'Bag' -> bag_size(Subject);
         _ -> length(dictionary_pairs(Subject))
@@ -517,7 +522,7 @@ collection_fields(Subject, Page) ->
 -spec keyed_collection_pairs(term()) -> {ok, [{term(), term()}]} | not_keyed.
 keyed_collection_pairs(Subject) when is_map(Subject) ->
     case beamtalk_tagged_map:class_of(Subject, 'Dictionary') of
-        'Bag' -> {ok, dictionary_pairs(maps:get(counts, Subject, #{}))};
+        'Bag' -> {ok, bag_counts_pairs(Subject)};
         Class when Class =:= 'Array'; Class =:= 'Set' -> not_keyed;
         _ -> {ok, dictionary_pairs(Subject)}
     end;
@@ -531,21 +536,46 @@ ordered_elements(Subject) when is_list(Subject) ->
     Subject;
 ordered_elements(Subject) when is_map(Subject) ->
     case beamtalk_tagged_map:class_of(Subject, 'Dictionary') of
-        'Array' -> array:to_list(maps:get(data, Subject, array:new()));
+        'Array' -> array:to_list(array_data(Subject));
         'Set' -> set_elements(Subject);
         _ -> []
     end.
 
-%% The `ordsets`-backed element list of a `Set`.
+%% The `array`-backing of an `Array` tagged map. A forged/malformed tagged map
+%% (e.g. `#{'$beamtalk_class' => 'Array', data => 42}`) whose `data` is missing or
+%% not a real `array` must not crash `array:size/1`/`array:to_list/1` — degrade to
+%% an empty array (BT-2509). `array:is_array/1` is total (false for any non-array).
+-spec array_data(map()) -> array:array().
+array_data(Subject) ->
+    Data = maps:get(data, Subject, array:new()),
+    case array:is_array(Data) of
+        true -> Data;
+        false -> array:new()
+    end.
+
+%% The `ordsets`-backed element list of a `Set` — `[]` for a forged map whose
+%% `elements` field is not a list (must not crash `length/1`/`lists:nth/2`).
 -spec set_elements(map()) -> [term()].
 set_elements(Subject) ->
-    maps:get(elements, Subject, []).
+    case maps:get(elements, Subject, []) of
+        Elements when is_list(Elements) -> Elements;
+        _ -> []
+    end.
 
-%% A `Bag`'s total size — the sum of its element counts.
+%% A `Bag`'s total size — the sum of its element counts. A forged map whose
+%% `counts` field is not a map degrades to `0` (`dictionary_pairs/1` requires a
+%% map).
 -spec bag_size(map()) -> non_neg_integer().
 bag_size(Subject) ->
-    Counts = maps:get(counts, Subject, #{}),
-    lists:sum([C || {_K, C} <- dictionary_pairs(Counts), is_integer(C)]).
+    lists:sum([C || {_K, C} <- bag_counts_pairs(Subject), is_integer(C)]).
+
+%% The `{Element, Count}` pairs of a `Bag`, tolerating a forged non-map `counts`.
+-spec bag_counts_pairs(map()) -> [{term(), term()}].
+bag_counts_pairs(Subject) ->
+    case maps:get(counts, Subject, #{}) of
+        Counts when is_map(Counts) -> dictionary_pairs(Counts);
+        _ -> []
+    end.
 
 %% The user key→value pairs of a (tagged or plain) Dictionary map, in a stable
 %% sorted order so windows are deterministic. The `'$beamtalk_class'` tag (if any)
@@ -592,7 +622,7 @@ element_at(Subject, Index) when is_integer(Index), Index >= 1 ->
         _ when is_map(Subject) ->
             case beamtalk_tagged_map:class_of(Subject, 'Dictionary') of
                 'Array' ->
-                    Arr = maps:get(data, Subject, array:new()),
+                    Arr = array_data(Subject),
                     case Index =< array:size(Arr) of
                         true -> {ok, array:get(Index - 1, Arr)};
                         false -> out_of_range
@@ -778,7 +808,10 @@ immutable term cannot move on its own). The new cursor preserves `parent` and
 """.
 -spec refresh(inspector()) -> inspector().
 refresh(#{kind := actor, pid := Pid, parent := Parent, path := Path}) ->
-    cursor(Pid, Parent, Path);
+    %% Re-snapshot as an `#actor`, not via `cursor/3` (→ `process_cursor`): a now
+    %% dead actor would re-classify as `#foreign` and lose the actor kind. A dead
+    %% actor stays `#actor` with `available => false` (BT-2509).
+    actor_cursor(Pid, Parent, Path);
 refresh(#{kind := foreign, pid := Pid, parent := Parent, path := Path}) ->
     cursor(Pid, Parent, Path);
 refresh(#{kind := collection, subject := Subject, page := Page, parent := Parent, path := Path}) ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_inspector_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_inspector_tests.erl
@@ -364,3 +364,49 @@ foreign_evaluate_unsupported_test() ->
     {error, Err} = beamtalk_inspector:evaluate(I, <<"self">>),
     ?assertEqual(actor_eval_unsupported, Err#beamtalk_error.kind),
     gen_server:stop(Pid).
+
+%%====================================================================
+%% Edge cases (BT-2509)
+%%====================================================================
+
+%% The empty list `#()` is a leaf `#value`, not a `#collection` — consistent with
+%% a drilled empty-list field (which is also a leaf).
+empty_list_is_value_leaf_test() ->
+    I = beamtalk_inspector:on([]),
+    ?assertEqual(value, beamtalk_inspector:kindOf(I)),
+    %% A tagged value whose slot holds `#()` renders that slot as a non-drillable
+    %% leaf field.
+    V = #{'$beamtalk_class' => 'Holder', items => []},
+    HF = hd([
+        F
+     || F <- beamtalk_inspector:fieldsOf(beamtalk_inspector:on(V)),
+        maps:get(name, F) =:= items
+    ]),
+    ?assertEqual(false, maps:get(drillable, HF)).
+
+%% `refresh` of an `#actor` whose process has died stays `#actor` (unavailable),
+%% rather than re-classifying as `#foreign` and losing the actor kind.
+dead_actor_refresh_stays_actor_test() ->
+    Pid = start_actor(point(1, 2)),
+    I = beamtalk_inspector:on(Pid),
+    ?assertEqual(actor, beamtalk_inspector:kindOf(I)),
+    gen_server:stop(Pid),
+    R = beamtalk_inspector:refresh(I),
+    ?assertEqual(actor, beamtalk_inspector:kindOf(R)),
+    [StatusF] = beamtalk_inspector:fieldsOf(R),
+    ?assertEqual(status, maps:get(name, StatusF)),
+    ?assertEqual(unavailable, maps:get(value, StatusF)).
+
+%% A forged/malformed collection-tagged map (wrong-typed `data`/`elements`/`counts`)
+%% must not crash `array:size/1`, `length/1`, etc. — it degrades to an empty view.
+forged_collection_maps_never_crash_test() ->
+    Array = #{'$beamtalk_class' => 'Array', data => 42},
+    IA = beamtalk_inspector:on(Array),
+    ?assertEqual(collection, beamtalk_inspector:kindOf(IA)),
+    ?assertEqual(0, beamtalk_inspector:sizeOf(IA)),
+    ?assertEqual([], beamtalk_inspector:fieldsOf(IA)),
+    ?assert(is_binary(beamtalk_inspector:printString(IA, 1))),
+    Set = #{'$beamtalk_class' => 'Set', elements => not_a_list},
+    ?assertEqual(0, beamtalk_inspector:sizeOf(beamtalk_inspector:on(Set))),
+    Bag = #{'$beamtalk_class' => 'Bag', counts => not_a_map},
+    ?assertEqual(0, beamtalk_inspector:sizeOf(beamtalk_inspector:on(Bag))).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace.erl
@@ -13,6 +13,7 @@ It delegates to beamtalk_workspace_meta for workspace metadata.
 """.
 
 -export([status/0, resolve_name/2, resolve_class_reference/2, resolve_singleton_instance/1]).
+-export([raise_undefined_variable/1]).
 
 -doc """
 Resolve a bare name against session locals + live workspace sources (ADR 0081).
@@ -25,6 +26,19 @@ classes → undefined_variable) shared with `Session resolve:`.
 -spec resolve_name(map(), atom()) -> term().
 resolve_name(Locals, Name) ->
     beamtalk_workspace_interface_primitives:resolve_name(Locals, Name).
+
+-doc """
+Raise the `undefined_variable` error for `Name` directly, bypassing the workspace
+resolution tiers (BT-2509).
+
+The REPL `self` codegen uses this on a bindings-map miss: a top-level `self` has
+no receiver and must be `undefined_variable`, NOT resolved through
+`resolve_name/2` — whose `bind:as:` tier would let a user binding named `self`
+silently shadow the reserved word.
+""".
+-spec raise_undefined_variable(atom()) -> no_return().
+raise_undefined_variable(Name) ->
+    beamtalk_error:raise(beamtalk_repl_errors:ensure_structured_error({undefined_variable, Name})).
 
 -doc """
 Resolve a capitalised class reference not found in the session locals (ADR 0081).


### PR DESCRIPTION
Four of the five LOW edge-case findings from the BT-2503 review, fixed.

| # | Finding | Fix |
|---|---------|-----|
| 1 | REPL `bind: #self as: X` silently shadows the reserved word `self` | A top-level `self` miss raises `undefined_variable` directly (new `beamtalk_workspace:raise_undefined_variable/1`) instead of routing through `resolve_name` (whose `bind:as:` tier found the user binding). Codegen test added. |
| 2 | Empty list `#()` classified `#collection` directly but leaf when drilled | `is_collection([])` → `false`; `#()` is now consistently a leaf `#value`. |
| 3 | `refresh` of a dead `#actor` flips it to `#foreign`, losing the kind | `refresh` re-snapshots via `actor_cursor` — a dead actor stays `#actor` (unavailable). |
| 5 | Forged collection-tagged maps (`#{'$beamtalk_class' => 'Array', data => 42}`) crash `array:size/1` | `array_data/1`, `set_elements/1`, `bag_counts_pairs/1` guard the wrong-typed field and degrade to empty. |

Regression tests: `empty_list_is_value_leaf_test`, `dead_actor_refresh_stays_actor_test`, `forged_collection_maps_never_crash_test` (runtime EUnit), and `repl_self_miss_raises_undefined_variable_not_resolve_name` (codegen). Local `just ci` green.

## Deferred — finding #4 (charlist rendering)
Charlists from foreign state render as integer collections. The obvious fix (exclude `io_lib:printable_list/1` from `is_collection`) is a **global** heuristic that would mis-render legitimate Beamtalk integer lists like `#(72, 73)` as `"HI"` — a worse regression. A correct fix needs foreign-state-scoped (provenance-aware) detection. Tracked as a follow-up so it isn't silently dropped.

https://claude.ai/code/session_019WgxJuqbkQDvwYW8L8TrAM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the `self` identifier handling in the REPL to prevent accidental shadowing by user bindings.
  * Enhanced collection introspection to gracefully handle malformed or empty collections without crashes.
  * Refined dead actor handling in the inspector to maintain consistent state classification.

* **Tests**
  * Added comprehensive edge case tests for collection introspection and dead actor refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->