### PR TITLE
LiveView IDE: Inspector × closes only the Inspector, not the whole RHS column (BT-2611)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1196,8 +1196,27 @@ defmodule BtAttachWeb.WorkspaceLive do
     {:noreply, assign(socket, show_browser: false)}
   end
 
+  # Close *only* the Inspector pane (BT-2611), not the whole right column. The `×`
+  # lives in the Inspector sub-pane header, so it must dismiss just the Inspector
+  # and leave the Bindings pane (and the column) visible — the whole-column
+  # show/hide stays on `toggle_inspector`/`.panel-toggle`. We reset the inspector
+  # target/rows/crumbs/error back to the empty state and tear down the live
+  # subscription via `track_object(nil)` so re-inspecting an object later rebinds
+  # cleanly. Unfreeze too, so a frozen pane doesn't reopen stale on the next
+  # inspect. `show_inspector` is intentionally left untouched.
   def handle_event("close_inspector", _params, socket) do
-    {:noreply, assign(socket, show_inspector: false)}
+    socket =
+      socket
+      |> assign(
+        inspect_target: nil,
+        inspect_rows: [],
+        inspect_crumbs: [],
+        inspect_error: nil,
+        inspect_frozen: false
+      )
+      |> track_object(nil)
+
+    {:noreply, socket}
   end
 
   # Drill into an object-valued field of a *floating window* (BT-2493): the field
@@ -7434,8 +7453,8 @@ defmodule BtAttachWeb.WorkspaceLive do
                       type="button"
                       class="panel-close"
                       phx-click="close_inspector"
-                      aria-label="Close the Inspector and Bindings column"
-                      title="Close the Inspector + Bindings column"
+                      aria-label="Close the Inspector (the Bindings pane stays open)"
+                      title="Close the Inspector (the Bindings pane stays open)"
                     >
                       ×
                     </button>

--- a/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
@@ -956,7 +956,10 @@ defmodule BtAttachWeb.WorkspaceBrowserTest do
       "the left seam gutter should return when the browser column reopens"
     )
     # The same for the Inspector/Bindings column and its right seam gutter.
-    |> click("#inspector-panel button[phx-click='close_inspector']")
+    # The column is collapsed via the top-bar toggle (toggle_inspector); the
+    # inspector panel's own × now closes only the Inspector pane, not the column
+    # (BT-2611), so it no longer drives the column collapse class.
+    |> click("button[phx-click='toggle_inspector']")
     |> assert_has(".cockpit.inspector-hidden")
     |> assert_eventually(
       "getComputedStyle(document.getElementById('col-gutter-right')).display === 'none'",

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -287,6 +287,48 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert html =~ "7"
   end
 
+  test "the Inspector × closes only the Inspector, leaving Bindings + column (BT-2611)", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, "/")
+    suffix = System.unique_integer([:positive])
+    class = "Counter#{suffix}"
+    name = "counter_#{suffix}"
+
+    class_src = """
+    Actor subclass: #{class}
+      state: count = 7
+
+      count => self.count
+    """
+
+    view |> form("#eval-form") |> render_submit(%{expr: class_src})
+    view |> form("#eval-form") |> render_submit(%{expr: "#{name} := #{class} spawn"})
+    assert eventually(fn -> render(view) =~ name end)
+
+    # Inspect the binding so the docked Inspector is populated.
+    html = view |> element("button[phx-value-name='#{name}']") |> render_click()
+    assert html =~ "Inspecting"
+
+    # The `×` in the Inspector header must close ONLY the Inspector (BT-2611): the
+    # Inspector drops back to its empty state, but the Bindings pane and the whole
+    # right column stay rendered (the column toggle still drives `show_inspector`).
+    html = view |> element("#inspector-panel button.panel-close") |> render_click()
+    refute html =~ "Inspecting"
+    # Empty-state prompt is back, and the column + Bindings pane are still present.
+    assert html =~ "then Inspect it to"
+    assert html =~ ~s(id="bindings-panel")
+    assert html =~ ~s(id="inspector-panel")
+    # The whole-column control is untouched — the column was NOT collapsed, so the
+    # cockpit grid does not carry the `inspector-hidden` collapse class.
+    refute html =~ "inspector-hidden"
+
+    # Re-inspecting the same binding repopulates the Inspector after a close.
+    html = view |> element("button[phx-value-name='#{name}']") |> render_click()
+    assert html =~ "Inspecting"
+    assert html =~ "count"
+  end
+
   test "method editor: save a method, then an eval observes the new behaviour (BT-2409)", %{
     conn: conn
   } do


### PR DESCRIPTION
## Summary

The right-hand column of the LiveView IDE stacks **Bindings** (top) and **Inspector** (bottom). The `×` close button lives in the *Inspector* pane header, so users expect it to dismiss only the Inspector — but it fired `close_inspector`, which set `show_inspector: false`, the flag that gates the **entire** Bindings + Inspector column. Clicking it collapsed the Bindings pane too.

This PR makes the `×` close **only** the Inspector, leaving the Bindings pane and the column visible. The whole-column show/hide stays on the existing column toggle (`toggle_inspector` / `.panel-toggle`).

Fixes [BT-2611](https://linear.app/beamtalk/issue/BT-2611).

## Key changes

- `handle_event("close_inspector", ...)` now resets the Inspector state (`inspect_target`, `inspect_rows`, `inspect_crumbs`, `inspect_error`, `inspect_frozen`) back to the empty state and tears down the live object subscription via the existing `track_object(nil)` path — **without** touching `show_inspector`. The Inspector falls back to its existing empty-state prompt; the Bindings pane and column stay rendered.
- Updated the `×` button's `aria-label`/`title` from "Close the Inspector and Bindings column" to "Close the Inspector (the Bindings pane stays open)" to match the corrected behaviour.
- Added a `:workspace`-tagged regression test (`workspace_live_test.exs`) that inspects a binding, clicks the `×`, asserts the Inspector returns to empty-state while `#bindings-panel`/`#inspector-panel` stay present and the cockpit grid does **not** carry the `inspector-hidden` collapse class, then re-inspects to confirm the Inspector repopulates after a close.

## Acceptance criteria

- ✅ Clicking `×` closes only the Inspector pane; Bindings stays visible
- ✅ Whole-column show/hide remains on the existing column toggle
- ✅ `×` `aria-label`/`title` updated to describe the corrected behaviour
- ✅ Re-opening the Inspector works after closing it this way
- ✅ No regression to the freeze toggle, drill breadcrumb, or `@inspect_target` rendering (only `inspect_frozen` is reset, by design)
- ✅ Inspector close test added

## Testing

- `mix test` (liveview CI lane): 252 passed, 117 excluded (the new test is `:workspace`-tagged like the existing BT-2408 inspect test, so it runs in the workspace/e2e lane with a live backend).
- `mix format --check-formatted`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSaj9LoBscUqYcVurSenXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSaj9LoBscUqYcVurSenXj)_