### PR TITLE
System Browser: nest Hierarchy view under real superclass (BT-2637)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -319,8 +319,10 @@
   flex: 1 1 auto; min-width: 0;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.row.subclass { padding-left: 24px; }
-.row.subclass2 { padding-left: 38px; }
+/* Hierarchy indent (BT-2637): the class tree's left-indent is set inline per row
+   (`padding-left`) so it scales with the true superclass depth — uncapped —
+   instead of two fixed levels. `.subclass` stays as a marker hook for indented
+   rows; the actual indent lives in the row's inline style. */
 .row .meta { margin-left: auto; color: var(--faint); font-size: 10.5px; }
 /* Method rows are also `.row`, so the same right-pinned badge column applies
    (BT-2610): the selector name grows + truncates so the trailing origin/runtime

--- a/editors/liveview/lib/bt_attach_web/live/class_tree.ex
+++ b/editors/liveview/lib/bt_attach_web/live/class_tree.ex
@@ -30,11 +30,13 @@ defmodule BtAttachWeb.ClassTree do
   """
   @spec hierarchy_rows([class_row()]) :: [{class_row(), non_neg_integer()}]
   def hierarchy_rows(classes) do
+    names = MapSet.new(classes, &Map.get(&1, "name"))
+
     by_parent =
       Enum.group_by(classes, fn c ->
         super_name = Map.get(c, "superclass")
 
-        if super_name && Enum.any?(classes, &(Map.get(&1, "name") == super_name)),
+        if super_name && MapSet.member?(names, super_name),
           do: super_name,
           else: :__root
       end)

--- a/editors/liveview/lib/bt_attach_web/live/class_tree.ex
+++ b/editors/liveview/lib/bt_attach_web/live/class_tree.ex
@@ -1,0 +1,57 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.ClassTree do
+  @moduledoc """
+  Pure layout helpers for the System Browser class tree (ADR 0096, BT-2491).
+
+  Extracted from `BtAttachWeb.WorkspaceLive` so the Hierarchy walk is unit
+  testable (BT-2637): it has no LiveView state — it maps the browse-classes rows
+  (each a `%{"name" => binary, "superclass" => binary | nil, ...}`) to the
+  ordered `{row, indent}` list the template renders.
+  """
+
+  @typedoc "A browse-classes row — at minimum `name` and `superclass`."
+  @type class_row :: %{optional(String.t()) => term()}
+
+  @doc """
+  The Hierarchy view's rows: a flat, ordered list of `{class_row, indent}`
+  walking the superclass tree from roots down. `indent` is the **true** depth in
+  the superclass chain (BT-2637: previously capped at 2, which collapsed the deep
+  kernel chain — ProtoObject → Object → Value → Number → … — onto a single visual
+  level and read as flat).
+
+  A class whose superclass is not itself in the browse set is treated as a root
+  (indent 0), so an external/kernel superclass doesn't hide its subclasses. Any
+  class unreachable from a root — e.g. a member of a superclass cycle in a
+  transiently-inconsistent live image, where every member has an in-set
+  superclass so none is a root — is appended at indent 0 rather than silently
+  dropped from the view (it still renders, just un-nested).
+  """
+  @spec hierarchy_rows([class_row()]) :: [{class_row(), non_neg_integer()}]
+  def hierarchy_rows(classes) do
+    by_parent =
+      Enum.group_by(classes, fn c ->
+        super_name = Map.get(c, "superclass")
+
+        if super_name && Enum.any?(classes, &(Map.get(&1, "name") == super_name)),
+          do: super_name,
+          else: :__root
+      end)
+
+    walked = Enum.reverse(walk_hierarchy(by_parent, :__root, 0, []))
+    emitted = MapSet.new(walked, fn {class, _indent} -> Map.get(class, "name") end)
+    orphans = for c <- classes, not MapSet.member?(emitted, Map.get(c, "name")), do: {c, 0}
+    walked ++ Enum.sort_by(orphans, fn {c, _} -> Map.get(c, "name") end)
+  end
+
+  defp walk_hierarchy(by_parent, parent, indent, acc) do
+    by_parent
+    |> Map.get(parent, [])
+    |> Enum.sort_by(&Map.get(&1, "name"))
+    |> Enum.reduce(acc, fn class, acc ->
+      acc = [{class, indent} | acc]
+      walk_hierarchy(by_parent, Map.get(class, "name"), indent + 1, acc)
+    end)
+  end
+end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4031,42 +4031,18 @@ defmodule BtAttachWeb.WorkspaceLive do
   # ── System Browser view helpers (BT-2491) ───────────────────────────────────
 
   # The class rows in display order for the active view. Hierarchy walks
-  # roots→children indenting by superclass depth (capped at 2 like the spike);
+  # roots→children indenting by the *true* superclass depth (BT-2637: no cap — the
+  # real kernel chain is ProtoObject→Object→Value→Number→…, far deeper than the
+  # spike's two levels, so a cap collapsed everything onto one indent and read as
+  # flat). `class_rows/1` scales the visible indent from this depth.
   # Category groups by the class annotation, each group a `{category, rows}` pair.
   # Both return `{row, indent}` tuples so the template renders one branch.
 
   # Hierarchy: a flat, ordered list of `{class_row, indent}` walking the
-  # superclass tree from roots down. A class whose superclass is not itself in the
-  # browse set is treated as a root, so an external/kernel superclass doesn't hide
-  # its subclasses. Any class unreachable from a root — e.g. a member of a
-  # superclass cycle in a transiently-inconsistent live image, where every member
-  # has an in-set superclass so none is a root — is appended at indent 0 rather
-  # than silently dropped from the view (it still renders, just un-nested).
-  defp hierarchy_rows(classes) do
-    by_parent =
-      Enum.group_by(classes, fn c ->
-        super_name = Map.get(c, "superclass")
-
-        if super_name && Enum.any?(classes, &(Map.get(&1, "name") == super_name)),
-          do: super_name,
-          else: :__root
-      end)
-
-    walked = Enum.reverse(walk_hierarchy(by_parent, :__root, 0, []))
-    emitted = MapSet.new(walked, fn {class, _indent} -> Map.get(class, "name") end)
-    orphans = for c <- classes, not MapSet.member?(emitted, Map.get(c, "name")), do: {c, 0}
-    walked ++ Enum.sort_by(orphans, fn {c, _} -> Map.get(c, "name") end)
-  end
-
-  defp walk_hierarchy(by_parent, parent, indent, acc) do
-    by_parent
-    |> Map.get(parent, [])
-    |> Enum.sort_by(&Map.get(&1, "name"))
-    |> Enum.reduce(acc, fn class, acc ->
-      acc = [{class, indent} | acc]
-      walk_hierarchy(by_parent, Map.get(class, "name"), min(indent + 1, 2), acc)
-    end)
-  end
+  # superclass tree from roots down — see `BtAttachWeb.ClassTree.hierarchy_rows/1`
+  # for the (unit-tested) layout logic. `indent` is the true superclass depth
+  # (BT-2637: uncapped) and `class_rows/1` scales the visible left-indent from it.
+  defp hierarchy_rows(classes), do: BtAttachWeb.ClassTree.hierarchy_rows(classes)
 
   # Category: `{category, [class_row]}` groups, each group's classes sorted by
   # name, the groups themselves sorted by category. A class with no category falls
@@ -6422,10 +6398,10 @@ defmodule BtAttachWeb.WorkspaceLive do
       :for={{class, indent} <- @rows}
       class={[
         "row",
-        indent == 2 && "subclass2",
-        indent == 1 && "subclass",
+        indent > 0 && "subclass",
         @selected_class == class["name"] && "sel"
       ]}
+      style={class_row_indent(indent)}
       phx-click="browser_select_class"
       phx-value-class={class["name"]}
       title={class["name"]}
@@ -6448,6 +6424,17 @@ defmodule BtAttachWeb.WorkspaceLive do
     </div>
     """
   end
+
+  # Hierarchy indent → inline `padding-left` (BT-2637). Depth is uncapped, so the
+  # indent scales with the true superclass depth rather than collapsing every deep
+  # class onto the spike's single `.subclass2` level (which read as flat). Each
+  # level adds 14px on top of the row's base 10px — matching the old fixed steps
+  # (24px at depth 1, 38px at depth 2) and continuing past them. Depth 0 (roots)
+  # keeps the base padding, so no inline override is emitted.
+  defp class_row_indent(0), do: nil
+
+  defp class_row_indent(indent) when is_integer(indent) and indent > 0,
+    do: "padding-left: #{10 + indent * 14}px"
 
   # The protocol + method pane (the spike's MethodList): a protocol filter row
   # ("all" + one row per protocol, BT-2491) over the method list for the current

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -6431,10 +6431,10 @@ defmodule BtAttachWeb.WorkspaceLive do
   # level adds 14px on top of the row's base 10px — matching the old fixed steps
   # (24px at depth 1, 38px at depth 2) and continuing past them. Depth 0 (roots)
   # keeps the base padding, so no inline override is emitted.
-  defp class_row_indent(0), do: nil
-
   defp class_row_indent(indent) when is_integer(indent) and indent > 0,
     do: "padding-left: #{10 + indent * 14}px"
+
+  defp class_row_indent(_), do: nil
 
   # The protocol + method pane (the spike's MethodList): a protocol filter row
   # ("all" + one row per protocol, BT-2491) over the method list for the current

--- a/editors/liveview/test/bt_attach_web/class_tree_test.exs
+++ b/editors/liveview/test/bt_attach_web/class_tree_test.exs
@@ -1,0 +1,111 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.ClassTreeTest do
+  @moduledoc """
+  Unit tests for the System Browser Hierarchy layout (BT-2637). Pure functions,
+  no workspace node — runs in the bare `mix test` lane.
+  """
+  use ExUnit.Case, async: true
+
+  alias BtAttachWeb.ClassTree
+
+  # Browse-classes rows carry binary `name`/`superclass` (the Erlang side emits
+  # `atom_to_binary`); a root's superclass is `nil` (Erlang `null`).
+  defp row(name, superclass), do: %{"name" => name, "superclass" => superclass}
+
+  # Reduce the `{row, indent}` output to the `{name, indent}` pairs we assert on.
+  defp names(rows), do: Enum.map(rows, fn {c, i} -> {c["name"], i} end)
+
+  describe "hierarchy_rows/1" do
+    test "nests a chain Object -> Actor -> ActorSnapshot at increasing indents" do
+      classes = [
+        row("ActorSnapshot", "Actor"),
+        row("Actor", "Object"),
+        row("Object", nil)
+      ]
+
+      # Order is roots-down, siblings alphabetical; indent is the true depth.
+      assert names(ClassTree.hierarchy_rows(classes)) == [
+               {"Object", 0},
+               {"Actor", 1},
+               {"ActorSnapshot", 2}
+             ]
+    end
+
+    test "lifts the old indent cap so depth > 2 keeps nesting (BT-2637)" do
+      # The real kernel chain is deeper than Object -> X -> Y. Before BT-2637 the
+      # indent was capped at 2, collapsing every deep class onto one level (flat).
+      classes = [
+        row("ProtoObject", nil),
+        row("Object", "ProtoObject"),
+        row("Value", "Object"),
+        row("Number", "Value"),
+        row("Integer", "Number")
+      ]
+
+      assert names(ClassTree.hierarchy_rows(classes)) == [
+               {"ProtoObject", 0},
+               {"Object", 1},
+               {"Value", 2},
+               {"Number", 3},
+               {"Integer", 4}
+             ]
+    end
+
+    test "siblings render at the same indent under a shared superclass" do
+      classes = [
+        row("Object", nil),
+        row("Value", "Object"),
+        row("Boolean", "Value"),
+        row("Number", "Value")
+      ]
+
+      assert names(ClassTree.hierarchy_rows(classes)) == [
+               {"Object", 0},
+               {"Value", 1},
+               # alphabetical among siblings
+               {"Boolean", 2},
+               {"Number", 2}
+             ]
+    end
+
+    test "a class whose superclass is outside the browse set is a root (no orphan regression)" do
+      # `Object`/`ProtoObject` are not loaded; Actor's superclass is out of set, so
+      # Actor is a root and ActorSnapshot still nests beneath it.
+      classes = [
+        row("ActorSnapshot", "Actor"),
+        row("Actor", "Object")
+      ]
+
+      assert names(ClassTree.hierarchy_rows(classes)) == [
+               {"Actor", 0},
+               {"ActorSnapshot", 1}
+             ]
+    end
+
+    test "every input row is emitted exactly once" do
+      classes = [
+        row("Object", nil),
+        row("Actor", "Object"),
+        row("ActorSnapshot", "Actor"),
+        row("Number", "Object")
+      ]
+
+      rows = ClassTree.hierarchy_rows(classes)
+      assert length(rows) == length(classes)
+      assert MapSet.new(rows, fn {c, _} -> c["name"] end) == MapSet.new(classes, & &1["name"])
+    end
+
+    test "a superclass cycle (no root) still renders every member, un-nested" do
+      # A transiently-inconsistent image: A <-> B reference each other, so neither
+      # is a root. Both must still appear (at indent 0) rather than vanish.
+      classes = [
+        row("A", "B"),
+        row("B", "A")
+      ]
+
+      assert names(ClassTree.hierarchy_rows(classes)) == [{"A", 0}, {"B", 0}]
+    end
+  end
+end


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2637

## Summary

The System Browser **Hierarchy** view rendered essentially flat — every class at one indent under `Object` instead of nested under its real superclass.

**Confirmed root cause (b+c, NOT a):** the browse-row data was correct — `superclass` arrives as a binary matching `name` exactly (`ActorSnapshot` → `<<"Actor">>`), and the grouping/walk logic was sound. The bug was `walk_hierarchy`'s `min(indent + 1, 2)` **indent cap** plus only two CSS indent classes. The real kernel chain is far deeper than Object→X→Y (ProtoObject→Object→Value→Number→Integer…), so over a real 101-class image **97 of 101 classes collapsed onto indent 2** — a flat sibling list, exactly the reported symptom.

## Fix

- Lifted the cap: `walk_hierarchy` now emits true superclass depth; indent rendered via inline `padding-left: 10 + depth*14px` (continues the old 24px/38px steps past two levels, no unbounded CSS classes). Verified on the real image: depths span 0–5 and chains nest visibly (Actor under Object, Boolean under Value, Integer under Number, ActorSnapshot under Actor).
- Extracted the pure `hierarchy_rows/1` + `walk_hierarchy/4` into a new `class_tree.ex` for testability.

## Key changes

- `class_tree.ex` (new) — pure hierarchy builder.
- `workspace_live.ex` — delegate to `ClassTree`; uncap; `class_row_indent/1` inline padding.
- `app.css` — removed the dead fixed-padding `.subclass2`.
- `class_tree_test.exs` (new) — 6 regression cases incl. the Object→Actor→ActorSnapshot chain order/indents and out-of-set-superclass-stays-root.

No orphan/root regression; the "Tests" bucket and source-origin filter are untouched.

## Verification

- `just build` ✓
- LiveView ExUnit — 307 passed (incl. 6 new) ✓
- `mix compile --warnings-as-errors` ✓, `mix format --check-formatted` ✓, `just clippy` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_