### PR TITLE
docs: daily refresh 2026-06-19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@
 - **LiveView IDE `bin/server` launcher** — the release now includes a `bin/server <workspace-id>` convenience script that resolves node + cookie from `~/.beamtalk/workspaces/` and generates an ephemeral `SECRET_KEY_BASE` if unset (#2555).
 - Fix LiveView IDE eval/inspect/browse sending nested params instead of flat op params to the workspace protocol (BT-2496).
 - Fix LiveView IDE method editor class/selector inputs not populating at mount — fields now sync from the starter tab into edit assigns (BT-2518).
-- **Cockpit: resizeable panels** — all cockpit panel dividers are now draggable (vertical and horizontal), with min-size clamps and `localStorage` persistence across sessions (BT-2576).
+- **Cockpit: resizable panels** — all cockpit panel dividers are now draggable (vertical and horizontal), with min-size clamps and `localStorage` persistence across sessions (BT-2576).
 - **Cockpit: System Browser native-class Erlang source** — `native:` classes show a read-only "Erlang backend" pane on the class-definition tab, with jump-to-implementation from a `self delegate` facade method to the corresponding `handle_call` clause in the backing `.erl` module (BT-2578).
 - **Cockpit: collapsible method-editor doc block** — the method-editor doc block is now collapsed by default (signature line visible as expand/collapse toggle), removing the duplicated doc-comment display between the rendered block and the editable source (BT-2558).
 - **Cockpit: New Class form in System Browser** — the create-a-class widget moves from the method-editor panel into the System Browser header as a collapsed-by-default form; the target path `src/<ClassName>.bt` is derived automatically from the declared class name (BT-2293).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,13 @@
 - **LiveView IDE `bin/server` launcher** — the release now includes a `bin/server <workspace-id>` convenience script that resolves node + cookie from `~/.beamtalk/workspaces/` and generates an ephemeral `SECRET_KEY_BASE` if unset (#2555).
 - Fix LiveView IDE eval/inspect/browse sending nested params instead of flat op params to the workspace protocol (BT-2496).
 - Fix LiveView IDE method editor class/selector inputs not populating at mount — fields now sync from the starter tab into edit assigns (BT-2518).
+- **Cockpit: resizeable panels** — all cockpit panel dividers are now draggable (vertical and horizontal), with min-size clamps and `localStorage` persistence across sessions (BT-2576).
+- **Cockpit: System Browser native-class Erlang source** — `native:` classes show a read-only "Erlang backend" pane on the class-definition tab, with jump-to-implementation from a `self delegate` facade method to the corresponding `handle_call` clause in the backing `.erl` module (BT-2578).
+- **Cockpit: collapsible method-editor doc block** — the method-editor doc block is now collapsed by default (signature line visible as expand/collapse toggle), removing the duplicated doc-comment display between the rendered block and the editable source (BT-2558).
+- **Cockpit: New Class form in System Browser** — the create-a-class widget moves from the method-editor panel into the System Browser header as a collapsed-by-default form; the target path `src/<ClassName>.bt` is derived automatically from the declared class name (BT-2293).
+- Fix LiveView IDE System Browser not showing stdlib class definitions — class definitions are now synthesized from reflection for every loaded class, independent of a disk source file. The method editor opens to an empty tab strip with a "new method" entry for creating methods directly in the browser (#2637, #2634).
+- Fix LiveView IDE method-editor false `expected expression, found ⇒` diagnostics — the `diagnostics` op now accepts a `mode` parameter so the System Browser parses bare method bodies with `parse_method` instead of the full-module grammar (BT-2569).
+- Fix LiveView IDE method-editor doc block rendering template whitespace — `white-space: pre-wrap` on doc-block spans no longer inherits into toggle/signature elements (#2633).
 
 ### Internal
 

--- a/docs/beamtalk-tooling.md
+++ b/docs/beamtalk-tooling.md
@@ -833,16 +833,16 @@ just web <name>   # Start the LiveView IDE, connecting to workspace <name>
 
 **Current capabilities (Cockpit UI):**
 
-- **Tabbed IDE shell** — Cockpit layout with Workspace/Transcript/Changes dock, docked Inspector, method editor, and tweaks panel. CSS-variable theming (theme/accent/syntax-highlight/density/fonts)
+- **Tabbed IDE shell** — Cockpit layout with Workspace/Transcript/Changes dock, docked Inspector, method editor, and tweaks panel. CSS-variable theming (theme/accent/syntax-highlight/density/fonts). All panel dividers are draggable (vertical and horizontal) with min-size clamps and `localStorage` persistence
 - **Workspace pane** — expression evaluation (doIt/printIt/inspectIt) with display-formatted results, same surface-shared rules as CLI / REPL / MCP
 - **Transcript pane** — real-time captured output via `beamtalk_repl_subscriptions`
 - **Bindings pane** — live session bindings list, updated in real time via the bindings subscription stream; object-valued bindings offer an Inspect action
 - **Inspector pane** — navigable `Inspector` cursor view (ADR 0095) with breadcrumb drill navigation, type/pid chips, and drillable reference-following into nested objects. Live tracking mode: field-flash highlights changed fields on actor state writes, freeze/unfreeze toggle, pid stats chips (queue depth, memory, reductions, status), and poke (evaluate expressions against the inspected object). Inspector instances can be popped out into draggable overlay windows for side-by-side comparison
-- **System Browser pane** — hierarchy view (class tree), category view (grouped by package), protocol/selector panes (instance/class side) with layered protocol categorization, method source viewer, and class definition viewer
-- **Method Editor pane** — tabbed editor with compile/save (⌘S), dirty tracking, breadcrumb navigation, class definition view, and Senders/Implementors navigation popovers
+- **System Browser pane** — hierarchy view (class tree), category view (grouped by package), protocol/selector panes (instance/class side) with layered protocol categorization, method source viewer, class definition viewer, and read-only Erlang backend view for `native:` classes (jump from a `self delegate` facade to the backing `handle_call` clause). New Class form (collapsed-by-default) derives the target path `src/<ClassName>.bt` from the declared class name. Stdlib classes show synthesized definitions from reflection
+- **Method Editor pane** — tabbed editor with compile/save (⌘S), dirty tracking, breadcrumb navigation, class definition view, collapsible doc block (collapsed by default), Senders/Implementors navigation popovers, and "new method" entries for creating methods directly from the browser
 - **Omni search** — top-bar class + selector search with keyboard navigation, backed by the `nav-symbols` index
 - **Changes pane** — ChangeLog view of pending edits; Flush persists all changes to disk
-- **System Browser backend** — four browse ops (`browse-classes`, `browse-protocols`, `browse-method-source`, `browse-class-definition`) through `beamtalk_repl_ops` — pure reflection, Observer-grantable `:read` capability (ADR 0096)
+- **System Browser backend** — five browse ops (`browse-classes`, `browse-protocols`, `browse-method-source`, `browse-class-definition`, `browse-native-source`) through `beamtalk_repl_ops` — pure reflection, Observer-grantable `:read` capability (ADR 0096)
 - **Per-tab session isolation** — each browser tab gets its own workspace-supervised session via a per-tab `sessionStorage` token; bindings and loaded classes persist across evals
 - **Session resume** — reconnecting tabs (LiveView reconnect, page reload) resume their existing session within a grace window instead of starting fresh
 - **Hot-reload coherence** — a method saved in one tab is immediately visible to evals in all tabs (inherent to the shared workspace node in the Attach topology)


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 13 commits merged to `main` in the last 24 hours.

**Files updated:**
- `CHANGELOG.md` — 7 new Tooling entries (4 features, 3 fixes)
- `docs/beamtalk-tooling.md` — LiveView IDE capabilities list updated (resizeable panels, native-class Erlang source view, collapsible doc block, New Class form, browse-native-source op, new-method entries)

## Commits reviewed

| SHA | Title | Classification | Doc change |
|-----|-------|---------------|------------|
| `5458984` | System Browser: read-only native backing Erlang source for `native:` classes (BT-2578) | Tooling | CHANGELOG + tooling doc |
| `b17d856` | Fix flush corrupting doc-commented methods (BT-2577) | Tooling fix | Already in CHANGELOG (by commit) |
| `5b9049d` | fix(liveview): show stdlib class definitions; open the method editor empty | Tooling fix | CHANGELOG + tooling doc |
| `d108a29` | Resizeable cockpit panels in the LiveView IDE (BT-2576) | Tooling | CHANGELOG + tooling doc |
| `f832ad3` | Collapse ChangeLog pending view to latest entry per method (BT-2574) | Stdlib + Tooling | Already in CHANGELOG + language-features (by commit) |
| `978e055` | Fix method-editor false diagnostics (BT-2569) | Tooling fix | CHANGELOG |
| `b95f19f` | fix(liveview): seed class-definition tab with the class skeleton | Tooling fix | Combined with `5b9049d` entry |
| `8697a95` | fix(liveview): stop method-editor doc block rendering template whitespace | Tooling fix (minor) | CHANGELOG |
| `cab4c32` | Collapse the method-editor doc block to remove duplicated docs | Tooling | CHANGELOG + tooling doc |
| `0703e7c` | Move New File widget into System Browser as collapsible New Class form | Tooling | CHANGELOG + tooling doc |
| `b727f0f` | Fix beamtalk repl / beamtalk-mcp --start hang on Windows (BT-2568) | Tooling fix | Already in CHANGELOG (by commit) |

### Skipped

| SHA | Title | Reason |
|-----|-------|--------|
| `1865116` | docs(adr-0097): add OS-reserved keybindings as a Tauri justification | Purely under `docs/ADR/` (excluded by scope) |
| `22b8c68` | refactor(codegen): extract generate_while_simple to eliminate while-loop duplication | Internal refactor only — no user-visible change |

## Test plan

- [ ] Verify CHANGELOG entries match existing style (one line per change, user-facing phrasing, BT issue or PR number linked)
- [ ] Verify `docs/beamtalk-tooling.md` LiveView IDE section accurately reflects current capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BamL1HkjNorGC64WXcjbBP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BamL1HkjNorGC64WXcjbBP)_