### PR TITLE
CI: grant Claude reviewer read-only tools + write verdict via Write tool

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,7 +55,11 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 25 --model claude-sonnet-4-6"
+          # Read-only investigation tools only. The reviewer never needs to mutate
+          # the repo: it reads code, runs read-only git, and emits inline comments.
+          # The verdict file is created with the Write tool (a default-allowed file
+          # operation), so no write or arbitrary Bash is granted.
+          claude_args: '--max-turns 25 --model claude-sonnet-4-6 --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*)"'
           prompt: |
             You are reviewing a PR for BeamTalk: a Smalltalk-inspired language that
             compiles to the BEAM (Erlang VM), with a compiler/CLI written in Rust.
@@ -123,10 +127,9 @@ jobs:
               outside the incremental range and you cannot attach an inline comment to
               it. In that case, name the unresolved out-of-range Blocker in your summary.
 
-            At the very end of your response, write a single line to the file
+            At the very end of your response, use the Write tool to create the file
             .claude-verdict in the repo root containing exactly one word: BLOCK if
             there are any Blockers, otherwise PASS. No other content in that file.
-            Use a shell command to write it: echo PASS > .claude-verdict
 
       - name: Gate on verdict
         if: always()


### PR DESCRIPTION
## Summary

Fixes the Claude review gate's permission failure. On the first real run (PR #2560, run 27465888843) the action completed (`num_turns: 12`, under the 25 cap — the turn bump worked) but hit **6 permission denials**: in `agent` mode the action grants **no arbitrary Bash**, so `echo PASS > .claude-verdict` was refused → no verdict → fail-closed BLOCK.

Changes:
- **Grant a read-only investigation tool set** via `--allowedTools`: `Read,Grep,Glob` plus read-only `Bash(git diff:*)`, `Bash(git log:*)`, `Bash(git show:*)`, `Bash(git status:*)`, `Bash(cat:*)`, `Bash(ls:*)`, `Bash(find:*)`. No write or arbitrary Bash.
- **Write the verdict via the `Write` tool** (a default-allowed file operation) instead of a shell redirect, so the verdict no longer depends on arbitrary Bash.

## Notes

- This PR edits the review workflow, so its **own** "Claude BeamTalk Review" check will self-skip (red) via the workflow-validation guard — expected; admin-merge as with the bootstrap and max-turns PRs.
- The fix can only be validated on the **next normal PR** after this lands on `main` (one that doesn't touch the workflow). That run also tells us whether `--allowedTools` extends or replaces the action's default inline-comment MCP tool.
- Same change currently also rides on #2560's branch (commit 286bdaa); once this is on `main` that copy becomes identical and #2560's review runs normally again after it syncs `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012WPbhGs34FykjqJmetVoX8)_