### PR TITLE
Add liveview-release.yml: per-platform IDE release archives (BT-2515)

### DIFF
--- a/.github/workflows/liveview-release.yml
+++ b/.github/workflows/liveview-release.yml
@@ -1,0 +1,148 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+#
+# LiveView IDE Release Pipeline
+# =============================
+# Builds self-contained, ERTS-embedded `mix release` archives of the LiveView
+# IDE (bt_attach) and, on a full release, uploads them to the GitHub Release.
+#
+# The IDE ships on its OWN release lane — separate from the compiler/runtime
+# bundle (release.yml) and the VS Code extension (release-vscode.yml) — because:
+#   1. It is a separate consumer (Attach topology, ADR 0017/0091): its own BEAM
+#      node, reached over Erlang distribution; it never lives in the core bundle.
+#   2. Its Elixir/Phoenix toolchain must not be forced onto every CLI install.
+#   3. It can ship fixes without a full compiler release.
+#
+# Trigger modes (mirrors release-vscode.yml):
+#   - workflow_call: invoked by release.yml during a full release (uploads to the
+#     GitHub Release by default).
+#   - workflow_dispatch: manual build (artifacts only unless `publish` is set).
+#
+# Windows is out of scope: per ADR 0091 the remote IDE host is Linux/macOS;
+# Windows is a browser-only client.
+#
+# Related: release.yml (core bundle), liveview.yml (per-PR CI)
+# Issue: BT-2515 (epic BT-2512)
+
+name: LiveView IDE Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Upload archives to the GitHub Release (otherwise build artifacts only)'
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      publish:
+        description: 'Upload archives to the GitHub Release'
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: liveview-release-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build IDE release (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    permissions:
+      contents: write # gh release upload on a full release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux-x86_64
+          - runner: macos-latest
+            platform: macos-arm64
+          - runner: macos-15-intel
+            platform: macos-x86_64
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      # The IDE version tracks the repo VERSION file (BT-2514), matching the
+      # version mix.exs embeds in the release — so the archive name agrees with
+      # what `bin/bt_attach version` reports.
+      - name: Determine version
+        id: version
+        shell: bash
+        run: echo "version=$(tr -d '[:space:]' < VERSION)" >> "$GITHUB_OUTPUT"
+
+      # setup-beam installs an Elixir precompiled for OTP 27 — the supported
+      # toolchain (never the distro `elixir`, which pins erlang < 26).
+      - name: Install Erlang/OTP + Elixir
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
+        with:
+          otp-version: '27.0'
+          elixir-version: '1.18'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Mix deps and build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            editors/liveview/deps
+            editors/liveview/_build
+          key: ${{ runner.os }}-${{ matrix.platform }}-liveview-rel-${{ hashFiles('editors/liveview/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.platform }}-liveview-rel-
+
+      - name: Build release
+        working-directory: editors/liveview
+        run: |
+          export MIX_ENV=prod
+          mix deps.get --only prod
+          mix assets.setup
+          mix assets.deploy
+          mix release --overwrite
+
+      # Boot the ERTS-embedded release without binding a socket — proves the
+      # archive is self-contained and the prod config provider (runtime.exs,
+      # incl. OIDC fail-closed resolution) loads. A full HTTP/attach smoke needs
+      # a live workspace and is covered by the workspace-gated e2e (BT-2510).
+      - name: Smoke test (release boots)
+        working-directory: editors/liveview
+        env:
+          # `eval` runs the prod config provider (runtime.exs), which requires a
+          # signing secret. A throwaway one suffices — we never bind a socket.
+          SECRET_KEY_BASE: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+        run: |
+          _build/prod/rel/bt_attach/bin/bt_attach version
+          _build/prod/rel/bt_attach/bin/bt_attach eval 'IO.puts("boot-ok " <> to_string(Application.spec(:bt_attach, :vsn)))'
+
+      - name: Package archive
+        id: package
+        run: scripts/ci/package-liveview-release.sh "${{ steps.version.outputs.version }}" "${{ matrix.platform }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: beamtalk-ide-${{ steps.version.outputs.version }}-${{ matrix.platform }}
+          path: |
+            ${{ steps.package.outputs.archive }}
+            ${{ steps.package.outputs.archive }}.sha256
+          retention-days: 7
+
+      # On a full release (release.yml calls this workflow with publish=true),
+      # attach the archive to the GitHub Release. GITHUB_REF_NAME is the tag.
+      - name: Upload to GitHub Release
+        if: github.event_name == 'release' && inputs.publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" \
+            "${{ steps.package.outputs.archive }}" \
+            "${{ steps.package.outputs.archive }}.sha256" \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,3 +400,12 @@ jobs:
       publish: ${{ github.event_name == 'release' }}
     secrets:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+  # ─── LiveView IDE (delegated to liveview-release.yml) ────────────────────
+  # Ships the IDE on its own lane (BT-2512): self-contained mix-release archives,
+  # uploaded to the GitHub Release on a full release. Independent of the core
+  # bundle above — the Elixir/Phoenix toolchain is never added to it.
+  liveview-ide:
+    uses: ./.github/workflows/liveview-release.yml
+    with:
+      publish: ${{ github.event_name == 'release' }}

--- a/scripts/ci/package-liveview-release.sh
+++ b/scripts/ci/package-liveview-release.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+#
+# Package a LiveView IDE (bt_attach) release archive with SHA-256 checksum.
+#
+# The IDE ships on its own release lane (BT-2512), separate from the core
+# beamtalk-<version> toolchain bundle (scripts/ci/package-release.sh). This
+# packages the self-contained, ERTS-embedded `mix release` produced by
+# `just dist-liveview` (BT-2513) into a tarball a user can extract and run with
+# `bin/bt_attach start` — no Elixir/Mix required on the host.
+#
+# Usage: scripts/ci/package-liveview-release.sh <version> <platform>
+#
+# Platform should be one of: linux-x86_64, macos-x86_64, macos-arm64.
+# (Windows is out of scope — the remote IDE host is Linux/macOS per ADR 0091.)
+#
+# Expects the prod release at editors/liveview/_build/prod/rel/bt_attach
+# (run `just dist-liveview` or `MIX_ENV=prod mix release` first).
+#
+# Outputs (to $GITHUB_OUTPUT if set, else stdout):
+#   archive=beamtalk-ide-0.4.0-linux-x86_64.tar.gz
+
+set -euo pipefail
+
+VERSION="${1:?Usage: package-liveview-release.sh <version> <platform>}"
+PLATFORM="${2:?Usage: package-liveview-release.sh <version> <platform>}"
+
+REL_DIR="editors/liveview/_build/prod/rel/bt_attach"
+if [ ! -d "${REL_DIR}" ] || [ ! -x "${REL_DIR}/bin/bt_attach" ]; then
+    echo "❌ Release not found at ${REL_DIR}. Run 'just dist-liveview' first."
+    exit 1
+fi
+
+ARCHIVE="beamtalk-ide-${VERSION}-${PLATFORM}.tar.gz"
+TOPLEVEL="beamtalk-ide-${VERSION}"
+
+rm -rf "${TOPLEVEL}"
+# Dereference symlinks (-L on cp): the release bundles the ERTS, which the
+# archive must carry as real files so it is self-contained on extraction.
+cp -RL "${REL_DIR}" "${TOPLEVEL}"
+tar -czf "${ARCHIVE}" "${TOPLEVEL}"
+rm -rf "${TOPLEVEL}"
+
+# Generate SHA-256 checksum (cross-platform: macOS uses shasum).
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
+else
+    shasum -a 256 "${ARCHIVE}" > "${ARCHIVE}.sha256"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "archive=${ARCHIVE}" >> "${GITHUB_OUTPUT}"
+else
+    echo "archive=${ARCHIVE}"
+fi
+
+echo "📦 Created ${ARCHIVE} ($(du -h "${ARCHIVE}" | cut -f1))"
+echo "🔒 Checksum: $(cat "${ARCHIVE}.sha256")"


### PR DESCRIPTION
## What

Ships the LiveView IDE (`bt_attach`) on its **own release lane** (epic BT-2512), mirroring how `release.yml` delegates the VS Code extension to `release-vscode.yml`.

- **`.github/workflows/liveview-release.yml`** (new) — builds the ERTS-embedded `mix release` per platform (**linux-x86_64, macos-arm64, macos-x86_64**), boot-smokes it (release `version` + `eval`, no socket bind), packages a tarball, uploads an artifact, and on a full release uploads to the GitHub Release. Trigger modes: `workflow_call` (from `release.yml`) and `workflow_dispatch` (artifacts-only unless `publish`). Windows is out of scope (browser-only client per ADR 0091).
- **`scripts/ci/package-liveview-release.sh`** (new) — tars `editors/liveview/_build/prod/rel/bt_attach` into `beamtalk-ide-<version>-<platform>.tar.gz` + `.sha256` (version from `VERSION`, matching what `bin/bt_attach version` reports).
- **`.github/workflows/release.yml`** — adds a delegated `liveview-ide` job (`publish: github.event_name == 'release'`). The core `beamtalk-<version>` bundle is untouched.

## Verification (local)

```
$ scripts/ci/package-liveview-release.sh 0.4.0 linux-x86_64
📦 Created beamtalk-ide-0.4.0-linux-x86_64.tar.gz (26M)
# extract → bin/bt_attach version → "bt_attach 0.4.0"
$ bin/bt_attach eval 'IO.puts("boot-ok " <> to_string(Application.spec(:bt_attach, :vsn)))'
boot-ok 0.4.0
```

YAML parses, `shellcheck` + `bash -n` clean. The smoke uses `eval` (not `start`) deliberately: it boots the runtime and runs the prod config provider (`runtime.exs`, incl. OIDC fail-closed resolution) **without binding a socket** — avoiding the prod IPv6 (`::`) bind, and keeping the cross-platform smoke independent of a live workspace. A full HTTP/attach smoke is covered by the workspace-gated e2e (BT-2510). The smoke sets a throwaway `SECRET_KEY_BASE` (required by the prod config provider).

Part of epic BT-2512. Blocked-by BT-2513/BT-2514 (both merged).

https://claude.ai/code/session_01W8pYcUFqHjKEzrjnr127W3

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8pYcUFqHjKEzrjnr127W3)_