### PR TITLE
Move New File widget into System Browser as collapsible New Class form

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -222,6 +222,15 @@
   flex: none;
 }
 .panel-head .panel-close:hover { color: var(--ink); background: var(--hover); }
+/* New Class ＋ toggle (BT-2293): a header icon button matching `.panel-close`
+   chrome; `.on` reflects the open form so it reads as a pressed toggle. */
+.panel-head .panel-icon {
+  border: 0; background: transparent; cursor: pointer; color: var(--faint);
+  font-size: 14px; padding: 0 4px; line-height: 1; border-radius: 4px;
+  flex: none;
+}
+.panel-head .panel-icon:hover { color: var(--ink); background: var(--hover); }
+.panel-head .panel-icon.on { color: var(--accent); background: var(--hover); }
 
 /* top-bar panel toggle buttons */
 .topbar .panel-toggles { display: flex; gap: 4px; }
@@ -733,21 +742,22 @@
 }
 .btn-link:hover { color: var(--accent); }
 
-/* New File form (BT-2293): the System Browser's create-a-class affordance under
-   the method editor — a path input + a compact source box + submit. */
-.new-file-form {
-  display: grid; grid-template-columns: 1fr auto; gap: .5rem; margin-top: .75rem;
-  padding-top: .6rem; border-top: 1px solid var(--line-soft); align-items: start;
+/* New Class form (BT-2293): the System Browser's collapsible create-a-class
+   affordance under the panel head — a compact source box + submit. The `.bt`
+   path is derived from the class name server-side, so there is no path field. */
+.new-class-form {
+  display: grid; grid-template-columns: 1fr auto; gap: .5rem; flex: none;
+  padding: .6rem 10px; border-bottom: 1px solid var(--line); align-items: start;
+  background: var(--panel-2);
 }
-.new-file-label { grid-column: 1 / -1; font-size: 12px; font-weight: 600; color: var(--ink); }
-.new-file-path, .new-file-source {
+.new-class-label { grid-column: 1 / -1; font-size: 12px; font-weight: 600; color: var(--ink); }
+.new-class-source {
   border: 1px solid var(--line); background: var(--code-bg); border-radius: 6px;
   padding: 6px 9px; font-size: 12.5px; color: var(--ink); outline: none;
+  grid-column: 1; resize: vertical;
 }
-.new-file-path:focus, .new-file-source:focus { border-color: var(--accent); }
-.new-file-path { grid-column: 1 / -1; }
-.new-file-source { grid-column: 1; resize: vertical; }
-.new-file-form .btn { grid-column: 2; grid-row: 3; align-self: end; }
+.new-class-source:focus { border-color: var(--accent); }
+.new-class-form .btn { grid-column: 2; align-self: end; }
 
 .field {
   border: 1px solid var(--line); background: var(--code-bg); border-radius: 6px;

--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -1029,7 +1029,7 @@ defmodule BtAttach.Workspace do
   (`{ok, ClassObjects} | {error, Reason}`) rather than the raising FFI surface
   (`beamtalk_workspace_interface_primitives:newClass/2`). `source` is the class
   definition (e.g. `"Object subclass: Greeter"`), `path` the in-project target
-  (e.g. `"src/greeter.bt"`).
+  (e.g. `"src/Greeter.bt"`, as the LiveView derives from the class name).
 
   Returns:
 

--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -1020,7 +1020,7 @@ defmodule BtAttach.Workspace do
   @doc """
   Create a brand-new class from a source String at a target path (ADR 0082
   Phase 5 `Workspace newClass:at:`, BT-2293). This is the System Browser's
-  "New File" action — the in-memory class install + a durable
+  "New Class" action — the in-memory class install + a durable
   `kind: "new-class"` ChangeLog entry; the `.bt` file itself is written later on
   `flush/0`.
 

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4525,7 +4525,7 @@ defmodule BtAttachWeb.WorkspaceLive do
           class={["panel-icon", @new_class_open && "on"]}
           phx-click="toggle_new_class"
           aria-expanded={to_string(@new_class_open)}
-          aria-controls={@new_class_open && "new-class-form"}
+          aria-controls={if @new_class_open, do: "new-class-form"}
           aria-label="New class"
           title="New class"
         >

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1200,9 +1200,18 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   # Toggle the System Browser's "New Class" form open/closed (BT-2293). Collapsed
   # by default so it doesn't occupy the class tree's space until the owner wants
-  # to create a class; the ＋ button in the browser head flips it.
+  # to create a class; the ＋ button in the browser head flips it. Opening the
+  # form clears any stale validation/create status from a prior attempt so the
+  # user gets a clean slate.
   def handle_event("toggle_new_class", _params, socket) do
-    {:noreply, assign(socket, new_class_open: !socket.assigns.new_class_open)}
+    opening? = !socket.assigns.new_class_open
+
+    socket =
+      if opening?,
+        do: assign(socket, save_error: nil, save_result: nil),
+        else: socket
+
+    {:noreply, assign(socket, new_class_open: opening?)}
   end
 
   # Create a brand-new class from the New Class form's source ("New Class",
@@ -4501,7 +4510,7 @@ defmodule BtAttachWeb.WorkspaceLive do
           class={["panel-icon", @new_class_open && "on"]}
           phx-click="toggle_new_class"
           aria-expanded={to_string(@new_class_open)}
-          aria-controls="new-class-form"
+          aria-controls={@new_class_open && "new-class-form"}
           aria-label="New class"
           title="New class"
         >
@@ -4529,7 +4538,8 @@ defmodule BtAttachWeb.WorkspaceLive do
         class="new-class-form"
       >
         <label class="new-class-label" for="new-class-source">
-          New Class <span class="muted-note">— path derived from the class name</span>
+          New Class
+          <span class="muted-note">— saved under <code>src/</code> as <code>ClassName.bt</code></span>
         </label>
         <textarea
           id="new-class-source"

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1206,9 +1206,18 @@ defmodule BtAttachWeb.WorkspaceLive do
   def handle_event("toggle_new_class", _params, socket) do
     opening? = !socket.assigns.new_class_open
 
+    # Clear the whole shared status area on open (all four assigns, matching
+    # `status_error/2`) so no stale save *or* flush banner lingers behind the
+    # freshly-opened form.
     socket =
       if opening?,
-        do: assign(socket, save_error: nil, save_result: nil),
+        do:
+          assign(socket,
+            save_error: nil,
+            save_result: nil,
+            flush_error: nil,
+            flush_result: nil
+          ),
         else: socket
 
     {:noreply, assign(socket, new_class_open: opening?)}
@@ -2339,6 +2348,12 @@ defmodule BtAttachWeb.WorkspaceLive do
   # convention) basename match, so the PascalCase name maps cleanly. Returns
   # `:error` when no `… subclass: Name` header is present so the caller can surface
   # a friendly "looks like a class definition?" message instead of a path error.
+  #
+  # The `src/` prefix is assumed — it's the canonical package source dir the
+  # runtime resolves (`resolve_package_module` tries `src/` then `test/`). A
+  # project with a different layout would get a `target_outside_project` error at
+  # creation time (not silently on flush). If per-project source dirs ever land,
+  # this is the spot to read the configured dir instead of hardcoding `src/`.
   @new_class_name_re ~r/\bsubclass:\s*([A-Z][A-Za-z0-9_]*)/
   defp derive_class_path(source) do
     case Regex.run(@new_class_name_re, source) do

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -488,6 +488,10 @@ defmodule BtAttachWeb.WorkspaceLive do
       |> assign(:selected_protocol, nil)
       |> assign(:browser_protocols, [])
       |> assign(:browser_error, nil)
+      # New Class form (BT-2293): the System Browser's owner-only create-a-class
+      # affordance, collapsed by default (it lives in the browser head's ＋ button)
+      # so it never crowds the class tree until wanted.
+      |> assign(:new_class_open, false)
       # Navigation aids (BT-2495, epic BT-2482 Phase 3): the top-bar omni search
       # and the method-editor Senders/Implementors popovers. Both ride thin
       # `:read` facade ops over the navigation channel (ADR 0096), so they work
@@ -1194,19 +1198,28 @@ defmodule BtAttachWeb.WorkspaceLive do
     {:noreply, flush_changes(socket)}
   end
 
-  # Create a brand-new class from the New File form's source + path ("New File",
-  # ADR 0082 Phase 5 `Workspace newClass:at:`, BT-2293). A successful create logs
-  # a durable `new-class` ChangeLog entry (written to disk later on flush) and
-  # appears in the Changes pane.
-  def handle_event("new_file", %{"source" => source, "path" => path}, socket)
-      when is_binary(source) and is_binary(path) do
-    {:noreply, new_file(socket, source, path)}
+  # Toggle the System Browser's "New Class" form open/closed (BT-2293). Collapsed
+  # by default so it doesn't occupy the class tree's space until the owner wants
+  # to create a class; the ＋ button in the browser head flips it.
+  def handle_event("toggle_new_class", _params, socket) do
+    {:noreply, assign(socket, new_class_open: !socket.assigns.new_class_open)}
   end
 
-  # Malformed payload (missing keys / non-binary values): surface a validation
+  # Create a brand-new class from the New Class form's source ("New Class",
+  # ADR 0082 Phase 5 `Workspace newClass:at:`, BT-2293). The target `.bt` path is
+  # *derived from the declared class name* (`Greeter` → `src/Greeter.bt`) rather
+  # than typed — the user thinks in classes, not files. A successful create logs
+  # a durable `new-class` ChangeLog entry (written to disk later on flush) and
+  # appears in the Changes pane.
+  def handle_event("new_class", %{"source" => source}, socket)
+      when is_binary(source) do
+    {:noreply, new_class(socket, source)}
+  end
+
+  # Malformed payload (missing key / non-binary value): surface a validation
   # error rather than letting a crafted event crash the LiveView.
-  def handle_event("new_file", _params, socket) do
-    {:noreply, status_error(socket, "Invalid new-file form payload.")}
+  def handle_event("new_class", _params, socket) do
+    {:noreply, status_error(socket, "Invalid new-class form payload.")}
   end
 
   # Revert one pending in-memory method patch (ADR 0082 Phase 5 `Workspace
@@ -1219,7 +1232,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   # Malformed payload (missing keys / non-binary values): surface a validation
-  # error rather than silently no-op'ing, consistent with `new_file`/`save_method`.
+  # error rather than silently no-op'ing, consistent with `new_class`/`save_method`.
   def handle_event("revert", _params, socket) do
     {:noreply, status_error(socket, "Invalid revert request.")}
   end
@@ -2264,39 +2277,64 @@ defmodule BtAttachWeb.WorkspaceLive do
     end
   end
 
-  # Create a new class from the New File form (BT-2293). Empty source/path is a
-  # local validation error (no round-trip); a real create threads source + path
-  # straight to the workspace newClass chokepoint and refreshes the Changes pane
-  # so the durable `new-class` entry is visible (ChangeLog coherence).
-  defp new_file(socket, source, path) do
-    # Trim both up front so the emptiness guards and the dispatched payload see
-    # the same normalised values (whitespace around a class definition or path
-    # is never significant).
+  # Create a new class from the New Class form (BT-2293). Empty source is a local
+  # validation error (no round-trip); a real create derives the target `.bt` path
+  # from the declared class name (so the user never types a file path), threads
+  # source + derived path straight to the workspace newClass chokepoint, refreshes
+  # the Changes pane so the durable `new-class` entry is visible (ChangeLog
+  # coherence), and collapses the form.
+  defp new_class(socket, source) do
+    # Trim up front so the emptiness guard and the dispatched payload see the same
+    # normalised value (whitespace around a class definition is never significant).
     source = String.trim(source)
-    path = String.trim(path)
 
     cond do
       source == "" ->
-        status_error(socket, "Enter a class definition to create a file.")
-
-      path == "" ->
-        status_error(socket, "Enter a target path to create a file.")
+        status_error(socket, "Enter a class definition to create a class.")
 
       true ->
-        case Facade.dispatch(:new_class, %{source: source, path: path}, ctx(socket)) do
-          {:ok, created_path} ->
-            socket
-            |> assign(
-              save_result: "Created new class — #{created_path}",
-              save_error: nil,
-              flush_result: nil,
-              flush_error: nil
-            )
-            |> assign_changes()
+        case derive_class_path(source) do
+          {:ok, path} ->
+            dispatch_new_class(socket, source, path)
 
-          {:error, reason} ->
-            status_error(socket, facade_error(reason))
+          :error ->
+            status_error(
+              socket,
+              "Couldn't find a class name — start with e.g. `Object subclass: Greeter`."
+            )
         end
+    end
+  end
+
+  defp dispatch_new_class(socket, source, path) do
+    case Facade.dispatch(:new_class, %{source: source, path: path}, ctx(socket)) do
+      {:ok, created_path} ->
+        socket
+        |> assign(
+          save_result: "Created new class — #{created_path}",
+          save_error: nil,
+          flush_result: nil,
+          flush_error: nil,
+          new_class_open: false
+        )
+        |> assign_changes()
+
+      {:error, reason} ->
+        status_error(socket, facade_error(reason))
+    end
+  end
+
+  # Derive the in-project `.bt` path for a new class from its definition's
+  # declared name (BT-2293): `Object subclass: Greeter` → `src/Greeter.bt`. The
+  # runtime's `newClass:at:` validation accepts an exact (`Greeter.bt`, the stdlib
+  # convention) basename match, so the PascalCase name maps cleanly. Returns
+  # `:error` when no `… subclass: Name` header is present so the caller can surface
+  # a friendly "looks like a class definition?" message instead of a path error.
+  @new_class_name_re ~r/\bsubclass:\s*([A-Z][A-Za-z0-9_]*)/
+  defp derive_class_path(source) do
+    case Regex.run(@new_class_name_re, source) do
+      [_, name] -> {:ok, "src/" <> name <> ".bt"}
+      _ -> :error
     end
   end
 
@@ -2322,7 +2360,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   # Set the active error line, clearing the other three status assigns so only
-  # the most recent New File / revert outcome shows in the shared status area
+  # the most recent New Class / revert outcome shows in the shared status area
   # (BT-2293). Keeps the validation/error branches from leaving a stale flush
   # banner visible — the success branches already clear all four inline.
   defp status_error(socket, message) do
@@ -4431,6 +4469,11 @@ defmodule BtAttachWeb.WorkspaceLive do
   attr :browser_classes, :list, required: true
   attr :selected_class, :string, default: nil
   attr :browser_error, :string, default: nil
+  # Owner-only "New Class" affordance (BT-2293): `role` gates the ＋ button (only
+  # the owner can `newClass:at:`); `new_class_open` is the collapsed/expanded
+  # state of the inline create form. Both default so read-only callers can omit.
+  attr :role, :atom, default: :observer
+  attr :new_class_open, :boolean, default: false
 
   defp system_browser_classes(assigns) do
     ~H"""
@@ -4450,6 +4493,20 @@ defmodule BtAttachWeb.WorkspaceLive do
             {label}
           </button>
         </div>
+        <%!-- New Class (BT-2293): owner-only ＋ toggle. Reveals the inline create
+             form below; the new class then appears right in the tree under it. --%>
+        <button
+          :if={@role == :owner}
+          type="button"
+          class={["panel-icon", @new_class_open && "on"]}
+          phx-click="toggle_new_class"
+          aria-expanded={to_string(@new_class_open)}
+          aria-controls="new-class-form"
+          aria-label="New class"
+          title="New class"
+        >
+          ＋
+        </button>
         <button
           type="button"
           class="panel-close"
@@ -4460,6 +4517,32 @@ defmodule BtAttachWeb.WorkspaceLive do
           ×
         </button>
       </div>
+      <%!-- NEW CLASS (BT-2293, ADR 0082 Phase 5): create a brand-new class from a
+           source definition (`Workspace newClass:at:`). The target `.bt` path is
+           derived from the declared class name server-side, so the owner thinks in
+           classes, not files. Collapsed by default; the new-class entry appears in
+           the Changes pane and is written to disk on the next flush. --%>
+      <form
+        :if={@role == :owner and @new_class_open}
+        id="new-class-form"
+        phx-submit="new_class"
+        class="new-class-form"
+      >
+        <label class="new-class-label" for="new-class-source">
+          New Class <span class="muted-note">— path derived from the class name</span>
+        </label>
+        <textarea
+          id="new-class-source"
+          name="source"
+          class="new-class-source mono"
+          rows="2"
+          placeholder="Object subclass: Greeter"
+          phx-mounted={Phoenix.LiveView.JS.focus()}
+        ></textarea>
+        <button class="btn" type="submit" phx-disable-with="Creating…">
+          Create
+        </button>
+      </form>
       <div class="panel-body" id="system-browser-tree" phx-hook="ScrollToSelected">
         <div :if={@browser_error} class="io-block err">{@browser_error}</div>
         <%= if @browser_classes == [] do %>
@@ -4869,6 +4952,8 @@ defmodule BtAttachWeb.WorkspaceLive do
                   browser_classes={@browser_classes}
                   selected_class={@selected_class}
                   browser_error={@browser_error}
+                  role={@role}
+                  new_class_open={@new_class_open}
                 />
                 <.system_browser_methods
                   browser_protocols={@browser_protocols}
@@ -5525,34 +5610,10 @@ defmodule BtAttachWeb.WorkspaceLive do
                         </button>
                       </div>
                     </form>
-
-                    <%!-- NEW FILE (BT-2293, ADR 0082 Phase 5): create a brand-new
-                         class from a source definition at a target `.bt` path
-                         (`Workspace newClass:at:`). Self-contained owner-only form
-                         (its own source + path), so it never depends on the method
-                         editor's tab state. The new-class entry appears in the
-                         Changes pane and is written to disk on the next flush. --%>
-                    <form id="new-file-form" phx-submit="new_file" class="new-file-form">
-                      <label class="new-file-label">
-                        New File <span class="muted-note">— create a class</span>
-                      </label>
-                      <input
-                        type="text"
-                        name="path"
-                        class="new-file-path mono"
-                        placeholder="src/greeter.bt"
-                        autocomplete="off"
-                      />
-                      <textarea
-                        name="source"
-                        class="new-file-source mono"
-                        rows="2"
-                        placeholder="Object subclass: Greeter"
-                      ></textarea>
-                      <button class="btn" type="submit" phx-disable-with="Creating…">
-                        New File
-                      </button>
-                    </form>
+                    <%!-- NEW CLASS (BT-2293, ADR 0082 Phase 5): the create-a-class
+                         affordance now lives in the System Browser head (class-
+                         oriented, collapsed by default), not here under the method
+                         editor — see `system_browser_classes`. --%>
                   <% else %>
                     <p class="muted-note">
                       Your role is read-only — evaluation and editing are disabled. You can

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -87,14 +87,15 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
       assert Process.alive?(view.pid)
     end
 
-    test "the New File form is hidden for an Observer (BT-2293)", %{conn: conn} do
-      # `new_class` is an :execute op, so the write-surface "New File" affordance
-      # is owner-gated in the template (same as the eval form) — an Observer must
-      # not see it.
+    test "the New Class affordance is hidden for an Observer (BT-2293)", %{conn: conn} do
+      # `new_class` is an :execute op, so the System Browser's "New Class"
+      # affordance is owner-gated in the template (same as the eval form) — an
+      # Observer must see neither the ＋ toggle nor the form it reveals.
       {:ok, _view, html} = live(observer_conn(conn), "/")
       assert html =~ "read-only (Observer)"
-      refute html =~ ~s(id="new-file-form")
-      refute html =~ ~s(phx-submit="new_file")
+      refute html =~ ~s(phx-click="toggle_new_class")
+      refute html =~ ~s(id="new-class-form")
+      refute html =~ ~s(phx-submit="new_class")
     end
 
     test "the Tests pane is read-only for an Observer: catalogue listed, Run hidden, run refused (BT-2557)",
@@ -435,63 +436,78 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert view |> form("#eval-form") |> render_submit(%{expr: "6 * 7"}) =~ "42"
   end
 
-  test "the New File form is present on the owner's connected render (BT-2293)", %{conn: conn} do
-    {:ok, _view, html} = live(conn, "/")
+  test "the New Class toggle is present on the owner's connected render (BT-2293)", %{conn: conn} do
+    {:ok, view, html} = live(conn, "/")
 
-    # The System Browser's "New File" affordance: a self-contained source + path
-    # form that drives `Workspace newClass:at:`.
-    assert html =~ ~s(id="new-file-form")
-    assert html =~ ~s(phx-submit="new_file")
-    assert html =~ ~s(name="path")
-    assert html =~ ~s(name="source")
+    # The System Browser's "New Class" affordance is collapsed by default (it must
+    # not crowd the class tree): only the ＋ toggle shows on the connected render.
+    assert html =~ ~s(phx-click="toggle_new_class")
+    refute html =~ ~s(id="new-class-form")
+
+    # Toggling it open reveals the source-only form (no path field — the `.bt`
+    # path is derived from the declared class name server-side).
+    opened = view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
+    assert opened =~ ~s(id="new-class-form")
+    assert opened =~ ~s(phx-submit="new_class")
+    assert opened =~ ~s(name="source")
+    refute opened =~ ~s(name="path")
   end
 
-  test "New File validates an empty path before any create (BT-2293)", %{conn: conn} do
+  test "New Class validates an empty source before any create (BT-2293)", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/")
+    view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
 
     html =
       view
-      |> form("#new-file-form")
-      |> render_submit(%{"source" => "Object subclass: Greeter", "path" => ""})
-
-    assert html =~ "Enter a target path"
-  end
-
-  test "New File validates an empty source before any create (BT-2293)", %{conn: conn} do
-    {:ok, view, _html} = live(conn, "/")
-
-    html =
-      view
-      |> form("#new-file-form")
-      |> render_submit(%{"source" => "", "path" => "src/greeter.bt"})
+      |> form("#new-class-form")
+      |> render_submit(%{"source" => ""})
 
     assert html =~ "Enter a class definition"
   end
 
-  test "New File creates a class end-to-end via newClass:at: (BT-2293)", %{conn: conn} do
+  test "New Class rejects source with no class header (BT-2293)", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/")
-    suffix = System.unique_integer([:positive])
-    class = "Greeter#{suffix}"
-    # The declared class name must match the path basename (snake_cased); a
-    # single-word name + numeric suffix maps cleanly (`Greeter12` ↔ `greeter12`).
-    path = "src/greeter#{suffix}.bt"
+    view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
 
-    # Drive a real `newClass:at:` round-trip — the success path the validation
-    # tests don't reach: button → `:new_class` facade op → workspace
-    # `beamtalk_repl_eval:new_class/2`. Phase 1 installs the class in memory and
-    # logs a durable new-class ChangeEntry; the `.bt` file is only written on
-    # flush, so this leaves no on-disk artifact. A wiring bug (wrong RPC module
-    # or transposed source/path args) would fail here, not just in validation.
+    # No `… subclass: Name` header → there is no class name to derive a path from,
+    # so the LiveView surfaces a friendly hint rather than dispatching a doomed
+    # round-trip.
     html =
       view
-      |> form("#new-file-form")
-      |> render_submit(%{"source" => "Object subclass: #{class}", "path" => path})
+      |> form("#new-class-form")
+      |> render_submit(%{"source" => "1 + 1"})
+
+    assert html =~ "Couldn't find a class name"
+  end
+
+  test "New Class creates a class end-to-end via newClass:at: (BT-2293)", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
+    suffix = System.unique_integer([:positive])
+    class = "Greeter#{suffix}"
+    # The path is derived from the declared class name: `Greeter12` → its exact
+    # PascalCase basename `src/Greeter12.bt` (the stdlib convention the runtime's
+    # `newClass:at:` validation accepts as an exact match).
+    path = "src/#{class}.bt"
+
+    # Drive a real `newClass:at:` round-trip — the success path the validation
+    # tests don't reach: form (source only) → derived path → `:new_class` facade
+    # op → workspace `beamtalk_repl_eval:new_class/2`. Phase 1 installs the class
+    # in memory and logs a durable new-class ChangeEntry; the `.bt` file is only
+    # written on flush, so this leaves no on-disk artifact. A derivation bug
+    # (wrong basename/case) would fail here, not just in validation.
+    html =
+      view
+      |> form("#new-class-form")
+      |> render_submit(%{"source" => "Object subclass: #{class}"})
 
     assert html =~ "Created new class — #{path}"
     refute html =~ "beamtalk_error"
     refute html =~ "{:error"
     # ChangeLog coherence: the new-class entry is now in the Changes viewer.
     assert html =~ class
+    # The form collapses again after a successful create.
+    refute html =~ ~s(id="new-class-form")
   end
 
   # ── Phase 1 JS hook foundation (BT-2485, BT-2539) ───────────────────────────

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -477,7 +477,10 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
       |> form("#new-class-form")
       |> render_submit(%{"source" => "1 + 1"})
 
-    assert html =~ "Couldn't find a class name"
+    # Match a non-apostrophe substring of "Couldn't find a class name …": the
+    # rendered HTML escapes the apostrophe (`Couldn&#39;t`), so asserting the
+    # literal contraction would spuriously fail.
+    assert html =~ "find a class name"
   end
 
   test "New Class creates a class end-to-end via newClass:at: (BT-2293)", %{conn: conn} do


### PR DESCRIPTION
## Problem

The create-a-class affordance in the LiveView IDE was a permanently-expanded **"New File"** form pinned to the bottom of the center method-editor panel. Two problems:

1. **Wrong mental model** — it framed class creation around a *file path* (the user had to invent and type `src/greeter.bt`) when the underlying operation is really "create a class". The facade op was already `:new_class`; the "file" framing was pure UI cruft (the label even read *"New File — create a class"*).
2. **Wasted space** — it occupied fixed vertical room competing with the editing surface, even when idle.

## Change

- **Relocated** to the **System Browser** — the class-oriented panel where new classes already appear in the tree — behind an owner-only **＋ toggle** in the panel head, **collapsed by default**. Create a class → it shows up in the tree right below.
- **Dropped the path field entirely.** The target `.bt` path is now derived from the declared class name server-side (`Object subclass: Greeter` → `src/Greeter.bt`), which the runtime's `newClass:at:` validation accepts as an exact basename match (and `src/` is the canonical package source dir). The user thinks in classes, not files. A source with no `subclass:` header gets a friendly hint instead of a doomed round-trip.
- **Renamed** the event/form/helpers `new_file` → `new_class` to match the operation, and updated the LiveView tests (toggle → derive → create flow; observer still sees neither toggle nor form).
- Focus-on-open via `phx-mounted={JS.focus()}`; the form collapses again after a successful create.

## Files

- `lib/bt_attach_web/live/workspace_live.ex` — form relocation, path derivation, toggle state/event
- `assets/css/app.css` — `.new-file-*` → `.new-class-*`, `.panel-icon` for the ＋ button
- `lib/bt_attach/workspace.ex` — doc wording
- `test/bt_attach_web/workspace_live_test.exs` — rewritten for the new flow

## Testing notes

Verified locally: all changed Elixir files parse cleanly and HEEx structure is balanced; path derivation matches the runtime's `validate_new_class` rules. `mix test`/`mix format` could not run in the dev container (hex.pm unreachable, deps not vendored) — they run on the LiveView IDE CI lane.

Relates to BT-2293 (ADR 0082 Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTffB2ZFNP1P2bt8AcpKcf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTffB2ZFNP1P2bt8AcpKcf)_