### PR TITLE
test: extract setUp/tearDown in ActorAliasedSelfSendTest

### DIFF
--- a/stdlib/test/actor_aliased_self_send_test.bt
+++ b/stdlib/test/actor_aliased_self_send_test.bt
@@ -5,22 +5,20 @@
 // dispatch directly without deadlocking via gen_server:call.
 
 TestCase subclass: ActorAliasedSelfSendTest
+  field: a = nil
+
+  setUp => self withA: AliasedSelfSendActor spawn
+
+  tearDown => self.a isNil ifFalse: [self.a stop]
 
   testAliasedFieldNames =>
-    a := AliasedSelfSendActor spawn
-    names := a aliasedFieldNames
+    names := self.a aliasedFieldNames
     self assert: names size equals: 2
     self assert: (names includes: #x)
     self assert: (names includes: #y)
 
-  testAliasedFieldAt =>
-    a := AliasedSelfSendActor spawn
-    self assert: a aliasedFieldAt equals: 0
+  testAliasedFieldAt => self assert: self.a aliasedFieldAt equals: 0
 
-  testAliasedFieldAtPut =>
-    a := AliasedSelfSendActor spawn
-    self assert: a aliasedFieldAtPut equals: 42
+  testAliasedFieldAtPut => self assert: self.a aliasedFieldAtPut equals: 42
 
-  testAliasedUserMethod =>
-    a := AliasedSelfSendActor spawn
-    self assert: a aliasedUserMethod equals: 0
+  testAliasedUserMethod => self assert: self.a aliasedUserMethod equals: 0


### PR DESCRIPTION
## Summary

- `stdlib/test/actor_aliased_self_send_test.bt` had 4 test methods each repeating `a := AliasedSelfSendActor spawn` with no tearDown
- Extracted to `field: a`, `setUp => self withA: AliasedSelfSendActor spawn`, `tearDown => self.a isNil ifFalse: [self.a stop]`
- Single-expression test methods inlined to `method => expr` per Beamtalk formatter convention

## Test plan

- [x] `just test-bunit` — 2589 tests, 0 failures
- [x] Push hooks — all lint checks passed (clippy, fmt, dialyzer, erlfmt, Beamtalk fmt, Biome)

## Why it is safe

BUnit creates a fresh `TestCase` instance per test method, so `setUp` still runs before each test and each test gets its own independent `AliasedSelfSendActor`. Semantics are identical. `tearDown` adds missing cleanup to stop orphaned actor processes after each test.

Pattern sourced from `actor_conditional_mutations_test.bt` (lines 11–16), the established convention for this case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QitjzQ9STPyx74URmg1cG

---
_Generated by [Claude Code](https://claude.ai/code/session_017QitjzQ9STPyx74URmg1cG)_