### PR TITLE
fix(liveview): disambiguate modifier + -> binary selector in new-method parse (BT-2625)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4500,17 +4500,46 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp strip_method_modifiers(header) do
     case String.split(header, ~r/\s+/, parts: 2) do
       [word, rest] when word in ["class", "internal", "sealed"] ->
-        # `class`/`internal`/`sealed` are modifiers only when a selector follows;
-        # if the next token opens the body (`=>`) or a return type (`->`), the
-        # word itself is the (unary) selector.
-        if String.starts_with?(rest, "=>") or String.starts_with?(rest, "->") do
-          header
-        else
-          strip_method_modifiers(rest)
+        # `class`/`internal`/`sealed` are modifiers only when a selector follows.
+        cond do
+          # The next token opens the body (`=>`): the word itself is the (unary)
+          # selector — a method *named* `class`/`internal`/`sealed`.
+          String.starts_with?(rest, "=>") ->
+            header
+
+          # The next token is `->`. This is ambiguous without type context
+          # (BT-2625): `sealed -> Type =>` is a unary method named `sealed` with a
+          # return type, while `sealed -> arg =>` is a `sealed` *binary* method
+          # whose selector is `->`. Disambiguate by the token after `->`, matching
+          # the parser's grammar: a Capitalized token reads as a return Type (the
+          # modifier word is the unary selector, so keep the header), a lowercase
+          # token reads as a binary-selector argument (strip the modifier so `->`
+          # becomes the selector).
+          String.starts_with?(rest, "->") ->
+            if return_type_follows_arrow?(rest), do: header, else: strip_method_modifiers(rest)
+
+          true ->
+            strip_method_modifiers(rest)
         end
 
       _ ->
         header
+    end
+  end
+
+  # Decide whether the text starting at a `->` is a *return-type* annotation
+  # (`-> Type`) rather than a binary selector whose argument follows (`-> arg`).
+  # A return type is a Capitalized identifier (a Type name); a binary-selector
+  # parameter is a lowercase identifier. Matches the compiler's method-header
+  # grammar (BT-2625). A `->` with no following identifier is treated as a binary
+  # selector (not a return type).
+  defp return_type_follows_arrow?(rest) do
+    rest
+    |> String.replace_prefix("->", "")
+    |> String.trim_leading()
+    |> case do
+      <<first::utf8, _::binary>> -> first in ?A..?Z
+      _ -> false
     end
   end
 

--- a/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
@@ -420,4 +420,67 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
       refute saved =~ "new-method-selector"
     end
   end
+
+  describe "new-method selector derivation: modifier + -> disambiguation (BT-2625)" do
+    # The breadcrumb derives the selector live from the typed body. For a method
+    # *header* that begins with a modifier (`class`/`internal`/`sealed`) followed
+    # by `->`, the shape is ambiguous without type context:
+    #
+    #   * `sealed -> Self => …`  — a *unary* method named `sealed` with a return
+    #     type, so the derived selector is the modifier word.
+    #   * `sealed -> arg => …`   — a `sealed` *binary* method whose selector is
+    #     `->`, so the modifier is stripped and the selector is `->`.
+    #
+    # Disambiguate by the token after `->`: Capitalized = return Type (keep the
+    # modifier as the unary selector), lowercase = binary argument (strip the
+    # modifier, `->` is the selector). The breadcrumb is the only surface for this
+    # client-side parse — the authoritative parse still runs server-side on save.
+
+    # Drive the new-method tab body and return the rendered breadcrumb selector
+    # span (HTML-escaped, so `->` reads as `-&gt;`).
+    defp derived_breadcrumb(view, source) do
+      view
+      |> form("form[phx-submit='save_method']")
+      |> render_change(%{"source" => source})
+    end
+
+    setup %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
+
+      view
+      |> element(~s(div[phx-click="new_method"][phx-value-class="Counter"]))
+      |> render_click()
+
+      {:ok, view: view}
+    end
+
+    for modifier <- ["class", "internal", "sealed"] do
+      test "#{modifier} => body derives `#{modifier}` (modifier word is the unary selector)",
+           %{view: view} do
+        html = derived_breadcrumb(view, ~s|#{unquote(modifier)} => "hi"|)
+        assert html =~ ~s(<span class="mono">#{unquote(modifier)}</span>)
+      end
+
+      test "#{modifier} -> ReturnType => body derives `#{modifier}` (unary with return type)",
+           %{view: view} do
+        html = derived_breadcrumb(view, ~s|#{unquote(modifier)} -> Self => self|)
+        assert html =~ ~s(<span class="mono">#{unquote(modifier)}</span>)
+      end
+
+      test "#{modifier} -> arg => body derives `->` (modifier-stripped binary selector)",
+           %{view: view} do
+        html = derived_breadcrumb(view, ~s|#{unquote(modifier)} -> other => self|)
+        assert html =~ ~s(<span class="mono">-&gt;</span>)
+        refute html =~ ~s(<span class="mono">#{unquote(modifier)}</span>)
+      end
+
+      test "#{modifier} other => body derives a real unary selector (modifier stripped)",
+           %{view: view} do
+        html = derived_breadcrumb(view, ~s|#{unquote(modifier)} increment => self|)
+        assert html =~ ~s(<span class="mono">increment</span>)
+        refute html =~ ~s(<span class="mono">#{unquote(modifier)}</span>)
+      end
+    end
+  end
 end

--- a/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
@@ -482,5 +482,21 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
         refute html =~ ~s(<span class="mono">#{unquote(modifier)}</span>)
       end
     end
+
+    test "stacked modifiers `class sealed spawn -> Self =>` derive the unary selector (real stdlib shape)",
+         %{view: view} do
+      # `class sealed spawn -> Self => …` is a real stdlib header: two stacked
+      # modifiers, a unary selector `spawn`, and a `Self` return type. The
+      # recursion strips both modifiers and the `-> Self` return type is kept as
+      # part of the `spawn` header, so the derived selector is `spawn`.
+      html = derived_breadcrumb(view, ~s|class sealed spawn -> Self => self|)
+      assert html =~ ~s(<span class="mono">spawn</span>)
+    end
+
+    test "stacked modifiers `class sealed -> arg =>` derive `->` (binary selector after modifiers)",
+         %{view: view} do
+      html = derived_breadcrumb(view, ~s|class sealed -> other => self|)
+      assert html =~ ~s(<span class="mono">-&gt;</span>)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to BT-2606. The client-side `strip_method_modifiers/1` / new-method selector parse in `workspace_live.ex` had an ambiguous edge case: a method modifier (`class`/`internal`/`sealed`) followed by `->` could be either a unary method with a return-type annotation (`sealed -> ReturnType => …`) or a sealed/internal/class **binary** method whose selector is `->` (`sealed -> arg => …`).

This disambiguates by the token after `->`: a **Capitalized** token reads as a return *Type* (the modifier word is the unary selector), a **lowercase** token reads as a binary-selector argument (strip the modifier, `->` is the selector) — matching the parser grammar where return types are Type names and parameters are lowercase.

This is pre-flight/breadcrumb only; the authoritative parse remains server-side in the `:save` op, so no wrong selector is ever installed.

## Changes
- `editors/liveview/lib/bt_attach_web/live/workspace_live.ex` — `strip_method_modifiers/1` disambiguation
- Tests covering all four header shapes (`sealed => …`, `sealed -> Type => …`, `sealed -> arg => …`) for each modifier, including stacked-modifier real-stdlib header shapes

Closes BT-2625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)