### PR TITLE
fix: stop cloud-setup verify block aborting silently under set -e

### DIFF
--- a/scripts/setup-cloud.sh
+++ b/scripts/setup-cloud.sh
@@ -474,6 +474,14 @@ echo ""
 info "Verifying installations..."
 ERRORS=0
 
+# The verify block is purely diagnostic: every capture is meant to degrade to an
+# empty string (→ "NOT FOUND") and be tallied in ERRORS, with a single exit at
+# the end. errexit/pipefail defeat that — a `$(awk … missing-file)` (exit 2) or a
+# version pipeline whose grep finds nothing (exit 1) would abort the whole script
+# with NO output before any check prints. Disable them for this section so verify
+# always runs to completion and reports what actually failed.
+set +e +o pipefail
+
 # Read the pins so the assertions stay in lockstep with .tool-versions /
 # rust-toolchain.toml — the single sources of truth.
 PIN_ERLANG="$(awk '/^erlang[[:space:]]/{print $2}' "${TOOL_VERSIONS}" 2>/dev/null)"


### PR DESCRIPTION
## Problem

Follow-up to #2608 / #2609 / #2610. The cloud setup now installs everything, but failed at the final step with a bare, output-less exit:

```
==> Verifying installations...


Edit your environment's setup script and start a new session.
```

No per-tool check lines, no "✗ N tool(s) missing" — the script died *immediately after* the verify header.

## Cause

The verify block is purely diagnostic: each capture is designed to degrade to an empty string (→ `NOT FOUND`), tally `ERRORS`, and exit once at the end via `check_version`/`check_present`. But the script runs under `set -euo pipefail`, and several captures can return non-zero:

- `PIN_RUST="$(awk … "${REPO_ROOT}/rust-toolchain.toml" …)"` — awk exits **2** if the file isn't beside the resolved `.tool-versions` (e.g. the GitHub-fallback temp dir from #2609).
- `ELIXIR_VER="$(elixir --version | grep -o … | awk …)"` and the `erl`/`rebar3` captures — exit **1** under `pipefail` when the pipeline matches nothing or the tool errors.

Any of these aborts the whole script *before a single check prints*, turning a precise diagnostic into a mystery exit. Confirmed locally: under `set -e`, `x=$(awk … /missing)` aborts; with `set +e` the capture yields `""` and verify runs to completion.

## Fix

Scope `set +e +o pipefail` to the verify block so it always runs to completion and reports the real status (`nounset` stays on). Either the run now succeeds, or it prints exactly which tool is missing/mismatched instead of dying silently.

## Verification

- `bash -n` — parses; `shellcheck` — clean
- Reproduced the silent abort before the change and confirmed the block runs to completion + reports after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)