### PR TITLE
LiveView: skip cursor-only select_workspace round-trips (BT-2538 follow-up)

### DIFF
--- a/editors/liveview/assets/js/hooks/cm_editor.js
+++ b/editors/liveview/assets/js/hooks/cm_editor.js
@@ -66,6 +66,7 @@ export const CmEditor = {
 
     this.selectEvent = this.el.dataset.selectEvent || null
     this.lastSelection = null
+    this.hadSelection = false
     const readOnly = this.field.readOnly || this.el.dataset.readonly === "true"
     const placeholderText = this.el.dataset.placeholder || ""
 
@@ -119,6 +120,12 @@ export const CmEditor = {
 
   reportSelection(update) {
     const range = update.state.selection.main
+    // Skip cursor-only moves (range.empty): they'd push text:"" to the server on
+    // every keystroke — a no-op re-render (only the "evaluates buffer/selection"
+    // label). Still send ONE empty report when collapsing a prior non-empty
+    // selection, so `ws_selection` is cleared and eval falls back to the buffer.
+    if (range.empty && !this.hadSelection) return
+    this.hadSelection = !range.empty
     const text = update.state.sliceDoc(range.from, range.to)
     const key = range.from + ":" + range.to + ":" + text
     if (key === this.lastSelection) return

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1288,7 +1288,7 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   # The code an action evaluates: the Workspace editor's tracked selection if
   # there is one (the spike's "evaluates selection"), else the whole entered
-  # buffer ("evaluates buffer"). The Workspace editor's SelectionTracker keeps
+  # buffer ("evaluates buffer"). The Workspace editor's CmEditor hook keeps
   # `ws_selection` current (distinct from the method editor's `edit_selection`);
   # an empty or whitespace-only selection falls back to the buffer.
   defp eval_target(expr, socket) do


### PR DESCRIPTION
Follow-up to #2575 (BT-2538). These two items from that PR's PASS review were validated locally but landed just after the merge, so they're carried here.

## Changes
- **`cm_editor.js` — skip cursor-only `select_workspace` round-trips.** `reportSelection` was firing on every keystroke (cursor-only, `text:""`), pushing a no-op `select_workspace` event + server re-render per character. It now skips `range.empty` moves, while still sending **one** empty report when collapsing a prior non-empty selection (so `ws_selection` clears and eval falls back to the buffer). Note: the reviewer's one-line `if (from===to) return` would have skipped that clearing report and left a stale selection — this does it correctly.
- **`workspace_live.ex` — stale comment** referencing `SelectionTracker` → `CmEditor`.

## Validation
Full Playwright workspace suite **16/16** locally (booted workspace + headless Chromium) with these changes.

No behavior change to eval/selection semantics beyond eliminating the redundant round-trips.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHW3pQBrXwfSqAaZEGRPgh)_