### PR TITLE
CI: enable inline review comments + code suggestions

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,9 +25,9 @@ jobs:
     timeout-minutes: 20
     permissions:
       id-token: write       # OIDC token exchange for the OAuth subscription auth
-      contents: write       # needed if the action pushes fix-commits
-      pull-requests: write  # post inline review comments
-      issues: write
+      contents: read        # checkout + read source; the reviewer never commits/pushes
+      pull-requests: write  # post inline review comments + suggestions
+      issues: write         # upsert the sticky summary comment
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,11 +55,15 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Read-only investigation tools only. The reviewer never needs to mutate
-          # the repo: it reads code, runs read-only git, and emits inline comments.
-          # The verdict file is created with the Write tool (a default-allowed file
-          # operation), so no write or arbitrary Bash is granted.
-          claude_args: '--max-turns 25 --model claude-sonnet-4-6 --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*)"'
+          # The reviewer never mutates the repo directly: it reads code, runs
+          # read-only git, posts inline review comments (incl. ```suggestion fixes),
+          # and writes the verdict/summary files with the Write tool (a default-allowed
+          # file op). No commit/push or arbitrary Bash is granted — proposed fixes are
+          # delivered as applyable GitHub suggestions, not pushed commits.
+          # mcp__github_inline_comment__create_inline_comment is the action's own tool
+          # for line-anchored comments; it must be listed explicitly because
+          # --allowedTools REPLACES the action's default tool set rather than extending it.
+          claude_args: '--max-turns 25 --model claude-sonnet-4-6 --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"'
           prompt: |
             You are reviewing a PR for BeamTalk: a Smalltalk-inspired language that
             compiles to the BEAM (Erlang VM), with a compiler/CLI written in Rust.
@@ -121,7 +125,13 @@ jobs:
             SCOPING:
             - Run `git diff ${{ steps.ranges.outputs.incr }}` and post inline comments
               ONLY on lines within that incremental range. Do not re-comment on code
-              outside it.
+              outside it. Attach each finding to the exact line it concerns using the
+              create_inline_comment tool — do not relegate an in-range finding to the
+              summary when it can be anchored to a line.
+            - When a fix is concrete and small, include a GitHub ```suggestion block in
+              the inline comment so the author can apply it in one click. Use suggestions
+              for clear, mechanical fixes; describe the change in prose when it is larger
+              or needs judgement.
             - Run `git diff ${{ steps.ranges.outputs.full }}` to assess the verdict.
               A Blocker ANYWHERE in the full PR range means BLOCK, even if it falls
               outside the incremental range and you cannot attach an inline comment to


### PR DESCRIPTION
## Summary

Fixes the root cause of "all findings land in the summary instead of on the line," and adds applyable code suggestions.

**Diagnosis (from the green #2560 run):** the action logged its SDK options as `allowedTools: [Read, Grep, Glob, Write, Bash(...)...]` — *exactly* our list. So `--allowedTools` **replaces** the action's default tool set rather than extending it, which silently dropped the inline-comment MCP tool. The log confirms it: `permission_denials_count: 0` but `No buffered inline comments`. With no tool to anchor a comment to a line, every finding fell back to the summary.

**Changes:**
- Add **`mcp__github_inline_comment__create_inline_comment`** to `--allowedTools` (verified as the action's registered server key + tool name) so findings can be posted on the exact line.
- Prompt: explicitly tell the reviewer to anchor in-range findings to their line (not relegate them to the summary), and to include **` ```suggestion `** blocks for concrete, mechanical fixes so the author can apply them in one click.

**Security posture unchanged:** suggestions are delivered as GitHub review-comment suggestions (the author clicks "Apply"), *not* pushed commits. The reviewer still has no commit/push or arbitrary-Bash access — it remains a read-only reviewer that proposes rather than mutates.

## Note

Workflow-editing PR → its own "Claude BeamTalk Review" check self-skips (red), as before — admin-merge. Takes effect on the next normal PR; the first in-range finding after that will show inline comments + suggestions for real (the last unproven piece).

---
_Generated by [Claude Code](https://claude.ai/code/session_012WPbhGs34FykjqJmetVoX8)_