### PR TITLE
System Browser: classify dependency classes by package, not just file path (BT-2640)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
@@ -829,19 +829,47 @@ origin_of(SourceFile) when is_binary(SourceFile) -> <<"both">>.
 %% carried in a separate `package` row field, never packed into this value.
 -spec source_origin_of(atom(), binary() | null) -> binary().
 source_origin_of(ModName, SourceFile) when is_atom(ModName) ->
+    %% Stdlib always wins first (BT-2552).
     case beamtalk_class_registry:is_stdlib_module(ModName) of
         true ->
             <<"stdlib">>;
         false ->
-            case SourceFile of
-                null ->
-                    <<"project">>;
-                Bin when is_binary(Bin) ->
-                    case classify_source_origin(Bin) of
-                        project -> <<"project">>;
-                        dependency -> <<"dependency">>
-                    end
-            end
+            classify_origin(package_of_module(ModName), project_package_name(), SourceFile)
+    end.
+
+%% Classification rule (BT-2640): the module's package segment is the *primary*
+%% signal, not the filesystem path. `bt@{pkg}@{class}` encodes the owning package;
+%% comparing it to the project's own package name correctly labels dependency
+%% classes whose sources happen to resolve under the project tree, and avoids
+%% dumping everything into `project` when `project_path` metadata is missing.
+%%
+%%   - package present, ≠ project package         -> dependency
+%%   - package present, == project package        -> project
+%%   - package present but project package unknown -> path fallback (then project)
+%%   - no package segment                          -> path fallback (null -> project)
+-spec classify_origin(binary() | nil, binary() | null, binary() | null) -> binary().
+classify_origin(Pkg, ProjectPkg, _SourceFile) when
+    is_binary(Pkg), is_binary(ProjectPkg)
+->
+    case Pkg =:= ProjectPkg of
+        true -> <<"project">>;
+        false -> <<"dependency">>
+    end;
+classify_origin(Pkg, _ProjectPkg, SourceFile) when is_binary(Pkg) ->
+    %% Package known but project package unresolvable: defer to the path check.
+    path_origin(SourceFile);
+classify_origin(nil, _ProjectPkg, SourceFile) ->
+    %% No package segment in the module atom: fall back to the path-prefix check.
+    path_origin(SourceFile).
+
+%% Secondary, path-prefix fallback used only when the package can't decide.
+-spec path_origin(binary() | null) -> binary().
+path_origin(null) ->
+    <<"project">>;
+path_origin(SourceFile) when is_binary(SourceFile) ->
+    case classify_source_origin(SourceFile) of
+        project -> <<"project">>;
+        dependency -> <<"dependency">>
     end.
 
 %% Package name a class lives in, for ALL origins (BT-2643): `stdlib` for stdlib
@@ -885,9 +913,11 @@ package_of_module(ModName) when is_atom(ModName) ->
             nil
     end.
 
-%% Determine if a source file belongs to the project or a dependency.
-%% Falls back to `project` when metadata is unavailable (startup, no workspace)
-%% — a wrong "project" badge is less confusing than a wrong "dependency" badge.
+%% Secondary fallback (BT-2640): determine if a source file belongs to the
+%% project or a dependency by filesystem path. Used only by `classify_origin/3`
+%% when the module's package segment can't decide. Falls back to `project` when
+%% metadata is unavailable (startup, no workspace) — a wrong "project" badge is
+%% less confusing than a wrong "dependency" badge.
 -spec classify_source_origin(binary()) -> project | dependency.
 classify_source_origin(SourceFile) ->
     SourceStr = binary_to_list(SourceFile),

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
@@ -1039,6 +1039,140 @@ package_of_module_extraction_test() ->
     ?assertEqual(nil, beamtalk_repl_ops_browse:package_of_module(no_at_signs)).
 
 %%====================================================================
+%% Package-based source_origin classification — BT-2640
+%%====================================================================
+
+%% Without a running workspace_meta the project package is unknown, so a
+%% packaged dependency-looking module degrades to the path-prefix fallback;
+%% with a null source that lands on `project` (a wrong "project" badge is less
+%% confusing than a wrong "dependency" badge).
+source_origin_no_meta_packaged_null_source_is_project_test() ->
+    ?assertEqual(
+        <<"project">>,
+        beamtalk_repl_ops_browse:source_origin_of('bt@cowboy@Listener', null)
+    ).
+
+%% No package segment + null source + no meta => project (path fallback).
+source_origin_no_segment_null_source_is_project_test() ->
+    ?assertEqual(
+        <<"project">>,
+        beamtalk_repl_ops_browse:source_origin_of(plain_mod, null)
+    ).
+
+%% Stdlib still wins first, even with a project package configured.
+source_origin_with_meta_stdlib_wins_test() ->
+    with_project_package(<<"myapp">>, fun() ->
+        ?assertEqual(
+            <<"stdlib">>,
+            beamtalk_repl_ops_browse:source_origin_of('bt@stdlib@OrderedCollection', null)
+        )
+    end).
+
+%% Package == project package => project, regardless of where the source file
+%% resolves on disk (the primary signal is the package segment, not the path).
+source_origin_with_meta_project_package_is_project_test() ->
+    with_project_package(<<"myapp">>, fun() ->
+        ?assertEqual(
+            <<"project">>,
+            beamtalk_repl_ops_browse:source_origin_of('bt@myapp@Counter', null)
+        ),
+        %% Even a source resolving under the project tree stays `project`.
+        ?assertEqual(
+            <<"project">>,
+            beamtalk_repl_ops_browse:source_origin_of(
+                'bt@myapp@Counter', <<"src/counter.bt">>
+            )
+        )
+    end).
+
+%% Package =/= project package => dependency, even when the dependency source
+%% resolves under the project tree (the BT-2640 bug: a path-only check would
+%% mislabel this `project`).
+source_origin_with_meta_dependency_package_is_dependency_test() ->
+    with_project_package(<<"myapp">>, fun() ->
+        ?assertEqual(
+            <<"dependency">>,
+            beamtalk_repl_ops_browse:source_origin_of('bt@http@Server', null)
+        ),
+        %% Dep source nested under the project root still classifies as a dep.
+        ?assertEqual(
+            <<"dependency">>,
+            beamtalk_repl_ops_browse:source_origin_of(
+                'bt@http@Server', <<"_build/deps/http/src/server.bt">>
+            )
+        )
+    end).
+
+%% Missing-metadata robustness: meta running but with no `project_path` (so no
+%% package detected) leaves the project package unknown, and a packaged module
+%% falls back to the path check. With no project root to compare against, the
+%% path check cannot prove a dependency, so it degrades to `project` rather than
+%% dumping a wrong "dependency" badge.
+source_origin_meta_without_project_path_falls_back_to_path_test() ->
+    with_started_meta(#{}, fun() ->
+        ?assertEqual(
+            <<"project">>,
+            beamtalk_repl_ops_browse:source_origin_of(
+                'bt@http@Server', <<"/elsewhere/http/server.bt">>
+            )
+        ),
+        ?assertEqual(
+            <<"project">>,
+            beamtalk_repl_ops_browse:source_origin_of('bt@http@Server', null)
+        )
+    end).
+
+%% Start workspace_meta with a project_path pointing at a temp dir whose
+%% beamtalk.toml declares package `Pkg`, run `Fun`, then tear meta down.
+with_project_package(Pkg, Fun) ->
+    Dir = make_project_dir(Pkg),
+    try
+        with_started_meta(#{project_path => Dir}, Fun)
+    after
+        _ = file:delete(filename:join(Dir, "beamtalk.toml")),
+        _ = file:del_dir(Dir)
+    end.
+
+%% Start workspace_meta with the given extra init metadata (workspace_id,
+%% created_at, repl=false are supplied), run `Fun`, then stop the server.
+with_started_meta(Extra, Fun) ->
+    %% Defensive: a stray server from another test would shadow ours.
+    case whereis(beamtalk_workspace_meta) of
+        undefined -> ok;
+        Existing -> stop_meta(Existing)
+    end,
+    Base = #{
+        workspace_id => <<"bt2640-test">>,
+        created_at => erlang:system_time(second),
+        repl => false
+    },
+    {ok, Pid} = beamtalk_workspace_meta:start_link(maps:merge(Base, Extra)),
+    try
+        Fun()
+    after
+        stop_meta(Pid)
+    end.
+
+stop_meta(Pid) when is_pid(Pid) ->
+    Ref = erlang:monitor(process, Pid),
+    unlink(Pid),
+    exit(Pid, shutdown),
+    receive
+        {'DOWN', Ref, process, Pid, _} -> ok
+    after 2000 -> ok
+    end.
+
+make_project_dir(Pkg) ->
+    Uniq = erlang:integer_to_list(erlang:unique_integer([positive, monotonic])),
+    Dir = filename:join(
+        beamtalk_file:'tempDirectory'(), "bt2640_proj_" ++ Uniq
+    ),
+    ok = filelib:ensure_dir(filename:join(Dir, "x")),
+    Toml = <<"[package]\nname = \"", Pkg/binary, "\"\n">>,
+    ok = file:write_file(filename:join(Dir, "beamtalk.toml"), Toml),
+    Dir.
+
+%%====================================================================
 %% Row helpers
 %%====================================================================
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
@@ -1159,7 +1159,9 @@ stop_meta(Pid) when is_pid(Pid) ->
     exit(Pid, shutdown),
     receive
         {'DOWN', Ref, process, Pid, _} -> ok
-    after 2000 -> ok
+    after 2000 ->
+        erlang:demonitor(Ref, [flush]),
+        ok
     end.
 
 make_project_dir(Pkg) ->


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2640

## Summary

Fixes the System Browser source filter: selecting **Proj** was showing dependency classes (e.g. the whole HTTP package) and **Deps** was empty, because dependency classes were misclassified as `project`.

Root cause: `source_origin` classification was purely filesystem-path-based (a class was `dependency` only if its source was *not* under the project root, falling back to `project` when metadata was missing) — so deps whose sources resolve under the project tree, or any class when `project_path` is absent, were mislabeled `project`.

## Key changes

- `beamtalk_repl_ops_browse.erl`: `source_origin_of/2` now uses the **module package segment** (`bt@<pkg>@<class>`) as the primary signal. New `classify_origin/3` (package vs project package) + `path_origin/1` (the old path-prefix check, demoted to a secondary fallback). Rule: stdlib wins first → `stdlib`; package ≠ project package → `dependency`; package == project package → `project`; package/project-package indeterminable → path fallback. Reuses BT-2643's `package_of_module/1` and `project_package_name/0`.
- Robust to dependency sources resolving under the project tree and to missing `project_path` metadata.
- The LiveView `filter_by_source/2` already matches `source_origin == "dependency"` (from BT-2643) — verified, no change.

## Verification

- `just build` ✓
- `beamtalk_repl_ops_browse` EUnit — 54 tests, 0 failures (added coverage: stdlib-wins, project-package incl. source under project tree, dependency-package incl. dep source nested under project tree, null source, no-package-segment, meta-without-project_path) ✓
- LiveView ExUnit — 279 passed ✓
- `just clippy` ✓, `rebar3 dialyzer` clean ✓, `rebar3 fmt --check` clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_