### PR TITLE
fix(workspace): compute disk_differs from a live disk re-read (BT-2567)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -2803,12 +2803,16 @@ defmodule BtAttachWeb.WorkspaceLive do
   # The carried `existing.disk_source` is only as fresh as tab-open time: if the file
   # is rewritten out-of-band (another session flushes, an external editor) *while the
   # image is diverged*, the carried body goes stale, and a later compile of the *old*
-  # on-disk body would clear `unflushed` against disk that has since moved on. This is
-  # a narrow false-negative (concurrent out-of-band writes during divergence); the
-  # backend's `disk_differs` is itself a load-time snapshot, not a live re-read, so
-  # the editor already trusts a tab-open view of disk. The conservative pre-BT-2565
-  # path avoided this only by re-flagging *every* re-activated diverged tab — the
-  # false-positive BT-2565 fixes. The common-case win is worth the narrow tradeoff.
+  # on-disk body would clear `unflushed` against disk that has since moved on — a
+  # narrow false-negative (concurrent out-of-band writes during divergence, BT-2567).
+  # As of BT-2567 the backend's `disk_differs` is a *live* re-read of the on-disk
+  # file (not a load-time snapshot), so this self-corrects on the next re-activation:
+  # `info.disk_differs` comes back `true` and the `existing.disk_differs or
+  # info.disk_differs` merge re-raises the badge. The residual window is only the
+  # transient between an out-of-band write and the next re-activation — and only when
+  # the user re-compiles the *old* on-disk body in that gap. The conservative
+  # pre-BT-2565 path avoided even that by re-flagging *every* re-activated diverged
+  # tab — the false-positive BT-2565 fixes. The common-case win is worth the residual.
   @doc false
   def reactivation_disk_source(_existing, %{runtime_only: true}), do: nil
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
@@ -257,7 +257,7 @@ take_protocol(Row) ->
 %% object's stored method source (`{method, Sel}` / `{class_method, Sel}` →
 %% `__source__`) — the patch-aware per-method text (BT-2196). source_status from
 %% xref. `disk_differs` compares the image body against a live re-read of the
-%% on-disk class source (BT-2567; `current_disk_source/1`).
+%% on-disk class source (BT-2567; `current_disk_source/2`).
 -spec browse_method_source(atom(), boolean(), atom()) -> beamtalk_repl_ops:op_result().
 browse_method_source(ClassName, ClassSide, Selector) ->
     case beamtalk_runtime_api:whereis_class(ClassName) of
@@ -289,7 +289,7 @@ browse_method_source(ClassName, ClassSide, Selector) ->
                 <<"source_status">> => atom_to_binary(SourceStatus, utf8),
                 <<"origin">> => origin_for_provenance(Provenance, SourceFile),
                 <<"source_origin">> => source_origin_of(ModName, SourceFile),
-                <<"disk_differs">> => disk_differs(ClassName, Source)
+                <<"disk_differs">> => disk_differs(SourceFile, ClassName, Source)
             }}
     end.
 
@@ -524,19 +524,20 @@ origin_for_provenance(_Provenance, _SourceFile) -> <<"both">>.
 %% `class_definition_disk_differs/1`.
 %%
 %% BT-2567: the comparison source is a *live re-read* of the on-disk class
-%% file (`current_disk_source/1`), not the load-time snapshot held in
+%% file (`current_disk_source/2`), not the load-time snapshot held in
 %% `beamtalk_workspace_meta`. The snapshot goes stale under out-of-band writes
 %% (an external editor, or another session flushing the file) and is mutated by
 %% in-memory `>>` patches (`load_recompiled_method/7` appends the patched body
 %% to it), both of which let `disk_differs` under-report divergence. Reading the
 %% file each browse keeps the signal pinned to the actual disk state; the
 %% snapshot remains the fallback when no source file is on record or the read
-%% fails.
--spec disk_differs(atom(), binary() | null) -> boolean() | null.
-disk_differs(_ClassName, null) ->
+%% fails. `SourceFile` is threaded in from the caller (already resolved there)
+%% so the divergence diff does not re-derive it with another class-process call.
+-spec disk_differs(binary() | null, atom(), binary() | null) -> boolean() | null.
+disk_differs(_SourceFile, _ClassName, null) ->
     null;
-disk_differs(ClassName, ImageText) when is_binary(ImageText) ->
-    case current_disk_source(ClassName) of
+disk_differs(SourceFile, ClassName, ImageText) when is_binary(ImageText) ->
+    case current_disk_source(SourceFile, ClassName) of
         undefined ->
             null;
         DiskSource when is_binary(DiskSource) ->
@@ -551,17 +552,33 @@ disk_differs(ClassName, ImageText) when is_binary(ImageText) ->
 %% load-time snapshot when the class has no source file on record or the file
 %% cannot be read (deleted/moved/permissions) — degrading to the pre-BT-2567
 %% behaviour rather than dropping the signal entirely.
--spec current_disk_source(atom()) -> binary() | undefined.
-current_disk_source(ClassName) ->
-    case source_file_for_class(ClassName) of
-        null ->
-            disk_source(ClassName);
-        Path when is_binary(Path) ->
-            case file:read_file(Path) of
-                {ok, Bin} -> Bin;
-                {error, _Reason} -> disk_source(ClassName)
-            end
+-spec current_disk_source(binary() | null, atom()) -> binary() | undefined.
+current_disk_source(null, ClassName) ->
+    disk_source(ClassName);
+current_disk_source(Path, ClassName) when is_binary(Path) ->
+    case file:read_file(Path) of
+        {ok, Bin} ->
+            Bin;
+        {error, Reason} ->
+            disk_read_fallback(Reason, Path, ClassName)
     end.
+
+%% A vanished/moved file (`enoent`/`enotdir`) is the expected race when a tab
+%% outlives its on-disk class — fall back to the snapshot quietly. Any other
+%% error (`eacces`, I/O) is worth surfacing: behaviour is unchanged (still the
+%% snapshot fallback), but a log line makes a permission/FS problem diagnosable.
+-spec disk_read_fallback(file:posix() | badarg | terminated | system_limit, binary(), atom()) ->
+    binary() | undefined.
+disk_read_fallback(Reason, _Path, ClassName) when Reason =:= enoent; Reason =:= enotdir ->
+    disk_source(ClassName);
+disk_read_fallback(Reason, Path, ClassName) ->
+    ?LOG_WARNING(
+        "browse-method-source: disk_differs falling back to snapshot for ~p; "
+        "could not read ~ts: ~p",
+        [ClassName, Path, Reason],
+        #{domain => [beamtalk, runtime]}
+    ),
+    disk_source(ClassName).
 
 -spec disk_source(atom()) -> binary() | undefined.
 disk_source(ClassName) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
@@ -256,8 +256,8 @@ take_protocol(Row) ->
 %% Fetches one method's source, image-accurate. Source comes from the live class
 %% object's stored method source (`{method, Sel}` / `{class_method, Sel}` →
 %% `__source__`) — the patch-aware per-method text (BT-2196). source_status from
-%% xref. `disk_differs` compares the image body against the static/disk class
-%% source recorded at load time (`beamtalk_workspace_meta:get_class_source/1`).
+%% xref. `disk_differs` compares the image body against a live re-read of the
+%% on-disk class source (BT-2567; `current_disk_source/1`).
 -spec browse_method_source(atom(), boolean(), atom()) -> beamtalk_repl_ops:op_result().
 browse_method_source(ClassName, ClassSide, Selector) ->
     case beamtalk_runtime_api:whereis_class(ClassName) of
@@ -513,26 +513,54 @@ origin_for_provenance(_Provenance, null) -> <<"runtime">>;
 origin_for_provenance(_Provenance, _SourceFile) -> <<"both">>.
 
 %% disk_differs (browse-method-source, op 3): true when the live per-method
-%% source is absent from the static/disk class source recorded at load time —
-%% the signature of an unflushed live `>>` patch (ADR 0082). null when there is
-%% no static source to compare (file-less class, or a sourceless runtime method
-%% whose source is itself null). Heuristic: the disk store is whole-class source
-%% text and contains method bodies, so a patched body that no longer matches the
-%% disk text reads as `differs`; a whitespace-only reformat could read as a
-%% false positive, which is acceptable for a "you may be viewing unflushed
-%% state" cue. The class-definition pane (op 4) does NOT use this — see
+%% source is absent from the *current* on-disk class source — the signature of
+%% an unflushed live `>>` patch (ADR 0082). null when there is no static source
+%% to compare (file-less class, or a sourceless runtime method whose source is
+%% itself null). Heuristic: the disk store is whole-class source text and
+%% contains method bodies, so a patched body that no longer matches the disk
+%% text reads as `differs`; a whitespace-only reformat could read as a false
+%% positive, which is acceptable for a "you may be viewing unflushed state" cue.
+%% The class-definition pane (op 4) does NOT use this — see
 %% `class_definition_disk_differs/1`.
+%%
+%% BT-2567: the comparison source is a *live re-read* of the on-disk class
+%% file (`current_disk_source/1`), not the load-time snapshot held in
+%% `beamtalk_workspace_meta`. The snapshot goes stale under out-of-band writes
+%% (an external editor, or another session flushing the file) and is mutated by
+%% in-memory `>>` patches (`load_recompiled_method/7` appends the patched body
+%% to it), both of which let `disk_differs` under-report divergence. Reading the
+%% file each browse keeps the signal pinned to the actual disk state; the
+%% snapshot remains the fallback when no source file is on record or the read
+%% fails.
 -spec disk_differs(atom(), binary() | null) -> boolean() | null.
 disk_differs(_ClassName, null) ->
     null;
 disk_differs(ClassName, ImageText) when is_binary(ImageText) ->
-    case disk_source(ClassName) of
+    case current_disk_source(ClassName) of
         undefined ->
             null;
         DiskSource when is_binary(DiskSource) ->
             %% The image text is a fragment of the whole-class disk source; it
             %% "differs" when the disk source does not contain it verbatim.
             binary:match(DiskSource, ImageText) =:= nomatch
+    end.
+
+%% The class' current on-disk source for the divergence diff (BT-2567). Prefer a
+%% live re-read of the recorded source file so the comparison reflects the file
+%% as it is *now*, not as it was at load time. Falls back to the in-memory
+%% load-time snapshot when the class has no source file on record or the file
+%% cannot be read (deleted/moved/permissions) — degrading to the pre-BT-2567
+%% behaviour rather than dropping the signal entirely.
+-spec current_disk_source(atom()) -> binary() | undefined.
+current_disk_source(ClassName) ->
+    case source_file_for_class(ClassName) of
+        null ->
+            disk_source(ClassName);
+        Path when is_binary(Path) ->
+            case file:read_file(Path) of
+                {ok, Bin} -> Bin;
+                {error, _Reason} -> disk_source(ClassName)
+            end
     end.
 
 -spec disk_source(atom()) -> binary() | undefined.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
@@ -857,6 +857,56 @@ t_install_method_preserves_comments(_Proj) ->
     Src2 = stored_method_source('InstallDoc', bumped),
     ?assertEqual(Src1, Src2).
 
+%% BT-2567: `browse-method-source`'s `disk_differs` re-reads the on-disk class
+%% file *live* each browse, so an out-of-band rewrite (an external editor, or
+%% another session flushing) is detected even though the image body is
+%% unchanged. A pre-BT-2567 diff against the load-time `workspace_meta` snapshot
+%% would stay `false` here — the snapshot still matches the image body.
+t_disk_differs_reflects_live_disk(_Proj) ->
+    Proj = live_project_dir(),
+    Path = write_bt_under(
+        Proj,
+        "src",
+        "DiskDiff.bt",
+        <<"Actor subclass: DiskDiff\n  state: v = 1\n\n  value -> Integer => self.v\n">>
+    ),
+    State0 = beamtalk_repl_state:new(undefined, 0),
+    {ok, _, _State1} = beamtalk_repl_loader:handle_load(Path, State0),
+    %% A fresh file load gives the module a `beamtalk_source` attribute, which is
+    %% how `disk_differs` finds the file to re-read.
+    ?assert(is_binary(beamtalk_reflection:source_file_from_module(current_module_of('DiskDiff')))),
+    %% (1) Image == disk: the live method body appears verbatim on disk → not
+    %% diverged. Capture the image body the diff compares against.
+    Value0 = browse_method_value('DiskDiff'),
+    ImageSource = maps:get(<<"source">>, Value0),
+    ?assert(is_binary(ImageSource)),
+    ?assertEqual(false, maps:get(<<"disk_differs">>, Value0)),
+    {ok, OnDisk0} = file:read_file(Path),
+    ?assertNotEqual(nomatch, binary:match(OnDisk0, ImageSource)),
+    %% (2) Rewrite the file out-of-band (no reload): the image body is now absent
+    %% from disk. A live re-read must report divergence; the load-time snapshot
+    %% (unchanged) would not.
+    NewFile = <<"Actor subclass: DiskDiff\n  state: v = 1\n\n  value -> Integer => self.w\n">>,
+    ?assertEqual(nomatch, binary:match(NewFile, ImageSource)),
+    ok = file:write_file(Path, NewFile),
+    Value1 = browse_method_value('DiskDiff'),
+    ?assertEqual(true, maps:get(<<"disk_differs">>, Value1)).
+
+%% browse-method-source for the instance `value' selector, term form (the same
+%% path the System Browser drives). `Msg' is unused by this op.
+browse_method_value(Class) ->
+    {value, V} = beamtalk_repl_ops_browse:handle_term(
+        <<"browse-method-source">>,
+        #{
+            <<"class">> => atom_to_binary(Class, utf8),
+            <<"side">> => <<"instance">>,
+            <<"selector">> => <<"value">>
+        },
+        {protocol_msg, <<"browse">>, <<"t1">>, <<"s1">>, #{}, false},
+        self()
+    ),
+    V.
+
 t_install_method_accumulation_preserves_siblings(_Proj) ->
     Proj = live_project_dir(),
     %% Round-trip fidelity across saves: the stored class source accumulates via
@@ -1005,6 +1055,9 @@ loader_integration_test_() ->
             end},
             {"install_method preserves leading comments, idempotently (bug 1)", fun() ->
                 t_install_method_preserves_comments(Proj)
+            end},
+            {"disk_differs re-reads the on-disk file live (BT-2567)", fun() ->
+                t_disk_differs_reflects_live_disk(Proj)
             end},
             {"install_method on test/ class keeps package", fun() ->
                 t_install_method_test_dir_keeps_package(Proj)


### PR DESCRIPTION
## Summary

Resolves **BT-2567** — the documented edge case from the BT-2565 (PR #2620) review where the System Browser's `unflushed` badge could go stale under concurrent out-of-band disk writes while the image is diverged.

The root cause is in the backend: `browse-method-source`'s `disk_differs` flag diffed the live method body against the **in-memory load-time class-source snapshot** held in `beamtalk_workspace_meta` (`get_class_source/1`), not the actual file. That snapshot:

- goes **stale under out-of-band writes** (an external editor, or another session flushing the file), and
- is **mutated by in-memory `>>` patches** (`load_recompiled_method/7` appends the patched body to it),

both of which let `disk_differs` under-report divergence.

## Change

- `disk_differs/2` now compares against a **live re-read of the recorded on-disk source file** (`current_disk_source/1`), so the divergence signal is pinned to the actual disk state. The backend already tracks the source-file path (`source_file_for_class/1`), so no new plumbing is needed.
- The in-memory snapshot remains the **fallback** when the class has no source file on record or the read fails (deleted/moved/permissions) — degrading to the pre-BT-2567 behaviour rather than dropping the signal.
- Because the badge is re-derived from the backend on each tab re-activation, the LiveView IDE's badge now **self-corrects** on the next re-activation. Updated the `reactivation_disk_source/2` comment to reflect the now-narrowed residual window (the transient between an out-of-band write and the next re-activation).

## Tests

Adds an end-to-end loader integration test (`t_disk_differs_reflects_live_disk`): load a class from a real file, assert `disk_differs` is `false`, rewrite the file out-of-band (no reload), and assert the live re-read reports divergence. A pre-BT-2567 snapshot diff would stay `false` here.

- `just test-runtime` — 6419 tests, 0 failures
- `just dialyzer` — clean
- erlfmt + `mix format` checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoXRBuggpa8zWehYXfQ4ym)_