### PR TITLE
fix: close workspace-startup race (session_sup before repl_server) + diagnostics (BT-2532)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,12 @@ jobs:
         if: failure()
         run: |
           epmd -names || true
-          for f in $(ls -t "$HOME"/.beamtalk/workspaces/*/startup.log 2>/dev/null | head -5); do
+          # startup.log holds VM boot / -eval crash output; workspace.log holds the
+          # OTP logger stream where beamtalk_ws_handler writes session/auth failures
+          # (e.g. "Session creation failed"). The "port accepting TCP but WS health
+          # check failed" flake (BT-2532) leaves startup.log empty — the real cause
+          # is in workspace.log — so dump both.
+          for f in $(ls -t "$HOME"/.beamtalk/workspaces/*/startup.log "$HOME"/.beamtalk/workspaces/*/workspace.log 2>/dev/null | head -10); do
             echo "=== $f ==="
             cat "$f"
           done

--- a/crates/beamtalk-cli/src/commands/workspace/mod.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/mod.rs
@@ -260,6 +260,27 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_cookie_is_args_file_safe() {
+        // A cookie passed via `-args_file` as `-setcookie <cookie>` must not be
+        // mistaken for a VM flag. Erlang treats any token starting with `-` or
+        // `+` as a flag, and `+`/`/` anywhere break parsing — so the node would
+        // boot with the wrong cookie and every WebSocket auth would fail with
+        // "Invalid cookie" (BT-2532). Run enough iterations to exercise the
+        // ~1.5% leading-`-` reroll path.
+        for _ in 0..5_000 {
+            let cookie = generate_cookie();
+            assert!(
+                !cookie.starts_with('-') && !cookie.starts_with('+'),
+                "cookie must not start with a flag prefix: {cookie:?}"
+            );
+            assert!(
+                !cookie.contains('+') && !cookie.contains('/'),
+                "cookie must not contain '+' or '/': {cookie:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_workspace_dir_contains_id() {
         let dir = workspace_dir("test-ws-123").unwrap();
         assert!(dir.ends_with("workspaces/test-ws-123"));

--- a/crates/beamtalk-cli/src/commands/workspace/mod.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/mod.rs
@@ -262,20 +262,23 @@ mod tests {
     #[test]
     fn test_generate_cookie_is_args_file_safe() {
         // A cookie passed via `-args_file` as `-setcookie <cookie>` must not be
-        // mistaken for a VM flag. Erlang treats any token starting with `-` or
-        // `+` as a flag, and `+`/`/` anywhere break parsing — so the node would
-        // boot with the wrong cookie and every WebSocket auth would fail with
-        // "Invalid cookie" (BT-2532). Run enough iterations to exercise the
-        // ~1.5% leading-`-` reroll path.
+        // mistaken for a VM flag, or the node boots with the wrong cookie and
+        // every WebSocket auth fails with "Invalid cookie" (BT-2532). Run enough
+        // iterations to exercise the ~1.5% leading-`-` reroll path.
         for _ in 0..5_000 {
             let cookie = generate_cookie();
+            // The live guard: URL-safe base64 can begin with `-`, which the
+            // args-file reader treats as a flag prefix. The reroll must prevent it.
             assert!(
-                !cookie.starts_with('-') && !cookie.starts_with('+'),
-                "cookie must not start with a flag prefix: {cookie:?}"
+                !cookie.starts_with('-'),
+                "cookie must not start with '-' (args_file flag prefix): {cookie:?}"
             );
+            // Tripwire: `+`/`/` are impossible under URL-safe base64 today, but
+            // would reintroduce the original parsing bug if the encoding were ever
+            // swapped back to standard base64. Fail loudly if that regresses.
             assert!(
                 !cookie.contains('+') && !cookie.contains('/'),
-                "cookie must not contain '+' or '/': {cookie:?}"
+                "cookie encoding must stay args_file-safe (no '+' or '/'): {cookie:?}"
             );
         }
     }

--- a/crates/beamtalk-cli/src/commands/workspace/process.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/process.rs
@@ -515,8 +515,9 @@ fn wait_for_tcp_ready(
         if attempt > 0 && !is_process_alive(pid) {
             return Err(miette!(
                 "BEAM node (PID {pid}) crashed while WebSocket health checks were \
-                 in progress on port {port}.{log_suffix}{}",
-                ws_err_detail(last_ws_err.as_deref())
+                 in progress on port {port}.{log_suffix}{}{}",
+                ws_err_detail(last_ws_err.as_deref()),
+                read_startup_log_content(workspace_id).unwrap_or_default()
             ));
         }
         std::thread::sleep(Duration::from_millis(ws_health_delay_ms(attempt)));
@@ -538,8 +539,9 @@ fn wait_for_tcp_ready(
     } else {
         miette!(
             "BEAM node (PID {pid}) crashed after WebSocket port {port} started accepting. \
-             Ensure Erlang/OTP is installed correctly.{log_suffix}{}",
-            ws_err_detail(last_ws_err.as_deref())
+             Ensure Erlang/OTP is installed correctly.{log_suffix}{}{}",
+            ws_err_detail(last_ws_err.as_deref()),
+            read_startup_log_content(workspace_id).unwrap_or_default()
         )
     })
 }

--- a/crates/beamtalk-cli/src/commands/workspace/process.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/process.rs
@@ -390,6 +390,7 @@ pub fn start_detached_node(
 
     // Wait for WebSocket health endpoint to be fully ready before returning.
     wait_for_tcp_ready(
+        workspace_id,
         node_info.connect_host(),
         actual_port,
         pid,
@@ -430,6 +431,7 @@ pub fn start_detached_node(
 /// `log_path` is `Some(path)` only when the startup log file was successfully
 /// opened; it is included in timeout error messages to guide diagnosis.
 fn wait_for_tcp_ready(
+    workspace_id: &str,
     host: &str,
     port: u16,
     pid: u32,
@@ -487,40 +489,61 @@ fn wait_for_tcp_ready(
     // initial probes catch quick readiness; slower later probes avoid
     // busy-spinning while cowboy finishes route registration.
     let request = serde_json::json!({"op": "health"});
+    // Remember the most recent WS-level failure so the final timeout error can name
+    // the actual cause (auth/session error, handshake rejection, read timeout)
+    // instead of the opaque "health check failed". Without this the recurring
+    // "port accepting TCP but WS health failed" flake is undiagnosable (BT-2532):
+    // ProtocolClient::connect's error was previously discarded.
+    let mut last_ws_err: Option<String> = None;
     for attempt in 0..WS_HEALTH_RETRIES {
-        if let Ok(mut client) = ProtocolClient::connect(
+        match ProtocolClient::connect(
             host,
             port,
             cookie,
             Some(Duration::from_millis(READINESS_READ_TIMEOUT_MS)),
         ) {
-            if client.send_raw(&request).is_ok() {
-                return Ok(());
-            }
+            Ok(mut client) => match client.send_raw(&request) {
+                Ok(_) => return Ok(()),
+                Err(e) => last_ws_err = Some(format!("health request failed: {e}")),
+            },
+            Err(e) => last_ws_err = Some(format!("WebSocket connect/auth failed: {e}")),
         }
         // Check after the first attempt so we don't mask a quick crash with a
         // misleading "port accepting" error variant.
         if attempt > 0 && !is_process_alive(pid) {
             return Err(miette!(
                 "BEAM node (PID {pid}) crashed while WebSocket health checks were \
-                 in progress on port {port}.{log_suffix}"
+                 in progress on port {port}.{log_suffix}{}",
+                ws_err_detail(last_ws_err.as_deref())
             ));
         }
         std::thread::sleep(Duration::from_millis(ws_health_delay_ms(attempt)));
     }
 
     Err(if is_process_alive(pid) {
+        // The node is alive but never served a healthy `/ws`. Inline the last
+        // WS error and any startup.log crash output so the failure is actionable
+        // from the CI log alone (server-side details still land in workspace.log).
+        let ws_detail = ws_err_detail(last_ws_err.as_deref());
+        let log_detail = read_startup_log_detail(workspace_id);
         miette!(
             "BEAM node started (PID {pid}) and port {port} is accepting TCP connections, \
              but the WebSocket health check failed. The workspace may be in a degraded \
-             state — try again.{log_suffix}"
+             state — try again.{log_suffix}{ws_detail}{log_detail}"
         )
     } else {
         miette!(
             "BEAM node (PID {pid}) crashed after WebSocket port {port} started accepting. \
-             Ensure Erlang/OTP is installed correctly.{log_suffix}"
+             Ensure Erlang/OTP is installed correctly.{log_suffix}{}",
+            ws_err_detail(last_ws_err.as_deref())
         )
     })
+}
+
+/// Format the last WebSocket health-probe error for inclusion in a timeout
+/// message. Returns an empty string when no WS error was recorded.
+fn ws_err_detail(last_ws_err: Option<&str>) -> String {
+    last_ws_err.map_or_else(String::new, |e| format!(" Last WebSocket error: {e}."))
 }
 
 /// Compute the delay for a Phase 2 WS health retry with exponential backoff.

--- a/crates/beamtalk-cli/src/commands/workspace/process.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/process.rs
@@ -428,8 +428,10 @@ pub fn start_detached_node(
 /// Phase 2 checks after every attempt; the delay between attempts grows via
 /// `ws_health_delay_ms` (exponential backoff, see BT-1598).
 ///
-/// `log_path` is `Some(path)` only when the startup log file was successfully
-/// opened; it is included in timeout error messages to guide diagnosis.
+/// `workspace_id` is used to read `startup.log` for inlining into timeout
+/// errors. `log_path` is `Some(path)` only when the startup log file was
+/// successfully opened; it is included in timeout error messages to guide
+/// diagnosis.
 fn wait_for_tcp_ready(
     workspace_id: &str,
     host: &str,
@@ -524,8 +526,10 @@ fn wait_for_tcp_ready(
         // The node is alive but never served a healthy `/ws`. Inline the last
         // WS error and any startup.log crash output so the failure is actionable
         // from the CI log alone (server-side details still land in workspace.log).
+        // Use read_startup_log_content (not _detail) so we don't append a
+        // misleading "Check Erlang/OTP is installed" hint — the node clearly started.
         let ws_detail = ws_err_detail(last_ws_err.as_deref());
-        let log_detail = read_startup_log_detail(workspace_id);
+        let log_detail = read_startup_log_content(workspace_id).unwrap_or_default();
         miette!(
             "BEAM node started (PID {pid}) and port {port} is accepting TCP connections, \
              but the WebSocket health check failed. The workspace may be in a degraded \
@@ -565,37 +569,47 @@ fn ws_health_delay_ms(attempt: usize) -> u64 {
 /// keeping terminal output manageable.
 const STARTUP_LOG_MAX_BYTES: usize = 4096;
 
-/// Read crash diagnostics from `startup.log` written by the eval try/catch.
+/// Read `startup.log` content (written by the eval try/catch) if present.
 ///
-/// Returns a formatted detail string suitable for appending to an error message.
-/// If the log contains content, it's shown inline (truncated to `STARTUP_LOG_MAX_BYTES`);
-/// otherwise a generic hint is returned.
-fn read_startup_log_detail(workspace_id: &str) -> String {
+/// Returns `Some(formatted)` with the log shown inline (truncated to
+/// `STARTUP_LOG_MAX_BYTES`) when the file exists and is non-empty, or `None`
+/// when there is nothing to show. Callers that know the node is alive use this
+/// directly so they do not append a misleading "Erlang/OTP" hint.
+fn read_startup_log_content(workspace_id: &str) -> Option<String> {
     workspace_dir(workspace_id)
         .ok()
         .map(|d| d.join("startup.log"))
         .and_then(|p| std::fs::read(&p).ok())
         .filter(|bytes| !bytes.is_empty())
-        .map_or_else(
-            || "\nCheck Erlang/OTP is installed.".to_string(),
-            |log| {
-                if log.len() <= STARTUP_LOG_MAX_BYTES {
-                    format!("\nStartup log:\n{}", String::from_utf8_lossy(&log))
-                } else {
-                    // Truncate to the last STARTUP_LOG_MAX_BYTES, keeping the most
-                    // recent (and usually most relevant) output.  Operating on raw
-                    // bytes avoids panicking on multibyte UTF-8 boundaries;
-                    // from_utf8_lossy replaces any split characters with U+FFFD.
-                    let tail = &log[log.len() - STARTUP_LOG_MAX_BYTES..];
-                    // Find the first newline to avoid cutting mid-line.
-                    let start = tail.iter().position(|&b| b == b'\n').map_or(0, |i| i + 1);
-                    format!(
-                        "\nStartup log (last {STARTUP_LOG_MAX_BYTES} bytes, truncated):\n{}",
-                        String::from_utf8_lossy(&tail[start..])
-                    )
-                }
-            },
-        )
+        .map(|log| {
+            if log.len() <= STARTUP_LOG_MAX_BYTES {
+                format!("\nStartup log:\n{}", String::from_utf8_lossy(&log))
+            } else {
+                // Truncate to the last STARTUP_LOG_MAX_BYTES, keeping the most
+                // recent (and usually most relevant) output.  Operating on raw
+                // bytes avoids panicking on multibyte UTF-8 boundaries;
+                // from_utf8_lossy replaces any split characters with U+FFFD.
+                let tail = &log[log.len() - STARTUP_LOG_MAX_BYTES..];
+                // Find the first newline to avoid cutting mid-line.
+                let start = tail.iter().position(|&b| b == b'\n').map_or(0, |i| i + 1);
+                format!(
+                    "\nStartup log (last {STARTUP_LOG_MAX_BYTES} bytes, truncated):\n{}",
+                    String::from_utf8_lossy(&tail[start..])
+                )
+            }
+        })
+}
+
+/// Read crash diagnostics from `startup.log` for paths where the node is *not*
+/// known to be alive.
+///
+/// Shows the log inline if present, otherwise falls back to a generic
+/// "Check Erlang/OTP is installed" hint — appropriate only when the node may
+/// have failed to boot. On "node alive but unhealthy" paths use
+/// [`read_startup_log_content`] instead, where that hint would be misleading.
+fn read_startup_log_detail(workspace_id: &str) -> String {
+    read_startup_log_content(workspace_id)
+        .unwrap_or_else(|| "\nCheck Erlang/OTP is installed.".to_string())
 }
 
 /// Build the Erlang `-eval` string for workspace node startup.

--- a/crates/beamtalk-cli/src/commands/workspace/storage.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/storage.rs
@@ -185,16 +185,26 @@ pub(super) fn write_secure_file(path: &Path, content: &[u8]) -> Result<()> {
 
 /// Generate a unique Erlang cookie for a workspace.
 ///
-/// Uses URL-safe base64 (RFC 4648 §5) to avoid `+` and `/` characters,
-/// which Erlang's `-args_file` parser misinterprets as ERTS VM flags when
-/// they appear at the start of a token (e.g. `-setcookie +abc` treats `+abc`
-/// as an ERTS flag rather than the cookie value).
+/// Uses URL-safe base64 (RFC 4648 §5) to avoid `+` and `/` characters, then
+/// rerolls any value that starts with `-`. All three of `+`, `/`, and a leading
+/// `-` are misinterpreted by Erlang's `-args_file` reader: a token that begins
+/// with `+` or `-` is parsed as a VM flag rather than the value of `-setcookie`,
+/// so the node boots without the intended cookie and every WebSocket auth then
+/// fails with "Invalid cookie" (an intermittent workspace-startup CI flake,
+/// BT-2532). URL-safe base64 rules out `+`/`/` anywhere; the reroll rules out a
+/// leading `-` (the only place `-` is a flag prefix — `-` and `_` elsewhere in
+/// the token are harmless). 24 bytes encode to 32 chars with no `=` padding.
 pub fn generate_cookie() -> String {
     use rand::Rng;
     let mut rng = rand::rng();
-    let mut bytes = vec![0u8; 24];
-    rng.fill_bytes(&mut bytes);
-    base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE, &bytes)
+    loop {
+        let mut bytes = vec![0u8; 24];
+        rng.fill_bytes(&mut bytes);
+        let cookie = base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE, &bytes);
+        if !cookie.starts_with('-') {
+            return cookie;
+        }
+    }
 }
 
 /// Save workspace cookie with secure permissions (owner read/write only).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_sup.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_sup.erl
@@ -26,10 +26,10 @@ beamtalk_workspace_sup
   ├─ beamtalk_actor_registry       % Workspace-wide actor registry
   ├─ beamtalk_workspace_bootstrap % Class var bootstrap (ADR 0019)
   │     (also initialises sealed Object singletons: BeamtalkInterface, WorkspaceInterface)
-  ├─ beamtalk_repl_server         % TCP server (session-per-connection)
-  ├─ beamtalk_idle_monitor        % Tracks activity, self-terminates if idle
   ├─ beamtalk_actor_sup           % Supervises user actors
-  └─ beamtalk_session_sup         % Supervises session shell processes
+  ├─ beamtalk_session_sup         % Supervises session shell processes (before repl_server)
+  ├─ beamtalk_repl_server         % TCP server (session-per-connection)
+  └─ beamtalk_idle_monitor        % Tracks activity, self-terminates if idle
 ```
 """.
 
@@ -197,6 +197,27 @@ repl_child_specs(false, _TcpPort, _WorkspaceId, _BindAddr, _AutoCleanup, _MaxIdl
     [];
 repl_child_specs(true, TcpPort, WorkspaceId, BindAddr, AutoCleanup, MaxIdleSeconds) ->
     [
+        %% Session supervisor (one child per REPL connection).
+        %%
+        %% MUST start before beamtalk_repl_server: the REPL server's init/1 binds
+        %% the cowboy `/ws` listener AND writes the port file (the CLI's readiness
+        %% signal) before returning. If session_sup started after repl_server, the
+        %% CLI could discover the port and open a `/ws` connection during the window
+        %% where session_sup does not yet exist, so beamtalk_ws_handler's
+        %% create_session -> supervisor:start_child(beamtalk_session_sup, _) exits
+        %% with `noproc`, the handler crashes, and the connection is dropped. The CLI
+        %% sees "port accepting TCP but WebSocket health check failed" and retries on
+        %% a fresh node (flaky workspace-startup CI failures, BT-2532). Ordering
+        %% session_sup first gates the port file behind a ready session tier.
+        #{
+            id => beamtalk_session_sup,
+            start => {beamtalk_session_sup, start_link, []},
+            restart => permanent,
+            shutdown => infinity,
+            type => supervisor,
+            modules => [beamtalk_session_sup]
+        },
+
         %% REPL WebSocket server (session-per-connection architecture)
         #{
             id => beamtalk_repl_server,
@@ -228,16 +249,6 @@ repl_child_specs(true, TcpPort, WorkspaceId, BindAddr, AutoCleanup, MaxIdleSecon
             shutdown => 5000,
             type => worker,
             modules => [beamtalk_idle_monitor]
-        },
-
-        %% Session supervisor (one child per REPL connection)
-        #{
-            id => beamtalk_session_sup,
-            start => {beamtalk_session_sup, start_link, []},
-            restart => permanent,
-            shutdown => infinity,
-            type => supervisor,
-            modules => [beamtalk_session_sup]
         }
     ].
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_sup_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_sup_tests.erl
@@ -217,6 +217,20 @@ bootstrap_after_singletons_before_repl_test() ->
     ?assert(BootstrapIdx > ActorRegistryIdx),
     ?assert(BootstrapIdx < ReplServerIdx).
 
+session_sup_before_repl_server_test() ->
+    %% The session supervisor MUST start before the REPL server. repl_server's
+    %% init/1 binds the cowboy `/ws` listener and writes the port file (the CLI's
+    %% readiness signal) before returning; if session_sup is not yet up when a
+    %% client connects, beamtalk_ws_handler:create_session exits with `noproc` and
+    %% the connection is dropped, surfacing as the flaky "port accepting TCP but
+    %% WebSocket health check failed" CI failure (BT-2532).
+    {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(test_config()),
+
+    Ids = [maps:get(id, S) || S <- ChildSpecs],
+    SessionSupIdx = index_of(beamtalk_session_sup, Ids),
+    ReplServerIdx = index_of(beamtalk_repl_server, Ids),
+    ?assert(SessionSupIdx < ReplServerIdx).
+
 %%% Helpers
 
 index_of(Elem, List) ->


### PR DESCRIPTION
## Problem

The recurring CI flake tracked as **BT-2532** (and originally BT-1599) — *"BEAM node started … port accepting TCP connections, but the WebSocket health check failed"* — is still live. A fresh occurrence landed on 2026-06-17 (run [`27681144697`](https://github.com/jamesc/beamtalk/actions/runs/27681144697)), failing `test_start_detached_node_cleans_up_tombstone_integration` across all 3 retries. BT-2532 was previously closed having only added a failure-time log dump; its root-cause/fix acceptance criteria were never completed.

## Root cause (a real ordering race)

`beamtalk_workspace_sup` started `beamtalk_repl_server` **before** `beamtalk_session_sup`. The REPL server binds the cowboy `/ws` listener **and writes the port file — the CLI's readiness signal — inside its own `init/1`**, before `session_sup` exists. So the CLI discovers the port the instant repl_server binds and can open a `/ws` connection during the window where `beamtalk_ws_handler:create_session` calls `supervisor:start_child(beamtalk_session_sup, _)`, which exits `noproc`. The handler crashes, the connection is dropped, and the CLI reports a degraded WS health check and retries on a fresh node.

This also explains why every prior occurrence was undiagnosable: `wait_for_tcp_ready` discarded the real `ProtocolClient::connect` error, and the server-side `"Session creation failed"` log lands in `workspace.log`, which the CI dump never captured (only `startup.log`, which is empty in this mode).

## Changes

- **`beamtalk_workspace_sup`**: reorder `repl_child_specs` so `beamtalk_session_sup` starts **before** `beamtalk_repl_server`. The port file (readiness signal) is now gated behind a ready session tier, eliminating the window. Added regression test `session_sup_before_repl_server_test`.
- **`process.rs` (`wait_for_tcp_ready`)**: capture and inline the actual WS connect/auth error (previously discarded) plus `startup.log` detail into the degraded-state timeout error, so any residual occurrence is diagnosable from the CLI message alone.
- **`ci.yml`**: dump `workspace.log` alongside `startup.log` on `test-integration` failure — the server-side session/auth errors live there.

## Verification

- `just build`, `cargo clippy`, `cargo fmt`, `rebar3 fmt --check`, `just dialyzer-specs` — all clean.
- Workspace integration suite (7 tests, incl. the flaking one) ✅
- MCP integration (21) ✅
- `beamtalk_workspace_sup_tests` (39, incl. new test) ✅
- `beamtalk_repl_server_tests` + `beamtalk_session_sup_tests` (279) ✅

## Caveat

The reorder definitively closes the session-readiness race that matches this symptom, but the flake is load-dependent and the exact 70s-persistent variant could not be reproduced locally. If a different residual cause remains, the new client-side and server-side diagnostics will name it on the next occurrence instead of leaving an empty log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015358A5mbM54qHEdBWKR8CF)_