### PR TITLE
refactor(test): add setUp/tearDown to TypedParamErasureTest

### DIFF
--- a/stdlib/test/bt1944_typed_param_erasure_test.bt
+++ b/stdlib/test/bt1944_typed_param_erasure_test.bt
@@ -5,23 +5,24 @@
 // Adding `:: Integer | Nil` should NOT change runtime behavior.
 
 TestCase subclass: TypedParamErasureTest
+  field: actor = nil
+
+  setUp => self withActor: BT1944TypedParamActor spawn
+
+  tearDown => self.actor isNil ifFalse: [self.actor stop]
 
   testUntypedParamNil =>
-    actor := BT1944TypedParamActor spawn
-    actor doUntyped: nil
-    self assert: actor count equals: 1
+    self.actor doUntyped: nil
+    self assert: self.actor count equals: 1
 
   testTypedParamNil =>
-    actor := BT1944TypedParamActor spawn
-    actor doTyped: nil
-    self assert: actor count equals: 1
+    self.actor doTyped: nil
+    self assert: self.actor count equals: 1
 
   testTypedObjectParamNil =>
-    actor := BT1944TypedParamActor spawn
-    actor doTypedObject: nil
-    self assert: actor count equals: 1
+    self.actor doTypedObject: nil
+    self assert: self.actor count equals: 1
 
   testTypedParamInteger =>
-    actor := BT1944TypedParamActor spawn
-    actor doTyped: 42
-    self assert: actor count equals: 1
+    self.actor doTyped: 42
+    self assert: self.actor count equals: 1


### PR DESCRIPTION
## Summary

Fixes #2646. Removes 4 duplicate `BT1944TypedParamActor spawn` lines from `stdlib/test/bt1944_typed_param_erasure_test.bt` by introducing a `field: actor` with `setUp`/`tearDown`, following the established pattern used by `actor_monitor_test.bt`, `actor_conditional_mutations_test.bt`, and others.

Each test method was ⅓ setup boilerplate. After this change the test body is purely the typed-param erasure assertion.

## Changes

- `stdlib/test/bt1944_typed_param_erasure_test.bt`: add `field: actor = nil`, `setUp`, `tearDown`; replace 4 local spawn lines with `self.actor` references

## Test plan

- [x] `just test-bunit` — 2580 tests, 0 failed
- [x] Lint clean (bt-lint-checker)
- [x] Pre-push CI hook passed (dialyzer, clippy, fmt, BUnit, stdlib tests)

🤖 Generated with Claude Code

https://claude.ai/code/session_017gN8t3tj4KAdK5vtfQdHLf

---
_Generated by [Claude Code](https://claude.ai/code/session_017gN8t3tj4KAdK5vtfQdHLf)_