### PR TITLE
CI: raise review max-turns to 50 + make reviewer ADR-aware

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -34,6 +34,17 @@ downgrade them to Suggestions:
 - Security: unsafe atom creation, path traversal, injection, secret exposure.
 Suggestions = real improvements that are not merge-blocking. Nits = style / naming / docs.
 
+ACCEPTED-TRADEOFF CHECK (do this BEFORE you BLOCK on a robustness concern): a
+robustness / atomicity / ordering / idempotency concern is NOT a Blocker if the codebase
+explicitly accepts it as a design tradeoff. Before classifying such a concern as a Blocker,
+grep `docs/ADR/` (and the relevant module's doc comments) for a decision covering it — e.g.
+weaker-than-serialized ordering, fire-and-forget facades that return `ok`, self-healing on
+reconnect/restart, or "best-effort" refresh streams. If you find an accepting decision, do
+NOT block: note it as a Suggestion citing the ADR (or stay silent if fully addressed). This
+check applies ONLY to concerns you would otherwise BLOCK on — do not spelunk ADRs for nits.
+A genuine cross-session leak, data loss, or crash on a documented-safe path is still a
+Blocker regardless; an ADR cannot bless those.
+
 CORRECTNESS LENS (apply to every change, all languages):
 - Concurrency & lifecycle: races, idempotency of subscribe/unsubscribe/register,
   reconnect and restart windows, monitor/link gaps, message ordering and duplication.
@@ -100,6 +111,12 @@ DO NOT FLAG (legitimate patterns — stay quiet on these):
 - Idiomatic Rust. Generics, traits, and builder patterns are not YAGNI violations — the
   keyword-minimalism rule is about Beamtalk surface syntax, not Rust internals. Verbose
   generated Core Erlang is expected output.
+- Robustness / atomicity / ordering tradeoffs that an ADR (`docs/ADR/`) or module doc
+  explicitly accepts — e.g. a fire-and-forget facade that returns `ok` and self-heals on
+  reconnect, or a "best-effort" refresh stream with weaker-than-serialized ordering. A
+  documented, accepted tradeoff is not a bug. (If genuinely undocumented, it is still fair
+  game — and a cross-session leak, data loss, or documented-safe-path crash is a Blocker
+  even when an ADR exists, since those are bugs, not tradeoffs.)
 - Pre-existing code the diff doesn't touch, and abstractions the PR description explicitly
   justifies. Review the change, not the world.
 - Anything rustfmt / clippy / CI already enforces.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -84,7 +84,7 @@ jobs:
           # mcp__github_inline_comment__create_inline_comment is the action's own tool
           # for line-anchored comments; it must be listed explicitly because
           # --allowedTools REPLACES the action's default tool set rather than extending it.
-          claude_args: '--max-turns 25 --model claude-sonnet-4-6 --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"'
+          claude_args: '--max-turns 50 --model claude-sonnet-4-6 --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"'
           prompt: ${{ steps.load_prompt.outputs.prompt }}
 
       - name: Post review summary


### PR DESCRIPTION
## Summary

Two reviewer-tuning fixes prompted by the #2562 runs:

### 1. `--max-turns` 25 → 50
The correctness-first prompt does a much deeper full-`base...head` review. On the large #2562 (27 files) it hit `error_max_turns` at the 25-turn cap *before* writing the verdict:

```
"subtype": "error_max_turns", "num_turns": 26, "total_cost_usd": 1.56
##[error] Reached maximum number of turns (25)
```

→ action errored → no `.claude-verdict` → gate red, and the "did not complete" fallback clobbered a previously-good BLOCK summary.

`--max-turns` is a **ceiling, not a target**: small PRs use few turns regardless, so raising the cap only lets large PRs finish — it does not make small reviews more expensive. 50 gives headroom over the observed 26 and still fits the 20-min timeout (~13s/turn). Large/complex PRs run ~$1.5–3 per review (vs ~$0.27 under the old shallow prompt); small PRs stay cheap.

### 2. ADR-aware severity (`.github/claude-review-prompt.md`)
On #2562 the reviewer correctly spotted the non-atomic multi-class subscribe but filed it as a **Blocker** — when **ADR 0093 D6 explicitly accepts** weaker-than-serialized guarantees for those fire-and-forget refresh streams (they self-heal on reconnect). CodeRabbit withdrew the same concern via its learnings memory; our reviewer has none and over-blocked.

Adds an **ACCEPTED-TRADEOFF check**: before blocking on a robustness/atomicity/ordering/idempotency concern, grep `docs/ADR/` (and module docs) for an accepting decision; if found, downgrade to a Suggestion citing the ADR instead of BLOCK. Scoped to would-be Blockers only (no ADR spelunking for nits), and it explicitly does **not** excuse real bugs — a cross-session leak, data loss, or documented-safe-path crash stays a Blocker regardless. Uses the reviewer's existing read-only tools.

## Note
Workflow-editing PR → its own "Claude BeamTalk Review" check self-skips (red) — admin-merge as before. After this lands, re-running #2562 should (a) finish within budget and (b) re-classify the half-subscribe finding as a Suggestion citing ADR 0093, while keeping the real `clear_bindings` Blocker.