### PR TITLE
Document installing & running the packaged LiveView IDE (BT-2517)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,13 @@ If your stdlib source files are outside the project root, set:
 
 `beamtalk.stdlib.sourceDir` can be absolute (including outside the project) or relative to the Beamtalk project root (directory containing `beamtalk.toml`). See [editors/vscode/README.md](editors/vscode/README.md) for full extension configuration.
 
+### LiveView IDE
+
+A browser-based Smalltalk-style workspace (Workspace + live Transcript, Inspector, method editing) that attaches to a running Beamtalk workspace over Erlang distribution. It ships on its **own release lane** — a self-contained release archive and a Docker image (`ghcr.io/jamesc/beamtalk-ide`) — separate from the toolchain bundle.
+
+- From source (contributors): `just web <workspace>` — see [editors/liveview/README.md](editors/liveview/README.md).
+- Prebuilt archive / Docker, and remote (OIDC) deployment: [docs/deployment/remote-liveview-ide.md](docs/deployment/remote-liveview-ide.md).
+
 ### REPL Usage
 
 **New to Beamtalk?** See the [REPL Tutorial](examples/repl-tutorial.md) for a complete beginner's guide!

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+# Identifiers allowed in doc comments without backticks (clippy::doc_markdown).
+# `..` extends clippy's default allowlist rather than replacing it.
+#
+# The README is included as crate docs (beamtalk-core/src/lib.rs), so product
+# names that look like camelCase identifiers — e.g. "LiveView" (the Phoenix
+# LiveView IDE, BT-2512) — would otherwise trip the lint in prose/headings.
+doc-valid-idents = ["LiveView", ".."]

--- a/docs/deployment/remote-liveview-ide.md
+++ b/docs/deployment/remote-liveview-ide.md
@@ -10,6 +10,37 @@ For the security model and trust path, see
 > on localhost stay zero-config (cookie handshake, no OIDC). Everything here is
 > opt-in and applies only when you expose the IDE beyond the local machine.
 
+## Installing the IDE
+
+The IDE ships on its **own release lane** (separate from the `beamtalk-<version>`
+toolchain bundle — it runs as its own BEAM node and attaches over distribution).
+Three ways to get it, from most turnkey to most hands-on:
+
+1. **Docker image** (recommended for remote/operator deployments) —
+   `ghcr.io/jamesc/beamtalk-ide:<version>` bundles Elixir + OTP + the built
+   assets; the host needs only Docker. See [Run with Docker](#run-with-docker).
+2. **Release archive** — `beamtalk-ide-<version>-<platform>.tar.gz` from the
+   [GitHub Release](https://github.com/jamesc/beamtalk/releases) is a
+   self-contained, ERTS-embedded build that runs with no Elixir/Mix on the host:
+
+   ```sh
+   tar -xzf beamtalk-ide-<version>-<platform>.tar.gz
+   cd beamtalk-ide-<version>
+   PHX_SERVER=true SECRET_KEY_BASE="$(openssl rand -base64 48)" \
+   PHX_HOST=ide.example.com \
+   BT_WORKSPACE_NODE=... BT_WORKSPACE_COOKIE=... \
+     bin/bt_attach start          # OIDC env per step 1 below
+   ```
+
+   Available for `linux-x86_64`, `macos-arm64`, `macos-x86_64`. (Windows is a
+   browser-only client — there is no IDE-host build for it.)
+3. **From source** (contributors) — `just web <ws>` / `just web-remote <ws>`
+   from a checkout; see [editors/liveview/README.md](../../editors/liveview/README.md).
+
+All three run the same release and read the same configuration (below). The rest
+of this guide configures the IDE for **non-localhost** access; it applies
+identically however you installed it.
+
 ## The shape
 
 ```text

--- a/editors/liveview/README.md
+++ b/editors/liveview/README.md
@@ -56,6 +56,19 @@ mix assets.build                # bundle JS + CSS into priv/static/assets/
 
 ## Run
 
+There are three ways to run the IDE, by audience:
+
+| Way | For | Where |
+| --- | --- | --- |
+| **From source** (`just web` / `just web-remote`) | contributors hacking on the IDE | this section |
+| **Release archive** (`beamtalk-ide-<version>-<platform>.tar.gz`) | users who want a self-contained build, no Elixir/Mix | [deployment guide](../../docs/deployment/remote-liveview-ide.md#installing-the-ide) |
+| **Docker** (`ghcr.io/jamesc/beamtalk-ide`) | remote / operator deployments (OIDC) | [deployment guide](../../docs/deployment/remote-liveview-ide.md#run-with-docker) |
+
+The archive and image are produced by the IDE's own release lane
+(`.github/workflows/liveview-release.yml` and `liveview-docker.yml`); both run the
+same release as `just dist-liveview`. The rest of this section is the from-source
+path.
+
 ```bash
 # from the repo root: build Beamtalk on OTP 27 and start a workspace
 just build


### PR DESCRIPTION
## What

Documents how to install and run the now-packaged LiveView IDE (final piece of epic BT-2512), distinct from the from-source path (which stays for contributors).

- **`docs/deployment/remote-liveview-ide.md`** — new **"Installing the IDE"** section near the top: Docker image (`ghcr.io/jamesc/beamtalk-ide`), self-contained release archive (`beamtalk-ide-<version>-<platform>.tar.gz` with an extract + `bin/bt_attach start` example), and from-source — all reading the same config. Notes Windows is browser-only.
- **`editors/liveview/README.md`** — a three-ways-to-run table (source / archive / Docker) by audience, linking to the deployment guide anchors.
- **`README.md`** — a **LiveView IDE** subsection alongside the VS Code extension for discoverability.

Docs-only; no surface/behaviour change (no `surface-parity.md` update needed). Part of epic BT-2512; blocked-by BT-2515/BT-2516 (merged).

https://claude.ai/code/session_01W8pYcUFqHjKEzrjnr127W3

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8pYcUFqHjKEzrjnr127W3)_