### PR TITLE
LiveView IDE: center the Bindings empty-state (BT-2644)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -7942,7 +7942,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                   <div class="panel-body">
                     <div :if={@bindings_error} class="io-block err">{@bindings_error}</div>
                     <%= if @bindings == [] do %>
-                      <p class="muted-note">No bindings yet. Try <code>x := 42</code>.</p>
+                      <p class="empty">No bindings yet. Try <code>x := 42</code>.</p>
                     <% else %>
                       <%!-- Spike Bindings list (inspector.jsx `BindingsList`): each row is
                            `name := printString` with a type/kind chip. An object-valued


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2644

## Summary

The Bindings pane's empty-state ("No bindings yet. Try `x := 42`.") was left-aligned (`class="muted-note"`), inconsistent with every other cockpit empty-state which is centered (`class="empty"` — editor, Inspector, System Browser).

Switches it to `class="empty"` so it centers and matches its siblings (notably the Inspector empty-state directly below it). One-line change; `.empty`'s `padding: 28px 16px; text-align: center` reads correctly within the bindings `.panel-body`.

## Verification

- `mix compile --warnings-as-errors` ✓, `mix format --check-formatted` ✓
- LiveView ExUnit — 307 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_