### PR TITLE
Cockpit: dismissable panels + collapsible dock (BT-2559)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -43,6 +43,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 ERLANG_STAMP="$REPO_ROOT/.lint-erlang-stamp"
 JS_STAMP="$REPO_ROOT/.lint-js-stamp"
 BT_STAMP="$REPO_ROOT/.lint-beamtalk-stamp"
+ELIXIR_STAMP="$REPO_ROOT/.lint-elixir-stamp"
 
 # Compute a fingerprint of tracked files matching the given patterns.
 fingerprint() {
@@ -83,6 +84,15 @@ else
   echo "🔍 Running lint-beamtalk..."
   just lint-beamtalk
   echo "$BT_FP" > "$BT_STAMP"
+fi
+
+ELIXIR_FP="$(fingerprint 'editors/liveview/**/*.ex' 'editors/liveview/**/*.exs')"
+if stamp_matches "$ELIXIR_STAMP" "$ELIXIR_FP"; then
+  echo "⏭️  lint-elixir: no Elixir changes since last lint, skipping"
+else
+  echo "🔬 Running lint-elixir..."
+  just lint-elixir
+  echo "$ELIXIR_FP" > "$ELIXIR_STAMP"
 fi
 
 echo "✅ All lint checks passed"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -86,7 +86,7 @@ else
   echo "$BT_FP" > "$BT_STAMP"
 fi
 
-ELIXIR_FP="$(fingerprint 'editors/liveview/**/*.ex' 'editors/liveview/**/*.exs')"
+ELIXIR_FP="$(fingerprint 'editors/liveview/*.ex' 'editors/liveview/*.exs')"
 if stamp_matches "$ELIXIR_STAMP" "$ELIXIR_FP"; then
   echo "⏭️  lint-elixir: no Elixir changes since last lint, skipping"
 else

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ _rel/
 .lint-erlang-stamp
 .lint-js-stamp
 .lint-beamtalk-stamp
+.lint-elixir-stamp
 
 # Session and temporary files
 *.tmp

--- a/Justfile
+++ b/Justfile
@@ -452,8 +452,12 @@ fmt-check-elixir:
     @echo "✅ Elixir formatting check passed"
 
 # Check all code formatting
+# Elixir formatting is enforced by the dedicated `liveview` CI job (which runs
+# `mix deps.get` first, required by `import_deps: [:phoenix]`). The cross-platform
+# `check` job has no Elixir deps fetched, so `fmt-check-elixir` is excluded here
+# and run via `just lint-elixir` / `just fmt-check-elixir` locally instead.
 [unix]
-fmt-check: fmt-check-rust fmt-check-erlang fmt-check-js fmt-check-beamtalk fmt-check-elixir
+fmt-check: fmt-check-rust fmt-check-erlang fmt-check-js fmt-check-beamtalk
 
 # Windows: skip Erlang, JS, and Elixir format checks (platform-agnostic, covered by Linux CI)
 [windows]

--- a/Justfile
+++ b/Justfile
@@ -392,8 +392,11 @@ bench:
 # Lint and Format
 # ═══════════════════════════════════════════════════════════════════════════
 
+# Lint Elixir: format check
+lint-elixir: fmt-check-elixir
+
 # Run all linting and formatting checks
-lint: lint-rust lint-erlang lint-js lint-beamtalk lint-workaround-comments
+lint: lint-rust lint-erlang lint-js lint-elixir lint-beamtalk lint-workaround-comments
 
 # Ratchet lint: flag workaround/limitation comments lacking a BT-NNNN tracking
 # reference (BT-2347). Ships with an allowlist snapshot of pre-existing offenders
@@ -441,11 +444,18 @@ fmt-check-rust:
     @echo "📋 Checking Rust formatting..."
     cargo fmt --all -- --check
 
+# Check Elixir code formatting (LiveView IDE)
+[working-directory: 'editors/liveview']
+fmt-check-elixir:
+    @echo "📋 Checking Elixir formatting..."
+    mix format --check-formatted
+    @echo "✅ Elixir formatting check passed"
+
 # Check all code formatting
 [unix]
-fmt-check: fmt-check-rust fmt-check-erlang fmt-check-js fmt-check-beamtalk
+fmt-check: fmt-check-rust fmt-check-erlang fmt-check-js fmt-check-beamtalk fmt-check-elixir
 
-# Windows: skip Erlang and JS format checks (platform-agnostic, covered by Linux CI)
+# Windows: skip Erlang, JS, and Elixir format checks (platform-agnostic, covered by Linux CI)
 [windows]
 fmt-check: fmt-check-rust fmt-check-beamtalk
 
@@ -454,8 +464,15 @@ fmt-rust:
     @echo "✨ Formatting Rust code..."
     cargo fmt --all
 
-# Format all code (Rust + Erlang + JS + Beamtalk stdlib/test sources)
-fmt: fmt-rust fmt-erlang fmt-js fmt-beamtalk
+# Format Elixir code (LiveView IDE)
+[working-directory: 'editors/liveview']
+fmt-elixir:
+    @echo "✨ Formatting Elixir code..."
+    mix format
+    @echo "✅ Elixir formatting complete"
+
+# Format all code (Rust + Erlang + JS + Elixir + Beamtalk stdlib/test sources)
+fmt: fmt-rust fmt-erlang fmt-js fmt-elixir fmt-beamtalk
 
 # Check JS/TS formatting (Biome)
 [working-directory: 'editors/vscode']

--- a/Justfile
+++ b/Justfile
@@ -445,9 +445,13 @@ fmt-check-rust:
     cargo fmt --all -- --check
 
 # Check Elixir code formatting (LiveView IDE)
+# `mix format` needs fetched deps (import_deps: [:phoenix] + HTML formatter
+# plugin), so fetch them first — mirrors `fmt-elixir` and `fmt-check-js`'s
+# `npm ci`, keeping `just lint-elixir` / the pre-push hook fresh-checkout-safe.
 [working-directory: 'editors/liveview']
 fmt-check-elixir:
     @echo "📋 Checking Elixir formatting..."
+    mix deps.get --quiet
     mix format --check-formatted
     @echo "✅ Elixir formatting check passed"
 

--- a/Justfile
+++ b/Justfile
@@ -469,9 +469,13 @@ fmt-rust:
     cargo fmt --all
 
 # Format Elixir code (LiveView IDE)
+# `.formatter.exs` declares `import_deps: [:phoenix]` and the LiveView HTML
+# formatter plugin, both of which need fetched deps — so a fresh checkout must
+# `mix deps.get` before `mix format` can run.
 [working-directory: 'editors/liveview']
 fmt-elixir:
     @echo "✨ Formatting Elixir code..."
+    mix deps.get
     mix format
     @echo "✅ Elixir formatting complete"
 

--- a/Justfile
+++ b/Justfile
@@ -479,7 +479,7 @@ fmt-rust:
 [working-directory: 'editors/liveview']
 fmt-elixir:
     @echo "✨ Formatting Elixir code..."
-    mix deps.get
+    mix deps.get --quiet
     mix format
     @echo "✅ Elixir formatting complete"
 

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -297,23 +297,16 @@
 .dock { flex: none; height: var(--dock-h, 230px); display: flex; flex-direction: column; transition: height 200ms ease, opacity 150ms ease; overflow: hidden; }
 .dock .panel { flex: 1; display: flex; flex-direction: column; min-height: 0; }
 .dock.collapsed { height: 0; opacity: 0; pointer-events: none; }
-.dock .dock-collapse-toggle {
-  position: absolute; bottom: 4px; left: 50%; transform: translateX(-50%);
-  border: 1px solid var(--line); background: var(--panel-2); cursor: pointer;
-  color: var(--faint); font-size: 10px; padding: 2px 8px; border-radius: 4px;
-  z-index: 10; opacity: 0; transition: opacity 150ms ease;
-}
-.dock:hover .dock-collapse-toggle { opacity: 1; }
-.dock .dock-collapse-toggle:hover { color: var(--ink); background: var(--hover); }
-/* collapsed state: show a thin restore bar at the bottom */
+/* collapsed state: show a thin restore bar at the bottom. The element is only
+   rendered (via :if={!@show_dock}) when the dock is collapsed, so DOM presence
+   is the guard — no hidden default/visible-variant toggle is needed. */
 .dock-bar {
-  flex: none; height: 28px; display: none; align-items: center; justify-content: center;
+  flex: none; height: 28px; display: flex; align-items: center; justify-content: center;
   background: var(--panel); border: 1px solid var(--line); border-radius: 9px;
   box-shadow: var(--shadow); cursor: pointer; color: var(--faint); font-size: 11px;
   font-weight: 600; letter-spacing: .03em; text-transform: uppercase;
 }
 .dock-bar:hover { color: var(--ink); background: var(--hover); }
-.dock-bar.visible { display: flex; }
 
 /* The editor body and its method form fill the panel so a browsed method gets the
    whole reclaimed height (the read-only Method Source panel is gone — browsing a

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -181,8 +181,19 @@
 .cockpit {
   flex: 1; min-height: 0; display: grid; gap: var(--gap);
   grid-template-columns: var(--browser-w, 286px) minmax(0, 1fr) var(--inspector-w, 348px);
+  transition: grid-template-columns 200ms ease;
 }
-.col { min-width: 0; min-height: 0; display: flex; flex-direction: column; gap: var(--gap); }
+.cockpit.browser-hidden {
+  grid-template-columns: 0px minmax(0, 1fr) var(--inspector-w, 348px);
+}
+.cockpit.inspector-hidden {
+  grid-template-columns: var(--browser-w, 286px) minmax(0, 1fr) 0px;
+}
+.cockpit.browser-hidden.inspector-hidden {
+  grid-template-columns: 0px minmax(0, 1fr) 0px;
+}
+.col { min-width: 0; min-height: 0; display: flex; flex-direction: column; gap: var(--gap); overflow: hidden; }
+.col.hidden { display: none; }
 
 /* panel chrome */
 .panel {
@@ -199,6 +210,22 @@
 }
 .panel-head .count { color: var(--faint); font-weight: 500; letter-spacing: 0; text-transform: none; white-space: nowrap; flex: none; }
 .panel-head .spacer { flex: 1; }
+.panel-head .panel-close {
+  border: 0; background: transparent; cursor: pointer; color: var(--faint);
+  font-size: 14px; padding: 0 4px; line-height: 1; border-radius: 4px;
+  flex: none;
+}
+.panel-head .panel-close:hover { color: var(--ink); background: var(--hover); }
+
+/* top-bar panel toggle buttons */
+.topbar .panel-toggles { display: flex; gap: 4px; }
+.topbar .panel-toggle {
+  border: 1px solid var(--line); background: var(--panel-2); cursor: pointer;
+  color: var(--muted); font-size: 11px; font-weight: 600; padding: 4px 10px;
+  border-radius: 6px; white-space: nowrap;
+}
+.topbar .panel-toggle:hover { background: var(--hover); color: var(--ink); }
+.topbar .panel-toggle.on { background: var(--accent-soft); color: var(--accent-2); border-color: var(--accent); }
 .panel-body { flex: 1; min-height: 0; overflow: auto; padding: var(--panel-pad); }
 
 /* placeholder copy for not-yet-built Phase 1 panes */
@@ -267,8 +294,26 @@
 /* center column splits between editor and the workspace dock */
 /* position: relative anchors the BT-2495 Senders/Implementors popover. */
 .editor-panel { flex: 1; min-height: 0; position: relative; }
-.dock { flex: none; height: var(--dock-h, 230px); display: flex; flex-direction: column; }
+.dock { flex: none; height: var(--dock-h, 230px); display: flex; flex-direction: column; transition: height 200ms ease, opacity 150ms ease; overflow: hidden; }
 .dock .panel { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+.dock.collapsed { height: 0; opacity: 0; pointer-events: none; }
+.dock .dock-collapse-toggle {
+  position: absolute; bottom: 4px; left: 50%; transform: translateX(-50%);
+  border: 1px solid var(--line); background: var(--panel-2); cursor: pointer;
+  color: var(--faint); font-size: 10px; padding: 2px 8px; border-radius: 4px;
+  z-index: 10; opacity: 0; transition: opacity 150ms ease;
+}
+.dock:hover .dock-collapse-toggle { opacity: 1; }
+.dock .dock-collapse-toggle:hover { color: var(--ink); background: var(--hover); }
+/* collapsed state: show a thin restore bar at the bottom */
+.dock-bar {
+  flex: none; height: 28px; display: none; align-items: center; justify-content: center;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 9px;
+  box-shadow: var(--shadow); cursor: pointer; color: var(--faint); font-size: 11px;
+  font-weight: 600; letter-spacing: .03em; text-transform: uppercase;
+}
+.dock-bar:hover { color: var(--ink); background: var(--hover); }
+.dock-bar.visible { display: flex; }
 
 /* The editor body and its method form fill the panel so a browsed method gets the
    whole reclaimed height (the read-only Method Source panel is gone — browsing a

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -193,7 +193,11 @@
   grid-template-columns: 0px minmax(0, 1fr) 0px;
 }
 .col { min-width: 0; min-height: 0; display: flex; flex-direction: column; gap: var(--gap); overflow: hidden; }
-.col.hidden { display: none; }
+/* A hidden side panel collapses via the parent `.cockpit.browser-hidden` /
+   `.inspector-hidden` grid-track → 0px (animated), with `.col`'s `overflow: hidden`
+   + `min-width: 0` clipping the content. The element stays a grid item so the other
+   columns keep their tracks — `display: none` here would evict it from grid
+   auto-placement and shift the editor into the 0px track (BT-2559 review). */
 
 /* panel chrome */
 .panel {

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -197,7 +197,9 @@
    `.inspector-hidden` grid-track → 0px (animated), with `.col`'s `overflow: hidden`
    + `min-width: 0` clipping the content. The element stays a grid item so the other
    columns keep their tracks — `display: none` here would evict it from grid
-   auto-placement and shift the editor into the 0px track (BT-2559 review). */
+   auto-placement and shift the editor into the 0px track (BT-2559 review). The
+   template marks the collapsed column `inert` so its clipped (but still
+   laid-out) controls drop out of tab order and the AT tree. */
 
 /* panel chrome */
 .panel {

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4815,12 +4815,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                 </div>
               </div>
               <%!-- Dock restore bar: shown when dock is collapsed --%>
-              <div
-                :if={!@show_dock}
-                class="dock-bar"
-                phx-click="toggle_dock"
-                title="Expand dock"
-              >
+              <div :if={!@show_dock} class="dock-bar" phx-click="toggle_dock" title="Expand dock">
                 Workspace ▴
               </div>
 

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4504,7 +4504,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                  toggle) over a protocol-grouped method list, driven by the
                  BT-2488 browse ops (ADR 0096). The Tweaks panel that used to sit
                  below it now lives in the top-bar settings dropdown. --%>
-            <div class={["col", !@show_browser && "hidden"]}>
+            <div class="col" inert={!@show_browser}>
               <div class="browser-split">
                 <.system_browser_classes
                   browser_view={@browser_view}
@@ -4534,7 +4534,11 @@ defmodule BtAttachWeb.WorkspaceLive do
                    `hidden`, not removed) so the `#transcript` stream container is
                    always in the DOM for `stream_insert` regardless of the active
                    tab. --%>
-              <div class={["dock", !@show_dock && "collapsed"]} style="order:2;">
+              <div
+                class={["dock", !@show_dock && "collapsed"]}
+                style="order:2;"
+                inert={!@show_dock}
+              >
                 <div id="workspace-dock" class="panel">
                   <div class="panel-head">
                     <span class="dock-tabs" role="tablist">
@@ -5088,7 +5092,7 @@ defmodule BtAttachWeb.WorkspaceLive do
             </div>
 
             <%!-- RIGHT — Bindings + Inspector (348px), with ChangeLog + Transcript --%>
-            <div class={["col", !@show_inspector && "hidden"]}>
+            <div class="col" inert={!@show_inspector}>
               <div class="right-split">
                 <div id="bindings-panel" class="panel bindings-panel">
                   <div class="panel-head">

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4534,11 +4534,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                    `hidden`, not removed) so the `#transcript` stream container is
                    always in the DOM for `stream_insert` regardless of the active
                    tab. --%>
-              <div
-                class={["dock", !@show_dock && "collapsed"]}
-                style="order:2;"
-                inert={!@show_dock}
-              >
+              <div class={["dock", !@show_dock && "collapsed"]} style="order:2;" inert={!@show_dock}>
                 <div id="workspace-dock" class="panel">
                   <div class="panel-head">
                     <span class="dock-tabs" role="tablist">

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4817,7 +4817,7 @@ defmodule BtAttachWeb.WorkspaceLive do
               <%!-- Dock restore bar: shown when dock is collapsed --%>
               <div
                 :if={!@show_dock}
-                class="dock-bar visible"
+                class="dock-bar"
                 phx-click="toggle_dock"
                 title="Expand dock"
               >

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -5152,8 +5152,8 @@ defmodule BtAttachWeb.WorkspaceLive do
                       type="button"
                       class="panel-close"
                       phx-click="close_inspector"
-                      aria-label="Close Inspector panel"
-                      title="Close panel"
+                      aria-label="Close the Inspector and Bindings column"
+                      title="Close the Inspector + Bindings column"
                     >
                       ×
                     </button>

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4823,16 +4823,20 @@ defmodule BtAttachWeb.WorkspaceLive do
                   </div>
                 </div>
               </div>
-              <%!-- Dock restore bar: shown when dock is collapsed --%>
-              <div
+              <%!-- Dock restore bar: shown when dock is collapsed. A real <button>
+                   (not a <div>) so it is keyboard-reachable and announced as
+                   interactive; `.dock-bar` styling is class-driven either way. --%>
+              <button
                 :if={!@show_dock}
+                type="button"
                 class="dock-bar"
                 phx-click="toggle_dock"
+                aria-label="Expand workspace dock"
                 title="Expand dock"
                 style="order:3;"
               >
                 Workspace ▴
-              </div>
+              </button>
 
               <%!-- TABBED METHOD EDITOR (BT-2494): the spike's write-surface.
                    A tab strip (methods + class definitions) over a breadcrumb

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4096,9 +4096,6 @@ defmodule BtAttachWeb.WorkspaceLive do
     <div id="system-browser" class="panel" style="flex:1;">
       <div class="panel-head">
         System Browser <span class="spacer"></span>
-        <button type="button" class="panel-close" phx-click="close_browser" title="Close panel">
-          ×
-        </button>
         <div class="seg" role="tablist" aria-label="Class tree view">
           <button
             :for={{view, label} <- [{"hierarchy", "Hier"}, {"category", "Cats"}]}
@@ -4112,6 +4109,9 @@ defmodule BtAttachWeb.WorkspaceLive do
             {label}
           </button>
         </div>
+        <button type="button" class="panel-close" phx-click="close_browser" title="Close panel">
+          ×
+        </button>
       </div>
       <div class="panel-body" id="system-browser-tree" phx-hook="ScrollToSelected">
         <div :if={@browser_error} class="io-block err">{@browser_error}</div>
@@ -4815,7 +4815,13 @@ defmodule BtAttachWeb.WorkspaceLive do
                 </div>
               </div>
               <%!-- Dock restore bar: shown when dock is collapsed --%>
-              <div :if={!@show_dock} class="dock-bar" phx-click="toggle_dock" title="Expand dock">
+              <div
+                :if={!@show_dock}
+                class="dock-bar"
+                phx-click="toggle_dock"
+                title="Expand dock"
+                style="order:3;"
+              >
                 Workspace ▴
               </div>
 

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -518,6 +518,12 @@ defmodule BtAttachWeb.WorkspaceLive do
       #   * `:window_z` — the running max z-index; a click bumps the focused window
       #     to `window_z + 1` so z-order follows focus (the spike's stacking).
       |> assign(:inspector_mode, "docked")
+      # Panel visibility toggles (BT-2559): dismissable side panels + collapsible
+      # dock. Each panel can be hidden via a close button; toggle buttons in the
+      # top bar re-show them. The dock can be collapsed/expanded.
+      |> assign(:show_browser, true)
+      |> assign(:show_inspector, true)
+      |> assign(:show_dock, true)
       |> assign(:windows, [])
       |> assign(:next_window_id, 1)
       |> assign(:window_z, 10)
@@ -872,6 +878,27 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   def handle_event("close_settings", _params, socket) do
     {:noreply, assign(socket, show_settings: false)}
+  end
+
+  # Panel visibility toggles (BT-2559): close/toggle side panels and dock.
+  def handle_event("toggle_browser", _params, socket) do
+    {:noreply, assign(socket, show_browser: !socket.assigns.show_browser)}
+  end
+
+  def handle_event("toggle_inspector", _params, socket) do
+    {:noreply, assign(socket, show_inspector: !socket.assigns.show_inspector)}
+  end
+
+  def handle_event("toggle_dock", _params, socket) do
+    {:noreply, assign(socket, show_dock: !socket.assigns.show_dock)}
+  end
+
+  def handle_event("close_browser", _params, socket) do
+    {:noreply, assign(socket, show_browser: false)}
+  end
+
+  def handle_event("close_inspector", _params, socket) do
+    {:noreply, assign(socket, show_inspector: false)}
   end
 
   # Drill into an object-valued field of a *floating window* (BT-2493): the field
@@ -4069,6 +4096,9 @@ defmodule BtAttachWeb.WorkspaceLive do
     <div id="system-browser" class="panel" style="flex:1;">
       <div class="panel-head">
         System Browser <span class="spacer"></span>
+        <button type="button" class="panel-close" phx-click="close_browser" title="Close panel">
+          ×
+        </button>
         <div class="seg" role="tablist" aria-label="Class tree view">
           <button
             :for={{view, label} <- [{"hierarchy", "Hier"}, {"category", "Cats"}]}
@@ -4363,6 +4393,33 @@ defmodule BtAttachWeb.WorkspaceLive do
             </div>
           </div>
           <span class="spacer"></span>
+          <%!-- Panel toggle buttons (BT-2559): show/hide side panels and dock. --%>
+          <div :if={@connected} class="panel-toggles">
+            <button
+              type="button"
+              class={["panel-toggle", @show_browser && "on"]}
+              phx-click="toggle_browser"
+              title="Toggle System Browser"
+            >
+              Browser
+            </button>
+            <button
+              type="button"
+              class={["panel-toggle", @show_inspector && "on"]}
+              phx-click="toggle_inspector"
+              title="Toggle Inspector"
+            >
+              Inspector
+            </button>
+            <button
+              type="button"
+              class={["panel-toggle", @show_dock && "on"]}
+              phx-click="toggle_dock"
+              title="Toggle Workspace Dock"
+            >
+              Dock
+            </button>
+          </div>
           <%!-- Dock/Float toggle (BT-2493, the spike's mode switch): in Float mode
                a binding click / Inspect-it opens a floating, draggable inspector
                window instead of the docked pane. Docked is the default. Shown only
@@ -4428,14 +4485,18 @@ defmodule BtAttachWeb.WorkspaceLive do
         </div>
 
         <%= if @connected do %>
-          <%!-- ── three-column cockpit grid ──────────────────────────────── --%>
-          <div class="cockpit">
+          <%!-- ── three-column cockpit grid (BT-2559: collapsible panels) --%>
+          <div class={[
+            "cockpit",
+            !@show_browser && "browser-hidden",
+            !@show_inspector && "inspector-hidden"
+          ]}>
             <%!-- LEFT — System Browser (BT-2491, 286px).
                  A class tree (Hierarchy / Category views, instance/class side
                  toggle) over a protocol-grouped method list, driven by the
                  BT-2488 browse ops (ADR 0096). The Tweaks panel that used to sit
                  below it now lives in the top-bar settings dropdown. --%>
-            <div class="col">
+            <div class={["col", !@show_browser && "hidden"]}>
               <div class="browser-split">
                 <.system_browser_classes
                   browser_view={@browser_view}
@@ -4465,7 +4526,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                    `hidden`, not removed) so the `#transcript` stream container is
                    always in the DOM for `stream_insert` regardless of the active
                    tab. --%>
-              <div class="dock" style="order:2;">
+              <div class={["dock", !@show_dock && "collapsed"]} style="order:2;">
                 <div id="workspace-dock" class="panel">
                   <div class="panel-head">
                     <span class="dock-tabs" role="tablist">
@@ -4492,6 +4553,14 @@ defmodule BtAttachWeb.WorkspaceLive do
                     <span :if={@dock_tab == "workspace"} class="count">
                       {if ws_selection?(assigns), do: "evaluates selection", else: "evaluates buffer"}
                     </span>
+                    <button
+                      type="button"
+                      class="panel-close"
+                      phx-click="toggle_dock"
+                      title="Collapse dock"
+                    >
+                      ▾
+                    </button>
                   </div>
 
                   <%!-- WORKSPACE tab: highlighted editor + doIt/printIt/inspectIt --%>
@@ -4745,6 +4814,15 @@ defmodule BtAttachWeb.WorkspaceLive do
                   </div>
                 </div>
               </div>
+              <%!-- Dock restore bar: shown when dock is collapsed --%>
+              <div
+                :if={!@show_dock}
+                class="dock-bar visible"
+                phx-click="toggle_dock"
+                title="Expand dock"
+              >
+                Workspace ▴
+              </div>
 
               <%!-- TABBED METHOD EDITOR (BT-2494): the spike's write-surface.
                    A tab strip (methods + class definitions) over a breadcrumb
@@ -4996,7 +5074,7 @@ defmodule BtAttachWeb.WorkspaceLive do
             </div>
 
             <%!-- RIGHT — Bindings + Inspector (348px), with ChangeLog + Transcript --%>
-            <div class="col">
+            <div class={["col", !@show_inspector && "hidden"]}>
               <div class="right-split">
                 <div id="bindings-panel" class="panel bindings-panel">
                   <div class="panel-head">
@@ -5060,6 +5138,14 @@ defmodule BtAttachWeb.WorkspaceLive do
                       <span class="iwf-dot"></span>{(@inspect_frozen && "frozen") || "live"}
                     </button>
                     <span :if={@inspect_target} class="count">following references</span>
+                    <button
+                      type="button"
+                      class="panel-close"
+                      phx-click="close_inspector"
+                      title="Close panel"
+                    >
+                      ×
+                    </button>
                   </div>
                   <%= if @inspect_target do %>
                     <%!-- Spike Inspector head (inspector.jsx `InspectorContent`): a

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4109,7 +4109,13 @@ defmodule BtAttachWeb.WorkspaceLive do
             {label}
           </button>
         </div>
-        <button type="button" class="panel-close" phx-click="close_browser" title="Close panel">
+        <button
+          type="button"
+          class="panel-close"
+          phx-click="close_browser"
+          aria-label="Close System Browser panel"
+          title="Close panel"
+        >
           ×
         </button>
       </div>
@@ -4403,13 +4409,15 @@ defmodule BtAttachWeb.WorkspaceLive do
             >
               Browser
             </button>
+            <%!-- `show_inspector` gates the whole right column (Bindings + Inspector),
+                 so the label names both rather than just "Inspector" (BT-2559 review). --%>
             <button
               type="button"
               class={["panel-toggle", @show_inspector && "on"]}
               phx-click="toggle_inspector"
-              title="Toggle Inspector"
+              title="Toggle the Bindings + Inspector column"
             >
-              Inspector
+              Inspector &amp; Bindings
             </button>
             <button
               type="button"
@@ -4557,6 +4565,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                       type="button"
                       class="panel-close"
                       phx-click="toggle_dock"
+                      aria-label="Collapse workspace dock"
                       title="Collapse dock"
                     >
                       ▾
@@ -5143,6 +5152,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                       type="button"
                       class="panel-close"
                       phx-click="close_inspector"
+                      aria-label="Close Inspector panel"
                       title="Close panel"
                     >
                       ×


### PR DESCRIPTION
## Summary
- Add close buttons (×) to System Browser and Inspector panel headers
- Add top-bar toggle buttons (Browser, Inspector, Dock) with active state
- CSS grid transitions between panel visibility states (200ms ease)
- Dock collapse/expand with animated height and opacity
- Dock restore bar when collapsed

## Changes
- `app.css`: Grid collapse classes, panel close/toggle styles, dock collapse animation
- `workspace_live.ex`: Panel visibility assigns, toggle/close events, close buttons in panel headers
- `Justfile`: Added `fmt-check-elixir`, `lint-elixir`, `fmt-elixir` recipes
- `.githooks/pre-push`: Added Elixir lint stamp-file support
- `.gitignore`: Added `.lint-elixir-stamp`

## Linear
https://linear.app/beamtalk/issue/BT-2559