### PR TITLE
Tighten placeholder assertions in inspector_evaluate.btscript (BT-2562)

### DIFF
--- a/tests/repl-protocol/cases/inspector_evaluate.btscript
+++ b/tests/repl-protocol/cases/inspector_evaluate.btscript
@@ -121,13 +121,13 @@ p path
 
 // --- ACTOR: inspect captures a live snapshot; refresh re-snapshots ---
 c := Counter spawn
-// => _
+// => Actor(Counter, _)
 
 c increment
-// => _
+// => 1
 
 c increment
-// => _
+// => 2
 
 // `c inspect` runs inside the actor and seeds the cursor from its in-hand state
 // (no self-`sys:get_state` deadlock) — the snapshot shows value 2.
@@ -142,7 +142,7 @@ ci printString includesSubstring: "value: 2"
 
 // The snapshot is frozen at inspect-time: mutating the actor does not change it.
 c increment
-// => _
+// => 3
 
 ci printString includesSubstring: "value: 2"
 // => true


### PR DESCRIPTION
## Summary

Replaces 4 `// => _` wildcard assertions in the actor-inspect section of `inspector_evaluate.btscript` with their deterministic concrete values.

- `Counter spawn` → `// => Actor(Counter, _)`
- First `c increment` → `// => 1`
- Second `c increment` → `// => 2`
- Third `c increment` (post-snapshot) → `// => 3`

The values are provably correct from the test itself: the same file asserts `ci printString includesSubstring: "value: 2"` and `ci refresh printString includesSubstring: "value: 3"` immediately after the respective increments.

## Changes

- `tests/repl-protocol/cases/inspector_evaluate.btscript` — 4 lines tightened

## Test plan

- [x] `just test-repl-protocol` passes (all 3 tests green)

https://linear.app/beamtalk/issue/BT-2562/tighten-placeholder-assertions-in-inspector-evaluatebtscript

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW31pLL6rfs8vZymEbvqq)_