### PR TITLE
LiveView IDE: collapse doc block when method/class has no comment (BT-2604)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -467,12 +467,6 @@
 }
 .doc-block .doc-caret { color: var(--muted); font-size: 10px; flex: none; }
 .doc-block .doc-sig-text { flex: 1 1 auto; min-width: 0; }
-/* The signature-only (non-collapsible) line keeps its original spacing/divider.
-   Scoped to `div.doc-sig` so it doesn't also hit the toggle button (which shares
-   the `.doc-sig` class but draws its divider only when `.open`). */
-.doc-block > div.doc-sig {
-  margin-bottom: 6px; padding-bottom: 6px; border-bottom: 1px solid var(--line);
-}
 .doc-block .doc-body .doc-h {
   color: var(--ink); font-size: 12px; font-weight: 700;
   margin: 8px 0 4px; line-height: 1.3;

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -7009,43 +7009,42 @@ defmodule BtAttachWeb.WorkspaceLive do
                        rendered to safe HTML by `BtAttach.DocFormat` (author text
                        is escaped first), so `{...}` interpolation is safe. --%>
                     <% doc_tab = active_tab(assigns) %>
+                    <%!-- The doc block earns its vertical space only when there's an
+                       actual `///` doc / class comment to collapse/expand (BT-2604).
+                       A method/class with no comment renders nothing here — its
+                       signature already shows in the breadcrumb and the editable
+                       source below — so the source sits directly under the
+                       breadcrumb with no bare signature line or extra gap. --%>
                     <section
-                      :if={doc_tab.doc || doc_tab.signature}
-                      class={"doc-block" <> if(doc_tab.doc && @doc_expanded, do: " open", else: "")}
+                      :if={doc_tab.doc}
+                      class={"doc-block" <> if(@doc_expanded, do: " open", else: "")}
                       aria-label="Documentation"
                     >
-                      <%!-- When the tab carries a `///` doc / class comment the
-                         signature line doubles as the collapse toggle (the body is
-                         also present verbatim in the editable source below, so it
-                         stays hidden until asked for). A method with only a
-                         signature has nothing to expand, so it renders as a plain,
-                         non-interactive line. --%>
-                      <%= if doc_tab.doc do %>
-                        <button
-                          type="button"
-                          class="doc-sig doc-toggle"
-                          phx-click="toggle_doc"
-                          aria-expanded={to_string(@doc_expanded)}
-                          aria-controls={if @doc_expanded, do: "doc-body-content"}
-                          title={
-                            if @doc_expanded,
-                              do: "Collapse documentation",
-                              else: "Expand documentation"
-                          }
-                        >
-                          <span class="doc-caret" aria-hidden="true">
-                            {if @doc_expanded, do: "▾", else: "▸"}
-                          </span>
-                          <span class="doc-sig-text">
-                            {doc_tab.signature || doc_summary_label(doc_tab)}
-                          </span>
-                        </button>
-                        <div :if={@doc_expanded} id="doc-body-content" class="doc-body">
-                          {BtAttach.DocFormat.to_html(doc_tab.doc)}
-                        </div>
-                      <% else %>
-                        <div :if={doc_tab.signature} class="doc-sig">{doc_tab.signature}</div>
-                      <% end %>
+                      <%!-- The signature line doubles as the collapse toggle; the
+                         body is also present verbatim in the editable source below,
+                         so it stays hidden until asked for. --%>
+                      <button
+                        type="button"
+                        class="doc-sig doc-toggle"
+                        phx-click="toggle_doc"
+                        aria-expanded={to_string(@doc_expanded)}
+                        aria-controls={if @doc_expanded, do: "doc-body-content"}
+                        title={
+                          if @doc_expanded,
+                            do: "Collapse documentation",
+                            else: "Expand documentation"
+                        }
+                      >
+                        <span class="doc-caret" aria-hidden="true">
+                          {if @doc_expanded, do: "▾", else: "▸"}
+                        </span>
+                        <span class="doc-sig-text">
+                          {doc_tab.signature || doc_summary_label(doc_tab)}
+                        </span>
+                      </button>
+                      <div :if={@doc_expanded} id="doc-body-content" class="doc-body">
+                        {BtAttach.DocFormat.to_html(doc_tab.doc)}
+                      </div>
                     </section>
                     <%!-- BT-2578: on a `self delegate` method (ADR 0056), a jump
                        to its Erlang implementation. Opens the class-definition

--- a/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
@@ -89,7 +89,7 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
       assert html =~ "<code>c increment</code>"
     end
 
-    test "a method with no doc-comment shows only its signature", %{conn: conn} do
+    test "a method with no doc-comment renders no doc block at all (BT-2604)", %{conn: conn} do
       {:ok, view, _html} = live(owner_conn(conn), "/")
 
       view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
@@ -99,10 +99,15 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
         |> element(~s(div[phx-value-selector="value"]))
         |> render_click()
 
-      assert html =~ ~s(class="doc-block")
-      assert html =~ "value -&gt; Integer"
-      # No `///` doc → no rendered doc body.
+      # BT-2604: with no `///` doc-comment the read-only doc block earns no space.
+      # A bare signature line would only duplicate the breadcrumb and the editable
+      # source below, so the whole block collapses away — the source sits directly
+      # under the breadcrumb.
+      refute html =~ ~s(class="doc-block")
       refute html =~ ~s(class="doc-body")
+      # No bare signature line is left behind either — the breadcrumb still names
+      # the method, so the source sits directly beneath it.
+      refute html =~ ~s(class="doc-sig")
     end
 
     test "the expanded state is sticky across tab switches", %{conn: conn} do
@@ -115,9 +120,10 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
       html = view |> element(~s(button[phx-click="toggle_doc"])) |> render_click()
       assert html =~ ~s(class="doc-body")
 
-      # Switching to a method with no doc collapses to a plain signature (nothing
-      # to expand) but must not reset the preference…
+      # Switching to a method with no doc renders no doc block at all (BT-2604),
+      # but must not reset the expand preference…
       html = view |> element(~s(div[phx-value-selector="value"])) |> render_click()
+      refute html =~ ~s(class="doc-block")
       refute html =~ ~s(class="doc-body")
 
       # …so returning to the doc'd method shows the body again *without* re-toggling.


### PR DESCRIPTION
## Summary

In the LiveView IDE method editor, the read-only documentation block (BT-2558) rendered whenever the active tab had *either* a `///` doc-comment *or* a signature. When a method (or class) had **no** comment, `doc_tab.doc` was `nil` but `doc_tab.signature` was still present, so the `else` branch rendered a bare, non-interactive `doc-sig` line containing just the signature (e.g. `double → self`).

That line was redundant — the signature already shows in the breadcrumb (`Counter › instance › double`) and in the editable source body below — and it left an extra separator / vertical gap above the source. The doc block earns its space only when there's an actual comment to collapse/expand.

This PR gates the whole `<section>` on `doc_tab.doc` only, so with no comment it collapses away entirely (reclaiming its `margin-bottom` too) and the source sits directly under the breadcrumb. When a comment is present the existing collapsible toggle (▸/▾) behaviour is unchanged.

## Key changes

- `editors/liveview/lib/bt_attach_web/live/workspace_live.ex` — doc-block `<section>` `:if` guard changed from `doc_tab.doc || doc_tab.signature` to `doc_tab.doc`; removed the now-dead `else` branch that rendered the bare `doc-sig` line; simplified the `class` open-state expression accordingly.
- `editors/liveview/assets/css/app.css` — removed the now-dead `.doc-block > div.doc-sig` rule that styled the removed bare line.
- `editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs` — updated the no-comment tests to assert the doc block no longer renders (no `doc-block`/`doc-sig`/`doc-body`); doc'd-method and class-comment cases unchanged.

## Acceptance criteria

- [x] No-comment method/class tab renders no bare signature line and consumes no vertical space
- [x] With a comment, existing collapsible toggle behaviour is unchanged
- [x] No extra separator/gap left above the editable source when there is no comment
- [x] Applies to both method doc-comments and class comments (same doc block)
- [x] Verified via updated `workspace_doc_block_test.exs` (full LiveView suite green: 251 passed)

## Testing

`mix test` in `editors/liveview` — 251 passed, 0 failures (`:workspace`/`:playwright`-tagged tests excluded, require live workspace/browser).

Linear: https://linear.app/beamtalk/issue/BT-2604

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSaj9LoBscUqYcVurSenXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSaj9LoBscUqYcVurSenXj)_