### PR TITLE
Inspector: recognize supervisor tuples as drillable refs (BT-2633)

### DIFF
--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -1008,8 +1008,15 @@ defmodule BtAttach.Workspace do
   inspectable: name-resolving proxies carry `{:registered, name}` in the identity
   slot (ADR 0079) and have no pid to `sys:get_state/2`, so they are not
   drillable here.
+
+  Supervisor handles arrive as `{:beamtalk_supervisor, class, module, pid}`
+  (`beamtalk_supervisor.erl`, distinct from `#beamtalk_object{}`). A pid-backed
+  supervisor is a live, drillable handle too, so it is inspectable — even though
+  its inspection *content* (the supervision tree) is not yet implemented and
+  currently degrades to an empty field set (see `inspect_value/1`).
   """
   def inspectable?({:beamtalk_object, _class, _module, pid}) when is_pid(pid), do: true
+  def inspectable?({:beamtalk_supervisor, _class, _module, pid}) when is_pid(pid), do: true
   def inspectable?(_term), do: false
 
   @doc """
@@ -1049,6 +1056,17 @@ defmodule BtAttach.Workspace do
       {:badrpc, reason} ->
         {:error, {:unreachable, reason}}
     end
+  end
+
+  # A supervisor handle is a live, drillable reference (so it is inspectable),
+  # but its inspection content — the supervision tree / children — is a separate
+  # follow-up (BT-2633 is recognition-only). Crucially, a supervisor pid is NOT
+  # an actor backed by `sys:get_state/2`, so routing it through the actor inspect
+  # op above would error. Degrade gracefully instead: return an empty field set,
+  # which the caller renders as a drillable head with no inspectable fields yet —
+  # the same shape an actor with no user-visible state yields ({:ok, %{}}).
+  def inspect_value({:beamtalk_supervisor, _class, _module, pid} = _term) when is_pid(pid) do
+    {:ok, %{}}
   end
 
   def inspect_value(_term), do: {:error, :not_inspectable}

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -5899,6 +5899,18 @@ defmodule BtAttachWeb.WorkspaceLive do
     }
   end
 
+  # Supervisor handles are pid-backed live refs too: chip the class + pid the same
+  # way as objects so the head renders as a drillable target (content/children is
+  # a follow-up — see `Workspace.inspect_value/1`).
+  defp target_info(label, {:beamtalk_supervisor, class, _module, pid} = term) when is_pid(pid) do
+    %{
+      label: to_string(label),
+      header: Workspace.render_term(term),
+      class_name: to_string(class),
+      pid: inspect(pid)
+    }
+  end
+
   defp target_info(label, term) do
     %{
       label: to_string(label),
@@ -5925,6 +5937,14 @@ defmodule BtAttachWeb.WorkspaceLive do
     |> Enum.sort_by(& &1.name)
   end
 
+  # Supervisor handles ({:beamtalk_supervisor, …, pid}) never reach `scalar_kind`:
+  # they are `inspectable?/1` (BT-2633), so they are routed through the drillable
+  # `ref` path (`target_info/2` has its own supervisor clause, and the
+  # "no fields to inspect" else-branch that calls `scalar_kind` only runs for
+  # NON-inspectable terms). They therefore never fall through to the `"value"`
+  # catch-all below — a dedicated clause here would be unreachable (and flagged by
+  # the type checker). This comment documents that the catch-all is unreachable
+  # for supervisors by construction.
   defp scalar_kind(term) when is_integer(term), do: "number"
   defp scalar_kind(term) when is_float(term), do: "number"
   defp scalar_kind(term) when is_binary(term), do: "string"
@@ -5939,6 +5959,9 @@ defmodule BtAttachWeb.WorkspaceLive do
   # A boolean must be matched before the integer guard (`is_boolean` ⊂ atoms, not
   # integers, but kept explicit and first for clarity).
   defp term_kind({:beamtalk_object, _class, _module, pid}) when is_pid(pid), do: "ref"
+  # Supervisor handles ({:beamtalk_supervisor, …}) are pid-backed live refs too —
+  # drillable, not opaque values — so they take the same `ref` chip as objects.
+  defp term_kind({:beamtalk_supervisor, _class, _module, pid}) when is_pid(pid), do: "ref"
   defp term_kind(term) when is_boolean(term), do: "bool"
   defp term_kind(term) when is_integer(term) or is_float(term), do: "int"
   defp term_kind(term) when is_binary(term), do: "string"

--- a/editors/liveview/test/bt_attach/workspace_inspect_test.exs
+++ b/editors/liveview/test/bt_attach/workspace_inspect_test.exs
@@ -37,6 +37,22 @@ defmodule BtAttach.WorkspaceInspectTest do
       refute Workspace.inspectable?([1, 2, 3])
       refute Workspace.inspectable?(%{a: 1})
     end
+
+    test "a pid-backed supervisor handle is inspectable (BT-2633)" do
+      # A supervisor handle arrives as {:beamtalk_supervisor, Class, Module, Pid}
+      # (beamtalk_supervisor.erl) — distinct from #beamtalk_object{}. A pid-backed
+      # supervisor is a live, drillable ref, so it is recognized as inspectable
+      # (content is a follow-up).
+      sup = {:beamtalk_supervisor, :AppSup, :bt@my_app@app_sup, self()}
+      assert Workspace.inspectable?(sup)
+    end
+
+    test "a pid-backed dynamic supervisor handle is inspectable (BT-2633)" do
+      # DynamicSupervisor carries the same tuple tag/shape, so it is recognized
+      # identically to a static supervisor.
+      sup = {:beamtalk_supervisor, :WorkerSup, :bt@my_app@worker_sup, self()}
+      assert Workspace.inspectable?(sup)
+    end
   end
 
   describe "inspect_value/1 — non-object short-circuit (no RPC)" do
@@ -49,6 +65,18 @@ defmodule BtAttach.WorkspaceInspectTest do
     test "a registered proxy (no pid) is rejected with :not_inspectable" do
       proxy = {:beamtalk_object, :Counter, :counter, {:registered, :counter}}
       assert {:error, :not_inspectable} = Workspace.inspect_value(proxy)
+    end
+
+    test "a pid-backed supervisor degrades gracefully to empty fields (BT-2633)" do
+      # Recognition-only: a supervisor is drillable, but its supervision-tree
+      # content is a separate follow-up. A supervisor pid is NOT an actor backed
+      # by sys:get_state/2, so it must not route through the actor inspect RPC.
+      # Instead it returns an empty field set ({:ok, %{}}) — the same shape an
+      # actor with no user-visible state yields — which renders as a drillable
+      # head with no inspectable fields. No RPC, no crash.
+      sup = {:beamtalk_supervisor, :AppSup, :bt@my_app@app_sup, self()}
+      assert {:ok, fields} = Workspace.inspect_value(sup)
+      assert fields == %{}
     end
   end
 


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2633

## Summary

Inspecting a supervisor (or DynamicSupervisor) in the LiveView IDE showed a `class value` chip and "… is a value — no fields to inspect" instead of a drillable live object.

Root cause was a **tuple-tag mismatch**: live handles come in two shapes — `{:beamtalk_object, class, module, pid}` (actors/objects) and `{:beamtalk_supervisor, class, module, pid}` (supervisors) — but the inspector's classification functions only matched the `:beamtalk_object` tag, so supervisor tuples fell through to the scalar/`value` catch-alls.

This PR is **recognition-only** (supervisor inspection *content* is a separate follow-up, BT-2634).

## Key changes (all Elixir; no `.erl` touched)

- `workspace.ex`: `inspectable?/1` and `inspect_value/1` clauses for pid-backed `{:beamtalk_supervisor, …}`. `inspect_value/1` short-circuits to `{:ok, %{}}` (graceful empty fields) instead of the actor `sys:get_state` RPC path — so a supervisor degrades cleanly rather than erroring.
- `workspace_live.ex`: `term_kind/1` returns `"ref"` for supervisors; `target_info/2` supervisor clause (class + pid chips like an object); documented why `scalar_kind/1`'s `"value"` catch-all is now structurally unreachable for supervisors (they route through `inspectable?`).
- Tests: 3 new — supervisor + dynamic-supervisor recognized as inspectable/ref; supervisor `inspect_value` degrades to `{:ok, %{}}`. Existing registered-name-proxy non-drillable tests unchanged (no regression).

## Note on `scalar_kind/1`

The acceptance criterion ("scalar_kind no longer reaches the `value` catch-all for a supervisor") is satisfied structurally: because supervisors are now `inspectable?`, both `scalar_kind` call sites provably never receive a supervisor tuple (Elixir 1.18 flagged a defensive clause as unreachable). Documented via comment rather than an unreachable clause fighting warnings-as-errors.

## Verification

- `just build` ✓
- LiveView ExUnit — 291 passed (incl. 3 new) ✓
- `mix compile --warnings-as-errors` ✓, `mix format --check-formatted` ✓, `just clippy` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_