### PR TITLE
Extract duplicate project_root/beamtalk_binary into cli_common (BT-2560)

### DIFF
--- a/crates/beamtalk-cli/tests/cli_common/mod.rs
+++ b/crates/beamtalk-cli/tests/cli_common/mod.rs
@@ -13,6 +13,29 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use tempfile::TempDir;
 
+/// Resolve the workspace root (repo root) from `CARGO_MANIFEST_DIR`.
+///
+/// `CARGO_MANIFEST_DIR` points at `crates/beamtalk-cli`, so two `parent()`
+/// calls reach the repo root.
+#[allow(dead_code)]
+pub fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Path to the debug `beamtalk` binary.
+///
+/// Used by ignored integration tests that spawn the binary via
+/// `std::process::Command` rather than `assert_cmd`.
+#[allow(dead_code)]
+pub fn beamtalk_binary() -> PathBuf {
+    project_root().join("target/debug/beamtalk")
+}
+
 /// Path to the `beamtalk` binary built by `cargo`.
 ///
 /// `assert_cmd::Command::cargo_bin` works because `beamtalk-cli` declares

--- a/crates/beamtalk-cli/tests/gen_native.rs
+++ b/crates/beamtalk-cli/tests/gen_native.rs
@@ -9,21 +9,9 @@
 //! Tests are `#[ignore]` because they require the beamtalk binary.
 //! Run with: `cargo test --test gen_native -- --ignored`
 
-use std::path::PathBuf;
+mod cli_common;
+
 use std::process::Command;
-
-fn project_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .to_path_buf()
-}
-
-fn beamtalk_binary() -> PathBuf {
-    project_root().join("target/debug/beamtalk")
-}
 
 #[test]
 #[ignore = "requires beamtalk binary"]
@@ -39,7 +27,7 @@ fn gen_native_generates_valid_erlang_stub() {
     std::fs::write(tmp.path().join("TestActor.bt"), bt_source).expect("write .bt");
 
     // Run gen-native
-    let output = Command::new(beamtalk_binary())
+    let output = Command::new(cli_common::beamtalk_binary())
         .args(["gen-native", "TestActor"])
         .current_dir(tmp.path())
         .output()
@@ -104,7 +92,7 @@ fn gen_native_errors_on_missing_native_declaration() {
     let bt_source = "Actor subclass: PlainActor\n  getValue -> Integer => 42\n";
     std::fs::write(tmp.path().join("PlainActor.bt"), bt_source).expect("write .bt");
 
-    let output = Command::new(beamtalk_binary())
+    let output = Command::new(cli_common::beamtalk_binary())
         .args(["gen-native", "PlainActor"])
         .current_dir(tmp.path())
         .output()
@@ -127,7 +115,7 @@ fn gen_native_errors_on_missing_native_declaration() {
 fn gen_native_errors_on_missing_file() {
     let tmp = tempfile::tempdir().expect("create tempdir");
 
-    let output = Command::new(beamtalk_binary())
+    let output = Command::new(cli_common::beamtalk_binary())
         .args(["gen-native", "NonExistent"])
         .current_dir(tmp.path())
         .output()
@@ -160,7 +148,7 @@ fn gen_native_refuses_to_overwrite_existing_file() {
         .expect("write existing .erl");
 
     // Run gen-native without --force — should fail
-    let output = Command::new(beamtalk_binary())
+    let output = Command::new(cli_common::beamtalk_binary())
         .args(["gen-native", "TestActor"])
         .current_dir(tmp.path())
         .output()
@@ -200,7 +188,7 @@ fn gen_native_force_overwrites_existing_file() {
         .expect("write existing .erl");
 
     // Run gen-native with --force — should succeed
-    let output = Command::new(beamtalk_binary())
+    let output = Command::new(cli_common::beamtalk_binary())
         .args(["gen-native", "--force", "TestActor"])
         .current_dir(tmp.path())
         .output()
@@ -233,7 +221,7 @@ fn gen_native_output_passes_erlc_syntax_check() {
     std::fs::write(tmp.path().join("TestActor.bt"), bt_source).expect("write .bt");
 
     // Generate the stub
-    let output = Command::new(beamtalk_binary())
+    let output = Command::new(cli_common::beamtalk_binary())
         .args(["gen-native", "TestActor"])
         .current_dir(tmp.path())
         .output()

--- a/crates/beamtalk-cli/tests/spec_validation.rs
+++ b/crates/beamtalk-cli/tests/spec_validation.rs
@@ -9,24 +9,13 @@
 //! Tests are `#[ignore]` because they require the beamtalk binary, `erlc`, and `escript`.
 //! Run with: `cargo test --test spec_validation -- --ignored`
 
+mod cli_common;
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-fn project_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .to_path_buf()
-}
-
-fn beamtalk_binary() -> PathBuf {
-    project_root().join("target/debug/beamtalk")
-}
-
 fn validate_specs_script() -> PathBuf {
-    project_root().join("scripts/validate_specs.escript")
+    cli_common::project_root().join("scripts/validate_specs.escript")
 }
 
 /// Compile a `.bt` file and return the path to the build directory containing `.core` files.
@@ -34,7 +23,7 @@ fn compile_bt_to_core(bt_source: &str, work_dir: &Path) -> PathBuf {
     let bt_path = work_dir.join("test_input.bt");
     std::fs::write(&bt_path, bt_source).expect("write .bt file");
 
-    let output = Command::new(beamtalk_binary())
+    let output = Command::new(cli_common::beamtalk_binary())
         .args(["build", bt_path.to_str().unwrap()])
         .output()
         .expect("run beamtalk build");


### PR DESCRIPTION
## Summary

Closes https://linear.app/beamtalk/issue/BT-2560

`spec_validation.rs` and `gen_native.rs` each contained byte-for-byte identical `project_root()` and `beamtalk_binary()` helpers. A shared `cli_common/mod.rs` already exists in the same `tests/` directory and is the established pattern for all other CLI integration test files. These two files were added later without reusing it.

## Changes

- **`tests/cli_common/mod.rs`** — Added `pub fn project_root()` and `pub fn beamtalk_binary()` with `#[allow(dead_code)]`, consistent with the existing `beamtalk()` / `fixture_project()` pattern
- **`tests/spec_validation.rs`** — Removed 11 duplicate lines; added `mod cli_common;`; updated `validate_specs_script()` and `compile_bt_to_core()` to call `cli_common::*`
- **`tests/gen_native.rs`** — Removed 11 duplicate lines; added `mod cli_common;`; updated all 6 `Command::new(beamtalk_binary())` call sites

## Test plan

- [x] `just clippy` — clean (no warnings)
- [x] `just fmt-check` — clean
- [x] `cargo test -p beamtalk-cli --tests` — non-ignored tests pass; `cli_doc::test_docs_runs_on_passing_doctest` failure is pre-existing on `main` (verified by stash/unstash check), unrelated to this change
- [x] Ignored tests compile cleanly (all references resolve to `cli_common::*`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7nkGvJbzqRXQFtMYGgsa4)_