### PR TITLE
Fix flaky e2e senders/implementors test: define Counter in-test (BT-2528)

### DIFF
--- a/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
@@ -344,7 +344,12 @@ defmodule BtAttachWeb.WorkspaceBrowserTest do
     |> visit("/")
     |> assert_has("#workspace-editor-source")
     # Define a class whose method sends a selector we can then trace. The starter
-    # tab targets Counter#increment; define both so a real implementor exists.
+    # tab targets Counter#increment, so `Counter` MUST exist before ⌘S can save
+    # `increment` onto it — define it here rather than leaning on another test
+    # having defined it first (the suite shares one workspace and runs in a
+    # seed-randomised order, so that ordering is not guaranteed: BT-2528). A
+    # second class (NavCounter) gives `increment` a real implementor to trace.
+    |> eval_do("Actor subclass: Counter\n  state: value = 0\n\n  value => self.value")
     |> eval_do(
       "Actor subclass: NavCounter\n  state: value = 0\n\n  step => self.value := self.value + 1"
     )


### PR DESCRIPTION
## Summary

Fixes **BT-2528** — the `e2e` (real-Chromium) Senders/Implementors Playwright case (`workspace_browser_test.exs:342`) failed deterministically at its ⌘S method-save setup:

```
Could not find element "#method-editor" [text: "Saved increment on Counter"]
```

## Root cause (not a timing flake)

The test saves `increment` onto **`Counter`** via ⌘S (the starter method tab targets `Counter#increment`), but only ever defined `NavCounter` — never `Counter`. The browser suite runs `async: false` against a single shared persistent workspace, in ExUnit's seed-randomised order, so the test was silently relying on the BT-2485 ⌘S case (line 163) having defined `Counter` first.

The toolchain pin (`1428a77`, #2548) bumped Elixir/ExUnit and shifted the default seed, flipping the order so the senders test now runs first. With `Counter` undefined, `beamtalk_repl_eval:compile_method` returns `{error, …}` instead of `{ok, "Counter"}`, so `save_result` stays `nil`, "Saved increment on Counter" never renders, and the setup assertion fails every run.

The test's own comment already said *"define both"* — the code just didn't.

## Fix

Make the test self-contained by defining `Counter` before the save, removing the cross-test ordering dependency. `NavCounter` is kept so `increment` still has a real implementor to trace. The added definition is identical to the formatter-accepted one already used in the BT-2485 case, and re-compiling a class across tests is the supported workspace path.

A longer `assert_has` timeout would **not** have fixed this — the save genuinely errored rather than being slow, so the missing class definition is the real bug.

## Acceptance criteria

- [x] Root cause identified (latent test-ordering dependency surfaced by the seed shift from the toolchain pin, not a save→compile→confirm regression).
- [x] Test hardened to be self-contained (no reliance on inter-test ordering).
- [ ] `e2e` green with the senders/implementors case passing — runs in the dedicated `liveview-e2e.yml` lane (provisions workspace + Chromium, not available locally).

Test-only change, 6 insertions / 1 deletion.

https://claude.ai/code/session_01K3sBKY2tvfkRy9WsDMDRqf

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3sBKY2tvfkRy9WsDMDRqf)_