### PR TITLE
refactor(codegen): replace format!("StateAcc{n}") with versioned_var

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/exception_handling.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/exception_handling.rs
@@ -59,7 +59,7 @@ impl CoreErlangGenerator {
     fn state_acc_var_doc(state_version: usize) -> Document<'static> {
         match state_version {
             0 => docvec!["StateAcc"],
-            n => leaf::var(format!("StateAcc{n}")),
+            n => leaf::var(super::super::util::versioned_var("StateAcc", n)),
         }
     }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -2318,11 +2318,7 @@ impl CoreErlangGenerator {
         let (body_doc, final_state_version) =
             self.generate_threaded_loop_body(body, plan, &BodyKind::Letrec)?;
         docs.push(body_doc);
-        let final_state_var = if final_state_version == 0 {
-            "StateAcc".to_string()
-        } else {
-            format!("StateAcc{final_state_version}")
-        };
+        let final_state_var = super::util::versioned_var("StateAcc", final_state_version);
 
         self.pop_scope();
 
@@ -2968,11 +2964,7 @@ impl CoreErlangGenerator {
         if let Expression::Assignment { target, value, .. } = expr {
             if let Expression::Identifier(id) = target.as_ref() {
                 let val_var = self.fresh_temp_var("Val");
-                let current_state = if self.state_version() == 0 {
-                    "StateAcc".to_string()
-                } else {
-                    format!("StateAcc{}", self.state_version())
-                };
+                let current_state = super::util::versioned_var("StateAcc", self.state_version());
 
                 // BT-790: In REPL mode, use the plain variable name as the key
                 // (no __local__ prefix) since there are no actor fields to collide with.

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
@@ -249,11 +249,7 @@ impl CoreErlangGenerator {
         let (body_doc, final_state_version) =
             self.generate_threaded_loop_body(body, &plan, &BodyKind::Letrec)?;
         docs.push(body_doc);
-        let final_state_var = if final_state_version == 0 {
-            "StateAcc".to_string()
-        } else {
-            format!("StateAcc{final_state_version}")
-        };
+        let final_state_var = super::super::util::versioned_var("StateAcc", final_state_version);
 
         let exit_arm = if negate {
             "<'true'> when 'true' -> {'nil', StateAcc} "

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -271,11 +271,7 @@ impl CoreErlangGenerator {
                             if self.in_hybrid_loop {
                                 self.current_state_var()
                             } else if self.in_loop_body {
-                                if self.state_version() == 0 {
-                                    "StateAcc".to_string()
-                                } else {
-                                    format!("StateAcc{}", self.state_version())
-                                }
+                                super::util::versioned_var("StateAcc", self.state_version())
                             } else {
                                 self.current_state_var()
                             }


### PR DESCRIPTION
## Summary

- Replaces 5 `format!("StateAcc{n}")` / `format!("StateAcc{}", ...)` calls in the Core Erlang codegen with the existing `versioned_var("StateAcc", n)` helper, fixing CLAUDE.md violations of the rule: *"NEVER use `format!()` or string concatenation to produce Core Erlang fragments."*
- `versioned_var` was introduced in BT-875 for exactly this purpose (uses `write!` on a pre-allocated buffer, handles version-0 edge case). It was applied to State/ClassVars/Self in `mod.rs` but missed in the `control_flow` submodules and `expressions.rs`.
- Zero behavioral change — generated Core Erlang output is byte-for-byte identical.

## Violation sites fixed

| File | Line(s) | Before | After |
|------|---------|--------|-------|
| `control_flow/exception_handling.rs` | 62 | `leaf::var(format!("StateAcc{n}"))` | `leaf::var(super::super::util::versioned_var("StateAcc", n))` |
| `control_flow/while_loops.rs` | 252–256 | 4-line if/else with `format!` | single `versioned_var` call |
| `control_flow/mod.rs` | 2321–2325 | 4-line if/else with `format!` | single `versioned_var` call |
| `control_flow/mod.rs` | 2971–2975 | 4-line if/else with `format!` | single `versioned_var` call |
| `expressions.rs` | 274–278 | 4-line if/else with `format!` | single `versioned_var` call |

## Test plan

- [x] `just ci` — all 18 checks green (Rust build, Erlang build, clippy, fmt, dialyzer, specs, 5600+ Rust unit tests, 250 stdlib tests, 2589 BUnit tests, 6500+ runtime EUnit tests, integration tests, MCP tests, parity tests, surface drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRbLeTBz9t61d8AjJKtcc3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRbLeTBz9t61d8AjJKtcc3)_