### PR TITLE
test(stdlib): add single-element asList boundary test for Interval

### DIFF
--- a/stdlib/test/interval_test.bt
+++ b/stdlib/test/interval_test.bt
@@ -104,6 +104,8 @@ TestCase subclass: IntervalTest
 
   testAsListForward => self assert: (1 to: 5) asList equals: #(1, 2, 3, 4, 5)
 
+  testAsListSingleElement => self assert: (3 to: 3) asList equals: #(3)
+
   testAsListForwardByStep =>
     self assert: (1 to: 10 by: 3) asList equals: #(1, 4, 7, 10)
 


### PR DESCRIPTION
## Summary

Follow-up to #2626 (BT-2535). Adds the single-element boundary test `(3 to: 3) asList → #(3)` that the review bot flagged as a minor coverage gap. Exercises the `From =:= To` branch of `beamtalk_interval:from/3` (line 29).

## Verification
- `just build` — green
- `just test-bunit` — 2571 passed / 0 failed (incl. new `testAsListSingleElement`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012QnBvSdwx83u8zNhJBKRdo)_