### PR TITLE
Cockpit Phase 3: floating inspector windows (overlay mode) (BT-2493)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -720,3 +720,48 @@
   border-radius: 3px; padding: 0 4px; margin: 0 3px;
 }
 .nav-loc { font-size: 10.5px; color: var(--faint); }
+
+/* ── floating inspector windows (BT-2493, epic BT-2482 Phase 3) ──────────────
+   The Float-mode overlay: draggable, stackable inspector windows. The overlay
+   layer fills the app and is pointer-inert so it never eats clicks on the
+   cockpit beneath; each window re-enables pointer events on itself. Window
+   position (left/top) + stacking (z-index) are set inline from server state
+   (the WindowDrag hook reports them on drop / focus). Each window reuses the
+   docked Inspector's head/crumbs/chips/ivar-table/poke styles. */
+.insp-overlay {
+  position: fixed; inset: 0; z-index: 50; pointer-events: none;
+}
+.insp-window {
+  position: absolute; pointer-events: auto;
+  width: 340px; max-height: 70vh; display: flex; flex-direction: column;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 9px;
+  box-shadow: 0 8px 28px rgba(40, 28, 10, .28);
+  overflow: hidden;
+}
+.insp-window.dragging { box-shadow: 0 14px 38px rgba(40, 28, 10, .38); }
+/* title bar: the drag handle. `grab`/`grabbing` cursor signals the affordance. */
+.insp-window .iw-bar {
+  flex: none; display: flex; align-items: center; gap: 7px;
+  height: 30px; padding: 0 8px 0 12px;
+  background: var(--panel-2); border-bottom: 1px solid var(--line);
+  cursor: grab; user-select: none;
+}
+.insp-window.dragging .iw-bar { cursor: grabbing; }
+.insp-window .iw-bar .spacer { flex: 1; }
+.insp-window .iw-title {
+  font-size: 12px; font-weight: 600; color: var(--accent-2);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.insp-window .iw-close {
+  flex: none; border: 0; background: transparent; color: var(--muted);
+  cursor: pointer; font-size: 17px; line-height: 1; padding: 0 4px;
+}
+.insp-window .iw-close:hover { color: var(--ink); }
+.insp-window .iw-body { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+.insp-window .iw-content { overflow: auto; min-height: 0; }
+/* the freeze toggle on a window's title bar must not start a drag — the hook
+   already excludes buttons, but keep the default cursor over it too. */
+.insp-window .iw-bar .insp-freeze { cursor: pointer; }
+
+/* Dock/Float mode toggle in the top bar (reuses the `.seg` segmented control). */
+.topbar .insp-mode { flex: none; }

--- a/editors/liveview/assets/js/hooks/index.js
+++ b/editors/liveview/assets/js/hooks/index.js
@@ -15,6 +15,9 @@
 //   OmniSearch        — top-bar symbol search keyboard nav (arrow/enter/escape);
 //                       filtering is server-side, the hook drives the highlight
 //                       + open (BT-2495, epic BT-2482 Phase 3)
+//   WindowDrag        — drags a floating inspector window by its title bar and
+//                       raises it to the front on click; reports the final
+//                       position on drop (BT-2493, epic BT-2482 Phase 3)
 //
 // The Workspace dock and method editor (later Phase 1 issues) build on these.
 
@@ -24,6 +27,7 @@ import { SelectionTracker } from "./selection_tracker"
 import { TweaksPanel } from "./tweaks_panel"
 import { FieldFlash } from "./field_flash"
 import { OmniSearch } from "./omni_search"
+import { WindowDrag } from "./window_drag"
 
 export const Hooks = {
   CodeEditor,
@@ -32,4 +36,5 @@ export const Hooks = {
   TweaksPanel,
   FieldFlash,
   OmniSearch,
+  WindowDrag,
 }

--- a/editors/liveview/assets/js/hooks/window_drag.js
+++ b/editors/liveview/assets/js/hooks/window_drag.js
@@ -1,0 +1,121 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+//
+// WindowDrag — the floating inspector window's drag + focus hook (BT-2493, epic
+// BT-2482 Phase 3). Attached to each `.insp-window`, it makes the window
+// draggable by its title bar and brings it to the front on a click, mirroring the
+// spike's window management (spikes/cockpit-ux-spike/app.jsx).
+//
+// Architecture (per the issue): position (x, y) and z-order are CLIENT-SIDE — the
+// drag moves the element directly via inline `left`/`top` for a smooth, no-latency
+// drag, and the final position is reported to the server ONCE on drop
+// (`pushEvent("window_moved", {id, x, y})`), never per-mousemove. The server holds
+// the authoritative x/y/z in LiveView state, so a window's position survives an
+// unrelated re-render. A mousedown anywhere in the window pushes
+// `window_focus` so z-order follows focus (the server bumps its z above the rest).
+//
+//   <section class="insp-window" phx-hook="WindowDrag" data-window-id="win-3"
+//            style="left:120px;top:96px;z-index:11;">
+//     <header data-window-drag-handle> … title bar … </header>
+//     …
+//   </section>
+//
+// Only a drag that STARTS on the `[data-window-drag-handle]` title bar moves the
+// window — a mousedown on a button / table inside the body brings the window to
+// front (focus) but does not drag, so the close button, breadcrumb and ivar rows
+// stay clickable.
+
+export const WindowDrag = {
+  mounted() {
+    this.id = this.el.dataset.windowId
+    this.handle = this.el.querySelector("[data-window-drag-handle]") || this.el
+
+    // Drag state — null when not dragging.
+    this.drag = null
+
+    this.onDown = (e) => this.start(e)
+    this.onMove = (e) => this.move(e)
+    this.onUp = (e) => this.end(e)
+
+    // A press anywhere in the window raises it to the front (focus → z-order).
+    // We listen on the whole element (capture) so a click on the body raises it
+    // too, but only a press that lands on the title bar begins a drag.
+    this.onFocusDown = () => this.raise()
+
+    this.el.addEventListener("mousedown", this.onFocusDown)
+    this.handle.addEventListener("mousedown", this.onDown)
+  },
+
+  destroyed() {
+    // Belt-and-braces: a window can be closed mid-drag (the close button lives on
+    // the title bar), so always tear the document-level listeners down.
+    this.el.removeEventListener("mousedown", this.onFocusDown)
+    this.handle.removeEventListener("mousedown", this.onDown)
+    document.removeEventListener("mousemove", this.onMove)
+    document.removeEventListener("mouseup", this.onUp)
+  },
+
+  // Bring this window to the front. Cheap to fire on every press — the server
+  // bumps the z only if needed and the re-render just updates one z-index.
+  raise() {
+    this.pushEvent("window_focus", { id: this.id })
+  },
+
+  start(e) {
+    // Don't begin a drag from an interactive control on the title bar (the freeze
+    // toggle, the close button): let those receive their click.
+    if (e.target.closest("button")) return
+    // Left button only.
+    if (e.button !== 0) return
+
+    e.preventDefault()
+
+    const rect = this.el.getBoundingClientRect()
+    const parent = this.el.offsetParent || document.body
+    const parentRect = parent.getBoundingClientRect()
+
+    this.drag = {
+      // Pointer offset within the window, so the grab point stays under the cursor.
+      offsetX: e.clientX - rect.left,
+      offsetY: e.clientY - rect.top,
+      parentLeft: parentRect.left,
+      parentTop: parentRect.top,
+      x: this.el.offsetLeft,
+      y: this.el.offsetTop,
+    }
+
+    this.el.classList.add("dragging")
+    document.addEventListener("mousemove", this.onMove)
+    document.addEventListener("mouseup", this.onUp)
+  },
+
+  move(e) {
+    if (!this.drag) return
+    e.preventDefault()
+
+    // New top-left, relative to the offset parent, clamped to non-negative so a
+    // window can't be dragged off the top/left edge into oblivion.
+    const x = Math.max(0, e.clientX - this.drag.parentLeft - this.drag.offsetX)
+    const y = Math.max(0, e.clientY - this.drag.parentTop - this.drag.offsetY)
+
+    this.drag.x = Math.round(x)
+    this.drag.y = Math.round(y)
+
+    // Move the element directly for a smooth drag — no server round-trip per move.
+    this.el.style.left = `${this.drag.x}px`
+    this.el.style.top = `${this.drag.y}px`
+  },
+
+  end() {
+    if (!this.drag) return
+
+    this.el.classList.remove("dragging")
+    document.removeEventListener("mousemove", this.onMove)
+    document.removeEventListener("mouseup", this.onUp)
+
+    // Report the FINAL position once, so the server persists it in LV state and
+    // the window keeps its place across re-renders.
+    this.pushEvent("window_moved", { id: this.id, x: this.drag.x, y: this.drag.y })
+    this.drag = null
+  },
+}

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -455,6 +455,27 @@ defmodule BtAttachWeb.WorkspaceLive do
       |> assign(:omni_results, [])
       |> assign(:omni_open, false)
       |> assign(:nav_popover, nil)
+      # Floating inspector windows (BT-2493, epic BT-2482 Phase 3): the spike's
+      # Dock/Float toggle (spikes/cockpit-ux-spike/app.jsx). In `"float"` mode a
+      # binding click / Inspect-it opens a *floating, draggable, stackable*
+      # inspector window instead of driving the docked pane; `"docked"` (the
+      # default) keeps the single right-column Inspector.
+      #
+      #   * `:inspector_mode` — `"docked"` | `"float"`. Persisted in LV state so it
+      #     survives re-render; the top-bar toggle flips it.
+      #   * `:windows` — the open floating windows, each a self-contained inspector
+      #     (its own drill `crumbs`, `rows`, `target`, live `watch`/`stats`/`frozen`
+      #     + `flash_gen`, and `x`/`y`/`z` placement). The window list (id + drill
+      #     stack + content) lives server-side; only x/y/z are client-reported by
+      #     the WindowDrag hook on drop / focus, so there is no per-mousemove
+      #     round-trip and positions survive an unrelated re-render.
+      #   * `:next_window_id` — a monotonic counter minting unique window ids.
+      #   * `:window_z` — the running max z-index; a click bumps the focused window
+      #     to `window_z + 1` so z-order follows focus (the spike's stacking).
+      |> assign(:inspector_mode, "docked")
+      |> assign(:windows, [])
+      |> assign(:next_window_id, 1)
+      |> assign(:window_z, 10)
       |> assign_browser_classes()
       |> assign_bindings(pid)
       |> assign_changes()
@@ -556,11 +577,19 @@ defmodule BtAttachWeb.WorkspaceLive do
   def handle_event("dock_tab", _params, socket), do: {:noreply, socket}
 
   # Inspect a binding by name: look up its live term and drill into it via the
-  # read-surface `inspect` op. Reference-following starts here.
+  # read-surface `inspect` op. Reference-following starts here. In `"float"` mode
+  # (BT-2493) the click opens a *new floating window* on the binding instead of
+  # driving the docked pane; in `"docked"` mode it drives the docked Inspector as
+  # before. Docked is the default, so the existing single-pane flow is untouched
+  # unless the user flipped the top-bar Dock/Float toggle.
   @impl true
   def handle_event("inspect", %{"name" => name}, %{assigns: %{session_pid: pid}} = socket)
       when is_pid(pid) do
-    {:noreply, inspect_binding(socket, pid, name)}
+    if socket.assigns.inspector_mode == "float" do
+      {:noreply, open_window(socket, pid, name)}
+    else
+      {:noreply, inspect_binding(socket, pid, name)}
+    end
   end
 
   # Drill into an object-valued field of the currently-inspected object: the
@@ -622,6 +651,107 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   def handle_event("poke", _params, socket), do: {:noreply, socket}
+
+  # ── floating inspector windows (BT-2493, epic BT-2482 Phase 3) ───────────────
+
+  # Flip the Inspector between docked and floating ("overlay") modes (the spike's
+  # Dock/Float toggle). Switching to docked leaves the open windows alone — they
+  # stay in state and reappear if the user flips back — so a misclick doesn't tear
+  # down a desk full of inspectors and their subscriptions. Only an explicit
+  # window close releases a window's watch.
+  def handle_event("set_inspector_mode", %{"mode" => mode}, socket)
+      when mode in ~w(docked float) do
+    {:noreply, assign(socket, inspector_mode: mode)}
+  end
+
+  def handle_event("set_inspector_mode", _params, socket), do: {:noreply, socket}
+
+  # Drill into an object-valued field of a *floating window* (BT-2493): the field
+  # term is carried by index against that window's current rows, exactly like the
+  # docked `"drill"` event but scoped to one window. Defensive against a malformed
+  # id/index so a crafted event can't crash the LiveView.
+  def handle_event("window_drill", %{"id" => id, "index" => index}, socket) do
+    with %{} = win <- find_window(socket, id),
+         {i, ""} when i >= 0 <- Integer.parse(index),
+         %{term: term, name: name} <- Enum.at(win.rows, i) do
+      crumbs = win.crumbs ++ [%{label: to_string(name), term: term}]
+
+      {:noreply,
+       update_window(socket, id, fn w -> inspect_window(socket, w, name, term, crumbs) end)}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("window_drill", _params, socket), do: {:noreply, socket}
+
+  # Walk a floating window's drill breadcrumb back to an earlier level: truncate
+  # its crumb trail at the clicked index and re-inspect that level's live term.
+  def handle_event("window_crumb", %{"id" => id, "index" => index}, socket) do
+    with %{} = win <- find_window(socket, id),
+         {i, ""} when i >= 0 <- Integer.parse(index),
+         %{term: term, label: label} <- Enum.at(win.crumbs, i) do
+      crumbs = Enum.take(win.crumbs, i + 1)
+
+      {:noreply,
+       update_window(socket, id, fn w -> inspect_window(socket, w, label, term, crumbs) end)}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("window_crumb", _params, socket), do: {:noreply, socket}
+
+  # Close a floating window: drop it from the list and release its per-object
+  # change subscription (BT-2493 acceptance: "Close removes the window and releases
+  # any subscriptions"). Idempotent — closing an unknown id is a no-op.
+  def handle_event("window_close", %{"id" => id}, socket) do
+    {:noreply, close_window(socket, id)}
+  end
+
+  def handle_event("window_close", _params, socket), do: {:noreply, socket}
+
+  # Bring a floating window to the front (z-order follows focus, the spike's
+  # stacking). The WindowDrag JS hook fires this on a mousedown anywhere in the
+  # window; we bump the clicked window's z above the current max so it overlays the
+  # others. Pure view state — no workspace round-trip.
+  def handle_event("window_focus", %{"id" => id}, socket) do
+    {:noreply, focus_window(socket, id)}
+  end
+
+  def handle_event("window_focus", _params, socket), do: {:noreply, socket}
+
+  # Persist a floating window's final position after a drag (BT-2493): the
+  # WindowDrag hook reports x/y ONCE on drop (no per-mousemove round-trip), so the
+  # position lives in LV state and survives an unrelated re-render. Coordinates are
+  # clamped to non-negative integers so a crafted payload can't place a window off
+  # into NaN-land.
+  def handle_event("window_moved", %{"id" => id, "x" => x, "y" => y}, socket) do
+    {:noreply,
+     update_window(socket, id, fn w -> %{w | x: clamp_coord(x), y: clamp_coord(y)} end)}
+  end
+
+  def handle_event("window_moved", _params, socket), do: {:noreply, socket}
+
+  # Freeze / unfreeze a single floating window's live tracking (per-window freeze,
+  # mirroring the docked `"freeze_toggle"`). Each window watches independently, so
+  # one frozen window holds its snapshot while others keep tracking.
+  def handle_event("window_freeze", %{"id" => id}, socket) do
+    {:noreply, update_window(socket, id, fn w -> toggle_window_freeze(socket, w) end)}
+  end
+
+  def handle_event("window_freeze", _params, socket), do: {:noreply, socket}
+
+  # Owner-only per-window poke (the docked `"poke"`, scoped to one window): send
+  # the typed message to that window's inspected actor by eval'ing
+  # `<binding> <message>`. Rides the same RBAC-gated eval op + well-formedness gate
+  # as the docked poke; a window not at a named-binding root reports it can't send.
+  def handle_event("window_poke", %{"id" => id, "message" => message}, socket)
+      when is_binary(message) do
+    {:noreply, update_window(socket, id, fn w -> poke_window(socket, w, message) end)}
+  end
+
+  def handle_event("window_poke", _params, socket), do: {:noreply, socket}
 
   # ── method editor (Wave 3, write-surface ADR 0082) ──────────────────────────
 
@@ -922,18 +1052,26 @@ defmodule BtAttachWeb.WorkspaceLive do
   # watch server warns it may deliver one final push after we unsubscribe (a
   # navigate-away/freeze race), so we drop a push whose pid doesn't match the head.
   def handle_info({:object_changed, pid, _slots}, %{assigns: assigns} = socket) do
-    cond do
-      assigns.inspect_frozen or not watched_pid?(assigns.inspect_watch, pid) ->
-        {:noreply, socket}
+    # The push fans out to TWO independent watchers: the docked Inspector (its
+    # `:inspect_watch`) and any floating windows watching this same pid (BT-2493).
+    # Each coalesces its own burst, so we schedule the docked refresh here and let
+    # `notify_windows_changed/2` schedule a per-pid window refresh — a single push
+    # can pulse both the docked pane and a float window on the same actor.
+    docked =
+      cond do
+        assigns.inspect_frozen or not watched_pid?(assigns.inspect_watch, pid) ->
+          socket
 
-      assigns.refresh_pending ->
-        # A refresh is already queued for this burst — collapse this push into it.
-        {:noreply, socket}
+        assigns.refresh_pending ->
+          # A refresh is already queued for this burst — collapse this push into it.
+          socket
 
-      true ->
-        Process.send_after(self(), :do_object_refresh, refresh_debounce_ms())
-        {:noreply, assign(socket, refresh_pending: true)}
-    end
+        true ->
+          Process.send_after(self(), :do_object_refresh, refresh_debounce_ms())
+          assign(socket, refresh_pending: true)
+      end
+
+    {:noreply, notify_windows_changed(docked, pid)}
   end
 
   # The coalesced refresh fired by `{:object_changed, …}`: re-read the watched
@@ -949,6 +1087,37 @@ defmodule BtAttachWeb.WorkspaceLive do
     {:noreply, assign(socket, refresh_pending: false)}
   end
 
+  # The coalesced per-window refresh fired by `notify_windows_changed/2` for one
+  # `pid`: re-read every floating window whose watched head is that pid, clearing
+  # ONLY those windows' pending flags so the burst collapses into one re-read +
+  # flash per window. A window watching a *different* pid keeps its own
+  # `:refresh_pending` untouched — its own `{:do_window_refresh, otherpid}` timer
+  # is still in flight and must not be pre-empted (else that window's refresh would
+  # be silently dropped). A window that froze or navigated off this pid since the
+  # timer armed no longer matches `watched_pid?/2`, so it is left as-is.
+  def handle_info({:do_window_refresh, pid}, socket) do
+    windows =
+      Enum.map(socket.assigns.windows, fn w ->
+        cond do
+          # Pending refresh for this pid: re-read + flash, clearing the flag.
+          w.refresh_pending and watched_pid?(w.watch, pid) ->
+            refresh_window(%{w | refresh_pending: false}, socket, w.watch)
+
+          # Still watching this pid but not pending (already serviced / never
+          # scheduled): clear any stale flag so it can't wedge future refreshes.
+          watched_pid?(w.watch, pid) ->
+            %{w | refresh_pending: false}
+
+          # A different pid (or no watch): leave it untouched — its own timer (if
+          # any) is still in flight and must not be pre-empted.
+          true ->
+            w
+        end
+      end)
+
+    {:noreply, assign(socket, :windows, windows)}
+  end
+
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   # True when `pid` is the pid backing the currently-watched object term — so a
@@ -960,6 +1129,18 @@ defmodule BtAttachWeb.WorkspaceLive do
        do: watched == pid
 
   defp watched_pid?(_watch, _pid), do: false
+
+  # The distinct live terms watched by the open floating windows (BT-2493) — the
+  # set we must unsubscribe on terminate. Deduped on the watched pid so two windows
+  # on the same actor unsubscribe it once.
+  defp window_watched_terms(nil), do: []
+
+  defp window_watched_terms(windows) when is_list(windows) do
+    windows
+    |> Enum.map(& &1.watch)
+    |> Enum.filter(&match?({:beamtalk_object, _c, _m, p} when is_pid(p), &1))
+    |> Enum.uniq_by(fn {:beamtalk_object, _c, _m, pid} -> pid end)
+  end
 
   @impl true
   def terminate(_reason, socket) do
@@ -991,6 +1172,14 @@ defmodule BtAttachWeb.WorkspaceLive do
 
         _ ->
           :ok
+      end
+
+      # And drop every floating window's per-object subscription (BT-2493). The
+      # watch server keys subscriptions by `(pid, subscriber)` so one unsubscribe
+      # per distinct watched pid suffices even if several windows share an actor —
+      # `Enum.uniq` over the watched terms avoids a redundant (harmless) RPC.
+      for term <- window_watched_terms(socket.assigns[:windows]) do
+        Workspace.unsubscribe_object_changes(term, self())
       end
 
       case socket.assigns[:token] do
@@ -1064,14 +1253,22 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   defp eval_success(socket, "inspect_it", term, output, expr) do
-    socket
-    |> assign(
-      result: Workspace.render_term(term),
-      output: present(output),
-      error: nil,
-      expr: expr
-    )
-    |> inspect_term("→ result", term, [%{label: "→ result", term: term}])
+    socket =
+      assign(socket,
+        result: Workspace.render_term(term),
+        output: present(output),
+        error: nil,
+        expr: expr
+      )
+
+    # In `"float"` mode (BT-2493) Inspect-it opens a floating window on the
+    # `→ result` term rather than driving the docked pane; docked mode keeps the
+    # original single-pane behaviour.
+    if socket.assigns.inspector_mode == "float" do
+      open_window_for_term(socket, "→ result", term)
+    else
+      inspect_term(socket, "→ result", term, [%{label: "→ result", term: term}])
+    end
   end
 
   # print_it (and the historical default).
@@ -1873,15 +2070,35 @@ defmodule BtAttachWeb.WorkspaceLive do
     |> assign(inspect_stats: nil, poke_result: nil, poke_error: nil)
   end
 
-  # Drop the current per-object subscription (if any) and forget the watched term.
-  # Idempotent: a nil watch unsubscribes nothing.
+  # Drop the docked Inspector's per-object subscription (if any) and forget the
+  # watched term. Idempotent: a nil watch unsubscribes nothing.
+  #
+  # Reference-aware (BT-2493): the workspace keys subscriptions by `(pid,
+  # subscriber)` and our subscriber is always this LiveView, so one unsubscribe
+  # would silence EVERY this-pid watcher in this process. If a floating window
+  # still watches the same actor, we must NOT unsubscribe here — the window still
+  # needs the push. (Before floating windows existed the docked pane was the sole
+  # watcher, so this collapses to the original unconditional unsubscribe.)
   defp unwatch(%{assigns: %{inspect_watch: term}} = socket)
        when not is_nil(term) do
-    Facade.dispatch(:unsubscribe_object, %{term: term, pid: self()}, ctx(socket))
+    unless docked_pid_watched_by_window?(socket, term) do
+      Facade.dispatch(:unsubscribe_object, %{term: term, pid: self()}, ctx(socket))
+    end
+
     assign(socket, inspect_watch: nil)
   end
 
   defp unwatch(socket), do: assign(socket, inspect_watch: nil)
+
+  # True when the pid backing the docked pane's `term` is also watched by an open
+  # floating window — so the docked pane releasing it must keep the subscription
+  # alive for the window.
+  defp docked_pid_watched_by_window?(socket, {:beamtalk_object, _c, _m, pid})
+       when is_pid(pid) do
+    Enum.any?(socket.assigns[:windows] || [], fn w -> watched_pid?(w.watch, pid) end)
+  end
+
+  defp docked_pid_watched_by_window?(_socket, _term), do: false
 
   # Read the inspected actor's live process metrics (mailbox/reductions/status/…)
   # and assign the snapshot for the head chips. A read failure clears the chips
@@ -1945,6 +2162,477 @@ defmodule BtAttachWeb.WorkspaceLive do
   # delay collapses a flurry of rapid writes into a single re-read + flash. Kept as
   # a function so a test can drive it deterministically if needed.
   defp refresh_debounce_ms, do: 60
+
+  # ── floating inspector windows (BT-2493, epic BT-2482 Phase 3) ───────────────
+  #
+  # Each floating window is a self-contained inspector: its own drill `crumbs`,
+  # `rows`, `target`, live `watch`/`stats`/`frozen` and a `flash_gen`, plus its
+  # `x`/`y`/`z` placement (client-reported by the WindowDrag hook on drop / focus).
+  # The window-list lives in `:windows`; helpers below open / drill / close / focus
+  # / freeze a window by id and route change pushes to the right window. They reuse
+  # the same read-surface ops (`:inspect`, `:subscribe_object`, `:pid_stats`) and
+  # the same `target_info` / `field_rows` builders as the docked pane (BT-2486), so
+  # a window's content is the docked Inspector parameterised by window id.
+
+  # The window placement step (px): each new window is offset down-right from the
+  # last so a burst of opens cascades rather than stacking dead-on (the spike's
+  # `+24` cascade). The first window opens near the top-left of the overlay.
+  defp window_origin_x, do: 120
+  defp window_origin_y, do: 96
+  defp window_cascade, do: 28
+
+  # Open a floating window on a session binding selected by name: resolve its live
+  # term (same path as the docked `inspect_binding/3`), then build a window on it.
+  # A binding that no longer resolves opens a window showing the error rather than
+  # silently doing nothing.
+  defp open_window(socket, pid, name) do
+    case Facade.dispatch(:bindings, %{session_pid: pid}, ctx(socket)) do
+      pairs when is_list(pairs) ->
+        case List.keyfind(pairs, name, 0) do
+          {^name, term} -> open_window_for_term(socket, to_string(name), term)
+          nil -> open_window_error(socket, to_string(name), "binding not found: #{name}")
+        end
+
+      {:error, reason} ->
+        open_window_error(socket, to_string(name), Workspace.render_error(reason))
+    end
+  end
+
+  # Open a floating window on an already-resolved live `term` (used by Inspect-it,
+  # whose head is the `→ result`, and by `open_window/3`). Mints a fresh id +
+  # cascade position, fills its first inspector level, and arms its watch.
+  defp open_window_for_term(socket, label, term) do
+    {id, socket} = mint_window_id(socket)
+    {x, y, socket} = next_window_pos(socket)
+    z = socket.assigns.window_z + 1
+
+    win = %{
+      id: id,
+      label: to_string(label),
+      crumbs: [%{label: to_string(label), term: term}],
+      target: nil,
+      rows: [],
+      error: nil,
+      watch: nil,
+      stats: nil,
+      frozen: false,
+      refresh_pending: false,
+      flash_gen: 0,
+      poke_result: nil,
+      poke_error: nil,
+      x: x,
+      y: y,
+      z: z
+    }
+
+    win = inspect_window(socket, win, label, term, win.crumbs)
+
+    socket
+    |> assign(:windows, socket.assigns.windows ++ [win])
+    |> assign(:window_z, z)
+  end
+
+  # Open a window that carries only an error head (a binding that vanished): still
+  # gives the user a closable window explaining what happened rather than a no-op.
+  defp open_window_error(socket, label, message) do
+    {id, socket} = mint_window_id(socket)
+    {x, y, socket} = next_window_pos(socket)
+    z = socket.assigns.window_z + 1
+
+    win = %{
+      id: id,
+      label: to_string(label),
+      crumbs: [],
+      target: nil,
+      rows: [],
+      error: message,
+      watch: nil,
+      stats: nil,
+      frozen: false,
+      refresh_pending: false,
+      flash_gen: 0,
+      poke_result: nil,
+      poke_error: nil,
+      x: x,
+      y: y,
+      z: z
+    }
+
+    socket
+    |> assign(:windows, socket.assigns.windows ++ [win])
+    |> assign(:window_z, z)
+  end
+
+  # Inspect a live `term` into a window `w` (parameterised twin of the docked
+  # `inspect_term/4`): read the object's fields via the read-surface, set the
+  # window's target/rows/crumbs/error, then (re)arm its per-object watch + stats.
+  # A re-inspect (drill / crumb walk-back) rebinds the watch onto the new head and
+  # releases the previous one — but only if no OTHER watcher (window or docked
+  # pane) still needs that pid (so closing one of two windows on the same actor
+  # doesn't silence the other).
+  defp inspect_window(socket, w, label, term, crumbs) do
+    if Workspace.inspectable?(term) do
+      case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
+        {:ok, fields} when is_map(fields) ->
+          %{
+            w
+            | target: target_info(label, term),
+              rows: field_rows(fields),
+              crumbs: crumbs,
+              error: nil
+          }
+          |> track_window(socket, term)
+
+        {:ok, scalar} ->
+          %{
+            w
+            | target: target_info(label, term),
+              rows: [
+                %{
+                  name: "value",
+                  value: Workspace.format_value(scalar),
+                  term: scalar,
+                  drillable: false,
+                  kind: term_kind(scalar)
+                }
+              ],
+              crumbs: crumbs,
+              error: nil
+          }
+          |> track_window(socket, scalar)
+
+        {:error, reason} ->
+          %{
+            w
+            | target: nil,
+              rows: [],
+              crumbs: [],
+              error: Workspace.render_error(reason)
+          }
+          |> track_window(socket, nil)
+      end
+    else
+      %{
+        w
+        | target: target_info(label, term),
+          rows: [],
+          crumbs: crumbs,
+          error: "#{label} is a #{scalar_kind(term)} — no fields to inspect"
+      }
+      |> track_window(socket, term)
+    end
+  end
+
+  # Arm (or tear down) a window's per-object change subscription + pid-stats read
+  # for `term`, called on every `inspect_window/5`. Mirrors the docked
+  # `track_object/2` but scoped to one window's `watch`. The previously-watched
+  # term is released first (guarded so a pid another watcher still needs is kept
+  # subscribed), then a non-frozen pid-backed head re-subscribes + reads stats.
+  defp track_window(w, socket, {:beamtalk_object, _c, _m, pid} = term) when is_pid(pid) do
+    w = unwatch_window(w, socket)
+
+    w =
+      if w.frozen do
+        %{w | watch: nil}
+      else
+        case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
+          :ok -> %{w | watch: term}
+          _ -> %{w | watch: nil}
+        end
+      end
+
+    %{w | refresh_pending: false}
+    |> refresh_window_stats(socket, term)
+    |> Map.merge(%{poke_result: nil, poke_error: nil})
+  end
+
+  defp track_window(w, socket, _term) do
+    w
+    |> unwatch_window(socket)
+    |> Map.merge(%{stats: nil, poke_result: nil, poke_error: nil})
+  end
+
+  # Drop a window's per-object subscription, unless the same pid is still watched
+  # by another window or the docked pane (reference-aware unsubscribe). Idempotent.
+  defp unwatch_window(%{watch: nil} = w, _socket), do: w
+
+  defp unwatch_window(%{watch: term} = w, socket) do
+    unless pid_watched_elsewhere?(socket, term, w.id) do
+      Facade.dispatch(:unsubscribe_object, %{term: term, pid: self()}, ctx(socket))
+    end
+
+    %{w | watch: nil}
+  end
+
+  # True when the pid backing `term` is still watched by some watcher OTHER than
+  # window `except_id` — another floating window, or the docked Inspector. Used to
+  # avoid unsubscribing a pid a sibling watcher still depends on (the workspace
+  # keys subscriptions by `(pid, subscriber)`, so one unsubscribe would silence all
+  # this-pid watchers in this LiveView).
+  defp pid_watched_elsewhere?(socket, {:beamtalk_object, _c, _m, pid}, except_id)
+       when is_pid(pid) do
+    docked = watched_pid?(socket.assigns[:inspect_watch], pid)
+
+    windowed =
+      Enum.any?(socket.assigns.windows, fn w ->
+        w.id != except_id and watched_pid?(w.watch, pid)
+      end)
+
+    docked or windowed
+  end
+
+  defp pid_watched_elsewhere?(_socket, _term, _except_id), do: false
+
+  # Read a window's inspected actor's live pid stats for its head chips. A failure
+  # clears the chips rather than rendering stale numbers (same contract as the
+  # docked `refresh_stats/2`).
+  defp refresh_window_stats(w, socket, term) do
+    case Facade.dispatch(:pid_stats, %{term: term}, ctx(socket)) do
+      {:ok, stats} when is_map(stats) -> %{w | stats: stats}
+      _ -> %{w | stats: nil}
+    end
+  end
+
+  # Re-read a window's *already-watched* object after a change push WITHOUT
+  # re-arming the subscription (the watch is still live). Bumps the window's
+  # `flash_gen` so its FieldFlash hook flashes the changed cells. Mirrors the
+  # docked `refresh_inspector/2`.
+  defp refresh_window(w, socket, {:beamtalk_object, _c, _m, pid} = term) when is_pid(pid) do
+    label = window_label(w)
+
+    case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
+      {:ok, fields} when is_map(fields) ->
+        %{
+          w
+          | target: target_info(label, term),
+            rows: field_rows(fields),
+            error: nil
+        }
+        |> refresh_window_stats(socket, term)
+        |> bump_window_flash()
+
+      {:ok, _scalar} ->
+        w |> refresh_window_stats(socket, term) |> bump_window_flash()
+
+      {:error, _reason} ->
+        w
+    end
+  end
+
+  defp refresh_window(w, _socket, _term), do: w
+
+  # The label at a window's current head: its last drill crumb, falling back to its
+  # target label.
+  defp window_label(w) do
+    case List.last(w.crumbs) do
+      %{label: label} -> label
+      _ -> (w.target || %{})[:label] || "value"
+    end
+  end
+
+  defp bump_window_flash(w), do: %{w | flash_gen: w.flash_gen + 1}
+
+  # Per-window freeze toggle (the docked `toggle_freeze/1`, scoped to one window).
+  # Unfreeze re-arms the window's watch on its current head and catches up; freeze
+  # drops its subscription (reference-aware) and holds the snapshot.
+  defp toggle_window_freeze(socket, %{frozen: true} = w) do
+    w = %{w | frozen: false, refresh_pending: false}
+
+    case window_head_term(w) do
+      {:beamtalk_object, _c, _m, pid} = term when is_pid(pid) ->
+        w
+        |> rearm_window_watch(socket, term)
+        |> refresh_window(socket, term)
+
+      _ ->
+        w
+    end
+  end
+
+  defp toggle_window_freeze(socket, w) do
+    w
+    |> unwatch_window(socket)
+    |> Map.put(:frozen, true)
+  end
+
+  defp rearm_window_watch(w, socket, term) do
+    case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
+      :ok -> %{w | watch: term}
+      _ -> %{w | watch: nil}
+    end
+  end
+
+  # The live term at a window's current head (its last crumb), or nil.
+  defp window_head_term(w) do
+    case List.last(w.crumbs) do
+      %{term: term} -> term
+      _ -> nil
+    end
+  end
+
+  # Send `message` to a window's inspected actor by eval'ing `<binding> <message>`
+  # against the session (the docked `poke_object/2`, scoped to one window). The
+  # actor is addressed by its window's single-crumb binding label; a window not at
+  # a named-binding root can't be poked. On success the window re-reads so its
+  # fields reflect the write synchronously (the docked `refresh_poked_inspector`).
+  defp poke_window(socket, w, message) do
+    message = String.trim(message)
+    pid = socket.assigns[:session_pid]
+    label = window_poke_label(w)
+
+    cond do
+      not is_pid(pid) ->
+        %{w | poke_result: nil, poke_error: "not attached to workspace"}
+
+      message == "" ->
+        %{w | poke_result: nil, poke_error: "Enter a message to send."}
+
+      is_nil(label) ->
+        %{
+          w
+          | poke_result: nil,
+            poke_error: "Can only send to a bound object — inspect a binding to poke it."
+        }
+
+      true ->
+        send_window_poke(socket, w, pid, label, message)
+    end
+  end
+
+  defp send_window_poke(socket, w, pid, label, message) do
+    code = "#{label} #{message}"
+
+    case Facade.dispatch(:eval, %{session_pid: pid, code: code}, ctx(socket)) do
+      {:ok, term, _output, _warnings} ->
+        w = %{w | poke_result: "→ #{Workspace.render_term(term)}", poke_error: nil}
+
+        case w.watch do
+          {:beamtalk_object, _c, _m, p} = watched when is_pid(p) ->
+            refresh_window(w, socket, watched)
+
+          _ ->
+            w
+        end
+
+      {:error, reason, _output, _warnings} ->
+        %{w | poke_result: nil, poke_error: Workspace.render_error(reason)}
+
+      {:error, reason} ->
+        %{w | poke_result: nil, poke_error: facade_error(reason)}
+    end
+  end
+
+  # The binding name to address a window poke to (its single-crumb root label), or
+  # nil — the same well-formedness gate as the docked `poke_label/1`.
+  defp window_poke_label(%{crumbs: [%{label: label}]}) when is_binary(label) do
+    if valid_receiver?(label), do: label, else: nil
+  end
+
+  defp window_poke_label(_w), do: nil
+
+  # ── window-list manipulation (pure view state, no workspace round-trip) ──────
+
+  # Mint the next unique window id (a string so it rides DOM ids + phx-value cleanly)
+  # and advance the counter.
+  defp mint_window_id(socket) do
+    n = socket.assigns.next_window_id
+    {"win-#{n}", assign(socket, :next_window_id, n + 1)}
+  end
+
+  # The cascade position for the next window: offset down-right by one step per
+  # already-open window, wrapping after a few so a long-lived session doesn't march
+  # windows off-screen. Returns {x, y, socket} (socket unchanged — kept symmetric
+  # with `mint_window_id/1` for a tidy call site).
+  defp next_window_pos(socket) do
+    step = rem(length(socket.assigns.windows), 8)
+    x = window_origin_x() + step * window_cascade()
+    y = window_origin_y() + step * window_cascade()
+    {x, y, socket}
+  end
+
+  # Look up a window by id, or nil.
+  defp find_window(socket, id), do: Enum.find(socket.assigns.windows, &(&1.id == id))
+
+  # Replace the window `id` with `fun.(window)`, leaving the list order (and so the
+  # DOM order) stable — z-order is carried by each window's `:z`, not list position,
+  # so an update never reshuffles the windows and resets their drag positions.
+  defp update_window(socket, id, fun) do
+    windows =
+      Enum.map(socket.assigns.windows, fn w ->
+        if w.id == id, do: fun.(w), else: w
+      end)
+
+    assign(socket, :windows, windows)
+  end
+
+  # Close a window: release its watch (reference-aware) and drop it from the list.
+  defp close_window(socket, id) do
+    case find_window(socket, id) do
+      nil ->
+        socket
+
+      w ->
+        _ = unwatch_window(w, socket)
+        assign(socket, :windows, Enum.reject(socket.assigns.windows, &(&1.id == id)))
+    end
+  end
+
+  # Bring window `id` to the front: bump its z above the current max so it overlays
+  # the others. No-op for an unknown id.
+  defp focus_window(socket, id) do
+    case find_window(socket, id) do
+      nil ->
+        socket
+
+      _w ->
+        z = socket.assigns.window_z + 1
+
+        socket
+        |> assign(:window_z, z)
+        |> update_window(id, fn w -> %{w | z: z} end)
+    end
+  end
+
+  # Clamp a client-reported drag coordinate to a non-negative integer (a crafted
+  # payload could send a float/NaN/negative).
+  defp clamp_coord(n) when is_integer(n) and n >= 0, do: n
+  defp clamp_coord(n) when is_float(n) and n >= 0.0, do: trunc(n)
+
+  defp clamp_coord(n) when is_binary(n) do
+    case Integer.parse(n) do
+      {i, _} when i >= 0 -> i
+      _ -> 0
+    end
+  end
+
+  defp clamp_coord(_), do: 0
+
+  # Route an `{:object_changed, pid, …}` push to every open floating window whose
+  # watched head is that pid (a non-frozen, currently-watching window). Each such
+  # window coalesces its own burst via its `:refresh_pending` flag and schedules a
+  # per-window deferred refresh. Windows watching a different pid (or frozen) are
+  # untouched. Returns the updated socket.
+  defp notify_windows_changed(socket, pid) do
+    {windows, scheduled} =
+      Enum.map_reduce(socket.assigns.windows, false, fn w, sched ->
+        cond do
+          w.frozen or not watched_pid?(w.watch, pid) ->
+            {w, sched}
+
+          w.refresh_pending ->
+            {w, sched}
+
+          true ->
+            {%{w | refresh_pending: true}, true}
+        end
+      end)
+
+    if scheduled do
+      Process.send_after(self(), {:do_window_refresh, pid}, refresh_debounce_ms())
+    end
+
+    assign(socket, :windows, windows)
+  end
 
   # Flip the freeze flag and (un)arm tracking accordingly. Freezing unsubscribes
   # the live object change stream (the pane now holds a snapshot). Unfreezing
@@ -2632,6 +3320,23 @@ defmodule BtAttachWeb.WorkspaceLive do
             </div>
           </div>
           <span class="spacer"></span>
+          <%!-- Dock/Float toggle (BT-2493, the spike's mode switch): in Float mode
+               a binding click / Inspect-it opens a floating, draggable inspector
+               window instead of the docked pane. Docked is the default. Shown only
+               once attached, since it governs the connected Inspector. --%>
+          <div :if={@connected} class="seg insp-mode" role="tablist" aria-label="Inspector mode">
+            <button
+              :for={{mode, label} <- [{"docked", "Dock"}, {"float", "Float"}]}
+              type="button"
+              role="tab"
+              class={[@inspector_mode == mode && "on"]}
+              aria-selected={to_string(@inspector_mode == mode)}
+              phx-click="set_inspector_mode"
+              phx-value-mode={mode}
+            >
+              {label}
+            </button>
+          </div>
           <%= if @connected do %>
             <div class="attach">
               <span class="dot live"></span>
@@ -3225,6 +3930,15 @@ defmodule BtAttachWeb.WorkspaceLive do
               </div>
             </div>
           </div>
+          <%!-- Floating inspector windows (BT-2493): the overlay layer of draggable,
+               stackable inspector windows opened in Float mode. Rendered whenever
+               windows are open — even if the user has since flipped back to Docked,
+               so their state + positions persist — but pointer-inert (the layer is
+               `pointer-events:none`; each window re-enables its own) so it never
+               eats clicks on the cockpit beneath when empty. Each window reuses the
+               docked Inspector's content (target/crumbs/rows/chips/poke) keyed by
+               its id, with its own drag handle, close button and z-order. --%>
+          <.inspector_windows :if={@windows != []} windows={@windows} role={@role} />
           <%!-- The Changes (ChangeLog) viewer and the live Transcript stream now
                live in the tabbed Workspace dock above (BT-2490), not a separate
                full-width footer. --%>
@@ -3254,4 +3968,179 @@ defmodule BtAttachWeb.WorkspaceLive do
     </div>
     """
   end
+
+  # ── floating inspector windows (BT-2493, epic BT-2482 Phase 3) ───────────────
+  #
+  # The overlay layer: one draggable, stackable inspector window per `:windows`
+  # entry. The layer itself is pointer-inert so it never eats clicks on the
+  # cockpit beneath; each window re-enables pointer events on itself. Window
+  # position (`left`/`top`) and stacking (`z-index`) come straight from the
+  # per-window state the WindowDrag hook reports on drop / focus, so they survive an
+  # unrelated re-render. Each window's content reuses the docked Inspector's markup
+  # (head + breadcrumb + chips + ivar table + poke), parameterised by window id so
+  # its drill/crumb/close/freeze/poke events carry the id back to the right window.
+
+  attr :windows, :list, required: true
+  attr :role, :atom, required: true
+
+  defp inspector_windows(assigns) do
+    ~H"""
+    <div class="insp-overlay" id="inspector-overlay">
+      <.inspector_window :for={w <- @windows} win={w} role={@role} />
+    </div>
+    """
+  end
+
+  attr :win, :map, required: true
+  attr :role, :atom, required: true
+
+  defp inspector_window(assigns) do
+    ~H"""
+    <section
+      class="insp-window"
+      id={"inspector-window-#{@win.id}"}
+      style={"left:#{@win.x}px;top:#{@win.y}px;z-index:#{@win.z};"}
+      phx-hook="WindowDrag"
+      data-window-id={@win.id}
+    >
+      <%!-- Title bar: the drag handle (`.iw-title`, grabbed by the WindowDrag hook)
+           plus the live freeze toggle and the close button. Dragging the bar moves
+           the window client-side; the hook reports the final x/y on drop. --%>
+      <header class="iw-bar" data-window-drag-handle>
+        <span class="iw-title mono">
+          {(@win.target && @win.target.label) || @win.label}
+        </span>
+        <span class="spacer"></span>
+        <button
+          :if={@win.target && @win.target.pid}
+          type="button"
+          class={["insp-freeze", (@win.frozen && "frozen") || "live"]}
+          phx-click="window_freeze"
+          phx-value-id={@win.id}
+          title={
+            if @win.frozen,
+              do: "Frozen snapshot — click to track live",
+              else: "Tracking live (subscribed to changes) — click to freeze a snapshot"
+          }
+        >
+          <span class="iwf-dot"></span>{(@win.frozen && "frozen") || "live"}
+        </button>
+        <button
+          type="button"
+          class="iw-close"
+          phx-click="window_close"
+          phx-value-id={@win.id}
+          title="Close window"
+          aria-label="Close window"
+        >
+          ×
+        </button>
+      </header>
+      <div class="iw-body">
+        <%= if @win.target do %>
+          <div class="insp-head">
+            <div :if={length(@win.crumbs) > 1} class="insp-crumbs">
+              <%= for {crumb, i} <- Enum.with_index(@win.crumbs) do %>
+                <span :if={i > 0} class="sep">›</span>
+                <span
+                  class="c"
+                  phx-click="window_crumb"
+                  phx-value-id={@win.id}
+                  phx-value-index={i}
+                >
+                  {crumb.label}
+                </span>
+              <% end %>
+            </div>
+            <div class="ps mono">
+              Inspecting <strong>{@win.target.label}</strong>
+              <span class="ps-header">{@win.target.header}</span>
+            </div>
+            <div class="proc-chips">
+              <span class="chip">class <b>{@win.target.class_name}</b></span>
+              <span :if={@win.target.pid} class="chip">
+                pid <b>{@win.target.pid}</b>
+              </span>
+              <span :if={stat_status(@win.stats)} class="chip pid-stat">
+                <span class="dot"></span>{stat_status(@win.stats)}
+              </span>
+              <span :if={not is_nil(stat_mailbox(@win.stats))} class="chip pid-stat">
+                mailbox <b>{stat_mailbox(@win.stats)}</b>
+              </span>
+              <span :if={not is_nil(stat_reductions(@win.stats))} class="chip pid-stat">
+                reductions <b>{stat_reductions(@win.stats)}</b>
+              </span>
+            </div>
+          </div>
+        <% end %>
+        <div class="iw-content">
+          <div :if={@win.error} class="io-block warn">{@win.error}</div>
+          <%= if @win.target && @win.rows != [] do %>
+            <table
+              id={"inspector-window-fields-#{@win.id}"}
+              class="ivar-table"
+              phx-hook="FieldFlash"
+              data-flash-gen={@win.flash_gen}
+            >
+              <tbody>
+                <tr
+                  :for={{row, i} <- Enum.with_index(@win.rows)}
+                  class={row.drillable && "drillable"}
+                  phx-click={row.drillable && "window_drill"}
+                  phx-value-id={row.drillable && @win.id}
+                  phx-value-index={row.drillable && i}
+                >
+                  <td class="k">{row.name}</td>
+                  <td
+                    class={["v", row.kind]}
+                    data-flash-key={row.name}
+                    data-flash-val={row.value}
+                  >
+                    {row.value}
+                  </td>
+                  <td class="follow">
+                    <span :if={row.drillable} class="follow-link">follow →</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          <% else %>
+            <p :if={@win.target == nil && @win.error == nil} class="empty">
+              Nothing to inspect.
+            </p>
+          <% end %>
+          <%!-- Owner-only poke bar (BT-2492), per-window: pokeable only at a single
+               named-binding crumb root (the same well-formedness gate the docked
+               pane uses), and only for the owner role. --%>
+          <div
+            :if={@win.target && @win.target.pid && @role == :owner && window_pokeable?(@win)}
+            class="poke"
+          >
+            <div class="poke-label">Send a message to {@win.target.label}</div>
+            <form class="poke-row" phx-submit="window_poke" phx-value-id={@win.id}>
+              <span class="poke-recv mono">‹recv›</span>
+              <input
+                class="field mono"
+                name="message"
+                autocomplete="off"
+                placeholder="increment   ·   incrementBy: 10"
+              />
+              <button type="submit" class="btn">Send</button>
+            </form>
+            <div :if={@win.poke_result} class="poke-out ok mono">{@win.poke_result}</div>
+            <div :if={@win.poke_error} class="poke-out warn mono">{@win.poke_error}</div>
+          </div>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  # Whether a floating window's head can be poked: a pid-backed object at the
+  # inspection root with a valid-identifier binding name (the same contract as the
+  # docked `pokeable?/1`, scoped to one window's crumbs).
+  defp window_pokeable?(%{crumbs: [%{label: label}]}) when is_binary(label),
+    do: valid_receiver?(label)
+
+  defp window_pokeable?(_w), do: false
 end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -2418,8 +2418,6 @@ defmodule BtAttachWeb.WorkspaceLive do
     end
   end
 
-  defp refresh_window(w, _socket, _term), do: w
-
   # The label at a window's current head: its last drill crumb, falling back to its
   # target label.
   defp window_label(w) do

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -727,8 +727,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # clamped to non-negative integers so a crafted payload can't place a window off
   # into NaN-land.
   def handle_event("window_moved", %{"id" => id, "x" => x, "y" => y}, socket) do
-    {:noreply,
-     update_window(socket, id, fn w -> %{w | x: clamp_coord(x), y: clamp_coord(y)} end)}
+    {:noreply, update_window(socket, id, fn w -> %{w | x: clamp_coord(x), y: clamp_coord(y)} end)}
   end
 
   def handle_event("window_moved", _params, socket), do: {:noreply, socket}
@@ -4042,12 +4041,7 @@ defmodule BtAttachWeb.WorkspaceLive do
             <div :if={length(@win.crumbs) > 1} class="insp-crumbs">
               <%= for {crumb, i} <- Enum.with_index(@win.crumbs) do %>
                 <span :if={i > 0} class="sep">›</span>
-                <span
-                  class="c"
-                  phx-click="window_crumb"
-                  phx-value-id={@win.id}
-                  phx-value-index={i}
-                >
+                <span class="c" phx-click="window_crumb" phx-value-id={@win.id} phx-value-index={i}>
                   {crumb.label}
                 </span>
               <% end %>
@@ -4091,11 +4085,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                   phx-value-index={row.drillable && i}
                 >
                   <td class="k">{row.name}</td>
-                  <td
-                    class={["v", row.kind]}
-                    data-flash-key={row.name}
-                    data-flash-val={row.value}
-                  >
+                  <td class={["v", row.kind]} data-flash-key={row.name} data-flash-val={row.value}>
                     {row.value}
                   </td>
                   <td class="follow">

--- a/editors/liveview/test/bt_attach/workspace_test.exs
+++ b/editors/liveview/test/bt_attach/workspace_test.exs
@@ -177,9 +177,12 @@ defmodule BtAttach.WorkspaceTest do
     end
 
     test "the navigation wrappers reject non-binary arguments (guard contract)" do
-      assert_raise FunctionClauseError, fn -> Workspace.senders_of(:increment) end
-      assert_raise FunctionClauseError, fn -> Workspace.implementors_of(42) end
-      assert_raise FunctionClauseError, fn -> Workspace.symbol_index(:all) end
+      # Dispatch via apply/3 so the runtime guard is exercised without Elixir's
+      # compile-time type checker statically flagging the deliberately-bad literal
+      # against the binary() guard (a --warnings-as-errors failure on a full build).
+      assert_raise FunctionClauseError, fn -> apply(Workspace, :senders_of, [:increment]) end
+      assert_raise FunctionClauseError, fn -> apply(Workspace, :implementors_of, [42]) end
+      assert_raise FunctionClauseError, fn -> apply(Workspace, :symbol_index, [:all]) end
     end
   end
 end

--- a/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
@@ -361,6 +361,106 @@ defmodule BtAttachWeb.WorkspaceBrowserTest do
     |> assert_has(".nav-popover .nav-pop-head", text: "Implementors")
   end
 
+  # ── Phase 3 floating inspector windows / overlay mode (BT-2493) ─────────────
+  #
+  # The Float toggle, opening / drilling / closing a floating window, and
+  # click-to-front (z-order) are connected-render JS behaviours: the WindowDrag
+  # hook (`window_drag.js`) drags a window by its title bar and raises it on a
+  # press, and the window content re-renders live over distribution. The drag
+  # *motion* is hard to assert deterministically (a manual/best-effort check per
+  # the issue), but the open → drill → close flow and click-to-front are covered
+  # here. `Phoenix.LiveViewTest` never loads `app.js`, so these MUST run in a real
+  # browser (the e2e lane).
+
+  test "Float mode opens a draggable inspector window, which drills then closes (BT-2493)", %{
+    conn: conn
+  } do
+    conn
+    |> visit("/")
+    |> assert_has("#workspace-editor-source")
+    # A live object graph: a Boxx actor holding a Leaf actor (same shape as the
+    # docked breadcrumb test), so the floating window has a reference to drill.
+    |> eval_do("Actor subclass: WinLeaf\n  state: n = 99\n\n  n => self.n")
+    |> eval_do(
+      "Actor subclass: WinBoxx\n  state: item = nil\n\n  setItem: x => self.item := x\n  item => self.item"
+    )
+    |> eval_do("winleaf := WinLeaf spawn")
+    |> eval_do("winbox := WinBoxx spawn")
+    |> eval_do("winbox setItem: winleaf")
+    |> assert_has("#bindings-panel .bname", text: "winbox")
+    # Flip the top-bar Dock/Float toggle to Float.
+    |> click(".insp-mode button[phx-value-mode='float']")
+    # Inspecting the binding now opens a FLOATING window (the overlay layer), not
+    # the docked pane — a connected-render path driven by the inspector_mode assign.
+    |> click(".obj-row[phx-value-name='winbox'] .obj-inspect")
+    |> assert_has("#inspector-overlay .insp-window", text: "Inspecting")
+    |> assert_has(".insp-window .ivar-table", text: "WinLeaf")
+    # Drill into the referenced Leaf inside the window: its own field (n = 99) reads
+    # live over distribution. This is the window's independent drill stack.
+    |> click(".insp-window tr.drillable")
+    |> assert_has(".insp-window .ivar-table", text: "99")
+    # Walk back via the window's own breadcrumb to box's `item` field.
+    |> click(".insp-window .insp-crumbs .c[phx-value-index='0']")
+    |> assert_has(".insp-window .ivar-table", text: "item")
+    # Close the window via its × button: the overlay empties (the window is gone).
+    |> click(".insp-window .iw-close")
+    |> evaluate("new Promise((resolve) => setTimeout(resolve, 250))")
+    |> evaluate("document.querySelectorAll('.insp-window').length", fn count ->
+      assert count == 0, "closing the window did not remove it from the overlay"
+    end)
+  end
+
+  test "clicking a floating window brings it to the front (z-order) (BT-2493)", %{conn: conn} do
+    conn
+    |> visit("/")
+    |> assert_has("#workspace-editor-source")
+    |> eval_do("Actor subclass: ZCounter\n  state: value = 0\n\n  value => self.value")
+    |> eval_do("za := ZCounter spawn")
+    |> eval_do("zb := ZCounter spawn")
+    |> assert_has("#bindings-panel .bname", text: "za")
+    |> assert_has("#bindings-panel .bname", text: "zb")
+    |> click(".insp-mode button[phx-value-mode='float']")
+    # Open two floating windows. The second-opened starts on top (higher z-index).
+    |> click(".obj-row[phx-value-name='za'] .obj-inspect")
+    |> click(".obj-row[phx-value-name='zb'] .obj-inspect")
+    |> assert_has("#inspector-window-win-1")
+    |> assert_has("#inspector-window-win-2")
+    |> evaluate(
+      """
+      (() => {
+        const z = (id) => parseInt(getComputedStyle(document.getElementById(id)).zIndex || "0", 10);
+        return z("inspector-window-win-2") > z("inspector-window-win-1");
+      })()
+      """,
+      fn second_on_top ->
+        assert second_on_top, "the second-opened window should start on top"
+      end
+    )
+    # Press the FIRST window's title bar: the WindowDrag hook pushes window_focus,
+    # the server bumps its z above the max, and it now overlays the second — z-order
+    # follows focus (the click-to-front behaviour, a connected-render JS path).
+    |> evaluate("""
+    (() => {
+      const bar = document.querySelector("#inspector-window-win-1 [data-window-drag-handle]");
+      bar.dispatchEvent(new MouseEvent("mousedown", {bubbles: true, button: 0}));
+      bar.dispatchEvent(new MouseEvent("mouseup", {bubbles: true, button: 0}));
+    })()
+    """)
+    |> evaluate("new Promise((resolve) => setTimeout(resolve, 250))")
+    |> evaluate(
+      """
+      (() => {
+        const z = (id) => parseInt(getComputedStyle(document.getElementById(id)).zIndex || "0", 10);
+        return z("inspector-window-win-1") > z("inspector-window-win-2");
+      })()
+      """,
+      fn first_now_on_top ->
+        assert first_now_on_top,
+               "clicking the first window did not raise it to the front (z-order follows focus)"
+      end
+    )
+  end
+
   # ── helpers ─────────────────────────────────────────────────────────────────
 
   # Type `query` into the omni search input and fire the `keyup` event the server

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -741,6 +741,315 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert Process.alive?(view.pid)
   end
 
+  # ── Phase 3: floating inspector windows / overlay mode (BT-2493) ─────────────
+  #
+  # The window-list lifecycle — open / drill / close / focus (z-order) / mode
+  # toggle — is server-side LiveView state, fully exercisable through
+  # `Phoenix.LiveViewTest`: we drive the events the WindowDrag hook pushes and
+  # assert the resulting render. (The drag *motion* + click-to-front interaction
+  # need a real browser and are covered by the Playwright lane.) Window ids are
+  # minted deterministically per session from 1, so a freshly-opened window is
+  # always `#inspector-window-win-1`, the next `win-2`, … — which lets these
+  # assert on the rendered DOM rather than poking the LiveView's internal state.
+
+  # Spawn + bind a live Counter actor in `view`'s session WITHOUT inspecting it,
+  # returning its binding name. In Float mode the inspect click opens a window
+  # rather than the docked pane, so the window tests open windows themselves.
+  defp spawn_counter(view) do
+    suffix = System.unique_integer([:positive])
+    class = "WinCounter#{suffix}"
+    name = "wc_#{suffix}"
+
+    class_src = """
+    Actor subclass: #{class}
+      state: value = 0
+
+      value => self.value
+
+      increment => self.value := self.value + 1
+    """
+
+    view |> form("#eval-form") |> render_submit(%{expr: class_src})
+    view |> form("#eval-form") |> render_submit(%{expr: "#{name} := #{class} spawn"})
+    assert eventually(fn -> render(view) =~ name end)
+    name
+  end
+
+  # Put `view` in Float mode and open a floating window on binding `name`. Returns
+  # the deterministic window id of the just-opened window.
+  defp open_float_window(view, name) do
+    render_hook(view, "set_inspector_mode", %{"mode" => "float"})
+    view |> element("button[phx-value-name='#{name}']") |> render_click()
+    # The most-recently-opened window is the last `inspector-window-win-N` in the
+    # render; derive its id so the test can address it without internal state.
+    ids = Regex.scan(~r/inspector-window-(win-\d+)"/, render(view))
+    assert ids != [], "expected a floating window to be open"
+    ids |> List.last() |> Enum.at(1)
+  end
+
+  test "the Dock/Float toggle flips inspector mode and is reflected in the render (BT-2493)", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/")
+
+    # Docked is the default — the top-bar toggle is present and no floating overlay
+    # exists yet.
+    html = render(view)
+    assert html =~ ~s(phx-click="set_inspector_mode")
+    refute html =~ ~s(id="inspector-overlay")
+
+    # Flip to Float: the toggle marks Float selected (aria-selected on its tab). No
+    # windows yet, so still no overlay until one opens.
+    html = render_hook(view, "set_inspector_mode", %{"mode" => "float"})
+    assert html =~ ~s(phx-value-mode="float")
+    refute html =~ ~s(id="inspector-overlay")
+
+    # A bad mode is ignored, not a crash.
+    render_hook(view, "set_inspector_mode", %{"mode" => "bogus"})
+    assert Process.alive?(view.pid)
+  end
+
+  test "in Float mode an inspect click opens a floating window on the binding (BT-2493)", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/")
+    name = spawn_counter(view)
+
+    render_hook(view, "set_inspector_mode", %{"mode" => "float"})
+
+    # The bindings pane's Inspect button fires "inspect"; in Float mode that opens a
+    # floating window rather than driving the docked pane.
+    html = view |> element("button[phx-value-name='#{name}']") |> render_click()
+
+    assert html =~ ~s(id="inspector-overlay")
+    assert html =~ ~s(id="inspector-window-win-1")
+    assert html =~ "Inspecting"
+    # The window's title bar carries the binding label and the window renders its
+    # live field (value = 0).
+    assert html =~ "iw-title"
+    assert html =~ "value"
+  end
+
+  test "multiple windows target objects independently, each with its own breadcrumb (BT-2493)",
+       %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    a = spawn_counter(view)
+    b = spawn_counter(view)
+
+    render_hook(view, "set_inspector_mode", %{"mode" => "float"})
+    view |> element("button[phx-value-name='#{a}']") |> render_click()
+    html = view |> element("button[phx-value-name='#{b}']") |> render_click()
+
+    # Two independent windows in the overlay, with distinct deterministic ids.
+    assert html =~ ~s(id="inspector-window-win-1")
+    assert html =~ ~s(id="inspector-window-win-2")
+    # Each window addresses its own drill/close events by its id.
+    assert html =~ ~s(phx-value-id="win-1")
+    assert html =~ ~s(phx-value-id="win-2")
+  end
+
+  test "drilling a floating window extends only that window's breadcrumb (BT-2493)", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/")
+    suffix = System.unique_integer([:positive])
+    leaf = "WLeaf#{suffix}"
+    boxx = "WBoxx#{suffix}"
+    name = "wbox_#{suffix}"
+
+    view
+    |> form("#eval-form")
+    |> render_submit(%{expr: "Actor subclass: #{leaf}\n  state: n = 99\n\n  n => self.n"})
+
+    view
+    |> form("#eval-form")
+    |> render_submit(%{
+      expr:
+        "Actor subclass: #{boxx}\n  state: item = nil\n\n  setItem: x => self.item := x\n  item => self.item"
+    })
+
+    view |> form("#eval-form") |> render_submit(%{expr: "wleaf_#{suffix} := #{leaf} spawn"})
+    view |> form("#eval-form") |> render_submit(%{expr: "#{name} := #{boxx} spawn"})
+    view |> form("#eval-form") |> render_submit(%{expr: "#{name} setItem: wleaf_#{suffix}"})
+    assert eventually(fn -> render(view) =~ name end)
+
+    id = open_float_window(view, name)
+
+    # The window shows box's `item` (a live Leaf reference). Drill into it (index 0,
+    # the sole drillable row): the referenced Leaf's own field (n = 99) renders and
+    # the window's breadcrumb now has two levels (a back-crumb at index 0).
+    html = render_hook(view, "window_drill", %{"id" => id, "index" => "0"})
+    assert html =~ "99"
+    assert html =~ ~s(phx-value-index="0")
+
+    # Walk back via the window's breadcrumb (crumb 0): back to box's `item` field.
+    html = render_hook(view, "window_crumb", %{"id" => id, "index" => "0"})
+    assert html =~ "item"
+  end
+
+  test "closing a floating window removes it from the overlay (BT-2493)", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    name = spawn_counter(view)
+
+    id = open_float_window(view, name)
+    assert render(view) =~ ~s(id="inspector-window-#{id}")
+
+    # Close it: the window is dropped from the list (releasing its subscription —
+    # the window no longer exists to receive pushes). The overlay empties.
+    html = render_hook(view, "window_close", %{"id" => id})
+    refute html =~ ~s(id="inspector-window-#{id}")
+    refute html =~ ~s(id="inspector-overlay")
+
+    # Closing an unknown id is a harmless no-op.
+    render_hook(view, "window_close", %{"id" => "win-does-not-exist"})
+    assert Process.alive?(view.pid)
+  end
+
+  test "clicking a window brings it to the front (z-order follows focus) (BT-2493)", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/")
+    a = spawn_counter(view)
+    b = spawn_counter(view)
+
+    render_hook(view, "set_inspector_mode", %{"mode" => "float"})
+    view |> element("button[phx-value-name='#{a}']") |> render_click()
+    view |> element("button[phx-value-name='#{b}']") |> render_click()
+
+    # The second-opened window (win-2) starts on top: a higher inline z-index.
+    assert window_z(render(view), "win-2") > window_z(render(view), "win-1")
+
+    # Focus the FIRST window: its z is bumped above the current max, so it now wins.
+    render_hook(view, "window_focus", %{"id" => "win-1"})
+    html = render(view)
+    assert window_z(html, "win-1") > window_z(html, "win-2")
+    # The DOM order is unchanged — only z moved, so a focus never reshuffles windows
+    # (which would reset their drag positions): win-1 still precedes win-2.
+    assert window_dom_index(html, "win-1") < window_dom_index(html, "win-2")
+  end
+
+  test "a drag-drop persists a window's position and it survives re-render (BT-2493)", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/")
+    name = spawn_counter(view)
+    id = open_float_window(view, name)
+
+    # The WindowDrag hook reports the final position on drop; the server persists it
+    # into the window's inline left/top.
+    html = render_hook(view, "window_moved", %{"id" => id, "x" => 412, "y" => 233})
+    assert html =~ "left:412px"
+    assert html =~ "top:233px"
+
+    # The position survives an unrelated re-render (a bindings re-read from another
+    # eval) — positions are not reset on unrelated state changes.
+    view
+    |> form("#eval-form")
+    |> render_submit(%{expr: "unrelated_#{System.unique_integer([:positive])} := 1"})
+
+    html = render(view)
+    assert html =~ "left:412px"
+    assert html =~ "top:233px"
+
+    # A crafted non-numeric / negative payload clamps rather than crashing.
+    render_hook(view, "window_moved", %{"id" => id, "x" => "bogus", "y" => -5})
+    assert Process.alive?(view.pid)
+  end
+
+  test "windows persist when toggling back to Docked mode (BT-2493)", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    name = spawn_counter(view)
+    id = open_float_window(view, name)
+    assert render(view) =~ ~s(id="inspector-window-#{id}")
+
+    # Flipping back to Docked does NOT tear down open windows — they stay rendered
+    # (and keep their subscriptions) so a misclick can't destroy a desk of
+    # inspectors.
+    html = render_hook(view, "set_inspector_mode", %{"mode" => "docked"})
+    assert html =~ ~s(id="inspector-window-#{id}")
+  end
+
+  test "a per-window freeze toggle holds that window's snapshot (BT-2493)", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    name = spawn_counter(view)
+    id = open_float_window(view, name)
+
+    # Tracking is live by default — the window's freeze button reads "live".
+    assert render(view) =~ "insp-freeze live"
+
+    # Freeze: the window drops its subscription and holds the snapshot ("frozen").
+    html = render_hook(view, "window_freeze", %{"id" => id})
+    assert html =~ "insp-freeze frozen"
+
+    # Unfreeze: re-arm the watch + catch up; the button reads "live" again.
+    html = render_hook(view, "window_freeze", %{"id" => id})
+    assert html =~ "insp-freeze live"
+  end
+
+  test "crafted window events with bad ids/indexes are ignored, not crashes (BT-2493)", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/")
+
+    # No windows open: every window event is a safe no-op (no overlay, no crash).
+    render_hook(view, "window_drill", %{"id" => "win-x", "index" => "0"})
+    render_hook(view, "window_crumb", %{"id" => "win-x", "index" => "3"})
+    render_hook(view, "window_focus", %{"id" => "win-x"})
+    render_hook(view, "window_moved", %{"id" => "win-x", "x" => 1, "y" => 2})
+    render_hook(view, "window_freeze", %{"id" => "win-x"})
+    render_hook(view, "window_close", %{"id" => "win-x"})
+    # Malformed payloads (missing keys) hit the catch-all clauses.
+    render_hook(view, "window_drill", %{"garbage" => true})
+    render_hook(view, "window_poke", %{"id" => "win-x"})
+    assert Process.alive?(view.pid)
+    refute render(view) =~ ~s(id="inspector-overlay")
+  end
+
+  test "two windows on the same actor are independent; closing one keeps the other (BT-2493)", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/")
+    name = spawn_counter(view)
+
+    # Open TWO floating windows on the SAME binding. The workspace keys per-object
+    # subscriptions by (pid, subscriber) and our subscriber is this one LiveView, so
+    # both windows share the single underlying subscription — the reference-aware
+    # unwatch must NOT release it while the other window still needs it.
+    render_hook(view, "set_inspector_mode", %{"mode" => "float"})
+    view |> element("button[phx-value-name='#{name}']") |> render_click()
+    view |> element("button[phx-value-name='#{name}']") |> render_click()
+
+    html = render(view)
+    assert html =~ ~s(id="inspector-window-win-1")
+    assert html =~ ~s(id="inspector-window-win-2")
+
+    # Close the first window: the second stays open and live (its watch is intact —
+    # the guard kept the shared subscription rather than silencing window 2).
+    html = render_hook(view, "window_close", %{"id" => "win-1"})
+    refute html =~ ~s(id="inspector-window-win-1")
+    assert html =~ ~s(id="inspector-window-win-2")
+    assert html =~ "insp-freeze live"
+    assert Process.alive?(view.pid)
+  end
+
+  # The inline z-index of the floating window `id` (`win-N`), parsed out of the
+  # render — the server-authoritative stacking the WindowDrag hook reads.
+  defp window_z(html, id) do
+    case Regex.run(~r/id="inspector-window-#{id}"[^>]*style="[^"]*z-index:(\d+)/, html) do
+      [_, n] -> String.to_integer(n)
+      _ -> 0
+    end
+  end
+
+  # The byte offset of window `id`'s `<section>` in the render — a proxy for DOM
+  # order, so a test can assert focus did NOT reshuffle the windows.
+  defp window_dom_index(html, id) do
+    case :binary.match(html, "inspector-window-#{id}") do
+      {pos, _len} -> pos
+      :nomatch -> -1
+    end
+  end
+
   # ── Wave 4: multi-tab isolation / session resume / teardown (BT-2410) ────────
 
   test "two tabs map to two isolated workspace sessions (BT-2410)", %{conn: conn} do


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2493

Final child of the Cockpit UI epic ([BT-2482](https://linear.app/beamtalk/issue/BT-2482), Phase 3 polish). Adds a **Dock/Float toggle**: in overlay mode, inspecting a binding / Inspect-it opens a floating, draggable, stackable inspector window instead of using the docked pane. Docked mode remains the default.

## What's implemented
- **Window list** (`id`, root target, drill stack, `x`/`y`/`z`) lives in LiveView assigns; each window reuses the same inspector component as the docked pane (BT-2486), parameterized by window id. A window's position survives unrelated re-renders (server holds authoritative x/y/z).
- **`WindowDrag` JS hook** (`assets/js/hooks/window_drag.js`): client-side drag via inline `left`/`top` for a smooth, no-latency drag; the final position is reported to the server **once on drop** (`window_moved`), never per-mousemove. A mousedown pushes `window_focus` so z-order follows focus (server bumps z above the rest).
- Open / drill / close per window with its own breadcrumb; close releases the window (and any subscription).

## Tests
- **Playwright** (`workspace_browser_test.exs`, `:playwright`): float-mode open → drill → close, and click-to-front z-order (the connected-render JS the docked-pane LiveViewTest can't see). Drag motion itself is best-effort/manual per the issue.
- **ExUnit** (`workspace_live_test.exs`): the window-list assigns lifecycle (open/drill/close, position persistence).

## Notes
- Authored by an agent that completed the implementation + two review passes (fixing a docked/window shared-subscription bug and a refresh-pending cross-pid bug) but terminated before opening the PR; the parent finished commit/push/PR. CI is the validation gate (no local `mix`/Elixir in the agent sandbox).

https://claude.ai/code/session_01QMA1Pcoqi77E3ao7GnQ811

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMA1Pcoqi77E3ao7GnQ811)_