### PR TITLE
chore: make mise honour the rust-toolchain.toml Rust pin

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+# BEAM toolchain versions live in .tool-versions; Rust is pinned in
+# rust-toolchain.toml. This setting makes mise read rust-toolchain.toml
+# directly so there is a single source of truth for the Rust version.
+[settings]
+idiomatic_version_file_enable_tools = ["rust"]


### PR DESCRIPTION
## Summary

mise disables idiomatic version files by default, so developers using mise were resolving Rust from their **global** mise config rather than the repo's `rust-toolchain.toml` pin (1.94.0). The versions happen to match today, but would silently drift on the next toolchain bump.

This adds a repo-root `mise.toml` enabling `idiomatic_version_file_enable_tools = ["rust"]`, so mise reads `rust-toolchain.toml` directly. rustup, CI, and mise now share a single source of truth — no version is duplicated.

Complements #2548, which pinned the BEAM toolchain in `.tool-versions`.

## Key changes

- New `mise.toml` with the idiomatic-version-file setting for rust (no version numbers in it)

## Notes for developers

- Each developer must run `mise trust` once in the repo (mise prompts on any new `mise.toml`)
- Future Rust bumps still happen only in `rust-toolchain.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)