### PR TITLE
Add a Docker image for the LiveView IDE (BT-2516)

### DIFF
--- a/.github/workflows/liveview-docker.yml
+++ b/.github/workflows/liveview-docker.yml
@@ -1,0 +1,98 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+#
+# LiveView IDE Docker image
+# =========================
+# Builds (and, on a full release, publishes) the container image for the
+# LiveView IDE (bt_attach) — the turnkey artifact for ADR 0091's remote/OIDC
+# deployment (docs/deployment/remote-liveview-ide.md).
+#
+# The IDE ships on its own lane (BT-2512), separate from the core toolchain
+# bundle. This is a *standalone* workflow (its own `release` trigger) rather
+# than a job in release.yml, so it composes with the archive lane
+# (liveview-release.yml) without coupling the two.
+#
+# Trigger modes:
+#   - pull_request (Dockerfile-related paths): build only — verifies the image
+#     builds. No registry push.
+#   - release (published): build + push ghcr.io/<owner>/beamtalk-ide:<version>
+#     and :latest.
+#   - workflow_dispatch: build, and push only when `push: true`.
+#
+# Windows is out of scope (browser-only client per ADR 0091).
+#
+# Related: liveview-release.yml (archive lane), release.yml (core bundle)
+# Issue: BT-2516 (epic BT-2512)
+
+name: LiveView IDE Docker
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'editors/liveview/Dockerfile'
+      - 'editors/liveview/.dockerignore'
+      - '.github/workflows/liveview-docker.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Push the image to GHCR (otherwise build only)'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: liveview-docker-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      # Push on a full release, or on a manual dispatch that opts in. PRs always
+      # build-only (verifies the Dockerfile) and never push.
+      - name: Resolve build parameters
+        id: params
+        shell: bash
+        run: |
+          version="$(tr -d '[:space:]' < VERSION)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          # ghcr image refs must be lowercase.
+          owner="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          echo "image=ghcr.io/${owner}/beamtalk-ide" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "release" ] || \
+             { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.push }}" = "true" ]; }; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GHCR
+        if: steps.params.outputs.push == 'true'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build image
+        run: |
+          docker build \
+            -f editors/liveview/Dockerfile \
+            --build-arg VERSION="${{ steps.params.outputs.version }}" \
+            -t "${{ steps.params.outputs.image }}:${{ steps.params.outputs.version }}" \
+            -t "${{ steps.params.outputs.image }}:latest" \
+            editors/liveview
+
+      - name: Push image
+        if: steps.params.outputs.push == 'true'
+        run: |
+          docker push "${{ steps.params.outputs.image }}:${{ steps.params.outputs.version }}"
+          docker push "${{ steps.params.outputs.image }}:latest"

--- a/docs/deployment/remote-liveview-ide.md
+++ b/docs/deployment/remote-liveview-ide.md
@@ -113,6 +113,33 @@ and starts Phoenix in prod mode (server on `:8443` by default; put a TLS
 terminator in front, or add `https:` to the endpoint). OIDC must be configured
 (step 1) or boot fails closed.
 
+### Run with Docker
+
+The published image (`ghcr.io/jamesc/beamtalk-ide`) is the turnkey option — it
+bundles Elixir + OTP + the built assets, so the host needs only Docker. It runs
+the same ERTS-embedded release as `just dist-liveview`, configured by the same
+env. Pin a version tag (it tracks the toolchain version) rather than `latest`:
+
+```sh
+docker run --network host \
+  -e SECRET_KEY_BASE="$(openssl rand -base64 48)" \
+  -e PHX_HOST=ide.example.com \
+  -e BT_WORKSPACE_NODE="beamtalk_workspace_ws@localhost" \
+  -e BT_WORKSPACE_COOKIE="$(cat ~/.beamtalk/workspaces/ws/cookie)" \
+  -e BT_OIDC_ISSUER=https://idp.example.com \
+  -e BT_OIDC_CLIENT_ID=beamtalk-ide \
+  -e BT_OIDC_CLIENT_SECRET="$BT_OIDC_CLIENT_SECRET" \
+  ghcr.io/jamesc/beamtalk-ide:0.4.0
+```
+
+`--network host` co-locates the container with the workspace so the Phoenix ↔
+workspace **Erlang distribution link stays on loopback** (ADR 0091 Decision 5);
+the only network-facing service is Phoenix's HTTP(S) port. Do **not** publish
+epmd/dist ports — keep distribution off untrusted networks (co-located or a
+private interface). The cookie is an infrastructure secret passed via env; it is
+never sent to a browser. Boot fails closed if OIDC is requested but
+misconfigured.
+
 ### Cookie rotation
 
 Rotate with `beamtalk workspace rotate-cookie` (future CLI work, ADR 0020),

--- a/editors/liveview/.dockerignore
+++ b/editors/liveview/.dockerignore
@@ -1,0 +1,13 @@
+# Build outputs and fetched deps — regenerated inside the image build.
+_build/
+deps/
+node_modules/
+assets/node_modules/
+# Digested/static asset outputs — phx.digest regenerates them in the release.
+priv/static/assets/
+priv/static/cache_manifest.json
+# Local cruft.
+*.tar.gz
+erl_crash.dump
+.elixir_ls/
+.DS_Store

--- a/editors/liveview/Dockerfile
+++ b/editors/liveview/Dockerfile
@@ -1,0 +1,80 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+#
+# LiveView IDE (bt_attach) container image — the turnkey artifact for the
+# remote/OIDC deployment (ADR 0091, docs/deployment/remote-liveview-ide.md).
+# Ships on the IDE's own release lane (BT-2512), never the core toolchain bundle.
+#
+# Build context is editors/liveview (the version is injected, not read from the
+# repo tree). Build from the repo root with:
+#   docker build -f editors/liveview/Dockerfile \
+#     --build-arg VERSION="$(cat VERSION)" -t beamtalk-ide editors/liveview
+#
+# Run (operator supplies the ADR 0091 env; the dist link stays internal):
+#   docker run --network host \
+#     -e SECRET_KEY_BASE=... -e PHX_HOST=ide.example.com \
+#     -e BT_WORKSPACE_NODE=... -e BT_WORKSPACE_COOKIE=... \
+#     -e BT_OIDC_ISSUER=... -e BT_OIDC_CLIENT_ID=... -e BT_OIDC_CLIENT_SECRET=... \
+#     ghcr.io/jamesc/beamtalk-ide:latest
+#
+# The only network-facing service is Phoenix's HTTP(S) port. Keep the
+# Phoenix<->workspace Erlang distribution link off untrusted networks
+# (co-located / private interface) — never expose epmd/dist publicly.
+
+ARG ELIXIR_IMAGE=elixir:1.18-otp-27
+ARG RUNTIME_IMAGE=debian:bookworm-slim
+
+# ─── Build stage ─────────────────────────────────────────────────────────
+FROM ${ELIXIR_IMAGE} AS build
+
+ENV MIX_ENV=prod \
+    LANG=C.UTF-8
+
+# bt_attach version tracks the repo VERSION (BT-2514). The build context is the
+# editors/liveview dir, so it is injected and written where mix.exs reads it
+# (../../VERSION, relative to mix.exs at /src/app/mix.exs).
+ARG VERSION=0.0.0
+RUN mkdir -p /src && printf '%s' "${VERSION}" > /src/VERSION
+
+WORKDIR /src/app
+
+RUN mix local.hex --force && mix local.rebar --force
+
+# Dependencies first, for layer caching.
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only prod
+
+# Config is needed to compile deps (Phoenix reads compile-time config).
+COPY config ./config
+RUN mix deps.compile
+
+# App sources + assets, then bundle (minified + digested) and cut the release.
+COPY . ./
+RUN mix assets.setup \
+ && mix assets.deploy \
+ && mix release --overwrite
+
+# ─── Runtime stage ───────────────────────────────────────────────────────
+# The release embeds its own ERTS, so the runtime image needs only the C
+# libraries OTP links against — no Erlang/Elixir/Mix install.
+FROM ${RUNTIME_IMAGE} AS app
+
+ENV LANG=C.UTF-8 \
+    PHX_SERVER=true \
+    PORT=8443
+
+RUN apt-get update -y \
+ && apt-get install -y --no-install-recommends \
+      libstdc++6 libncurses6 openssl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Run as a non-root user.
+RUN useradd --create-home --uid 1000 app
+WORKDIR /app
+COPY --from=build --chown=app:app /src/app/_build/prod/rel/bt_attach ./
+USER app
+
+EXPOSE 8443
+
+ENTRYPOINT ["/app/bin/bt_attach"]
+CMD ["start"]


### PR DESCRIPTION
## What

Containerises the LiveView IDE (`bt_attach`) — the turnkey artifact for ADR 0091's remote/OIDC deployment (epic BT-2512).

- **`editors/liveview/Dockerfile`** — multi-stage: an `elixir:1.18-otp-27` builder fetches prod deps, bundles minified + digested assets, and cuts the ERTS-embedded `mix release`; a `debian:bookworm-slim` runtime carries **only** the release (no Erlang/Elixir/Mix), running as a non-root user. The version is injected via `--build-arg VERSION` (lockstep, BT-2514) so the build context can be just `editors/liveview`.
- **`editors/liveview/.dockerignore`** — excludes `deps/`, `_build/`, `node_modules/`, generated assets.
- **`.github/workflows/liveview-docker.yml`** — a **standalone** lane: build-only on Dockerfile-touching PRs (verifies the image builds), and build+push `ghcr.io/<owner>/beamtalk-ide:<version>` + `:latest` on a full release or an opt-in `workflow_dispatch`. It uses its **own `release` trigger** so it composes with the archive lane (#2531 / `liveview-release.yml`) **without touching `release.yml`** — keeping this PR file-disjoint from BT-2515.
- **`docs/deployment/remote-liveview-ide.md`** — a `docker run` example wired for the ADR 0091 env (`SECRET_KEY_BASE`, `PHX_HOST`, `BT_WORKSPACE_NODE/COOKIE`, `BT_OIDC_*`) with the keep-dist-internal caveat.

## Verification

YAML parses. **No Docker daemon in this dev container**, so the image build is verified by this PR's `pull_request` trigger (build-only, no push) — the `liveview-docker` check on this PR is the verifier. Push to GHCR is gated to releases / opt-in dispatch.

Windows is out of scope (browser-only client per ADR 0091). Part of epic BT-2512; blocked-by BT-2513/BT-2514 (merged).

https://claude.ai/code/session_01W8pYcUFqHjKEzrjnr127W3

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8pYcUFqHjKEzrjnr127W3)_