### PR TITLE
fix(liveview): stop method-editor doc block rendering template whitespace

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -405,10 +405,16 @@
 /* Cap the height only when expanded, so a long doc scrolls instead of crowding
    the editor; collapsed, the block hugs its single summary line. */
 .doc-block.open { max-height: 40%; }
+/* `white-space: normal` (not `pre-wrap`): this rule is inherited by the toggle's
+   `.doc-caret` / `.doc-sig-text` spans, whose content carries the HEEx template's
+   own indentation whitespace and newlines. `pre-wrap` would render that leading
+   whitespace verbatim — shoving the caret + signature far to the right (so the
+   line reads as "centred") and adding blank lines that balloon the block.
+   `normal` collapses it; long signatures still wrap via `word-break`. */
 .doc-block .doc-sig {
   color: var(--accent-2); font-family: var(--code-font, monospace);
   font-size: 12px; font-weight: 600;
-  white-space: pre-wrap; word-break: break-word;
+  white-space: normal; word-break: break-word;
 }
 /* The signature-as-toggle: a full-width, borderless button that reads as the
    plain signature line, with a disclosure caret. Only `.open` draws the divider


### PR DESCRIPTION
## Summary

The System Browser's collapsible method-editor doc block (BT-2558) rendered with broken layout: the disclosure caret and signature were shoved to the right (reading as "centred") and the block was padded with blank lines, making the box far too tall.

## Root cause

The signature toggle `<button>` carries class `doc-sig`, and `.doc-block .doc-sig { white-space: pre-wrap }` is **inherited by its child `.doc-caret` / `.doc-sig-text` spans**. Those spans wrap `{...}` interpolations that sit on their own indented HEEx lines, so their text content includes the template's leading newlines and indentation. With `pre-wrap`, that whitespace renders verbatim — pushing the caret/signature right and inflating the block height.

Confirmed by dumping the live-rendered markup, where each span's content is literally `\n` + ~22 spaces around the value.

## Fix

Switch the rule to `white-space: normal`, which collapses the template whitespace. Long signatures still wrap via the existing `word-break: break-word`. The signature-only `div.doc-sig` path interpolates `{doc_tab.signature}` with no surrounding template whitespace, so it's visually unaffected.

## Testing

- Existing `workspace_doc_block_test.exs` suite passes (5/5) — its HTML assertions are unchanged.
- The bug was purely visual CSS (whitespace rendering), which the ExUnit HTML suite can't observe and there's no CSS test harness, so no new automated test is feasible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVMKssLLRHR2NZ9NS7wsC6)_