### PR TITLE
Generic type argument with a class metatype (List(Actor class)) fails to parse (BT-2630)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -554,7 +554,7 @@ impl Parser {
         if !is_type_name_token(self.peek_at(o)) {
             return None;
         }
-        o += 1;
+        o = self.skip_type_name_with_metatype(o);
         // Skip optional bound: `:: Protocol`
         o = self.skip_optional_type_param_bound(o);
         // Nested generic: `Name(Type(...))`
@@ -567,7 +567,7 @@ impl Parser {
             if !is_type_name_token(self.peek_at(o)) {
                 return None;
             }
-            o += 1;
+            o = self.skip_type_name_with_metatype(o);
             if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
                 o = self.skip_paren_type_params(o)?;
             }
@@ -578,7 +578,7 @@ impl Parser {
             if !is_type_name_token(self.peek_at(o)) {
                 return None;
             }
-            o += 1;
+            o = self.skip_type_name_with_metatype(o);
             // Skip optional bound: `:: Protocol`
             o = self.skip_optional_type_param_bound(o);
             // Nested generic
@@ -591,7 +591,7 @@ impl Parser {
                 if !is_type_name_token(self.peek_at(o)) {
                     return None;
                 }
-                o += 1;
+                o = self.skip_type_name_with_metatype(o);
                 if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
                     o = self.skip_paren_type_params(o)?;
                 }

--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -542,7 +542,8 @@ impl Parser {
     /// malformed (e.g., missing closing paren or non-identifier content).
     ///
     /// Also handles bounded type parameters: `(T :: Printable, E)` — skips the
-    /// `:: Bound` portion when present (ADR 0068 Phase 2d).
+    /// `:: Bound` portion when present (ADR 0068 Phase 2d). Also handles `class`
+    /// metatype suffixes in type argument position: `List(Actor class)` (BT-2630).
     pub(super) fn skip_paren_type_params(&self, offset: usize) -> Option<usize> {
         debug_assert!(matches!(self.peek_at(offset), Some(TokenKind::LeftParen)));
         let mut o = offset + 1; // past `(`

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
@@ -1420,3 +1420,40 @@ fn parse_class_metatype_generic_in_return_type() {
         parameters[0]
     );
 }
+
+#[test]
+fn parse_class_metatype_in_generic_union_arg() {
+    // BT-2630: `List(Actor class | Nil)` — metatype in union position within
+    // generic args. The lookahead's pipe-union loop must also consume the
+    // `class` suffix in lock-step with `parse_single_type_annotation`.
+    let module = parse_ok(
+        "Object subclass: Foo
+  m: x :: List(Actor class | Nil) => x",
+    );
+    let ty = module.classes[0].methods[0].parameters[0]
+        .type_annotation
+        .as_ref()
+        .unwrap();
+    let TypeAnnotation::Generic {
+        base, parameters, ..
+    } = ty
+    else {
+        panic!("expected generic, got {ty:?}");
+    };
+    assert_eq!(base.name, "List");
+    assert_eq!(parameters.len(), 1);
+    let TypeAnnotation::Union { types, .. } = &parameters[0] else {
+        panic!("expected union arg, got {:?}", parameters[0]);
+    };
+    assert_eq!(types.len(), 2);
+    assert!(
+        matches!(&types[0], TypeAnnotation::ClassOf { class_name, .. } if class_name.name == "Actor"),
+        "Expected ClassOf(Actor), got {:?}",
+        types[0]
+    );
+    assert!(
+        matches!(&types[1], TypeAnnotation::Simple(id) if id.name == "Nil"),
+        "Expected Simple(Nil), got {:?}",
+        types[1]
+    );
+}

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
@@ -1335,3 +1335,88 @@ fn parse_singleton_does_not_consume_class_suffix() {
         "infinity",
     );
 }
+
+// ========================================================================
+// Class metatype inside generic type arguments (BT-2630)
+// ========================================================================
+
+#[test]
+fn parse_class_metatype_inside_generic_type() {
+    // BT-2630: `List(Actor class)` must parse as a Generic whose argument is ClassOf(Actor)
+    let module = parse_ok(
+        "Object subclass: Foo
+  m: x :: List(Actor class) => x",
+    );
+    let ty = module.classes[0].methods[0].parameters[0]
+        .type_annotation
+        .as_ref()
+        .unwrap();
+    let TypeAnnotation::Generic {
+        base, parameters, ..
+    } = ty
+    else {
+        panic!("expected generic, got {ty:?}");
+    };
+    assert_eq!(base.name, "List");
+    assert_eq!(parameters.len(), 1);
+    assert!(
+        matches!(&parameters[0], TypeAnnotation::ClassOf { class_name, .. } if class_name.name == "Actor"),
+        "Expected ClassOf(Actor), got {:?}",
+        parameters[0]
+    );
+}
+
+#[test]
+fn parse_class_metatype_inside_nested_generic() {
+    // BT-2630: `Map(String, Actor class)` must parse with ClassOf(Actor) as second param
+    let module = parse_ok(
+        "Object subclass: Foo
+  m: x :: Map(String, Actor class) => x",
+    );
+    let ty = module.classes[0].methods[0].parameters[0]
+        .type_annotation
+        .as_ref()
+        .unwrap();
+    let TypeAnnotation::Generic {
+        base, parameters, ..
+    } = ty
+    else {
+        panic!("expected generic, got {ty:?}");
+    };
+    assert_eq!(base.name, "Map");
+    assert_eq!(parameters.len(), 2);
+    assert!(
+        matches!(&parameters[0], TypeAnnotation::Simple(id) if id.name == "String"),
+        "Expected Simple(String), got {:?}",
+        parameters[0]
+    );
+    assert!(
+        matches!(&parameters[1], TypeAnnotation::ClassOf { class_name, .. } if class_name.name == "Actor"),
+        "Expected ClassOf(Actor), got {:?}",
+        parameters[1]
+    );
+}
+
+#[test]
+fn parse_class_metatype_generic_in_return_type() {
+    // BT-2630: `-> List(Actor class)` return type must be recognized
+    let module = parse_ok(
+        "Object subclass: Foo
+  getActors -> List(Actor class) => nil",
+    );
+    let method = &module.classes[0].methods[0];
+    let ret_ty = method.return_type.as_ref().unwrap();
+    let TypeAnnotation::Generic {
+        base, parameters, ..
+    } = ret_ty
+    else {
+        panic!("expected generic return type, got {ret_ty:?}");
+    };
+    assert_eq!(base.name, "List");
+    assert_eq!(parameters.len(), 1);
+    assert!(
+        matches!(&parameters[0], TypeAnnotation::ClassOf { class_name, .. } if class_name.name == "Actor"),
+        "Expected ClassOf(Actor), got {:?}",
+        parameters[0]
+    );
+}

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
@@ -1423,9 +1423,10 @@ fn parse_class_metatype_generic_in_return_type() {
 
 #[test]
 fn parse_class_metatype_in_generic_union_arg() {
-    // BT-2630: `List(Actor class | Nil)` — metatype in union position within
-    // generic args. The lookahead's pipe-union loop must also consume the
-    // `class` suffix in lock-step with `parse_single_type_annotation`.
+    // BT-2630: `List(Actor class | Nil)` — metatype as the *first* union member
+    // inside a generic type arg. Exercises the first-param path in
+    // `skip_paren_type_params` (the `skip_type_name_with_metatype` call at the
+    // "First type param" block). The trailing `Nil` is a plain identifier.
     let module = parse_ok(
         "Object subclass: Foo
   m: x :: List(Actor class | Nil) => x",
@@ -1454,6 +1455,44 @@ fn parse_class_metatype_in_generic_union_arg() {
     assert!(
         matches!(&types[1], TypeAnnotation::Simple(id) if id.name == "Nil"),
         "Expected Simple(Nil), got {:?}",
+        types[1]
+    );
+}
+
+#[test]
+fn parse_class_metatype_as_later_union_member_in_generic_arg() {
+    // BT-2630: `List(Foo | Actor class)` — metatype as a *later* union member
+    // inside a generic type arg. This is the path the pipe-union loop in
+    // `skip_paren_type_params` must handle: the lookahead has to consume the
+    // trailing `class` on `Actor` in lock-step with `parse_single_type_annotation`.
+    let module = parse_ok(
+        "Object subclass: Foo
+  m: x :: List(Foo | Actor class) => x",
+    );
+    let ty = module.classes[0].methods[0].parameters[0]
+        .type_annotation
+        .as_ref()
+        .unwrap();
+    let TypeAnnotation::Generic {
+        base, parameters, ..
+    } = ty
+    else {
+        panic!("expected generic, got {ty:?}");
+    };
+    assert_eq!(base.name, "List");
+    assert_eq!(parameters.len(), 1);
+    let TypeAnnotation::Union { types, .. } = &parameters[0] else {
+        panic!("expected union arg, got {:?}", parameters[0]);
+    };
+    assert_eq!(types.len(), 2);
+    assert!(
+        matches!(&types[0], TypeAnnotation::Simple(id) if id.name == "Foo"),
+        "Expected Simple(Foo), got {:?}",
+        types[0]
+    );
+    assert!(
+        matches!(&types[1], TypeAnnotation::ClassOf { class_name, .. } if class_name.name == "Actor"),
+        "Expected ClassOf(Actor), got {:?}",
         types[1]
     );
 }


### PR DESCRIPTION
## Summary
- Fix: `skip_paren_type_params` lookahead now calls `skip_type_name_with_metatype` instead of raw `o += 1`, keeping the lookahead in lock-step with `parse_single_type_annotation`
- Add 3 parser tests covering `List(Actor class)`, `Map(String, Actor class)`, and `-> List(Actor class)` return type

## Details
The signature-detection lookahead `skip_paren_type_params` advanced past type name tokens with `o += 1` instead of calling `skip_type_name_with_metatype`. This caused trailing `class` metatype suffixes to be orphaned during lookahead, making `List(Actor class)` fail to parse as a method signature.

## Acceptance Criteria
- [x] `List(Actor class)` (and nested `Map(String, Actor class)`) parse, producing a `Generic` whose argument is `TypeAnnotation::ClassOf`
- [x] Parser test covering the behaviour
- [x] `just test` / `just clippy` pass

## Linear
https://linear.app/beamtalk/issue/BT-2630