### PR TITLE
Tests pane: async run/load + clear browser selection on filter narrow (BT-2597)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -406,6 +406,11 @@ defmodule BtAttachWeb.WorkspaceLive do
       |> assign(:test_classes, nil)
       |> assign(:test_results, nil)
       |> assign(:tests_error, nil)
+      # BT-2597: a run/load is in flight on the workspace node. Set while the
+      # `:test_op` async task runs so the run/load controls disable themselves —
+      # `phx-disable-with` alone reverts as soon as the (now-immediate) event
+      # handler re-renders, since the work moved off-socket to `start_async`.
+      |> assign(:tests_running, false)
       # REPL tab (BT-2543): a classic TUI request→response scrollback with the
       # input pinned at the bottom. `:repl` is the scrollback stream (so long
       # history never bloats the assigns/diff); `:repl_seq` mints stable entry
@@ -1494,9 +1499,22 @@ defmodule BtAttachWeb.WorkspaceLive do
   # Narrow the class tree by source origin (project / deps / stdlib / all). Pure
   # view state over the already-loaded rows — no workspace round-trip; an unknown
   # value is ignored rather than blanking the tree (BT-2596).
+  #
+  # BT-2597: if the new filter hides the currently-selected class, clear the
+  # selection (and its protocol/method pane) so the right pane can't show a
+  # "ghost" selection for a class no longer visible in the tree.
   def handle_event("browser_source", %{"src" => src}, socket)
       when src in ~w(all project deps stdlib) do
-    {:noreply, assign(socket, browser_source: src)}
+    socket = assign(socket, browser_source: src)
+
+    socket =
+      if selected_class_visible?(socket) do
+        socket
+      else
+        assign(socket, selected_class: nil, selected_protocol: nil, browser_protocols: [])
+      end
+
+    {:noreply, socket}
   end
 
   def handle_event("browser_source", _params, socket), do: {:noreply, socket}
@@ -1845,6 +1863,40 @@ defmodule BtAttachWeb.WorkspaceLive do
        git_status: nil,
        git_log: [],
        git_error: "Couldn't load git status — the load failed unexpectedly."
+     )}
+  end
+
+  # BT-2597: the off-socket test run/load (`run_tests/2` / `load_tests/1`)
+  # completed. The task tags its dispatch result `{:run, _}` or `{:load, _}` so
+  # the right result-application path runs; either way the op is no longer in
+  # flight, so the controls re-enable.
+  def handle_async(:test_op, {:ok, {:run, dispatch_result}}, socket) do
+    {:noreply, socket |> apply_test_result(dispatch_result) |> assign(tests_running: false)}
+  end
+
+  def handle_async(:test_op, {:ok, {:load, dispatch_result}}, socket) do
+    {:noreply, socket |> apply_test_load(dispatch_result) |> assign(tests_running: false)}
+  end
+
+  # A newer run/load `cancel_async`-ed this one. Safe as a no-op only because
+  # every `cancel_async(:test_op, …)` is immediately followed by a paired
+  # `start_async(:test_op, …)` (in `run_tests/2` / `load_tests/1`) that has
+  # already set `tests_running: true` — so the replacement task owns the running
+  # state. A future standalone `cancel_async(:test_op, …)` (e.g. a Cancel button)
+  # would need to reset `tests_running` itself. Mirrors the `:git_load` no-op.
+  def handle_async(:test_op, {:exit, :cancelled}, socket), do: {:noreply, socket}
+
+  def handle_async(:test_op, {:exit, reason}, socket) do
+    Logger.error("test run/load crashed: #{inspect(reason)}", domain: [:beamtalk, :liveview])
+
+    # Clear any prior run's results so a stale pass/fail table can't sit beside
+    # the crash banner (a torn read) — matching the `:git_load` crash handler and
+    # the `apply_test_result/2` dispatch-error path.
+    {:noreply,
+     assign(socket,
+       tests_running: false,
+       test_results: nil,
+       tests_error: "The test run failed unexpectedly."
      )}
   end
 
@@ -2931,42 +2983,72 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   # Run all tests (`class` = nil) or a single class (`run_tests`, `:execute`).
-  # The result map drives the per-case render; an error (including an RBAC
-  # denial for a non-Owner) surfaces as `tests_error` and leaves the prior
-  # results in place.
+  #
+  # BT-2597: the run compiles + evaluates user code on the workspace node, which
+  # can take seconds for a large suite — so it runs off-socket in a `:test_op`
+  # `start_async` task (mirroring the git panel's `:git_load`, BT-2590) rather
+  # than blocking the LiveView process. A rapid second action `cancel_async`-es
+  # the in-flight op so only the latest result wins. The result lands in
+  # `handle_async(:test_op, …)`; `tests_running` disables the controls meanwhile.
   defp run_tests(socket, class) do
-    case Facade.dispatch(:run_tests, %{class: class}, ctx(socket)) do
-      {:ok, result} when is_map(result) ->
-        assign(socket, test_results: result, tests_error: nil)
+    ctx = ctx(socket)
 
-      {:error, reason} ->
-        # Clear any prior run's results so a stale pass/fail summary can't sit
-        # next to the new error and confuse what just failed.
-        assign(socket, test_results: nil, tests_error: facade_error(reason))
-    end
+    socket
+    |> assign(tests_running: true, tests_error: nil)
+    |> cancel_async(:test_op, :cancelled)
+    |> start_async(:test_op, fn ->
+      # Off the LiveView process — capture only `ctx`, never `socket`.
+      {:run, Facade.dispatch(:run_tests, %{class: class}, ctx)}
+    end)
   end
 
   # Load the project's test/ files (`load_tests`, `:execute`), then re-discover
   # the catalogue so the newly-loaded TestCase subclasses appear immediately.
-  # A load error (including an RBAC denial for a non-Owner) surfaces as
-  # `tests_error`; on success any compile errors are surfaced too, but the
-  # catalogue still refreshes to show whatever loaded.
+  #
+  # BT-2597: like `run_tests/2`, the load compiles user code, so it runs in the
+  # off-socket `:test_op` task; the result lands in `handle_async(:test_op, …)`.
   defp load_tests(socket) do
-    case Facade.dispatch(:load_tests, %{}, ctx(socket)) do
-      {:ok, %{"errors" => [_ | _] = errors}} ->
-        socket
-        |> assign_test_classes()
-        |> assign(tests_error: load_tests_error(errors))
+    ctx = ctx(socket)
 
-      {:ok, _result} ->
-        socket
-        |> assign_test_classes()
-        |> assign(tests_error: nil)
-
-      {:error, reason} ->
-        assign(socket, tests_error: facade_error(reason))
-    end
+    socket
+    |> assign(tests_running: true, tests_error: nil)
+    |> cancel_async(:test_op, :cancelled)
+    |> start_async(:test_op, fn ->
+      {:load, Facade.dispatch(:load_tests, %{}, ctx)}
+    end)
   end
+
+  # Apply a completed `run_tests` dispatch to the socket. Pure (no dispatch);
+  # shared by `handle_async/3` so the async path and any future sync caller agree
+  # (mirrors `apply_git_status/2`). An error (incl. a non-Owner RBAC denial)
+  # surfaces as `tests_error` and clears any stale results.
+  defp apply_test_result(socket, {:ok, result}) when is_map(result),
+    do: assign(socket, test_results: result, tests_error: nil)
+
+  defp apply_test_result(socket, {:error, reason}),
+    do: assign(socket, test_results: nil, tests_error: facade_error(reason))
+
+  defp apply_test_result(socket, _other),
+    do: assign(socket, test_results: nil, tests_error: facade_error(:unexpected_test_result))
+
+  # Apply a completed `load_tests` dispatch: refresh the catalogue to show
+  # whatever loaded, surfacing partial compile errors as `tests_error`. The
+  # `assign_test_classes/1` re-discovery is a lightweight `:read` reflection (not
+  # the heavy compile), so it stays synchronous here.
+  defp apply_test_load(socket, {:ok, %{"errors" => [_ | _] = errors}}),
+    do: socket |> assign_test_classes() |> assign(tests_error: load_tests_error(errors))
+
+  # `assign_test_classes/1` already clears `tests_error` on a successful
+  # re-discovery and sets it on failure — so it is the last writer, with no
+  # trailing `assign(tests_error: nil)` that would swallow a re-discovery error.
+  defp apply_test_load(socket, {:ok, _result}),
+    do: assign_test_classes(socket)
+
+  defp apply_test_load(socket, {:error, reason}),
+    do: assign(socket, tests_error: facade_error(reason))
+
+  defp apply_test_load(socket, _other),
+    do: assign(socket, tests_error: facade_error(:unexpected_test_result))
 
   # Summarise compile errors from a partial test load into one line. Each error
   # is a `%{"path" => ..., "message" => ...}` map (the load-project error shape).
@@ -3614,6 +3696,17 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   defp filter_by_source(classes, _src), do: classes
+
+  # True when no class is selected, or the selected class survives the current
+  # source filter (BT-2597). Used to decide whether switching filters should
+  # clear a now-hidden selection.
+  defp selected_class_visible?(%{assigns: %{selected_class: nil}}), do: true
+
+  defp selected_class_visible?(%{assigns: assigns}) do
+    assigns.browser_classes
+    |> filter_by_source(assigns.browser_source)
+    |> Enum.any?(&(Map.get(&1, "name") == assigns.selected_class))
+  end
 
   # The flat method list for the current protocol filter: all selectors across the
   # protocol tree (filter = nil → "all") or just the selected protocol's, each
@@ -6364,12 +6457,16 @@ defmodule BtAttachWeb.WorkspaceLive do
                        editor. --%>
                   <div class="dock-pane panel-body test-pane" hidden={@dock_tab != "tests"}>
                     <div class="test-toolbar">
+                      <%!-- BT-2597: disabled while a run/load is in flight off-socket
+                           (`@tests_running`) — `phx-disable-with` alone reverts the
+                           moment the async event handler re-renders. --%>
                       <button
                         :if={@role == :owner}
                         type="button"
                         class="btn"
                         phx-click="run_tests"
                         phx-disable-with="Running…"
+                        disabled={@tests_running}
                       >
                         Run all
                       </button>
@@ -6383,12 +6480,23 @@ defmodule BtAttachWeb.WorkspaceLive do
                         class="btn ghost"
                         phx-click="load_tests"
                         phx-disable-with="Loading…"
+                        disabled={@tests_running}
                       >
                         Load tests
                       </button>
-                      <button type="button" class="btn ghost" phx-click="tests_refresh">
+                      <%!-- BT-2597: also gated by `@tests_running` — a manual
+                           refresh mid-load issues a synchronous `list_tests`
+                           that would race the in-flight load's own re-discovery
+                           (`apply_test_load`) and could flash a stale catalogue. --%>
+                      <button
+                        type="button"
+                        class="btn ghost"
+                        phx-click="tests_refresh"
+                        disabled={@tests_running}
+                      >
                         Refresh
                       </button>
+                      <span :if={@tests_running} class="muted-note">Running…</span>
                       <span
                         :if={@test_results}
                         class={["test-summary", @test_results["failed"] > 0 && "fail"]}
@@ -6494,6 +6602,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                                   phx-click="run_test_class"
                                   phx-value-class={tc["class"]}
                                   phx-disable-with="Running…"
+                                  disabled={@tests_running}
                                 >
                                   run
                                 </button>

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -108,9 +108,12 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
       refute listed =~ "Not authorized"
 
       # Running (`run_tests`) is :execute — the Run controls are owner-gated away,
-      # and a crafted run event is refused by RBAC (BT-2421), not crashed.
+      # and a crafted run event is refused by RBAC (BT-2421), not crashed. BT-2597:
+      # the run dispatches off-socket (`start_async`), so the RBAC refusal lands
+      # via `handle_async` — await it with `render_async/2` before asserting.
       refute listed =~ ~s(phx-click="run_tests")
-      refused = render_hook(view, "run_tests", %{})
+      render_hook(view, "run_tests", %{})
+      refused = render_async(view, 30_000)
       assert refused =~ "Not authorized"
       assert Process.alive?(view.pid)
     end
@@ -137,7 +140,10 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
 
       # Run all: the result summary + per-case rows render, with the failing case
       # and its detail surfaced (run-all → test-all op, live session, no CLI).
-      ran = render_hook(view, "run_tests", %{})
+      # BT-2597: the run is off-socket (`start_async(:test_op, …)`), so the hook
+      # returns before results land — `render_async/2` awaits the async task.
+      render_hook(view, "run_tests", %{})
+      ran = render_async(view, 30_000)
       assert ran =~ "testPasses"
       assert ran =~ "testFails"
       assert ran =~ "failed"
@@ -156,8 +162,10 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
       })
 
       render_hook(view, "dock_tab", %{"tab" => "tests"})
-      # Run just this class (the row's "run" button → run_test_class).
-      ran = render_hook(view, "run_test_class", %{"class" => "CockpitRunnerSelectTest"})
+      # Run just this class (the row's "run" button → run_test_class). BT-2597:
+      # off-socket async, so await the task before asserting on the result.
+      render_hook(view, "run_test_class", %{"class" => "CockpitRunnerSelectTest"})
+      ran = render_async(view, 30_000)
       assert ran =~ "testOk"
       assert ran =~ "passed"
       assert Process.alive?(view.pid)

--- a/editors/liveview/test/bt_attach_web/workspace_tests_pane_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_tests_pane_test.exs
@@ -1,0 +1,179 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.WorkspaceTestsPaneTest do
+  @moduledoc """
+  Integration tests for the cockpit Tests pane's non-blocking run/load and the
+  System Browser source filter's selection handling (BT-2597), driven through the
+  full LiveView stack against the fully-stubbed workspace client
+  (`StubWorkspaceClient`). No `:workspace` tag, so this runs in the bare
+  `mix test` lane.
+
+  Covers the two BT-2597 acceptance criteria:
+
+    * F1 — `run_tests` / `load_tests` run off-socket via `start_async(:test_op, …)`
+      so the event handler returns immediately and the result fills in from
+      `handle_async`; an error degrades to a `tests_error` rather than crashing.
+    * F2 — switching to a source filter that hides the selected class clears the
+      selection (and its method pane).
+  """
+  use BtAttachWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias BtAttachWeb.StubWorkspaceClient
+
+  setup do
+    Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
+
+    Application.put_env(:bt_attach, :oidc, %{
+      issuer: "https://idp",
+      client_id: "id",
+      redirect_uri: "https://ide/callback",
+      groups_claim: "groups",
+      client_secret: "x",
+      roles: %{"owner" => ["beamtalk-owners"], "observer" => ["beamtalk-observers"]}
+    })
+
+    Application.put_env(:bt_attach, :session_ttl_secs, 3600)
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      Application.delete_env(:bt_attach, :oidc)
+      Application.delete_env(:bt_attach, :session_ttl_secs)
+      StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    {:ok, _} = StubWorkspaceClient.start_state()
+
+    :ok
+  end
+
+  defp owner_conn(conn) do
+    Plug.Test.init_test_session(conn, %{
+      "bt_user" => %{"sub" => "alice", "groups" => ["beamtalk-owners"]},
+      "bt_logged_in_at" => System.system_time(:second)
+    })
+  end
+
+  describe "F1: non-blocking test run/load (start_async, BT-2597)" do
+    test "Run all resolves off-socket and renders per-case pass/fail", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # Opening the Tests tab discovers the stub catalogue.
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+      assert render(view) =~ "StubDemoTest"
+
+      # Run all kicks off the `:test_op` async task and returns immediately; the
+      # per-case rows land once the async result resolves via handle_async.
+      render_click(view, "run_tests")
+      html = render_async(view)
+
+      assert html =~ "testOne"
+      assert html =~ "testTwo"
+      assert html =~ "failed"
+      assert Process.alive?(view.pid)
+    end
+
+    test "Load tests resolves off-socket and refreshes the catalogue", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+
+      render_click(view, "load_tests")
+      html = render_async(view)
+
+      # The post-load re-discovery shows the catalogue, and no error banner.
+      assert html =~ "StubDemoTest"
+      refute html =~ "failed to load"
+      assert Process.alive?(view.pid)
+    end
+
+    test "a run error degrades to a pane error, not a LiveView crash", %{conn: conn} do
+      # The async task's dispatch returns an error; `apply_test_result/2` folds it
+      # into `tests_error` and the socket survives (no per-case results shown).
+      StubWorkspaceClient.set_run_tests({:error, :workspace_unreachable})
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+
+      render_click(view, "run_tests")
+      html = render_async(view)
+
+      refute html =~ "testOne"
+      assert Process.alive?(view.pid)
+    end
+
+    test "an unexpected run reply shape degrades, not crashes", %{conn: conn} do
+      # A non-{:ok,_}/{:error,_} reply must hit the total `apply_test_result/2`
+      # clause rather than crashing handle_async on an unmatched shape.
+      StubWorkspaceClient.set_run_tests(:bogus)
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+
+      render_click(view, "run_tests")
+      html = render_async(view)
+
+      assert html =~ "unexpected_test_result"
+      assert Process.alive?(view.pid)
+    end
+
+    test "a load error degrades to a pane error, not a LiveView crash", %{conn: conn} do
+      # `apply_test_load(socket, {:error, reason})` surfaces the error and the
+      # socket survives (symmetric with the run-error path).
+      StubWorkspaceClient.set_load_tests({:error, :unauthorized})
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+
+      render_click(view, "load_tests")
+      html = render_async(view)
+
+      assert html =~ "Not authorized"
+      assert Process.alive?(view.pid)
+    end
+
+    test "an unexpected load reply shape degrades, not crashes", %{conn: conn} do
+      # A non-{:ok,_}/{:error,_} reply must hit the total `apply_test_load/2`
+      # clause rather than crashing handle_async on an unmatched shape.
+      StubWorkspaceClient.set_load_tests(:bogus)
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+
+      render_click(view, "load_tests")
+      html = render_async(view)
+
+      assert html =~ "unexpected_test_result"
+      assert Process.alive?(view.pid)
+    end
+  end
+
+  describe "F2: source filter clears a now-hidden selection (BT-2597)" do
+    test "switching to a filter that hides the selected class clears it", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # Select a project class — its instance selectors fill the method pane.
+      view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
+      assert render(view) =~ "increment"
+
+      # Narrowing to "stdlib" hides the project class; its selection (and method
+      # pane) is cleared rather than left as a ghost.
+      html = render_click(view, "browser_source", %{"src" => "stdlib"})
+      refute html =~ "increment"
+      assert Process.alive?(view.pid)
+    end
+
+    test "switching to a filter that still shows the class keeps the selection", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
+      assert render(view) =~ "increment"
+
+      # "Project" still includes Counter, so the selection (and method pane) stays.
+      html = render_click(view, "browser_source", %{"src" => "project"})
+      assert html =~ "increment"
+      assert Process.alive?(view.pid)
+    end
+  end
+end

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -29,6 +29,13 @@ defmodule BtAttachWeb.StubWorkspaceClient do
               autoflush: false,
               git_status: nil,
               git_log: nil,
+              # BT-2597: seeded test-runner pane results so the async run/load
+              # path (`start_async(:test_op, …)` → `handle_async`) can be
+              # exercised without a real workspace node. `nil` = use the canned
+              # default; a test can override to drive error/partial-load paths.
+              test_classes: nil,
+              run_tests_result: nil,
+              load_tests_result: nil,
               calls: []
   end
 
@@ -190,20 +197,79 @@ defmodule BtAttachWeb.StubWorkspaceClient do
     %{branch: "main", upstream: nil, ahead: 0, behind: 0, files: []}
   end
 
+  # ── Test-runner pane (BT-2557, async in BT-2597) ──────────────────────────
+  # Canned catalogue + run/load results so the Tests pane's `start_async`
+  # (`:test_op`) path can be driven without a real workspace node. Each can be
+  # overridden via the `set_*` helpers to exercise error / partial-load paths.
+
+  def list_tests do
+    record({:list_tests})
+    get(:test_classes) || {:ok, default_test_classes()}
+  end
+
+  def run_tests(class) do
+    record({:run_tests, class})
+    get(:run_tests_result) || {:ok, default_run_result()}
+  end
+
+  def load_tests do
+    record({:load_tests})
+    get(:load_tests_result) || {:ok, default_load_result()}
+  end
+
+  @doc "Test helper: seed the simulated `list_tests` result."
+  def set_test_classes(result), do: put(:test_classes, result)
+
+  @doc "Test helper: seed the simulated `run_tests` result."
+  def set_run_tests(result), do: put(:run_tests_result, result)
+
+  @doc "Test helper: seed the simulated `load_tests` result."
+  def set_load_tests(result), do: put(:load_tests_result, result)
+
+  defp default_test_classes do
+    [%{"class" => "StubDemoTest", "selectors" => ["testOne", "testTwo"]}]
+  end
+
+  defp default_run_result do
+    %{
+      "total" => 2,
+      "passed" => 1,
+      "failed" => 1,
+      "skipped" => 0,
+      "duration" => 0.05,
+      "tests" => [
+        %{"name" => "testOne", "class" => "StubDemoTest", "status" => "pass", "detail" => ""},
+        %{"name" => "testTwo", "class" => "StubDemoTest", "status" => "fail", "detail" => "boom"}
+      ]
+    }
+  end
+
+  defp default_load_result do
+    %{"classes" => ["StubDemoTest"], "errors" => [], "summary" => "Reloaded 1 of 1 files"}
+  end
+
   # ── Browse ops ───────────────────────────────────────────────────────────
 
   def browse_classes do
     base = [
-      %{"name" => "Counter", "source_file" => "src/counter.bt"},
+      %{"name" => "Counter", "source_file" => "src/counter.bt", "source_origin" => "project"},
       # BT-2578: a native: class in the tree so the System Browser's "Erlang
       # backend" badge + native pane can be reached by real navigation.
-      %{"name" => "Subprocess", "source_file" => "src/subprocess.bt"}
+      %{
+        "name" => "Subprocess",
+        "source_file" => "src/subprocess.bt",
+        "source_origin" => "project"
+      }
     ]
 
     extra =
       get(:defined_classes)
       |> Enum.map(fn name ->
-        %{"name" => name, "source_file" => "src/#{Macro.underscore(name)}.bt"}
+        %{
+          "name" => name,
+          "source_file" => "src/#{Macro.underscore(name)}.bt",
+          "source_origin" => "project"
+        }
       end)
 
     {:value, base ++ extra}


### PR DESCRIPTION
## Follow-ups from PR #2664 review ([BT-2597](https://linear.app/beamtalk/issue/BT-2597))

Two non-blocking polish items the Claude review flagged on #2664, both in the LiveView cockpit.

### F1 — async-ify `run_tests` / `load_tests` (don't block the socket)

`handle_event("run_tests" | "load_tests", …)` dispatched synchronously on the LiveView process. Each compiles + evaluates user code on the workspace node, so a large suite (or a slow run) could leave the socket unresponsive to other events for seconds.

- Both now run off-socket in a single `start_async(:test_op, …)` task (mirroring the git panel's `:git_load`, BT-2590), tagged `{:run, _}` / `{:load, _}` so `handle_async/3` applies the right result path.
- Result application is split into total `apply_test_result/2` / `apply_test_load/2` helpers (like `apply_git_status/2`), so an unexpected reply shape degrades to a pane error instead of crashing `handle_async`.
- A crash (`{:exit, reason}`) surfaces a `tests_error`; a newer action `cancel_async`-es the in-flight one so only the latest result wins.
- A new `tests_running` assign disables the Run all / Load tests / per-class run controls while a run is in flight (`phx-disable-with` alone reverts the moment the now-immediate handler re-renders).

### F2 — clear a "ghost" selection when the source filter hides it

Switching the System Browser source filter (All → Project/Deps/Stdlib) could hide the selected class while the method pane kept showing its selectors. `handle_event("browser_source", …)` now clears `selected_class` (and its protocol/method pane) when the new filter excludes it.

## Testing

- **New** `test/bt_attach_web/workspace_tests_pane_test.exs` (stub-based, bare `mix test` lane): async run/load success, error degradation, unexpected-shape degradation, and both selection-filter paths.
- The existing `:workspace` integration tests now `render_async` after triggering a run so the e2e lane awaits the off-socket task.
- Full bare suite: **239 passed, 0 failures**. `mix compile --warnings-as-errors` + `mix format --check-formatted` clean.

## Note

The #2664 code/docs referenced `BT-2596`, which is actually an unrelated git-panel issue — a mislabel from that PR. This PR uses the correct **BT-2597**. Correcting the merged `BT-2596` references is tracked separately (pending direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2gzYAMpBpKtarAwKEt7Nh)_