### PR TITLE
LiveView IDE: tighten editor chrome

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -468,6 +468,7 @@
   margin-bottom: 6px; padding: 3px 10px;
   background: var(--panel-2); border: 1px solid var(--line); border-radius: 6px;
   font-size: 12px; line-height: 1.4; color: var(--muted);
+}
 
 /* Inline doc toggle on the breadcrumb line (BT-2604): a compact button that
    shows the caret + "Class comment" / "Documentation" label without taking a

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -468,53 +468,27 @@
   margin-bottom: 6px; padding: 3px 10px;
   background: var(--panel-2); border: 1px solid var(--line); border-radius: 6px;
   font-size: 12px; line-height: 1.4; color: var(--muted);
+
+/* Inline doc toggle on the breadcrumb line (BT-2604): a compact button that
+   shows the caret + "Class comment" / "Documentation" label without taking a
+   full row. Positioned after the breadcrumb, before the spacer. */
+.doc-toggle-inline {
+  display: inline-flex; align-items: center; gap: 4px;
+  margin: 0; padding: 0 6px; border: none; background: none;
+  cursor: pointer; color: var(--accent-2); font-size: 11px;
+  font-family: var(--code-font, monospace); font-weight: 600;
+  white-space: nowrap; flex: none;
 }
-/* Collapsed, the block is a single tight toggle row (the padding above hugs it).
-   Expanded, restore the roomier padding and cap the height so a long doc scrolls
-   instead of crowding the editor. */
-.doc-block.open { max-height: 40%; padding: 8px 10px; line-height: 1.5; }
-/* `white-space: normal` (not `pre-wrap`): this rule is inherited by the toggle's
-   `.doc-caret` / `.doc-sig-text` spans, whose content carries the HEEx template's
-   own indentation whitespace and newlines. `pre-wrap` would render that leading
-   whitespace verbatim — shoving the caret + signature far to the right (so the
-   line reads as "centred") and adding blank lines that balloon the block.
-   `normal` collapses it; long signatures still wrap via `word-break`. */
-.doc-block .doc-sig {
-  color: var(--accent-2); font-family: var(--code-font, monospace);
-  font-size: 12px; font-weight: 600;
-  white-space: normal; word-break: break-word;
-}
-/* The signature-as-toggle: a full-width, borderless button that reads as the
-   plain signature line, with a disclosure caret. Only `.open` draws the divider
-   under it (a separator above the body). */
-.doc-block button.doc-toggle {
-  display: flex; align-items: baseline; gap: 6px;
-  width: 100%; margin: 0; padding: 0; text-align: left;
-  background: none; border: none; cursor: pointer;
-}
-.doc-block.open button.doc-toggle {
-  margin-bottom: 6px; padding-bottom: 6px; border-bottom: 1px solid var(--line);
-}
-.doc-block .doc-caret { color: var(--muted); font-size: 10px; flex: none; }
-.doc-block .doc-sig-text { flex: 1 1 auto; min-width: 0; }
-.doc-block .doc-body .doc-h {
-  color: var(--ink); font-size: 12px; font-weight: 700;
-  margin: 8px 0 4px; line-height: 1.3;
-}
-.doc-block .doc-body .doc-h:first-child { margin-top: 0; }
-.doc-block .doc-body .doc-p { margin: 4px 0; }
-.doc-block .doc-body .doc-list { margin: 4px 0; padding-left: 18px; }
-.doc-block .doc-body .doc-list li { margin: 2px 0; }
-.doc-block .doc-body code {
-  font-family: var(--code-font, monospace); font-size: 11.5px;
-  background: var(--code-bg); padding: 1px 4px; border-radius: 3px;
-}
-.doc-block .doc-body .doc-code {
-  margin: 6px 0; padding: 8px 10px; overflow-x: auto;
-  background: var(--code-bg); border-radius: 4px;
-}
-.doc-block .doc-body .doc-code code {
-  background: none; padding: 0; font-size: 11.5px; white-space: pre;
+.doc-toggle-inline:hover { color: var(--accent); }
+.doc-toggle-inline .doc-caret { font-size: 9px; color: var(--muted); }
+.doc-toggle-inline .doc-label { /* inherits color from parent */ }
+/* Inline doc body: rendered below the breadcrumb when the doc toggle is open.
+   A subtle panel that doesn't need the old full-width bordered box. */
+.doc-body-inline {
+  padding: 8px 12px; margin-bottom: 6px;
+  background: var(--panel-2); border-radius: 6px;
+  font-size: 12px; line-height: 1.5; color: var(--muted);
+  max-height: 40%; overflow: auto;
 }
 
 /* ----------------------------------------------------------------------------
@@ -911,6 +885,7 @@ body.col-resizing .cockpit { transition: none; }
 .btn.ghost { border-color: transparent; background: transparent; color: var(--muted); }
 .btn.ghost:hover { background: var(--hover); color: var(--ink); }
 .btn:disabled { opacity: .4; cursor: default; }
+.btn-sm { padding: 3px 8px; font-size: 11px; border-radius: 5px; }
 
 /* inline text-button (ChangeLog revert, BT-2293): minimal affordance inside a
    data-table row, not a full chrome button. */

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -144,7 +144,7 @@
 .topbar {
   display: flex; align-items: center; gap: 14px;
   background: var(--panel); border: 1px solid var(--line);
-  border-radius: 9px; padding: 0 12px; height: 46px;
+  border-radius: 9px; padding: 0 12px; height: 38px;
   box-shadow: var(--shadow); flex: none;
 }
 .brand { display: flex; align-items: baseline; gap: 8px; }
@@ -729,7 +729,7 @@
    hit targets that tint on hover. */
 .split-gutter { flex: none; background: transparent; border-radius: 3px; }
 .split-gutter:hover { background: var(--accent); }
-.split-gutter-y { height: 6px; margin: calc(var(--gap) / -2) 0; cursor: row-resize; }
+.split-gutter-y { height: 8px; margin: calc(var(--gap) / -2) 0; cursor: row-resize; }
 .split-gutter-x {
   position: absolute; top: 0; bottom: 0; width: 8px; z-index: 6; cursor: col-resize;
 }

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -465,13 +465,14 @@
    ========================================================================== */
 .doc-block {
   flex: none; overflow: auto;
-  margin-bottom: 8px; padding: 8px 10px;
+  margin-bottom: 6px; padding: 3px 10px;
   background: var(--panel-2); border: 1px solid var(--line); border-radius: 6px;
-  font-size: 12px; line-height: 1.5; color: var(--muted);
+  font-size: 12px; line-height: 1.4; color: var(--muted);
 }
-/* Cap the height only when expanded, so a long doc scrolls instead of crowding
-   the editor; collapsed, the block hugs its single summary line. */
-.doc-block.open { max-height: 40%; }
+/* Collapsed, the block is a single tight toggle row (the padding above hugs it).
+   Expanded, restore the roomier padding and cap the height so a long doc scrolls
+   instead of crowding the editor. */
+.doc-block.open { max-height: 40%; padding: 8px 10px; line-height: 1.5; }
 /* `white-space: normal` (not `pre-wrap`): this rule is inherited by the toggle's
    `.doc-caret` / `.doc-sig-text` spans, whose content carries the HEEx template's
    own indentation whitespace and newlines. `pre-wrap` would render that leading

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -7385,7 +7385,9 @@ defmodule BtAttachWeb.WorkspaceLive do
                       class="doc-toggle-inline"
                       phx-click="toggle_doc"
                       aria-expanded={to_string(@doc_expanded)}
-                      title={if @doc_expanded, do: "Collapse documentation", else: "Expand documentation"}
+                      title={
+                        if @doc_expanded, do: "Collapse documentation", else: "Expand documentation"
+                      }
                     >
                       <span class="doc-caret">{if @doc_expanded, do: "▾", else: "▸"}</span>
                       <span class="doc-label">{doc_summary_label(doc_tab)}</span>

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -3844,10 +3844,11 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   defp doc_text(_), do: nil
 
-  # Summary label for the collapsible doc block (BT-2558) when there is no method
-  # signature to show — i.e. a class-definition tab, whose doc *is* the class
-  # comment. The breadcrumb already names the class, so a short generic label reads
-  # cleanly as the collapse toggle.
+  # Label for the collapsible doc block's toggle (BT-2558, BT-2604). Deliberately a
+  # short generic label rather than the method signature: the signature already shows
+  # in the breadcrumb and as the first line of the editable source below, so repeating
+  # it on the toggle just triples it. A class-definition tab's doc *is* the class
+  # comment, hence the distinct wording.
   defp doc_summary_label(%{kind: :def}), do: "Class comment"
   defp doc_summary_label(_), do: "Documentation"
 
@@ -7421,8 +7422,10 @@ defmodule BtAttachWeb.WorkspaceLive do
                       class={"doc-block" <> if(@doc_expanded, do: " open", else: "")}
                       aria-label="Documentation"
                     >
-                      <%!-- The signature line doubles as the collapse toggle; the
-                         body is also present verbatim in the editable source below,
+                      <%!-- A short generic label is the collapse toggle — never the
+                         method signature, which already shows in the breadcrumb and
+                         as the first line of the editable source below (BT-2604).
+                         The rendered doc body is the same `///` text from that source,
                          so it stays hidden until asked for. --%>
                       <button
                         type="button"
@@ -7440,7 +7443,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                           {if @doc_expanded, do: "▾", else: "▸"}
                         </span>
                         <span class="doc-sig-text">
-                          {doc_tab.signature || doc_summary_label(doc_tab)}
+                          {doc_summary_label(doc_tab)}
                         </span>
                       </button>
                       <div :if={@doc_expanded} id="doc-body-content" class="doc-body">

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -7416,10 +7416,10 @@ defmodule BtAttachWeb.WorkspaceLive do
                       ⚡
                     </span>
                     <span :if={@role != :owner} class="meta-note read-only">
-                      read-only · Observer
+                      read-only
                     </span>
                     <span :if={@role == :owner and active_tab(assigns).new} class="meta-note edited">
-                      new method — ⌘S to compile
+                      new
                     </span>
                     <span
                       :if={
@@ -7427,7 +7427,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                       }
                       class="meta-note edited"
                     >
-                      edited — ⌘S to compile
+                      edited
                     </span>
                     <span
                       :if={
@@ -7461,7 +7461,6 @@ defmodule BtAttachWeb.WorkspaceLive do
                       class="native-delegate-link"
                     >
                       <span class="native-badge">Native delegate</span>
-                      <span class="native-delegate-note">Implemented in the Erlang backend.</span>
                       <button
                         type="button"
                         class="native-toggle"
@@ -7469,7 +7468,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                         phx-value-class={doc_tab.class}
                         phx-value-selector={doc_tab.selector}
                       >
-                        → Erlang implementation
+                        → Erlang source
                       </button>
                     </div>
                     <%!-- BT-2578: read-only native backing-source pane. On a

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -6648,7 +6648,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                    `hidden`, not removed) so the `#transcript` stream container is
                    always in the DOM for `stream_insert` regardless of the active
                    tab. --%>
-              <div class={["dock", !@show_dock && "collapsed"]} style="order:2;" inert={!@show_dock}>
+              <div class={["dock", !@show_dock && "collapsed"]} style="order:3;" inert={!@show_dock}>
                 <div id="workspace-dock" class="panel">
                   <div class="panel-head">
                     <span class="dock-tabs" role="tablist">
@@ -7272,6 +7272,29 @@ defmodule BtAttachWeb.WorkspaceLive do
                 Workspace ▴
               </button>
 
+              <%!-- Draggable divider (BT-2576) between the method editor and the
+                   workspace dock. The SplitDrag hook writes `--dock-h` on this
+                   `.col` parent; the dock reads it. Hidden when the dock is
+                   collapsed. --%>
+              <div
+                :if={@show_dock}
+                id="dock-split-gutter"
+                class="split-gutter split-gutter-y"
+                phx-hook="SplitDrag"
+                phx-update="ignore"
+                role="separator"
+                aria-orientation="horizontal"
+                aria-label="Resize the editor and workspace dock"
+                data-split="dock"
+                data-axis="y"
+                data-edge="end"
+                data-var="--dock-h"
+                data-min="100"
+                data-min-other="120"
+                style="order:2;"
+              >
+              </div>
+
               <%!-- TABBED METHOD EDITOR (BT-2494): the spike's write-surface.
                    A tab strip (methods + class definitions) over a breadcrumb
                    and the BT-2485 highlighted editor. The single save_method
@@ -7354,6 +7377,19 @@ defmodule BtAttachWeb.WorkspaceLive do
                     >
                       {badge.label}
                     </span>
+                    <%!-- Doc toggle inline on the breadcrumb line (BT-2604). --%>
+                    <% doc_tab = active_tab(assigns) %>
+                    <button
+                      :if={doc_tab.doc != nil}
+                      type="button"
+                      class="doc-toggle-inline"
+                      phx-click="toggle_doc"
+                      aria-expanded={to_string(@doc_expanded)}
+                      title={if @doc_expanded, do: "Collapse documentation", else: "Expand documentation"}
+                    >
+                      <span class="doc-caret">{if @doc_expanded, do: "▾", else: "▸"}</span>
+                      <span class="doc-label">{doc_summary_label(doc_tab)}</span>
+                    </button>
                     <span class="spacer"></span>
                     <%!-- image-divergence badges carried from the browse snapshot
                        (the indicators the old read-only Method Source pane showed):
@@ -7403,53 +7439,17 @@ defmodule BtAttachWeb.WorkspaceLive do
                   </div>
 
                   <div class="panel-body">
-                    <%!-- Read-only documentation block (BT-2558): the active
-                       method's signature + rendered `///` doc-comment, or — on a
-                       class-definition tab — the class comment. Distinct from the
-                       editable source body below, and shown to every role (it
-                       rides the `:read`-capability browse ops). The doc text is
-                       rendered to safe HTML by `BtAttach.DocFormat` (author text
-                       is escaped first), so `{...}` interpolation is safe. --%>
-                    <% doc_tab = active_tab(assigns) %>
-                    <%!-- The doc block earns its vertical space only when there's an
-                       actual `///` doc / class comment to collapse/expand (BT-2604).
-                       A method/class with no comment renders nothing here — its
-                       signature already shows in the breadcrumb and the editable
-                       source below — so the source sits directly under the
-                       breadcrumb with no bare signature line or extra gap. --%>
-                    <section
-                      :if={doc_tab.doc}
-                      class={"doc-block" <> if(@doc_expanded, do: " open", else: "")}
-                      aria-label="Documentation"
+                    <%!-- Read-only documentation body (BT-2558, BT-2604): the toggle
+                       now lives on the breadcrumb line; here we only render the
+                       expanded doc body when the user has opened it. `doc_tab` is
+                       already bound in the breadcrumb section above. --%>
+                    <div
+                      :if={doc_tab.doc != nil and @doc_expanded}
+                      id="doc-body-content"
+                      class="doc-body-inline"
                     >
-                      <%!-- A short generic label is the collapse toggle — never the
-                         method signature, which already shows in the breadcrumb and
-                         as the first line of the editable source below (BT-2604).
-                         The rendered doc body is the same `///` text from that source,
-                         so it stays hidden until asked for. --%>
-                      <button
-                        type="button"
-                        class="doc-sig doc-toggle"
-                        phx-click="toggle_doc"
-                        aria-expanded={to_string(@doc_expanded)}
-                        aria-controls={if @doc_expanded, do: "doc-body-content"}
-                        title={
-                          if @doc_expanded,
-                            do: "Collapse documentation",
-                            else: "Expand documentation"
-                        }
-                      >
-                        <span class="doc-caret" aria-hidden="true">
-                          {if @doc_expanded, do: "▾", else: "▸"}
-                        </span>
-                        <span class="doc-sig-text">
-                          {doc_summary_label(doc_tab)}
-                        </span>
-                      </button>
-                      <div :if={@doc_expanded} id="doc-body-content" class="doc-body">
-                        {BtAttach.DocFormat.to_html(doc_tab.doc)}
-                      </div>
-                    </section>
+                      {BtAttach.DocFormat.to_html(doc_tab.doc)}
+                    </div>
                     <%!-- BT-2578: on a `self delegate` method (ADR 0056), a jump
                        to its Erlang implementation. Opens the class-definition
                        tab's native pane with this selector's `handle_call` clause
@@ -7636,11 +7636,11 @@ defmodule BtAttachWeb.WorkspaceLive do
                             <.nav_popover nav={@nav_popover} />
                           </div>
                           <span class="spacer"></span>
-                          <button class="btn primary" type="submit">
+                          <button class="btn btn-sm primary" type="submit">
                             Compile <span class="k">⌘S</span>
                           </button>
-                          <button class="btn" type="button" phx-click="flush">
-                            Save All to Disk (flush)
+                          <button class="btn btn-sm" type="button" phx-click="flush">
+                            Save All to Disk
                           </button>
                         </div>
                       </form>

--- a/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
@@ -70,24 +70,20 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
         |> element(~s(div[phx-value-selector="increment"]))
         |> render_click()
 
-      # The doc block is present, distinct from the editable source.
-      assert html =~ ~s(class="doc-block")
-      # The toggle carries a short generic label (BT-2604), never the method
-      # signature — that already shows in the breadcrumb and the editable source,
-      # so repeating it on the toggle would just triple it.
-      assert html =~ ~s(class="doc-sig-text")
+      # The doc toggle is inline on the breadcrumb line, and the expanded body
+      # is a separate div below it.
+      assert html =~ ~s(class="doc-toggle-inline")
       assert html =~ "Documentation"
       refute html =~ "increment -&gt; Counter"
-      # Collapsed by default (BT-2558): the rendered body (which is also present
-      # verbatim in the editable source) is hidden until expanded, so the docs
-      # aren't shown twice and don't crowd the editor.
-      refute html =~ ~s(class="doc-body")
+      # Collapsed by default (BT-2558): the rendered body is hidden until
+      # expanded, so the docs aren't shown twice and don't crowd the editor.
+      refute html =~ ~s(class="doc-body-inline")
 
       # Expanding the block reveals the rendered Markdown: prose, a heading, fenced
       # code. The generic label doubles as the toggle (phx-click="toggle_doc").
       html = view |> element(~s(button[phx-click="toggle_doc"])) |> render_click()
 
-      assert html =~ ~s(class="doc-body")
+      assert html =~ ~s(class="doc-body-inline")
       assert html =~ "Increment the counter by one."
       assert html =~ ~s(<h4 class="doc-h">Examples</h4>)
       assert html =~ "<code>c increment</code>"
@@ -103,15 +99,9 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
         |> element(~s(div[phx-value-selector="value"]))
         |> render_click()
 
-      # BT-2604: with no `///` doc-comment the read-only doc block earns no space.
-      # A bare signature line would only duplicate the breadcrumb and the editable
-      # source below, so the whole block collapses away — the source sits directly
-      # under the breadcrumb.
-      refute html =~ ~s(class="doc-block")
-      refute html =~ ~s(class="doc-body")
-      # No bare signature line is left behind either — the breadcrumb still names
-      # the method, so the source sits directly beneath it.
-      refute html =~ ~s(class="doc-sig")
+      # BT-2604: with no `///` doc-comment the inline doc toggle earns no space.
+      refute html =~ ~s(class="doc-toggle-inline")
+      refute html =~ ~s(class="doc-body-inline")
     end
 
     test "the expanded state is sticky across tab switches", %{conn: conn} do
@@ -122,17 +112,17 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
 
       # Expand the doc'd method's block.
       html = view |> element(~s(button[phx-click="toggle_doc"])) |> render_click()
-      assert html =~ ~s(class="doc-body")
+      assert html =~ ~s(class="doc-body-inline")
 
-      # Switching to a method with no doc renders no doc block at all (BT-2604),
+      # Switching to a method with no doc renders no doc toggle at all (BT-2604),
       # but must not reset the expand preference…
       html = view |> element(~s(div[phx-value-selector="value"])) |> render_click()
-      refute html =~ ~s(class="doc-block")
-      refute html =~ ~s(class="doc-body")
+      refute html =~ ~s(class="doc-toggle-inline")
+      refute html =~ ~s(class="doc-body-inline")
 
       # …so returning to the doc'd method shows the body again *without* re-toggling.
       html = view |> element(~s(div[phx-value-selector="increment"])) |> render_click()
-      assert html =~ ~s(class="doc-body")
+      assert html =~ ~s(class="doc-body-inline")
       assert html =~ "Increment the counter by one."
     end
   end
@@ -150,12 +140,12 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
         |> element(~s(div[phx-value-selector="increment"]))
         |> render_click()
 
-      assert html =~ ~s(class="doc-block")
+      assert html =~ ~s(class="doc-toggle-inline")
       assert html =~ "Documentation"
       refute html =~ "increment -&gt; Counter"
       # The toggle is present and expands the body for an observer too.
       html = view |> element(~s(button[phx-click="toggle_doc"])) |> render_click()
-      assert html =~ ~s(class="doc-body")
+      assert html =~ ~s(class="doc-body-inline")
       assert html =~ "Increment the counter by one."
     end
   end
@@ -174,7 +164,7 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
         |> element(~s([phx-click="browser_open_definition"]))
         |> render_click()
 
-      assert html =~ ~s(class="doc-block")
+      assert html =~ ~s(class="doc-toggle-inline")
       # A class-definition tab has no signature, so the toggle reads "Class comment".
       assert html =~ "Class comment"
 

--- a/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_doc_block_test.exs
@@ -58,7 +58,7 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
   end
 
   describe "method doc block (BT-2558)" do
-    test "selecting a method shows its signature and rendered doc-comment", %{conn: conn} do
+    test "selecting a method shows a doc toggle and rendered doc-comment", %{conn: conn} do
       {:ok, view, _html} = live(owner_conn(conn), "/")
 
       # Select Counter (always present in the stub), then open the `increment`
@@ -72,15 +72,19 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
 
       # The doc block is present, distinct from the editable source.
       assert html =~ ~s(class="doc-block")
-      # Signature (HEEx-escaped `->`) — always visible as the collapse toggle.
-      assert html =~ "increment -&gt; Counter"
+      # The toggle carries a short generic label (BT-2604), never the method
+      # signature — that already shows in the breadcrumb and the editable source,
+      # so repeating it on the toggle would just triple it.
+      assert html =~ ~s(class="doc-sig-text")
+      assert html =~ "Documentation"
+      refute html =~ "increment -&gt; Counter"
       # Collapsed by default (BT-2558): the rendered body (which is also present
       # verbatim in the editable source) is hidden until expanded, so the docs
       # aren't shown twice and don't crowd the editor.
       refute html =~ ~s(class="doc-body")
 
       # Expanding the block reveals the rendered Markdown: prose, a heading, fenced
-      # code. The signature line doubles as the toggle (phx-click="toggle_doc").
+      # code. The generic label doubles as the toggle (phx-click="toggle_doc").
       html = view |> element(~s(button[phx-click="toggle_doc"])) |> render_click()
 
       assert html =~ ~s(class="doc-body")
@@ -147,7 +151,8 @@ defmodule BtAttachWeb.WorkspaceDocBlockTest do
         |> render_click()
 
       assert html =~ ~s(class="doc-block")
-      assert html =~ "increment -&gt; Counter"
+      assert html =~ "Documentation"
+      refute html =~ "increment -&gt; Counter"
       # The toggle is present and expands the body for an observer too.
       html = view |> element(~s(button[phx-click="toggle_doc"])) |> render_click()
       assert html =~ ~s(class="doc-body")

--- a/editors/liveview/test/bt_attach_web/workspace_native_pane_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_native_pane_test.exs
@@ -156,7 +156,7 @@ defmodule BtAttachWeb.WorkspaceNativePaneTest do
 
       # The method tab offers the jump to its Erlang implementation.
       assert html =~ "Native delegate"
-      assert html =~ "→ Erlang implementation"
+      assert html =~ "→ Erlang source"
 
       # Jumping opens the class-definition tab's native pane with readLine's
       # handle_call clause resolved and highlighted.


### PR DESCRIPTION
## Summary
- Move doc toggle onto the breadcrumb line instead of a separate section
- Add draggable splitter between editor and workspace dock
- Shrink Compile / Save All to Disk buttons
- Remove dead .doc-block CSS

## Changes
- **Breadcrumb line**: Doc toggle (caret + "Class comment" / "Documentation") now rides the `Counter › class definition` line, saving a full row when collapsed
- **Dock splitter**: New `SplitDrag` gutter between editor and workspace dock — dock height is resizable via drag, persisted to localStorage
- **Smaller buttons**: Compile and Save All use `.btn-sm` for less visual weight
- **CSS cleanup**: Removed unused `.doc-block` / `.doc-toggle` / `.doc-sig` rules, replaced by `.doc-toggle-inline` + `.doc-body-inline`