### PR TITLE
refactor(workspace): add beamtalk_repl_errors:make/3,4 + asList coverage tests (BT-2477, BT-2535)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_errors.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_errors.erl
@@ -16,6 +16,8 @@ Used by protocol handlers and op modules.
 -include_lib("beamtalk_runtime/include/beamtalk.hrl").
 
 -export([
+    make/3,
+    make/4,
     ensure_structured_error/1,
     ensure_structured_error/2,
     format_name/1,
@@ -23,6 +25,26 @@ Used by protocol handlers and op modules.
 ]).
 
 %%% Public API
+
+-doc """
+Build a structured #beamtalk_error{} from a kind, source class, and message.
+
+Collapses the repeated `new` -> `with_message` chain used across the REPL
+op modules.
+""".
+-spec make(atom(), atom(), term()) -> #beamtalk_error{}.
+make(Kind, Source, Message) ->
+    beamtalk_error:with_message(beamtalk_error:new(Kind, Source), Message).
+
+-doc """
+Build a structured #beamtalk_error{} from a kind, source class, message, and hint.
+
+Collapses the repeated `new` -> `with_message` -> `with_hint` chain used across
+the REPL op modules. A hint of `undefined` is dropped by `beamtalk_error:with_hint/2`.
+""".
+-spec make(atom(), atom(), term(), term()) -> #beamtalk_error{}.
+make(Kind, Source, Message, Hint) ->
+    beamtalk_error:with_hint(make(Kind, Source, Message), Hint).
 
 -doc """
 Safely convert a binary to an existing atom, returning error instead of creating new atoms.
@@ -61,93 +83,63 @@ ensure_structured_error({eval_error, _Class, Reason}) ->
     ensure_structured_error(Reason);
 ensure_structured_error({compile_error, [#{message := Msg} = Diag | _]}) ->
     %% BT-1235: structured diagnostic list — extract message and hint from first diagnostic
-    Err0 = beamtalk_error:new(compile_error, 'Compiler'),
-    Err1 = beamtalk_error:with_message(Err0, Msg),
     % elp:fixme W0032 maps:find with complex branch logic
     case maps:find(hint, Diag) of
-        {ok, Hint} when is_binary(Hint) -> beamtalk_error:with_hint(Err1, Hint);
-        _ -> Err1
+        {ok, Hint} when is_binary(Hint) -> make(compile_error, 'Compiler', Msg, Hint);
+        _ -> make(compile_error, 'Compiler', Msg)
     end;
 ensure_structured_error({compile_error, Msg}) when is_binary(Msg) ->
-    Err0 = beamtalk_error:new(compile_error, 'Compiler'),
-    beamtalk_error:with_message(Err0, Msg);
+    make(compile_error, 'Compiler', Msg);
 ensure_structured_error({compile_error, Msg}) when is_list(Msg) ->
-    Err0 = beamtalk_error:new(compile_error, 'Compiler'),
     MsgBin =
         try
             list_to_binary(Msg)
         catch
             error:badarg -> iolist_to_binary(io_lib:format("~p", [Msg]))
         end,
-    beamtalk_error:with_message(Err0, MsgBin);
+    make(compile_error, 'Compiler', MsgBin);
 ensure_structured_error({compile_error, Reason}) ->
-    Err0 = beamtalk_error:new(compile_error, 'Compiler'),
-    beamtalk_error:with_message(
-        Err0,
-        iolist_to_binary([<<"Compile error: ">>, format_name(Reason)])
-    );
+    make(compile_error, 'Compiler', iolist_to_binary([<<"Compile error: ">>, format_name(Reason)]));
 ensure_structured_error({undefined_variable, Name}) ->
-    Err0 = beamtalk_error:new(undefined_variable, 'REPL'),
-    beamtalk_error:with_message(
-        Err0,
+    make(
+        undefined_variable,
+        'REPL',
         iolist_to_binary([<<"Undefined variable: ">>, format_name(Name)])
     );
 ensure_structured_error({file_not_found, Path}) ->
-    Err0 = beamtalk_error:new(file_not_found, 'File'),
-    beamtalk_error:with_message(
-        Err0,
-        iolist_to_binary([<<"File not found: ">>, format_name(Path)])
-    );
+    make(file_not_found, 'File', iolist_to_binary([<<"File not found: ">>, format_name(Path)]));
 ensure_structured_error({read_error, Reason}) ->
-    Err0 = beamtalk_error:new(io_error, 'File'),
-    beamtalk_error:with_message(
-        Err0,
-        iolist_to_binary([<<"Failed to read file: ">>, format_name(Reason)])
-    );
+    make(io_error, 'File', iolist_to_binary([<<"Failed to read file: ">>, format_name(Reason)]));
 ensure_structured_error({load_error, Reason}) ->
-    Err0 = beamtalk_error:new(io_error, 'File'),
-    beamtalk_error:with_message(
-        Err0,
+    make(
+        io_error,
+        'File',
         iolist_to_binary([<<"Failed to load bytecode: ">>, format_name(Reason)])
     );
 ensure_structured_error({registration_error, {ModuleName, Reason}}) ->
-    Err0 = beamtalk_error:new(registration_error, 'Runtime'),
-    beamtalk_error:with_message(
-        Err0,
+    make(
+        registration_error,
+        'Runtime',
         iolist_to_binary(
             io_lib:format("Class registration failed for ~s: ~p", [ModuleName, Reason])
         )
     );
 ensure_structured_error({registration_error, Reason}) ->
-    Err0 = beamtalk_error:new(registration_error, 'Runtime'),
-    beamtalk_error:with_message(
-        Err0,
+    make(
+        registration_error,
+        'Runtime',
         iolist_to_binary([<<"Class registration failed: ">>, format_name(Reason)])
     );
 ensure_structured_error({parse_error, Details}) ->
-    Err0 = beamtalk_error:new(compile_error, 'Compiler'),
-    beamtalk_error:with_message(
-        Err0,
-        iolist_to_binary([<<"Parse error: ">>, format_name(Details)])
-    );
+    make(compile_error, 'Compiler', iolist_to_binary([<<"Parse error: ">>, format_name(Details)]));
 ensure_structured_error({invalid_request, Reason}) ->
-    Err0 = beamtalk_error:new(internal_error, 'REPL'),
-    beamtalk_error:with_message(
-        Err0,
-        iolist_to_binary([<<"Invalid request: ">>, format_name(Reason)])
-    );
+    make(internal_error, 'REPL', iolist_to_binary([<<"Invalid request: ">>, format_name(Reason)]));
 ensure_structured_error(empty_expression) ->
-    Err0 = beamtalk_error:new(empty_expression, 'REPL'),
-    beamtalk_error:with_message(Err0, <<"Empty expression">>);
+    make(empty_expression, 'REPL', <<"Empty expression">>);
 ensure_structured_error(timeout) ->
-    Err0 = beamtalk_error:new(timeout, 'REPL'),
-    beamtalk_error:with_message(Err0, <<"Request timed out">>);
+    make(timeout, 'REPL', <<"Request timed out">>);
 ensure_structured_error(Reason) ->
-    Err0 = beamtalk_error:new(internal_error, 'REPL'),
-    beamtalk_error:with_message(
-        Err0,
-        iolist_to_binary(io_lib:format("~p", [Reason]))
-    ).
+    make(internal_error, 'REPL', iolist_to_binary(io_lib:format("~p", [Reason]))).
 
 -doc """
 Ensure an error reason is structured, with exception class context.
@@ -178,9 +170,9 @@ ensure_structured_error({invalid_request, _} = Reason, _Class) ->
 ensure_structured_error({registration_error, _} = Reason, _Class) ->
     ensure_structured_error(Reason);
 ensure_structured_error(Reason, Class) ->
-    Err0 = beamtalk_error:new(internal_error, 'REPL'),
-    beamtalk_error:with_message(
-        Err0,
+    make(
+        internal_error,
+        'REPL',
         iolist_to_binary([
             atom_to_binary(Class, utf8),
             <<": ">>,

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_actors.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_actors.erl
@@ -22,13 +22,10 @@ wrapper that encodes the term result via `beamtalk_repl_ops:encode/2`.
 -spec invalid_pid_error(atom(), string()) -> beamtalk_error:error().
 invalid_pid_error(Reason, PidStr) ->
     PidBin = list_to_binary(PidStr),
-    Err0 = beamtalk_error:new(Reason, 'Actor'),
-    Err1 = beamtalk_error:with_message(
-        Err0,
-        iolist_to_binary([<<"Invalid actor PID: ">>, PidBin])
-    ),
-    beamtalk_error:with_hint(
-        Err1,
+    beamtalk_repl_errors:make(
+        Reason,
+        'Actor',
+        iolist_to_binary([<<"Invalid actor PID: ">>, PidBin]),
         <<"Use :actors to list valid actor PIDs.">>
     ).
 
@@ -85,20 +82,20 @@ handle_term(<<"inspect">>, Params, _Msg, _SessionPid) ->
                         end
                     catch
                         _:_ ->
-                            Err3 = beamtalk_error:new(inspect_failed, 'Actor'),
-                            Err4 = beamtalk_error:with_message(
-                                Err3,
-                                iolist_to_binary([<<"Failed to inspect actor: ">>, PidBin])
-                            ),
-                            {error, Err4}
+                            {error,
+                                beamtalk_repl_errors:make(
+                                    inspect_failed,
+                                    'Actor',
+                                    iolist_to_binary([<<"Failed to inspect actor: ">>, PidBin])
+                                )}
                     end;
                 false ->
-                    Err3 = beamtalk_error:new(actor_not_alive, 'Actor'),
-                    Err4 = beamtalk_error:with_message(
-                        Err3,
-                        iolist_to_binary([<<"Actor is not alive: ">>, PidBin])
-                    ),
-                    {error, Err4}
+                    {error,
+                        beamtalk_repl_errors:make(
+                            actor_not_alive,
+                            'Actor',
+                            iolist_to_binary([<<"Actor is not alive: ">>, PidBin])
+                        )}
             end
     end;
 handle_term(<<"kill">>, Params, _Msg, _SessionPid) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
@@ -965,8 +965,10 @@ safe_class_call(Pid, Call) ->
 
 -spec arg_error(binary(), binary()) -> {error, #beamtalk_error{}}.
 arg_error(Op, Reason) ->
-    Err = beamtalk_error:new(argument_error, 'REPL'),
-    {error, beamtalk_error:with_message(Err, iolist_to_binary([Op, <<": ">>, Reason]))}.
+    {error,
+        beamtalk_repl_errors:make(
+            argument_error, 'REPL', iolist_to_binary([Op, <<": ">>, Reason])
+        )}.
 
 -spec not_found_error(binary(), atom()) -> {error, #beamtalk_error{}}.
 not_found_error(Op, ClassName) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -200,10 +200,13 @@ handle_term(<<"erlang-help">>, Params, _Msg, _SessionPid) ->
     FunctionBin = nonempty_or_undefined(maps:get(<<"function">>, Params, undefined)),
     case ModuleBin of
         <<>> ->
-            Err = beamtalk_error:new(invalid_argument, 'REPL'),
-            Err1 = beamtalk_error:with_message(Err, <<"Module name required">>),
-            Err2 = beamtalk_error:with_hint(Err1, <<"Usage: :help Erlang <module>">>),
-            {error, Err2};
+            {error,
+                beamtalk_repl_errors:make(
+                    invalid_argument,
+                    'REPL',
+                    <<"Module name required">>,
+                    <<"Usage: :help Erlang <module>">>
+                )};
         _ ->
             %% Use binary_to_existing_atom to prevent atom table exhaustion
             %% from repeated queries with typos (atoms are never GC'd).
@@ -265,15 +268,13 @@ handle_term(<<"show-codegen">>, Params, _Msg, SessionPid) ->
     %% so behaviour is consistent regardless of which entry point is used.
     case {SelectorBin, ClassBin} of
         {SB, undefined} when SB =/= undefined ->
-            Err = beamtalk_error:new(invalid_argument, 'REPL'),
-            Err1 = beamtalk_error:with_message(
-                Err, <<"'selector' requires 'class' to be specified">>
-            ),
-            Err2 = beamtalk_error:with_hint(
-                Err1,
-                <<"Provide 'class' along with 'selector' to inspect a specific method.">>
-            ),
-            {error, Err2};
+            {error,
+                beamtalk_repl_errors:make(
+                    invalid_argument,
+                    'REPL',
+                    <<"'selector' requires 'class' to be specified">>,
+                    <<"Provide 'class' along with 'selector' to inspect a specific method.">>
+                )};
         _ ->
             case {ClassBin, CodeBin} of
                 {CB, _} when CB =/= undefined ->
@@ -282,12 +283,13 @@ handle_term(<<"show-codegen">>, Params, _Msg, SessionPid) ->
                     Code = binary_to_list(CB),
                     case Code of
                         [] ->
-                            Err = beamtalk_error:new(empty_expression, 'REPL'),
-                            Err1 = beamtalk_error:with_message(Err, <<"Empty expression">>),
-                            Err2 = beamtalk_error:with_hint(
-                                Err1, <<"Enter an expression to compile.">>
-                            ),
-                            {error, Err2};
+                            {error,
+                                beamtalk_repl_errors:make(
+                                    empty_expression,
+                                    'REPL',
+                                    <<"Empty expression">>,
+                                    <<"Enter an expression to compile.">>
+                                )};
                         _ ->
                             case beamtalk_repl_shell:show_codegen(SessionPid, Code) of
                                 {ok, CoreErlang, Warnings} ->
@@ -300,13 +302,13 @@ handle_term(<<"show-codegen">>, Params, _Msg, SessionPid) ->
                             end
                     end;
                 {undefined, undefined} ->
-                    Err = beamtalk_error:new(empty_expression, 'REPL'),
-                    Err1 = beamtalk_error:with_message(Err, <<"Missing required parameter">>),
-                    Err2 = beamtalk_error:with_hint(
-                        Err1,
-                        <<"Provide 'code' to compile an expression, or 'class' to inspect a loaded class.">>
-                    ),
-                    {error, Err2}
+                    {error,
+                        beamtalk_repl_errors:make(
+                            empty_expression,
+                            'REPL',
+                            <<"Missing required parameter">>,
+                            <<"Provide 'code' to compile an expression, or 'class' to inspect a loaded class.">>
+                        )}
             end
     end;
 handle_term(<<"methods">>, Params, _Msg, _SessionPid) ->
@@ -438,17 +440,15 @@ handle_term(<<"test">>, Params, _Msg, _SessionPid) ->
     FilePath = maps:get(<<"file">>, Params, undefined),
     case {ClassName, FilePath} of
         {CN, FP} when CN =/= undefined, FP =/= undefined ->
-            Err0 = beamtalk_error:new(invalid_argument, 'TestRunner'),
-            Err1 = beamtalk_error:with_message(
-                Err0, <<"'class' and 'file' are mutually exclusive">>
-            ),
-            {error, Err1};
+            {error,
+                beamtalk_repl_errors:make(
+                    invalid_argument, 'TestRunner', <<"'class' and 'file' are mutually exclusive">>
+                )};
         {undefined, FP} when FP =/= undefined, not is_binary(FP) ->
-            Err0 = beamtalk_error:new(invalid_argument, 'TestRunner'),
-            Err1 = beamtalk_error:with_message(
-                Err0, <<"'file' must be a binary path">>
-            ),
-            {error, Err1};
+            {error,
+                beamtalk_repl_errors:make(
+                    invalid_argument, 'TestRunner', <<"'file' must be a binary path">>
+                )};
         {undefined, FP} when FP =/= undefined ->
             run_test_op_file(FP);
         _ ->
@@ -527,16 +527,16 @@ show_codegen_class_method(ClassBin, SelectorBin) ->
                         exit:{noproc, _} ->
                             {error, make_class_not_found_error(ClassBin)};
                         exit:{timeout, _} ->
-                            Err0 = beamtalk_error:new(runtime_error, ClassAtom),
-                            Err1 = beamtalk_error:with_message(
-                                Err0,
-                                iolist_to_binary([
-                                    <<"Class '">>,
-                                    ClassBin,
-                                    <<"' is not responding (may be under heavy load)">>
-                                ])
-                            ),
-                            {error, Err1}
+                            {error,
+                                beamtalk_repl_errors:make(
+                                    runtime_error,
+                                    ClassAtom,
+                                    iolist_to_binary([
+                                        <<"Class '">>,
+                                        ClassBin,
+                                        <<"' is not responding (may be under heavy load)">>
+                                    ])
+                                )}
                     end
             end
     end.
@@ -571,16 +571,16 @@ compile_class_source(ClassBin, ClassAtom, ClassPid) ->
         end,
     case SourceResult of
         {error, no_source} ->
-            Err0 = beamtalk_error:new(runtime_error, ClassAtom),
-            Err1 = beamtalk_error:with_message(
-                Err0,
-                iolist_to_binary([
-                    <<"No source for ">>,
-                    ClassBin,
-                    <<". Class may have been defined inline.">>
-                ])
-            ),
-            {error, Err1};
+            {error,
+                beamtalk_repl_errors:make(
+                    runtime_error,
+                    ClassAtom,
+                    iolist_to_binary([
+                        <<"No source for ">>,
+                        ClassBin,
+                        <<". Class may have been defined inline.">>
+                    ])
+                )};
         {ok, SourceBin} ->
             case beamtalk_repl_compiler:compile_file_for_codegen(SourceBin, CompilePath) of
                 {ok, CoreErlang, Warnings} ->
@@ -589,14 +589,14 @@ compile_class_source(ClassBin, ClassAtom, ClassPid) ->
                     {error, beamtalk_repl_errors:ensure_structured_error(ErrorReason)}
             end;
         {error, Reason} ->
-            Err0 = beamtalk_error:new(runtime_error, ClassAtom),
-            Err1 = beamtalk_error:with_message(
-                Err0,
-                iolist_to_binary(
-                    io_lib:format("Cannot read source file ~s: ~p", [SourcePath, Reason])
-                )
-            ),
-            {error, Err1}
+            {error,
+                beamtalk_repl_errors:make(
+                    runtime_error,
+                    ClassAtom,
+                    iolist_to_binary(
+                        io_lib:format("Cannot read source file ~s: ~p", [SourcePath, Reason])
+                    )
+                )}
     end.
 
 -doc """
@@ -623,20 +623,17 @@ validate_selector_if_present(ClassBin, ClassAtom, ClassPid, SelectorBin) ->
         true ->
             ok;
         false ->
-            Err0 = beamtalk_error:new(not_found, ClassAtom),
-            Err1 = beamtalk_error:with_message(
-                Err0,
-                iolist_to_binary([
-                    <<"Selector '">>, SelectorBin, <<"' not found on ">>, ClassBin
-                ])
-            ),
-            Err2 = beamtalk_error:with_hint(
-                Err1,
-                iolist_to_binary([
-                    <<"Use :help ">>, ClassBin, <<" to see available selectors.">>
-                ])
-            ),
-            {error, Err2}
+            {error,
+                beamtalk_repl_errors:make(
+                    not_found,
+                    ClassAtom,
+                    iolist_to_binary([
+                        <<"Selector '">>, SelectorBin, <<"' not found on ">>, ClassBin
+                    ]),
+                    iolist_to_binary([
+                        <<"Use :help ">>, ClassBin, <<" to see available selectors.">>
+                    ])
+                )}
     end.
 
 -doc """
@@ -666,11 +663,12 @@ run_test_op(undefined) ->
             {error, Err};
         _Class:Reason ->
             ?LOG_ERROR("test-all op failed: ~p", [Reason], #{domain => [beamtalk, runtime]}),
-            Err0 = beamtalk_error:new(runtime_error, 'TestRunner'),
-            Err1 = beamtalk_error:with_message(
-                Err0, iolist_to_binary(io_lib:format("Test run failed: ~p", [Reason]))
-            ),
-            {error, Err1}
+            {error,
+                beamtalk_repl_errors:make(
+                    runtime_error,
+                    'TestRunner',
+                    iolist_to_binary(io_lib:format("Test run failed: ~p", [Reason]))
+                )}
     end;
 run_test_op(ClassName) when is_binary(ClassName) ->
     case beamtalk_repl_errors:safe_to_existing_atom(ClassName) of
@@ -687,14 +685,14 @@ run_test_op(ClassName) when is_binary(ClassName) ->
                     ?LOG_ERROR("test op failed for ~s: ~p", [ClassName, Reason], #{
                         domain => [beamtalk, runtime]
                     }),
-                    Err0 = beamtalk_error:new(runtime_error, 'TestRunner'),
-                    Err1 = beamtalk_error:with_message(
-                        Err0,
-                        iolist_to_binary(
-                            io_lib:format("Test run failed for ~s: ~p", [ClassName, Reason])
-                        )
-                    ),
-                    {error, Err1}
+                    {error,
+                        beamtalk_repl_errors:make(
+                            runtime_error,
+                            'TestRunner',
+                            iolist_to_binary(
+                                io_lib:format("Test run failed for ~s: ~p", [ClassName, Reason])
+                            )
+                        )}
             end
     end.
 
@@ -716,14 +714,14 @@ run_test_op_file(FilePath) ->
             ?LOG_ERROR("test file op failed for ~s: ~p", [FilePath, Reason], #{
                 domain => [beamtalk, runtime]
             }),
-            Err0 = beamtalk_error:new(runtime_error, 'TestRunner'),
-            Err1 = beamtalk_error:with_message(
-                Err0,
-                iolist_to_binary(
-                    io_lib:format("Test run failed for file ~s: ~p", [FilePath, Reason])
-                )
-            ),
-            {error, Err1}
+            {error,
+                beamtalk_repl_errors:make(
+                    runtime_error,
+                    'TestRunner',
+                    iolist_to_binary(
+                        io_lib:format("Test run failed for file ~s: ~p", [FilePath, Reason])
+                    )
+                )}
     end.
 
 %%% Internal helpers
@@ -1988,13 +1986,10 @@ camel_to_snake([H | T], _PrevWasLower, Acc) ->
 -spec make_class_not_found_error(atom() | binary()) -> #beamtalk_error{}.
 make_class_not_found_error(ClassName) ->
     NameBin = beamtalk_repl_protocol:to_binary(ClassName),
-    Err0 = beamtalk_error:new(class_not_found, 'REPL'),
-    Err1 = beamtalk_error:with_message(
-        Err0,
-        iolist_to_binary([<<"Unknown class: ">>, NameBin])
-    ),
-    beamtalk_error:with_hint(
-        Err1,
+    beamtalk_repl_errors:make(
+        class_not_found,
+        'REPL',
+        iolist_to_binary([<<"Unknown class: ">>, NameBin]),
         <<"Use Workspace classes to see loaded classes.">>
     ).
 
@@ -2094,9 +2089,7 @@ should_include_class(Name, _Super, _ModName, {superclass, FilterAtom}) ->
 -doc "Build a \"not found\" error term for Erlang help lookups (BT-2402).".
 -spec erlang_not_found_error(binary(), binary()) -> {error, #beamtalk_error{}}.
 erlang_not_found_error(What, Hint) ->
-    Err = beamtalk_error:new(does_not_understand, 'Erlang'),
-    Err1 = beamtalk_error:with_message(
-        Err, iolist_to_binary([What, <<" not found">>])
-    ),
-    Err2 = beamtalk_error:with_hint(Err1, Hint),
-    {error, Err2}.
+    {error,
+        beamtalk_repl_errors:make(
+            does_not_understand, 'Erlang', iolist_to_binary([What, <<" not found">>]), Hint
+        )}.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
@@ -42,10 +42,13 @@ handle_term(<<"eval">>, Params, _Msg, SessionPid) ->
     Trace = maps:get(<<"trace">>, Params, false) =:= true,
     case Code of
         [] ->
-            Err = beamtalk_error:new(empty_expression, 'REPL'),
-            Err1 = beamtalk_error:with_message(Err, <<"Empty expression">>),
-            Err2 = beamtalk_error:with_hint(Err1, <<"Enter an expression to evaluate.">>),
-            {error, Err2};
+            {error,
+                beamtalk_repl_errors:make(
+                    empty_expression,
+                    'REPL',
+                    <<"Empty expression">>,
+                    <<"Enter an expression to evaluate.">>
+                )};
         _ when Trace ->
             case beamtalk_repl_shell:eval_trace(SessionPid, Code) of
                 {ok, Steps, Output, Warnings} ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
@@ -80,14 +80,11 @@ sync_project(Path, Options) ->
     ManifestPath = filename:join(AbsPath, "beamtalk.toml"),
     case filelib:is_file(ManifestPath) of
         false ->
-            Err0 = beamtalk_error:new(file_not_found, 'WorkspaceInterface'),
-            Err1 = beamtalk_error:with_message(
-                Err0,
-                iolist_to_binary(["No beamtalk.toml found in: ", AbsPath])
-            ),
             {error,
-                beamtalk_error:with_hint(
-                    Err1,
+                beamtalk_repl_errors:make(
+                    file_not_found,
+                    'WorkspaceInterface',
+                    iolist_to_binary(["No beamtalk.toml found in: ", AbsPath]),
                     <<"Provide a directory path containing beamtalk.toml">>
                 )};
         true ->
@@ -316,10 +313,13 @@ handle_term(<<"load-source">>, Params, _Msg, SessionPid) ->
     Source = maps:get(<<"source">>, Params, <<>>),
     case Source of
         <<>> ->
-            Err = beamtalk_error:new(empty_expression, 'REPL'),
-            Err1 = beamtalk_error:with_message(Err, <<"Empty source">>),
-            Err2 = beamtalk_error:with_hint(Err1, <<"Enter Beamtalk source code to compile.">>),
-            {error, Err2};
+            {error,
+                beamtalk_repl_errors:make(
+                    empty_expression,
+                    'REPL',
+                    <<"Empty source">>,
+                    <<"Enter Beamtalk source code to compile.">>
+                )};
         _ ->
             case beamtalk_repl_shell:load_source(SessionPid, Source) of
                 {ok, Classes} ->
@@ -335,12 +335,12 @@ handle_term(<<"unload">>, Params, _Msg, SessionPid) ->
     ClassNameBin = maps:get(<<"module">>, Params, <<>>),
     case beamtalk_repl_errors:safe_to_existing_atom(ClassNameBin) of
         {error, badarg} ->
-            Err0 = beamtalk_error:new(class_not_found, 'REPL'),
-            Err1 = beamtalk_error:with_message(
-                Err0,
-                iolist_to_binary([<<"Class not found: '">>, ClassNameBin, <<"'">>])
-            ),
-            {error, Err1};
+            {error,
+                beamtalk_repl_errors:make(
+                    class_not_found,
+                    'REPL',
+                    iolist_to_binary([<<"Class not found: '">>, ClassNameBin, <<"'">>])
+                )};
         {ok, ClassName} ->
             case beamtalk_runtime_api:remove_class_from_system(ClassName) of
                 {ok, ModuleName} ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_nav.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_nav.erl
@@ -89,9 +89,10 @@ handle_term(<<"nav-query">>, Params, _Msg, _SessionPid) ->
             Pairs = beamtalk_xref:implementors_of(Selector),
             {value, implementors_value(Pairs, Selector)};
         {error, Reason} ->
-            Err = beamtalk_error:new(argument_error, 'REPL'),
-            Msg1 = iolist_to_binary([<<"nav-query: ">>, Reason]),
-            {error, beamtalk_error:with_message(Err, Msg1)}
+            {error,
+                beamtalk_repl_errors:make(
+                    argument_error, 'REPL', iolist_to_binary([<<"nav-query: ">>, Reason])
+                )}
     end.
 
 -doc "Advertise the `nav-query` op in `describe`.".

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_nav_symbols.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_nav_symbols.erl
@@ -114,11 +114,10 @@ handle_term(<<"nav-symbols">>, Params, _Msg, _SessionPid) ->
             ),
             {value, #{<<"classes">> => Sorted}};
         {error, Reason} ->
-            Err0 = beamtalk_error:new(argument_error, 'REPL'),
-            Err1 = beamtalk_error:with_message(
-                Err0, iolist_to_binary([<<"nav-symbols: ">>, Reason])
-            ),
-            {error, Err1}
+            {error,
+                beamtalk_repl_errors:make(
+                    argument_error, 'REPL', iolist_to_binary([<<"nav-symbols: ">>, Reason])
+                )}
     end.
 
 -doc "Advertise the `nav-symbols` op in `describe`.".

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_session.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_session.erl
@@ -57,15 +57,15 @@ handle_term(<<"clone">>, _Params, _Msg, _SessionPid) ->
         {ok, _NewPid} ->
             {ok, NewSessionId, <<>>, []};
         {error, Reason} ->
-            Err0 = beamtalk_error:new(session_error, 'REPL'),
-            Err1 = beamtalk_error:with_message(
-                Err0,
-                iolist_to_binary([
-                    <<"Failed to create session: ">>,
-                    io_lib:format("~p", [Reason])
-                ])
-            ),
-            {error, Err1}
+            {error,
+                beamtalk_repl_errors:make(
+                    session_error,
+                    'REPL',
+                    iolist_to_binary([
+                        <<"Failed to create session: ">>,
+                        io_lib:format("~p", [Reason])
+                    ])
+                )}
     end;
 handle_term(<<"close">>, _Params, _Msg, _SessionPid) ->
     {status, ok};
@@ -91,10 +91,11 @@ handle_term(<<"shutdown">>, Params, _Msg, _SessionPid) ->
             {status, ok};
         false ->
             ?LOG_WARNING("Shutdown rejected: invalid cookie", #{domain => [beamtalk, runtime]}),
-            Err0 = beamtalk_error:new(auth_error, 'REPL'),
-            Err1 = beamtalk_error:with_message(Err0, <<"Invalid cookie">>),
-            Err2 = beamtalk_error:with_hint(
-                Err1, <<"Provide the correct node cookie for shutdown.">>
-            ),
-            {error, Err2}
+            {error,
+                beamtalk_repl_errors:make(
+                    auth_error,
+                    'REPL',
+                    <<"Invalid cookie">>,
+                    <<"Provide the correct node cookie for shutdown.">>
+                )}
     end.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_watch.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_watch.erl
@@ -112,13 +112,10 @@ format_mfa(_) ->
 -spec invalid_pid_error(atom(), string()) -> beamtalk_error:error().
 invalid_pid_error(Reason, PidStr) ->
     PidBin = list_to_binary(PidStr),
-    Err0 = beamtalk_error:new(Reason, 'Actor'),
-    Err1 = beamtalk_error:with_message(
-        Err0,
-        iolist_to_binary([<<"Invalid actor PID: ">>, PidBin])
-    ),
-    beamtalk_error:with_hint(
-        Err1,
+    beamtalk_repl_errors:make(
+        Reason,
+        'Actor',
+        iolist_to_binary([<<"Invalid actor PID: ">>, PidBin]),
         <<"Use :actors to list valid actor PIDs.">>
     ).
 

--- a/stdlib/test/interval_test.bt
+++ b/stdlib/test/interval_test.bt
@@ -101,3 +101,24 @@ TestCase subclass: IntervalTest
     self assert: (1 to: 10 by: -1) size equals: 0
 
   testZeroStepRaisesError => self should: [1 to: 10 by: 0] raise: #user_error
+
+  testAsListForward => self assert: (1 to: 5) asList equals: #(1, 2, 3, 4, 5)
+
+  testAsListForwardByStep =>
+    self assert: (1 to: 10 by: 3) asList equals: #(1, 4, 7, 10)
+
+  testAsListEmptyInterval => self assert: (1 to: 0) asList equals: #()
+
+  testAsListNegativeStep =>
+    self assert: (5 to: 1 by: -1) asList equals: #(5, 4, 3, 2, 1)
+
+  testAsListNegativeStepBy2 =>
+    self assert: (10 to: 2 by: -2) asList equals: #(10, 8, 6, 4, 2)
+
+  testAsListWrongDirectionPos =>
+    // step > 0 but from > to — empty list (beamtalk_interval:from/3 line 31)
+    self assert: (5 to: 3 by: 1) asList equals: #()
+
+  testAsListWrongDirectionNeg =>
+    // step < 0 but from < to — empty list (beamtalk_interval:from/3 line 31)
+    self assert: (1 to: 5 by: -1) asList equals: #()


### PR DESCRIPTION
## Summary

Two small, independent changes refreshed and implemented together on one branch.

### BT-2477 — Extract repeated `beamtalk_error` construction chain into `make/3,4`
Adds `make/3` (`new` → `with_message`) and `make/4` (`new` → `with_message` → `with_hint`) builder helpers to `beamtalk_repl_errors.erl`, collapsing the repeated 2- and 3-step `beamtalk_error` construction chain across **all 9** REPL op modules (`actors`, `browse`, `dev`, `eval`, `load`, `nav`, `nav_symbols`, `session`, `watch`) **and** the module's own `ensure_structured_error/1,2` clauses. Pure refactor — no behaviour change.

### BT-2535 — `asList` coverage tests for `beamtalk_interval.erl`
Adds 7 `asList` tests to `interval_test.bt` exercising forward, stepped, empty, negative-step and wrong-direction intervals. These cover the previously-uncovered negative-step (`from/3` line 30) and wrong-direction (line 31) paths, raising `beamtalk_interval.erl` from ~40% → ~80% line coverage.

## Verification
- `just build` — green
- `just dialyzer` — clean (0 warnings)
- `just test-bunit` — 2570 passed / 0 failed (incl. all 7 new `asList` tests)
- Runtime EUnit — 4887 tests / 0 failures
- Stdlib — 1533 tests / 0 failures

Closes BT-2477, BT-2535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012QnBvSdwx83u8zNhJBKRdo)_