### PR TITLE
test(liveview): make stub browse_method_source image-aware (BT-2566)

### DIFF
--- a/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
@@ -212,5 +212,52 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
       assert reflush_html =~ "Saved increment on Counter"
       refute reflush_html =~ "unflushed"
     end
+
+    test "re-activating a compiled tab after navigating away shows the compiled body (BT-2566)",
+         %{conn: conn} do
+      # BT-2566: in production `browse_method_source` returns the current *image*
+      # body, so after a `>>` compile the editor re-seeds the compiled body on
+      # re-activation. The stub now tracks the compiled source per method, so this
+      # asserts the source-content path the BT-2565 badge test left unchecked.
+      #
+      # Navigating to a *different* tab and back re-keys the CodeMirror host on
+      # `@active_tab`, so the re-activated `increment` editor remounts and renders
+      # the freshly re-seeded buffer (a same-tab re-click is `phx-update="ignore"`).
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      new_body = "increment => self.value := self.value + 2"
+
+      view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
+      view |> element(~s(div[phx-value-selector="increment"])) |> render_click()
+
+      # 1. Compile a different body — the image now diverges from the on-disk stub.
+      save_html =
+        view
+        |> form("form[phx-submit='save_method']")
+        |> render_submit(%{
+          "class" => "Counter",
+          "selector" => "increment",
+          "source" => new_body,
+          "tab" => "method:Counter:instance:increment"
+        })
+
+      assert save_html =~ "unflushed"
+
+      # 2. Navigate away to a different method tab (`value`), re-keying the editor.
+      view |> element(~s(div[phx-value-selector="value"])) |> render_click()
+
+      # 3. Re-activate `increment`: its editor remounts and the buffer is re-seeded
+      #    from the live image — the compiled body, not the original on-disk stub.
+      reactivate_html =
+        view |> element(~s(div[phx-value-selector="increment"])) |> render_click()
+
+      # Match the escape-safe tail of the compiled body: the rendered buffer HTML-
+      # escapes `=>`, but `:= self.value + 2` survives verbatim and is unique to the
+      # compiled body. The editor's `data-placeholder` carries the "+ 1" disk body
+      # unconditionally, so we assert the compiled body is present (the "+ 2" tail)
+      # rather than refuting the disk body. Pre-fix, the re-activated buffer reverts
+      # to the on-disk stub ("+ 1") and this tail is absent.
+      assert reactivate_html =~ ":= self.value + 2"
+    end
   end
 end

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -18,6 +18,11 @@ defmodule BtAttachWeb.StubWorkspaceClient do
     @moduledoc false
     defstruct defined_classes: MapSet.new(),
               changes: %{},
+              # BT-2566: the compiled body per `{class, selector}`, recorded on
+              # `save_method/3`. In production `browse_method_source` returns the
+              # current *image* body, which after a `>>` compile is the compiled
+              # body — so the stub serves this over the hardcoded on-disk body.
+              compiled_sources: %{},
               calls: []
   end
 
@@ -89,11 +94,17 @@ defmodule BtAttachWeb.StubWorkspaceClient do
 
   # ── Write-surface: save / flush / changes ─────────────────────────────────
 
-  def save_method(class, selector, _source) do
+  def save_method(class, selector, source) do
     record({:save, class, selector})
 
     update(:changes, fn changes ->
       Map.put(changes, {class, selector}, "src/#{Macro.underscore(class)}.bt")
+    end)
+
+    # BT-2566: remember the compiled body so a later `browse_method_source/3`
+    # returns the image body (as production does) rather than the on-disk stub.
+    update(:compiled_sources, fn sources ->
+      Map.put(sources, {class, selector}, source)
     end)
 
     {:ok, class}
@@ -161,7 +172,7 @@ defmodule BtAttachWeb.StubWorkspaceClient do
   end
 
   def browse_method_source(class, _side, selector) do
-    {source, doc, signature} =
+    {disk_source, doc, signature} =
       case selector do
         "increment" ->
           {"increment => self.value := self.value + 1",
@@ -176,9 +187,14 @@ defmodule BtAttachWeb.StubWorkspaceClient do
           {"stub => nil", nil, nil}
       end
 
+    # BT-2566: in production `browse_method_source` returns the current *image*
+    # body, which after a `save_method` `>>` compile is the compiled body. Serve
+    # the tracked compiled source when one exists, falling back to the on-disk stub.
+    source = Map.get(get(:compiled_sources), {class, selector}, disk_source)
+
     # A saved-but-unflushed method has an image body that diverges from disk, so a
-    # re-browse reports `disk_differs: true` (BT-2565). `source` stays the on-disk
-    # body — the backend's `disk_differs` is a load-time snapshot, not a live diff.
+    # re-browse reports `disk_differs: true` (BT-2565). The backend's `disk_differs`
+    # is a load-time snapshot, not a live diff.
     disk_differs = Map.has_key?(get(:changes), {class, selector})
 
     {:value,


### PR DESCRIPTION
## Summary

Follow-up from BT-2565 (PR #2620 review). The stub workspace client's `browse_method_source/3` always returned the hardcoded on-disk body, even after a `save_method` compile. In production, `browse_method_source` returns the current **image** body — which after a `>>` compile is the compiled body. Because the stub reverted to the on-disk body, the re-activation branch's `source: info.source` update in `open_method_tab/4` silently reverted the displayed buffer in tests, a path the BT-2565 badge test never asserted on (it only inspects `disk_differs`).

## Changes

- **`stub_workspace_client.ex`**: track the compiled source per `{class, selector}` in stub state on `save_method/3`; serve it from `browse_method_source/3` when present, falling back to the hardcoded on-disk body otherwise.
- **`workspace_flush_badge_test.exs`**: add a regression test that compiles a new body, navigates to a different method tab (re-keying the editor so the buffer content is observable), then re-activates the original tab and asserts the buffer shows the **compiled** body rather than reverting to the on-disk stub.

## Notes

Test-infrastructure fidelity only; no production behaviour change. The new test fails without the stub fix (verified) and passes with it.

## Test plan

- [x] `mix test` — 187 passed, 109 excluded (workspace/playwright lanes)
- [x] New test is a genuine regression test (fails on reverted stub)
- [x] Local pre-push CI green: clippy, rustfmt, dialyzer, spec validation, erlfmt, `mix format --check`

https://linear.app/beamtalk/issue/BT-2566

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7Z3xWrroYNcT8kkZjzsY3

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7Z3xWrroYNcT8kkZjzsY3)_