### PR TITLE
LiveView IDE: fix active dock tab underline shifting the tab label (BT-2602)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -576,15 +576,15 @@
 .dock-tabs { display: flex; gap: 2px; align-items: center; }
 .dock-tab {
   font-size: 11px; font-weight: 600; letter-spacing: .03em; text-transform: uppercase;
-  color: var(--muted); cursor: pointer; padding: 0 4px; background: transparent;
+  color: var(--muted); cursor: pointer; padding: 0 4px 8px; background: transparent;
   border: 0; line-height: inherit; font-family: inherit;
 }
 .dock-tab:hover { color: var(--ink); }
-.dock-tab.on { color: var(--ink); }
-.dock-tab.on::after {
-  content: ""; display: block; height: 2px; background: var(--accent);
-  margin-top: 6px; border-radius: 2px;
-}
+/* Active underline drawn as an inset box-shadow so it does not participate in
+   layout (mirrors `.tabstrip .tab.on`). The uniform `padding-bottom` on every
+   `.dock-tab` reserves the underline gap for active and inactive tabs alike, so
+   switching the active tab never shifts a label vertically (BT-2602). */
+.dock-tab.on { color: var(--ink); box-shadow: inset 0 -2px 0 var(--accent); border-radius: 2px; }
 .tab-count {
   display: inline-block; margin-left: 5px; font-size: 9.5px; font-weight: 700;
   background: var(--accent-soft); color: var(--accent-2); border-radius: 8px; padding: 0 5px;


### PR DESCRIPTION
Fixes [BT-2602](https://linear.app/beamtalk/issue/BT-2602).

## Problem

In the workspace dock tab strip (`WORKSPACE / REPL / TRANSCRIPT / CHANGES / GIT / TESTS`), the **active** tab's label sat slightly higher than the inactive tabs — the active-tab underline indicator was a layout-participating element, so selecting a tab shifted its label and threw off the row's vertical alignment.

## Fix

CSS-only change in `editors/liveview/assets/css/app.css`: replace the layout-participating `.dock-tab.on::after` underline with an inset `box-shadow` plus a uniform `padding-bottom` on all dock tabs, so the active indicator no longer occupies layout space and the label stays put when a tab becomes active.

## Notes

- No markup change, so existing dock-tab Playwright/e2e selectors and assertions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSaj9LoBscUqYcVurSenXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSaj9LoBscUqYcVurSenXj)_