### PR TITLE
fix: advertise http://localhost for LiveView IDE prod when PHX_HOST unset

### DIFF
--- a/editors/liveview/config/runtime.exs
+++ b/editors/liveview/config/runtime.exs
@@ -49,13 +49,23 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
-  host = System.get_env("PHX_HOST") || "example.com"
   port = String.to_integer(System.get_env("PORT") || "4000")
+
+  # The advertised URL (boot banner + generated absolute URLs) must match how
+  # the IDE is actually reached. An unset PHX_HOST is the zero-config local-trial
+  # mode `bin/server` documents — advertise http://localhost:<port>, which is
+  # what `http:` binds below. A set PHX_HOST means a real deployment terminating
+  # TLS in front of us, so advertise https://<host>:443.
+  {url_scheme, url_host, url_port} =
+    case System.get_env("PHX_HOST") do
+      nil -> {"http", "localhost", port}
+      host -> {"https", host, 443}
+    end
 
   config :bt_attach, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
   config :bt_attach, BtAttachWeb.Endpoint,
-    url: [host: host, port: 443, scheme: "https"],
+    url: [host: url_host, port: url_port, scheme: url_scheme],
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.

--- a/editors/liveview/config/runtime.exs
+++ b/editors/liveview/config/runtime.exs
@@ -52,14 +52,14 @@ if config_env() == :prod do
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   # The advertised URL (boot banner + generated absolute URLs) must match how
-  # the IDE is actually reached. An unset PHX_HOST is the zero-config local-trial
-  # mode `bin/server` documents — advertise http://localhost:<port>, which is
-  # what `http:` binds below. A set PHX_HOST means a real deployment terminating
-  # TLS in front of us, so advertise https://<host>:443.
+  # the IDE is actually reached. An unset or empty PHX_HOST is the zero-config
+  # local-trial mode `bin/server` documents — advertise http://localhost:<port>,
+  # which is what `http:` binds below. A non-empty PHX_HOST means a real
+  # deployment terminating TLS in front of us, so advertise https://<host>:443.
   {url_scheme, url_host, url_port} =
     case System.get_env("PHX_HOST") do
-      nil -> {"http", "localhost", port}
-      host -> {"https", host, 443}
+      host when is_binary(host) and host != "" -> {"https", host, 443}
+      _ -> {"http", "localhost", port}
     end
 
   config :bt_attach, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")


### PR DESCRIPTION
## Summary

The `bt_attach` LiveView IDE release boots in `:prod`, where `config/runtime.exs` hardcoded the stock Phoenix scaffold default:

```elixir
url: [host: "example.com", port: 443, scheme: "https"]
```

For the zero-config **local-trial** mode that `bin/server` documents (no `PHX_HOST` set), this had two user-visible failures:

1. The boot banner advertised an unreachable `https://example.com`.
2. Phoenix derives `check_origin` from the `url:` host, so the LiveView socket **rejected the `http://localhost:4000` origin**, fell back to longpoll, and retried mount indefinitely (`_mount_attempts` climbing into the hundreds).

## Change

Resolve the advertised URL from `PHX_HOST`:

- **unset** → `http://localhost:<PORT>` (matches the `http:` binding — the local-trial story)
- **set** → `https://<host>:443` (real TLS deployment, behaviour unchanged)

Single file, config-only (`editors/liveview/config/runtime.exs`).

## Verification

Built the release with `just dist-liveview` and ran `bin/server <workspace-id>` against a live workspace:

- Banner now reads `Access BtAttachWeb.Endpoint at http://localhost:4000`
- LiveView socket **connects over `:websocket` on the first attempt** (`_mount_attempts => 0`); previously `:longpoll` with `_mount_attempts => 146`
- `GET /` returns 200; authz/browse_classes/bindings all `decision=allow`

Standalone fix (no Linear issue) — an oversight from the BT-2513 release-config work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)