### PR TITLE
Show class definition in System Browser; relabel method icon to "m"

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -296,7 +296,6 @@
 .row .source-origin-tag.dependency { background: #fef3c7; color: #b45309; }
 .row .source-origin-tag.project { display: none; }
 .sb-classdef { border-bottom: 1px solid var(--line-soft); padding-bottom: 2px; }
-.sb-classdef .mname { font-family: var(--code-font, monospace); }
 .sb-protocols { border-bottom: 1px solid var(--line-soft); padding-bottom: 2px; }
 
 /* center column splits between editor and the workspace dock */

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -295,6 +295,8 @@
 .row .source-origin-tag.stdlib { background: #e8d5f5; color: #7c3aed; }
 .row .source-origin-tag.dependency { background: #fef3c7; color: #b45309; }
 .row .source-origin-tag.project { display: none; }
+.sb-classdef { border-bottom: 1px solid var(--line-soft); padding-bottom: 2px; }
+.sb-classdef .mname { font-family: var(--code-font, monospace); }
 .sb-protocols { border-bottom: 1px solid var(--line-soft); padding-bottom: 2px; }
 
 /* center column splits between editor and the workspace dock */

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1166,6 +1166,16 @@ defmodule BtAttachWeb.WorkspaceLive do
     {:noreply, open_definition(socket)}
   end
 
+  # Open the *selected* class's definition tab from the System Browser's "class
+  # definition" entry (BT-2491). The class rides the click; a malformed payload
+  # is ignored rather than crashing the LiveView.
+  def handle_event("browser_open_definition", %{"class" => class}, socket)
+      when is_binary(class) do
+    {:noreply, open_definition(socket, class)}
+  end
+
+  def handle_event("browser_open_definition", _params, socket), do: {:noreply, socket}
+
   # Track edits to the active tab so its dirty dot reflects unsaved changes
   # (BT-2494). The save_method form's `phx-change` reports the live source on
   # each keystroke; we stash it on the active tab and recompute its dirty flag
@@ -3022,7 +3032,13 @@ defmodule BtAttachWeb.WorkspaceLive do
   # first open it also reads the class' comment (BT-2558) so the editor can show
   # it as a read-only documentation block above the editable definition body.
   defp open_definition(socket) do
-    class = active_tab(socket.assigns).class
+    open_definition(socket, active_tab(socket.assigns).class)
+  end
+
+  # Open (or re-focus) a class-definition tab for a named class — the System
+  # Browser's "class definition" entry opens the *selected* class's definition,
+  # which need not be the active tab's class.
+  defp open_definition(socket, class) do
     id = "def:" <> class
 
     case find_tab(socket, id) do
@@ -3122,6 +3138,16 @@ defmodule BtAttachWeb.WorkspaceLive do
 
       _ ->
         nil
+    end
+  end
+
+  # The class whose definition tab is focused, so the System Browser's "class
+  # definition" entry can track the editor (mirrors `selected_method_ref/1` for
+  # method tabs). nil when the active tab is a method or there is no def tab.
+  defp selected_def_ref(assigns) do
+    case active_tab(assigns) do
+      %{kind: :def, class: class} -> class
+      _ -> nil
     end
   end
 
@@ -4450,6 +4476,9 @@ defmodule BtAttachWeb.WorkspaceLive do
   # for a class-definition tab — drives the "sel" highlight so the browser tracks
   # whatever the editor is showing.
   attr :active_method, :map, default: nil
+  # The class whose *definition* tab is focused (or nil) — highlights the "class
+  # definition" entry when the editor is showing this class's definition.
+  attr :active_def, :string, default: nil
 
   defp system_browser_methods(assigns) do
     assigns =
@@ -4472,6 +4501,19 @@ defmodule BtAttachWeb.WorkspaceLive do
         <%= if @selected_class == nil do %>
           <div class="empty">Select a class to browse its methods.</div>
         <% else %>
+          <%!-- class definition entry: opens (or focuses) the class-definition
+               tab so the class shape is browsable, not just its methods. Saving
+               that tab compiles the class (ADR 0082). --%>
+          <div class="tree sb-classdef">
+            <div
+              class={["row", @active_def == @selected_class && "sel"]}
+              phx-click="browser_open_definition"
+              phx-value-class={@selected_class}
+            >
+              <span class="twig" style="color: var(--accent);">▸</span>
+              <span class="mname mono">class definition</span>
+            </div>
+          </div>
           <%!-- protocol filter row: ∗ "all" + one row per protocol --%>
           <div class="tree sb-protocols">
             <div
@@ -4510,7 +4552,7 @@ defmodule BtAttachWeb.WorkspaceLive do
               phx-value-side={@browser_side}
               phx-value-selector={m["selector"]}
             >
-              <span class="twig" style="color: var(--accent);">ƒ</span>
+              <span class="twig" style="color: var(--accent);">m</span>
               <span class="mname mono">{m["selector"]}</span>
               <span
                 :if={m["source_origin"] && m["source_origin"] != "project"}
@@ -4753,6 +4795,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                   selected_class={@selected_class}
                   browser_side={@browser_side}
                   active_method={selected_method_ref(assigns)}
+                  active_def={selected_def_ref(assigns)}
                 />
               </div>
             </div>

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1170,7 +1170,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # definition" entry (BT-2491). The class rides the click; a malformed payload
   # is ignored rather than crashing the LiveView.
   def handle_event("browser_open_definition", %{"class" => class}, socket)
-      when is_binary(class) do
+      when is_binary(class) and class != "" do
     {:noreply, open_definition(socket, class)}
   end
 

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -790,10 +790,10 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
       |> element(~s(div[phx-click="browser_open_definition"][phx-value-class="#{class}"]))
       |> render_click()
 
-    # A class-definition tab is now open and focused for the selected class — the
-    # breadcrumb reads "<Class> › class definition" (parity with the "+ def" path).
-    assert opened =~ "class definition"
-    assert opened =~ class
+    # A class-definition tab is now open and focused for the selected class — its
+    # tab label reads "<Class> ▸ def" (the def-tab marker, which only exists once
+    # a def tab is open), parity with the "+ def" path.
+    assert opened =~ "#{class} ▸ def"
   end
 
   test "the instance/class side toggle re-populates the method list (BT-2491)", %{conn: conn} do

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -779,6 +779,21 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert html =~ "value"
     assert html =~ ">all<"
     assert html =~ ~s(phx-click="browser_select_protocol")
+
+    # The method pane leads with a "class definition" entry so the class shape is
+    # browsable, not only its methods — clicking it opens the def tab (BT-2491).
+    assert html =~ "class definition"
+    assert html =~ ~s(phx-click="browser_open_definition")
+
+    opened =
+      view
+      |> element(~s(div[phx-click="browser_open_definition"][phx-value-class="#{class}"]))
+      |> render_click()
+
+    # A class-definition tab is now open and focused for the selected class — the
+    # breadcrumb reads "<Class> › class definition" (parity with the "+ def" path).
+    assert opened =~ "class definition"
+    assert opened =~ class
   end
 
   test "the instance/class side toggle re-populates the method list (BT-2491)", %{conn: conn} do


### PR DESCRIPTION
## Summary

Two small System Browser (BT-2491) usability fixes reported by the user:

1. **No in-pane way to view a class's own definition.** The method pane only listed methods — the class definition was reachable only via the `+ def` tab affordance. This adds a **"class definition" entry at the top of the method pane** that opens (or re-focuses) the class-definition tab for the *selected* class. Browsing the class tree stays tab-free; the class shape is now one click away, and saving that tab still compiles the class (ADR 0082).

2. **The per-method twig icon read as "ƒ" (function).** Relabelled to **"m"** so it reads as "method".

## Approach

Rather than auto-opening a definition tab on every class-tree click (which would clutter the tab strip while browsing), the class definition is an explicit entry in the method pane — discoverable, and it reuses the existing `open_definition` machinery. `open_definition/1` was split into `open_definition/2` so it can target the selected class (not just the active tab's class). A new `selected_def_ref/1` + `active_def` attr drives a `sel` highlight when that def tab is focused, mirroring how method rows track the editor.

## Key changes

- `workspace_live.ex` — new `class definition` row + `browser_open_definition` event handler; `open_definition/1` → `/2`; `selected_def_ref/1` + `active_def` highlight; `ƒ` → `m`.
- `app.css` — `.sb-classdef` separator above the protocol filter.
- `workspace_live_test.exs` — test asserting the entry renders and clicking it opens the def tab.

## Verification

App compiles clean; ran the workspace-gated LiveView suite against a real Beamtalk node — **83 passed**, including the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzPcTxgjKH4uW3nBG2kYcD)_