### PR TITLE
test: replace hardcoded /tmp with File tempDirectory in file_directory_test

### DIFF
--- a/stdlib/test/file_directory_test.bt
+++ b/stdlib/test/file_directory_test.bt
@@ -32,8 +32,7 @@ TestCase subclass: FileDirectoryTest
 
   testIsDirectoryAbsolutePath =>
     // Absolute paths now work (ADR 0063)
-    System osFamily == "unix" ifFalse: [^self skip: "Unix only"]
-    self assert: (File isDirectory: "/tmp")
+    self assert: (File isDirectory: File tempDirectory)
 
   testIsFileOnFile =>
     self assert: (File writeAll: "target/bt-test-tmp/fdt/isfile_check.txt" contents: "data") isOk
@@ -45,9 +44,8 @@ TestCase subclass: FileDirectoryTest
     self deny: (File isFile: "target/bt-test-tmp/fdt/no_such_file.txt")
 
   testIsFileAbsolutePath =>
-    // Absolute paths now work (ADR 0063) — /tmp is a directory, not a file
-    System osFamily == "unix" ifFalse: [^self skip: "Unix only"]
-    self deny: (File isFile: "/tmp")
+    // Absolute paths now work (ADR 0063) — tempDirectory is a directory, not a file
+    self deny: (File isFile: File tempDirectory)
 
   testMkdir =>
     self assert: (File mkdir: "target/bt-test-tmp/fdt/mkdir_test") isOk
@@ -119,8 +117,7 @@ TestCase subclass: FileDirectoryTest
 
   testListDirectoryAbsolutePath =>
     // Absolute paths now accepted (ADR 0063)
-    System osFamily == "unix" ifFalse: [^self skip: "Unix only"]
-    self assert: (File listDirectory: "/tmp") isOk
+    self assert: (File listDirectory: File tempDirectory) isOk
 
   testListDirectoryTypeErrorRaisesError =>
     @expect type


### PR DESCRIPTION
## Summary

Three tests in `FileDirectoryTest` (`stdlib/test/file_directory_test.bt`) used the hardcoded Unix-specific path `/tmp` to exercise absolute-path support added in ADR 0063. This violates the CLAUDE.md cross-platform rule ("Never hardcode `/tmp/` in tests").

- Replace `/tmp` with `File tempDirectory` in `testIsDirectoryAbsolutePath`, `testIsFileAbsolutePath`, and `testListDirectoryAbsolutePath`
- Drop the `System osFamily == "unix" ifFalse: [^self skip: "Unix only"]` guard from all three — the guard only existed because `/tmp` is Unix-specific; `File tempDirectory` is cross-platform

Net diff: 4 insertions, 7 deletions. No coverage change — same assertions, better paths.

## Test plan

- [x] `just test-bunit` — 2565 tests, 2563 passed, 0 failed
- [x] Pre-push CI hook — all lint, format, dialyzer, and test checks green

🤖 Generated with Claude Code (nightly test-quality pass)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcTYqMGdxY8J7vHtsXjjnK)_