### PR TITLE
fix(liveview): persist doc-block expand state across WebSocket reconnect (BT-2570)

### DIFF
--- a/editors/liveview/lib/bt_attach/session_registry.ex
+++ b/editors/liveview/lib/bt_attach/session_registry.ex
@@ -82,6 +82,7 @@ defmodule BtAttach.SessionRegistry do
       :reap_timer,
       :reap_tag,
       :window_stash,
+      :doc_stash,
       :owner_pid
     ]
   end
@@ -163,6 +164,38 @@ defmodule BtAttach.SessionRegistry do
   def window_stash(server \\ __MODULE__, token)
   def window_stash(_server, token) when not is_binary(token), do: nil
   def window_stash(server, token), do: GenServer.call(server, {:take_stash, token})
+
+  @doc """
+  Stash `token`'s method-editor doc-block expand state so a resume can restore it.
+
+  Called from the LiveView's `terminate/2` alongside `release/1`. The read-only
+  doc block's expand/collapse state (`:doc_expanded`) is a socket assign, so a
+  reconnect — which mounts a brand-new process with `:doc_expanded` back at its
+  collapsed default — would otherwise re-collapse a block the user had expanded
+  on any transient socket drop, redeploy, or laptop wake (BT-2570). The stash
+  rides the registry entry (Phoenix-node memory that outlives the reconnect) and
+  is read back by `doc_stash/2` on the resuming mount. A `nil`/non-binary or
+  unknown token is a harmless no-op; the stash dies with the entry when the
+  session is reaped, so a genuinely-closed tab leaves nothing.
+  """
+  @spec stash_doc(GenServer.server(), term(), term()) :: :ok
+  def stash_doc(server \\ __MODULE__, token, expanded)
+  def stash_doc(_server, token, _expanded) when not is_binary(token), do: :ok
+
+  def stash_doc(server, token, expanded),
+    do: GenServer.call(server, {:stash_doc, token, expanded})
+
+  @doc """
+  Read (and clear) `token`'s stashed doc-block expand state, or `nil` when none.
+
+  Read once by the resuming mount after `checkout/1` resumes the session; the
+  stash is cleared so a later re-render can't replay a stale value. A
+  `nil`/non-binary or unknown token returns `nil`.
+  """
+  @spec doc_stash(GenServer.server(), term()) :: term() | nil
+  def doc_stash(server \\ __MODULE__, token)
+  def doc_stash(_server, token) when not is_binary(token), do: nil
+  def doc_stash(server, token), do: GenServer.call(server, {:take_doc_stash, token})
 
   @doc """
   Mark `token`'s session releasable: schedule a grace-period reap.
@@ -249,6 +282,28 @@ defmodule BtAttach.SessionRegistry do
     case Map.fetch(state.entries, token) do
       {:ok, %Entry{window_stash: stash} = entry} ->
         {:reply, stash, put_entry(state, token, %Entry{entry | window_stash: nil})}
+
+      :error ->
+        {:reply, nil, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:stash_doc, token, expanded}, _from, state) do
+    case Map.fetch(state.entries, token) do
+      {:ok, %Entry{} = entry} ->
+        {:reply, :ok, put_entry(state, token, %Entry{entry | doc_stash: expanded})}
+
+      :error ->
+        {:reply, :ok, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:take_doc_stash, token}, _from, state) do
+    case Map.fetch(state.entries, token) do
+      {:ok, %Entry{doc_stash: stash} = entry} ->
+        {:reply, stash, put_entry(state, token, %Entry{entry | doc_stash: nil})}
 
       :error ->
         {:reply, nil, state}

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -296,6 +296,7 @@ defmodule BtAttachWeb.WorkspaceLive do
               socket
               |> bind_session(session_id, pid)
               |> restore_windows(token, origin)
+              |> restore_doc(token, origin)
 
             {:error, reason} ->
               assign(socket,
@@ -548,7 +549,11 @@ defmodule BtAttachWeb.WorkspaceLive do
       # which is *also* present verbatim in the editable source below — is hidden
       # until the user expands it, so it no longer crowds the editor by default.
       # Server-held (not a native <details>) so the open state survives the
-      # frequent phx-change re-renders morphdom would otherwise reset.
+      # frequent phx-change re-renders morphdom would otherwise reset. This is the
+      # collapsed default for a fresh session; on a reconnect (which mounts a brand-
+      # new process) the prior expand state is restored from the registry stash by
+      # `restore_doc/3`, so an expanded block stays expanded across a socket drop,
+      # redeploy, or laptop wake (BT-2570).
       |> assign(:doc_expanded, false)
       |> assign(:windows, [])
       |> assign(:next_window_id, 1)
@@ -1034,7 +1039,10 @@ defmodule BtAttachWeb.WorkspaceLive do
   # Expand/collapse the method-editor doc block (BT-2558). The signature stays
   # visible either way; this only reveals/hides the rendered `///` doc body so it
   # doesn't permanently occupy the top of the editor. Sticky across tab switches —
-  # one preference, not per-method — so a user who wants docs open keeps them open.
+  # one preference, not per-method — so a user who wants docs open keeps them open,
+  # and sticky across reconnects too (BT-2570): `terminate/2` stashes this flag in
+  # the registry and `restore_doc/3` re-applies it on the resuming mount, so a
+  # socket drop / redeploy / laptop wake no longer re-collapses an expanded block.
   def handle_event("toggle_doc", _params, socket) do
     {:noreply, assign(socket, doc_expanded: !socket.assigns.doc_expanded)}
   end
@@ -1756,10 +1764,13 @@ defmodule BtAttachWeb.WorkspaceLive do
       case socket.assigns[:token] do
         token when is_binary(token) ->
           # Resumable session: stash the open floating-inspector windows so a
-          # reconnect within the grace window rebuilds the desk (BT-2527 #3), then
-          # defer teardown to the grace window. The stash dies with the entry if
-          # no reconnect arrives, so a genuinely-closed tab leaves nothing behind.
+          # reconnect within the grace window rebuilds the desk (BT-2527 #3), and
+          # likewise stash the doc-block expand state so an expanded block survives
+          # the reconnect rather than re-collapsing (BT-2570), then defer teardown
+          # to the grace window. The stash dies with the entry if no reconnect
+          # arrives, so a genuinely-closed tab leaves nothing behind.
           SessionRegistry.stash_windows(token, build_window_stash(socket))
+          SessionRegistry.stash_doc(token, socket.assigns[:doc_expanded])
           SessionRegistry.release(token)
 
         _ ->
@@ -4092,6 +4103,25 @@ defmodule BtAttachWeb.WorkspaceLive do
 
       _ ->
         socket
+    end
+  end
+
+  # Restore the method-editor doc-block expand state on a genuine session resume
+  # (BT-2570). The block's `:doc_expanded` is a socket assign that a fresh mount —
+  # which every reconnect is — re-inits to its collapsed default, so a user who
+  # expanded it would lose that on any transient socket drop, redeploy, or laptop
+  # wake. `terminate/2` stashes the flag in the registry (Phoenix-node memory that
+  # outlives the reconnect); here we read it back and re-apply it. A fresh session
+  # or a failed bind (not connected) leaves the collapsed default untouched; a
+  # missing stash (nothing was expanded) likewise leaves the default.
+  defp restore_doc(socket, _token, :fresh), do: socket
+
+  defp restore_doc(socket, token, :resumed) do
+    with true <- socket.assigns[:connected],
+         expanded when is_boolean(expanded) <- SessionRegistry.doc_stash(token) do
+      assign(socket, :doc_expanded, expanded)
+    else
+      _ -> socket
     end
   end
 

--- a/editors/liveview/test/bt_attach/session_registry_test.exs
+++ b/editors/liveview/test/bt_attach/session_registry_test.exs
@@ -105,6 +105,42 @@ defmodule BtAttach.SessionRegistryTest do
     assert SessionRegistry.window_stash(reg, "tab-stash") == nil
   end
 
+  test "stash_doc persists the doc-block state that doc_stash reads once on resume (BT-2570)",
+       %{reg: reg} do
+    pid = fake_session()
+    SessionRegistry.register(reg, "tab-doc", "phoenix-doc", pid)
+
+    # Nothing stashed yet — a first connect has no prior expand state.
+    assert SessionRegistry.doc_stash(reg, "tab-doc") == nil
+
+    # terminate/2 stashes the expanded flag before the grace window opens.
+    assert :ok = SessionRegistry.stash_doc(reg, "tab-doc", true)
+
+    # The resuming mount reads it once and re-applies it...
+    assert SessionRegistry.doc_stash(reg, "tab-doc") == true
+    # ...then it's cleared, so a later re-render can't replay a stale value.
+    assert SessionRegistry.doc_stash(reg, "tab-doc") == nil
+  end
+
+  test "stash_doc round-trips a collapsed state too (BT-2570)", %{reg: reg} do
+    pid = fake_session()
+    SessionRegistry.register(reg, "tab-doc2", "phoenix-doc2", pid)
+
+    # A user who collapsed an expanded block should keep it collapsed on resume:
+    # `false` is a real preference, distinct from "nothing stashed" (`nil`).
+    assert :ok = SessionRegistry.stash_doc(reg, "tab-doc2", false)
+    assert SessionRegistry.doc_stash(reg, "tab-doc2") == false
+    assert SessionRegistry.doc_stash(reg, "tab-doc2") == nil
+  end
+
+  test "a doc stash for an unknown/non-binary token is a harmless no-op (BT-2570)", %{reg: reg} do
+    assert :ok = SessionRegistry.stash_doc(reg, "never", true)
+    assert SessionRegistry.doc_stash(reg, "never") == nil
+
+    assert :ok = SessionRegistry.stash_doc(reg, 123, true)
+    assert SessionRegistry.doc_stash(reg, nil) == nil
+  end
+
   test "a stash for an unknown/non-binary token is a harmless no-op", %{reg: reg} do
     # Unknown token: nothing to attach the stash to, and nothing to read back.
     assert :ok = SessionRegistry.stash_windows(reg, "never", %{windows: []})

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -1484,6 +1484,34 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert selected_inspector_mode(html) == "float"
   end
 
+  test "the doc-block expand state survives a socket reconnect (BT-2570)", %{conn: conn} do
+    # A transient socket drop / redeploy / laptop wake must not re-collapse a doc
+    # block the user had expanded: `:doc_expanded` is a socket assign a fresh mount
+    # (which every reconnect is) re-inits to its collapsed default, so terminate/2
+    # stashes it in the registry and the resuming mount restores it. Same token
+    # across two mounts simulates the drop + reconnect (mirrors the window-resume
+    # test above). We drive the `toggle_doc` event and read the restored assign off
+    # the socket — `:doc_expanded` rides the editor toggle independently of whether
+    # any docced method is open, so the resume is asserted at the assign level.
+    conn = with_token(conn, "doc-resume-#{System.unique_integer([:positive])}")
+
+    {:ok, view1, _} = live(conn, "/")
+    assert :sys.get_state(view1.pid).socket.assigns.doc_expanded == false
+
+    # Expand the doc block on the first mount.
+    render_click(view1, "toggle_doc", %{})
+    assert :sys.get_state(view1.pid).socket.assigns.doc_expanded == true
+
+    # Disconnect: terminate/2 stashes the expand state and opens the grace window.
+    GenServer.stop(view1.pid)
+
+    # Reconnect inside the grace window with the SAME token: the session resumes and
+    # the stashed expand state is restored — the new mount comes up expanded even
+    # though its fresh assigns started from the collapsed default.
+    {:ok, view2, _} = live(conn, "/")
+    assert eventually(fn -> :sys.get_state(view2.pid).socket.assigns.doc_expanded == true end)
+  end
+
   test "Tidy windows re-cascades every window back on-screen (BT-2527)", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/")
     name = spawn_counter(view)


### PR DESCRIPTION
## Summary

The LiveView IDE method editor's read-only doc block (`:doc_expanded`) was re-initialised to `false` on every connected `mount/3`, including reconnects — so an expanded doc block silently collapsed on any WebSocket reconnect (network blip, redeploy, laptop wake), contradicting the surrounding "sticky" framing. This persists the expand state across reconnects using the existing `SessionRegistry` stash/restore pattern.

## Changes

- `editors/liveview/lib/bt_attach_web/live/workspace_live.ex`: stash/restore `:doc_expanded` across reconnect.
- `editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs`: covering test that the expanded state survives a reconnect.

(See the implementing commit for the exact approach taken — Option 1 persist vs. Option 2 document.)

## Linear

https://linear.app/beamtalk/issue/BT-2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cr41od4p5JmVtW3yETyKd3)_