### PR TITLE
Fix singleton-in-union type-checking gaps (BT-2624)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1869,6 +1869,15 @@ impl TypeChecker {
     /// - ALL non-nil members respond → no warning, return union of return types.
     /// - SOME non-nil members respond → DNU hint naming the non-responding members.
     /// - NO non-nil members respond → existing DNU warning.
+    /// Infer the result of sending `selector` to a union receiver.
+    ///
+    /// Note: the equality / identity comparison operators (`=`, `==`, `=:=`,
+    /// `/=`, `=/=`) short-circuit to `Boolean` without per-member resolution
+    /// (see the inline note). A member class that overrides `=` to return
+    /// something other than `Boolean` would therefore still infer `Boolean`
+    /// here — an intentional tradeoff matching the non-union `Meta` path, since
+    /// these operators are part of the universal `Object`/`ProtoObject`
+    /// protocol and are not modelled as per-class hierarchy methods.
     #[allow(clippy::too_many_lines)]
     fn infer_union_message_send(
         &mut self,
@@ -2315,6 +2324,9 @@ impl TypeChecker {
                         .iter()
                         .any(|c| c == class_name)
             }
+            // `Meta`, `Never`, etc. do not admit a singleton: a class object or
+            // a divergent value can never equal a symbol literal, so a
+            // `metaVar = #foo` test is correctly flagged "can never be true".
             _ => false,
         }
     }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -977,7 +977,7 @@ impl TypeChecker {
             Self::detect_narrowing(receiver)
                 .map(|info| self.refine_responds_to_narrowing(info))
                 .map(|info| Self::refine_result_narrowing(info, env, hierarchy))
-                .map(|info| Self::refine_singleton_narrowing(info, env, hierarchy))
+                .map(|info| self.refine_singleton_narrowing(info, env, hierarchy, receiver.span()))
         } else {
             None
         };
@@ -1893,6 +1893,21 @@ impl TypeChecker {
             return InferredType::Dynamic(DynamicReason::DynamicReceiver);
         }
 
+        // BT-2624: The equality / identity comparison operators (`=`, `==`,
+        // `=:=`, `/=`, `=/=`) are universal value/identity comparisons every
+        // object supports at runtime via the `Object`/`ProtoObject` protocol,
+        // but they are not modelled as per-class hierarchy methods (bare `=` is
+        // a codegen alias for `=:=`, BT-952). The non-union `Meta` receiver path
+        // already special-cases them for exactly this reason — mirror it here so
+        // a union receiver does not spuriously report that a concrete member
+        // (e.g. `Integer does not understand '='`) or a singleton member fails
+        // to understand the operator. This also keeps the idiomatic
+        // `unionVar = #singleton` narrowing guard (BT-2617) warning-free. These
+        // selectors always return `Boolean`.
+        if is_equality_comparison_op(selector) {
+            return InferredType::known("Boolean");
+        }
+
         for member in members {
             // Dynamic members: no warning, contribute Dynamic to return type.
             let Some(member_name) = member.as_known() else {
@@ -1907,19 +1922,34 @@ impl TypeChecker {
             if WellKnownClass::from_str(member_name).is_some_and(WellKnownClass::is_nil_class) {
                 continue;
             }
-            if !hierarchy.has_class(member_name) {
+            // BT-2624: A singleton member (`#foo`) is a subtype of `Symbol` (see
+            // the singleton-as-Symbol convention in `type_resolver`). Resolve its
+            // method set through `Symbol` so inherited methods (`asString`,
+            // `printString`, `=:=`, …) are visible. Without this, `#foo` looks
+            // like an unknown class and is treated as an *uncertain* member,
+            // which both poisons the union's return type with `Dynamic` (a
+            // genuine responder like `=:=` then infers `Dynamic` instead of
+            // `Boolean`) and downgrades genuine non-responder warnings to hints.
+            // The original `member_name` (`#foo`) is still used for the
+            // user-facing missing-selector message and for `Self`-typed returns.
+            let resolve_name: &str = if member_name.starts_with('#') {
+                "Symbol"
+            } else {
+                member_name.as_str()
+            };
+            if !hierarchy.has_class(resolve_name) {
                 uncertain_member_count += 1;
                 return_types.push(InferredType::Dynamic(DynamicReason::DynamicReceiver));
                 continue;
             }
-            if hierarchy.has_instance_dnu_override(member_name) {
+            if hierarchy.has_instance_dnu_override(resolve_name) {
                 uncertain_member_count += 1;
                 return_types.push(InferredType::Dynamic(DynamicReason::DynamicReceiver));
                 continue;
             }
-            if hierarchy.resolves_selector(member_name, selector) {
+            if hierarchy.resolves_selector(resolve_name, selector) {
                 responding_count += 1;
-                if let Some(method) = hierarchy.find_method(member_name, selector) {
+                if let Some(method) = hierarchy.find_method(resolve_name, selector) {
                     if let Some(ref ret_ty) = method.return_type {
                         if ret_ty.as_str() == "Self" {
                             // Self resolves to the concrete member type (with type args)
@@ -2164,14 +2194,45 @@ impl TypeChecker {
     /// `#infinity` ⇒ `Integer`). For an inequality (`/=`, `=/=`) the two
     /// branches are swapped.
     pub(super) fn refine_singleton_narrowing(
+        &mut self,
         mut info: NarrowingInfo,
         env: &TypeEnv,
         hierarchy: &ClassHierarchy,
+        test_span: Span,
     ) -> NarrowingInfo {
         let Some(eq) = info.singleton_eq.clone() else {
             return info;
         };
         let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+
+        // BT-2624 (item 1): when the tested singleton can never be a value of
+        // the variable's current type, the comparison is statically decidable —
+        // an equality test (`= #foo`) can never hold and an inequality test
+        // (`/= #foo`) always holds. Only flag this when certain: skip `Dynamic`
+        // (unknown) and `Never` (the branch is already unreachable), and skip
+        // when any member admits the singleton (it is the singleton itself, or
+        // `Symbol`/one of its supertypes).
+        if !matches!(current_ty, InferredType::Dynamic(_) | InferredType::Never)
+            && !Self::type_admits_singleton(&current_ty, &eq.singleton, hierarchy)
+        {
+            let ty_display = current_ty.display_for_diagnostic().unwrap_or_default();
+            let message = if eq.negated {
+                format!(
+                    "comparison is always true: `{}` is never a value of `{ty_display}`",
+                    eq.singleton
+                )
+            } else {
+                format!(
+                    "comparison can never be true: `{}` is not a value of `{ty_display}`",
+                    eq.singleton
+                )
+            };
+            self.diagnostics.push(
+                Diagnostic::hint(message, test_span)
+                    .with_category(crate::source_analysis::DiagnosticCategory::Type),
+            );
+        }
+
         let matched = InferredType::known(eq.singleton.clone());
         let remainder = Self::union_without(&current_ty, &eq.singleton);
         if eq.negated {
@@ -2225,6 +2286,34 @@ impl TypeChecker {
             }
             InferredType::Known { class_name, .. } if class_name == removed => InferredType::Never,
             _ => ty.clone(),
+        }
+    }
+
+    /// BT-2624: Whether the singleton `singleton` (`#foo`) could be a runtime
+    /// value of `ty`. A member admits the singleton when it *is* that singleton,
+    /// or when it is a supertype of every singleton — `Symbol` or one of its
+    /// ancestors (`Object`, `ProtoObject`). Other concrete members (`Integer`, a
+    /// *different* singleton, …) do not admit it. `Dynamic` admits anything, so
+    /// callers stay conservative when the type is unknown.
+    fn type_admits_singleton(
+        ty: &InferredType,
+        singleton: &EcoString,
+        hierarchy: &ClassHierarchy,
+    ) -> bool {
+        match ty {
+            InferredType::Dynamic(_) => true,
+            InferredType::Union { members, .. } => members
+                .iter()
+                .any(|m| Self::type_admits_singleton(m, singleton, hierarchy)),
+            InferredType::Known { class_name, .. } => {
+                class_name == singleton
+                    || class_name == "Symbol"
+                    || hierarchy
+                        .superclass_chain("Symbol")
+                        .iter()
+                        .any(|c| c == class_name)
+            }
+            _ => false,
         }
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1957,8 +1957,10 @@ impl TypeChecker {
                         } else if ret_ty.as_str() == "Self class" {
                             // ADR 0083: `Self class` resolves to the metatype of
                             // the concrete union member (was Dynamic pre-0083,
-                            // BT-1952).
-                            return_types.push(InferredType::meta(member_name.clone()));
+                            // BT-1952). Use `resolve_name` so a singleton member
+                            // yields `Symbol class` (`#foo class` is `Symbol` at
+                            // runtime), not a phantom `Meta("#foo")` (BT-2624).
+                            return_types.push(InferredType::meta(EcoString::from(resolve_name)));
                         } else if let Some(meta_class) = ret_ty
                             .as_str()
                             .strip_suffix(" class")

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1869,7 +1869,6 @@ impl TypeChecker {
     /// - ALL non-nil members respond → no warning, return union of return types.
     /// - SOME non-nil members respond → DNU hint naming the non-responding members.
     /// - NO non-nil members respond → existing DNU warning.
-    /// Infer the result of sending `selector` to a union receiver.
     ///
     /// Note: the equality / identity comparison operators (`=`, `==`, `=:=`,
     /// `/=`, `=/=`) short-circuit to `Boolean` without per-member resolution

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
@@ -507,7 +507,8 @@ fn test_refine_singleton_eq_splits_union() {
         vec![symbol_lit("infinity")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let mut checker = TypeChecker::new();
+    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
     assert_eq!(refined.true_type, InferredType::known("#infinity"));
     assert_eq!(refined.false_type, Some(InferredType::known("Integer")));
 }
@@ -524,7 +525,8 @@ fn test_refine_singleton_inequality_swaps_branches() {
         vec![symbol_lit("infinity")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let mut checker = TypeChecker::new();
+    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
     assert_eq!(refined.true_type, InferredType::known("Integer"));
     assert_eq!(refined.false_type, Some(InferredType::known("#infinity")));
 }
@@ -545,7 +547,8 @@ fn test_refine_singleton_eq_multi_member_union_keeps_rest() {
         vec![symbol_lit("north")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let mut checker = TypeChecker::new();
+    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
     assert_eq!(refined.true_type, InferredType::known("#north"));
     assert_eq!(
         refined.false_type,
@@ -566,7 +569,8 @@ fn test_refine_singleton_eq_all_removed_is_never() {
         vec![symbol_lit("north")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let mut checker = TypeChecker::new();
+    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
     assert_eq!(refined.true_type, InferredType::known("#north"));
     assert_eq!(refined.false_type, Some(InferredType::Never));
 }
@@ -584,7 +588,8 @@ fn test_refine_singleton_eq_dynamic_variable_keeps_false_dynamic() {
         vec![symbol_lit("foo")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let mut checker = TypeChecker::new();
+    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
     assert_eq!(refined.true_type, InferredType::known("#foo"));
     assert_eq!(
         refined.false_type,
@@ -606,9 +611,104 @@ fn test_refine_singleton_symbol_left_inequality_swaps_branches() {
         vec![var("ms")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let mut checker = TypeChecker::new();
+    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
     assert_eq!(refined.true_type, InferredType::known("Integer"));
     assert_eq!(refined.false_type, Some(InferredType::known("#infinity")));
+}
+
+/// BT-2624 (item 1): testing a variable against a singleton it can never hold
+/// (`#west` is not a member of `#north | #south`) is statically false — emit a
+/// "can never be true" hint and do NOT flag the present-member case.
+#[test]
+fn bt2624_singleton_eq_impossible_member_emits_hint() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("d", InferredType::simple_union(&["#north", "#south"]));
+    let expr = msg_send(
+        var("d"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("west")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let mut checker = TypeChecker::new();
+    let _ = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+    let hints: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("can never be true"))
+        .collect();
+    assert_eq!(
+        hints.len(),
+        1,
+        "expected one impossibility hint, got: {:?}",
+        checker.diagnostics()
+    );
+    assert!(
+        hints[0].message.contains("#west") && hints[0].message.contains("#north | #south"),
+        "hint should name the singleton and the type: {}",
+        hints[0].message
+    );
+}
+
+/// BT-2624 (item 1): the negated form against an impossible member is always
+/// true — emit the complementary "always true" hint.
+#[test]
+fn bt2624_singleton_inequality_impossible_member_always_true() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("d", InferredType::simple_union(&["#north", "#south"]));
+    let expr = msg_send(
+        var("d"),
+        MessageSelector::Binary("/=".into()),
+        vec![symbol_lit("west")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let mut checker = TypeChecker::new();
+    let _ = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+    assert!(
+        checker
+            .diagnostics()
+            .iter()
+            .any(|d| d.message.contains("always true") && d.message.contains("#west")),
+        "expected an 'always true' hint, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+/// BT-2624 (item 1): a singleton that IS a member must not be flagged, and a
+/// `Symbol`-typed (or `Dynamic`) variable admits any singleton — no hint.
+#[test]
+fn bt2624_singleton_eq_possible_member_no_hint() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("d", InferredType::simple_union(&["#north", "#south"]));
+    // `d = #north` — #north is a member, so the test is satisfiable.
+    let member_expr = msg_send(
+        var("d"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("north")],
+    );
+    let info = TypeChecker::detect_narrowing(&member_expr).unwrap();
+    let mut checker = TypeChecker::new();
+    let _ = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+
+    // `s :: Symbol` admits every singleton.
+    let mut sym_env = TypeEnv::new();
+    sym_env.set_local("s", InferredType::known("Symbol"));
+    let sym_expr = msg_send(
+        var("s"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("anything")],
+    );
+    let sym_info = TypeChecker::detect_narrowing(&sym_expr).unwrap();
+    let _ = checker.refine_singleton_narrowing(sym_info, &sym_env, &hierarchy, span());
+
+    assert!(
+        checker.diagnostics().is_empty(),
+        "satisfiable comparisons must not warn, got: {:?}",
+        checker.diagnostics()
+    );
 }
 
 #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_if_true_if_false.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_if_true_if_false.rs
@@ -384,3 +384,79 @@ fn bt_2039_if_true_if_false_known_branch_suppresses_ffi_warning() {
             .collect::<Vec<_>>()
     );
 }
+
+// ── BT-2624 item 4: singleton-union narrowing, integration through infer_expr ──
+
+/// BT-2624 item 4 — the previously-blocked end-to-end narrowing check for
+/// BT-2617, at the highest level currently reachable.
+///
+/// A singleton union (`Integer | #infinity`) cannot yet be *constructed* from
+/// parseable source — it is unwritable as a type annotation (the parser rejects
+/// `#foo` in type position), bare `=` does not parse as an equality operator,
+/// and an `ifTrue:ifFalse:` assignment collapses its branches rather than
+/// unioning them. So the union is seeded as a local and the guard expression is
+/// built and run through the real `infer_expr` pipeline (narrowing + union
+/// message-send), which is exactly what items 1–3 changed.
+///
+/// `(ms =:= #infinity) ifTrue: [0] ifFalse: [ms + 1]` — in the `ifFalse:` branch
+/// `ms` narrows to `Integer`, so `ms + 1` resolves cleanly. The *unnarrowed*
+/// `ms + 1` on the bare union warns (item 3: `#infinity` resolves its `Symbol`
+/// method set and does not understand `+`). The contrast proves the narrowing.
+#[test]
+fn bt2624_singleton_union_narrowing_suppresses_branch_warning() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    let union = InferredType::simple_union(&["Integer", "#infinity"]);
+    let ms_plus_one = || {
+        msg_send(
+            var("ms"),
+            MessageSelector::Binary("+".into()),
+            vec![int_lit(1)],
+        )
+    };
+    let guard = msg_send(
+        var("ms"),
+        MessageSelector::Binary("=:=".into()),
+        vec![Expression::Literal(
+            Literal::Symbol("infinity".into()),
+            span(),
+        )],
+    );
+    let guarded = if_true_if_false(
+        guard,
+        block_expr(vec![int_lit(0)]),
+        block_expr(vec![ms_plus_one()]),
+    );
+
+    // Narrowed: the `+` send lives in the `ifFalse:` branch where `ms :: Integer`.
+    let mut narrowed = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local("ms", union.clone());
+    let _ = narrowed.infer_expr(&guarded, &hierarchy, &mut env, false);
+    assert!(
+        narrowed
+            .diagnostics()
+            .iter()
+            .all(|d| !d.message.contains("understand")),
+        "narrowing should suppress the '+' warning in the ifFalse: branch, got: {:?}",
+        narrowed.diagnostics()
+    );
+
+    // Unnarrowed control: the same `+` send on the bare union must warn, naming
+    // the singleton that does not understand it.
+    let mut unnarrowed = TypeChecker::new();
+    let mut env2 = TypeEnv::new();
+    env2.set_local("ms", union);
+    let _ = unnarrowed.infer_expr(&ms_plus_one(), &hierarchy, &mut env2, false);
+    let plus_dnu: Vec<_> = unnarrowed
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("understand") && d.message.contains("'+'"))
+        .collect();
+    assert_eq!(
+        plus_dnu.len(),
+        1,
+        "the unnarrowed union must warn about '+', got: {:?}",
+        unnarrowed.diagnostics()
+    );
+    assert!(plus_dnu[0].message.contains("#infinity"));
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
@@ -786,3 +786,30 @@ fn bt2624_union_singleton_partial_nonresponder_hints_singleton() {
         "Integer responds but #infinity does not — hint should name the singleton: {dnu:?}"
     );
 }
+
+/// BT-2624 (review follow-up): `#foo class` on a union resolves through
+/// `Symbol`, so a singleton member's `Self class` return is `Symbol class`
+/// (`Meta("Symbol")`) — not a phantom `Meta("#foo")`. A union of singletons
+/// collapses to a single `Meta("Symbol")`.
+#[test]
+fn bt2624_union_singleton_class_resolves_to_symbol_metatype() {
+    let module = Module::new(
+        vec![ExpressionStatement::bare(msg_send(
+            Expression::Identifier(ident("x")),
+            MessageSelector::Unary("class".into()),
+            vec![],
+        ))],
+        span(),
+    );
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local("x", InferredType::simple_union(&["#north", "#south"]));
+    let ty = checker.infer_expr(
+        &module.expressions[0].expression,
+        &hierarchy,
+        &mut env,
+        false,
+    );
+    assert_eq!(ty, InferredType::meta("Symbol"), "got: {ty:?}");
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
@@ -673,3 +673,116 @@ fn is_assignable_to_integer_or_string() {
         &hierarchy
     ));
 }
+
+// ── BT-2624: singleton members in unions ────────────────────────────────
+
+/// Infer `x <selector>` (optionally with `arg`) where `x :: Integer | #infinity`,
+/// returning the inferred type and the rendered diagnostics (`"Severity: msg"`).
+fn infer_singleton_union_send(
+    selector: MessageSelector,
+    args: Vec<Expression>,
+) -> (InferredType, Vec<String>) {
+    let module = Module::new(
+        vec![ExpressionStatement::bare(msg_send(
+            Expression::Identifier(ident("x")),
+            selector,
+            args,
+        ))],
+        span(),
+    );
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local("x", InferredType::simple_union(&["Integer", "#infinity"]));
+    let ty = checker.infer_expr(
+        &module.expressions[0].expression,
+        &hierarchy,
+        &mut env,
+        false,
+    );
+    let diags = checker
+        .diagnostics()
+        .iter()
+        .map(|d| format!("{:?}: {}", d.severity, d.message))
+        .collect();
+    (ty, diags)
+}
+
+/// BT-2624 (item 2): the equality alias `=` on a union receiver is a universal
+/// comparison — it returns Boolean without a spurious "does not understand '='".
+#[test]
+fn bt2624_union_equality_alias_returns_boolean_no_warning() {
+    let (ty, diags) = infer_singleton_union_send(
+        MessageSelector::Binary("=".into()),
+        vec![Expression::Literal(
+            Literal::Symbol("infinity".into()),
+            span(),
+        )],
+    );
+    assert_eq!(ty, InferredType::known("Boolean"));
+    assert!(
+        diags.iter().all(|d| !d.contains("understand")),
+        "no DNU expected for `=` on a union, got: {diags:?}"
+    );
+}
+
+/// BT-2624 (item 2/3): identity comparison `=:=` on a singleton-bearing union
+/// returns Boolean, not Dynamic — the singleton member no longer poisons it.
+#[test]
+fn bt2624_union_identity_comparison_returns_boolean_not_dynamic() {
+    let (ty, diags) = infer_singleton_union_send(
+        MessageSelector::Binary("=:=".into()),
+        vec![Expression::Literal(
+            Literal::Symbol("infinity".into()),
+            span(),
+        )],
+    );
+    assert_eq!(ty, InferredType::known("Boolean"));
+    assert!(diags.is_empty(), "no diagnostics expected, got: {diags:?}");
+}
+
+/// BT-2624 (item 3): a singleton member resolves its inherited `Symbol` methods,
+/// so a method every member understands (`asString`) infers a concrete type
+/// rather than `Dynamic`, with no warning.
+#[test]
+fn bt2624_union_singleton_resolves_inherited_symbol_method() {
+    let (ty, diags) = infer_singleton_union_send(MessageSelector::Unary("asString".into()), vec![]);
+    assert_eq!(ty, InferredType::known("String"));
+    assert!(
+        diags.iter().all(|d| !d.contains("understand")),
+        "asString resolves on both members, got: {diags:?}"
+    );
+}
+
+/// BT-2624 (item 3): when NO member understands the selector, the singleton is
+/// resolved (via Symbol) too, so this is a definite failure — a Warning, not a
+/// downgraded Hint. (Two members → the plural "do not understand" wording.)
+#[test]
+fn bt2624_union_singleton_genuine_nonresponder_warns() {
+    let (_ty, diags) =
+        infer_singleton_union_send(MessageSelector::Unary("frobnicate".into()), vec![]);
+    let dnu: Vec<_> = diags.iter().filter(|d| d.contains("understand")).collect();
+    assert_eq!(dnu.len(), 1, "expected one DNU diagnostic, got: {diags:?}");
+    assert!(
+        dnu[0].starts_with("Warning:"),
+        "a definite non-responder should warn, not hint: {dnu:?}"
+    );
+    assert!(
+        dnu[0].contains("Integer") && dnu[0].contains("#infinity"),
+        "both members should be named: {dnu:?}"
+    );
+}
+
+/// BT-2624 (item 3): when only the singleton fails to respond, the singleton is
+/// surfaced by name in a Hint (previously it was silently masked as Dynamic).
+#[test]
+fn bt2624_union_singleton_partial_nonresponder_hints_singleton() {
+    let (ty, diags) = infer_singleton_union_send(MessageSelector::Unary("abs".into()), vec![]);
+    assert_eq!(ty, InferredType::known("Integer"));
+    let dnu: Vec<_> = diags.iter().filter(|d| d.contains("understand")).collect();
+    assert_eq!(dnu.len(), 1, "expected one DNU hint, got: {diags:?}");
+    assert!(
+        dnu[0].starts_with("Hint:") && dnu[0].contains("#infinity"),
+        "Integer responds but #infinity does not — hint should name the singleton: {dnu:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes three orthogonal singleton-in-union type-checking gaps surfaced by BT-2617 singleton-equality narrowing. All concern how singleton symbol members (`#foo`) inside a union are checked. Type-checker-only change (no codegen/runtime impact).

**1. Impossible-comparison diagnostic (item 1).** `refine_singleton_narrowing` now emits a hint when the tested singleton can never be a value of the variable's type (`= #foo` always false / `/= #foo` always true), staying silent when the type is `Dynamic`, `Never`, or admits the singleton (it *is* the singleton, or `Symbol`/an ancestor).

**2. Equality operators on a union receiver (item 2).** `infer_union_message_send` now recognises the universal value/identity comparisons (`=`, `==`, `=:=`, `/=`, `=/=`) and returns `Boolean` without per-member DNU resolution — mirroring the existing `Meta`-receiver special-case. Bare `=` is only a codegen alias for `=:=` (BT-952) and is in no class method table, so a union receiver previously reported a spurious *"Integer does not understand '='"*.

**3. Singleton members resolve via `Symbol` (item 3).** A `#foo` union member now resolves its inherited `Symbol` method set instead of being treated as an unknown (uncertain) class. Consequences:
- genuine non-responders now **warn** (not a downgraded hint),
- genuine responders infer a concrete type instead of poisoning the union return with `Dynamic`,
- a partial non-responder surfaces the singleton by name.

**4. End-to-end narrowing test (item 4).** Drives the narrowed-vs-unnarrowed `+` difference through `infer_expr`.

## A note on the e2e test

The item-4 test seeds the union as a local rather than building it from source. While implementing this I found a singleton union **cannot currently be constructed from parseable source** — three independent gaps:
- `#foo` is unwritable in any type-annotation position (the parser has no `#` arm → "Expected type name"),
- bare `=` does not parse as an equality operator anywhere (only `==`/`=:=`/`/=`/`=/=` do),
- an `ifTrue:ifFalse:` assignment collapses singleton branches rather than unioning them.

These are documented in the test comments and tracked as follow-ups (**BT-2627** for the parser gap, which blocks BT-2618).

## Testing

- 9 new tests (impossible-comparison hint + always-true variant + satisfiable no-hint; equality-alias Boolean; identity-comparison not-Dynamic; inherited-Symbol-method resolution; genuine non-responder warns; partial non-responder hints the singleton; integration narrowing test).
- All `beamtalk-core` type-checker tests pass; `cargo clippy` / `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQB3c9h5ii7TUYdoKskM7w

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQB3c9h5ii7TUYdoKskM7w)_