### PR TITLE
Pin BEAM toolchain in .tool-versions, enable Elixir warnings-as-errors

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,28 +10,37 @@
 #
 # GitHub Copilot CLI and workspace setup are handled by devcontainer.json features.
 
-FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
+# trixie: mise's precompiled OTP 28 builds need glibc >= 2.38 (bookworm has
+# 2.36), and it matches the Debian base of the shipped IDE image
+# (editors/liveview/Dockerfile).
+FROM mcr.microsoft.com/devcontainers/rust:1-trixie
 
-# Install Erlang Solutions repository, Erlang/OTP, git, and networking/debugging tools
+# Install git and networking/debugging tools
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
         ca-certificates gnupg \
-    && mkdir -p /etc/apt/keyrings \
-    && curl -fsSL --retry 5 --retry-connrefused --retry-delay 2 \
-        https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.asc \
-        -o /tmp/GPG-KEY-pmanager.asc \
-    && grep -q "BEGIN PGP PUBLIC KEY BLOCK" /tmp/GPG-KEY-pmanager.asc \
-    && gpg --dearmor -o /etc/apt/keyrings/erlang-solutions.gpg /tmp/GPG-KEY-pmanager.asc \
-    && rm -f /tmp/GPG-KEY-pmanager.asc \
-    && echo "deb [signed-by=/etc/apt/keyrings/erlang-solutions.gpg] http://binaries2.erlang-solutions.com/debian/ bookworm-esl-erlang-27 contrib" \
-        > /etc/apt/sources.list.d/erlang-solutions.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        esl-erlang git gettext-base \
+        git gettext-base \
         socat netcat-openbsd lsof unzip \
         curl wget jq htop strace \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Erlang/OTP + Elixir via mise, pinned by the repo-root .tool-versions
+# (the same single source of truth dev machines and CI's setup-beam use, so
+# the devcontainer toolchain never drifts from what CI compiles with).
+# mise fetches precompiled BEAM builds — no source compile.
+#
+# .tool-versions is copied to / so mise resolves the pins from any directory
+# (it walks up from $PWD; the workspace checkout carries the same file).
+# MISE_DATA_DIR is world-readable so the vscode user runs the root-installed
+# toolchain via the shims on PATH.
+ARG MISE_VERSION=v2026.6.3
+ENV MISE_DATA_DIR=/usr/local/share/mise
+ENV PATH="/usr/local/share/mise/shims:${PATH}"
+COPY .tool-versions /.tool-versions
+RUN curl -fsSL --retry 5 --retry-connrefused --retry-delay 2 https://mise.run \
+        | MISE_VERSION=${MISE_VERSION} MISE_INSTALL_PATH=/usr/local/bin/mise sh \
+    && mise install
 
 # Install Node.js (LTS) via NodeSource
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
@@ -77,32 +86,14 @@ RUN echo 'export PATH="/home/vscode/.amp/bin:/home/vscode/.local/bin:$PATH"' > /
     && chmod +x /etc/profile.d/amp.sh
 ENV PATH="/home/vscode/.amp/bin:/home/vscode/.local/bin:${PATH}"
 
-# Install rebar3 (pinned version for reproducible builds)
-ARG REBAR3_VERSION=3.26.0
-RUN git clone --depth 1 --branch ${REBAR3_VERSION} https://github.com/erlang/rebar3.git /tmp/rebar3 \
-    && cd /tmp/rebar3 \
-    && ./bootstrap \
-    && install -m 755 rebar3 /usr/local/bin/rebar3 \
-    && cd / \
-    && rm -rf /tmp/rebar3
-
-# Install Elixir (precompiled for OTP 27) for the editors/liveview Mix project.
-# BT-2401: NOT the distro `elixir` package — it pins erlang < 26 and conflicts
-# with OTP 27. We unzip a release built for OTP 27 and install Hex + rebar3 so
-# `mix deps.get` works out of the box.
-ARG ELIXIR_VERSION=1.18.4
-RUN curl -fsSL --retry 5 --retry-connrefused --retry-delay 2 \
-        "https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/elixir-otp-27.zip" \
-        -o /tmp/elixir-otp-27.zip \
-    && mkdir -p /opt/elixir \
-    && unzip -q /tmp/elixir-otp-27.zip -d /opt/elixir \
-    && rm -f /tmp/elixir-otp-27.zip \
-    && ln -sf /opt/elixir/bin/elixir /usr/local/bin/elixir \
-    && ln -sf /opt/elixir/bin/elixirc /usr/local/bin/elixirc \
-    && ln -sf /opt/elixir/bin/mix /usr/local/bin/mix \
-    && ln -sf /opt/elixir/bin/iex /usr/local/bin/iex \
-    && ELIXIR_ERL_OPTIONS="+fnu" mix local.hex --force \
-    && ELIXIR_ERL_OPTIONS="+fnu" mix local.rebar rebar3 /usr/local/bin/rebar3 --force
+# Erlang, Elixir, and rebar3 all come from mise (see the .tool-versions block
+# above — never the distro `elixir` package, which pins an old erlang).
+# Install Hex + rebar3 for the vscode remoteUser so `mix deps.get` works out
+# of the box.
+USER vscode
+RUN ELIXIR_ERL_OPTIONS="+fnu" mix local.hex --force \
+    && ELIXIR_ERL_OPTIONS="+fnu" mix local.rebar rebar3 /usr/local/share/mise/shims/rebar3 --force
+USER root
 
 # Verify installations
 RUN rustc --version && cargo --version && erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -83,10 +83,10 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Erlang/rebar3 artifacts (Windows)
         if: runner.os == 'Windows'
@@ -95,10 +95,10 @@ jobs:
           path: |
             ~/AppData/Local/rebar3
             runtime/_build
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Use toolchain cargo directly (macOS)
         if: runner.os == 'macOS'
@@ -140,8 +140,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -154,10 +154,10 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -190,8 +190,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -204,10 +204,10 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -235,8 +235,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -249,19 +249,19 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Dialyzer PLT
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             runtime/_build/default/*_plt
-          key: ${{ runner.os }}-dialyzer-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-dialyzer-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-dialyzer-otp-27.0-
+            ${{ runner.os }}-dialyzer-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -308,8 +308,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -322,10 +322,10 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -363,8 +363,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -377,10 +377,10 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/cross-repo.yml
+++ b/.github/workflows/cross-repo.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -84,10 +84,10 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Build compiler and stdlib
         run: just build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -60,10 +60,10 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -77,9 +77,9 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: edge-${{ runner.os }}-erlang-otp-27.0-rebar3-3.27-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**') }}
+          key: edge-${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**') }}
           restore-keys: |
-            edge-${{ runner.os }}-erlang-otp-27.0-rebar3-3.27-
+            edge-${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Build distribution
         run: just dist

--- a/.github/workflows/liveview-e2e.yml
+++ b/.github/workflows/liveview-e2e.yml
@@ -54,14 +54,14 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      # setup-beam installs an Elixir precompiled for OTP 27 (the supported
-      # toolchain) plus rebar3 for the runtime build — matching ci.yml + liveview.yml.
+      # Erlang/Elixir/rebar3 versions all come from the repo-root
+      # .tool-versions (shared with mise on dev machines and the
+      # devcontainer) — matching liveview.yml and ci.yml.
       - name: Install Erlang/OTP + Elixir + rebar3
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          elixir-version: '1.18'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install just
@@ -76,9 +76,9 @@ jobs:
           path: |
             ~/.cache/rebar3
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
 
       - name: Cache LiveView Mix deps and build
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/liveview-release.yml
+++ b/.github/workflows/liveview-release.yml
@@ -79,13 +79,14 @@ jobs:
         shell: bash
         run: echo "version=$(tr -d '[:space:]' < VERSION)" >> "$GITHUB_OUTPUT"
 
-      # setup-beam installs an Elixir precompiled for OTP 27 — the supported
-      # toolchain (never the distro `elixir`, which pins erlang < 26).
+      # Erlang/Elixir versions come from the repo-root .tool-versions — the
+      # single source of truth shared with mise (dev machines, devcontainer),
+      # so the release is built with the same toolchain CI tested.
       - name: Install Erlang/OTP + Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          elixir-version: '1.18'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Mix deps and build

--- a/.github/workflows/liveview.yml
+++ b/.github/workflows/liveview.yml
@@ -36,14 +36,16 @@ jobs:
         with:
           persist-credentials: false
 
-      # setup-beam installs an Elixir precompiled for the chosen OTP version —
-      # the supported toolchain (never the distro `elixir` package, which pins
-      # erlang < 26 and conflicts with Beamtalk's OTP 27).
+      # Versions come from the repo-root .tool-versions — the single source of
+      # truth shared with mise (dev machines, devcontainer), so CI compiles
+      # with the same Erlang/Elixir devs see locally and warnings-as-errors
+      # catches the same warnings. Never the distro `elixir` package, which
+      # pins an old erlang.
       - name: Install Erlang/OTP + Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          elixir-version: '1.18'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Mix deps and build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,8 +85,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -102,9 +102,9 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: nightly-${{ runner.os }}-arm64-erlang-otp-27.0-rebar3-3.27-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**') }}
+          key: nightly-${{ runner.os }}-arm64-erlang-beam-${{ hashFiles('.tool-versions') }}-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**') }}
           restore-keys: |
-            nightly-${{ runner.os }}-arm64-erlang-otp-27.0-rebar3-3.27-
+            nightly-${{ runner.os }}-arm64-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Build
         run: just build
@@ -169,8 +169,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -185,9 +185,9 @@ jobs:
           path: |
             ~/AppData/Local/rebar3
             runtime/_build
-          key: nightly-${{ runner.os }}-erlang-otp-27.0-rebar3-3.27-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**') }}
+          key: nightly-${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**') }}
           restore-keys: |
-            nightly-${{ runner.os }}-erlang-otp-27.0-rebar3-3.27-
+            nightly-${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Build
         run: just build
@@ -253,8 +253,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -270,9 +270,9 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: nightly-${{ runner.os }}-x86_64-erlang-otp-27.0-rebar3-3.27-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**') }}
+          key: nightly-${{ runner.os }}-x86_64-erlang-beam-${{ hashFiles('.tool-versions') }}-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**') }}
           restore-keys: |
-            nightly-${{ runner.os }}-x86_64-erlang-otp-27.0-rebar3-3.27-
+            nightly-${{ runner.os }}-x86_64-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Build and install distribution
         run: just install dist
@@ -312,8 +312,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -329,9 +329,9 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: nightly-${{ runner.os }}-erlang-otp-27.0-rebar3-3.27-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**') }}
+          key: nightly-${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**') }}
           restore-keys: |
-            nightly-${{ runner.os }}-erlang-otp-27.0-rebar3-3.27-
+            nightly-${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Build distribution
         run: just dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -76,10 +76,10 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-otp-27.0-rebar3-3.27
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -136,8 +136,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -150,9 +150,9 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-x86_64-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-x86_64-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-x86_64-erlang-otp-27.0-
+            ${{ runner.os }}-x86_64-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -209,8 +209,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Just
@@ -223,9 +223,9 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-arm64-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-arm64-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-arm64-erlang-otp-27.0-
+            ${{ runner.os }}-arm64-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -284,8 +284,8 @@ jobs:
       - name: Install Erlang/OTP
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: '27.0'
-          rebar3-version: '3.27'
+          version-file: .tool-versions
+          version-type: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Erlang/rebar3 artifacts
@@ -295,9 +295,9 @@ jobs:
             ~/.cache/rebar3
             runtime/_build
             ~/.rebar3
-          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-otp-27.0-rebar3-3.27
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-erlang-otp-27.0-
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+erlang 28.5
+elixir 1.20.1-otp-28
+rebar 3.27.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,15 +11,16 @@ Be kind, respectful, and constructive. We're building something fun — let's ke
 ### Prerequisites
 
 - **Rust** (latest stable) — compiler is written in Rust
-- **Erlang/OTP 27+** — runtime target; `erlc` must be on your PATH
+- **Erlang/OTP** — runtime target; `erlc` must be on your PATH. The supported
+  version is pinned in the repo-root `.tool-versions` (with Elixir and rebar3)
+  — `mise install` (or asdf) sets up all three; CI installs from the same file
 - **Docker Desktop** — for devcontainer support (recommended)
 - **VS Code** — with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 
 > **Optional — LiveView IDE (`editors/liveview`):** the web IDE is a Phoenix/Mix
-> project and needs **Elixir ≥ 1.17 built for OTP 27**. Install a precompiled
-> release or use asdf (`asdf install elixir 1.18.4-otp-27`) — **not** the distro
-> `elixir` package, which pins `erlang < 26` and conflicts with OTP 27. The
-> devcontainer and `scripts/setup-cloud.sh` install this for you. See
+> project. The pinned Elixir from `.tool-versions` covers it — **never** the
+> distro `elixir` package, which pins an old `erlang`. The devcontainer
+> installs it for you. See
 > [`editors/liveview/README.md`](editors/liveview/README.md).
 
 ### Development Environment
@@ -45,16 +46,16 @@ The devcontainer includes all tools pre-configured: Rust toolchain, Erlang/OTP, 
 If you prefer a local setup:
 
 1. Install Rust via [rustup](https://rustup.rs/)
-2. Install Erlang/OTP 27+ (e.g., via [asdf](https://github.com/asdf-vm/asdf-erlang) or your package manager)
+2. Install Erlang/OTP, Elixir, and rebar3 with [mise](https://mise.jdx.dev)
+   (or asdf): `mise install` from the repo root reads the pinned versions in
+   `.tool-versions`
 3. Install [Just](https://github.com/casey/just): `cargo install just`
-4. Install [rebar3](https://rebar3.org/)
-5. Build and test:
+4. Build and test:
    ```bash
    just ci
    ```
-6. _(Optional, for the LiveView IDE)_ Install Elixir ≥ 1.17 **built for OTP 27**
-   — a precompiled release or `asdf install elixir 1.18.4-otp-27`, never the
-   distro `elixir` package. Then `just web-setup`.
+5. _(Optional, for the LiveView IDE)_ `just web-setup` — the pinned Elixir
+   from step 2 covers it; never use the distro `elixir` package.
 
 ## Building & Testing
 

--- a/Justfile
+++ b/Justfile
@@ -139,7 +139,7 @@ dev-deploy-vscode: build-vscode
 [working-directory: 'editors/liveview']
 web-setup:
     @echo "📦 Fetching LiveView (editors/liveview) deps..."
-    mix deps.get
+    ELIXIR_ERL_OPTIONS="${ELIXIR_ERL_OPTIONS:-+fnu}" mix deps.get
     @echo "✅ Deps fetched. Run 'cd editors/liveview && mix assets.setup' once to"
     @echo "   install the esbuild + tailwind binaries (downloaded on first use)."
 
@@ -169,6 +169,7 @@ web name:
     fi
     export BT_WORKSPACE_NODE="${node}"
     export BT_WORKSPACE_COOKIE="$(cat "${cookie_file}")"
+    export ELIXIR_ERL_OPTIONS="${ELIXIR_ERL_OPTIONS:-+fnu}"
     echo "🌐 LiveView IDE → ${node}  (http://localhost:4000)"
     cd editors/liveview
     exec mix phx.server
@@ -206,6 +207,7 @@ web-remote name:
     # it is never placed in a page, assign, or URL (browser ↔ Phoenix is HTTPS).
     export BT_WORKSPACE_NODE="${node}"
     export BT_WORKSPACE_COOKIE="$(cat "${cookie_file}")"
+    export ELIXIR_ERL_OPTIONS="${ELIXIR_ERL_OPTIONS:-+fnu}"
     export PHX_SERVER=true
     export MIX_ENV=prod
     export PORT="${PORT:-8443}"
@@ -227,6 +229,7 @@ web-remote name:
 dist-liveview:
     #!/usr/bin/env bash
     set -euo pipefail
+    export ELIXIR_ERL_OPTIONS="${ELIXIR_ERL_OPTIONS:-+fnu}"
     export MIX_ENV=prod
     echo "📦 Building LiveView IDE release (bt_attach)..."
     mix deps.get --only prod

--- a/editors/liveview/Dockerfile
+++ b/editors/liveview/Dockerfile
@@ -21,8 +21,11 @@
 # Phoenix<->workspace Erlang distribution link off untrusted networks
 # (co-located / private interface) — never expose epmd/dist publicly.
 
-ARG ELIXIR_IMAGE=elixir:1.18-otp-27
-ARG RUNTIME_IMAGE=debian:bookworm-slim
+# Tracks the repo-root .tool-versions pins (erlang/elixir). The runtime image
+# must stay on the same Debian release as the build image's base (erlang:28 is
+# trixie-based) — the release embeds ERTS built against that glibc.
+ARG ELIXIR_IMAGE=elixir:1.20.1-otp-28
+ARG RUNTIME_IMAGE=debian:trixie-slim
 
 # ─── Build stage ─────────────────────────────────────────────────────────
 FROM ${ELIXIR_IMAGE} AS build

--- a/editors/liveview/README.md
+++ b/editors/liveview/README.md
@@ -26,16 +26,18 @@ This is the productionised successor to the BT-2394 spike
 
 ## Toolchain
 
-Requires **Elixir ≥ 1.17 built for OTP 27** — *not* the distro `elixir`
-package, which pins `erlang < 26` and conflicts with Beamtalk's OTP 27. Use a
-precompiled release or asdf:
+Erlang and Elixir versions are pinned in the repo-root `.tool-versions` — the
+single source of truth shared by mise (dev machines, devcontainer) and CI's
+`setup-beam`. Never use the distro `elixir` package, which pins an old
+`erlang`. With [mise](https://mise.jdx.dev) (or asdf) installed:
 
 ```bash
-asdf install elixir 1.18.4-otp-27   # or download elixir-otp-27.zip
+mise install        # from the repo root; reads .tool-versions
 ```
 
-The devcontainer (`.devcontainer/Dockerfile`) and `scripts/setup-cloud.sh`
-install a matching Elixir automatically.
+The devcontainer (`.devcontainer/Dockerfile`) installs the same pinned
+toolchain automatically; `scripts/setup-cloud.sh` installs a working (older)
+toolchain for cloud sessions.
 
 Assets are built by a real **esbuild + tailwind** pipeline (no vendored
 `*.min.js`). The standalone binaries are downloaded on first use by

--- a/editors/liveview/lib/bt_attach/ide_config.ex
+++ b/editors/liveview/lib/bt_attach/ide_config.ex
@@ -39,7 +39,6 @@ defmodule BtAttach.IdeConfig do
       }
   """
 
-  require Logger
   import Bitwise, only: [&&&: 2]
 
   @default_groups_claim "groups"

--- a/editors/liveview/mix.exs
+++ b/editors/liveview/mix.exs
@@ -20,6 +20,9 @@ defmodule BtAttach.MixProject do
       version: @version,
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
+      # Warnings-as-errors for our own code only — deps compile with their
+      # upstream settings and routinely warn under newer Elixir releases.
+      elixirc_options: [warnings_as_errors: true],
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
@@ -100,6 +103,9 @@ defmodule BtAttach.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "assets.setup", "assets.build"],
+      # Test .exs files compile at ExUnit runtime, outside elixirc_options —
+      # this flag is the only way to hold them to warnings-as-errors.
+      test: ["test --warnings-as-errors"],
       "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
       "assets.build": ["tailwind bt_attach", "esbuild bt_attach"],
       "assets.deploy": [

--- a/editors/liveview/test/bt_attach/workspace_test.exs
+++ b/editors/liveview/test/bt_attach/workspace_test.exs
@@ -142,11 +142,18 @@ defmodule BtAttach.WorkspaceTest do
     end
 
     test "the browse wrappers reject non-binary arguments (guard contract)" do
-      assert_raise FunctionClauseError, fn -> Workspace.browse_protocols(:Counter, "instance") end
-      assert_raise FunctionClauseError, fn -> Workspace.browse_class_definition(:Counter) end
+      # apply/3 keeps the deliberately mistyped arguments opaque to the
+      # compiler's type checker, which would otherwise warn on these calls.
+      assert_raise FunctionClauseError, fn ->
+        apply(Workspace, :browse_protocols, [:Counter, "instance"])
+      end
 
       assert_raise FunctionClauseError, fn ->
-        Workspace.browse_method_source("Counter", :instance, "increment")
+        apply(Workspace, :browse_class_definition, [:Counter])
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        apply(Workspace, :browse_method_source, ["Counter", :instance, "increment"])
       end
     end
   end


### PR DESCRIPTION
## Summary

- Add repo-root `.tool-versions` (erlang 28.5, elixir 1.20.1-otp-28, rebar 3.27.0) as the single source of truth for the BEAM toolchain across dev machines (mise), devcontainer (now installs via mise instead of ESL apt + manual Elixir zip), and all CI workflows (setup-beam reads `version-file` instead of hardcoded `otp-version`/`rebar3-version`)
- Enable `warnings_as_errors` on the LiveView Elixir app (compile + test alias), fix the two warnings it caught (unused `require Logger`, type-checker warning in guard-contract test)
- Silence the latin1 locale warning via `ELIXIR_ERL_OPTIONS=+fnu` in Justfile recipes
- Devcontainer base moved bookworm → trixie (glibc ≥ 2.38 required by OTP 28 precompiled builds)
- Docker IDE image bumped elixir:1.18-otp-27 → 1.20.1-otp-28, runtime bookworm-slim → trixie-slim
- CI cache keys now salt with `hashFiles('.tool-versions')` so they roll automatically on toolchain bumps

Follow-up: BT-2525 (align `scripts/setup-cloud.sh` — the one remaining unaligned installer)

## Test plan

- [x] LiveView app compiles warning-free under pinned toolchain (`mix compile --warnings-as-errors`)
- [x] LiveView test suite passes (119 passed, 47 excluded)
- [x] `mix format --check-formatted` passes
- [x] Erlang runtime builds clean on OTP 28.5 (`just build-erlang`)
- [x] Stdlib builds clean (100 modules, `--warnings-as-errors`)
- [x] Dialyzer passes on OTP 28.5 runtime (145 files, no warnings)
- [x] All 1010 generated `-spec` attributes validate against OTP 28.5 PLT
- [x] Full pre-push hook passes (clippy, fmt, dialyzer, specs, erlfmt, biome)
- [ ] CI runs on all platforms (first run will rebuild OTP 28.5 caches)
- [ ] Devcontainer builds successfully (not tested — Docker unavailable in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)