### PR TITLE
refactor(workspace): normalize unknown diagnostics mode at Erlang op boundary (BT-2572)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -39,7 +39,10 @@ Extracted from beamtalk_repl_server (BT-705).
 -ifdef(TEST).
 -export([
     get_session_bindings/1,
-    validate_selector_if_present/4
+    validate_selector_if_present/4,
+    %% BT-2572: white-box test of the diagnostics `mode` normalisation that
+    %% mirrors the Elixir facade at the Erlang op boundary.
+    normalize_diagnostics_mode/1
 ]).
 -endif.
 
@@ -151,7 +154,15 @@ handle_term(<<"diagnostics">>, Params, _Msg, _SessionPid) ->
     %% method body — the System Browser method editor, where the `=>` body
     %% separator is not a valid top-level token).
     Code = maps:get(<<"code">>, Params, <<>>),
-    Mode = maps:get(<<"mode">>, Params, <<"expression">>),
+    %% BT-2572: normalise an unknown-binary `mode` to <<"expression">> here, at
+    %% the Erlang op boundary, mirroring the Elixir `BtAttach.Facade` (which maps
+    %% anything but "method" to "expression"). Without this, an unknown binary
+    %% (e.g. <<"foo">>) flowed straight to the Rust port, which only special-cases
+    %% "method" and treats everything else as expression mode — so the runtime
+    %% behaviour was already correct, but the Erlang boundary was more permissive
+    %% than the facade. A non-binary `mode` is passed through unchanged so it
+    %% still degrades to `[]` via the `diagnostics_for/2` catch-all (BT-2569).
+    Mode = normalize_diagnostics_mode(maps:get(<<"mode">>, Params, <<"expression">>)),
     {diagnostics, diagnostics_for(Code, Mode)};
 handle_term(<<"erlang-complete">>, Params, _Msg, _SessionPid) ->
     %% BT-1903: Tab completion for `:h Erlang <module>` and `:h Erlang <mod> <fn>`.
@@ -863,6 +874,24 @@ diagnostics_for(Code, Mode) when is_binary(Code), is_binary(Mode) ->
 %% spec honest at the Erlang boundary (BT-2569).
 diagnostics_for(_, _) ->
     [].
+
+-doc """
+Normalise the `diagnostics` `mode` param at the Erlang op boundary (BT-2572).
+
+Mirrors the Elixir `BtAttach.Facade` (`invoke(:diagnostics, ...)`): a binary
+`mode` of <<"method">> is preserved; any other binary (e.g. <<"foo">>) is
+normalised to the safe default <<"expression">>. A non-binary `mode` is passed
+through unchanged so `diagnostics_for/2`'s catch-all still degrades it to `[]`
+(the existing BT-2569 behaviour) rather than silently treating it as expression
+mode.
+""".
+-spec normalize_diagnostics_mode(term()) -> term().
+normalize_diagnostics_mode(<<"method">>) ->
+    <<"method">>;
+normalize_diagnostics_mode(Mode) when is_binary(Mode) ->
+    <<"expression">>;
+normalize_diagnostics_mode(Mode) ->
+    Mode.
 
 -doc """
 Resolve hover documentation for the hovered token (BT-2555).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl
@@ -326,6 +326,58 @@ diagnostics_empty_code_encodes_done_status_test() ->
     ?assertEqual([<<"done">>], maps:get(<<"status">>, Decoded)).
 
 %%====================================================================
+%% normalize_diagnostics_mode/1 -- diagnostics mode normalisation (BT-2572)
+%%
+%% The Erlang op boundary normalises an unknown-binary `mode` to
+%% <<"expression">>, mirroring the Elixir BtAttach.Facade (anything but
+%% "method" -> "expression"). A non-binary `mode` is passed through unchanged so
+%% diagnostics_for/2's catch-all still degrades it to [] (BT-2569). These are
+%% white-box checks of the pure normaliser, so no compiler/port is needed.
+%%====================================================================
+
+diagnostics_unknown_binary_mode_normalised_to_expression_test() ->
+    %% BT-2572: an unknown binary mode (e.g. <<"foo">>) is normalised to the safe
+    %% default at the Erlang layer, not just in the Rust port.
+    ?assertEqual(
+        <<"expression">>,
+        beamtalk_repl_ops_dev:normalize_diagnostics_mode(<<"foo">>)
+    ).
+
+diagnostics_method_mode_preserved_test() ->
+    %% No behaviour change for the known <<"method">> mode.
+    ?assertEqual(
+        <<"method">>,
+        beamtalk_repl_ops_dev:normalize_diagnostics_mode(<<"method">>)
+    ).
+
+diagnostics_expression_mode_preserved_test() ->
+    %% No behaviour change for the known <<"expression">> mode.
+    ?assertEqual(
+        <<"expression">>,
+        beamtalk_repl_ops_dev:normalize_diagnostics_mode(<<"expression">>)
+    ).
+
+diagnostics_empty_binary_mode_normalised_to_expression_test() ->
+    %% An empty binary is "not method" and so normalises to expression.
+    ?assertEqual(
+        <<"expression">>,
+        beamtalk_repl_ops_dev:normalize_diagnostics_mode(<<>>)
+    ).
+
+diagnostics_non_binary_mode_passed_through_unchanged_test() ->
+    %% A non-binary mode is NOT normalised — it is passed through so the
+    %% diagnostics_for/2 catch-all degrades it to [] (BT-2569), rather than being
+    %% silently coerced into expression mode.
+    ?assertEqual(
+        42,
+        beamtalk_repl_ops_dev:normalize_diagnostics_mode(42)
+    ),
+    ?assertEqual(
+        undefined,
+        beamtalk_repl_ops_dev:normalize_diagnostics_mode(undefined)
+    ).
+
+%%====================================================================
 %% handle/4 -- show-codegen class+selector (BT-1236)
 %%====================================================================
 


### PR DESCRIPTION
## Summary

Mirrors the Elixir `BtAttach.Facade` normalization at the Erlang `diagnostics` op boundary: an unknown **binary** `mode` (e.g. `<<"foo">>`) now normalizes to `<<"expression">>` at the Erlang layer instead of relying on the Rust port's silent fallback. Non-binary modes continue to degrade to `[]` via the existing catch-all. No behaviour change for `<<"method">>` / `<<"expression">>` / absent mode. Makes a raw TCP/MCP client hitting the op directly see the same contract as the Elixir facade.

## Changes

- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl`: normalize unknown-binary mode at the op boundary.
- `runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl`: unit test for the unknown-binary case.

## Linear

https://linear.app/beamtalk/issue/BT-2572

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cr41od4p5JmVtW3yETyKd3)_