### PR TITLE
Extend impossible singleton-comparison hint beyond ifTrue:/ifFalse: guards (BT-2631)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1426,6 +1426,26 @@ impl TypeChecker {
         // Union-typed receiver: check selector on ALL members, warn if any lacks it.
         // Return type is the union of member return types.
         if let InferredType::Union { ref members, .. } = receiver_ty {
+            // BT-2631: a standalone singleton (in)equality send on a union
+            // receiver (`flag := unionVar =:= #west`) is statically decidable
+            // when `#west` can never be a member of the union — but
+            // `infer_union_message_send` short-circuits equality ops to
+            // `Boolean` before any membership check. Mirror the guard-scoped
+            // hint (`refine_singleton_narrowing`) here so the warning fires
+            // regardless of whether the comparison guards an `ifTrue:`. The
+            // receiver is the union operand, so its already-resolved
+            // `receiver_ty` is the variable's current type.
+            if let MessageSelector::Binary(op) = selector {
+                if let Some(eq) = narrowing::detect_singleton_eq(receiver, op, arguments) {
+                    self.check_impossible_singleton_comparison(
+                        &receiver_ty,
+                        &eq.info.singleton,
+                        eq.info.negated,
+                        hierarchy,
+                        span,
+                    );
+                }
+            }
             return self.infer_union_message_send(members, &selector_name, span, hierarchy);
         }
 
@@ -2216,32 +2236,17 @@ impl TypeChecker {
         let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
 
         // BT-2624 (item 1): when the tested singleton can never be a value of
-        // the variable's current type, the comparison is statically decidable —
-        // an equality test (`= #foo`) can never hold and an inequality test
-        // (`/= #foo`) always holds. Only flag this when certain: skip `Dynamic`
-        // (unknown) and `Never` (the branch is already unreachable), and skip
-        // when any member admits the singleton (it is the singleton itself, or
-        // `Symbol`/one of its supertypes).
-        if !matches!(current_ty, InferredType::Dynamic(_) | InferredType::Never)
-            && !Self::type_admits_singleton(&current_ty, &eq.singleton, hierarchy)
-        {
-            let ty_display = current_ty.display_for_diagnostic().unwrap_or_default();
-            let message = if eq.negated {
-                format!(
-                    "comparison is always true: `{}` is never a value of `{ty_display}`",
-                    eq.singleton
-                )
-            } else {
-                format!(
-                    "comparison can never be true: `{}` is not a value of `{ty_display}`",
-                    eq.singleton
-                )
-            };
-            self.diagnostics.push(
-                Diagnostic::hint(message, test_span)
-                    .with_category(crate::source_analysis::DiagnosticCategory::Type),
-            );
-        }
+        // the variable's current type, the comparison is statically decidable.
+        // Shared with the standalone-send path (BT-2631) so guard-scoped
+        // (`unionVar = #foo ifTrue: …`) and bare (`flag := unionVar =:= #foo`)
+        // equality tests warn identically.
+        self.check_impossible_singleton_comparison(
+            &current_ty,
+            &eq.singleton,
+            eq.negated,
+            hierarchy,
+            test_span,
+        );
 
         let matched = InferredType::known(eq.singleton.clone());
         let remainder = Self::union_without(&current_ty, &eq.singleton);
@@ -2257,6 +2262,42 @@ impl TypeChecker {
             info.false_type = Some(remainder);
         }
         info
+    }
+
+    /// BT-2624 / BT-2631: emits the "comparison can never be true" / "always
+    /// true" hint when a singleton (in)equality test (`var =:= #foo`) is
+    /// statically decidable — the singleton can never be a value of `current_ty`.
+    ///
+    /// Shared by the narrowing-guard path (`refine_singleton_narrowing`) and the
+    /// standalone-send path (`infer_union_message_send`'s equality short-circuit),
+    /// so the membership rule (`type_admits_singleton`) and the diagnostic
+    /// wording live in one place. Stays conservative: silent on `Dynamic`
+    /// (unknown) and `Never` (already-unreachable) receivers, and silent when any
+    /// member admits the singleton (it *is* the singleton, or `Symbol`/one of its
+    /// supertypes).
+    pub(super) fn check_impossible_singleton_comparison(
+        &mut self,
+        current_ty: &InferredType,
+        singleton: &EcoString,
+        negated: bool,
+        hierarchy: &ClassHierarchy,
+        test_span: Span,
+    ) {
+        if matches!(current_ty, InferredType::Dynamic(_) | InferredType::Never)
+            || Self::type_admits_singleton(current_ty, singleton, hierarchy)
+        {
+            return;
+        }
+        let ty_display = current_ty.display_for_diagnostic().unwrap_or_default();
+        let message = if negated {
+            format!("comparison is always true: `{singleton}` is never a value of `{ty_display}`")
+        } else {
+            format!("comparison can never be true: `{singleton}` is not a value of `{ty_display}`")
+        };
+        self.diagnostics.push(
+            Diagnostic::hint(message, test_span)
+                .with_category(crate::source_analysis::DiagnosticCategory::Type),
+        );
     }
 
     /// Removes every union member equal to the singleton named `removed` from

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2270,13 +2270,14 @@ impl TypeChecker {
     /// true" hint when a singleton (in)equality test (`var =:= #foo`) is
     /// statically decidable — the singleton can never be a value of `current_ty`.
     ///
-    /// Shared by the narrowing-guard path (`refine_singleton_narrowing`) and the
-    /// standalone-send path (`infer_union_message_send`'s equality short-circuit),
-    /// so the membership rule (`type_admits_singleton`) and the diagnostic
-    /// wording live in one place. Stays conservative: silent on `Dynamic`
-    /// (unknown) and `Never` (already-unreachable) receivers, and silent when any
-    /// member admits the singleton (it *is* the singleton, or `Symbol`/one of its
-    /// supertypes).
+    /// Called from `infer_message_send_with_receiver_ty`, which is the single
+    /// emitter for both the guarded path (`(unionVar = #foo) ifTrue: [...]`,
+    /// where the inner `=` send is inferred through that method) and the bare
+    /// standalone path (`unionVar = #foo` outside a guard), so the membership
+    /// rule (`type_admits_singleton`) and the diagnostic wording live in one
+    /// place. Stays conservative: silent on `Dynamic` (unknown) and `Never`
+    /// (already-unreachable) receivers, and silent when any member admits the
+    /// singleton (it *is* the singleton, or `Symbol`/one of its supertypes).
     pub(super) fn check_impossible_singleton_comparison(
         &mut self,
         current_ty: &InferredType,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -977,7 +977,7 @@ impl TypeChecker {
             Self::detect_narrowing(receiver)
                 .map(|info| self.refine_responds_to_narrowing(info))
                 .map(|info| Self::refine_result_narrowing(info, env, hierarchy))
-                .map(|info| self.refine_singleton_narrowing(info, env, hierarchy, receiver.span()))
+                .map(|info| Self::refine_singleton_narrowing(info, env, hierarchy))
         } else {
             None
         };
@@ -1423,22 +1423,26 @@ impl TypeChecker {
             }
         }
 
-        // Union-typed receiver: check selector on ALL members, warn if any lacks it.
-        // Return type is the union of member return types.
-        if let InferredType::Union { ref members, .. } = receiver_ty {
-            // BT-2631: a standalone singleton (in)equality send on a union
-            // receiver (`flag := unionVar =:= #west`) is statically decidable
-            // when `#west` can never be a member of the union — but
-            // `infer_union_message_send` short-circuits equality ops to
-            // `Boolean` before any membership check. Mirror the guard-scoped
-            // hint (`refine_singleton_narrowing`) here so the warning fires
-            // regardless of whether the comparison guards an `ifTrue:`. The
-            // receiver is the union operand, so its already-resolved
-            // `receiver_ty` is the variable's current type.
-            if let MessageSelector::Binary(op) = selector {
-                if let Some(eq) = narrowing::detect_singleton_eq(receiver, op, arguments) {
+        // BT-2631: a standalone singleton (in)equality send (`flag := unionVar
+        // =:= #west`) is statically decidable when `#west` can never be a member
+        // of the union — but `infer_union_message_send` short-circuits equality
+        // ops to `Boolean` before any membership check. Emit the same hint as the
+        // guard-scoped path here (and only here): an `ifTrue:`-guarded comparison
+        // is itself a `MessageSend` whose receiver is inferred through this path,
+        // so this is the single emitter for both guarded and bare comparisons —
+        // `refine_singleton_narrowing` deliberately no longer emits, avoiding a
+        // double hint. The union operand may be either side (`unionVar = #west`
+        // or `#west = unionVar`), so consult both operand types.
+        if let MessageSelector::Binary(op) = selector {
+            if let Some(eq) = narrowing::detect_singleton_eq(receiver, op, arguments) {
+                let arg_ty = arg_types.first();
+                let union_ty = [Some(&receiver_ty), arg_ty]
+                    .into_iter()
+                    .flatten()
+                    .find(|t| matches!(t, InferredType::Union { .. }));
+                if let Some(union_ty) = union_ty {
                     self.check_impossible_singleton_comparison(
-                        &receiver_ty,
+                        union_ty,
                         &eq.info.singleton,
                         eq.info.negated,
                         hierarchy,
@@ -1446,6 +1450,11 @@ impl TypeChecker {
                     );
                 }
             }
+        }
+
+        // Union-typed receiver: check selector on ALL members, warn if any lacks it.
+        // Return type is the union of member return types.
+        if let InferredType::Union { ref members, .. } = receiver_ty {
             return self.infer_union_message_send(members, &selector_name, span, hierarchy);
         }
 
@@ -2223,30 +2232,23 @@ impl TypeChecker {
     /// variable's type with that singleton removed (`Integer | #infinity` minus
     /// `#infinity` ⇒ `Integer`). For an inequality (`/=`, `=/=`) the two
     /// branches are swapped.
+    ///
+    /// BT-2624 (item 1) / BT-2631: the "comparison can never be true / always
+    /// true" hint for a statically decidable singleton test is *not* emitted
+    /// here. A guarded comparison (`unionVar = #foo ifTrue: …`) has its receiver
+    /// — the `=` send — inferred through `infer_message_send_with_receiver_ty`,
+    /// whose `check_impossible_singleton_comparison` is the single emitter for
+    /// both guarded and bare comparisons. Emitting here too would duplicate the
+    /// hint. This method only refines the branch types.
     pub(super) fn refine_singleton_narrowing(
-        &mut self,
         mut info: NarrowingInfo,
         env: &TypeEnv,
         hierarchy: &ClassHierarchy,
-        test_span: Span,
     ) -> NarrowingInfo {
         let Some(eq) = info.singleton_eq.clone() else {
             return info;
         };
         let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
-
-        // BT-2624 (item 1): when the tested singleton can never be a value of
-        // the variable's current type, the comparison is statically decidable.
-        // Shared with the standalone-send path (BT-2631) so guard-scoped
-        // (`unionVar = #foo ifTrue: …`) and bare (`flag := unionVar =:= #foo`)
-        // equality tests warn identically.
-        self.check_impossible_singleton_comparison(
-            &current_ty,
-            &eq.singleton,
-            eq.negated,
-            hierarchy,
-            test_span,
-        );
 
         let matched = InferredType::known(eq.singleton.clone());
         let remainder = Self::union_without(&current_ty, &eq.singleton);

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod visitors;
 use crate::ast::Expression;
 
 pub(crate) use info::NarrowingInfo;
+pub(crate) use rules::singleton_eq::detect_binary as detect_singleton_eq;
 
 /// Detect a narrowing from a receiver expression.
 ///

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/mod.rs
@@ -21,7 +21,7 @@ mod is_kind_of;
 mod is_nil;
 mod is_result;
 mod responds_to;
-mod singleton_eq;
+pub(crate) mod singleton_eq;
 
 /// A single narrowing pattern.
 ///

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/singleton_eq.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/singleton_eq.rs
@@ -14,7 +14,7 @@
 use ecow::{EcoString, eco_format};
 
 use crate::ast::{Expression, Literal, MessageSelector};
-use crate::semantic_analysis::type_checker::{DynamicReason, InferredType};
+use crate::semantic_analysis::type_checker::{DynamicReason, EnvKey, InferredType};
 
 use super::super::extract::{extract_variable_name, unwrap_parens};
 use super::super::info::{NarrowingInfo, SingletonEqInfo};
@@ -32,23 +32,9 @@ fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
     else {
         return None;
     };
-    let negated = match op.as_str() {
-        "=" | "=:=" => false,
-        "/=" | "=/=" => true,
-        _ => return None,
-    };
-    let lhs_expr = lhs.as_ref();
-    let rhs_expr = arguments.first()?;
-    // Accept either `x = #foo` or `#foo = x`; reject `#a = #b` (two literals)
-    // and any test where neither side is a singleton literal.
-    let (var_expr, symbol_name) = match (symbol_literal(lhs_expr), symbol_literal(rhs_expr)) {
-        (None, Some(name)) => (lhs_expr, name),
-        (Some(name), None) => (rhs_expr, name),
-        _ => return None,
-    };
-    let variable = extract_variable_name(var_expr)?;
+    let eq = detect_binary(lhs.as_ref(), op, arguments)?;
     Some(NarrowingInfo {
-        variable,
+        variable: eq.variable,
         // Provisional — `refine_singleton_narrowing` overwrites both branch
         // types once the variable's current union type is known.
         true_type: InferredType::Dynamic(DynamicReason::Unknown),
@@ -57,10 +43,48 @@ fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
         is_result_ok_check: false,
         is_result_error_check: false,
         responded_selector: None,
-        singleton_eq: Some(SingletonEqInfo {
+        singleton_eq: Some(eq.info),
+    })
+}
+
+/// A singleton (in)equality test recovered from a binary send: the tested
+/// variable plus the recorded singleton/negation (BT-2617, BT-2631).
+pub(crate) struct SingletonEqDetection {
+    pub(crate) variable: EnvKey,
+    pub(crate) info: SingletonEqInfo,
+}
+
+/// Recognises a singleton (in)equality test from the deconstructed binary send
+/// `lhs <op> rhs` (where `rhs` is `arguments.first()`). Reused by both the
+/// narrowing-guard path (via [`detect`]) and the standalone-send path
+/// (`infer_union_message_send`, BT-2631) so the operand-matching rule — accept
+/// `x = #foo` or `#foo = x`, reject `#a = #b` and non-singleton tests — lives in
+/// one place.
+pub(crate) fn detect_binary(
+    lhs: &Expression,
+    op: &EcoString,
+    arguments: &[Expression],
+) -> Option<SingletonEqDetection> {
+    let negated = match op.as_str() {
+        "=" | "=:=" => false,
+        "/=" | "=/=" => true,
+        _ => return None,
+    };
+    let rhs_expr = arguments.first()?;
+    // Accept either `x = #foo` or `#foo = x`; reject `#a = #b` (two literals)
+    // and any test where neither side is a singleton literal.
+    let (var_expr, symbol_name) = match (symbol_literal(lhs), symbol_literal(rhs_expr)) {
+        (None, Some(name)) => (lhs, name),
+        (Some(name), None) => (rhs_expr, name),
+        _ => return None,
+    };
+    let variable = extract_variable_name(var_expr)?;
+    Some(SingletonEqDetection {
+        variable,
+        info: SingletonEqInfo {
             singleton: eco_format!("#{symbol_name}"),
             negated,
-        }),
+        },
     })
 }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
@@ -507,8 +507,7 @@ fn test_refine_singleton_eq_splits_union() {
         vec![symbol_lit("infinity")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let mut checker = TypeChecker::new();
-    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
     assert_eq!(refined.true_type, InferredType::known("#infinity"));
     assert_eq!(refined.false_type, Some(InferredType::known("Integer")));
 }
@@ -525,8 +524,7 @@ fn test_refine_singleton_inequality_swaps_branches() {
         vec![symbol_lit("infinity")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let mut checker = TypeChecker::new();
-    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
     assert_eq!(refined.true_type, InferredType::known("Integer"));
     assert_eq!(refined.false_type, Some(InferredType::known("#infinity")));
 }
@@ -547,8 +545,7 @@ fn test_refine_singleton_eq_multi_member_union_keeps_rest() {
         vec![symbol_lit("north")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let mut checker = TypeChecker::new();
-    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
     assert_eq!(refined.true_type, InferredType::known("#north"));
     assert_eq!(
         refined.false_type,
@@ -569,8 +566,7 @@ fn test_refine_singleton_eq_all_removed_is_never() {
         vec![symbol_lit("north")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let mut checker = TypeChecker::new();
-    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
     assert_eq!(refined.true_type, InferredType::known("#north"));
     assert_eq!(refined.false_type, Some(InferredType::Never));
 }
@@ -588,8 +584,7 @@ fn test_refine_singleton_eq_dynamic_variable_keeps_false_dynamic() {
         vec![symbol_lit("foo")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let mut checker = TypeChecker::new();
-    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
     assert_eq!(refined.true_type, InferredType::known("#foo"));
     assert_eq!(
         refined.false_type,
@@ -611,28 +606,29 @@ fn test_refine_singleton_symbol_left_inequality_swaps_branches() {
         vec![var("ms")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let mut checker = TypeChecker::new();
-    let refined = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
     assert_eq!(refined.true_type, InferredType::known("Integer"));
     assert_eq!(refined.false_type, Some(InferredType::known("#infinity")));
 }
 
-/// BT-2624 (item 1): testing a variable against a singleton it can never hold
-/// (`#west` is not a member of `#north | #south`) is statically false — emit a
-/// "can never be true" hint and do NOT flag the present-member case.
+/// BT-2624 (item 1) / BT-2631: testing a variable against a singleton it can
+/// never hold (`#west` is not a member of `#north | #south`) is statically false
+/// — emit exactly one "can never be true" hint even when the comparison guards
+/// an `ifTrue:` (the guard receiver and the narrowing must not double-fire).
 #[test]
 fn bt2624_singleton_eq_impossible_member_emits_hint() {
     let hierarchy = ClassHierarchy::with_builtins();
     let mut env = TypeEnv::new();
     env.set_local("d", InferredType::simple_union(&["#north", "#south"]));
-    let expr = msg_send(
+    // `(d = #west) ifTrue: [nil]` — the comparison is the guard receiver.
+    let guard = msg_send(
         var("d"),
         MessageSelector::Binary("=".into()),
         vec![symbol_lit("west")],
     );
-    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let expr = if_true(guard, block_expr(vec![var("nil")]));
     let mut checker = TypeChecker::new();
-    let _ = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+    let _ = checker.infer_expr(&expr, &hierarchy, &mut env, false);
     let hints: Vec<_> = checker
         .diagnostics()
         .iter()
@@ -641,7 +637,7 @@ fn bt2624_singleton_eq_impossible_member_emits_hint() {
     assert_eq!(
         hints.len(),
         1,
-        "expected one impossibility hint, got: {:?}",
+        "expected exactly one impossibility hint (no double-fire), got: {:?}",
         checker.diagnostics()
     );
     assert!(
@@ -652,48 +648,55 @@ fn bt2624_singleton_eq_impossible_member_emits_hint() {
 }
 
 /// BT-2624 (item 1): the negated form against an impossible member is always
-/// true — emit the complementary "always true" hint.
+/// true — emit the complementary "always true" hint (here in a guard position).
 #[test]
 fn bt2624_singleton_inequality_impossible_member_always_true() {
     let hierarchy = ClassHierarchy::with_builtins();
     let mut env = TypeEnv::new();
     env.set_local("d", InferredType::simple_union(&["#north", "#south"]));
-    let expr = msg_send(
+    let guard = msg_send(
         var("d"),
         MessageSelector::Binary("/=".into()),
         vec![symbol_lit("west")],
     );
-    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let expr = if_true(guard, block_expr(vec![var("nil")]));
     let mut checker = TypeChecker::new();
-    let _ = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
-    assert!(
-        checker
-            .diagnostics()
-            .iter()
-            .any(|d| d.message.contains("always true") && d.message.contains("#west")),
-        "expected an 'always true' hint, got: {:?}",
+    let _ = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+    let hints: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("always true") && d.message.contains("#west"))
+        .collect();
+    assert_eq!(
+        hints.len(),
+        1,
+        "expected exactly one 'always true' hint, got: {:?}",
         checker.diagnostics()
     );
 }
 
 /// BT-2624 (item 1): a singleton that IS a member must not be flagged, and a
-/// `Symbol`-typed (or `Dynamic`) variable admits any singleton — no hint.
+/// `Symbol`-typed variable admits any singleton — no hint.
 #[test]
 fn bt2624_singleton_eq_possible_member_no_hint() {
     let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+
+    // `(d = #north) ifTrue: [nil]` — #north is a member, so satisfiable.
     let mut env = TypeEnv::new();
     env.set_local("d", InferredType::simple_union(&["#north", "#south"]));
-    // `d = #north` — #north is a member, so the test is satisfiable.
-    let member_expr = msg_send(
-        var("d"),
-        MessageSelector::Binary("=".into()),
-        vec![symbol_lit("north")],
+    let member_guard = if_true(
+        msg_send(
+            var("d"),
+            MessageSelector::Binary("=".into()),
+            vec![symbol_lit("north")],
+        ),
+        block_expr(vec![var("nil")]),
     );
-    let info = TypeChecker::detect_narrowing(&member_expr).unwrap();
-    let mut checker = TypeChecker::new();
-    let _ = checker.refine_singleton_narrowing(info, &env, &hierarchy, span());
+    let _ = checker.infer_expr(&member_guard, &hierarchy, &mut env, false);
 
-    // `s :: Symbol` admits every singleton.
+    // `s :: Symbol` admits every singleton — no impossibility hint for
+    // `s = #anything`.
     let mut sym_env = TypeEnv::new();
     sym_env.set_local("s", InferredType::known("Symbol"));
     let sym_expr = msg_send(
@@ -701,12 +704,16 @@ fn bt2624_singleton_eq_possible_member_no_hint() {
         MessageSelector::Binary("=".into()),
         vec![symbol_lit("anything")],
     );
-    let sym_info = TypeChecker::detect_narrowing(&sym_expr).unwrap();
-    let _ = checker.refine_singleton_narrowing(sym_info, &sym_env, &hierarchy, span());
+    let _ = checker.infer_expr(&sym_expr, &hierarchy, &mut sym_env, false);
 
+    // No "can never be true" / "always true" impossibility hint from any of the
+    // satisfiable comparisons above. (Other diagnostic kinds are out of scope
+    // for this test.)
     assert!(
-        checker.diagnostics().is_empty(),
-        "satisfiable comparisons must not warn, got: {:?}",
+        !checker.diagnostics().iter().any(|d| {
+            d.message.contains("can never be true") || d.message.contains("always true")
+        }),
+        "satisfiable comparisons must not emit an impossibility hint, got: {:?}",
         checker.diagnostics()
     );
 }
@@ -770,6 +777,35 @@ fn bt2631_standalone_singleton_inequality_impossible_member_always_true() {
             .iter()
             .any(|d| d.message.contains("always true") && d.message.contains("#west")),
         "expected a standalone-send 'always true' hint, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+/// BT-2631: the union operand may be on either side — `#west =:= unionVar`
+/// (singleton on the left, union as the *argument*) is just as decidable as the
+/// receiver-side form, so the hint fires there too.
+#[test]
+fn bt2631_standalone_singleton_eq_union_on_right_emits_hint() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("x", InferredType::simple_union(&["#north", "#south"]));
+    // `#west =:= x` — the union `x` is the argument, the singleton the receiver.
+    let expr = msg_send(
+        symbol_lit("west"),
+        MessageSelector::Binary("=:=".into()),
+        vec![var("x")],
+    );
+    let mut checker = TypeChecker::new();
+    let _ = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+    let hints: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("can never be true"))
+        .collect();
+    assert_eq!(
+        hints.len(),
+        1,
+        "expected one hint for the union-on-right form, got: {:?}",
         checker.diagnostics()
     );
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
@@ -711,6 +711,108 @@ fn bt2624_singleton_eq_possible_member_no_hint() {
     );
 }
 
+/// BT-2631: the impossible-comparison hint must also fire for a *standalone*
+/// singleton equality send (`unionVar =:= #west`), not only inside an
+/// `ifTrue:`/`ifFalse:` guard. The send still infers `Boolean`; the hint is the
+/// only added signal.
+#[test]
+fn bt2631_standalone_singleton_eq_impossible_member_emits_hint() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("x", InferredType::simple_union(&["#north", "#south"]));
+    // `x =:= #west` — #west is not a member of `#north | #south`.
+    let expr = msg_send(
+        var("x"),
+        MessageSelector::Binary("=:=".into()),
+        vec![symbol_lit("west")],
+    );
+    let mut checker = TypeChecker::new();
+    let ty = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+    assert_eq!(
+        ty,
+        InferredType::known("Boolean"),
+        "the comparison is still typed Boolean"
+    );
+    let hints: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("can never be true"))
+        .collect();
+    assert_eq!(
+        hints.len(),
+        1,
+        "expected one standalone-send impossibility hint, got: {:?}",
+        checker.diagnostics()
+    );
+    assert!(
+        hints[0].message.contains("#west") && hints[0].message.contains("#north | #south"),
+        "hint should name the singleton and the type: {}",
+        hints[0].message
+    );
+}
+
+/// BT-2631: the negated standalone send (`unionVar =/= #west`) is always true.
+#[test]
+fn bt2631_standalone_singleton_inequality_impossible_member_always_true() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("x", InferredType::simple_union(&["#north", "#south"]));
+    let expr = msg_send(
+        var("x"),
+        MessageSelector::Binary("=/=".into()),
+        vec![symbol_lit("west")],
+    );
+    let mut checker = TypeChecker::new();
+    let _ = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+    assert!(
+        checker
+            .diagnostics()
+            .iter()
+            .any(|d| d.message.contains("always true") && d.message.contains("#west")),
+        "expected a standalone-send 'always true' hint, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+/// BT-2631: a standalone send whose singleton IS a member, or whose union
+/// admits any singleton (a `Symbol` member), must stay silent — matching the
+/// conservative guard-path behaviour.
+#[test]
+fn bt2631_standalone_singleton_eq_admitted_no_hint() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+
+    // `x =:= #north` — #north IS a member, so the test is satisfiable.
+    let mut env = TypeEnv::new();
+    env.set_local("x", InferredType::simple_union(&["#north", "#south"]));
+    let member_expr = msg_send(
+        var("x"),
+        MessageSelector::Binary("=:=".into()),
+        vec![symbol_lit("north")],
+    );
+    let _ = checker.infer_expr(&member_expr, &hierarchy, &mut env, false);
+
+    // `#north | Symbol` admits every singleton (the `Symbol` member), so even a
+    // non-listed singleton like #west is satisfiable — no hint.
+    let mut sym_env = TypeEnv::new();
+    sym_env.set_local(
+        "y",
+        InferredType::union_of(&[InferredType::known("#north"), InferredType::known("Symbol")]),
+    );
+    let sym_expr = msg_send(
+        var("y"),
+        MessageSelector::Binary("=:=".into()),
+        vec![symbol_lit("west")],
+    );
+    let _ = checker.infer_expr(&sym_expr, &hierarchy, &mut sym_env, false);
+
+    assert!(
+        checker.diagnostics().is_empty(),
+        "satisfiable comparisons must not warn, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
 #[test]
 fn test_narrowing_does_not_leak_outside_block() {
     // Verify narrowing is scoped to block only:


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2631

## Summary

The "comparison can never be true / always true" hint (BT-2624) previously fired only inside a narrowing context (`ifTrue:` / `ifFalse:` / `ifTrue:ifFalse:` receivers, via `refine_singleton_narrowing`). A standalone equality send such as `flag := unionVar =:= #west` short-circuited to `Boolean` in `infer_union_message_send` before any membership check, so the statically decidable comparison went unwarned.

This PR extends the impossible-comparison detection to standalone singleton (in)equality sends on a union receiver, reusing the existing `type_admits_singleton` membership rule. It is a precision improvement, not a correctness fix — the comparison is already typed `Boolean` correctly; it just now warns when the result is statically decidable.

## Key changes

- Extracted the impossible-comparison check into a shared `check_impossible_singleton_comparison` helper (membership rule + diagnostic wording in one place).
- Made the equality-send inference path the **single emitter** for the hint, covering both guarded and bare comparisons. `refine_singleton_narrowing` no longer emits (its guard receiver is already inferred through that path), avoiding a double hint.
- Shared the operand-matching rule via a new `detect_binary` in the `singleton_eq` narrowing rule (accept `x = #foo` or `#foo = x`; both operand orders handled).
- Stays conservative: silent on `Dynamic` / `Never` receivers and when any union member admits the singleton (`Symbol` or the singleton itself).
- Tests: standalone-send (both operand orders, equality + negation), the conservative admitted case, and a regression test asserting a guarded comparison emits exactly one hint (no double-fire). Existing guard tests rewritten to drive full inference.

## Verification

- `beamtalk-core` lib suite: 4195 passed
- stdlib language-feature tests: 250 passed
- clippy + fmt clean; pre-push full CI passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DJHEUNkWpKVvgmF8jPJSH

---
_Generated by [Claude Code](https://claude.ai/code/session_013DJHEUNkWpKVvgmF8jPJSH)_