### PR TITLE
Browse ops: separate source_origin classification from package name (BT-2643)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4085,14 +4085,15 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp class_category_bucket(%{"is_protocol" => true}), do: "Protocols"
   defp class_category_bucket(class), do: Map.get(class, "category") || "(uncategorized)"
 
-  # Narrow class rows by source origin (BT-2557). `source_origin` is "project",
-  # "stdlib", or "dependency:<pkg>" (browse-classes). "all" is the identity
-  # filter; an unknown filter also passes everything through (fail-open so the
-  # tree is never silently blanked).
+  # Narrow class rows by source origin (BT-2557). `source_origin` is the bare
+  # classification "project", "stdlib", or "dependency" (BT-2643 — the package
+  # name now lives in a separate `package` field). "all" is the identity filter;
+  # an unknown filter also passes everything through (fail-open so the tree is
+  # never silently blanked).
   defp filter_by_source(classes, "all"), do: classes
 
   defp filter_by_source(classes, "deps") do
-    Enum.filter(classes, &String.starts_with?(Map.get(&1, "source_origin", ""), "dependency:"))
+    Enum.filter(classes, &(Map.get(&1, "source_origin") == "dependency"))
   end
 
   defp filter_by_source(classes, src) when src in ~w(project stdlib) do
@@ -4137,22 +4138,37 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp runtime_only?(%{"origin" => "runtime"}), do: true
   defp runtime_only?(_), do: false
 
-  # Source origin badge helpers (BT-2552). The source_origin field is
-  # "stdlib", "project", or "dependency[:packagename]".
+  # Source origin badge helpers (BT-2552, BT-2643). Two orthogonal fields drive
+  # the badge: `source_origin` is the classification ("stdlib" | "dependency" |
+  # "project") and keys the css class + title; `package` is the package name and
+  # supplies the visible label. The dependency badge still shows the package
+  # name, now read from `package` rather than packed into `source_origin`.
   defp source_origin_class(%{"source_origin" => "stdlib"}), do: "stdlib"
-  defp source_origin_class(%{"source_origin" => <<"dependency:", _::binary>>}), do: "dependency"
+  defp source_origin_class(%{"source_origin" => "dependency"}), do: "dependency"
   defp source_origin_class(_), do: "project"
 
   defp source_origin_label(%{"source_origin" => "stdlib"}), do: "stdlib"
-  defp source_origin_label(%{"source_origin" => <<"dependency:", pkg::binary>>}), do: pkg
+
+  defp source_origin_label(%{"source_origin" => "dependency"} = row),
+    do: package_name(row)
+
   defp source_origin_label(_), do: ""
 
   defp source_origin_title(%{"source_origin" => "stdlib"}), do: "Standard library"
 
-  defp source_origin_title(%{"source_origin" => <<"dependency:", pkg::binary>>}),
-    do: "Dependency: #{pkg}"
+  defp source_origin_title(%{"source_origin" => "dependency"} = row),
+    do: "Dependency: #{package_name(row)}"
 
   defp source_origin_title(_), do: "Project"
+
+  # The package name carried on a browse row's `package` field (BT-2643). Absent /
+  # null packages degrade to "unknown" so a dependency badge never renders blank.
+  defp package_name(row) do
+    case Map.get(row, "package") do
+      pkg when is_binary(pkg) and pkg != "" -> pkg
+      _ -> "unknown"
+    end
+  end
 
   # ── tabbed method editor data model (BT-2494) ───────────────────────────────
   #

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
@@ -71,8 +71,15 @@ See `docs/ADR/0096-system-browser-data-source.md`.
 
 -ifdef(TEST).
 %% Pure helpers exercised directly in EUnit (BT-2578): clause parsing and the
-%% delegate-source marker have no live-class dependency.
--export([handle_call_clause_lines/1, clause_selector/1, delegate_exported/2]).
+%% delegate-source marker have no live-class dependency. BT-2643: the
+%% source_origin (classification) / package (name) split helpers.
+-export([
+    handle_call_clause_lines/1,
+    clause_selector/1,
+    delegate_exported/2,
+    package_of/2,
+    package_of_module/1
+]).
 -endif.
 
 -doc """
@@ -177,6 +184,7 @@ class_row(Pid, TestClasses) ->
         Super = beamtalk_runtime_api:superclass(Pid),
         ModName = origin_module(Name, beamtalk_runtime_api:module_name(Pid)),
         SourceFile = source_file_of(ModName),
+        SourceOrigin = source_origin_of(ModName, SourceFile),
         {true, #{
             <<"name">> => atom_to_binary(Name, utf8),
             <<"superclass">> => atom_or_null(Super),
@@ -187,7 +195,8 @@ class_row(Pid, TestClasses) ->
             <<"internal">> => safe_bool(fun() -> beamtalk_runtime_api:is_internal(Pid) end),
             <<"source_file">> => SourceFile,
             <<"origin">> => origin_of(SourceFile),
-            <<"source_origin">> => source_origin_of(ModName, SourceFile),
+            <<"source_origin">> => SourceOrigin,
+            <<"package">> => package_of(ModName, SourceOrigin),
             <<"is_test">> => sets:is_element(Name, TestClasses),
             %% BT-2615: protocol class objects (ADR 0068) are sealed abstract
             %% subclasses of Protocol with no declared package, so they would
@@ -271,12 +280,14 @@ protocol_requirement_rows(ClassName, ClassSide, SourceFile, ModName) ->
 
 -spec requirement_row(atom(), binary() | null, atom()) -> map().
 requirement_row(Selector, SourceFile, ModName) ->
+    SourceOrigin = source_origin_of(ModName, SourceFile),
     #{
         <<"selector">> => atom_to_binary(Selector, utf8),
         <<"line">> => null,
         <<"source_status">> => <<"unindexed_runtime_fun">>,
         <<"origin">> => <<"runtime">>,
-        <<"source_origin">> => source_origin_of(ModName, SourceFile),
+        <<"source_origin">> => SourceOrigin,
+        <<"package">> => package_of(ModName, SourceOrigin),
         %% carried internally for grouping; stripped before emit
         '__protocol__' => <<"requirements">>
     }.
@@ -285,12 +296,14 @@ requirement_row(Selector, SourceFile, ModName) ->
 selector_row(ClassName, ClassSide, Selector, SourceFile, ModName) ->
     Info = beamtalk_xref:method_info(ClassName, ClassSide, Selector),
     {Line, SourceStatus, Provenance} = info_fields(Info),
+    SourceOrigin = source_origin_of(ModName, SourceFile),
     #{
         <<"selector">> => atom_to_binary(Selector, utf8),
         <<"line">> => Line,
         <<"source_status">> => atom_to_binary(SourceStatus, utf8),
         <<"origin">> => origin_for_provenance(Provenance, SourceFile),
-        <<"source_origin">> => source_origin_of(ModName, SourceFile),
+        <<"source_origin">> => SourceOrigin,
+        <<"package">> => package_of(ModName, SourceOrigin),
         %% carried internally for grouping; stripped before emit
         '__protocol__' => protocol_for_selector(Selector, Info, Provenance, SourceStatus, ClassSide)
     }.
@@ -358,6 +371,7 @@ browse_method_source(ClassName, ClassSide, Selector) ->
                 method_text_fields(ClassPid, ClassSide, Selector, SourceStatus),
             SourceFile = source_file_for_class(ClassName),
             ModName = beamtalk_runtime_api:module_name(ClassPid),
+            SourceOrigin = source_origin_of(ModName, SourceFile),
             {value, #{
                 <<"class">> => atom_to_binary(ClassName, utf8),
                 <<"side">> => side_to_binary(ClassSide),
@@ -384,7 +398,8 @@ browse_method_source(ClassName, ClassSide, Selector) ->
                 <<"line">> => Line,
                 <<"source_status">> => atom_to_binary(SourceStatus, utf8),
                 <<"origin">> => origin_for_provenance(Provenance, SourceFile),
-                <<"source_origin">> => source_origin_of(ModName, SourceFile),
+                <<"source_origin">> => SourceOrigin,
+                <<"package">> => package_of(ModName, SourceOrigin),
                 <<"disk_differs">> => disk_differs(SourceFile, ClassName, Source)
             }}
     end.
@@ -455,6 +470,7 @@ browse_class_definition(ClassName) ->
             %% definition pane's category/origin/source_origin are accurate.
             ModName = origin_module(ClassName, beamtalk_runtime_api:module_name(ClassPid)),
             SourceFile = source_file_of(ModName),
+            SourceOrigin = source_origin_of(ModName, SourceFile),
             State = state_slots(ClassPid),
             Definition = class_definition_text(ClassName, Super, State),
             %% BT-2578: native-backed classes (ADR 0056) carry their backing
@@ -480,7 +496,8 @@ browse_class_definition(ClassName) ->
                 <<"sealed">> => safe_bool(fun() -> beamtalk_runtime_api:is_sealed(ClassPid) end),
                 <<"abstract">> => safe_bool(fun() -> beamtalk_runtime_api:is_abstract(ClassPid) end),
                 <<"origin">> => origin_of(SourceFile),
-                <<"source_origin">> => source_origin_of(ModName, SourceFile),
+                <<"source_origin">> => SourceOrigin,
+                <<"package">> => package_of(ModName, SourceOrigin),
                 %% The definition pane renders a *synthesized* class skeleton
                 %% (header + state slots), not the verbatim on-disk class source
                 %% — so a substring diff against the disk store would be unsound
@@ -806,9 +823,10 @@ optional_selector(Params) ->
 origin_of(null) -> <<"runtime">>;
 origin_of(SourceFile) when is_binary(SourceFile) -> <<"both">>.
 
-%% Class source origin: whether a class comes from the project, a dependency,
-%% or the stdlib. Used for IDE badges (BT-2552). For dependencies, the package
-%% name is included (e.g. <<"dependency:cowboy">>).
+%% Class source origin: the *classification* of where a class comes from —
+%% `project`, `dependency`, or `stdlib`. Used for IDE badges (BT-2552). This is
+%% orthogonal to the *package name* (see `package_of/2`, BT-2643): the package is
+%% carried in a separate `package` row field, never packed into this value.
 -spec source_origin_of(atom(), binary() | null) -> binary().
 source_origin_of(ModName, SourceFile) when is_atom(ModName) ->
     case beamtalk_class_registry:is_stdlib_module(ModName) of
@@ -820,15 +838,40 @@ source_origin_of(ModName, SourceFile) when is_atom(ModName) ->
                     <<"project">>;
                 Bin when is_binary(Bin) ->
                     case classify_source_origin(Bin) of
-                        project ->
-                            <<"project">>;
-                        dependency ->
-                            case package_of_module(ModName) of
-                                nil -> <<"dependency:unknown">>;
-                                Pkg -> iolist_to_binary([<<"dependency:">>, Pkg])
-                            end
+                        project -> <<"project">>;
+                        dependency -> <<"dependency">>
                     end
             end
+    end.
+
+%% Package name a class lives in, for ALL origins (BT-2643): `stdlib` for stdlib
+%% classes, the dependency package for dependencies, and the project's own
+%% package name for project classes. Orthogonal to `source_origin_of/2`'s
+%% classification. The package comes from the module atom (`bt@{pkg}@{class}`)
+%% when encoded there; for project classes whose module carries no package
+%% segment, fall back to the workspace's configured package name. `null` when no
+%% package can be determined (e.g. unknown dependency, no workspace metadata).
+-spec package_of(atom(), binary()) -> binary() | null.
+package_of(ModName, <<"stdlib">>) when is_atom(ModName) ->
+    <<"stdlib">>;
+package_of(ModName, <<"dependency">>) when is_atom(ModName) ->
+    case package_of_module(ModName) of
+        nil -> null;
+        Pkg -> Pkg
+    end;
+package_of(ModName, <<"project">>) when is_atom(ModName) ->
+    case package_of_module(ModName) of
+        nil -> project_package_name();
+        Pkg -> Pkg
+    end.
+
+%% The workspace's configured package name (project's own package), or `null`
+%% when no workspace metadata is available (startup, no project).
+-spec project_package_name() -> binary() | null.
+project_package_name() ->
+    case beamtalk_workspace_meta:get_package_name() of
+        Name when is_binary(Name) -> Name;
+        _ -> null
     end.
 
 %% Extract the package name from a module atom (bt@{pkg}@{class} → {pkg}).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
@@ -480,18 +480,28 @@ browse_tests(#{class_name := Class}) ->
             ?assertEqual(null, maps:get(<<"source_file">>, Row)),
             ?assertEqual(<<"runtime">>, maps:get(<<"origin">>, Row))
         end},
-        {"browse-classes source_origin is present for all rows", fun() ->
-            %% BT-2552: source_origin field classifies project/dependency/stdlib.
+        {"browse-classes source_origin is a bare classification for all rows", fun() ->
+            %% BT-2552/BT-2643: source_origin is the bare classification
+            %% (project|dependency|stdlib) — the package name is NOT packed in.
             Value = decode_value(
                 beamtalk_repl_ops_browse:handle(<<"browse-classes">>, #{}, make_msg(), self())
             ),
             Row = find_class_row(Value, Class),
             SourceOrigin = maps:get(<<"source_origin">>, Row),
             ?assert(is_binary(SourceOrigin)),
-            ?assert(
-                lists:member(SourceOrigin, [<<"stdlib">>, <<"project">>, <<"dependency">>]) orelse
-                    binary:match(SourceOrigin, <<"dependency:">>) =/= nomatch
-            )
+            ?assert(lists:member(SourceOrigin, [<<"stdlib">>, <<"project">>, <<"dependency">>])),
+            ?assertEqual(nomatch, binary:match(SourceOrigin, <<"dependency:">>))
+        end},
+        {"browse-classes carries a separate package field on every row", fun() ->
+            %% BT-2643: package is orthogonal to source_origin and present
+            %% (binary or null) on every class row.
+            Value = decode_value(
+                beamtalk_repl_ops_browse:handle(<<"browse-classes">>, #{}, make_msg(), self())
+            ),
+            Row = find_class_row(Value, Class),
+            ?assert(maps:is_key(<<"package">>, Row)),
+            Package = maps:get(<<"package">>, Row),
+            ?assert(is_binary(Package) orelse Package =:= null)
         end},
         {"browse-class-definition reports native=false for a plain class", fun() ->
             %% BT-2578: a fixture class with no native facade meta is not
@@ -958,6 +968,75 @@ protocol_tests(#{proto_bin := Proto}) ->
             ?assertEqual(<<"requirements">>, protocol_of(Protocols, <<"fromString:">>))
         end}
     ].
+
+%%====================================================================
+%% source_origin (classification) / package (name) split — BT-2643
+%%====================================================================
+
+%% source_origin_of/2 returns the bare classification, never `dependency:<pkg>`.
+source_origin_stdlib_module_test() ->
+    %% A stdlib module classifies as stdlib regardless of its source file.
+    ?assertEqual(
+        <<"stdlib">>,
+        beamtalk_repl_ops_browse:source_origin_of('bt@stdlib@OrderedCollection', null)
+    ),
+    ?assertEqual(
+        <<"stdlib">>,
+        beamtalk_repl_ops_browse:source_origin_of(
+            'bt@stdlib@OrderedCollection', <<"stdlib/src/ordered_collection.bt">>
+        )
+    ).
+
+source_origin_null_source_is_project_test() ->
+    %% A non-stdlib module with no disk source (ClassBuilder / runtime class) is
+    %% classified `project` — the bare classification, no package packing.
+    ?assertEqual(
+        <<"project">>,
+        beamtalk_repl_ops_browse:source_origin_of('bt@myapp@Counter', null)
+    ).
+
+%% package_of/2 derives the package name for ALL origins, orthogonal to the
+%% classification.
+package_of_stdlib_test() ->
+    %% Stdlib classes report the package "stdlib".
+    ?assertEqual(
+        <<"stdlib">>,
+        beamtalk_repl_ops_browse:package_of('bt@stdlib@OrderedCollection', <<"stdlib">>)
+    ).
+
+package_of_project_package_module_test() ->
+    %% A project class whose module atom encodes its package reports that package.
+    ?assertEqual(
+        <<"myapp">>,
+        beamtalk_repl_ops_browse:package_of('bt@myapp@Counter', <<"project">>)
+    ).
+
+package_of_dependency_package_module_test() ->
+    %% A dependency class reports its package from the module atom.
+    ?assertEqual(
+        <<"cowboy">>,
+        beamtalk_repl_ops_browse:package_of('bt@cowboy@Listener', <<"dependency">>)
+    ).
+
+package_of_dependency_unknown_is_null_test() ->
+    %% A dependency module that carries no package segment degrades to null
+    %% (never the old "dependency:unknown" packing).
+    ?assertEqual(
+        null,
+        beamtalk_repl_ops_browse:package_of(some_native_mod, <<"dependency">>)
+    ).
+
+package_of_project_no_segment_falls_back_test() ->
+    %% A project class whose module atom has no package segment falls back to the
+    %% workspace package name — null here since no workspace_meta is running.
+    ?assertEqual(
+        null,
+        beamtalk_repl_ops_browse:package_of(plain_project_mod, <<"project">>)
+    ).
+
+package_of_module_extraction_test() ->
+    ?assertEqual(<<"http">>, beamtalk_repl_ops_browse:package_of_module('bt@http@Server')),
+    ?assertEqual(nil, beamtalk_repl_ops_browse:package_of_module(no_at_signs)).
 
 %%====================================================================
 %% Row helpers


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2643

## Summary

Splits the System Browser browse-ops `source_origin` field into two orthogonal fields:

- **`source_origin`** — bare classification: `project` | `dependency` | `stdlib` (drops the old `dependency:<pkg>` packing)
- **`package`** — the package name, populated for **all** origins (`stdlib` for stdlib, the dependency package for deps, the project package for project classes)

This is the data-model linchpin that BT-2641 (tree dep badge) and BT-2642 (editor-header package badge) build on — keeping origin (for filtering + colour) orthogonal to package (for the label), so consumers never string-parse a combined value.

## Key changes

- `beamtalk_repl_ops_browse.erl`: `source_origin_of/2` returns the bare classification; new `package_of/2` + `project_package_name/0` (via `beamtalk_workspace_meta:get_package_name/0`, `null` when unavailable); `package` added to the class / requirement / selector / method-source / class-definition rows.
- `workspace_live.ex`: `filter_by_source/2` "deps" matches `source_origin == "dependency"`; badge helpers split — `source_origin_class/1` / `source_origin_title/1` key off classification, dependency label reads the new `package` field via `package_name/1`.
- Tests: tightened browse-classes assertions to forbid the old `dependency:` packing and require a `package` key; added unit tests for `source_origin_of/2` and `package_of/2` across stdlib / project / dependency / unknown / no-segment.

## Verification

- `just build` ✓
- `beamtalk_repl_ops_browse` EUnit — 48 tests, 0 failures ✓
- LiveView ExUnit — 279 passed, 0 failures ✓
- `just clippy` ✓, `rebar3 dialyzer` clean ✓, `rebar3 fmt --check` clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_