### PR TITLE
Fix BT-2524: compiled actors publish object-changed for live Inspector flash

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -1213,7 +1213,17 @@ impl CoreErlangGenerator {
                 docvec![
                     line(),
                     "<{'reply', _CastResult, CastNewState}> when 'true' ->",
-                    nest(INDENT, docvec![line(), "{'noreply', CastNewState}"]),
+                    nest(
+                        INDENT,
+                        docvec![
+                            // BT-2524: same per-object change push as handle_call, for
+                            // a state write committed via a fire-and-forget cast.
+                            line(),
+                            "let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in",
+                            line(),
+                            "{'noreply', CastNewState}",
+                        ]
+                    ),
                     line(),
                     // BT-943: Log error but don't crash — caller expects no reply
                     // BT-1822: Destructure error triple to log stacktrace
@@ -1373,7 +1383,16 @@ impl CoreErlangGenerator {
                     "<{'reply', Result, NewState}> when 'true' ->",
                     nest(
                         INDENT,
-                        docvec![line(), "{'reply', {'ok', Result}, NewState}",]
+                        docvec![
+                            // BT-2524: notify the per-object change substrate so a
+                            // watched compiled actor's committed state write pushes
+                            // {object_changed, …} to the live Inspector — the runtime
+                            // beamtalk_actor path does this via log_dispatch_complete.
+                            line(),
+                            "let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in",
+                            line(),
+                            "{'reply', {'ok', Result}, NewState}",
+                        ]
                     ),
                     // Error case: pass error (now includes stacktrace) opaquely to caller
                     line(),

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -2534,6 +2534,39 @@ Actor subclass: Counter
 }
 
 #[test]
+fn test_bt2524_generated_callbacks_notify_state_change_substrate() {
+    // BT-2524: a compiled actor's generated handle_call/handle_cast must call
+    // beamtalk_actor:notify_state_change/2 after committing new state, so a
+    // *watched* actor's state writes push {object_changed,…} to the live
+    // Inspector. The runtime beamtalk_actor dispatch path does this via
+    // log_dispatch_complete/5; compiled actors run their own callbacks and would
+    // otherwise never publish (the changed field would never flash).
+    let src = "
+Actor subclass: Counter
+  state: value = 0
+  increment => self.value := self.value + 1
+";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let code = generate_module_with_warnings(&module, CodegenOptions::new("counter"))
+        .expect("codegen should succeed")
+        .code;
+
+    // handle_call commits NewState; the hook fires before returning the reply.
+    assert!(
+        code.contains("'beamtalk_actor':'notify_state_change'(State, NewState)"),
+        "handle_call must notify the per-object change substrate after committing \
+         state. Got:\n{code}"
+    );
+    // handle_cast (fire-and-forget) commits CastNewState; same hook.
+    assert!(
+        code.contains("'beamtalk_actor':'notify_state_change'(State, CastNewState)"),
+        "handle_cast must notify the per-object change substrate after committing \
+         state. Got:\n{code}"
+    );
+}
+
+#[test]
 fn test_bt1005_explicit_annotation_not_overwritten_by_writeback() {
     // BT-1005: An explicitly annotated method must NOT be changed by the writeback pass.
     let src = "

--- a/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
@@ -205,11 +205,11 @@ defmodule BtAttachWeb.WorkspaceBrowserTest do
   # pid_stats read only happen over the live socket. `Phoenix.LiveViewTest` never
   # loads `app.js`, so these MUST run in a real browser (the e2e lane).
 
-  # Deferred to BT-2524: the cross-node {:object_changed, …} push that drives the
-  # flash is not delivered to the LiveView on the e2e lane (the server-side
-  # assertion in workspace_live_test.exs is skipped for the same reason). The
-  # freeze/poke/chips browser cases below do not depend on the async push.
-  @tag skip: "BT-2524: cross-node object_changed push not delivered in e2e"
+  # BT-2524: the {:object_changed, …} push that drives the flash now fires for
+  # compiled actors (the generated gen_server callbacks call
+  # beamtalk_actor:notify_state_change/2 after a committed state write), so this
+  # Playwright case and its server-side counterpart in workspace_live_test.exs
+  # are both re-enabled.
   test "the Inspector flashes a field when the inspected actor changes (BT-2492)", %{conn: conn} do
     conn
     |> visit("/")

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -627,11 +627,12 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert html =~ "data-flash-gen"
   end
 
-  # Deferred to BT-2524: the cross-node {:object_changed, …} push from
-  # beamtalk_object_watch (workspace node) does not reach the LiveView Inspector
-  # (bt_attach node) on the e2e lane, so flash-gen never bumps. The other live
-  # features (chips/freeze/poke) pass; only the async-push flash is affected.
-  @tag skip: "BT-2524: cross-node object_changed push not delivered in e2e"
+  # BT-2524: a committed state write on a watched actor now pushes
+  # {:object_changed, …} from the workspace node to the LiveView Inspector, so
+  # flash-gen bumps and the changed field re-reads. The push fires because the
+  # compiled actor's generated handle_call/handle_cast call
+  # beamtalk_actor:notify_state_change/2 after committing new state (previously
+  # only the runtime beamtalk_actor dispatch path did, via log_dispatch_complete).
   test "a committed state write flashes the changed field and bumps flash-gen (BT-2492)", %{
     conn: conn
   } do

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -187,6 +187,10 @@ handle_getValue([], State) ->
 %% Internal dispatch
 -export([dispatch/4, make_self/1]).
 
+%% BT-2524: per-object change publish hook, called from compiled actor
+%% gen_server callbacks after a method commits new state.
+-export([notify_state_change/2]).
+
 %% Named registration (ADR 0079, BT-1987)
 -export([
     is_beamtalk_actor/1,
@@ -1788,6 +1792,31 @@ maybe_publish_state_change(NewState, ChangedKeys) ->
         true ->
             ActorClass = beamtalk_tagged_map:class_of(NewState, nil),
             beamtalk_object_watch:publish_change(Self, ActorClass, ChangedKeys);
+        false ->
+            ok
+    end.
+
+-doc """
+Per-object change publish hook for **compiled** actors (BT-2524).
+
+The runtime `beamtalk_actor` gen_server callbacks publish state changes via
+`log_dispatch_complete/5`. Compiled actor classes generate their *own*
+`handle_call/3` / `handle_cast/2` (codegen), which dispatch through
+`safe_dispatch/3` and never reach `log_dispatch_complete`, so without this hook a
+state write on a compiled actor was invisible to the live Inspector
+(`{object_changed, …}` never fired). The generated callbacks call this after a
+method commits `NewState`.
+
+Cheap on the common path: a single message-free `is_watched/1` ETS read
+short-circuits before any state diff, so an unwatched actor (the usual case)
+pays only that read — the `changed_state_keys/2` diff runs only for a watched
+actor.
+""".
+-spec notify_state_change(map(), map()) -> ok.
+notify_state_change(OldState, NewState) ->
+    case beamtalk_object_watch:is_watched(self()) of
+        true ->
+            maybe_publish_state_change(NewState, changed_state_keys(OldState, NewState));
         false ->
             ok
     end.

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_codegen.snap
@@ -118,6 +118,7 @@ module 'actor_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -141,6 +142,7 @@ module 'actor_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -171,6 +173,7 @@ module 'actor_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -188,6 +191,7 @@ module 'actor_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_codegen.snap
@@ -118,6 +118,7 @@ module 'actor_spawn_with_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -141,6 +142,7 @@ module 'actor_spawn_with_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -171,6 +173,7 @@ module 'actor_spawn_with_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -188,6 +191,7 @@ module 'actor_spawn_with_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_codegen.snap
@@ -118,6 +118,7 @@ module 'actor_state_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -141,6 +142,7 @@ module 'actor_state_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -171,6 +173,7 @@ module 'actor_state_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -188,6 +191,7 @@ module 'actor_state_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_codegen.snap
@@ -117,6 +117,7 @@ module 'async_keyword_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'async_keyword_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'async_keyword_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'async_keyword_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_codegen.snap
@@ -117,6 +117,7 @@ module 'async_unary_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'async_unary_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'async_unary_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'async_unary_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_codegen.snap
@@ -117,6 +117,7 @@ module 'async_with_await' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'async_with_await' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'async_with_await' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'async_with_await' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_codegen.snap
@@ -119,6 +119,7 @@ module 'binary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -142,6 +143,7 @@ module 'binary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -172,6 +174,7 @@ module 'binary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -189,6 +192,7 @@ module 'binary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_codegen.snap
@@ -118,6 +118,7 @@ module 'blocks_no_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -141,6 +142,7 @@ module 'blocks_no_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -171,6 +173,7 @@ module 'blocks_no_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -188,6 +191,7 @@ module 'blocks_no_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_codegen.snap
@@ -117,6 +117,7 @@ module 'boundary_deeply_nested' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'boundary_deeply_nested' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'boundary_deeply_nested' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'boundary_deeply_nested' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_codegen.snap
@@ -119,6 +119,7 @@ module 'boundary_long_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -142,6 +143,7 @@ module 'boundary_long_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -172,6 +174,7 @@ module 'boundary_long_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -189,6 +192,7 @@ module 'boundary_long_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_codegen.snap
@@ -117,6 +117,7 @@ module 'boundary_mixed_errors' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'boundary_mixed_errors' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'boundary_mixed_errors' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'boundary_mixed_errors' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_codegen.snap
@@ -117,6 +117,7 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1,
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1,
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1,
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1,
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_codegen.snap
@@ -117,6 +117,7 @@ module 'cascade_complex' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'cascade_complex' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'cascade_complex' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'cascade_complex' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascades_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascades_codegen.snap
@@ -117,6 +117,7 @@ module 'cascades' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'cascades' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'cascades' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'cascades' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__character_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__character_literals_codegen.snap
@@ -121,6 +121,7 @@ module 'character_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -144,6 +145,7 @@ module 'character_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -174,6 +176,7 @@ module 'character_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -191,6 +194,7 @@ module 'character_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_definition_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_definition_codegen.snap
@@ -119,6 +119,7 @@ module 'class_definition' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -142,6 +143,7 @@ module 'class_definition' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -172,6 +174,7 @@ module 'class_definition' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -189,6 +192,7 @@ module 'class_definition' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
@@ -121,6 +121,7 @@ module 'class_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -144,6 +145,7 @@ module 'class_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -174,6 +176,7 @@ module 'class_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -191,6 +194,7 @@ module 'class_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_codegen.snap
@@ -121,6 +121,7 @@ module 'comment_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -144,6 +145,7 @@ module 'comment_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -174,6 +176,7 @@ module 'comment_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -191,6 +194,7 @@ module 'comment_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_codegen.snap
@@ -126,6 +126,7 @@ module 'control_flow_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -149,6 +150,7 @@ module 'control_flow_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -179,6 +181,7 @@ module 'control_flow_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -196,6 +199,7 @@ module 'control_flow_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_codegen.snap
@@ -117,6 +117,7 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_codegen.snap
@@ -117,6 +117,7 @@ module 'empty_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'empty_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'empty_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'empty_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_codegen.snap
@@ -119,6 +119,7 @@ module 'empty_method_body' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -142,6 +143,7 @@ module 'empty_method_body' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -172,6 +174,7 @@ module 'empty_method_body' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -189,6 +192,7 @@ module 'empty_method_body' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_message_codegen.snap
@@ -118,6 +118,7 @@ module 'error_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -141,6 +142,7 @@ module 'error_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -171,6 +173,7 @@ module 'error_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -188,6 +191,7 @@ module 'error_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_codegen.snap
@@ -117,6 +117,7 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_codegen.snap
@@ -117,6 +117,7 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'start_link'/2, 'init
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'start_link'/2, 'init
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'start_link'/2, 'init
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'start_link'/2, 'init
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_codegen.snap
@@ -117,6 +117,7 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'start_link'/2, 'in
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'start_link'/2, 'in
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'start_link'/2, 'in
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'start_link'/2, 'in
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_codegen.snap
@@ -118,6 +118,7 @@ module 'expect_directive' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -141,6 +142,7 @@ module 'expect_directive' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -171,6 +173,7 @@ module 'expect_directive' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -188,6 +191,7 @@ module 'expect_directive' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__foreign_extension_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__foreign_extension_codegen.snap
@@ -117,6 +117,7 @@ module 'foreign_extension' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'foreign_extension' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'foreign_extension' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'foreign_extension' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_codegen.snap
@@ -117,6 +117,7 @@ module 'future_pattern_matching' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'future_pattern_matching' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'future_pattern_matching' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'future_pattern_matching' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_codegen.snap
@@ -124,6 +124,7 @@ module 'future_string_interpolation' ['start_link'/1, 'start_link'/2, 'init'/1, 
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -147,6 +148,7 @@ module 'future_string_interpolation' ['start_link'/1, 'start_link'/2, 'init'/1, 
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -177,6 +179,7 @@ module 'future_string_interpolation' ['start_link'/1, 'start_link'/2, 'init'/1, 
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -194,6 +197,7 @@ module 'future_string_interpolation' ['start_link'/1, 'start_link'/2, 'init'/1, 
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__hello_world_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__hello_world_codegen.snap
@@ -117,6 +117,7 @@ module 'hello_world' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'hello_world' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'hello_world' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'hello_world' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__map_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__map_literals_codegen.snap
@@ -117,6 +117,7 @@ module 'map_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'map_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'map_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'map_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_codegen.snap
@@ -117,6 +117,7 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_codegen.snap
@@ -117,6 +117,7 @@ module 'nested_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'nested_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'nested_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'nested_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_codegen.snap
@@ -117,6 +117,7 @@ module 'nested_keyword_messages' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'nested_keyword_messages' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'nested_keyword_messages' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'nested_keyword_messages' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__string_operations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__string_operations_codegen.snap
@@ -122,6 +122,7 @@ module 'string_operations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -145,6 +146,7 @@ module 'string_operations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -175,6 +177,7 @@ module 'string_operations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -192,6 +195,7 @@ module 'string_operations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_codegen.snap
@@ -119,6 +119,7 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -142,6 +143,7 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -172,6 +174,7 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -189,6 +192,7 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_codegen.snap
@@ -119,6 +119,7 @@ module 'typed_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -142,6 +143,7 @@ module 'typed_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -172,6 +174,7 @@ module 'typed_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -189,6 +192,7 @@ module 'typed_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_codegen.snap
@@ -118,6 +118,7 @@ module 'unary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -141,6 +142,7 @@ module 'unary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -171,6 +173,7 @@ module 'unary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -188,6 +191,7 @@ module 'unary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_codegen.snap
@@ -121,6 +121,7 @@ module 'unicode_string_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -144,6 +145,7 @@ module 'unicode_string_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -174,6 +176,7 @@ module 'unicode_string_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -191,6 +194,7 @@ module 'unicode_string_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_codegen.snap
@@ -117,6 +117,7 @@ module 'while_true_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'while_true_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'while_true_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'while_true_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_codegen.snap
@@ -119,6 +119,7 @@ module 'whitespace_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -142,6 +143,7 @@ module 'whitespace_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -172,6 +174,7 @@ module 'whitespace_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -189,6 +192,7 @@ module 'whitespace_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_codegen.snap
@@ -118,6 +118,7 @@ module 'workspace_binding_cascade' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -141,6 +142,7 @@ module 'workspace_binding_cascade' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -171,6 +173,7 @@ module 'workspace_binding_cascade' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -188,6 +191,7 @@ module 'workspace_binding_cascade' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_codegen.snap
@@ -118,6 +118,7 @@ module 'workspace_binding_send' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -141,6 +142,7 @@ module 'workspace_binding_send' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -171,6 +173,7 @@ module 'workspace_binding_send' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -188,6 +191,7 @@ module 'workspace_binding_send' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_mutations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_mutations_codegen.snap
@@ -117,6 +117,7 @@ module 'ws_list_ops_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'ws_list_ops_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'ws_list_ops_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'ws_list_ops_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_simple_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_simple_codegen.snap
@@ -117,6 +117,7 @@ module 'ws_list_ops_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'ws_list_ops_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'ws_list_ops_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'ws_list_ops_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_codegen.snap
@@ -117,6 +117,7 @@ module 'ws_stdlib_array' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'ws_stdlib_array' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'ws_stdlib_array' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'ws_stdlib_array' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_codegen.snap
@@ -119,6 +119,7 @@ module 'ws_stdlib_block' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -142,6 +143,7 @@ module 'ws_stdlib_block' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -172,6 +174,7 @@ module 'ws_stdlib_block' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -189,6 +192,7 @@ module 'ws_stdlib_block' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_codegen.snap
@@ -117,6 +117,7 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_codegen.snap
@@ -117,6 +117,7 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_codegen.snap
@@ -119,6 +119,7 @@ module 'ws_stdlib_integer' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -142,6 +143,7 @@ module 'ws_stdlib_integer' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -172,6 +174,7 @@ module 'ws_stdlib_integer' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -189,6 +192,7 @@ module 'ws_stdlib_integer' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_codegen.snap
@@ -117,6 +117,7 @@ module 'ws_stdlib_list' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'ws_stdlib_list' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'ws_stdlib_list' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'ws_stdlib_list' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_codegen.snap
@@ -117,6 +117,7 @@ module 'ws_stdlib_nil' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'ws_stdlib_nil' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'ws_stdlib_nil' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'ws_stdlib_nil' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_codegen.snap
@@ -122,6 +122,7 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -145,6 +146,7 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -175,6 +177,7 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -192,6 +195,7 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_codegen.snap
@@ -117,6 +117,7 @@ module 'ws_stdlib_set' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -140,6 +141,7 @@ module 'ws_stdlib_set' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -170,6 +172,7 @@ module 'ws_stdlib_set' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -187,6 +190,7 @@ module 'ws_stdlib_set' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_codegen.snap
@@ -119,6 +119,7 @@ module 'ws_stdlib_string' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -142,6 +143,7 @@ module 'ws_stdlib_string' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
                     {'noreply', CastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
@@ -172,6 +174,7 @@ module 'ws_stdlib_string' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
@@ -189,6 +192,7 @@ module 'ws_stdlib_string' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
                     {'reply', {'ok', Result}, NewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}


### PR DESCRIPTION
## Summary

Fixes **BT-2524** — a committed state write on a **compiled actor** never published `{object_changed, …}`, so the Cockpit Inspector's field-flash / live re-read never fired (the `:workspace` + `:playwright` flash tests were skipped).

## Root cause

Compiled actor classes generate their **own** `handle_call/3` and `handle_cast/2` (via the Core Erlang codegen, used by both `beamtalk build` and the REPL/eval compiler-port). Those generated callbacks dispatch through `safe_dispatch/3`, commit the new state, and return — but they **never invoked the per-object change-subscription hook**. Only the *runtime* `beamtalk_actor` gen_server callbacks call that hook, via `log_dispatch_complete/5 → maybe_publish_state_change/2`.

So for **every compiled actor** (which is every real actor, including REPL/eval-defined ones), a state write was invisible to `beamtalk_object_watch`: `is_watched/1` was never consulted, `publish_change/3` never ran, and neither the direct `{object_changed,…}` push nor the `ObjectStateChanged` announcement was produced. The break was in event **production**, not delivery — so it was not a cross-node / announcer-delivery issue.

This was confirmed by tracing against a live workspace node: the eval'd `increment` reached `beamtalk_actor:sync_send/3` → `gen_server:call` → the compiled actor's own `handle_call`, and `log_dispatch_complete` (hence `maybe_publish_state_change`) never fired.

## Fix

- **`beamtalk_actor:notify_state_change/2`** (new, exported): `is_watched/1`-gated so the common (unwatched) actor pays only a single message-free ETS read before any state diff; a watched actor diffs `changed_state_keys/2` and publishes via the existing `maybe_publish_state_change/2`.
- **Codegen** (`gen_server/callbacks.rs`): generated `handle_call` and `handle_cast` now call `beamtalk_actor:notify_state_change(State, NewState)` immediately after a method commits new state — mirroring what the runtime dispatch path does via `log_dispatch_complete`.
- **Re-enabled** the two flash tests skipped under BT-2524: the server-side `workspace_live_test.exs` case and the `:playwright` `workspace_browser_test.exs` case.
- **Added** a codegen regression test asserting the hook is emitted in both callbacks.

## Validation

Run in-sandbox against a real workspace node (now possible after the toolchain fix in #2554):

- ✅ Re-enabled field-flash test **passes**
- ✅ Full `:workspace` LiveView suite: **46 passed**
- ✅ `beamtalk-core`: **4114** + new codegen regression test pass
- ✅ stdlib: **250** tests, runtime EUnit: **6434** tests — **0 failures** (no actor regressions)
- ✅ clippy, `cargo fmt`, erlfmt clean

The `:playwright` counterpart is validated by the `liveview-e2e` lane (needs Chromium, not run in-sandbox).

https://claude.ai/code/session_0176SigTHQcyt3vUo8MoMYEo

---
_Generated by [Claude Code](https://claude.ai/code/session_0176SigTHQcyt3vUo8MoMYEo)_