### PR TITLE
fix: set mise BEAM tools as global defaults in cloud setup

### DIFF
--- a/scripts/setup-cloud.sh
+++ b/scripts/setup-cloud.sh
@@ -252,8 +252,10 @@ else
   #     build with a spurious "Dynamic in typed class (untyped FFI)" error. The
   #     global default carries the *same* pinned versions, so this resolves the
   #     out-of-tree cwd case without bypassing version management. Derived from
-  #     .tool-versions to stay in sync; non-fatal (rebar's release-list lookup may
-  #     warn behind a rate-limited/offline GitHub API, which is irrelevant here).
+  #     .tool-versions to stay in sync. Non-fatal (|| true): only erlang/elixir are
+  #     set here, but `mise use -g` re-evaluates the merged project config — which
+  #     also pins rebar — so it can emit a rebar release-list warning behind a
+  #     rate-limited/offline GitHub API. That warning is harmless here.
   for _tool in ${MISE_TOOLS}; do
     _ver="$(awk -v t="${_tool}" '$1==t {print $2; exit}' "${REPO_ROOT}/.tool-versions")"
     [ -n "${_ver}" ] && ("${MISE_BIN}" use -g "${_tool}@${_ver}" >/dev/null 2>&1 || true)

--- a/scripts/setup-cloud.sh
+++ b/scripts/setup-cloud.sh
@@ -241,6 +241,24 @@ else
     || warn "mise install reported issues (continuing — erlang/elixir may still be present)"
   (cd "${REPO_ROOT}" && "${MISE_BIN}" reshim >/dev/null 2>&1) || true
 
+  # 2b. Pin the BEAM tools as mise GLOBAL defaults too — not just the project
+  #     .tool-versions. A mise shim resolves its version by walking up from the
+  #     *current working directory* for a .tool-versions / mise config. With only
+  #     the project pin, any process that shells out to `erl` from a directory
+  #     OUTSIDE the repo finds no pin, no global default, and the shim aborts with
+  #     "No version is set for shim: erl". The Beamtalk compiler does exactly this:
+  #     it spawns its BEAM type-spec-extraction worker from $TMPDIR, so a
+  #     project-only pin made every FFI spec come back empty and broke the stdlib
+  #     build with a spurious "Dynamic in typed class (untyped FFI)" error. The
+  #     global default carries the *same* pinned versions, so this resolves the
+  #     out-of-tree cwd case without bypassing version management. Derived from
+  #     .tool-versions to stay in sync; non-fatal (rebar's release-list lookup may
+  #     warn behind a rate-limited/offline GitHub API, which is irrelevant here).
+  for _tool in ${MISE_TOOLS}; do
+    _ver="$(awk -v t="${_tool}" '$1==t {print $2; exit}' "${REPO_ROOT}/.tool-versions")"
+    [ -n "${_ver}" ] && ("${MISE_BIN}" use -g "${_tool}@${_ver}" >/dev/null 2>&1 || true)
+  done
+
   # 3. Put the mise shims first on PATH so erl/elixir/mix resolve to the pinned
   #    OTP — both for the rest of this script and (persisted below) every shell.
   case ":${PATH}:" in *":${MISE_SHIMS}:"*) ;; *) export PATH="${MISE_SHIMS}:${PATH}" ;; esac


### PR DESCRIPTION
## Summary

Fixes a stdlib build failure in cloud sessions that surfaced as a spurious type error:

```
× expression inferred as Dynamic in typed class `AnnouncementNavigation` (untyped FFI)
```

`AnnouncementNavigation` was only the first casualty — the real failure was that **FFI type-spec extraction returned empty for all 142 Erlang modules**, so every `(Erlang ...) ...` call in a `typed` class inferred as `Dynamic` and tripped the typed-class check. The build stops at the first such class, and `AnnouncementNavigation` is alphabetically first among the nav classes returning a bare FFI value.

## Root cause

- The Beamtalk compiler extracts Erlang `-spec`s by spawning a `beamtalk_build_worker` BEAM node, deliberately running it from `$TMPDIR` (avoids `getcwd()` errors; `-pa` paths are canonicalized for this reason).
- In the cloud image, `/usr/local/bin/erl` is a **mise shim** that resolves the OTP version by walking up from the **current working directory** for a `.tool-versions` / mise config.
- The toolchain was pinned **only** by the project `.tool-versions`, with **no mise global default**. From `$TMPDIR` (outside the repo) the shim finds no pin and aborts with `No version is set for shim: erl` → the worker never runs → empty specs → spurious build failure.

## Fix

`scripts/setup-cloud.sh` now also pins the same `.tool-versions`-derived erlang/elixir versions as mise **global** defaults, so the shims resolve from any working directory — including the `$TMPDIR` the compiler spawns its BEAM nodes from. Same versions, so this does not bypass version management; non-fatal and idempotent.

## Scope

Cloud-environment only — the compiler's intentional `$TMPDIR` cwd is left unchanged (the failure does not reproduce outside this mise-shim setup).

## Verification

- `shellcheck scripts/setup-cloud.sh` — clean
- Clean-cache `just build` — green (101 stdlib modules)
- Announcement/navigation BUnit tests — 64 passed, 8 skipped, 0 failed
- Confirmed `erl`/`elixir` resolve from `/tmp` after the global default is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbqDWqBXjJec9peBm2TeNW)_