### PR TITLE
CI: de-noise review diff + Haiku for config-only PRs

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -8,13 +8,23 @@ reconnect, restart, empty/boundary input, or an unexpected message?" Correctness
 first; invariant and style checks come after.
 
 REVIEW SCOPE (read carefully — this drives review quality):
-- Review the FULL PR diff for correctness: run `git diff __FULL_RANGE__` and reason about
-  the entire change set. Your review depth must NOT depend on how much landed in the most
-  recent push — a small last commit is not an excuse for a shallow review.
-- For inline comments, run `git diff __INCR_RANGE__` and attach each finding within that
-  incremental range to the exact line using the create_inline_comment tool. Include a
-  ```suggestion block for concrete, mechanical fixes so the author can apply them in one
-  click; describe the change in prose when it is larger or needs judgement.
+- Two pre-computed diffs are waiting for you in the repo root; READ THESE rather than
+  running your own `git diff` over the whole range:
+  - `.claude-review-full.diff` — the FULL PR (`__FULL_RANGE__`), ±20 lines of context.
+  - `.claude-review-incr.diff` — the INCREMENTAL change since the last review
+    (`__INCR_RANGE__`), ±20 lines of context.
+  Both already exclude lockfiles, generated Core Erlang, the generated
+  `beamtalk_stdlib.app.src`, and test fixtures — do not flag their absence, and do NOT run a
+  whole-range `git diff` to "get them back" (it wastes tokens on noise you are told to
+  ignore). If you need more than ±20 lines on ONE file, read that file directly or run
+  `git diff __FULL_RANGE__ -- <that file>`.
+- Review the FULL diff for correctness and reason about the entire change set. Your review
+  depth must NOT depend on how much landed in the most recent push — a small last commit is
+  not an excuse for a shallow review.
+- For inline comments, use the INCREMENTAL diff and attach each finding within it to the
+  exact line using the create_inline_comment tool. Include a ```suggestion block for
+  concrete, mechanical fixes so the author can apply them in one click; describe the change
+  in prose when it is larger or needs judgement.
 - A finding in the full range but outside the incremental range goes in the summary (name
   any out-of-range Blocker explicitly). Never silently drop a finding because it is
   out-of-range.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -52,6 +52,43 @@ jobs:
           echo "full=${base}...${head}" >> "$GITHUB_OUTPUT"
           echo "incr=${incr}" >> "$GITHUB_OUTPUT"
 
+          # Pre-compute de-noised diffs the reviewer reads instead of running its own
+          # `git diff` over the whole range. Excluding lockfiles, generated Core Erlang,
+          # the generated beamtalk_stdlib.app.src, and test fixtures keeps token cost down
+          # with no loss of review-relevant signal (these match the prompt's DO-NOT-FLAG
+          # list). The other *.app.src files are hand-maintained config and are kept.
+          # -U20 gives generous context so the agent rarely needs to open full files.
+          excludes=(.
+            ':(exclude,glob)**/*.lock'
+            ':(exclude,glob)**/*.core'
+            ':(exclude,glob)**/beamtalk_stdlib.app.src'
+            ':(exclude,glob)**/fixtures/**'
+            ':(exclude,glob)**/test_fixtures/**')
+          git diff -U20 "${base}...${head}" -- "${excludes[@]}" \
+            > "${GITHUB_WORKSPACE}/.claude-review-full.diff" || true
+          git diff -U20 "${incr}" -- "${excludes[@]}" \
+            > "${GITHUB_WORKSPACE}/.claude-review-incr.diff" || true
+
+      - name: Select model
+        id: model
+        env:
+          FULL_RANGE: ${{ steps.ranges.outputs.full }}
+        run: |
+          # Config-only PRs get the cheaper Haiku model; anything touching code OR docs
+          # (incl. ADRs under docs/, whose review is valuable) stays on Sonnet. Unknown
+          # extensions default to Sonnet — never silently downgrade a substantive change.
+          model='claude-sonnet-4-6'
+          files="$(git diff --name-only "${FULL_RANGE}")"
+          # A file is "config" if it matches this pattern. If grep finds any changed file
+          # that does NOT match (and is non-empty), the PR touches code/docs → Sonnet.
+          # If every changed file is config → Haiku. Empty file list also stays Sonnet.
+          config_re='\.(toml|ya?ml|json|lock|cfg|ini|conf|config)$|(^|/)\.(gitignore|gitattributes|editorconfig|dockerignore)$|^$'
+          if [ -n "${files}" ] && ! printf '%s\n' "${files}" | grep -qvE "${config_re}"; then
+            model='claude-haiku-4-5'
+          fi
+          echo "Selected model: ${model}"
+          echo "model=${model}" >> "$GITHUB_OUTPUT"
+
       # The review prompt lives in .github/claude-review-prompt.md so it can be edited
       # without touching the workflow. The action's `prompt` input is a plain string and
       # ${{ }} does not interpolate inside an external file, so the diff ranges are injected
@@ -84,7 +121,7 @@ jobs:
           # mcp__github_inline_comment__create_inline_comment is the action's own tool
           # for line-anchored comments; it must be listed explicitly because
           # --allowedTools REPLACES the action's default tool set rather than extending it.
-          claude_args: '--max-turns 50 --model claude-sonnet-4-6 --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"'
+          claude_args: '--max-turns 50 --model ${{ steps.model.outputs.model }} --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"'
           prompt: ${{ steps.load_prompt.outputs.prompt }}
 
       - name: Post review summary

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ _rel/
 # Claude review gate — written by CI, never committed
 .claude-verdict
 .claude-summary.md
+.claude-review-*.diff
 
 # Build outputs
 /build/


### PR DESCRIPTION
## Summary

Two token/quota optimizations you asked for. No quality loss on real code.

### 1. De-noised, pre-computed diff (lossless)
The `Compute diff ranges` step now pre-writes the diff with generous context and **git's own excludes** (the safe way to "reduce git output" — *we* choose what's dropped, not a lossy heuristic):
```
git diff -U20 <range> -- . \
  ':(exclude,glob)**/*.lock' ':(exclude,glob)**/*.core' \
  ':(exclude,glob)**/beamtalk_stdlib.app.src' \
  ':(exclude,glob)**/fixtures/**' ':(exclude,glob)**/test_fixtures/**'
```
Excludes lockfiles, generated Core Erlang, the **generated** `beamtalk_stdlib.app.src` (the other 3 hand-maintained `*.app.src` are **kept**), and fixtures — all of which the prompt already says to ignore. The prompt now **reads `.claude-review-full.diff` / `.claude-review-incr.diff`** instead of running its own whole-range `git diff` (which would pull the noise back in); it can still `git diff -- <file>` for one file when it needs more context.

### 2. Haiku for config-only PRs
New `Select model` step: if **every** changed file is config (`*.toml/yaml/json/lock/cfg/ini/conf` + dotfiles) → `claude-haiku-4-5`; otherwise `claude-sonnet-4-6`. **Code, docs, and ADRs (`docs/**/*.md`) stay on Sonnet** — ADR reviews are valuable and explicitly not downgraded. Unknown extensions default to Sonnet (never silently downgrade a substantive change).

## Verification (local)
- `actionlint` clean.
- Prompt substitutes to **0** leftover placeholders.
- Exclude pathspec is valid git syntax.
- Model-select correct across cases: `Cargo.toml`+CI yml → Haiku; ADR `.md` → Sonnet; `.rs` → Sonnet; `.app.src` → Sonnet; `.gitignore`-only → Haiku; empty → Sonnet.

## ⚠️ One thing to confirm
I used the model id **`claude-haiku-4-5`** (parallel to the working `claude-sonnet-4-6`). If the action rejects it, swap to the pinned `claude-haiku-4-5-20251001`. Worst case is a config-only PR's review erroring (low stakes, obvious) — not a code-PR risk.

## Notes
- Diff artifacts are gitignored (`.claude-review-*.diff`).
- `--max-turns 50` unchanged (it's a ceiling, not a target).
- Workflow-editing PR → own Claude check self-skips (red) — admin-merge as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_012WPbhGs34FykjqJmetVoX8)_