### PR TITLE
LiveView: guard method-editor select_source against stale/in-flight selection (BT-2549)

### DIFF
--- a/editors/liveview/assets/js/hooks/cm_editor.js
+++ b/editors/liveview/assets/js/hooks/cm_editor.js
@@ -65,6 +65,14 @@ export const CmEditor = {
     }
 
     this.selectEvent = this.el.dataset.selectEvent || null
+    // Tab-id stamp (BT-2549): the method editor re-keys this element per active
+    // tab, so `data-tab-id` captures the tab THIS editor instance edits. We send
+    // it with every selection push; the server ignores any push whose stamp ≠ the
+    // active tab, so a `select_source` the departing editor dispatched just before
+    // `destroyed()` can't re-populate `:edit_selection` with stale coordinates
+    // after a tab switch. Absent (Workspace editor) → null, which that handler
+    // doesn't read.
+    this.tabId = this.el.dataset.tabId || null
     this.lastSelection = null
     this.hadSelection = false
     const readOnly = this.field.readOnly || this.el.dataset.readonly === "true"
@@ -130,6 +138,11 @@ export const CmEditor = {
     const key = range.from + ":" + range.to + ":" + text
     if (key === this.lastSelection) return
     this.lastSelection = key
-    this.pushEvent(this.selectEvent, { text, start: range.from, end: range.to })
+    this.pushEvent(this.selectEvent, {
+      text,
+      start: range.from,
+      end: range.to,
+      tab_id: this.tabId,
+    })
   },
 }

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1033,17 +1033,29 @@ defmodule BtAttachWeb.WorkspaceLive do
   # than the whole buffer (the spike's "evaluates selection" vs "evaluates
   # buffer" distinction). The payload is client-supplied, so accept only the
   # well-formed shape and ignore anything else rather than crash the LiveView.
-  def handle_event("select_source", %{"text" => text} = params, socket)
+  def handle_event("select_source", %{"text" => text, "tab_id" => tab_id} = params, socket)
       when is_binary(text) do
-    selection = %{
-      text: text,
-      start: clamp_offset(params["start"]),
-      end: clamp_offset(params["end"])
-    }
+    # Stale/in-flight selection guard (BT-2549): a departing CmEditor can dispatch
+    # one final `select_source` via `pushEvent` just before its `destroyed()`
+    # callback runs; that event can land *after* `sync_active/2` cleared
+    # `:edit_selection` on the tab switch, re-populating it with coordinates from
+    # the closed tab. The editor instance stamps each push with the tab it edits
+    # (data-tab-id), so ignore any stamp that no longer matches the active tab.
+    if tab_id == socket.assigns.active_tab do
+      selection = %{
+        text: text,
+        start: clamp_offset(params["start"]),
+        end: clamp_offset(params["end"])
+      }
 
-    {:noreply, assign(socket, edit_selection: selection)}
+      {:noreply, assign(socket, edit_selection: selection)}
+    else
+      {:noreply, socket}
+    end
   end
 
+  # Malformed payload, or one carrying no tab-id stamp: ignore rather than crash
+  # the LiveView (the payload is client-supplied).
   def handle_event("select_source", _params, socket), do: {:noreply, socket}
 
   # Selection tracking for the Workspace dock's editor (BT-2490). Tracked in a
@@ -3951,6 +3963,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                         class="cm-wrap field"
                         phx-hook="CmEditor"
                         data-select-event="select_source"
+                        data-tab-id={@active_tab}
                         data-placeholder={
                           if active_tab(assigns).kind == :def,
                             do: "Actor subclass: Counter\n  state: value = 0",

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1054,8 +1054,10 @@ defmodule BtAttachWeb.WorkspaceLive do
     end
   end
 
-  # Malformed payload, or one carrying no tab-id stamp: ignore rather than crash
-  # the LiveView (the payload is client-supplied).
+  # Malformed payload (missing text, non-binary, or missing the "tab_id" key):
+  # ignore rather than crash the LiveView (the payload is client-supplied). A
+  # present-but-mismatched stamp (incl. `tab_id: null`) is handled by the guarded
+  # clause above, which drops it when it doesn't match the active tab.
   def handle_event("select_source", _params, socket), do: {:noreply, socket}
 
   # Selection tracking for the Workspace dock's editor (BT-2490). Tracked in a

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -1513,8 +1513,10 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
   # The active method-editor tab id, read from the CmEditor element's stamp
   # (`data-tab-id`) — the same value a real selection push carries (BT-2549).
   defp active_tab_id(html) do
-    [_, id] = Regex.run(~r/data-tab-id="([^"]+)"/, html)
-    id
+    case Regex.run(~r/data-tab-id="([^"]+)"/, html) do
+      [_, id] -> id
+      nil -> raise "data-tab-id not rendered in HTML"
+    end
   end
 
   # The internal `:edit_selection` assign — no rendered consumer yet (BT-2549),

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -430,20 +430,68 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
   test "the select_source hook event is accepted and ignored when malformed (BT-2485)", %{
     conn: conn
   } do
-    {:ok, view, _html} = live(conn, "/")
+    {:ok, view, html} = live(conn, "/")
 
-    # A well-formed selection payload must not crash the LiveView (the assign is
-    # internal, so we just prove the handler accepts it and re-renders).
+    # A well-formed selection payload stamped with the *active* tab id is stored
+    # (BT-2549: the stamp is what the guard matches against).
+    tab_id = active_tab_id(html)
+
     assert render_hook(view, "select_source", %{
              "text" => "self.value",
              "start" => 0,
-             "end" => 10
+             "end" => 10,
+             "tab_id" => tab_id
            })
+
+    assert edit_selection(view) == %{text: "self.value", start: 0, end: 10}
 
     # A malformed payload (no text key, or non-binary) is ignored, not a crash —
     # the LiveView keeps rendering, proving the defensive clause holds.
     assert render_hook(view, "select_source", %{"garbage" => true})
     assert render_hook(view, "select_source", %{"text" => 123})
+  end
+
+  test "select_source ignores a stale stamp from a departing tab (BT-2549)", %{conn: conn} do
+    {:ok, view, html} = live(conn, "/")
+    active = active_tab_id(html)
+
+    # Seed a real selection for the active tab so we can prove the stale event
+    # doesn't clobber *or* overwrite it.
+    render_hook(view, "select_source", %{
+      "text" => "self.value",
+      "start" => 0,
+      "end" => 10,
+      "tab_id" => active
+    })
+
+    assert edit_selection(view) == %{text: "self.value", start: 0, end: 10}
+
+    # The race: a `select_source` the *departing* CmEditor dispatched just before
+    # its `destroyed()` ran lands carrying the previous tab's id. Its stamp no
+    # longer matches `active_tab`, so the handler drops it — `:edit_selection`
+    # keeps the live tab's coordinates rather than stale ones from the closed tab.
+    render_hook(view, "select_source", %{
+      "text" => "stale.from.closed.tab",
+      "start" => 99,
+      "end" => 123,
+      "tab_id" => active <> ":stale"
+    })
+
+    assert edit_selection(view) == %{text: "self.value", start: 0, end: 10}
+
+    # A payload with no tab-id stamp at all is likewise ignored (defensive: a
+    # client that never stamps can't poison the assign).
+    render_hook(view, "select_source", %{"text" => "no.stamp", "start" => 1, "end" => 2})
+    assert edit_selection(view) == %{text: "self.value", start: 0, end: 10}
+  end
+
+  # The method editor stamps its CmEditor element with the active tab id so each
+  # selection push can be matched against the live tab (BT-2549).
+  test "the method editor stamps its CmEditor with the active tab id (BT-2549)", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/")
+
+    assert html =~ ~s(data-select-event="select_source")
+    assert html =~ ~s(data-tab-id="#{active_tab_id(html)}")
   end
 
   # ── Phase 2 tabbed method editor (BT-2494) ──────────────────────────────────
@@ -1460,6 +1508,19 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
       [_, n] -> String.to_integer(n)
       _ -> 0
     end
+  end
+
+  # The active method-editor tab id, read from the CmEditor element's stamp
+  # (`data-tab-id`) — the same value a real selection push carries (BT-2549).
+  defp active_tab_id(html) do
+    [_, id] = Regex.run(~r/data-tab-id="([^"]+)"/, html)
+    id
+  end
+
+  # The internal `:edit_selection` assign — no rendered consumer yet (BT-2549),
+  # so peek at the LiveView's socket to assert the selection-guard behaviour.
+  defp edit_selection(view) do
+    :sys.get_state(view.pid).socket.assigns.edit_selection
   end
 
   # ~6s total — generous for cross-node async transcript delivery under CI load.


### PR DESCRIPTION
## Summary

Follow-up from the BT-2539 PR review (#2583). The method editor reports its selection via the `CmEditor` hook (`select_source` → `:edit_selection`), and `sync_active/2` clears `:edit_selection` on every tab switch.

A latent race remained: a `select_source` event the **departing** `CmEditor` dispatched via `pushEvent` just before its `destroyed()` callback ran could arrive on the server **after** `sync_active/2` cleared `:edit_selection`, re-populating it with stale coordinates from the closed tab.

`:edit_selection` has no consumer yet, so this is not user-visible today — but it must be fixed **before** that consumer lands.

## Approach

Adopt the intent-based fix (option 1 from the issue): stamp each selection push with the active tab id and ignore any push whose stamp no longer matches the live tab.

## Key changes

- **`assets/js/hooks/cm_editor.js`** — read `data-tab-id` in `mounted()` and include `tab_id` in every `reportSelection` push (the editor instance captures its own tab id at mount, so a departing editor's final push carries the *old* id). The Workspace editor has no stamp → `null`, which its handler doesn't read.
- **`lib/bt_attach_web/live/workspace_live.ex`** — render `data-tab-id={@active_tab}` on the method-editor `CmEditor`; the `select_source` handler stores the selection only when the stamp equals `socket.assigns.active_tab`, otherwise ignores it. A payload with no stamp falls through to the catch-all clause (ignored, no crash).
- **`test/bt_attach_web/workspace_live_test.exs`** — assert the stamp is rendered, the happy path stores the selection, and a stale/missing stamp is dropped (peeking `:edit_selection` via `:sys.get_state` since it has no rendered consumer yet).

## Verification

- Workspace e2e suite: **59 passed** (against a freshly-built workspace node)
- Standard liveview lane: **137 passed, 75 excluded**
- `mix format --check-formatted`: clean
- `just dialyzer`: clean

## References

- Linear: https://linear.app/beamtalk/issue/BT-2549
- BT-2539 (the migration), BT-2485 / BT-2494 (selection-tracking groundwork)

https://claude.ai/code/session_019F5hhpb4jEt5Y2GvfqREPB

---
_Generated by [Claude Code](https://claude.ai/code/session_019F5hhpb4jEt5Y2GvfqREPB)_