### PR TITLE
chore: tidy DocFormat regex + document doc-comment test coverage (BT-2558 follow-up)

### DIFF
--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -633,6 +633,35 @@ just test-parity
 - A bug fix corrected a divergence between surfaces — add a regression case
 - A surface gets a new tool/command that maps to an existing REPL op
 
+### 10. LiveView IDE (Cockpit) Tests
+
+The Phoenix LiveView IDE under `editors/liveview` is tested in three layers,
+gated by tags in `test/test_helper.exs`:
+
+| Layer | Tag | Needs | Example |
+|-------|-----|-------|---------|
+| Pure / unit | *(none — bare `mix test`)* | nothing | `test/bt_attach/doc_format_test.exs` |
+| LiveView integration | *(none)* | the `StubWorkspaceClient` stub | `test/bt_attach_web/workspace_doc_block_test.exs` |
+| Workspace integration | `:workspace` | a live workspace node + `BT_WORKSPACE_COOKIE` | `test/bt_attach_web/workspace_live_test.exs` |
+| Browser e2e | `:playwright` | a workspace node **and** Playwright/Chromium (`PHX_PLAYWRIGHT=1`) | `test/bt_attach_web/workspace_browser_test.exs` |
+
+The bare `mix test` lane (the `liveview` CI job) runs the first two layers
+against the stub, so the full LiveView render path is covered without a node;
+the `:workspace` / `:playwright` lanes run in the `e2e` CI job.
+
+**Known coverage note — doc-comment rendering (BT-2558):** the System Browser
+doc block is covered at two seams — `beamtalk_repl_ops_browse_tests` asserts
+`browse-method-source` carries `doc`/`signature` (from a `beamtalk_object_class`
+fixture that populates `__doc__` directly), and `workspace_doc_block_test.exs`
+asserts the LiveView renders that payload as escaped HTML (against a stub). The
+compiler seam — that a `///` comment in `.bt` source actually flows through to
+`__doc__` / `get_doc` at runtime — is exercised by the `help:` tests
+(`beamtalk_repl_docs` / `beamtalk_interface_test.bt`), **not** through the
+browser. There is intentionally no browser e2e walking source → codegen →
+render (an earlier attempt was fragile against the mount-time class tree); if
+doc-comment rendering regresses, check those three suites in that order.
+
+
 ---
 
 ## CI Pipeline

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -635,7 +635,7 @@ just test-parity
 
 ### 10. LiveView IDE (Cockpit) Tests
 
-The Phoenix LiveView IDE under `editors/liveview` is tested in three layers,
+The Phoenix LiveView IDE under `editors/liveview` is tested in four layers,
 gated by tags in `test/test_helper.exs`:
 
 | Layer | Tag | Needs | Example |

--- a/editors/liveview/lib/bt_attach/doc_format.ex
+++ b/editors/liveview/lib/bt_attach/doc_format.ex
@@ -171,12 +171,15 @@ defmodule BtAttach.DocFormat do
   defp code_span(_), do: :no
 
   # Bold before italic so `**x**` is not mis-split by the single-`*` rule. Runs on
-  # already-escaped text, so the captured groups carry no raw HTML.
+  # already-escaped text, so the captured groups carry no raw HTML. No dotall flag
+  # is needed: `inline/1` only ever sees single-line text (paragraphs are joined
+  # with spaces, list items and headings are one line), so the spans never cross a
+  # newline.
   defp emphasis(escaped) do
     escaped
-    |> String.replace(~r/\*\*(.+?)\*\*/s, "<strong>\\1</strong>")
-    |> String.replace(~r/(?<![\*\w])\*(?!\s)([^*]+?)\*(?![\*\w])/s, "<em>\\1</em>")
-    |> String.replace(~r/(?<![_\w])_(?!\s)([^_]+?)_(?![_\w])/s, "<em>\\1</em>")
+    |> String.replace(~r/\*\*(.+?)\*\*/, "<strong>\\1</strong>")
+    |> String.replace(~r/(?<![\*\w])\*(?!\s)([^*]+?)\*(?![\*\w])/, "<em>\\1</em>")
+    |> String.replace(~r/(?<![_\w])_(?!\s)([^_]+?)_(?![_\w])/, "<em>\\1</em>")
   end
 
   # ── Line classifiers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up polish on the merged BT-2558 work (#2603), addressing the two non-blocking nits from the automated review.

- **Drop the dead `/s` flag** from the three `DocFormat.emphasis/1` regexes. `inline/1` only ever processes single-line text (paragraphs are joined with spaces before rendering; list items and headings are one line), so the bold/italic spans can never cross a newline — the dotall flag could never trigger. Removing it makes the intent clearer.
- **Document the LiveView IDE (Cockpit) test layers** in `docs/development/testing-strategy.md` (new §10): the unit / stub-integration / `:workspace` / `:playwright` lanes, plus a note on exactly where doc-comment rendering is and isn't covered (and why there's no source→codegen→render browser e2e), so a future regression has a clear trail.

No behavior change.

## Testing

- `DocFormat` unit tests: ✅ 12 pass (unchanged output after removing `/s`).
- `mix format` clean; clippy clean (pre-push hook).

https://claude.ai/code/session_01MxzKWQNcBrxsDtVpKuNX9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxzKWQNcBrxsDtVpKuNX9r)_