### PR TITLE
fix(liveview): preserve disk_source across tab re-activation (BT-2565)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -2789,6 +2789,16 @@ defmodule BtAttachWeb.WorkspaceLive do
   #     so the on-disk body stays pinned across the round-trip.
   #
   # A fresh snapshot (image back in sync with disk) always wins over the carried one.
+  #
+  # The carried `existing.disk_source` is only as fresh as tab-open time: if the file
+  # is rewritten out-of-band (another session flushes, an external editor) *while the
+  # image is diverged*, the carried body goes stale, and a later compile of the *old*
+  # on-disk body would clear `unflushed` against disk that has since moved on. This is
+  # a narrow false-negative (concurrent out-of-band writes during divergence); the
+  # backend's `disk_differs` is itself a load-time snapshot, not a live re-read, so
+  # the editor already trusts a tab-open view of disk. The conservative pre-BT-2565
+  # path avoided this only by re-flagging *every* re-activated diverged tab — the
+  # false-positive BT-2565 fixes. The common-case win is worth the narrow tradeoff.
   @doc false
   def reactivation_disk_source(_existing, %{runtime_only: true}), do: nil
 

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -2661,10 +2661,12 @@ defmodule BtAttachWeb.WorkspaceLive do
                 # Keeps the false → true invariant the `nil ->` branch documents.
                 disk_differs: existing.disk_differs or info.disk_differs,
                 runtime_only: info.runtime_only,
-                # Re-derive the on-disk body reference from the live image too, so
-                # a method that gained / lost an on-disk source out-of-band diffs a
-                # later compile against the current disk body (BT-2550).
-                disk_source: disk_body_snapshot(info),
+                # Carry the on-disk body forward across the re-activation. A fresh
+                # snapshot wins when the image is back in sync with disk; a method
+                # whose image diverged but is *still* disk-backed keeps the prior
+                # snapshot instead of regressing to nil (BT-2565); a now runtime-only
+                # method drops to nil (BT-2550).
+                disk_source: reactivation_disk_source(existing, info),
                 # Re-read the doc block from the live image too (BT-2558), so an
                 # out-of-band edit to the method's `///` doc / signature is
                 # reflected when the clean tab is re-activated.
@@ -2770,6 +2772,28 @@ defmodule BtAttachWeb.WorkspaceLive do
     do: src
 
   defp disk_body_snapshot(_), do: nil
+
+  # The on-disk body to carry forward when a *clean* tab is re-activated (BT-2565).
+  # `disk_body_snapshot/1` only yields a body while the image matches disk
+  # (`disk_differs: false`), so a tab whose image diverged from disk via an
+  # in-memory compile — `compile_clean/3` set `disk_differs: true` while preserving
+  # the body captured at open — would otherwise re-derive `nil` on re-activation,
+  # regressing a later exact-on-disk-body re-compile back to the conservative
+  # `unflushed` flag. We split the two ways `disk_body_snapshot/1` returns nil:
+  #
+  #   * now runtime-only (no on-disk body at all) → drop to nil, matching the
+  #     conservative fallback for a method that genuinely lost its disk source.
+  #     This guards against a naive `existing.disk_source || …` retaining a stale
+  #     snapshot for a method that legitimately transitioned to runtime-only.
+  #   * still disk-backed but image-diverged → keep the prior `existing.disk_source`
+  #     so the on-disk body stays pinned across the round-trip.
+  #
+  # A fresh snapshot (image back in sync with disk) always wins over the carried one.
+  @doc false
+  def reactivation_disk_source(_existing, %{runtime_only: true}), do: nil
+
+  def reactivation_disk_source(existing, info),
+    do: disk_body_snapshot(info) || existing.disk_source
 
   # Normalise a browse-payload doc/signature field to a non-empty binary or nil.
   # The op already returns `null` (decoded to nil) for absent fields; this also

--- a/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
@@ -158,5 +158,59 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
       assert save_html =~ "Saved increment on Counter"
       refute save_html =~ "unflushed"
     end
+
+    test "re-activating a compiled tab then re-saving the disk body clears unflushed (BT-2565)",
+         %{conn: conn} do
+      # Regression for BT-2565: re-activating a clean tab re-derives `disk_source`.
+      # `disk_body_snapshot/1` yields nil while the image diverges from disk, so the
+      # on-disk body captured at open used to be lost on re-activation — a later
+      # re-compile of the *exact* on-disk body then fell back to the conservative
+      # `unflushed` flag instead of recognising the image was back in sync.
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      disk_body = "increment => self.value := self.value + 1"
+      new_body = "increment => self.value := self.value + 2"
+
+      view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
+      open_html = view |> element(~s(div[phx-value-selector="increment"])) |> render_click()
+      refute open_html =~ "unflushed"
+
+      # 1. Compile a *different* body — a real divergence, so `unflushed` shows and the
+      #    stub now reports the method diverges from disk on a re-browse.
+      save_html =
+        view
+        |> form("form[phx-submit='save_method']")
+        |> render_submit(%{
+          "class" => "Counter",
+          "selector" => "increment",
+          "source" => new_body,
+          "tab" => "method:Counter:instance:increment"
+        })
+
+      assert save_html =~ "unflushed"
+
+      # 2. Re-activate the (now clean) tab: routes through the `%{} = existing` branch,
+      #    which re-derives `disk_source`. The image diverges from disk, so a fresh
+      #    snapshot is unavailable — the captured on-disk body must survive (BT-2565).
+      reactivate_html =
+        view |> element(~s(div[phx-value-selector="increment"])) |> render_click()
+
+      assert reactivate_html =~ "unflushed"
+
+      # 3. Re-compile the *exact on-disk body*. With the snapshot preserved this is a
+      #    no-op against disk → `unflushed` clears; losing it keeps the stale badge.
+      reflush_html =
+        view
+        |> form("form[phx-submit='save_method']")
+        |> render_submit(%{
+          "class" => "Counter",
+          "selector" => "increment",
+          "source" => disk_body,
+          "tab" => "method:Counter:instance:increment"
+        })
+
+      assert reflush_html =~ "Saved increment on Counter"
+      refute reflush_html =~ "unflushed"
+    end
   end
 end

--- a/editors/liveview/test/bt_attach_web/workspace_live_reconcile_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_reconcile_test.exs
@@ -98,4 +98,52 @@ defmodule BtAttachWeb.WorkspaceLiveReconcileTest do
                [def_tab]
     end
   end
+
+  describe "reactivation_disk_source/2 (BT-2565)" do
+    # `info` as `method_source_info/4` shapes it for the re-activation branch.
+    defp source_info(opts) do
+      %{
+        runtime_only: Keyword.get(opts, :runtime_only, false),
+        disk_differs: Keyword.get(opts, :disk_differs, false),
+        source: Keyword.get(opts, :source, "")
+      }
+    end
+
+    test "keeps the prior snapshot when the image diverged but stays disk-backed" do
+      # The bug: a tab compiled to a new body (disk_differs flipped true, disk_source
+      # preserved) is navigated away from and re-activated. The backend now reports
+      # `disk_differs: true`, so a fresh snapshot is unavailable — the carried body
+      # must survive instead of regressing to nil.
+      existing = %{disk_source: "increment => self.value := self.value + 1"}
+      info = source_info(disk_differs: true, source: "increment => self.value := self.value + 2")
+
+      assert WorkspaceLive.reactivation_disk_source(existing, info) ==
+               "increment => self.value := self.value + 1"
+    end
+
+    test "takes a fresh snapshot when the image is back in sync with disk" do
+      # Image matches disk again (disk_differs false): the live body *is* the on-disk
+      # body, so re-snapshot it — it supersedes any carried value.
+      existing = %{disk_source: "stale body"}
+      info = source_info(disk_differs: false, source: "fresh on-disk body")
+
+      assert WorkspaceLive.reactivation_disk_source(existing, info) == "fresh on-disk body"
+    end
+
+    test "drops to nil when the method is now runtime-only" do
+      # A method that legitimately lost its on-disk body must not retain a stale
+      # snapshot — fall back to nil so `compiled_disk_differs/2` stays conservative.
+      existing = %{disk_source: "was on disk"}
+      info = source_info(runtime_only: true, source: "runtime body")
+
+      assert WorkspaceLive.reactivation_disk_source(existing, info) == nil
+    end
+
+    test "drops to nil when image-diverged with no prior snapshot to carry" do
+      existing = %{disk_source: nil}
+      info = source_info(disk_differs: true, source: "diverged body")
+
+      assert WorkspaceLive.reactivation_disk_source(existing, info) == nil
+    end
+  end
 end

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -160,7 +160,7 @@ defmodule BtAttachWeb.StubWorkspaceClient do
     {:value, %{"protocols" => [%{"name" => "all", "selectors" => selectors}]}}
   end
 
-  def browse_method_source(_class, _side, selector) do
+  def browse_method_source(class, _side, selector) do
     {source, doc, signature} =
       case selector do
         "increment" ->
@@ -176,6 +176,11 @@ defmodule BtAttachWeb.StubWorkspaceClient do
           {"stub => nil", nil, nil}
       end
 
+    # A saved-but-unflushed method has an image body that diverges from disk, so a
+    # re-browse reports `disk_differs: true` (BT-2565). `source` stays the on-disk
+    # body — the backend's `disk_differs` is a load-time snapshot, not a live diff.
+    disk_differs = Map.has_key?(get(:changes), {class, selector})
+
     {:value,
      %{
        "source" => source,
@@ -183,7 +188,7 @@ defmodule BtAttachWeb.StubWorkspaceClient do
        "signature" => signature,
        "source_status" => "indexed",
        "origin" => "both",
-       "disk_differs" => false
+       "disk_differs" => disk_differs
      }}
   end
 


### PR DESCRIPTION
## Summary

Follow-up from BT-2550 (PR #2619 review). The clean-tab re-activation branch in `open_method_tab/4` unconditionally re-derived `disk_source` from `disk_body_snapshot/1`, which returns `nil` whenever the backend reports the image diverges from disk.

So this sequence lost the captured on-disk body:

1. Open tab → `disk_source = A`, `disk_differs = false`.
2. Compile body `B` → `disk_differs = true`, `disk_source = A` (preserved by `compile_clean/3`).
3. Navigate away, then re-activate → backend reports `disk_differs: true` → `disk_body_snapshot/1` returns `nil` → `disk_source` overwritten to `nil`.
4. Compile body `A` (the exact on-disk body) → `compiled_disk_differs/2` hits the `nil` catch-all → conservative `true` → `unflushed` badge shows even though the image now matches disk.

A conservative false-positive only (no data loss / crash), but inconsistent with the same compile on a never-re-activated tab.

## Fix

Introduce `reactivation_disk_source/2`, which distinguishes the two ways `disk_body_snapshot/1` yields `nil`:

- **now runtime-only** (no on-disk body at all) → drop to `nil`, matching the conservative fallback for a method that genuinely lost its disk source (guards against a naive `existing.disk_source || …` retaining a stale snapshot).
- **still disk-backed but image-diverged** → keep the prior `existing.disk_source` so the on-disk body stays pinned across the round-trip.

A fresh snapshot (image back in sync with disk) always wins over the carried one.

## Tests

- **Pure unit coverage** (`workspace_live_reconcile_test.exs`) for all `reactivation_disk_source/2` branches: keep-prior, fresh-snapshot, runtime-only-drop, and no-prior-snapshot.
- **Integration test** (`workspace_flush_badge_test.exs`) driving re-activation → exact-on-disk-body re-compile → `unflushed` badge clears. The stub workspace client now reports `disk_differs: true` for a saved-but-unflushed method so the regression path is exercised.
- Full bare LiveView suite: **186 passed**, format clean.

> Note (CLAUDE.md): this touches badge/output behaviour — it fixes a conservative false-positive so a re-activated tab matches a never-re-activated one; no intentional output is changed.

Closes BT-2565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYGGKAtNrsutkU21ZdNcVH)_