### PR TITLE
Collapse the method-editor doc block to remove duplicated docs

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -423,8 +423,10 @@
 }
 .doc-block .doc-caret { color: var(--muted); font-size: 10px; flex: none; }
 .doc-block .doc-sig-text { flex: 1 1 auto; min-width: 0; }
-/* The signature-only (non-collapsible) line keeps its original spacing/divider. */
-.doc-block > .doc-sig {
+/* The signature-only (non-collapsible) line keeps its original spacing/divider.
+   Scoped to `div.doc-sig` so it doesn't also hit the toggle button (which shares
+   the `.doc-sig` class but draws its divider only when `.open`). */
+.doc-block > div.doc-sig {
   margin-bottom: 6px; padding-bottom: 6px; border-bottom: 1px solid var(--line);
 }
 .doc-block .doc-body .doc-h {

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -389,18 +389,43 @@
    docs. `flex: none` so it sits above the growing CodeMirror editor; the body
    scrolls if a long doc would otherwise crowd the editor out. The HTML is
    produced by `BtAttach.DocFormat` (a small, escaped Markdown subset).
+
+   Collapsible (BT-2558): the same `///` text is already present verbatim in the
+   editable source below, so the rendered body would otherwise show it twice and
+   eat the top of the editor. The signature line is always visible and doubles as
+   a collapse toggle (`.doc-toggle`); the `.doc-body` only renders when the block
+   is `.open`. Collapsed, `.doc-block` is just the one-line summary.
    ========================================================================== */
 .doc-block {
-  flex: none; max-height: 40%; overflow: auto;
+  flex: none; overflow: auto;
   margin-bottom: 8px; padding: 8px 10px;
   background: var(--panel-2); border: 1px solid var(--line); border-radius: 6px;
   font-size: 12px; line-height: 1.5; color: var(--muted);
 }
+/* Cap the height only when expanded, so a long doc scrolls instead of crowding
+   the editor; collapsed, the block hugs its single summary line. */
+.doc-block.open { max-height: 40%; }
 .doc-block .doc-sig {
   color: var(--accent-2); font-family: var(--code-font, monospace);
-  font-size: 12px; font-weight: 600; margin-bottom: 6px;
-  padding-bottom: 6px; border-bottom: 1px solid var(--line);
+  font-size: 12px; font-weight: 600;
   white-space: pre-wrap; word-break: break-word;
+}
+/* The signature-as-toggle: a full-width, borderless button that reads as the
+   plain signature line, with a disclosure caret. Only `.open` draws the divider
+   under it (a separator above the body). */
+.doc-block button.doc-toggle {
+  display: flex; align-items: baseline; gap: 6px;
+  width: 100%; margin: 0; padding: 0; text-align: left;
+  background: none; border: none; cursor: pointer;
+}
+.doc-block.open button.doc-toggle {
+  margin-bottom: 6px; padding-bottom: 6px; border-bottom: 1px solid var(--line);
+}
+.doc-block .doc-caret { color: var(--muted); font-size: 10px; flex: none; }
+.doc-block .doc-sig-text { flex: 1 1 auto; min-width: 0; }
+/* The signature-only (non-collapsible) line keeps its original spacing/divider. */
+.doc-block > .doc-sig {
+  margin-bottom: 6px; padding-bottom: 6px; border-bottom: 1px solid var(--line);
 }
 .doc-block .doc-body .doc-h {
   color: var(--ink); font-size: 12px; font-weight: 700;

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -536,6 +536,13 @@ defmodule BtAttachWeb.WorkspaceLive do
       |> assign(:show_browser, true)
       |> assign(:show_inspector, true)
       |> assign(:show_dock, true)
+      # Method-editor doc block (BT-2558) starts collapsed: the signature is
+      # always shown as a one-line summary, but the rendered `///` doc body —
+      # which is *also* present verbatim in the editable source below — is hidden
+      # until the user expands it, so it no longer crowds the editor by default.
+      # Server-held (not a native <details>) so the open state survives the
+      # frequent phx-change re-renders morphdom would otherwise reset.
+      |> assign(:doc_expanded, false)
       |> assign(:windows, [])
       |> assign(:next_window_id, 1)
       |> assign(:window_z, 10)
@@ -1006,6 +1013,14 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   def handle_event("toggle_dock", _params, socket) do
     {:noreply, assign(socket, show_dock: !socket.assigns.show_dock)}
+  end
+
+  # Expand/collapse the method-editor doc block (BT-2558). The signature stays
+  # visible either way; this only reveals/hides the rendered `///` doc body so it
+  # doesn't permanently occupy the top of the editor. Sticky across tab switches —
+  # one preference, not per-method — so a user who wants docs open keeps them open.
+  def handle_event("toggle_doc", _params, socket) do
+    {:noreply, assign(socket, doc_expanded: !socket.assigns.doc_expanded)}
   end
 
   def handle_event("close_browser", _params, socket) do
@@ -2892,6 +2907,13 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   defp doc_text(_), do: nil
+
+  # Summary label for the collapsible doc block (BT-2558) when there is no method
+  # signature to show — i.e. a class-definition tab, whose doc *is* the class
+  # comment. The breadcrumb already names the class, so a short generic label reads
+  # cleanly as the collapse toggle.
+  defp doc_summary_label(%{kind: :def}), do: "Class comment"
+  defp doc_summary_label(_), do: "Documentation"
 
   # The class' comment text (`browse-class-definition` → `comment`) for the
   # class-definition tab's read-only doc block (BT-2558). `nil` when the class
@@ -5520,13 +5542,38 @@ defmodule BtAttachWeb.WorkspaceLive do
                   <% doc_tab = active_tab(assigns) %>
                   <section
                     :if={doc_tab.doc || doc_tab.signature}
-                    class="doc-block"
+                    class={"doc-block" <> if(doc_tab.doc && @doc_expanded, do: " open", else: "")}
                     aria-label="Documentation"
                   >
-                    <div :if={doc_tab.signature} class="doc-sig">{doc_tab.signature}</div>
-                    <div :if={doc_tab.doc} class="doc-body">
-                      {BtAttach.DocFormat.to_html(doc_tab.doc)}
-                    </div>
+                    <%!-- When the tab carries a `///` doc / class comment the
+                         signature line doubles as the collapse toggle (the body is
+                         also present verbatim in the editable source below, so it
+                         stays hidden until asked for). A method with only a
+                         signature has nothing to expand, so it renders as a plain,
+                         non-interactive line. --%>
+                    <%= if doc_tab.doc do %>
+                      <button
+                        type="button"
+                        class="doc-sig doc-toggle"
+                        phx-click="toggle_doc"
+                        aria-expanded={to_string(@doc_expanded)}
+                        title={
+                          if @doc_expanded, do: "Collapse documentation", else: "Expand documentation"
+                        }
+                      >
+                        <span class="doc-caret" aria-hidden="true">
+                          {if @doc_expanded, do: "▾", else: "▸"}
+                        </span>
+                        <span class="doc-sig-text">
+                          {doc_tab.signature || doc_summary_label(doc_tab)}
+                        </span>
+                      </button>
+                      <div :if={@doc_expanded} class="doc-body">
+                        {BtAttach.DocFormat.to_html(doc_tab.doc)}
+                      </div>
+                    <% else %>
+                      <div :if={doc_tab.signature} class="doc-sig">{doc_tab.signature}</div>
+                    <% end %>
                   </section>
                   <%= if @role == :owner do %>
                     <%!-- ⌘S submits this editor form via the KeyboardShortcuts

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -5557,6 +5557,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                         class="doc-sig doc-toggle"
                         phx-click="toggle_doc"
                         aria-expanded={to_string(@doc_expanded)}
+                        aria-controls={if @doc_expanded, do: "doc-body-content"}
                         title={
                           if @doc_expanded, do: "Collapse documentation", else: "Expand documentation"
                         }
@@ -5568,7 +5569,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                           {doc_tab.signature || doc_summary_label(doc_tab)}
                         </span>
                       </button>
-                      <div :if={@doc_expanded} class="doc-body">
+                      <div :if={@doc_expanded} id="doc-body-content" class="doc-body">
                         {BtAttach.DocFormat.to_html(doc_tab.doc)}
                       </div>
                     <% else %>

--- a/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
@@ -65,9 +65,18 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
 
       # The doc block is present, distinct from the editable source.
       assert html =~ ~s(class="doc-block")
-      # Signature (HEEx-escaped `->`).
+      # Signature (HEEx-escaped `->`) — always visible as the collapse toggle.
       assert html =~ "increment -&gt; Counter"
-      # The doc body, rendered from Markdown: prose, a heading, and fenced code.
+      # Collapsed by default (BT-2558): the rendered body (which is also present
+      # verbatim in the editable source) is hidden until expanded, so the docs
+      # aren't shown twice and don't crowd the editor.
+      refute html =~ ~s(class="doc-body")
+
+      # Expanding the block reveals the rendered Markdown: prose, a heading, fenced
+      # code. The signature line doubles as the toggle (phx-click="toggle_doc").
+      html = view |> element(~s(button[phx-click="toggle_doc"])) |> render_click()
+
+      assert html =~ ~s(class="doc-body")
       assert html =~ "Increment the counter by one."
       assert html =~ ~s(<h4 class="doc-h">Examples</h4>)
       assert html =~ "<code>c increment</code>"
@@ -102,6 +111,12 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
         |> render_click()
 
       assert html =~ ~s(class="doc-block")
+      # A class-definition tab has no signature, so the toggle reads "Class comment".
+      assert html =~ "Class comment"
+
+      # Expand to reveal the rendered class comment (collapsed by default, BT-2558).
+      html = view |> element(~s(button[phx-click="toggle_doc"])) |> render_click()
+
       assert html =~ "The Counter class."
       assert html =~ ~s(<h4 class="doc-h">Overview</h4>)
     end

--- a/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
@@ -50,6 +50,13 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
     })
   end
 
+  defp observer_conn(conn) do
+    Plug.Test.init_test_session(conn, %{
+      "bt_user" => %{"sub" => "bob", "groups" => ["beamtalk-observers"]},
+      "bt_logged_in_at" => System.system_time(:second)
+    })
+  end
+
   describe "method doc block (BT-2558)" do
     test "selecting a method shows its signature and rendered doc-comment", %{conn: conn} do
       {:ok, view, _html} = live(owner_conn(conn), "/")
@@ -96,6 +103,49 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
       assert html =~ "value -&gt; Integer"
       # No `///` doc → no rendered doc body.
       refute html =~ ~s(class="doc-body")
+    end
+
+    test "the expanded state is sticky across tab switches", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
+      view |> element(~s(div[phx-value-selector="increment"])) |> render_click()
+
+      # Expand the doc'd method's block.
+      html = view |> element(~s(button[phx-click="toggle_doc"])) |> render_click()
+      assert html =~ ~s(class="doc-body")
+
+      # Switching to a method with no doc collapses to a plain signature (nothing
+      # to expand) but must not reset the preference…
+      html = view |> element(~s(div[phx-value-selector="value"])) |> render_click()
+      refute html =~ ~s(class="doc-body")
+
+      # …so returning to the doc'd method shows the body again *without* re-toggling.
+      html = view |> element(~s(div[phx-value-selector="increment"])) |> render_click()
+      assert html =~ ~s(class="doc-body")
+      assert html =~ "Increment the counter by one."
+    end
+  end
+
+  describe "doc block visibility by role (BT-2558)" do
+    test "an observer sees the read-only doc block", %{conn: conn} do
+      {:ok, view, _html} = live(observer_conn(conn), "/")
+
+      # The doc block rides the `:read`-capability browse ops, so it renders for
+      # an observer even though the editable source form below does not.
+      view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
+
+      html =
+        view
+        |> element(~s(div[phx-value-selector="increment"]))
+        |> render_click()
+
+      assert html =~ ~s(class="doc-block")
+      assert html =~ "increment -&gt; Counter"
+      # The toggle is present and expands the body for an observer too.
+      html = view |> element(~s(button[phx-click="toggle_doc"])) |> render_click()
+      assert html =~ ~s(class="doc-body")
+      assert html =~ "Increment the counter by one."
     end
   end
 


### PR DESCRIPTION
## Problem

The method-editor doc block (BT-2558) renders the active method's `///` doc-comment pretty-printed at the top of the editor — but that same text is **also present verbatim in the editable source below**, so the docs show twice. The rendered block was capped at `max-height: 40%` of the panel, so it ate a large chunk of the editor before you'd typed a thing.

## Change

Make the doc block **collapsible, collapsed by default**:

- The **signature line stays visible** and doubles as the expand/collapse toggle (caret + `phx-click="toggle_doc"`).
- The rendered doc body only renders when expanded, so the docs are no longer shown twice and don't crowd the editor.
- The **editable source remains the single source of truth** for the comment text — you edit the `///` where it lives, and the pretty render is one click away.
- The height cap now applies **only when expanded** (long docs scroll); collapsed, the block hugs its one-line summary.
- State is **server-held** (`:doc_expanded`, toggled via `toggle_doc`) rather than a native `<details>`, so the open state survives the frequent `phx-change` re-renders morphdom would otherwise reset, and it stays **sticky across tab switches**.
- A class-definition tab (no signature) labels the toggle **"Class comment"**.

### Why collapsible over the alternatives
- **Hover** already exists (BT-2555 signature + doc tooltip), but it's transient and undiscoverable as the *primary* surface.
- **Auto-folding the `///` in the editor** would need new infrastructure — the CodeMirror editor bundles no `@codemirror/language` fold extensions. Collapsing the redundant top block was the cleaner, lower-risk fix.

## Tests
- Updated `workspace_doc_block_test.exs` to reflect the collapse-by-default contract (expand before asserting the rendered body; assert the "Class comment" toggle label for a class definition).
- Full `mix test` lane: **187 passed, 109 excluded** (the excluded are the playwright/workspace browser suite that needs a live backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc5TiA1r9KPgR8UzuUtEgc)_