### PR TITLE
LiveView IDE: System Browser source-filter selector overflows the panel head — convert to dropdown (BT-2603)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -274,6 +274,26 @@
 }
 .seg button.on { background: var(--panel); color: var(--ink); box-shadow: 0 1px 2px rgba(60, 45, 20, .12); }
 
+/* source-origin filter dropdown (BT-2603): replaces the `.seg` segmented
+   control so the filter holds a fixed, small width and never overflows the
+   panel head on a narrow System Browser. The wrapping <form> only exists to
+   carry `phx-change`; it must not add width/height to the header row. */
+.panel-head .src-filter { display: inline-flex; flex: none; margin: 0; }
+.panel-head .src-select {
+  appearance: none; height: 22px; padding: 0 18px 0 8px;
+  border: 1px solid var(--line); border-radius: 6px; background: var(--panel-3);
+  color: var(--ink); font: inherit; font-size: 10.5px; font-weight: 600;
+  letter-spacing: .02em; outline: none; cursor: pointer; flex: none;
+  /* a small chevron drawn into the right padding (appearance:none removes the
+     native arrow) so the control reads as a dropdown. */
+  background-image: linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+                    linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+  background-position: right 8px center, right 4px center;
+  background-size: 4px 4px, 4px 4px;
+  background-repeat: no-repeat;
+}
+.panel-head .src-select:focus { border-color: var(--accent); }
+
 /* the instance/class side toggle pinned to the class-tree footer */
 .actionbar.sb-side { border-top: 1px solid var(--line); border-bottom: 0; }
 .actionbar.sb-side .seg { flex: 1; display: flex; }

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -5674,7 +5674,11 @@ defmodule BtAttachWeb.WorkspaceLive do
              `handle_event("browser_source", %{"src" => src}, ...)` is unchanged;
              `phx-change` fires on each selection and the native <select> carries
              its own keyboard + listbox aria semantics. --%>
-        <form phx-change="browser_source" class="src-filter">
+        <%!-- `onsubmit="return false"`: this form only carries `phx-change`; there
+             is deliberately no submit path (selection drives the filter). The
+             guard makes a stray native submit — `form.submit()`, or a future
+             field added here — a no-op rather than an unhandled LiveView event. --%>
+        <form phx-change="browser_source" onsubmit="return false" class="src-filter">
           <select name="src" class="src-select" aria-label="Class source filter">
             <option
               :for={

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -5667,27 +5667,31 @@ defmodule BtAttachWeb.WorkspaceLive do
           </button>
         </div>
         <%!-- BT-2557: source-origin filter — narrow the tree to project / deps /
-             stdlib so a project's own classes aren't buried under the stdlib. --%>
-        <div class="seg" role="tablist" aria-label="Class source filter">
-          <button
-            :for={
-              {src, label} <- [
-                {"all", "All"},
-                {"project", "Proj"},
-                {"deps", "Deps"},
-                {"stdlib", "Std"}
-              ]
-            }
-            type="button"
-            role="tab"
-            class={[@browser_source == src && "on"]}
-            aria-selected={to_string(@browser_source == src)}
-            phx-click="browser_source"
-            phx-value-src={src}
-          >
-            {label}
-          </button>
-        </div>
+             stdlib so a project's own classes aren't buried under the stdlib.
+             BT-2603: a compact <select> rather than a segmented control so it
+             keeps a fixed, small width and never overflows / clips off the side
+             of a narrow panel head. The posted field is `src`, so the existing
+             `handle_event("browser_source", %{"src" => src}, ...)` is unchanged;
+             `phx-change` fires on each selection and the native <select> carries
+             its own keyboard + listbox aria semantics. --%>
+        <form phx-change="browser_source" class="src-filter">
+          <select name="src" class="src-select" aria-label="Class source filter">
+            <option
+              :for={
+                {src, label} <- [
+                  {"all", "All"},
+                  {"project", "Proj"},
+                  {"deps", "Deps"},
+                  {"stdlib", "Std"}
+                ]
+              }
+              value={src}
+              selected={@browser_source == src}
+            >
+              {label}
+            </option>
+          </select>
+        </form>
         <%!-- New Class (BT-2293): owner-only ＋ toggle. Reveals the inline create
              form below; the new class then appears right in the tree under it. --%>
         <button

--- a/editors/liveview/test/bt_attach_web/workspace_tests_pane_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_tests_pane_test.exs
@@ -176,4 +176,42 @@ defmodule BtAttachWeb.WorkspaceTestsPaneTest do
       assert Process.alive?(view.pid)
     end
   end
+
+  describe "F3: source filter renders as a compact dropdown (BT-2603)" do
+    test "renders a <select name=src> instead of a segmented control", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      html = render(view)
+
+      # The source-origin filter is a <select> (so it can't overflow the panel
+      # head) carrying the `src` field the handler reads. All four options are
+      # present and reachable, and the current selection ("all") is marked.
+      assert html =~ ~s(<select name="src")
+      assert html =~ ~s(aria-label="Class source filter")
+      assert html =~ ~s(<option value="all" selected="selected">)
+      assert html =~ ~s(<option value="project">)
+      assert html =~ ~s(<option value="deps">)
+      assert html =~ ~s(<option value="stdlib">)
+      assert html =~ "All"
+      assert html =~ "Proj"
+      assert html =~ "Deps"
+      assert html =~ "Std"
+    end
+
+    test "changing the dropdown dispatches the browser_source event", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
+      assert render(view) =~ "increment"
+
+      # Driving the rendered <select> (not a bare event) still narrows the tree:
+      # the phx-change form posts `%{"src" => "stdlib"}` to the unchanged handler.
+      html =
+        view
+        |> form(~s(form[phx-change="browser_source"]), %{"src" => "stdlib"})
+        |> render_change()
+
+      refute html =~ "increment"
+      assert Process.alive?(view.pid)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

In the LiveView IDE System Browser, the source-origin filter (`All` / `Proj` / `Deps` / `Std`) was a `.seg` segmented control packed into the `panel-head` alongside the `Hier`/`Cats` toggle and the owner-only `＋` / `×` buttons. On a narrow panel it slid off / clipped (`Std` cut off entirely).

This converts the source-origin filter from a segmented control to a compact `<select>` dropdown, so it occupies a fixed small width regardless of how many options exist and never overflows the header.

Linear: https://linear.app/beamtalk/issue/BT-2603

## Key changes

- **`workspace_live.ex`** — replaced the `.seg` `role=tablist` segmented control with a `<select name="src">` inside a `phx-change="browser_source"` form. The posted field stays `src`, so `handle_event("browser_source", %{"src" => src}, ...)` is **unchanged**. The native `<select>` carries its own keyboard + listbox aria semantics; kept `aria-label="Class source filter"`.
- **`assets/css/app.css`** — added `.src-filter` / `.src-select`: fixed compact width, `flex: none`, custom CSS chevron (native arrow removed via `appearance: none`), focus ring matching the rest of the IDE chrome. The wrapping form adds no width/height to the header row.
- **tests** — new regression coverage in `workspace_tests_pane_test.exs`: the dropdown renders `<select name="src">` with all four options and the current selection marked, and driving it via `render_change` still narrows the tree through `filter_by_source`.

## Acceptance criteria

- ✅ Source-origin filter no longer overflows / clips at normal/narrow panel width (fixed-width `<select>`)
- ✅ All four options (`all`/`project`/`deps`/`stdlib`) reachable; current selection visible (`selected`)
- ✅ `browser_source` event still dispatches `all`/`project`/`deps`/`stdlib`; `handle_event` unchanged
- ✅ Keyboard accessibility / aria preserved (native `<select>` + `aria-label`)
- ✅ `Hier`/`Cats` toggle and owner-only `＋`/`×` remain in the head without overflow (untouched)

## Verification

- `mix compile` clean (HEEx template compiles)
- `mix test test/bt_attach_web/workspace_tests_pane_test.exs` → 10 passed (incl. 2 new dropdown tests)
- `mix format --check-formatted` clean
- Pre-push hook (Elixir format + lint) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSaj9LoBscUqYcVurSenXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSaj9LoBscUqYcVurSenXj)_