### PR TITLE
feat(types): narrow singleton symbol types on (in)equality (BT-2617)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2136,6 +2136,12 @@ impl TypeChecker {
                 members,
                 provenance,
             } => {
+                debug_assert!(
+                    members
+                        .iter()
+                        .all(|m| !matches!(m, InferredType::Union { .. })),
+                    "union members are kept flat by `union_of`, so a single subtraction pass suffices"
+                );
                 let kept: Vec<InferredType> = members
                     .iter()
                     .filter(|m| m.as_known().is_none_or(|n| n != removed))
@@ -2440,7 +2446,8 @@ impl TypeChecker {
                 // Single argument: narrow in the false branch (complement)
                 if let Some(arg) = arguments.first() {
                     if let Some(ref false_ty) = info.false_type {
-                        // Explicit false type (e.g., Result isOk/isError — BT-1859)
+                        // Explicit false type (e.g., Result isOk/isError — BT-1859;
+                        // or singleton (in)equality complement — BT-2617)
                         let ty = self.infer_block_with_narrowing(
                             arg,
                             &info.variable,
@@ -2486,7 +2493,8 @@ impl TypeChecker {
                 }
                 if let Some(false_arg) = arguments.get(1) {
                     if let Some(ref false_ty) = info.false_type {
-                        // Explicit false type (e.g., Result isOk/isError — BT-1859)
+                        // Explicit false type (e.g., Result isOk/isError — BT-1859;
+                        // or singleton (in)equality complement — BT-2617)
                         let ty = self.infer_block_with_narrowing(
                             false_arg,
                             &info.variable,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -910,6 +910,7 @@ impl TypeChecker {
             Self::detect_narrowing(receiver)
                 .map(|info| self.refine_responds_to_narrowing(info))
                 .map(|info| Self::refine_result_narrowing(info, env, hierarchy))
+                .map(|info| Self::refine_singleton_narrowing(info, env, hierarchy))
         } else {
             None
         };
@@ -2083,6 +2084,75 @@ impl TypeChecker {
             info.false_type = None;
         }
         info
+    }
+
+    /// Refines a singleton (in)equality narrowing `x = #foo` / `#foo = x`
+    /// (BT-2617).
+    ///
+    /// `detect` only sees the AST, so it leaves the branch types provisional
+    /// and records the tested singleton in `singleton_eq`. Here we resolve the
+    /// variable's current type and split it: the branch where the test holds
+    /// narrows to the singleton, and the complementary branch narrows to the
+    /// variable's type with that singleton removed (`Integer | #infinity` minus
+    /// `#infinity` ⇒ `Integer`). For an inequality (`/=`, `=/=`) the two
+    /// branches are swapped.
+    pub(super) fn refine_singleton_narrowing(
+        mut info: NarrowingInfo,
+        env: &TypeEnv,
+        hierarchy: &ClassHierarchy,
+    ) -> NarrowingInfo {
+        let Some(eq) = info.singleton_eq.clone() else {
+            return info;
+        };
+        let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+        let matched = InferredType::known(eq.singleton.clone());
+        let remainder = Self::union_without(&current_ty, &eq.singleton);
+        if eq.negated {
+            // `x /= #foo`: the true branch removes the singleton; the false
+            // branch is the singleton.
+            info.true_type = remainder;
+            info.false_type = Some(matched);
+        } else {
+            // `x = #foo`: the true branch is the singleton; the false branch
+            // removes it.
+            info.true_type = matched;
+            info.false_type = Some(remainder);
+        }
+        info
+    }
+
+    /// Removes every union member equal to the singleton named `removed` from
+    /// `ty` (BT-2617). The singleton counterpart of [`non_nil_type`].
+    ///
+    /// - A union collapses to its single remaining member, or to `Never` when
+    ///   the singleton was its only member (the complementary branch is then
+    ///   unreachable).
+    /// - A non-union type that *is* the singleton yields `Never`; any other
+    ///   non-union type (including `Dynamic`) is returned unchanged, since
+    ///   there is no union to subtract from.
+    fn union_without(ty: &InferredType, removed: &EcoString) -> InferredType {
+        match ty {
+            InferredType::Union {
+                members,
+                provenance,
+            } => {
+                let kept: Vec<InferredType> = members
+                    .iter()
+                    .filter(|m| m.as_known().is_none_or(|n| n != removed))
+                    .cloned()
+                    .collect();
+                match kept.len() {
+                    0 => InferredType::Never,
+                    1 => kept.into_iter().next().unwrap(),
+                    _ => InferredType::Union {
+                        members: kept,
+                        provenance: *provenance,
+                    },
+                }
+            }
+            InferredType::Known { class_name, .. } if class_name == removed => InferredType::Never,
+            _ => ty.clone(),
+        }
     }
 
     /// BT-2045: Infer argument types for `on:do:` with exception class propagation.
@@ -4199,6 +4269,7 @@ mod tests {
             is_result_ok_check: true,
             is_result_error_check: false,
             responded_selector: None,
+            singleton_eq: None,
         };
         let hierarchy = ClassHierarchy::with_builtins();
         let refined = TypeChecker::refine_result_narrowing(info, &env, &hierarchy);
@@ -4221,6 +4292,7 @@ mod tests {
             is_result_ok_check: true,
             is_result_error_check: false,
             responded_selector: None,
+            singleton_eq: None,
         };
         let hierarchy = ClassHierarchy::with_builtins();
         let refined = TypeChecker::refine_result_narrowing(info, &env, &hierarchy);

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/info.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/info.rs
@@ -57,4 +57,27 @@ pub(crate) struct NarrowingInfo {
     /// protocol in the registry and narrow to that protocol type instead
     /// of `Dynamic` (BT-1833).
     pub(crate) responded_selector: Option<EcoString>,
+    /// The singleton (in)equality tested in a `x = #foo` / `#foo = x`
+    /// narrowing (BT-2617).
+    ///
+    /// When set, the narrowing was detected from an (in)equality test against
+    /// a singleton symbol literal.  `detect` cannot know the variable's current
+    /// union type, so `true_type` / `false_type` are left provisional and
+    /// `refine_singleton_narrowing` in `inference.rs` resolves the variable's
+    /// type, sets the matching branch to the singleton, and subtracts the
+    /// singleton from the union for the complementary branch.
+    pub(crate) singleton_eq: Option<SingletonEqInfo>,
+}
+
+/// Details of a singleton (in)equality narrowing (`x = #foo`, BT-2617).
+#[derive(Debug, Clone)]
+pub(crate) struct SingletonEqInfo {
+    /// The singleton type name, including the leading `#` (e.g. `#infinity`).
+    /// Matches the `InferredType::Known { class_name }` spelling produced by
+    /// `type_resolver` for `TypeAnnotation::Singleton`.
+    pub(crate) singleton: EcoString,
+    /// Whether the test was an *inequality* (`/=`, `=/=`).  When true the
+    /// true/false branches are swapped relative to an equality test: the true
+    /// branch removes the singleton and the false branch narrows to it.
+    pub(crate) negated: bool,
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/class_eq.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/class_eq.rs
@@ -55,5 +55,6 @@ fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
         is_result_ok_check: false,
         is_result_error_check: false,
         responded_selector: None,
+        singleton_eq: None,
     })
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_kind_of.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_kind_of.rs
@@ -37,5 +37,6 @@ fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
         is_result_ok_check: false,
         is_result_error_check: false,
         responded_selector: None,
+        singleton_eq: None,
     })
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_nil.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_nil.rs
@@ -41,5 +41,6 @@ fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
         is_result_ok_check: false,
         is_result_error_check: false,
         responded_selector: None,
+        singleton_eq: None,
     })
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_result.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/is_result.rs
@@ -78,5 +78,6 @@ fn build_info(inner_recv: &Expression, is_error: bool) -> Option<NarrowingInfo> 
         is_result_ok_check: !is_error,
         is_result_error_check: is_error,
         responded_selector: None,
+        singleton_eq: None,
     })
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/mod.rs
@@ -41,7 +41,10 @@ pub(crate) struct NarrowingRule {
 /// receiver is a unary `class` send, which none of the other rules inspect.
 /// The unary-selector rules (`is_nil`, `is_result`) discriminate on the
 /// selector name. Keyword-selector rules (`is_kind_of`, `responds_to`)
-/// discriminate on the first keyword. So any order is correct; we list them
+/// discriminate on the first keyword. `singleton_eq` runs on a binary
+/// `=` / `=:=` / `/=` / `=/=` send with exactly one Symbol-literal operand —
+/// distinct from `class_eq` (whose operand is a `ClassReference` and whose
+/// inner receiver is a `class` send). So any order is correct; we list them
 /// grouped by shape for readability.
 pub(crate) static RULES: &[NarrowingRule] = &[
     is_nil::RULE,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/mod.rs
@@ -21,6 +21,7 @@ mod is_kind_of;
 mod is_nil;
 mod is_result;
 mod responds_to;
+mod singleton_eq;
 
 /// A single narrowing pattern.
 ///
@@ -49,4 +50,5 @@ pub(crate) static RULES: &[NarrowingRule] = &[
     responds_to::RULE,
     is_kind_of::RULE,
     class_eq::RULE,
+    singleton_eq::RULE,
 ];

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/responds_to.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/responds_to.rs
@@ -44,5 +44,6 @@ fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
         is_result_ok_check: false,
         is_result_error_check: false,
         responded_selector: Some(sel_name.clone()),
+        singleton_eq: None,
     })
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/singleton_eq.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/singleton_eq.rs
@@ -1,0 +1,78 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! `x = #foo` / `#foo = x` singleton (in)equality narrowing (BT-2617).
+//!
+//! Detects an (in)equality test of a variable against a singleton symbol
+//! literal (`#foo`). `detect` only sees the AST, so it records the tested
+//! singleton and whether the test was negated; `refine_singleton_narrowing`
+//! in `inference.rs` resolves the variable's current union type and sets the
+//! branch types — the matching branch narrows to the singleton, the
+//! complementary branch to the union with that singleton removed
+//! (`Integer | #infinity` minus `#infinity` ⇒ `Integer`).
+
+use ecow::{EcoString, eco_format};
+
+use crate::ast::{Expression, Literal, MessageSelector};
+use crate::semantic_analysis::type_checker::{DynamicReason, InferredType};
+
+use super::super::extract::extract_variable_name;
+use super::super::info::{NarrowingInfo, SingletonEqInfo};
+use super::NarrowingRule;
+
+pub(super) const RULE: NarrowingRule = NarrowingRule { detect };
+
+fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
+    let Expression::MessageSend {
+        receiver: lhs,
+        selector: MessageSelector::Binary(op),
+        arguments,
+        ..
+    } = receiver
+    else {
+        return None;
+    };
+    let negated = match op.as_str() {
+        "=" | "=:=" => false,
+        "/=" | "=/=" => true,
+        _ => return None,
+    };
+    let lhs_expr = lhs.as_ref();
+    let rhs_expr = arguments.first()?;
+    // Accept either `x = #foo` or `#foo = x`; reject `#a = #b` (two literals)
+    // and any test where neither side is a singleton literal.
+    let (var_expr, symbol_name) = match (symbol_literal(lhs_expr), symbol_literal(rhs_expr)) {
+        (None, Some(name)) => (lhs_expr, name),
+        (Some(name), None) => (rhs_expr, name),
+        _ => return None,
+    };
+    let variable = extract_variable_name(var_expr)?;
+    Some(NarrowingInfo {
+        variable,
+        // Provisional — `refine_singleton_narrowing` overwrites both branch
+        // types once the variable's current union type is known.
+        true_type: InferredType::Dynamic(DynamicReason::Unknown),
+        false_type: None,
+        is_nil_check: false,
+        is_result_ok_check: false,
+        is_result_error_check: false,
+        responded_selector: None,
+        singleton_eq: Some(SingletonEqInfo {
+            singleton: eco_format!("#{symbol_name}"),
+            negated,
+        }),
+    })
+}
+
+/// Returns the symbol name of a `#foo` literal (without the leading `#`),
+/// unwrapping parentheses; `None` for any other expression.
+fn symbol_literal(expr: &Expression) -> Option<&EcoString> {
+    let inner = match expr {
+        Expression::Parenthesized { expression, .. } => expression.as_ref(),
+        other => other,
+    };
+    match inner {
+        Expression::Literal(Literal::Symbol(name), _) => Some(name),
+        _ => None,
+    }
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/singleton_eq.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/singleton_eq.rs
@@ -16,7 +16,7 @@ use ecow::{EcoString, eco_format};
 use crate::ast::{Expression, Literal, MessageSelector};
 use crate::semantic_analysis::type_checker::{DynamicReason, InferredType};
 
-use super::super::extract::extract_variable_name;
+use super::super::extract::{extract_variable_name, unwrap_parens};
 use super::super::info::{NarrowingInfo, SingletonEqInfo};
 use super::NarrowingRule;
 
@@ -65,13 +65,9 @@ fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
 }
 
 /// Returns the symbol name of a `#foo` literal (without the leading `#`),
-/// unwrapping parentheses; `None` for any other expression.
+/// unwrapping any nesting of parentheses; `None` for any other expression.
 fn symbol_literal(expr: &Expression) -> Option<&EcoString> {
-    let inner = match expr {
-        Expression::Parenthesized { expression, .. } => expression.as_ref(),
-        other => other,
-    };
-    match inner {
+    match unwrap_parens(expr) {
         Expression::Literal(Literal::Symbol(name), _) => Some(name),
         _ => None,
     }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
@@ -468,6 +468,22 @@ fn test_detect_narrowing_singleton_inequality_is_negated() {
 }
 
 #[test]
+fn test_detect_narrowing_singleton_eq_through_nested_parens() {
+    // `ms = ((#infinity))` — `symbol_literal` unwraps all paren levels.
+    let nested = Expression::Parenthesized {
+        expression: Box::new(Expression::Parenthesized {
+            expression: Box::new(symbol_lit("infinity")),
+            span: span(),
+        }),
+        span: span(),
+    };
+    let expr = msg_send(var("ms"), MessageSelector::Binary("=".into()), vec![nested]);
+    let info = TypeChecker::detect_narrowing(&expr).expect("should detect through nested parens");
+    assert_eq!(info.variable, EnvKey::local("ms"));
+    assert_eq!(info.singleton_eq.unwrap().singleton.as_str(), "#infinity");
+}
+
+#[test]
 fn test_detect_narrowing_two_symbol_literals_no_match() {
     // `#a = #b` has no variable to narrow.
     let expr = msg_send(

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
@@ -288,9 +288,10 @@ fn test_narrowing_union_with_nil_check() {
     // A parameter typed as String|UndefinedObject (union), after nil check,
     // should narrow to String in the false block.
     //
-    // For now, union types in annotations aren't parsed to InferredType::Union
-    // (they resolve to Dynamic), so this test validates the non_nil_type logic
-    // directly.
+    // This validates the `non_nil_type` subtraction logic directly. (Declared
+    // union annotations *do* resolve to `InferredType::Union` via
+    // `type_resolver` — see BT-2016 — so the union-narrowing path is also
+    // exercised end-to-end by the `ifNil:`/`ifTrue:ifFalse:` tests elsewhere.)
     let union = InferredType::simple_union(&["String", "UndefinedObject"]);
     let narrowed = TypeChecker::non_nil_type(&union);
     assert_eq!(
@@ -418,6 +419,140 @@ fn test_detect_narrowing_no_match() {
         TypeChecker::detect_narrowing(&expr).is_none(),
         "x + 1 should not be detected as narrowing"
     );
+}
+
+// ---- Singleton (in)equality narrowing (BT-2617) ----
+
+#[test]
+fn test_detect_narrowing_singleton_eq() {
+    // `ms = #infinity` records the singleton, not negated.
+    let expr = msg_send(
+        var("ms"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("infinity")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).expect("should detect singleton =");
+    assert_eq!(info.variable, EnvKey::local("ms"));
+    let eq = info.singleton_eq.expect("singleton_eq recorded");
+    assert_eq!(eq.singleton.as_str(), "#infinity");
+    assert!(!eq.negated);
+}
+
+#[test]
+fn test_detect_narrowing_singleton_eq_symmetric() {
+    // `#infinity = ms` detects the same as `ms = #infinity`.
+    let expr = msg_send(
+        symbol_lit("infinity"),
+        MessageSelector::Binary("=".into()),
+        vec![var("ms")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).expect("should detect #foo = x");
+    assert_eq!(info.variable, EnvKey::local("ms"));
+    assert_eq!(info.singleton_eq.unwrap().singleton.as_str(), "#infinity");
+}
+
+#[test]
+fn test_detect_narrowing_singleton_inequality_is_negated() {
+    for op in ["/=", "=/="] {
+        let expr = msg_send(
+            var("ms"),
+            MessageSelector::Binary(op.into()),
+            vec![symbol_lit("infinity")],
+        );
+        let info = TypeChecker::detect_narrowing(&expr).expect("should detect singleton /=");
+        assert!(
+            info.singleton_eq.unwrap().negated,
+            "operator {op} should be treated as negated"
+        );
+    }
+}
+
+#[test]
+fn test_detect_narrowing_two_symbol_literals_no_match() {
+    // `#a = #b` has no variable to narrow.
+    let expr = msg_send(
+        symbol_lit("a"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("b")],
+    );
+    assert!(TypeChecker::detect_narrowing(&expr).is_none());
+}
+
+#[test]
+fn test_refine_singleton_eq_splits_union() {
+    // ms :: Integer | #infinity, after `ms = #infinity`:
+    //   true branch → #infinity, false branch → Integer.
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("ms", InferredType::simple_union(&["Integer", "#infinity"]));
+    let expr = msg_send(
+        var("ms"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("infinity")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    assert_eq!(refined.true_type, InferredType::known("#infinity"));
+    assert_eq!(refined.false_type, Some(InferredType::known("Integer")));
+}
+
+#[test]
+fn test_refine_singleton_inequality_swaps_branches() {
+    // `ms /= #infinity`: true branch is the remainder (Integer), false is the singleton.
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("ms", InferredType::simple_union(&["Integer", "#infinity"]));
+    let expr = msg_send(
+        var("ms"),
+        MessageSelector::Binary("/=".into()),
+        vec![symbol_lit("infinity")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    assert_eq!(refined.true_type, InferredType::known("Integer"));
+    assert_eq!(refined.false_type, Some(InferredType::known("#infinity")));
+}
+
+#[test]
+fn test_refine_singleton_eq_multi_member_union_keeps_rest() {
+    // d :: #north | #south | #east, after `d = #north`:
+    //   false branch keeps #south | #east.
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local(
+        "d",
+        InferredType::simple_union(&["#north", "#south", "#east"]),
+    );
+    let expr = msg_send(
+        var("d"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("north")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    assert_eq!(refined.true_type, InferredType::known("#north"));
+    assert_eq!(
+        refined.false_type,
+        Some(InferredType::simple_union(&["#south", "#east"]))
+    );
+}
+
+#[test]
+fn test_refine_singleton_eq_all_removed_is_never() {
+    // d :: #north (already narrowed), after `d = #north`:
+    //   the false branch is unreachable → Never.
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("d", InferredType::known("#north"));
+    let expr = msg_send(
+        var("d"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("north")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    assert_eq!(refined.true_type, InferredType::known("#north"));
+    assert_eq!(refined.false_type, Some(InferredType::Never));
 }
 
 #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
@@ -572,6 +572,46 @@ fn test_refine_singleton_eq_all_removed_is_never() {
 }
 
 #[test]
+fn test_refine_singleton_eq_dynamic_variable_keeps_false_dynamic() {
+    // An unbound variable resolves to Dynamic; `x = #foo` narrows the true
+    // branch to #foo and leaves the false branch Dynamic — there is no union to
+    // subtract from (exercises the `_ => ty.clone()` arm of `union_without`).
+    let hierarchy = ClassHierarchy::with_builtins();
+    let env = TypeEnv::new(); // `x` is absent → Dynamic
+    let expr = msg_send(
+        var("x"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("foo")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    assert_eq!(refined.true_type, InferredType::known("#foo"));
+    assert_eq!(
+        refined.false_type,
+        Some(InferredType::Dynamic(DynamicReason::Unknown))
+    );
+}
+
+#[test]
+fn test_refine_singleton_symbol_left_inequality_swaps_branches() {
+    // `#infinity /= ms` — symbol on the left, negated. Same result as
+    // `ms /= #infinity`: true branch is the remainder (Integer), false branch
+    // is the singleton. (`negated` comes from the operator, not operand order.)
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("ms", InferredType::simple_union(&["Integer", "#infinity"]));
+    let expr = msg_send(
+        symbol_lit("infinity"),
+        MessageSelector::Binary("/=".into()),
+        vec![var("ms")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    assert_eq!(refined.true_type, InferredType::known("Integer"));
+    assert_eq!(refined.false_type, Some(InferredType::known("#infinity")));
+}
+
+#[test]
 fn test_narrowing_does_not_leak_outside_block() {
     // Verify narrowing is scoped to block only:
     //   process: x :: Object =>


### PR DESCRIPTION
## Summary

Singleton symbol types (`#infinity`, `#ok`, …) already exist as first-class types (ADR 0068), but flow narrowing didn't account for equality tests against a singleton literal. A parameter typed `ms :: Integer | #infinity` stayed widened in *both* branches of `ms = #infinity ifTrue: [...] ifFalse: [...]`, which made precise singleton annotations awkward to consume.

This adds singleton-equality narrowing:

```beamtalk
withTimeout: ms :: Integer | #infinity -> TimeoutProxy =>
  ms = #infinity
    ifTrue:  [ "ms : #infinity here" ]
    ifFalse: [ "ms : Integer here" ]   // now narrows, previously Integer | #infinity
```

## Approach

A new `singleton_eq` narrowing rule (mirrors the existing rule-table pattern) detects `x = #foo` / `#foo = x` and the inequalities `/=` / `=/=`. Detection only sees the AST, so it records the tested singleton and a `negated` flag; `refine_singleton_narrowing` then resolves the variable's current type and splits it:

- **true branch** → the singleton (`#infinity`)
- **false branch** → the variable's type with that singleton removed (`Integer | #infinity` minus `#infinity` ⇒ `Integer`)
- **inequality** (`/=`, `=/=`) swaps the two branches

A `union_without` helper (the singleton counterpart of the existing `non_nil_type`) does the subtraction: a union collapses to its single remaining member, or to `Never` when the singleton was the only one left (the complementary branch is then unreachable).

This follows the precedent of `respondsTo:` / Result narrowing, where `detect` records intent and an apply-time refinement uses the variable's env type that the detector can't see.

## Also

Corrects a stale comment in the narrowing tests claiming union annotations "resolve to Dynamic" — they resolve to `InferredType::Union` via `type_resolver` (since BT-2016).

## Tests

- **Detection**: equality, symmetric `#foo = x`, inequality (`/=`, `=/=`), two-literal non-match (`#a = #b`)
- **Refinement**: union split, inequality branch-swap, multi-member union (`#north | #south | #east`), all-removed → `Never`
- 4152 `beamtalk-core` lib tests + 250 stdlib tests pass; clippy clean; `just build` + `just test-stdlib` green (no new warnings)

Closes BT-2617. Unblocks BT-2618 (tightening over-broad `Symbol` stdlib annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQB3c9h5ii7TUYdoKskM7w)_