### PR TITLE
Add Claude PR review gate (Max subscription, verdict-based required check)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,21 +33,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Claude's fix commits push as you (a user PAT), so they re-trigger this
-      # workflow. Detect the loop's own commits by an in-band marker rather than
-      # by actor/author, which can't tell your manual push from the automated one.
-      - name: Detect automated fix commit
-        id: marker
-        run: |
-          msg=$(git log -1 --pretty=%B "${{ github.event.pull_request.head.sha }}")
-          if printf '%s' "$msg" | grep -qF '[skip-review]'; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: anthropics/claude-code-action@v1
-        if: steps.marker.outputs.skip == 'false'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--max-turns 8 --model claude-sonnet-4-6"
@@ -117,12 +103,6 @@ jobs:
       - name: Gate on verdict
         if: always()
         run: |
-          # Automated fix commits short-circuit to green so the required check
-          # stays present and passing without re-reviewing Claude's own fixes.
-          if [ "${{ steps.marker.outputs.skip }}" = "true" ]; then
-            echo "Automated fix commit ([skip-review]) — gate auto-passes."
-            exit 0
-          fi
           if [ ! -f .claude-verdict ]; then
             echo "::error::No verdict file written — treating as BLOCK"
             exit 1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,6 +33,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Compute diff ranges
+        id: ranges
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          before="${{ github.event.before }}"
+          # opened/reopened/ready_for_review have no usable `before`; a force-push
+          # can leave `before` pointing at a vanished commit. Fall back to full range.
+          if [ -z "$before" ] \
+             || [ "$before" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
+            incr="${base}...${head}"
+          else
+            incr="${before}...${head}"
+          fi
+          echo "full=${base}...${head}" >> "$GITHUB_OUTPUT"
+          echo "incr=${incr}" >> "$GITHUB_OUTPUT"
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -95,6 +113,15 @@ jobs:
             problems, skip praise. For design concerns, explain the invariant at stake,
             not just the line.
 
+            SCOPING:
+            - Run `git diff ${{ steps.ranges.outputs.incr }}` and post inline comments
+              ONLY on lines within that incremental range. Do not re-comment on code
+              outside it.
+            - Run `git diff ${{ steps.ranges.outputs.full }}` to assess the verdict.
+              A Blocker ANYWHERE in the full PR range means BLOCK, even if it falls
+              outside the incremental range and you cannot attach an inline comment to
+              it. In that case, name the unresolved out-of-range Blocker in your summary.
+
             At the very end of your response, write a single line to the file
             .claude-verdict in the repo root containing exactly one word: BLOCK if
             there are any Blockers, otherwise PASS. No other content in that file.
@@ -107,7 +134,7 @@ jobs:
             echo "::error::No verdict file written — treating as BLOCK"
             exit 1
           fi
-          verdict=$(cat .claude-verdict | tr -d '[:space:]')
+          verdict=$(tr -d '[:space:]' < .claude-verdict)
           echo "Claude verdict: $verdict"
           if [ "$verdict" != "PASS" ]; then
             echo "::error::Claude found Blockers — merge is gated"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,6 +24,7 @@ jobs:
       github.event.pull_request.user.login == 'jamesc'
     timeout-minutes: 20
     permissions:
+      id-token: write       # OIDC token exchange for the OAuth subscription auth
       contents: write       # needed if the action pushes fix-commits
       pull-requests: write  # post inline review comments
       issues: write

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,105 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    name: Claude BeamTalk Review
+    runs-on: ubuntu-latest
+    # Skip when claude[bot] pushes a fix — the prior human-triggered run already passed.
+    if: github.event.pull_request.draft == false && github.actor != 'claude[bot]'
+    permissions:
+      contents: write       # write .claude-verdict to the workspace
+      pull-requests: write  # post inline review comments
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--max-turns 8 --model claude-sonnet-4-6"
+          prompt: |
+            You are reviewing a PR for BeamTalk: a Smalltalk-inspired language that
+            compiles to the BEAM (Erlang VM), with a compiler/CLI written in Rust.
+            Review with two lenses depending on what the PR touches.
+
+            RUST TOOLCHAIN (compiler, CLI, LSP):
+            - Correctness of Rust→Core Erlang generation and the bytecode port boundary.
+            - Idiomatic error handling: surface real errors, don't swallow them.
+            - Flag panics on paths that should return Results to the caller.
+
+            BEAMTALK LANGUAGE & SEMANTICS — enforce these invariants:
+            - Two-entity model. Value Objects are immutable with auto-generated
+              accessors; Actors have OPAQUE state and communicate by message only.
+              Block anything that leaks Actor internals or adds mutable slots to a
+              Value Object.
+            - `initialize` is THE typed-slot verification boundary. Slot/type checks
+              belong there, not scattered through methods. Flag validation that has
+              drifted elsewhere.
+            - Three-tier visibility: sealed / internal / open. Flag changes that break
+              a seal or expose internal-only API to open consumers.
+            - Let-it-fail. Flag defensive try/rescue or nil-guards that mask failures a
+              supervisor should handle. New processes must sit under supervision.
+            - Erlang interop goes through the doesNotUnderstand: dynamic proxy. Flag
+              hand-written wrappers that duplicate what the proxy already provides.
+            - Categories are metadata, not syntax. Reject attempts to make them syntactic.
+
+            DESIGN PHILOSOPHY (weight heavily):
+            - YAGNI. Flag speculative generality, new keywords/syntax, or abstractions
+              added without a concrete present need. Minimal keyword surface is a goal,
+              not an accident — argue for removal when something earns its keep poorly.
+
+            DO NOT FLAG (legitimate patterns — stay quiet on these):
+            - Error handling at the Rust↔BEAM port boundary. The port can genuinely
+              fail (dead process, malformed bytecode); Result/try handling there is
+              correct, NOT a let-it-fail violation. Let-it-fail applies to BeamTalk
+              and OTP processes, not the Rust side talking to an external port.
+            - Auto-generated accessors on Value Objects. Expected by design — never
+              read these as "leaking state." Opacity is an Actor rule only.
+            - The doesNotUnderstand: proxy machinery itself, and ClassBuilder /
+              metaclass-as-process plumbing. This is the implementation OF the model,
+              not a violation of it. Don't call ClassBuilder "imperative class
+              construction" — that's its job.
+            - Test code reaching into internals, asserting private behavior, or using
+              defensive setup. Sealing and opacity rules do not apply to fixtures.
+            - Intentional crashes: `self error:` or contract-violation crashes are
+              correct. Do not request defensive guards around code meant to fail.
+            - Idiomatic Rust. Generics, traits, and builder patterns are not YAGNI
+              violations — the keyword-minimalism rule is about BeamTalk surface syntax,
+              not Rust internals. Verbose generated Core Erlang is expected output.
+            - Pre-existing code the diff doesn't touch, and abstractions the PR
+              description explicitly justifies. Review the change, not the world.
+            - Anything rustfmt / clippy / CI already enforces.
+
+            OUTPUT:
+            Categorize findings as Blockers / Suggestions / Nits. Be concise, surface
+            problems, skip praise. For design concerns, explain the invariant at stake,
+            not just the line.
+
+            At the very end of your response, write a single line to the file
+            .claude-verdict in the repo root containing exactly one word: BLOCK if
+            there are any Blockers, otherwise PASS. No other content in that file.
+            Use a shell command to write it: echo PASS > .claude-verdict
+
+      - name: Gate on verdict
+        if: always()
+        run: |
+          if [ ! -f .claude-verdict ]; then
+            echo "::error::No verdict file written — treating as BLOCK"
+            exit 1
+          fi
+          verdict=$(cat .claude-verdict | tr -d '[:space:]')
+          echo "Claude verdict: $verdict"
+          if [ "$verdict" != "PASS" ]; then
+            echo "::error::Claude found Blockers — merge is gated"
+            exit 1
+          fi
+          echo "No Blockers found — gate passed"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,8 +10,15 @@ jobs:
   review:
     name: Claude BeamTalk Review
     runs-on: ubuntu-latest
+    # Restrict to same-repo PRs from jamesc only — prevents fork PRs from accessing
+    # CLAUDE_CODE_OAUTH_TOKEN (critical on a public repo; forks run in a separate context
+    # but the secret would still be exposed if the job ran on a fork-originated PR).
     # Skip when claude[bot] pushes a fix — the prior human-triggered run already passed.
-    if: github.event.pull_request.draft == false && github.actor != 'claude[bot]'
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == 'jamesc' &&
+      github.actor != 'claude[bot]'
     permissions:
       contents: write       # write .claude-verdict to the workspace
       pull-requests: write  # post inline review comments

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+# Cancel an in-flight review if a newer push lands on the same PR.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
     name: Claude BeamTalk Review
@@ -13,12 +18,10 @@ jobs:
     # Restrict to same-repo PRs from jamesc only — prevents fork PRs from accessing
     # CLAUDE_CODE_OAUTH_TOKEN (critical on a public repo; forks run in a separate context
     # but the secret would still be exposed if the job ran on a fork-originated PR).
-    # Skip when claude[bot] pushes a fix — the prior human-triggered run already passed.
     if: |
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login == 'jamesc' &&
-      github.actor != 'claude[bot]'
+      github.event.pull_request.user.login == 'jamesc'
     timeout-minutes: 20
     permissions:
       contents: write       # needed if the action pushes fix-commits
@@ -30,7 +33,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Claude's fix commits push as you (a user PAT), so they re-trigger this
+      # workflow. Detect the loop's own commits by an in-band marker rather than
+      # by actor/author, which can't tell your manual push from the automated one.
+      - name: Detect automated fix commit
+        id: marker
+        run: |
+          msg=$(git log -1 --pretty=%B "${{ github.event.pull_request.head.sha }}")
+          if printf '%s' "$msg" | grep -qF '[skip-review]'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: anthropics/claude-code-action@v1
+        if: steps.marker.outputs.skip == 'false'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--max-turns 8 --model claude-sonnet-4-6"
@@ -81,7 +98,7 @@ jobs:
             - Intentional crashes: `self error:` or contract-violation crashes are
               correct. Do not request defensive guards around code meant to fail.
             - Idiomatic Rust. Generics, traits, and builder patterns are not YAGNI
-              violations — the keyword-minimalism rule is about BeamTalk surface syntax,
+              violations — the keyword-minimalism rule is about Beamtalk surface syntax,
               not Rust internals. Verbose generated Core Erlang is expected output.
             - Pre-existing code the diff doesn't touch, and abstractions the PR
               description explicitly justifies. Review the change, not the world.
@@ -100,6 +117,12 @@ jobs:
       - name: Gate on verdict
         if: always()
         run: |
+          # Automated fix commits short-circuit to green so the required check
+          # stays present and passing without re-reviewing Claude's own fixes.
+          if [ "${{ steps.marker.outputs.skip }}" = "true" ]; then
+            echo "Automated fix commit ([skip-review]) — gate auto-passes."
+            exit 0
+          fi
           if [ ! -f .claude-verdict ]; then
             echo "::error::No verdict file written — treating as BLOCK"
             exit 1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,8 +19,9 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login == 'jamesc' &&
       github.actor != 'claude[bot]'
+    timeout-minutes: 20
     permissions:
-      contents: write       # write .claude-verdict to the workspace
+      contents: write       # needed if the action pushes fix-commits
       pull-requests: write  # post inline review comments
       issues: write
 

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,9 @@ _rel/
 *.swp
 *.swo
 
+# Claude review gate — written by CI, never committed
+.claude-verdict
+
 # Build outputs
 /build/
 /lib/build/


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs Claude as a required PR gate, billed against the Max subscription via `CLAUDE_CODE_OAUTH_TOKEN`.

- **Verdict gate**: Claude writes `PASS` or `BLOCK` to `.claude-verdict`; the gate step fails the check on `BLOCK`, so branch protection enforces it
- **Bot deadlock fix**: Claude Code pushes fix-commits as `jamesc` (not `claude[bot]`), so actor-based skipping is unreliable. Instead, automated fix commits must include `[skip-review]` in the message — the marker step detects this and auto-passes the gate
- **Concurrency**: cancels in-flight reviews when a newer push arrives on the same PR
- **Public-repo protection**: restricted to same-repo PRs from `jamesc` only — fork PRs never access `CLAUDE_CODE_OAUTH_TOKEN`
- **Draft PRs excluded**; `reopened`/`ready_for_review` events included so reviews fire when a draft is promoted
- **20-minute timeout** prevents runaway sessions from burning Max quota
- `.claude-verdict` added to `.gitignore`

## Setup required (one-time)

1. `claude setup-token` → copy the OAuth token
2. Add `CLAUDE_CODE_OAUTH_TOKEN` as a repo secret (Settings → Secrets → Actions)
3. In branch protection for `main`: add **Claude BeamTalk Review** as a required status check

---
_Generated by [Claude Code](https://claude.ai/code/session_012WPbhGs34FykjqJmetVoX8)_