### PR TITLE
CI: raise Claude review max-turns to 25

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 8 --model claude-sonnet-4-6"
+          claude_args: "--max-turns 25 --model claude-sonnet-4-6"
           prompt: |
             You are reviewing a PR for BeamTalk: a Smalltalk-inspired language that
             compiles to the BEAM (Erlang VM), with a compiler/CLI written in Rust.


### PR DESCRIPTION
## Summary

Raises `--max-turns` for the Claude PR review action from **8 → 25**.

On the first real end-to-end run (PR #2560), the review exhausted its 8-turn budget before reaching the verdict step. The prompt requires the action to: diff the incremental range, diff the full range, read surrounding context, post inline comments, and write `.claude-verdict`. With no verdict written, the fail-closed gate correctly went red.

25 turns gives comfortable headroom for typical multi-file PRs; the 20-minute job timeout remains the outer cost bound. The gate stays fail-closed (no verdict → BLOCK) by design.

## Note

This PR edits the review workflow itself, so the `claude-code-action` workflow-validation guard will make **this PR's own "Claude BeamTalk Review" check skip (red)** — expected, same as the bootstrap PR. Admin-merge as before; the new turn budget takes effect for subsequent PRs once this is on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012WPbhGs34FykjqJmetVoX8)_