### PR TITLE
fix(liveview): seed class-definition tab with the class skeleton

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -2893,23 +2893,15 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   defp doc_text(_), do: nil
 
-  # The class' comment text (`browse-class-definition` → `comment`) for the
-  # class-definition tab's read-only doc block (BT-2558). `nil` when the class
-  # carries no comment or the browse fails — the editor then shows no doc block.
-  # This is the same comment `Beamtalk help:` renders, so the browser and the
-  # `help:` send agree on the docs for a class.
-  defp class_comment(socket, class) do
-    {_definition, comment} = class_definition_info(socket, class)
-    comment
-  end
-
   # The class' editable definition skeleton (`browse-class-definition` →
   # `definition`, the synthesized `Super subclass: Name` header + state slots)
   # paired with its doc-block comment, fetched in one browse op. Returns
   # `{definition, comment}` where `definition` is a binary (`""` for a file-less
   # ClassBuilder class with no skeleton, so the editor body is always a string)
-  # and `comment` is the rendered doc text or `nil`. `{"", nil}` if the browse
-  # fails — the tab then opens empty rather than erroring.
+  # and `comment` is the rendered doc text or `nil` (the same comment
+  # `Beamtalk help:` renders, so the browser and `help:` agree on a class' docs).
+  # `{"", nil}` if the browse fails — the tab then opens empty rather than
+  # erroring.
   defp class_definition_info(socket, class) do
     case Facade.dispatch(:browse_class_definition, %{class: class}, ctx(socket)) do
       {:value, %{} = result} ->
@@ -3190,8 +3182,11 @@ defmodule BtAttachWeb.WorkspaceLive do
         # doc block from the live image so an out-of-band class comment change
         # (MCP `save_class`, a `>>` patch) shows on re-focus instead of the
         # snapshot taken at first open. Only `doc:` is touched — the editable
-        # definition buffer and its dirty flag are left untouched.
-        refreshed = %{existing | doc: class_comment(socket, class)}
+        # definition buffer and its dirty flag are left untouched, so an
+        # in-progress edit survives a tab switch. The skeleton `definition` the
+        # browse also returns is intentionally discarded here.
+        {_definition, comment} = class_definition_info(socket, class)
+        refreshed = %{existing | doc: comment}
 
         socket
         |> update_active_tab_by_id(id, fn _ -> refreshed end)

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -2899,9 +2899,30 @@ defmodule BtAttachWeb.WorkspaceLive do
   # This is the same comment `Beamtalk help:` renders, so the browser and the
   # `help:` send agree on the docs for a class.
   defp class_comment(socket, class) do
+    {_definition, comment} = class_definition_info(socket, class)
+    comment
+  end
+
+  # The class' editable definition skeleton (`browse-class-definition` →
+  # `definition`, the synthesized `Super subclass: Name` header + state slots)
+  # paired with its doc-block comment, fetched in one browse op. Returns
+  # `{definition, comment}` where `definition` is a binary (`""` for a file-less
+  # ClassBuilder class with no skeleton, so the editor body is always a string)
+  # and `comment` is the rendered doc text or `nil`. `{"", nil}` if the browse
+  # fails — the tab then opens empty rather than erroring.
+  defp class_definition_info(socket, class) do
     case Facade.dispatch(:browse_class_definition, %{class: class}, ctx(socket)) do
-      {:value, %{"comment" => comment}} -> doc_text(comment)
-      _ -> nil
+      {:value, %{} = result} ->
+        definition =
+          case Map.get(result, "definition") do
+            text when is_binary(text) -> text
+            _ -> ""
+          end
+
+        {definition, doc_text(Map.get(result, "comment"))}
+
+      _ ->
+        {"", nil}
     end
   end
 
@@ -3177,14 +3198,21 @@ defmodule BtAttachWeb.WorkspaceLive do
         |> activate_tab(id)
 
       nil ->
+        # Fetch the class skeleton (header + state slots) and its comment in one
+        # browse op: the skeleton seeds the editable definition body, the comment
+        # the read-only doc block. Without the skeleton the editor opened empty —
+        # the doc block rendered but the class definition itself was missing
+        # (BT-2558 only wired the comment).
+        {definition, comment} = class_definition_info(socket, class)
+
         tab = %{
           id: id,
           kind: :def,
           class: class,
           side: nil,
           selector: nil,
-          source: "",
-          base: "",
+          source: definition,
+          base: definition,
           dirty: false,
           disk_differs: false,
           runtime_only: false,
@@ -3192,7 +3220,7 @@ defmodule BtAttachWeb.WorkspaceLive do
           disk_source: nil,
           # The class comment as the doc block; no per-method signature on a
           # class-definition tab.
-          doc: class_comment(socket, class),
+          doc: comment,
           signature: nil
         }
 

--- a/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
@@ -105,5 +105,19 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
       assert html =~ "The Counter class."
       assert html =~ ~s(<h4 class="doc-h">Overview</h4>)
     end
+
+    test "opening a class definition seeds the editor with the class skeleton",
+         %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      html =
+        view
+        |> element(~s(button[phx-click="open_definition"]))
+        |> render_click()
+
+      # The editable body (distinct from the doc block) carries the class
+      # skeleton the browse op returns — not an empty editor.
+      assert html =~ "Object subclass: Counter"
+    end
   end
 end


### PR DESCRIPTION
## Summary

Opening a class-definition tab in the LiveView System Browser (the **"class definition"** entry, or the **"+ def"** affordance) rendered the read-only doc block from the class comment but left the editor body **empty** — you saw the formatted doc comment but not the actual class definition in the window.

BT-2558 wired only `browse-class-definition`'s `comment` field into the tab; its `definition` field (the synthesized `Super subclass: Name` header + state slots) was never read, and the tab was built with a hardcoded `source: ""`.

## Changes

- Add `class_definition_info/2`, which fetches both `definition` and `comment` from `browse-class-definition` in a **single** browse op and returns `{definition, comment}`.
- `open_definition/2` now seeds the new tab's `source`/`base` with the class skeleton, so the definition shows in the editor alongside its docs.
- `class_comment/2` delegates to the shared helper (the tab re-focus path still refreshes only the doc block, leaving the editable buffer untouched — intentional).
- A file-less ClassBuilder class (`null` definition) still opens an empty editor; a failed browse opens empty rather than erroring.
- Add a regression test asserting the editor body carries the class skeleton (`Object subclass: Counter`), distinct from the doc block.

## Verification

- All 188 LiveView tests pass (`mix test`), including the new case.
- `mix format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxJXSQj7AELnLxZyViXWPy)_