### PR TITLE
LiveView IDE: re-apply dock split size on re-render (BT-2638)

### DIFF
--- a/editors/liveview/assets/js/hooks/split_drag.js
+++ b/editors/liveview/assets/js/hooks/split_drag.js
@@ -63,6 +63,25 @@ export const SplitDrag = {
     this.restore()
   },
 
+  // Re-apply the size after a LiveView re-render (BT-2638). The CSS var lives as
+  // an inline `style` on the target (`this.el.parentElement`). When LiveView
+  // patches that target — most visibly the center `.col` that holds the editor
+  // and the workspace dock, re-rendered on every "open diff" / "new method tab"
+  // — morphdom reconciles the element's attributes against the server template,
+  // which never renders the var, and strips the JS-set inline value, snapping
+  // the split back to its CSS default. `updated()` fires AFTER that patch, so
+  // re-applying here puts the persisted size back. Skipped while a drag is in
+  // flight so it never fights the live pointer value. `restore()` reads this
+  // instance's own `data-split` key, so it is idempotent and never crosses over
+  // to another splitter — safe for every shared instance.
+  //
+  // NOTE: this only runs for gutters WITHOUT `phx-update="ignore"`; LiveView
+  // skips ignored elements on patch, so the dock gutter drops that attribute
+  // (its div is empty — nothing to preserve) to let this callback fire.
+  updated() {
+    if (!this.drag) this.restore()
+  },
+
   destroyed() {
     // A reconnect (network blip / deploy) can destroy the hook mid-drag. Run
     // end() first so it tears the drag down — removes the document listeners and

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -7483,13 +7483,21 @@ defmodule BtAttachWeb.WorkspaceLive do
               <%!-- Draggable divider (BT-2576) between the method editor and the
                    workspace dock. The SplitDrag hook writes `--dock-h` on this
                    `.col` parent; the dock reads it. Hidden when the dock is
-                   collapsed. --%>
+                   collapsed.
+
+                   Unlike the other gutters this one is NOT `phx-update="ignore"`
+                   (BT-2638). Its `.col` parent is the center column that holds
+                   the editor + dock and re-renders on every diff/new-method tab;
+                   morphdom strips the JS-set `--dock-h` inline style off that
+                   `.col`, snapping the dock back to its 230px default. The empty
+                   gutter div has no hook-owned inner DOM to protect, so dropping
+                   `ignore` is safe and lets the hook's `updated()` callback fire
+                   after each patch to re-apply the persisted size. --%>
               <div
                 :if={@show_dock}
                 id="dock-split-gutter"
                 class="split-gutter split-gutter-y"
                 phx-hook="SplitDrag"
-                phx-update="ignore"
                 role="separator"
                 aria-orientation="horizontal"
                 aria-label="Resize the editor and workspace dock"


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2638

## Summary

After dragging the center gutter to resize the editor↔dock split, the next LiveView interaction that re-renders the center column (opening a diff, clicking a new method) snapped the dock back to its 230px default. Other splitters didn't regress — only this one.

**Root cause:** `--dock-h` is set by the `SplitDrag` hook as an inline `style` on the gutter's parent, the center `.col`, which holds the editor + dock and re-renders on open-diff / new-method-tab. morphdom reconciles `.col`'s attributes against the server template (which never renders the var) and strips the JS-set `--dock-h`, so `.dock { height: var(--dock-h, 230px) }` falls back to default. The hook only applied the size in `mounted()`/on drag — no `updated()`.

## Fix

- `split_drag.js`: added an `updated()` callback that re-applies the persisted size, guarded by `if (!this.drag)` so it never fights an in-flight drag.
- `workspace_live.ex`: removed `phx-update="ignore"` from the empty `dock-split-gutter` div so `updated()` actually fires for it after the patch (LiveView skips `ignore` elements entirely; the gutter has no hook-owned inner DOM to preserve, so dropping it is safe).

**Why other splits are safe:** browser / right / column-width gutters keep `phx-update="ignore"` (their `updated()` stays a no-op) — their var targets are stable containers that don't get stripped. `restore()` is key-scoped per `data-split` instance, so no cross-talk even if it ran.

## Verification

- `just build` ✓, `just clippy` ✓
- LiveView ExUnit — 307 passed; `mix compile --warnings-as-errors` ✓; `mix format --check-formatted` ✓
- `node --check split_drag.js` ✓

Note: no automated test covers the JS DOM hook (the project's `assets/` has no jest/vitest/eslint, only Playwright e2e); CI's `e2e`/`liveview` jobs build assets with esbuild. Manual repro to confirm: drag editor↔dock → open a diff → dock keeps its size; drag → click a new method → keeps its size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_