### PR TITLE
Follow-ups from BT-2620 review: union-member type-arg precision + Array-cons-tail diagnostic (BT-2623)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -63,6 +63,30 @@ impl TypeChecker {
         }
     }
 
+    /// Reports whether a list-literal cons tail is a *known, non-`List`* type —
+    /// i.e. one that would form an improper BEAM list at runtime (BT-2623).
+    ///
+    /// A cons tail (`[1 | tail]`) must evaluate to a proper list. A known type
+    /// whose base class is not `List` (most notably `Array`, which is
+    /// tuple-backed) would instead build an improper list. We surface this as a
+    /// diagnostic so the user sees a likely runtime bug rather than the silent
+    /// degradation to `List(Dynamic)` that [`tail_element_type`] performs.
+    ///
+    /// Returns `None` (no diagnostic) for `List` tails — proper by construction —
+    /// and for `Dynamic`/`Union`/`Meta`/`Never`, which are too uncertain to flag
+    /// without risking noise. When a diagnostic is warranted, returns the
+    /// offending type's user-facing display name.
+    fn improper_cons_tail_display(tail_ty: &InferredType) -> Option<EcoString> {
+        match tail_ty {
+            InferredType::Known { class_name, .. } if class_name != "List" => Some(
+                tail_ty
+                    .display_for_diagnostic()
+                    .unwrap_or_else(|| class_name.clone()),
+            ),
+            _ => None,
+        }
+    }
+
     /// Checks types in a module using the class hierarchy for method resolution.
     ///
     /// Method bodies are processed first so that inferred return types are
@@ -779,6 +803,24 @@ impl TypeChecker {
                     .collect();
                 if let Some(t) = tail {
                     let tail_ty = self.infer_expr(t, hierarchy, env, in_abstract_method);
+                    // BT-2623: A cons tail must be a proper list. A known
+                    // non-`List` tail (e.g. `Array`, tuple-backed) builds an
+                    // improper list at runtime; flag it instead of silently
+                    // widening the element type to `Dynamic`.
+                    if let Some(tail_display) = Self::improper_cons_tail_display(&tail_ty) {
+                        self.diagnostics.push(
+                            Diagnostic::warning(
+                                format!(
+                                    "Cons tail of a list literal is {tail_display}, not a List — this builds an improper list"
+                                ),
+                                t.span(),
+                            )
+                            .with_hint(format!(
+                                "A `[head | tail]` tail must be a List; {tail_display} would form an improper list at runtime"
+                            ))
+                            .with_category(DiagnosticCategory::Type),
+                        );
+                    }
                     element_types.push(Self::tail_element_type(&tail_ty));
                 }
                 let element_ty = Self::join_element_types(&element_types);
@@ -5157,6 +5199,91 @@ mod tests {
                 vec![InferredType::Dynamic(DynamicReason::Unknown)]
             )
         );
+        // BT-2623: the silent widening is now also surfaced as a diagnostic so
+        // the user sees the likely improper-list bug.
+        assert_eq!(
+            checker.diagnostics().len(),
+            1,
+            "Array cons tail should emit one improper-list diagnostic, got: {:?}",
+            checker.diagnostics()
+        );
+        assert!(
+            checker.diagnostics()[0].message.contains("improper list"),
+            "Diagnostic should mention improper list, got: {:?}",
+            checker.diagnostics()[0]
+        );
+        assert!(
+            checker.diagnostics()[0].message.contains("Array"),
+            "Diagnostic should name the offending Array tail, got: {:?}",
+            checker.diagnostics()[0]
+        );
+    }
+
+    #[test]
+    fn infer_expr_list_literal_list_tail_no_diagnostic() {
+        // BT-2623: a proper `List(T)` cons tail is valid — no diagnostic.
+        let hierarchy = ClassHierarchy::with_builtins();
+        let mut checker = TypeChecker::new();
+        let mut env = TypeEnv::new();
+        env.set_local(
+            "rest",
+            InferredType::known_with_args("List", vec![InferredType::known("Integer")]),
+        );
+        let expr = Expression::ListLiteral {
+            elements: vec![int_lit(1)],
+            tail: Some(Box::new(var("rest"))),
+            span: span(),
+        };
+        let _ = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+        assert!(
+            checker.diagnostics().is_empty(),
+            "List cons tail is proper — no diagnostic expected, got: {:?}",
+            checker.diagnostics()
+        );
+    }
+
+    #[test]
+    fn infer_expr_list_literal_dynamic_tail_no_diagnostic() {
+        // BT-2623: a `Dynamic` tail (e.g. unannotated param) is too uncertain to
+        // flag — staying silent avoids false-positive noise.
+        let hierarchy = ClassHierarchy::with_builtins();
+        let mut checker = TypeChecker::new();
+        let mut env = TypeEnv::new();
+        env.set_local("rest", InferredType::Dynamic(DynamicReason::Unknown));
+        let expr = Expression::ListLiteral {
+            elements: vec![int_lit(1)],
+            tail: Some(Box::new(var("rest"))),
+            span: span(),
+        };
+        let _ = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+        assert!(
+            checker.diagnostics().is_empty(),
+            "Dynamic cons tail should not be flagged, got: {:?}",
+            checker.diagnostics()
+        );
+    }
+
+    #[test]
+    fn infer_expr_list_literal_non_collection_tail_warns() {
+        // BT-2623: any known non-List tail (e.g. an Integer) would form an
+        // improper list, so it is flagged too — not just Array.
+        let hierarchy = ClassHierarchy::with_builtins();
+        let mut checker = TypeChecker::new();
+        let mut env = TypeEnv::new();
+        env.set_local("rest", InferredType::known("Integer"));
+        let expr = Expression::ListLiteral {
+            elements: vec![int_lit(1)],
+            tail: Some(Box::new(var("rest"))),
+            span: span(),
+        };
+        let _ = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+        assert_eq!(
+            checker.diagnostics().len(),
+            1,
+            "Integer cons tail should emit one improper-list diagnostic, got: {:?}",
+            checker.diagnostics()
+        );
+        assert!(checker.diagnostics()[0].message.contains("Integer"));
     }
 
     #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/unions_checking.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/unions_checking.rs
@@ -1688,6 +1688,188 @@ fn union_param_type_nil_compatible_with_object_union() {
     );
 }
 
+// --- BT-2623: parameterized union members keep their type args ---
+
+/// `Array(Integer)` is assignable to declared `Array(Integer)`.
+#[test]
+fn is_assignable_to_same_type_args_ok() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    assert!(TypeChecker::is_assignable_to(
+        &"Array(Integer)".into(),
+        &"Array(Integer)".into(),
+        &hierarchy
+    ));
+}
+
+/// BT-2623: `Array(String)` must NOT be assignable to declared `Array(Integer)` —
+/// before the fix the type args were dropped and both reduced to bare `Array`.
+#[test]
+fn is_assignable_to_mismatched_type_args_rejected() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    assert!(
+        !TypeChecker::is_assignable_to(
+            &"Array(String)".into(),
+            &"Array(Integer)".into(),
+            &hierarchy
+        ),
+        "Array(String) should not be assignable to Array(Integer)"
+    );
+}
+
+/// BT-2623: same precision for `is_type_compatible` (the argument-check path).
+#[test]
+fn is_type_compatible_mismatched_type_args_rejected() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    assert!(
+        !TypeChecker::is_type_compatible(
+            &"Array(String)".into(),
+            &"Array(Integer)".into(),
+            &hierarchy
+        ),
+        "Array(String) should not be compatible with Array(Integer)"
+    );
+    // A bare `Array` stays conservatively compatible (may be any Array(_)).
+    assert!(
+        TypeChecker::is_type_compatible(&"Array".into(), &"Array(Integer)".into(), &hierarchy),
+        "Bare Array should remain conservatively compatible"
+    );
+}
+
+/// BT-2623: a `classify_union_members`-driven check now distinguishes
+/// `Array(Integer) | Array(String)` checked against a declared `Array(Integer)`.
+/// The `Array(String)` member is incompatible, so a diagnostic must fire (and it
+/// must name the offending parameterized member, not bare `Array`).
+#[test]
+fn union_arg_parameterized_member_mismatch_warns() {
+    use crate::semantic_analysis::class_hierarchy::{ClassInfo, MethodInfo};
+    let mut hierarchy = ClassHierarchy::with_builtins();
+    hierarchy.add_from_beam_meta(vec![ClassInfo {
+        name: "Sink".into(),
+        superclass: Some("Object".into()),
+        is_sealed: false,
+        is_abstract: false,
+        is_typed: false,
+        is_internal: false,
+        package: None,
+        is_value: false,
+        is_native: false,
+        state: vec![],
+        state_types: HashMap::new(),
+        state_has_default: HashMap::new(),
+        methods: vec![MethodInfo {
+            selector: "take:".into(),
+            arity: 1,
+            kind: MethodKind::Primary,
+            defined_in: "Sink".into(),
+            is_sealed: false,
+            is_internal: false,
+            spawns_block: false,
+            return_type: None,
+            param_types: vec![Some("Array(Integer)".into())],
+            doc: None,
+        }],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        type_param_bounds: vec![],
+        superclass_type_args: vec![],
+    }]);
+
+    let arg = InferredType::union_of(&[
+        InferredType::known_with_args("Array", vec![InferredType::known("Integer")]),
+        InferredType::known_with_args("Array", vec![InferredType::known("String")]),
+    ]);
+    let mut checker = TypeChecker::new();
+    checker.check_argument_types(
+        &"Sink".into(),
+        "take:",
+        &[arg],
+        span(),
+        &hierarchy,
+        false,
+        None,
+        None,
+    );
+    assert!(
+        !checker.diagnostics().is_empty(),
+        "Array(Integer) | Array(String) vs Array(Integer): Array(String) member must be flagged, got no diagnostics"
+    );
+    // The offending member is rendered with its type arg, not bare `Array`.
+    assert!(
+        checker
+            .diagnostics()
+            .iter()
+            .any(|d| d.message.contains("Array(String)")
+                || d.hint
+                    .as_deref()
+                    .is_some_and(|h| h.contains("Array(String)"))),
+        "Diagnostic should name the parameterized member Array(String), got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+/// BT-2623: a parameterized union whose members are all compatible stays
+/// silent. `Array(Integer) | Array(Float)` against declared `Array(Number)` —
+/// Integer and Float are both subclasses of Number, so each member's type arg
+/// is compatible.
+#[test]
+fn union_arg_parameterized_members_all_match_no_warning() {
+    use crate::semantic_analysis::class_hierarchy::{ClassInfo, MethodInfo};
+    let mut hierarchy = ClassHierarchy::with_builtins();
+    hierarchy.add_from_beam_meta(vec![ClassInfo {
+        name: "Sink".into(),
+        superclass: Some("Object".into()),
+        is_sealed: false,
+        is_abstract: false,
+        is_typed: false,
+        is_internal: false,
+        package: None,
+        is_value: false,
+        is_native: false,
+        state: vec![],
+        state_types: HashMap::new(),
+        state_has_default: HashMap::new(),
+        methods: vec![MethodInfo {
+            selector: "take:".into(),
+            arity: 1,
+            kind: MethodKind::Primary,
+            defined_in: "Sink".into(),
+            is_sealed: false,
+            is_internal: false,
+            spawns_block: false,
+            return_type: None,
+            param_types: vec![Some("Array(Number)".into())],
+            doc: None,
+        }],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        type_param_bounds: vec![],
+        superclass_type_args: vec![],
+    }]);
+
+    let arg = InferredType::union_of(&[
+        InferredType::known_with_args("Array", vec![InferredType::known("Integer")]),
+        InferredType::known_with_args("Array", vec![InferredType::known("Float")]),
+    ]);
+    let mut checker = TypeChecker::new();
+    checker.check_argument_types(
+        &"Sink".into(),
+        "take:",
+        &[arg],
+        span(),
+        &hierarchy,
+        false,
+        None,
+        None,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "Array(Integer) | Array(Float) members are all Array(Number) — no diagnostic expected, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
 #[test]
 fn process_navigation_from_rejects_non_supervisor_or_pid() {
     // ADR 0092 (BT-2429): `ProcessNavigation from:` is typed `Supervisor | Pid`,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -29,22 +29,37 @@ impl TypeChecker {
     /// Classify how well a union's known members match a predicate.
     ///
     /// Returns `None` if any member is Dynamic (conservative skip).
-    /// Otherwise returns the count of members that satisfy `pred` and the total.
+    /// Otherwise returns the count of members that satisfy `pred` and the total,
+    /// plus the rendered names of the members that did *not* satisfy it.
+    ///
+    /// BT-2623: the predicate receives each member's *full* type string
+    /// (via [`inferred_type_to_string`], e.g. `"Array(Integer)"`), not the bare
+    /// `as_known()` class name. Before collection literals carried element types
+    /// a union like `Array(Integer) | Array(String)` could not arise (both
+    /// branches deduplicated to bare `Array`); now it can, and dropping the type
+    /// args would let `Array(String)` silently pass a check against a declared
+    /// `Array(Integer)`. The `as_known()` guard is still used solely to skip the
+    /// whole union when any member is `Dynamic`/`Union`/`Meta`/`Never`.
+    ///
+    /// [`inferred_type_to_string`]: Self::inferred_type_to_string
     fn classify_union_members<F>(
         members: &[InferredType],
         pred: F,
-    ) -> Option<(usize, usize, Vec<&EcoString>)>
+    ) -> Option<(usize, usize, Vec<EcoString>)>
     where
         F: Fn(&EcoString) -> bool,
     {
-        let known_members: Vec<&EcoString> = members.iter().filter_map(|m| m.as_known()).collect();
-        if known_members.len() < members.len() {
-            return None; // Contains Dynamic — skip
+        // Skip the whole union if any member is non-`Known` (Dynamic/Union/Meta/
+        // Never) — we can't reason about those conservatively.
+        if members.iter().any(|m| m.as_known().is_none()) {
+            return None;
         }
-        let compatible = known_members.iter().filter(|m| pred(m)).count();
-        let incompatible: Vec<&EcoString> =
-            known_members.iter().filter(|m| !pred(m)).copied().collect();
-        Some((compatible, known_members.len(), incompatible))
+        let member_names: Vec<EcoString> =
+            members.iter().map(Self::inferred_type_to_string).collect();
+        let compatible = member_names.iter().filter(|m| pred(m)).count();
+        let incompatible: Vec<EcoString> =
+            member_names.iter().filter(|m| !pred(m)).cloned().collect();
+        Some((compatible, member_names.len(), incompatible))
     }
 
     /// Collect deduplicated missing protocol methods across union members.
@@ -619,7 +634,7 @@ impl TypeChecker {
     /// - Same type → compatible
     /// - `expected` appears in `actual`'s superclass chain → compatible (e.g., Integer for Number)
     /// - Either type is unknown to the hierarchy → compatible (conservative)
-    fn is_type_compatible(
+    pub(super) fn is_type_compatible(
         actual: &EcoString,
         expected: &EcoString,
         hierarchy: &ClassHierarchy,
@@ -688,7 +703,13 @@ impl TypeChecker {
             .map_or(expected.as_str(), |(base, _)| base);
 
         if actual_base == expected_base {
-            return true;
+            // BT-2623: when *both* sides carry type arguments and the bases match
+            // (e.g. `Array(Integer)` vs `Array(String)`), don't blindly pass on
+            // the base alone — compare the type args invariantly so a union
+            // member like `Array(String)` is rejected against a declared
+            // `Array(Integer)`. If only one side is parameterized we stay
+            // conservative (bare `Array` may be any `Array(_)`).
+            return Self::type_args_match(actual, expected, hierarchy);
         }
         // If either type isn't known to the hierarchy, don't warn (conservative)
         if !hierarchy.has_class(actual_base) || !hierarchy.has_class(expected_base) {
@@ -699,6 +720,37 @@ impl TypeChecker {
         chain
             .iter()
             .any(|ancestor| ancestor.as_str() == expected_base)
+    }
+
+    /// BT-2623: Compare the *type arguments* of two same-base generic type
+    /// strings (e.g. `"Array(Integer)"` vs `"Array(String)"`).
+    ///
+    /// Returns `true` (compatible) unless both sides are parameterized with the
+    /// same arity and at least one arg pair is incompatible. When either side is
+    /// unparameterized (bare `Array`, which may stand for any `Array(_)`) or the
+    /// arities differ, we stay conservative and return `true` so this never
+    /// introduces a false positive on its own.
+    ///
+    /// Args are compared invariantly via [`is_type_compatible`], recursing into
+    /// nested generics (so `Array(Array(Integer))` vs `Array(Array(String))`
+    /// is also caught).
+    fn type_args_match(actual: &str, expected: &str, hierarchy: &ClassHierarchy) -> bool {
+        let (_, actual_args) = Self::parse_generic_type_string(actual);
+        let (_, expected_args) = Self::parse_generic_type_string(expected);
+        if actual_args.is_empty()
+            || expected_args.is_empty()
+            || actual_args.len() != expected_args.len()
+        {
+            return true; // Unparameterized or arity mismatch — conservative.
+        }
+        actual_args.iter().zip(expected_args.iter()).all(|(a, e)| {
+            // Generic placeholders (T, E, K, V) are symbolic — treat as
+            // compatible, matching `type_args_compatible`.
+            if super::is_generic_type_param(a) || super::is_generic_type_param(e) {
+                return true;
+            }
+            Self::is_type_compatible(&a.as_str().into(), &e.as_str().into(), hierarchy)
+        })
     }
 
     /// BT-2022: Recursive structural compatibility for one type-arg slot.
@@ -1516,7 +1568,10 @@ impl TypeChecker {
         let declared_base = super::type_resolver::base_name_of_string(declared_type);
         let value_base = super::type_resolver::base_name_of_string(value_type);
         if value_base == declared_base {
-            return true;
+            // BT-2623: same base — compare type args so `Array(String)` is not
+            // silently assignable to a declared `Array(Integer)`. Conservative
+            // (returns true) when either side is unparameterized.
+            return Self::type_args_match(value_type, declared_type, hierarchy);
         }
         // Check if value_type's base is a subclass of declared_type's base
         let value_eco: EcoString = value_base.into();
@@ -1771,8 +1826,11 @@ impl TypeChecker {
                 }
                 let Some((compat, total, non_conforming)) =
                     Self::classify_union_members(members, |m| {
+                        // BT-2623: members now carry type args (e.g. `Array(Integer)`);
+                        // conformance is a property of the base class, so strip them.
+                        let base = super::type_resolver::base_name_of_string(m);
                         protocol_registry
-                            .check_conformance(m, base_protocol, hierarchy)
+                            .check_conformance(base, base_protocol, hierarchy)
                             .is_ok()
                     })
                 else {
@@ -1919,8 +1977,11 @@ impl TypeChecker {
                     // BT-1832: Check all union members against the bound protocol.
                     let Some((compat, total, non_conforming)) =
                         Self::classify_union_members(members, |m| {
+                            // BT-2623: strip type args (`Array(Integer)` → `Array`);
+                            // conformance is checked on the base class.
+                            let base = super::type_resolver::base_name_of_string(m);
                             protocol_registry
-                                .check_conformance(m, bound_protocol, hierarchy)
+                                .check_conformance(base, bound_protocol, hierarchy)
                                 .is_ok()
                         })
                     else {


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2623

Implements the two non-blocking follow-ups surfaced by the BT-2620 (collection-literal element-type inference) review.

## 1. `classify_union_members` keeps parameterized type args

`classify_union_members` previously fed the predicate each member's bare `as_known()` class name, dropping type args — so `Array(Integer) | Array(String)` checked against a declared `Array(Integer)` saw `["Array", "Array"]` and silently passed. These unions became reachable only after BT-2620.

- The predicate now receives each member's full type string via `inferred_type_to_string` (e.g. `"Array(Integer)"`). The `as_known()` guard is retained solely to skip the whole union when any member is `Dynamic`/`Union`/`Meta`/`Never`.
- `is_type_compatible` and `is_assignable_to` now compare type args (new `type_args_match` helper) when both sides share a base class and are parameterized — staying conservative (compatible) for bare/arity-mismatched types so no new false positives are introduced.
- The protocol-conformance predicates strip the base name before `check_conformance` (conformance is a base-class property).

## 2. Improper-list cons-tail diagnostic

`[1 | someArray]` correctly widens to `List(Dynamic)` (an `Array` is tuple-backed and would form an improper BEAM list in cons position), but the widening was silent.

- The `ListLiteral` inference arm now emits a `Type` warning when the cons tail is a known non-`List` type (e.g. `Array`, or any non-collection), flagging the likely improper-list runtime bug. It stays silent (conservative) for `List`/`Dynamic`/`Union`/`Meta`/`Never` tails to avoid noise.

## Tests

- Unit tests for both follow-ups, including negative (no-warn) cases.
- `just test`, `just clippy`, `just fmt-check`, and stdlib tests (250/250) all pass; clean under warnings-as-errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DJHEUNkWpKVvgmF8jPJSH

---
_Generated by [Claude Code](https://claude.ai/code/session_013DJHEUNkWpKVvgmF8jPJSH)_