### PR TITLE
refactor: use receiver helper fns consistently in validators

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/validators/class_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/class_validators.rs
@@ -71,15 +71,8 @@ fn visit_abstract_instantiation(
             span,
             ..
         } => {
-            let receiver_name = match receiver.as_ref() {
-                Expression::Identifier(Identifier { name, .. }) => Some(name.as_str()),
-                Expression::ClassReference { name, .. } => Some(name.name.as_str()),
-                _ => None,
-            };
-
-            if let Some(name) = receiver_name {
+            if let Some(name) = receiver_class_name(receiver) {
                 let selector_name = selector.name();
-
                 if is_instantiation_selector(&selector_name) && hierarchy.is_abstract(name) {
                     diagnostics.push(abstract_class_error(name, *span));
                 }
@@ -88,12 +81,7 @@ fn visit_abstract_instantiation(
         Expression::Cascade {
             receiver, messages, ..
         } => {
-            let receiver_name = match receiver.as_ref() {
-                Expression::Identifier(Identifier { name, .. }) => Some(name.as_str()),
-                Expression::ClassReference { name, .. } => Some(name.name.as_str()),
-                _ => None,
-            };
-            if let Some(name) = receiver_name {
+            if let Some(name) = receiver_class_name(receiver) {
                 for msg in messages {
                     let sel = msg.selector.name();
                     if is_instantiation_selector(&sel) && hierarchy.is_abstract(name) {

--- a/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
@@ -106,6 +106,16 @@ fn dead_branch_hint(is_true: bool, selector: WellKnownSelector) -> &'static str 
     }
 }
 
+/// Returns `Some(true)` if `receiver` is the identifier `true`, `Some(false)` if `false`,
+/// or `None` for any other expression.
+fn literal_bool_receiver(receiver: &Expression) -> Option<bool> {
+    match receiver {
+        Expression::Identifier(Identifier { name, .. }) if name == "true" => Some(true),
+        Expression::Identifier(Identifier { name, .. }) if name == "false" => Some(false),
+        _ => None,
+    }
+}
+
 /// Checks a single expression node for literal boolean conditional patterns.
 ///
 /// Called by [`walk_module`] via [`check_literal_boolean_condition`]; the walker
@@ -118,12 +128,7 @@ fn check_literal_boolean_condition_at(expr: &Expression, diagnostics: &mut Vec<D
         ..
     } = expr
     {
-        let literal_val = match receiver.as_ref() {
-            Expression::Identifier(Identifier { name, .. }) if name == "true" => Some(true),
-            Expression::Identifier(Identifier { name, .. }) if name == "false" => Some(false),
-            _ => None,
-        };
-        if let Some(is_true) = literal_val {
+        if let Some(is_true) = literal_bool_receiver(receiver) {
             if let Some(well_known) = boolean_conditional(selector) {
                 let literal_name = if is_true { "true" } else { "false" };
                 diagnostics.push(
@@ -140,12 +145,7 @@ fn check_literal_boolean_condition_at(expr: &Expression, diagnostics: &mut Vec<D
         receiver, messages, ..
     } = expr
     {
-        let literal_val = match receiver.as_ref() {
-            Expression::Identifier(Identifier { name, .. }) if name == "true" => Some(true),
-            Expression::Identifier(Identifier { name, .. }) if name == "false" => Some(false),
-            _ => None,
-        };
-        if let Some(is_true) = literal_val {
+        if let Some(is_true) = literal_bool_receiver(receiver) {
             let literal_name = if is_true { "true" } else { "false" };
             for msg in messages {
                 if let Some(well_known) = boolean_conditional(&msg.selector) {


### PR DESCRIPTION
## Summary

Two validator functions were manually inlining a `match receiver.as_ref()` block instead of calling the private helper functions that already existed for exactly that purpose.

### `class_validators.rs` — `visit_abstract_instantiation`

The file defines `receiver_class_name(receiver: &Expression) -> Option<&str>` at line 112, used at 12 call sites throughout the file. `visit_abstract_instantiation` was the sole exception — it duplicated the same 4-line match block twice (once for `MessageSend`, once for `Cascade`). Replace both with `receiver_class_name(receiver)`.

### `lint_validators.rs` — `check_literal_boolean_condition_at`

The same 4-line `match receiver.as_ref()` pattern for extracting a literal boolean receiver appeared twice in the same function (MessageSend branch and Cascade branch). Extract a private `literal_bool_receiver(receiver: &Expression) -> Option<bool>` helper and call it in both branches.

## Changes

- `crates/beamtalk-core/src/semantic_analysis/validators/class_validators.rs` — 2 inline match blocks replaced with `receiver_class_name(receiver)` calls
- `crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs` — new `literal_bool_receiver()` helper, 2 inline match blocks replaced

**Net: 2 files, -12 lines. Zero behaviour change.**

## Test plan

- [x] `just clippy` — clean
- [x] `just fmt-check` — clean
- [x] `just dialyzer` — clean (run via pre-push hook)
- [x] `just test` — passes (Rust unit tests + BUnit + stdlib)
- [x] Pre-push hook passed in full

> **Note:** `just check-corpus` fails on `main` HEAD (corpus.json pre-existing out-of-date) — this is unrelated to this PR and not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015zM9KqvpEz2SjgbT4jY56d)_