### PR TITLE
test: fix order-dependent popover e2e flake + dump workspace startup logs on CI failure (BT-2532)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,20 @@ jobs:
       - name: Test REPL protocol (full pipeline)
         run: just test-repl-protocol
 
+      # On any failure, surface epmd state + the most recent workspace startup
+      # logs. The recurring "REPL did not report port" flake (BT-1599 and its
+      # 2026-06 recurrence) means a workspace BEAM node booted but never became
+      # healthy — startup.log holds the only crash/hang diagnostics, and they
+      # are unrecoverable once the runner is gone.
+      - name: Dump workspace startup logs
+        if: failure()
+        run: |
+          epmd -names || true
+          for f in $(ls -t "$HOME"/.beamtalk/workspaces/*/startup.log 2>/dev/null | head -5); do
+            echo "=== $f ==="
+            cat "$f"
+          done
+
   coverage:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/liveview-e2e.yml
+++ b/.github/workflows/liveview-e2e.yml
@@ -145,6 +145,16 @@ jobs:
           PHX_PLAYWRIGHT: '1'
         run: mix test --only playwright
 
+      # On any failure, surface the workspace node's startup log — the only
+      # diagnostic for "WebSocket health check failed" / degraded-workspace
+      # failures, which are otherwise unreproducible once the runner is gone
+      # (the create-step failure seen on the BT-2493 runs).
+      - name: Dump workspace startup log
+        if: failure()
+        run: |
+          epmd -names || true
+          cat "${HOME}/.beamtalk/workspaces/e2e/startup.log" || true
+
       # Stop the background workspace node regardless of suite outcome so the job
       # never leaves a stray distributed node behind (AC: created and torn down
       # cleanly). `|| true` keeps a teardown hiccup from masking a real failure.

--- a/editors/liveview/config/test.exs
+++ b/editors/liveview/config/test.exs
@@ -22,7 +22,14 @@ config :phoenix_test,
   endpoint: BtAttachWeb.Endpoint,
   playwright: [
     browser: :chromium,
-    headless: System.get_env("PLAYWRIGHT_HEADLESS", "true") != "false"
+    headless: System.get_env("PLAYWRIGHT_HEADLESS", "true") != "false",
+    # The 4s default is too tight for a cold Chromium spawn on slower dev
+    # machines (e.g. WSL2); CI launches well under either value. The pool must
+    # be declared explicitly: the global key only merges into browser_pools
+    # entries that are present in config (the implicit default pool keeps the
+    # 4s default — phoenix_test_playwright 0.14.0 Config.global/1).
+    browser_launch_timeout: 30_000,
+    browser_pools: [[id: :default_pool, browser_launch_timeout: 30_000]]
   ]
 
 # Print only warnings and errors during test

--- a/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
@@ -348,6 +348,12 @@ defmodule BtAttachWeb.WorkspaceBrowserTest do
     |> eval_do(
       "Actor subclass: NavCounter\n  state: value = 0\n\n  step => self.value := self.value + 1"
     )
+    # Define Counter itself: the Ctrl+S save below compiles `Counter >> increment`,
+    # which requires the class to EXIST in the workspace. Tests share one
+    # persistent workspace and ExUnit shuffles order per seed, so relying on
+    # another test (the Ctrl+S one) to have defined Counter is a seed-dependent
+    # flake — the exact failure seen on main + BT-2493 CI runs.
+    |> eval_do("Actor subclass: Counter\n  state: value = 0\n\n  value => self.value")
     # Select the starter method tab so the active selector is `increment`, then
     # open the Implementors popover for it.
     |> click(".tabstrip button[role='tab']")


### PR DESCRIPTION
## Summary

Resolves the two currently-actionable CI flakes and adds the diagnostics needed to crack the third (BT-2532).

### 1. Order-dependent popover e2e test (the flake that hit main)

The BT-2495 Senders/Implementors popover test (`workspace_browser_test.exs`) saves a method on class `Counter` **without defining it**, relying on another test (the Ctrl+S one at line 163, which defines `Counter` explicitly for exactly this reason) having run first in the shared persistent workspace. ExUnit shuffles test order per seed, so on unlucky seeds the save fails and `"Saved increment on Counter"` never renders:

- main run [27414204602](https://github.com/jamesc/beamtalk/actions/runs/27414204602) — failed with this signature
- BT-2493 run [27415429632](https://github.com/jamesc/beamtalk/actions/runs/27415429632) (attempt **2**, same content later passed on main as ba33483d) — confirmed flake, not a code bug

**Verified by deterministic repro:** ran the test alone against a freshly created workspace — fails pre-fix with the exact CI signature, passes post-fix. Full browser suite green (15 passed, 1 skip = documented BT-2524 deferral).

### 2. Failure-time workspace startup-log dumps (BT-2532)

The "workspace boots but never becomes healthy" family — all MCP client tests failing with `REPL did not report port` (main runs 27362860829, 27130719089) and the e2e `workspace create` WebSocket-health failure (run 27414952041) — is currently un-root-causeable: `-detached` nulls the BEAM's stderr, so `startup.log` is the only record of the crash/hang reason, and no lane surfaces it. Both `ci.yml` (test-integration job) and `liveview-e2e.yml` now dump `epmd -names` + recent workspace startup logs on failure. Tracked in [BT-2532](https://linear.app/beamtalk/issue/BT-2532).

### 3. Local-dev Playwright launch timeout

The 4s `browser_launch_timeout` default is too tight for a cold Chromium spawn on slower dev machines (WSL2); CI launches well under either value. The pool entry must be declared explicitly because the global key does not merge into the implicit `default_pool` in phoenix_test_playwright 0.14.0.

## Not changed here (already fixed elsewhere)

- The eunit `beamtalk_session_sup` leak family (4 failures/run incl. coverage job) — fixed by BT-2523 (#2547), all CI runs green since merge
- BT-2492 poke/flash e2e races — fixed/deferred during development (sync inspector re-read; `@tag skip` pending BT-2524)

## Test plan

- [x] Pre-fix repro: popover test alone vs fresh workspace → fails with CI signature
- [x] Post-fix: same scenario passes
- [x] Full `--only playwright` suite: 15 passed, 1 skipped
- [x] `--only workspace` suite: 45 passed, 1 skipped
- [x] `mix format --check-formatted` on changed Elixir files; pre-push lint (clippy, dialyzer, erlfmt) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)