### PR TITLE
Add a Mix release config + dist-liveview recipe to the LiveView IDE (BT-2513)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -216,6 +216,25 @@ web-remote name:
     mix assets.deploy
     exec mix phx.server
 
+# Build a self-contained, ERTS-embedded release of the LiveView IDE (BT-2513).
+# Bundles JS+CSS (minified, digested) and produces
+# editors/liveview/_build/prod/rel/bt_attach — runnable with no Elixir/Mix on
+# the host. This is the artifact the packaging lane ships (BT-2515 archive,
+# BT-2516 Docker), separate from the core `just dist` bundle (BT-2512).
+#   just dist-liveview
+[unix]
+[working-directory: 'editors/liveview']
+dist-liveview:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export MIX_ENV=prod
+    echo "📦 Building LiveView IDE release (bt_attach)..."
+    mix deps.get --only prod
+    mix assets.deploy
+    mix release --overwrite
+    echo "✅ LiveView IDE release at editors/liveview/_build/prod/rel/bt_attach"
+    echo "   Run: PHX_SERVER=true SECRET_KEY_BASE=... _build/prod/rel/bt_attach/bin/bt_attach start"
+
 # Build Erlang runtime
 [working-directory: 'runtime']
 build-erlang:

--- a/editors/liveview/mix.exs
+++ b/editors/liveview/mix.exs
@@ -22,7 +22,27 @@ defmodule BtAttach.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
-      deps: deps()
+      deps: deps(),
+      releases: releases()
+    ]
+  end
+
+  # Self-contained, ERTS-embedded OTP release of the LiveView IDE (BT-2513).
+  #
+  # `MIX_ENV=prod mix release` (see `just dist-liveview`) produces
+  # `_build/prod/rel/bt_attach`, runnable with `bin/bt_attach start` and no
+  # Elixir/Mix on the host. The server is enabled at boot by `PHX_SERVER=true`
+  # (config/runtime.exs); OIDC / workspace-attach env (ADR 0091) is read there
+  # too, so the release honours the same configuration as `just web-remote`.
+  # This is the artifact the packaging lane ships (BT-2515 archive, BT-2516
+  # Docker) — the IDE's own release lane, never the core toolchain bundle
+  # (BT-2512).
+  defp releases do
+    [
+      bt_attach: [
+        include_executables_for: [:unix],
+        applications: [bt_attach: :permanent]
+      ]
     ]
   end
 


### PR DESCRIPTION
## What

Adds a `mix release` story to the LiveView IDE (`bt_attach`), the foundation for shipping it on its own release lane (epic BT-2512).

- **`editors/liveview/mix.exs`** — new `releases/0` returning a `bt_attach` release (`include_executables_for: [:unix]`, `applications: [bt_attach: :permanent]`). Produces a self-contained, ERTS-embedded OTP release runnable with no Elixir/Mix on the host.
- **`Justfile`** — new `just dist-liveview` recipe wrapping `mix deps.get --only prod` + `mix assets.deploy` + `mix release --overwrite`, emitting `editors/liveview/_build/prod/rel/bt_attach`.
- No `config/runtime.exs` change needed: it already enables the server via `PHX_SERVER` and reads the ADR 0091 OIDC / workspace-attach env (`SECRET_KEY_BASE`, `PHX_HOST`, `PORT`, `BT_WORKSPACE_NODE/COOKIE`, `BT_OIDC_*`), so the release honours the same configuration as `just web-remote`. OIDC fail-closed behaviour is preserved (the `IdeConfig.load!()` path runs in prod).

## Verification

```
$ just dist-liveview
✅ LiveView IDE release at editors/liveview/_build/prod/rel/bt_attach
$ _build/prod/rel/bt_attach/bin/bt_attach version
bt_attach 0.4.0          # version lockstep (BT-2514)
```

Release serves minified + digested assets (`cache_manifest.json` generated). The packaging lane (BT-2515 archive, BT-2516 Docker) consumes this release; this PR does not touch the core `beamtalk-<version>` bundle.

> Note for BT-2515's CI smoke step: prod `runtime.exs` binds the HTTP listener on IPv6 `::`; the smoke runner must support IPv6 (or the step should bind IPv4 loopback).

Part of epic BT-2512.

https://claude.ai/code/session_01W8pYcUFqHjKEzrjnr127W3

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8pYcUFqHjKEzrjnr127W3)_