### PR TITLE
LiveView IDE: drop the new-method selector input, derive the selector from the body signature (BT-2606)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -378,17 +378,6 @@
 #method-editor-form { display: flex; flex-direction: column; flex: 1; min-height: 0; }
 #method-editor-form .cm-wrap { flex: 1; min-height: 6rem; }
 
-/* New-method tab: the one editor surface that still shows a selector input (the
-   breadcrumb can't name a selector that doesn't exist yet). */
-.new-method-selector {
-  display: flex;
-  align-items: center;
-  gap: .5rem;
-  margin-bottom: .5rem;
-}
-.new-method-selector .nm-label { color: var(--faint); flex: none; }
-.new-method-selector .field { flex: 1; }
-
 /* ============================================================================
    Tabbed method editor — write-surface tab strip + breadcrumb (BT-2494)
    ----------------------------------------------------------------------------

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1437,38 +1437,14 @@ defmodule BtAttachWeb.WorkspaceLive do
   # (source != the last-compiled base). Client-supplied, so a non-binary / absent
   # source is ignored rather than crashing.
   #
-  # On a *new-method* tab the form also carries the visible `selector` input. That
-  # input is controlled (`value={@edit_selector}`) and NOT `phx-update="ignore"`,
-  # so without capturing it here the server re-render (fired by typing in the
-  # CodeMirror source) would patch it back to `""` and wipe the author's typed
-  # selector — the next ⌘S would then fail the empty-selector guard. Mirror the
-  # payload's selector into `@edit_selector` so it survives the edit-source churn.
-  def handle_event("edit_source", %{"source" => source} = params, socket)
+  # A new-method tab no longer carries a separate selector input (BT-2606): the
+  # author writes the full method (signature + body) in the CodeMirror body, and
+  # the selector is parsed from that body on save — so there is nothing extra to
+  # mirror here. The breadcrumb derives its label live from the same tracked
+  # source (`breadcrumb/1`).
+  def handle_event("edit_source", %{"source" => source}, socket)
       when is_binary(source) do
-    socket = track_edit(socket, source)
-
-    socket =
-      case active_tab(socket.assigns) do
-        %{new: true} ->
-          case Map.get(params, "selector") do
-            sel when is_binary(sel) ->
-              # Mirror into BOTH the assign (so this render keeps the value) AND
-              # the tab struct (so `sync_active/2` restores it when the user
-              # switches away and back — otherwise the tab's `selector: ""` would
-              # wipe the typed name on re-focus).
-              socket
-              |> assign(edit_selector: sel)
-              |> update_active_tab(fn tab -> %{tab | selector: sel} end)
-
-            _ ->
-              socket
-          end
-
-        _ ->
-          socket
-      end
-
-    {:noreply, socket}
+    {:noreply, track_edit(socket, source)}
   end
 
   def handle_event("edit_source", _params, socket), do: {:noreply, socket}
@@ -2753,12 +2729,27 @@ defmodule BtAttachWeb.WorkspaceLive do
     end
   end
 
-  # Validate the edit form, then drive the write-surface save. Empty class or
-  # selector is a local validation error (rendered without a round-trip); a real
-  # save threads the body value straight to the workspace install chokepoint.
+  # Validate the edit form, then drive the write-surface save. Empty class or an
+  # un-derivable selector is a local validation error (rendered without a
+  # round-trip); a real save threads the body value straight to the workspace
+  # install chokepoint.
+  #
+  # On a *new-method* tab there is no selector input anymore (BT-2606): the author
+  # writes the full method (signature + body) in the body, so the selector is
+  # parsed from the source signature here and the form's (empty) `selector` field
+  # is ignored. An existing-method tab keeps the breadcrumb selector that rode the
+  # hidden field. The derived selector still passes through the `:save` op, where
+  # the compiler re-parses it from the body and rejects any mismatch — so a parse
+  # that disagrees with the compiler fails loudly rather than installing under the
+  # wrong key.
   defp save_method_body(socket, class, selector, source, tab_id) do
     class = String.trim(class)
-    selector = String.trim(selector)
+
+    selector =
+      case tab_id && find_tab(socket, tab_id) do
+        %{new: true} -> parse_method_signature_selector(source)
+        _ -> String.trim(selector)
+      end
 
     socket =
       assign(socket,
@@ -2772,7 +2763,10 @@ defmodule BtAttachWeb.WorkspaceLive do
         assign(socket, save_result: nil, save_error: "Enter a class name to save a method.")
 
       selector == "" ->
-        assign(socket, save_result: nil, save_error: "Enter a selector to save a method.")
+        assign(socket,
+          save_result: nil,
+          save_error: "Could not parse a method signature from the source."
+        )
 
       true ->
         case Facade.dispatch(
@@ -4449,8 +4443,135 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   # The Class › side › selector breadcrumb label parts for the active tab.
   defp breadcrumb(%{kind: :def, class: class}), do: {class, nil, "class definition"}
-  defp breadcrumb(%{new: true, class: class, side: side}), do: {class, side, "new method"}
+  # A new-method tab has no stored selector yet (BT-2606): derive it live from the
+  # body the author is typing so the breadcrumb names the method as soon as a
+  # recognizable signature appears, falling back to the `new method` placeholder
+  # until then.
+  defp breadcrumb(%{new: true, class: class, side: side, source: source}) do
+    case parse_method_signature_selector(source) do
+      "" -> {class, side, "new method"}
+      selector -> {class, side, selector}
+    end
+  end
+
   defp breadcrumb(%{class: class, side: side, selector: selector}), do: {class, side, selector}
+
+  # Parse the selector from a method's source signature (BT-2606), returning `""`
+  # when no valid signature is present yet. The author writes the full method
+  # (`selector ... => body`) in the editor body; this recovers the selector the
+  # same way the compiler's method header grammar does, so the new-method tab no
+  # longer needs a separate selector input.
+  #
+  # It is intentionally conservative: a string it can't confidently read as a
+  # header returns `""` (treated as "no signature yet"). The authoritative parse
+  # still runs server-side in the `:save` op, which rejects a selector that
+  # disagrees with the compiled body — so this client-side read only has to be
+  # right for the breadcrumb hint and the pre-flight validation, never the install
+  # key of record.
+  defp parse_method_signature_selector(source) when is_binary(source) do
+    source
+    |> strip_leading_comments()
+    |> strip_method_modifiers()
+    |> selector_from_header()
+  end
+
+  defp parse_method_signature_selector(_source), do: ""
+
+  # Drop leading blank lines and whole-line `//` / `///` comments, returning the
+  # first line that begins a real method header (mirrors the backend
+  # `skip_leading_comments/1`).
+  defp strip_leading_comments(source) do
+    trimmed = String.trim_leading(source)
+
+    if String.starts_with?(trimmed, "//") do
+      case String.split(trimmed, "\n", parts: 2) do
+        [_comment, rest] -> strip_leading_comments(rest)
+        [_comment] -> ""
+      end
+    else
+      trimmed
+    end
+  end
+
+  # Drop leading method modifiers (`class`, `internal`, `sealed`) that may precede
+  # the selector, matching the parser's `parse_method_definition` modifier loop. A
+  # modifier word is only stripped when more header text follows it — a bare
+  # `class =>` is a method *named* `class`, not the `class` modifier.
+  defp strip_method_modifiers(header) do
+    case String.split(header, ~r/\s+/, parts: 2) do
+      [word, rest] when word in ["class", "internal", "sealed"] ->
+        # `class`/`internal`/`sealed` are modifiers only when a selector follows;
+        # if the next token opens the body (`=>`) or a return type (`->`), the
+        # word itself is the (unary) selector.
+        if String.starts_with?(rest, "=>") or String.starts_with?(rest, "->") do
+          header
+        else
+          strip_method_modifiers(rest)
+        end
+
+      _ ->
+        header
+    end
+  end
+
+  # Recover the selector token(s) from the start of a method header: a keyword
+  # selector (`at:put:` from `at: i put: v => …`), a binary selector (`+`, `->`,
+  # `>>`, … from `+ other => …`), or a unary selector (`increment` from
+  # `increment => …`). Returns `""` when the head doesn't read as a header (no
+  # `=>` before the first statement break, or an empty/blank head).
+  defp selector_from_header(""), do: ""
+
+  defp selector_from_header(header) do
+    # Only the header up to the body arrow / first statement break can contribute
+    # a selector — bail when there is no `=>` before a `.` or newline.
+    head =
+      header
+      |> String.split(~r/\r?\n/, parts: 2)
+      |> List.first()
+
+    cond do
+      not String.contains?(head, "=>") ->
+        ""
+
+      true ->
+        head
+        |> String.split("=>", parts: 2)
+        |> List.first()
+        |> selector_from_signature_text()
+    end
+  end
+
+  # Extract the selector from the text *before* the `=>` arrow. Keyword selectors
+  # are the concatenation of their `keyword:` parts (parameter names, type
+  # annotations and the return type are dropped); a binary selector is its leading
+  # operator; a unary selector is its single identifier.
+  defp selector_from_signature_text(sig) do
+    sig = String.trim(sig)
+
+    keyword_parts = Regex.scan(~r/([A-Za-z_][A-Za-z0-9_]*):/, sig, capture: :all_but_first)
+
+    cond do
+      sig == "" ->
+        ""
+
+      keyword_parts != [] ->
+        keyword_parts |> Enum.map(fn [k] -> k <> ":" end) |> Enum.join()
+
+      true ->
+        case Regex.run(~r/^([A-Za-z_][A-Za-z0-9_]*)/, sig) do
+          [_, ident] ->
+            ident
+
+          nil ->
+            # Binary selector: the leading run of operator characters (e.g. `+`,
+            # `->`, `>>`, `<=`). Anything else is not a recognizable header.
+            case Regex.run(~r/^([-+*\/~<>=&|@%^?]+)/, sig) do
+              [_, op] -> op
+              nil -> ""
+            end
+        end
+    end
+  end
 
   # The method shown in the focused tab as a `%{class, side, selector}` ref (or nil
   # for a class-definition tab), so the System Browser can highlight the matching
@@ -7229,28 +7350,18 @@ defmodule BtAttachWeb.WorkspaceLive do
                         <%!-- Class + selector ride the form as hidden fields — the
                            breadcrumb above is the canonical display of "which
                            class › selector this tab edits", so the old editable
-                           inputs were redundant for an EXISTING method. The one
-                           exception is a "new method" tab: its selector doesn't
-                           exist yet (the breadcrumb can't name it), so it keeps a
-                           visible selector input for the author to fill. The
-                           save_method payload (class + selector + source) shape is
-                           identical in every case. --%>
+                           inputs are redundant: the author types the full method
+                           (signature + body) in the CodeMirror body, exactly like
+                           editing an existing method. A "new method" tab has no
+                           selector yet, so it posts an empty hidden field and the
+                           save handler derives the selector by parsing the body's
+                           signature (BT-2606). The save_method payload (class +
+                           selector + source) shape is identical in every case. --%>
                         <input type="hidden" name="class" value={@edit_class} />
                         <% tab = active_tab(assigns) %>
                         <%= cond do %>
                           <% tab.kind == :def -> %>
                             <input type="hidden" name="selector" value="▸ class definition" />
-                          <% tab.new -> %>
-                            <label class="new-method-selector">
-                              <span class="nm-label mono">selector</span>
-                              <input
-                                class="field"
-                                name="selector"
-                                value={@edit_selector}
-                                autocomplete="off"
-                                spellcheck="false"
-                              />
-                            </label>
                           <% true -> %>
                             <input type="hidden" name="selector" value={@edit_selector} />
                         <% end %>

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4522,8 +4522,8 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp selector_from_header(""), do: ""
 
   defp selector_from_header(header) do
-    # Only the header up to the body arrow / first statement break can contribute
-    # a selector — bail when there is no `=>` before a `.` or newline.
+    # Only the header up to the body arrow can contribute a selector — bail
+    # when there is no `=>` before the first newline.
     head =
       header
       |> String.split(~r/\r?\n/, parts: 2)
@@ -4548,7 +4548,9 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp selector_from_signature_text(sig) do
     sig = String.trim(sig)
 
-    keyword_parts = Regex.scan(~r/([A-Za-z_][A-Za-z0-9_]*):/, sig, capture: :all_but_first)
+    # `:(?!:)` so a compact type annotation (`i::Integer`) doesn't capture `i:` as
+    # a keyword part — only a real `keyword:` (single colon) counts.
+    keyword_parts = Regex.scan(~r/([A-Za-z_][A-Za-z0-9_]*):(?!:)/, sig, capture: :all_but_first)
 
     cond do
       sig == "" ->

--- a/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
@@ -274,20 +274,21 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
         |> render_click()
 
       # A new-method tab is open: the breadcrumb reads "new method" (no selector
-      # exists yet), and — uniquely among tabs — it shows a visible selector input
-      # for the author to fill.
+      # exists yet). There is no separate selector input anymore (BT-2606) — the
+      # author writes the full method in the body.
       assert opened =~ "new method"
-      assert opened =~ "new-method-selector"
+      refute opened =~ "new-method-selector"
       assert opened =~ "Counter ▸ new"
 
-      # Authoring + saving drives the same write-surface `save` as any method: the
-      # author-supplied selector rides the form, so the save reports it by name.
+      # Authoring + saving drives the same write-surface `save` as any method. The
+      # form posts no real selector (there is no input); the save handler parses it
+      # from the body signature, so the save reports it by name (BT-2606).
       saved =
         view
         |> form("form[phx-submit='save_method']")
         |> render_submit(%{
           "class" => "Counter",
-          "selector" => "greet",
+          "selector" => "",
           "source" => ~s|greet => "hi"|,
           "tab" => "new:Counter:instance"
         })
@@ -312,8 +313,9 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
       |> element(~s(div[phx-click="new_method"][phx-value-class="Counter"]))
       |> render_click()
 
-      # The selector input is blank until the author fills it — saving then trips
-      # the same empty-selector guard a method save always has.
+      # The body has no recognizable method signature (just `=> "hi"`), so the
+      # selector can't be parsed from it (BT-2606) — saving trips the local
+      # validation guard.
       html =
         view
         |> form("form[phx-submit='save_method']")
@@ -324,10 +326,12 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
           "tab" => "new:Counter:instance"
         })
 
-      assert html =~ "Enter a selector"
+      assert html =~ "Could not parse a method signature"
     end
 
-    test "a new-method tab keeps the typed selector across source edits", %{conn: conn} do
+    test "a new-method tab derives a keyword selector from the body on save (BT-2606)", %{
+      conn: conn
+    } do
       {:ok, view, _html} = live(owner_conn(conn), "/")
 
       view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
@@ -336,20 +340,24 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
       |> element(~s(div[phx-click="new_method"][phx-value-class="Counter"]))
       |> render_click()
 
-      # Typing in the CodeMirror source fires the form's phx-change="edit_source"
-      # carrying the selector input's current value. Without capturing it the
-      # server re-render would patch the (controlled, non-ignored) selector field
-      # back to "" — so a later ⌘S would fail the empty-selector guard. Drive that
-      # event and confirm the typed selector survives.
-      html =
+      # No selector input — the author writes the whole method (keyword signature +
+      # body) in the source, and the save handler parses the selector from it,
+      # concatenating the keyword parts into `at:put:` (BT-2606).
+      saved =
         view
         |> form("form[phx-submit='save_method']")
-        |> render_change(%{"source" => ~s|greet => "hi"|, "selector" => "greet"})
+        |> render_submit(%{
+          "class" => "Counter",
+          "selector" => "",
+          "source" => "at: i put: v => self",
+          "tab" => "new:Counter:instance"
+        })
 
-      assert html =~ ~s(name="selector" value="greet")
+      assert saved =~ "Saved at:put: on Counter"
     end
 
-    test "a new-method tab's typed selector survives a tab switch", %{conn: conn} do
+    test "a new-method tab's body survives a tab switch so its derived selector persists (BT-2606)",
+         %{conn: conn} do
       {:ok, view, _html} = live(owner_conn(conn), "/")
 
       view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
@@ -360,11 +368,10 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
       |> element(~s(div[phx-click="new_method"][phx-value-class="Counter"]))
       |> render_click()
 
-      # Type a selector — captured on the source change into both the assign and
-      # the tab struct.
+      # Type a full method body — tracked onto the tab struct as its source.
       view
       |> form("form[phx-submit='save_method']")
-      |> render_change(%{"source" => ~s|greet => "hi"|, "selector" => "greet"})
+      |> render_change(%{"source" => ~s|greet => "hi"|})
 
       # Switch away to the increment tab, then back to the new-method tab.
       view
@@ -378,8 +385,10 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
         |> element(~s(button[phx-click="tab_select"][phx-value-id="new:Counter:instance"]))
         |> render_click()
 
-      # `sync_active` restores the selector from the tab struct, not a blank "".
-      assert html =~ ~s(name="selector" value="greet")
+      # `sync_active` restores the body source from the tab struct, so the
+      # breadcrumb re-derives the `greet` selector instead of resetting to the
+      # "new method" placeholder.
+      assert html =~ "greet"
     end
 
     test "saving a new method whose selector is already open folds into that tab", %{conn: conn} do


### PR DESCRIPTION
Fixes [BT-2606](https://linear.app/beamtalk/issue/BT-2606).

## Problem

When authoring a new method in the LiveView IDE, the new-method tab was the only editor surface with a separate `selector` input box — even though the author must *also* type the full method signature in the body. The selector was entered twice (once in the box, once in the body signature), which was redundant and required an `edit_source` mirroring hack to keep the controlled input from being wiped on re-render.

## Fix

Remove the selector input. The author writes the full method (signature + body) in the CodeMirror body, exactly like editing an existing method, and the selector is derived by parsing the body signature:

- `save_method_body/5` — for a new-method tab, parses the selector from `source` via the new `parse_method_signature_selector/1` (keyword / binary / unary selectors), ignoring the empty form field. Existing-method tabs keep their breadcrumb selector.
- `breadcrumb/1` — new-method tabs derive the selector **live** from the tracked body source, falling back to the `new method` placeholder until a recognizable signature appears.
- `handle_event("edit_source", ...)` — drops the now-unneeded selector-mirroring branch.
- Removes the `.new-method-selector` markup and its dead CSS.
- Empty/unparseable signature → local validation error "Could not parse a method signature from the source."

The derived selector still flows through the `:save` op, where the compiler re-parses it from the body and rejects any mismatch — so the client-side parse only drives the breadcrumb hint + pre-flight validation, never the install key of record.

## Tests

Updated the new-method authoring tests in `workspace_flush_badge_test.exs` to the body-derived model (no selector input; save derives `greet` / `at:put:` from the body; validation error on an unparseable body; breadcrumb persists across tab switches). Full LiveView unit suite green locally (252 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSaj9LoBscUqYcVurSenXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSaj9LoBscUqYcVurSenXj)_