### PR TITLE
Derive LiveView IDE version from the repo VERSION file (BT-2514)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Prefer `stdlib/test/*.bt` (BUnit TestCase) for new tests. Only use `stdlib/boots
 Version flows automatically at build time:
 - **Rust:** `build.rs` reads `VERSION` + git state → `BEAMTALK_VERSION` compile-time env var
 - **Erlang:** `.app.src` files use `{vsn, {cmd, "escript ../../../scripts/version.escript"}}`
+- **LiveView IDE (Elixir):** `editors/liveview/mix.exs` reads `VERSION` at compile time, so the `bt_attach` release/Docker tag tracks the toolchain version (BT-2514). It ships on its own release lane (BT-2512), not the core bundle.
 - **Dev builds** (not on a git tag): version becomes `0.3.0-dev+<short sha>`
 - **Release builds** (on a git tag): version is the clean `0.3.0`
 
@@ -75,7 +76,7 @@ Version flows automatically at build time:
 4. Update version references in docs (`README.md`, `docs/beamtalk-tooling.md`, `docs/beamtalk-language-features.md`, `docs/repl-protocol.md`, `docs/beamtalk-ddd-model.md`, `crates/beamtalk-examples/corpus.json`)
 5. Tag the release commit: `git tag v<version>`
 
-**Do not** manually edit version strings in `.app.src` files or `build_stdlib.rs` — they are derived from `VERSION` at build time.
+**Do not** manually edit version strings in `.app.src` files, `build_stdlib.rs`, or `editors/liveview/mix.exs` — they are derived from `VERSION` at build time.
 
 ## Issue Workflow (Linear)
 

--- a/editors/liveview/mix.exs
+++ b/editors/liveview/mix.exs
@@ -1,10 +1,23 @@
 defmodule BtAttach.MixProject do
   use Mix.Project
 
+  # Single source of truth: the repo-root VERSION file (CLAUDE.md "Versioning &
+  # Releases"). The LiveView IDE ships on its own release lane (BT-2512) but
+  # tracks the same version as the eval/Transcript surface it attaches to
+  # (BT-2394 spike, BT-2514), so it is read here at compile time rather than
+  # hand-edited. Artifact-level dev suffixing (`-dev+<sha>` off a release tag)
+  # is applied by the packaging lane (BT-2515/BT-2516), matching how the Erlang
+  # apps derive theirs via scripts/version.escript. The fallback keeps `mix`
+  # usable when the app is built outside the monorepo tree.
+  @version (case File.read(Path.expand("../../VERSION", __DIR__)) do
+              {:ok, contents} -> String.trim(contents)
+              {:error, _} -> "0.0.0"
+            end)
+
   def project do
     [
       app: :bt_attach,
-      version: "0.1.0",
+      version: @version,
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## What

`editors/liveview/mix.exs` hardcoded `version: "0.1.0"`. It now reads the repo-root `VERSION` file at compile time, so the `bt_attach` LiveView IDE release/Docker artifacts track the toolchain version — the lockstep intent recorded in the BT-2394 topology spike.

- `@version` reads `Path.expand("../../VERSION", __DIR__)` with a `"0.0.0"` fallback so `mix` still works when the app is built outside the monorepo tree.
- Artifact-level dev suffixing (`-dev+<sha>` off a release tag) is left to the packaging lane (BT-2515 / BT-2516), matching how the Erlang apps derive theirs via `scripts/version.escript`.
- `CLAUDE.md` "Versioning & Releases" documents the new source and adds `mix.exs` to the "do not hand-edit version" note.

## Verification

```
$ cd editors/liveview && mix eval 'IO.puts(Mix.Project.config()[:version])'
0.4.0
$ mix format --check-formatted mix.exs   # clean
```

Part of epic BT-2512 (package & distribute the LiveView IDE as a separate release lane). Foundation issue — no behaviour change beyond the version string.

https://claude.ai/code/session_01W8pYcUFqHjKEzrjnr127W3

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8pYcUFqHjKEzrjnr127W3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version flow documentation for the LiveView IDE component and release process

* **Build**
  * LiveView IDE now derives version from a centralized VERSION file at compile time instead of a hardcoded value

<!-- end of auto-generated comment: release notes by coderabbit.ai -->