### PR TITLE
feat(liveview): route REPL meta-commands to IDE panes (BT-2543 follow-up)

### DIFF
--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -55,6 +55,18 @@ not change op output:
   per-op authorization runs before any dist call, keyed to the OIDC identity
   (`surface-specific`). See [`docs/security/threat-model.md`](../security/threat-model.md).
 
+The IDE's **REPL tab** (BT-2543) also carries a client-side meta-command layer,
+the GUI analogue of the CLI's `handle_repl_command()` (BT-2543 follow-up): a
+leading-colon submit is recognised in `WorkspaceLive` (`repl_meta_command/1`)
+and routed to the matching IDE surface instead of being sent to `eval` (which
+would reject `:h` as a parse error). `:help <Class>` — and a `Beamtalk help:
+<Class>` message-send — focus the **System Browser** on that class; `:bindings`,
+`:changes`/`:dirty`, `:flush` point at the Bindings pane / Changes tab; `:test`
+notes the forthcoming test-runner pane (BT-2557); unknown `:cmd`s get a friendly
+note. This is `surface-specific` UX routing — it adds no op vocabulary and
+changes no op output (the underlying capability is still the same `eval` /
+`browse_*` ops these panes already use).
+
 ## Core Operations
 
 | REPL op | CLI subcommand | REPL meta-command | MCP tool | LSP capability | Notes |

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -62,8 +62,10 @@ and routed to the matching IDE surface instead of being sent to `eval` (which
 would reject `:h` as a parse error). `:help <Class>` — and a `Beamtalk help:
 <Class>` message-send — focus the **System Browser** on that class; `:bindings`,
 `:changes`/`:dirty`, `:flush` point at the Bindings pane / Changes tab; `:test`
-notes the forthcoming test-runner pane (BT-2557); unknown `:cmd`s get a friendly
-note. This is `surface-specific` UX routing — it adds no op vocabulary and
+notes the forthcoming test-runner pane (BT-2557); `:sync`/`:s`, `:clear`,
+`:show-codegen`/`:sc`, and `:exit` get a `:point` note explaining the IDE
+equivalent (or that the op is CLI-only); unknown `:cmd`s get a friendly note.
+This is `surface-specific` UX routing — it adds no op vocabulary and
 changes no op output (the underlying capability is still the same `eval` /
 `browse_*` ops these panes already use).
 

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -397,6 +397,8 @@
 .repl-arrow { color: var(--accent); font-weight: 700; flex: none; }
 .repl-val { color: var(--accent-2); white-space: pre-wrap; overflow-wrap: break-word; min-width: 0; flex: 1; }
 .repl-entry.err .repl-arrow, .repl-entry.err .repl-val { color: var(--err); }
+/* Meta-command responses (`:help`, pane pointers): muted, not a result. */
+.repl-entry.meta .repl-arrow, .repl-entry.meta .repl-val { color: var(--muted); }
 
 /* Long responses collapse within their entry (capped open height, scroll past
    it) so one verbose result can't flood the scrollback. */

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1842,7 +1842,9 @@ defmodule BtAttachWeb.WorkspaceLive do
           "" -> nil
           stripped -> stripped
         end
-      [] -> nil
+
+      [] ->
+        nil
     end
   end
 

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -663,27 +663,41 @@ defmodule BtAttachWeb.WorkspaceLive do
   @impl true
   def handle_event("repl_eval", %{"expr" => expr}, %{assigns: %{session_pid: pid}} = socket)
       when is_pid(pid) do
-    if String.trim(expr) == "" do
-      # Empty submit (bare Enter) is a no-op — never append a blank entry or
-      # disturb the history cursor.
-      {:noreply, socket}
-    else
-      socket =
-        case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
-          {:ok, term, _output, _warnings} ->
-            repl_append_ok(socket, expr, term)
+    trimmed = String.trim(expr)
 
-          {:error, reason, _output, _warnings} ->
-            repl_append_error(socket, expr, Workspace.render_error(reason))
+    cond do
+      trimmed == "" ->
+        # Empty submit (bare Enter) is a no-op — never append a blank entry or
+        # disturb the history cursor.
+        {:noreply, socket}
 
-          # Facade short-circuit (RBAC denial / off-vocabulary op) — a 2-tuple the
-          # eval contract never produces; render it as the entry's response rather
-          # than crashing the LiveView.
-          {:error, reason} ->
-            repl_append_error(socket, expr, facade_error(reason))
-        end
+      meta = repl_meta_command(trimmed) ->
+        # A `:`-prefixed meta-command (BT-2543 follow-up). The IDE handles these
+        # itself — driving the matching pane or pointing at it — and NEVER sends
+        # them to `eval`, which would choke trying to compile `:h` as Beamtalk.
+        {:noreply,
+         socket
+         |> handle_repl_meta(meta, expr)
+         |> repl_record_history(expr)
+         |> repl_clear_input()}
 
-      {:noreply, socket |> repl_record_history(expr) |> repl_clear_input()}
+      true ->
+        socket =
+          case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+            {:ok, term, _output, _warnings} ->
+              socket |> repl_append_ok(expr, term) |> repl_help_followup(expr)
+
+            {:error, reason, _output, _warnings} ->
+              repl_append_error(socket, expr, Workspace.render_error(reason))
+
+            # Facade short-circuit (RBAC denial / off-vocabulary op) — a 2-tuple the
+            # eval contract never produces; render it as the entry's response rather
+            # than crashing the LiveView.
+            {:error, reason} ->
+              repl_append_error(socket, expr, facade_error(reason))
+          end
+
+        {:noreply, socket |> repl_record_history(expr) |> repl_clear_input()}
     end
   end
 
@@ -1788,6 +1802,176 @@ defmodule BtAttachWeb.WorkspaceLive do
   # set it by pushing to the ReplInput hook.
   defp repl_clear_input(socket) do
     push_event(socket, "repl_set_input", %{text: ""})
+  end
+
+  # ── REPL meta-commands (BT-2543 follow-up) ──────────────────────────────────
+  #
+  # The CLI REPL parses `:`-prefixed meta-commands client-side (see
+  # crates/beamtalk-cli/src/commands/repl/mod.rs); the LiveView REPL historically
+  # forwarded them straight to `eval`, which choked trying to compile `:h` as a
+  # Beamtalk expression. In a graphical IDE most of those commands map onto a pane
+  # that already exists (the System Browser, the Bindings pane, the Changes tab),
+  # so rather than re-implement the CLI's command DSL we recognise the leading
+  # colon and either DRIVE the matching pane (`:help X` focuses the System
+  # Browser) or POINT the user at it. Input without a leading colon is real code
+  # and falls through to `eval` untouched.
+  #
+  # Returns `nil` for non-meta input (the overwhelmingly common path) so the
+  # caller's `cond` falls through to eval; otherwise a parsed `{kind, …}` tuple
+  # `handle_repl_meta/3` routes.
+  defp repl_meta_command(input) do
+    if String.starts_with?(input, ":") do
+      case String.split(input, ~r/\s+/, parts: 2, trim: true) do
+        [cmd | rest] -> repl_meta_dispatch(cmd, meta_arg(rest))
+        # A bare ":" with nothing after it — treat as an unknown command rather
+        # than letting it reach `eval`.
+        [] -> {:unknown, ":"}
+      end
+    else
+      nil
+    end
+  end
+
+  # First whitespace-delimited token of a meta-command's argument, with a leading
+  # `#` stripped so `:help #Counter` and `:help Counter` agree. `nil` when the
+  # command had no argument.
+  defp meta_arg([]), do: nil
+
+  defp meta_arg([arg]) do
+    case String.split(arg, ~r/\s+/, parts: 2, trim: true) do
+      [token | _] -> String.trim_leading(token, "#")
+      [] -> nil
+    end
+  end
+
+  defp repl_meta_dispatch(cmd, arg) when cmd in [":help", ":h", ":?"], do: {:help, arg}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":bindings", ":b"],
+    do:
+      {:point,
+       "Bindings are listed live in the Bindings pane on the right — click one to inspect it."}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":changes", ":dirty"],
+    do: {:point, "Pending changes are shown in the Changes tab of this dock."}
+
+  defp repl_meta_dispatch(":flush", _),
+    do: {:point, "Use the Flush control in the Changes tab to write pending changes to disk."}
+
+  defp repl_meta_dispatch(":sync", _),
+    do: {:point, "The IDE tracks the live image as you work — there is no manual sync step."}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":test", ":t"],
+    do:
+      {:point,
+       "A test-runner pane is coming to the IDE (BT-2557). For now, run tests from the CLI with `beamtalk test`."}
+
+  defp repl_meta_dispatch(":clear", _),
+    do:
+      {:point,
+       "Session bindings clear with the workspace; there is no separate clear control yet."}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":exit", ":quit", ":q"],
+    do:
+      {:point,
+       "Close the browser tab to disconnect — there is no REPL process to exit in the IDE."}
+
+  defp repl_meta_dispatch(cmd, _), do: {:unknown, cmd}
+
+  # Route a parsed meta-command. `:help X` drives the System Browser; everything
+  # else appends an informational scrollback entry (a third `kind`, `:info`, the
+  # template styles muted rather than as an error).
+  defp handle_repl_meta(socket, {:help, nil}, expr),
+    do: repl_append_info(socket, expr, repl_help_text())
+
+  defp handle_repl_meta(socket, {:help, class}, expr),
+    do: repl_focus_class(socket, expr, class)
+
+  defp handle_repl_meta(socket, {:point, message}, expr),
+    do: repl_append_info(socket, expr, message)
+
+  defp handle_repl_meta(socket, {:unknown, cmd}, expr) do
+    repl_append_info(
+      socket,
+      expr,
+      "Unknown command #{cmd}. This is the IDE REPL — type :help for what's available, " <>
+        ":help <Class> to open a class in the System Browser, or just evaluate an expression."
+    )
+  end
+
+  # Focus the System Browser on `class` (the GUI equivalent of the CLI's
+  # `:help Class` → `Beamtalk help: Class`). We validate against the live symbol
+  # index first so an unknown name gives a clean message instead of pointing the
+  # browser at a class that doesn't exist.
+  defp repl_focus_class(socket, expr, class) do
+    if class in browser_class_names(socket) do
+      socket
+      |> open_class(class)
+      |> repl_append_info(expr, "Opened #{class} in the System Browser ◂")
+    else
+      repl_append_error(
+        socket,
+        expr,
+        "No class named #{class}. Browse classes in the System Browser, or search with the omni bar (top)."
+      )
+    end
+  end
+
+  # The class names known to the live image, from the same symbol index the omni
+  # search uses. An empty index (dispatch failure / RBAC denial) just means every
+  # `:help X` reports "no such class" rather than crashing.
+  defp browser_class_names(socket) do
+    socket
+    |> symbol_rows()
+    |> Enum.filter(&(&1.kind == "class"))
+    |> Enum.map(& &1.class)
+  end
+
+  # `:help` with no argument: a short tour of where the CLI REPL's commands live
+  # in the IDE, so a muscle-memory `:h` lands somewhere useful instead of erroring.
+  defp repl_help_text do
+    """
+    IDE REPL — evaluate any expression (Enter runs it, ↑/↓ recall history).
+    :help <Class>   open a class in the System Browser (left)
+    :bindings       → Bindings pane (right)
+    :changes        → Changes tab (this dock)
+    :test           test-runner pane coming soon (BT-2557)
+    Inspect results with the Inspect button; browse classes/methods on the left.\
+    """
+  end
+
+  # After a successful eval, if the expression was a `Beamtalk help: Class` send
+  # (the CLI's `:help` desugaring, and a natural thing to type directly), focus
+  # the System Browser on that class too — the help text stays in the scrollback
+  # AND the browser navigates to the subject. Non-help evals pass through
+  # untouched.
+  defp repl_help_followup(socket, expr) do
+    case Regex.run(~r/^\s*Beamtalk\s+help:\s+#?([A-Z]\w*)/, expr) do
+      [_, class] -> open_class(socket, class)
+      _ -> socket
+    end
+  end
+
+  # Append an informational meta-command response (`kind: :info`): no live term,
+  # so no Inspect affordance and nothing stashed. Mirrors `repl_append_error/3`'s
+  # bookkeeping (seq bump + term-map eviction in lockstep with the scrollback cap).
+  defp repl_append_info(socket, request, message) do
+    seq = socket.assigns.repl_seq + 1
+    id = repl_entry_id(seq)
+
+    entry = %{
+      id: id,
+      request: request,
+      kind: :info,
+      response: message,
+      inspectable: false,
+      long: repl_long?(message)
+    }
+
+    socket
+    |> assign(:repl_seq, seq)
+    |> update(:repl_terms, &repl_evict(&1, seq))
+    |> stream_insert(:repl, entry, limit: -@repl_scrollback_limit)
+    |> repl_scroll_to_bottom()
   end
 
   # ── method editor helpers (Wave 3) ──────────────────────────────────────────
@@ -4406,7 +4590,11 @@ defmodule BtAttachWeb.WorkspaceLive do
                       <div
                         :for={{dom_id, entry} <- @streams.repl}
                         id={dom_id}
-                        class={["repl-entry", entry.kind == :error && "err"]}
+                        class={[
+                          "repl-entry",
+                          entry.kind == :error && "err",
+                          entry.kind == :info && "meta"
+                        ]}
                       >
                         <div class="repl-req">
                           <span class="repl-mark">›</span>

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1836,15 +1836,13 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp meta_arg([]), do: nil
 
   defp meta_arg([arg]) do
-    case String.split(arg, ~r/\s+/, parts: 2, trim: true) do
-      [token | _] ->
-        case String.trim_leading(token, "#") do
-          "" -> nil
-          stripped -> stripped
-        end
+    # `arg` is the non-empty second part of the outer `parts: 2, trim: true` split,
+    # so this inner split always yields at least the first token.
+    [token | _] = String.split(arg, ~r/\s+/, parts: 2, trim: true)
 
-      [] ->
-        nil
+    case String.trim_leading(token, "#") do
+      "" -> nil
+      stripped -> stripped
     end
   end
 
@@ -1955,7 +1953,7 @@ defmodule BtAttachWeb.WorkspaceLive do
     :sync / :s             tracks the live image (loads beamtalk.toml on connect)
     :clear                 evaluates `Session current clear`
     :show-codegen / :sc    CLI-only — run from `beamtalk repl`
-    :test                  test-runner pane coming soon (BT-2557)
+    :test / :t             test-runner pane coming soon (BT-2557)
     :exit / :quit / :q     close the browser tab to disconnect
     Inspect results with the Inspect button; browse classes/methods on the left.\
     """

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1919,7 +1919,10 @@ defmodule BtAttachWeb.WorkspaceLive do
       |> open_class(class)
       |> repl_append_info(expr, "Opened #{class} in the System Browser ◂")
     else
-      repl_append_error(
+      # "No class named X" is feedback about a meta-command, not a code-evaluation
+      # failure, so it uses the muted `:info` styling (like an unknown `:cmd`) rather
+      # than the red error arrow reserved for eval errors.
+      repl_append_info(
         socket,
         expr,
         "No class named #{class}. Browse classes in the System Browser, or search with the omni bar (top)."
@@ -1946,9 +1949,14 @@ defmodule BtAttachWeb.WorkspaceLive do
     IDE REPL — evaluate any expression (Enter runs it, ↑/↓ recall history).
     :help / :h / :?        show this help
     :help <Class>          open a class in the System Browser (left)
-    :bindings              → Bindings pane (right)
-    :changes               → Changes tab (this dock)
+    :bindings / :b         → Bindings pane (right)
+    :changes / :dirty      → Changes tab (this dock)
+    :flush                 → Flush control (Changes tab)
+    :sync / :s             tracks the live image (loads beamtalk.toml on connect)
+    :clear                 evaluates `Session current clear`
+    :show-codegen / :sc    CLI-only — run from `beamtalk repl`
     :test                  test-runner pane coming soon (BT-2557)
+    :exit / :quit / :q     close the browser tab to disconnect
     Inspect results with the Inspect button; browse classes/methods on the left.\
     """
   end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1821,12 +1821,10 @@ defmodule BtAttachWeb.WorkspaceLive do
   # `handle_repl_meta/3` routes.
   defp repl_meta_command(input) do
     if String.starts_with?(input, ":") do
-      case String.split(input, ~r/\s+/, parts: 2, trim: true) do
-        [cmd | rest] -> repl_meta_dispatch(cmd, meta_arg(rest))
-        # A bare ":" with nothing after it — treat as an unknown command rather
-        # than letting it reach `eval`.
-        [] -> {:unknown, ":"}
-      end
+      # `input` starts with ":", so splitting on whitespace always yields at least
+      # the command token (a bare ":" splits to `[":"]`, routed to the catch-all).
+      [cmd | rest] = String.split(input, ~r/\s+/, parts: 2, trim: true)
+      repl_meta_dispatch(cmd, meta_arg(rest))
     else
       nil
     end
@@ -1931,10 +1929,11 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp repl_help_text do
     """
     IDE REPL — evaluate any expression (Enter runs it, ↑/↓ recall history).
-    :help <Class>   open a class in the System Browser (left)
-    :bindings       → Bindings pane (right)
-    :changes        → Changes tab (this dock)
-    :test           test-runner pane coming soon (BT-2557)
+    :help / :h / :?        show this help
+    :help <Class>          open a class in the System Browser (left)
+    :bindings              → Bindings pane (right)
+    :changes               → Changes tab (this dock)
+    :test                  test-runner pane coming soon (BT-2557)
     Inspect results with the Inspect button; browse classes/methods on the left.\
     """
   end
@@ -1944,6 +1943,12 @@ defmodule BtAttachWeb.WorkspaceLive do
   # the System Browser on that class too — the help text stays in the scrollback
   # AND the browser navigates to the subject. Non-help evals pass through
   # untouched.
+  #
+  # Unlike `repl_focus_class/3`, this skips the `browser_class_names/1` validation
+  # and calls `open_class` directly: the `eval` already succeeded, which proves the
+  # class exists in the runtime, so a symbol-index lookup would be redundant (and
+  # would falsely reject a class defined moments earlier if the index is briefly
+  # stale). `load_protocols` handles an empty result gracefully regardless.
   defp repl_help_followup(socket, expr) do
     case Regex.run(~r/^\s*Beamtalk\s+help:\s+#?([A-Z]\w*)/, expr) do
       [_, class] -> open_class(socket, class)

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1861,8 +1861,10 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp repl_meta_dispatch(":flush", _),
     do: {:point, "Use the Flush control in the Changes tab to write pending changes to disk."}
 
-  defp repl_meta_dispatch(":sync", _),
-    do: {:point, "The IDE tracks the live image as you work — there is no manual sync step."}
+  defp repl_meta_dispatch(cmd, _) when cmd in [":sync", ":s"],
+    do:
+      {:point,
+       "The IDE tracks the live image as you work, so there is no manual sync step — project files from `beamtalk.toml` load when you connect."}
 
   defp repl_meta_dispatch(cmd, _) when cmd in [":test", ":t"],
     do:
@@ -1872,7 +1874,12 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp repl_meta_dispatch(":clear", _),
     do:
       {:point,
-       "Session bindings clear with the workspace; there is no separate clear control yet."}
+       "Session bindings clear with the workspace. To clear them now, evaluate: Session current clear"}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":show-codegen", ":sc"],
+    do:
+      {:point,
+       "Generated-code inspection (:show-codegen) is CLI-only for now — run it from `beamtalk repl`."}
 
   defp repl_meta_dispatch(cmd, _) when cmd in [":exit", ":quit", ":q"],
     do:
@@ -1921,13 +1928,15 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   # The class names known to the live image, from the same symbol index the omni
-  # search uses. An empty index (dispatch failure / RBAC denial) just means every
-  # `:help X` reports "no such class" rather than crashing.
+  # search uses, as a MapSet so the `class in browser_class_names(socket)`
+  # membership check in `repl_focus_class/3` is O(1). An empty index (dispatch
+  # failure / RBAC denial) just means every `:help X` reports "no such class"
+  # rather than crashing.
   defp browser_class_names(socket) do
     socket
     |> symbol_rows()
     |> Enum.filter(&(&1.kind == "class"))
-    |> Enum.map(& &1.class)
+    |> MapSet.new(& &1.class)
   end
 
   # `:help` with no argument: a short tour of where the CLI REPL's commands live

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1837,7 +1837,11 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   defp meta_arg([arg]) do
     case String.split(arg, ~r/\s+/, parts: 2, trim: true) do
-      [token | _] -> String.trim_leading(token, "#")
+      [token | _] ->
+        case String.trim_leading(token, "#") do
+          "" -> nil
+          stripped -> stripped
+        end
       [] -> nil
     end
   end

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -1758,6 +1758,18 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
       assert html =~ "Not authorized"
       assert Process.alive?(view.pid)
     end
+
+    test "an Observer can run :help <Class> — meta routing performs no privileged op",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/")
+      # `:help` is a client-side meta-command: it routes through `handle_repl_meta`
+      # (driving the System Browser via the `:read` `:symbols` op), never the `:eval`
+      # op. So an Observer who cannot eval can still navigate with it — no 403, no
+      # crash — regardless of whether the class is in the symbol index.
+      html = render_hook(view, "repl_eval", %{"expr" => ":help Object"})
+      refute html =~ "Not authorized"
+      assert Process.alive?(view.pid)
+    end
   end
 
   # Set the per-tab resume token on the conn so the connected mount reads it back

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -1646,6 +1646,77 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert html =~ "n"
   end
 
+  # ── REPL meta-commands (BT-2543 follow-up) ──────────────────────────────────
+  #
+  # `:`-prefixed commands are an IDE concern, never sent to `eval` (which would
+  # choke compiling `:h` as Beamtalk). They drive a pane (`:help X` focuses the
+  # System Browser) or point at one (`:bindings` → Bindings pane); unknown colon
+  # input gets a friendly note rather than a parse error.
+
+  test ":help with no argument prints an info entry, not an eval error", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    html = view |> form("#repl-form") |> render_submit(%{expr: ":help"})
+    # Routed by the IDE: a muted `:info` entry, NOT an `err` entry, and never
+    # round-tripped through eval (which would reject `:help` as a parse error).
+    assert has_element?(view, ".repl-entry.meta")
+    refute has_element?(view, ".repl-entry.err")
+    assert html =~ "IDE REPL"
+  end
+
+  test ":help <Class> focuses the System Browser on that class", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    class = "ReplHelp#{System.unique_integer([:positive])}"
+    # Define the class in the image so it is in the live symbol index.
+    view
+    |> form("#repl-form")
+    |> render_submit(%{expr: "Object subclass: #{class}\n  greet => 1"})
+
+    html = view |> form("#repl-form") |> render_submit(%{expr: ":help #{class}"})
+    # Confirmation in the scrollback …
+    assert html =~ "Opened #{class} in the System Browser"
+    refute has_element?(view, ".repl-entry.err")
+    # … and the System Browser is now pointed at the class: its protocol pane
+    # heads on the class (`selected_class` set + protocols loaded).
+    assert view |> element(".panel-head", class) |> render() =~ "methods"
+  end
+
+  test ":help <Unknown> reports no such class instead of opening the browser", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    html = view |> form("#repl-form") |> render_submit(%{expr: ":help NoSuchClassHere"})
+    assert html =~ "No class named NoSuchClassHere"
+  end
+
+  test ":bindings points at the Bindings pane rather than evaluating", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    html = view |> form("#repl-form") |> render_submit(%{expr: ":bindings"})
+    assert has_element?(view, ".repl-entry.meta")
+    refute has_element?(view, ".repl-entry.err")
+    assert html =~ "Bindings pane"
+  end
+
+  test "an unrecognised :command gets a friendly note, never a parse error", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    html = view |> form("#repl-form") |> render_submit(%{expr: ":wat"})
+    assert has_element?(view, ".repl-entry.meta")
+    refute has_element?(view, ".repl-entry.err")
+    assert html =~ "Unknown command :wat"
+  end
+
+  test "`Beamtalk help: Class` evaluates AND focuses the System Browser", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    class = "ReplHelpSend#{System.unique_integer([:positive])}"
+
+    view
+    |> form("#repl-form")
+    |> render_submit(%{expr: "Object subclass: #{class}\n  greet => 1"})
+
+    # A real `help:` send: its help text still lands as a normal `→ result`
+    # entry, and the browser additionally navigates to the subject class.
+    view |> form("#repl-form") |> render_submit(%{expr: "Beamtalk help: #{class}"})
+    refute has_element?(view, ".repl-entry.err")
+    assert view |> element(".panel-head", class) |> render() =~ "methods"
+  end
+
   describe "REPL tab — read-only Observer (BT-2421)" do
     setup %{conn: conn} do
       Application.put_env(:bt_attach, :oidc, %{

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -1768,6 +1768,10 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
       # crash — regardless of whether the class is in the symbol index.
       html = render_hook(view, "repl_eval", %{"expr" => ":help Object"})
       refute html =~ "Not authorized"
+      # Routes to an `:info` meta entry (either "Opened Object" or, if the symbol
+      # index lacks it, "No class named Object") — never an `:eval` RBAC error.
+      assert has_element?(view, ".repl-entry.meta")
+      refute has_element?(view, ".repl-entry.err")
       assert Process.alive?(view.pid)
     end
   end


### PR DESCRIPTION
## Why

The new LiveView REPL tab forwarded `:`-prefixed input straight to `eval`, so `:h`, `:help`, `:t`, `:bindings` etc. failed with a parse error — the colon commands are a **client-side** concern (as in the CLI's `handle_repl_command`), never part of the REPL protocol. In a graphical IDE most of those commands map onto a pane that already exists, so this recognises them in `WorkspaceLive` and routes to the right surface rather than re-implementing the CLI's command DSL.

## What

- **`:help <Class>`** — and a **`Beamtalk help: <Class>`** send — focus the **System Browser** on that class (validated against the live symbol index; an unknown name gives a clean message). The `help:` send still evaluates *and* navigates.
- **`:help`** (bare) prints a short map of the CLI commands to their IDE homes.
- **`:bindings` / `:changes` / `:dirty` / `:flush` / `:sync` / `:clear` / `:exit`** point at the Bindings pane / Changes tab / etc.
- **`:test`** notes the forthcoming test-runner pane (BT-2557).
- **unknown `:cmd`** gets a friendly note, never a parse error.

New `:info` scrollback entry kind (muted styling). Meta-commands drive only `:read` browse ops or show text — no new op vocabulary, no RBAC change.

## Tests

6 new `workspace_live_test.exs` cases (help / help-class / unknown-class / bindings / unknown / `Beamtalk help:` send). Full file: **79 passed** against a live workspace node. `surface-parity.md` updated per the surface-parity rule.

## Follow-ups (filed)

- **BT-2557** — Cockpit test-runner / test-browser pane (the one CLI affordance with no GUI home).
- **BT-2558** — System Browser: render class comments + method doc-comments as formatted docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)