### PR TITLE
LiveView IDE: structured colored diff view in Changes/Git panes (BT-2636)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -969,23 +969,62 @@ body.col-resizing .cockpit { transition: none; }
 .bt-table .k { font-weight: 600; color: var(--accent-2); font-family: var(--code-font, ui-monospace, monospace); }
 .bt-table .v { width: 100%; color: var(--ink); }
 
-/* Changes pane net-vs-disk diff disclosure (BT-2575). Collapsed by default so
-   the table stays compact; the diff text keeps its +/- prefixes in a monospace,
-   scrollable block. */
-.bt-diff-disclosure > summary { cursor: pointer; color: var(--accent-2); font-size: 12px; }
+/* Structured unified-diff view (BT-2636). Shared by the Changes pane
+   (net-vs-disk, BT-2575) and the Git pane (staged/worktree). The diff string is
+   parsed into add/remove/context/hunk/meta lines (`parse_diff/1`) and rendered
+   by the `unified_diff/1` component: each line is a flex row whose +/-/space
+   marker sits in a fixed-width gutter so source content left-aligns across rows
+   regardless of marker. Scrollable + bounded so long diffs stay compact. */
 .bt-diff {
   margin: 6px 0 2px;
-  padding: 6px 8px;
+  padding: 4px 0;
   max-height: 220px;
   overflow: auto;
   font-family: var(--code-font, ui-monospace, monospace);
   font-size: 12px;
-  line-height: 1.4;
-  white-space: pre;
+  line-height: 1.45;
   background: var(--bg-soft, rgba(127, 127, 127, 0.08));
   border: 1px solid var(--line-soft);
   border-radius: 4px;
 }
+.diff-line {
+  display: flex;
+  align-items: flex-start;
+  white-space: pre;
+  padding: 0 6px;
+}
+/* Fixed-width gutter for the +/-/space marker — keeps content aligned. */
+.diff-gutter {
+  flex: 0 0 1.4em;
+  text-align: center;
+  user-select: none;
+  opacity: 0.7;
+}
+.diff-content { white-space: pre; }
+.diff-add { background: color-mix(in oklab, var(--ok) 14%, transparent); }
+.diff-add .diff-content { color: var(--ok); }
+.diff-del { background: color-mix(in oklab, var(--err) 14%, transparent); }
+.diff-del .diff-content { color: var(--err); }
+.diff-ctx .diff-content { color: var(--ink); }
+.diff-hunk { color: var(--accent-2); opacity: 0.85; }
+.diff-hunk .diff-content { color: var(--accent-2); font-weight: 600; }
+.diff-meta { color: var(--muted); }
+.diff-meta .diff-content { color: var(--muted); }
+
+/* Changes pane row-LHS disclosure caret (BT-2636). A leading column before
+   Class; the caret (›→▼) toggles the structured diff row beneath. */
+.bt-changes-table .diff-toggle-col { width: 1.6em; padding-right: 0; text-align: center; }
+.diff-toggle {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1;
+  padding: 0;
+}
+.diff-toggle:hover { color: var(--ink); }
+.bt-changes-table .diff-row > td { padding-top: 0; }
 
 /* test-runner pane (BT-2557) */
 .test-pane { padding: var(--panel-pad); gap: 10px; }

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -2276,6 +2276,10 @@ defmodule BtAttachWeb.WorkspaceLive do
   @doc false
   def parse_diff(diff) when is_binary(diff) and diff != "" do
     diff
+    # Strip the standard git/diff trailing newline so we don't emit a spurious
+    # blank meta row at the bottom; intentional blank context lines are
+    # space-prefixed and untouched.
+    |> String.trim_trailing("\n")
     |> String.split("\n")
     |> Enum.map(&classify_diff_line/1)
   end
@@ -3235,10 +3239,18 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp assign_changes(socket) do
     case Facade.dispatch(:changes, %{}, ctx(socket)) do
       rows when is_list(rows) ->
-        assign(socket, changes: rows, changes_error: nil)
+        # Prune expanded-diff carets for rows that have left @changes (flush /
+        # revert), so a re-saved method doesn't re-appear already-expanded.
+        live_keys = MapSet.new(rows, &{&1.class, &1.selector})
+        expanded = MapSet.intersection(socket.assigns.expanded_changes, live_keys)
+        assign(socket, changes: rows, changes_error: nil, expanded_changes: expanded)
 
       {:error, reason} ->
-        assign(socket, changes: [], changes_error: Workspace.render_error(reason))
+        assign(socket,
+          changes: [],
+          changes_error: Workspace.render_error(reason),
+          expanded_changes: MapSet.new()
+        )
     end
   end
 

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -586,6 +586,11 @@ defmodule BtAttachWeb.WorkspaceLive do
       |> assign(:window_z, 10)
       |> assign_browser_classes()
       |> assign_bindings(pid)
+      # BT-2636: the set of expanded Changes-pane rows (keyed by the row's
+      # `{class, selector}`), driven by the leading disclosure caret. A row's
+      # structured net-vs-disk diff renders beneath it only while its key is in
+      # this set; collapsed by default so the table stays compact.
+      |> assign(:expanded_changes, MapSet.new())
       |> assign_changes()
       # Git panel (BT-2586): the post-flush VCS surface. Loaded lazily the first
       # time the Git tab is opened (and refreshed after flush/save), so a page
@@ -1513,6 +1518,26 @@ defmodule BtAttachWeb.WorkspaceLive do
     {:noreply, status_error(socket, "Invalid revert request.")}
   end
 
+  # Toggle the structured diff disclosure for one Changes-pane row (BT-2636),
+  # keyed by the row's `{class, selector}` carried on the leading caret. Pure view
+  # state — no workspace round-trip; flips the key in/out of `:expanded_changes`,
+  # showing/hiding that row's `unified_diff` body.
+  def handle_event("toggle_change_diff", %{"class" => class, "selector" => selector}, socket)
+      when is_binary(class) and is_binary(selector) do
+    key = {class, selector}
+
+    expanded =
+      if MapSet.member?(socket.assigns.expanded_changes, key) do
+        MapSet.delete(socket.assigns.expanded_changes, key)
+      else
+        MapSet.put(socket.assigns.expanded_changes, key)
+      end
+
+    {:noreply, assign(socket, expanded_changes: expanded)}
+  end
+
+  def handle_event("toggle_change_diff", _params, socket), do: {:noreply, socket}
+
   # ── System Browser (BT-2491, epic BT-2482 Phase 2) ──────────────────────────
 
   # Toggle the class tree between Hierarchy (indented by superclass) and Category
@@ -2227,6 +2252,79 @@ defmodule BtAttachWeb.WorkspaceLive do
   # The Senders/Implementors popover heading for a nav kind (BT-2495).
   defp nav_kind_label(:senders), do: "Senders"
   defp nav_kind_label(:implementors), do: "Implementors"
+
+  # ── Structured unified-diff view (BT-2636) ──────────────────────────────────
+
+  # Parse a verbatim unified-diff string into structured lines for the
+  # `unified_diff/1` component. Presentation only: the diff text seam (Changes'
+  # `present_diff/1`, git's `git_diff/1`) is unchanged — we classify it here at
+  # render time so add/remove/context/hunk/meta lines can be coloured and the
+  # marker lifted into a fixed-width gutter.
+  #
+  # Each entry is `%{kind, marker, content}`:
+  #   * `:add`     — a `+` line; marker "+", content is the line WITHOUT the `+`.
+  #   * `:remove`  — a `-` line; marker "-", content without the `-`.
+  #   * `:context` — a ` ` (space-prefixed) line; marker " ".
+  #   * `:hunk`    — an `@@ … @@` header; the whole line is the content.
+  #   * `:meta`    — file headers (`diff --git`, `index`, `--- `, `+++ `, mode
+  #                  changes, `\ No newline…`, etc.); content is the whole line.
+  #
+  # The leading marker is stripped from add/remove/context content so source
+  # indentation lines up across rows regardless of marker; the marker rides the
+  # gutter instead. All other content (including any leading whitespace beyond
+  # the marker) is preserved verbatim. A blank/binary/nil diff yields `[]`.
+  @doc false
+  def parse_diff(diff) when is_binary(diff) and diff != "" do
+    diff
+    |> String.split("\n")
+    |> Enum.map(&classify_diff_line/1)
+  end
+
+  def parse_diff(_), do: []
+
+  # `--- ` / `+++ ` file headers must be classified as :meta BEFORE the bare
+  # `+`/`-` add/remove clauses, since they start with the same character.
+  defp classify_diff_line("+++ " <> _ = line), do: %{kind: :meta, marker: "", content: line}
+  defp classify_diff_line("--- " <> _ = line), do: %{kind: :meta, marker: "", content: line}
+  defp classify_diff_line("@@" <> _ = line), do: %{kind: :hunk, marker: "", content: line}
+  defp classify_diff_line("+" <> rest), do: %{kind: :add, marker: "+", content: rest}
+  defp classify_diff_line("-" <> rest), do: %{kind: :remove, marker: "-", content: rest}
+  defp classify_diff_line(" " <> rest), do: %{kind: :context, marker: " ", content: rest}
+
+  defp classify_diff_line("diff --git" <> _ = line),
+    do: %{kind: :meta, marker: "", content: line}
+
+  defp classify_diff_line("index " <> _ = line), do: %{kind: :meta, marker: "", content: line}
+  # Everything else (mode lines, `\ No newline at end of file`, blank trailing
+  # split fragments, etc.) is neutral metadata.
+  defp classify_diff_line(line), do: %{kind: :meta, marker: "", content: line}
+
+  # Per-line CSS class for the structured diff body.
+  defp diff_line_class(:add), do: "diff-line diff-add"
+  defp diff_line_class(:remove), do: "diff-line diff-del"
+  defp diff_line_class(:hunk), do: "diff-line diff-hunk"
+  defp diff_line_class(:meta), do: "diff-line diff-meta"
+  defp diff_line_class(:context), do: "diff-line diff-ctx"
+
+  # Shared structured diff renderer (BT-2636). Takes a verbatim unified-diff
+  # string and renders it as coloured, gutter-aligned rows — reused by the
+  # Changes pane (net-vs-disk) and the Git pane (staged/worktree). The marker
+  # (`+`/`-`/space) sits in a fixed-width gutter so content left-aligns across
+  # rows. A blank/binary diff renders nothing (callers show their own empty
+  # state, e.g. git's "No textual diff" note).
+  attr :diff, :string, required: true
+
+  defp unified_diff(assigns) do
+    assigns = assign(assigns, :lines, parse_diff(assigns.diff))
+
+    ~H"""
+    <div :if={@lines != []} class="bt-diff">
+      <div :for={line <- @lines} class={diff_line_class(line.kind)}>
+        <span class="diff-gutter" aria-hidden="true">{line.marker}</span><span class="diff-content">{line.content}</span>
+      </div>
+    </div>
+    """
+  end
 
   # ── Workspace dock actions (BT-2490) ────────────────────────────────────────
 
@@ -7100,62 +7198,86 @@ defmodule BtAttachWeb.WorkspaceLive do
                     <%= if @changes == [] do %>
                       <p class="muted-note">No pending changes. Save a method to record one.</p>
                     <% else %>
-                      <table class="bt-table">
+                      <table class="bt-table bt-changes-table">
                         <thead>
                           <tr>
+                            <%!-- BT-2636: leading disclosure column (the diff
+                                 caret), before Class. The old in-`Change`-column
+                                 `diff` summary is gone — the caret now expands a
+                                 structured, coloured diff beneath the row. --%>
+                            <th class="diff-toggle-col"></th>
                             <th>Class</th>
                             <th>Selector</th>
                             <th>Intent</th>
                             <th>Flushable</th>
                             <th>Author</th>
-                            <%!-- net-vs-disk diff column (BT-2575) --%>
-                            <th>Change</th>
                             <%!-- revert column (BT-2293): owner-only --%>
                             <th :if={@role == :owner}></th>
                           </tr>
                         </thead>
                         <tbody>
-                          <tr :for={c <- @changes}>
-                            <td class="k">{c.class}</td>
-                            <td>{c.selector}</td>
-                            <td>{c.intent}</td>
-                            <td>{if c.flushable, do: "yes", else: "no"}</td>
-                            <td>{c.author_kind}</td>
+                          <%= for c <- @changes do %>
+                            <% expanded = MapSet.member?(@expanded_changes, {c.class, c.selector}) %>
+                            <tr>
+                              <%!-- Leading disclosure caret (BT-2636): toggles
+                                   this row's structured net-vs-disk diff. Only
+                                   rendered when the entry carries a diff (the same
+                                   defensive `:if={c[:diff]}` guard the old
+                                   in-column disclosure used — a method reverted to
+                                   its on-disk body has no net change and never
+                                   reaches this pane). --%>
+                              <td class="diff-toggle-col">
+                                <button
+                                  :if={c[:diff]}
+                                  type="button"
+                                  class="diff-toggle"
+                                  phx-click="toggle_change_diff"
+                                  phx-value-class={c.class}
+                                  phx-value-selector={c.selector}
+                                  aria-expanded={to_string(expanded)}
+                                  title={if expanded, do: "Hide diff", else: "Show diff"}
+                                >
+                                  {if expanded, do: "▼", else: "›"}
+                                </button>
+                              </td>
+                              <td class="k">{c.class}</td>
+                              <td>{c.selector}</td>
+                              <td>{c.intent}</td>
+                              <td>{if c.flushable, do: "yes", else: "no"}</td>
+                              <td>{c.author_kind}</td>
+                              <%!-- Revert one pending method patch (ADR 0082
+                                   Phase 5). Owner-only (`revert` is an :execute
+                                   op). Only *instance-side* method patches are
+                                   revertable (`do_revert/2` rejects new-class and
+                                   class-side entries), so gate the button on a
+                                   positive `kind == "instance"` assertion: any
+                                   other / unanticipated kind hides the affordance
+                                   rather than offering one that always errors. --%>
+                              <td :if={@role == :owner}>
+                                <button
+                                  :if={c.kind == "instance"}
+                                  class="btn-link"
+                                  type="button"
+                                  phx-click="revert"
+                                  phx-value-class={c.class}
+                                  phx-value-selector={c.selector}
+                                  phx-disable-with="Reverting…"
+                                >
+                                  revert
+                                </button>
+                              </td>
+                            </tr>
                             <%!-- The net change vs disk (ADR 0082 Phase 5,
-                                 BT-2575): an expandable unified diff (on-disk →
-                                 in-memory). A method reverted back to its on-disk
-                                 body has no net change and never reaches this
-                                 pane (`activeEntries` drops it), so a row always
-                                 carries a real diff; the `:if` is defensive for
-                                 entries whose diff could not be computed. --%>
-                            <td>
-                              <details :if={c[:diff]} class="bt-diff-disclosure">
-                                <summary>diff</summary>
-                                <pre class="bt-diff">{c[:diff]}</pre>
-                              </details>
-                            </td>
-                            <%!-- Revert one pending method patch (ADR 0082
-                                 Phase 5). Owner-only (`revert` is an :execute
-                                 op). Only *instance-side* method patches are
-                                 revertable (`do_revert/2` rejects new-class and
-                                 class-side entries), so gate the button on a
-                                 positive `kind == "instance"` assertion: any
-                                 other / unanticipated kind hides the affordance
-                                 rather than offering one that always errors. --%>
-                            <td :if={@role == :owner}>
-                              <button
-                                :if={c.kind == "instance"}
-                                class="btn-link"
-                                type="button"
-                                phx-click="revert"
-                                phx-value-class={c.class}
-                                phx-value-selector={c.selector}
-                                phx-disable-with="Reverting…"
-                              >
-                                revert
-                              </button>
-                            </td>
-                          </tr>
+                                 BT-2575), now a structured, gutter-aligned,
+                                 coloured diff (BT-2636) rendered full-width
+                                 beneath the row while expanded. Reuses the shared
+                                 `unified_diff/1` renderer with the Git pane. --%>
+                            <tr :if={c[:diff] && expanded} class="diff-row">
+                              <td colspan={if @role == :owner, do: 7, else: 6}>
+                                <.unified_diff diff={c[:diff]} />
+                              </td>
+                            </tr>
+                          <% end %>
                         </tbody>
                       </table>
                     <% end %>
@@ -7257,15 +7379,20 @@ defmodule BtAttachWeb.WorkspaceLive do
                             </tr>
                           </tbody>
                         </table>
+                        <%!-- BT-2636: the git staged/worktree diffs reuse the
+                             shared structured `unified_diff/1` renderer (coloured,
+                             gutter-aligned) the Changes pane uses. The empty
+                             "No textual diff" state is preserved for binary /
+                             mode-only changes. --%>
                         <div :if={@git_diff} class="git-diff-view">
                           <p class="muted-note">{@git_diff_path}</p>
                           <div :if={@git_diff.staged != ""}>
                             <p class="muted-note">staged</p>
-                            <pre class="bt-diff">{@git_diff.staged}</pre>
+                            <.unified_diff diff={@git_diff.staged} />
                           </div>
                           <div :if={@git_diff.worktree != ""}>
                             <p class="muted-note">working tree</p>
-                            <pre class="bt-diff">{@git_diff.worktree}</pre>
+                            <.unified_diff diff={@git_diff.worktree} />
                           </div>
                           <p
                             :if={@git_diff.staged == "" and @git_diff.worktree == ""}

--- a/editors/liveview/test/bt_attach_web/workspace_diff_parse_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_diff_parse_test.exs
@@ -1,0 +1,87 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.WorkspaceDiffParseTest do
+  @moduledoc """
+  Unit tests for `WorkspaceLive.parse_diff/1` (BT-2636) — the presentation-only
+  classifier that turns a verbatim unified-diff string into structured lines for
+  the `unified_diff/1` component. Pure: no LiveView, no workspace.
+
+  Covers the acceptance criteria: classifies add/remove/context/hunk/meta;
+  handles empty/binary; preserves content (including leading whitespace) with the
+  +/-/space marker lifted into the gutter.
+  """
+  use ExUnit.Case, async: true
+
+  alias BtAttachWeb.WorkspaceLive
+
+  test "empty / nil / binary diffs yield no lines" do
+    assert WorkspaceLive.parse_diff("") == []
+    assert WorkspaceLive.parse_diff(nil) == []
+    assert WorkspaceLive.parse_diff(nil) == []
+    # A non-binary value (defensive) degrades to [].
+    assert WorkspaceLive.parse_diff(123) == []
+  end
+
+  test "classifies add / remove / context lines and strips the marker into the gutter" do
+    diff = " unchanged\n+added line\n-removed line"
+
+    assert [
+             %{kind: :context, marker: " ", content: "unchanged"},
+             %{kind: :add, marker: "+", content: "added line"},
+             %{kind: :remove, marker: "-", content: "removed line"}
+           ] = WorkspaceLive.parse_diff(diff)
+  end
+
+  test "classifies hunk headers and file-header meta lines" do
+    diff =
+      "diff --git a/x.bt b/x.bt\n" <>
+        "index 111..222 100644\n" <>
+        "--- a/x.bt\n" <>
+        "+++ b/x.bt\n" <>
+        "@@ -1,3 +1,4 @@ Foo class >> bar"
+
+    parsed = WorkspaceLive.parse_diff(diff)
+
+    kinds = Enum.map(parsed, & &1.kind)
+    assert kinds == [:meta, :meta, :meta, :meta, :hunk]
+
+    # The `--- ` / `+++ ` headers must NOT be mis-read as remove/add lines.
+    assert Enum.at(parsed, 2) == %{kind: :meta, marker: "", content: "--- a/x.bt"}
+    assert Enum.at(parsed, 3) == %{kind: :meta, marker: "", content: "+++ b/x.bt"}
+
+    hunk = List.last(parsed)
+    assert hunk.kind == :hunk
+    assert hunk.content == "@@ -1,3 +1,4 @@ Foo class >> bar"
+  end
+
+  test "preserves leading whitespace in content (only the marker is stripped)" do
+    # A real method diff line: marker, then the source's own indentation.
+    diff = "+    parseEtfBinary: bin offset: off size: sz acc: acc =>"
+
+    assert [
+             %{
+               kind: :add,
+               marker: "+",
+               content: "    parseEtfBinary: bin offset: off size: sz acc: acc =>"
+             }
+           ] =
+             WorkspaceLive.parse_diff(diff)
+  end
+
+  test "an empty added/removed line keeps an empty content (just the marker)" do
+    assert [
+             %{kind: :add, marker: "+", content: ""},
+             %{kind: :remove, marker: "-", content: ""}
+           ] = WorkspaceLive.parse_diff("+\n-")
+  end
+
+  test "no-newline marker and mode lines fall back to neutral meta" do
+    diff =
+      "old mode 100644\n" <>
+        "new mode 100755\n" <>
+        "\\ No newline at end of file"
+
+    assert Enum.all?(WorkspaceLive.parse_diff(diff), &(&1.kind == :meta))
+  end
+end

--- a/editors/liveview/test/bt_attach_web/workspace_diff_parse_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_diff_parse_test.exs
@@ -18,7 +18,6 @@ defmodule BtAttachWeb.WorkspaceDiffParseTest do
   test "empty / nil / binary diffs yield no lines" do
     assert WorkspaceLive.parse_diff("") == []
     assert WorkspaceLive.parse_diff(nil) == []
-    assert WorkspaceLive.parse_diff(nil) == []
     # A non-binary value (defensive) degrades to [].
     assert WorkspaceLive.parse_diff(123) == []
   end

--- a/editors/liveview/test/bt_attach_web/workspace_diff_view_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_diff_view_test.exs
@@ -1,0 +1,168 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.WorkspaceDiffViewTest do
+  @moduledoc """
+  Render tests for the structured diff view (BT-2636): the Changes-pane row-LHS
+  disclosure caret toggling a coloured, gutter-aligned diff, and the same shared
+  `unified_diff/1` renderer reused in the Git pane. Driven through the full
+  LiveView stack against the stubbed workspace client.
+  """
+  use BtAttachWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias BtAttachWeb.StubWorkspaceClient
+
+  @diff " increment => self.value\n-  self.value := self.value + 1\n+  self.value := self.value + 2"
+
+  setup do
+    Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
+
+    Application.put_env(:bt_attach, :oidc, %{
+      issuer: "https://idp",
+      client_id: "id",
+      redirect_uri: "https://ide/callback",
+      groups_claim: "groups",
+      client_secret: "x",
+      roles: %{"owner" => ["beamtalk-owners"], "observer" => ["beamtalk-observers"]}
+    })
+
+    Application.put_env(:bt_attach, :session_ttl_secs, 3600)
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      Application.delete_env(:bt_attach, :oidc)
+      Application.delete_env(:bt_attach, :session_ttl_secs)
+      StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    {:ok, _} = StubWorkspaceClient.start_state()
+
+    :ok
+  end
+
+  defp owner_conn(conn) do
+    Plug.Test.init_test_session(conn, %{
+      "bt_user" => %{"sub" => "alice", "groups" => ["beamtalk-owners"]},
+      "bt_logged_in_at" => System.system_time(:second)
+    })
+  end
+
+  defp eventually(fun, retries \\ 20)
+  defp eventually(fun, 0), do: fun.()
+
+  defp eventually(fun, retries) do
+    if fun.() do
+      true
+    else
+      Process.sleep(50)
+      eventually(fun, retries - 1)
+    end
+  end
+
+  describe "Changes pane row-LHS disclosure (BT-2636)" do
+    test "the leading caret toggles a structured, coloured diff beneath the row", %{conn: conn} do
+      # Seed a net-vs-disk diff for the change the save below records.
+      StubWorkspaceClient.set_change_diff("Counter", "increment", @diff)
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # Record a change so the Changes table has a row carrying the seeded diff.
+      view |> element(~s(div[phx-value-class="Counter"])) |> render_click()
+      view |> element(~s(div[phx-value-selector="increment"])) |> render_click()
+
+      view
+      |> form("form[phx-submit='save_method']")
+      |> render_submit(%{
+        "class" => "Counter",
+        "selector" => "increment",
+        "source" => "increment => self.value := self.value + 2",
+        "tab" => "method:Counter:instance:increment"
+      })
+
+      # Open the Changes tab and confirm the leading caret is present and collapsed.
+      changes_html = render_click(view, "dock_tab", %{"tab" => "changes"})
+      assert changes_html =~ "diff-toggle"
+      assert changes_html =~ "›"
+      # Collapsed: no structured diff body yet.
+      refute changes_html =~ "diff-add"
+
+      # Click the caret — the structured diff expands beneath the row.
+      expanded =
+        view
+        |> element("button.diff-toggle")
+        |> render_click()
+
+      assert expanded =~ "▼"
+      assert expanded =~ ~s(class="bt-diff")
+      assert expanded =~ "diff-add"
+      assert expanded =~ "diff-del"
+      assert expanded =~ "diff-ctx"
+      assert expanded =~ "diff-gutter"
+
+      # Clicking again collapses it.
+      collapsed = view |> element("button.diff-toggle") |> render_click()
+      refute collapsed =~ "diff-add"
+    end
+  end
+
+  describe "Git pane reuses the shared renderer (BT-2636)" do
+    test "a worktree diff renders as structured coloured lines, not a raw pre", %{conn: conn} do
+      StubWorkspaceClient.set_git_status(
+        {:ok,
+         %{
+           branch: "main",
+           upstream: nil,
+           ahead: 0,
+           behind: 0,
+           files: [%{path: "src/counter.bt", index: :unmodified, worktree: :modified}]
+         }}
+      )
+
+      StubWorkspaceClient.set_git_diff({:ok, %{worktree: @diff, staged: ""}})
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      render_click(view, "dock_tab", %{"tab" => "git"})
+      assert eventually(fn -> render(view) =~ "src/counter.bt" end)
+
+      diff_html =
+        view
+        |> element(~s(button[phx-click="git_diff"][phx-value-path="src/counter.bt"]))
+        |> render_click()
+
+      assert diff_html =~ "diff-add"
+      assert diff_html =~ "diff-del"
+      assert diff_html =~ "diff-gutter"
+    end
+
+    test "an empty git diff keeps the 'No textual diff' note", %{conn: conn} do
+      StubWorkspaceClient.set_git_status(
+        {:ok,
+         %{
+           branch: "main",
+           upstream: nil,
+           ahead: 0,
+           behind: 0,
+           files: [%{path: "bin.dat", index: :unmodified, worktree: :modified}]
+         }}
+      )
+
+      StubWorkspaceClient.set_git_diff({:ok, %{worktree: "", staged: ""}})
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      render_click(view, "dock_tab", %{"tab" => "git"})
+      assert eventually(fn -> render(view) =~ "bin.dat" end)
+
+      diff_html =
+        view
+        |> element(~s(button[phx-click="git_diff"][phx-value-path="bin.dat"]))
+        |> render_click()
+
+      assert diff_html =~ "No textual diff"
+      refute diff_html =~ "diff-add"
+    end
+  end
+end

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -50,6 +50,10 @@ defmodule BtAttachWeb.StubWorkspaceClient do
               # Inspect → children-render → drill-through path against the stub. `[]`
               # = no bindings (the default, matching a fresh session).
               bindings: [],
+              # BT-2636: seeded net-vs-disk diff strings per `{class, selector}`,
+              # surfaced by `change_history` so the Changes-pane disclosure caret +
+              # structured diff render can be driven without a real workspace.
+              change_diffs: %{},
               calls: []
   end
 
@@ -235,6 +239,8 @@ defmodule BtAttachWeb.StubWorkspaceClient do
   end
 
   def change_history do
+    diffs = get(:change_diffs) || %{}
+
     get(:changes)
     |> Enum.map(fn {{class, selector}, _file} ->
       %{
@@ -245,10 +251,17 @@ defmodule BtAttachWeb.StubWorkspaceClient do
         flushable: true,
         flushed: false,
         author_kind: "liveview",
-        diff: nil
+        # BT-2636: seeded net-vs-disk diff so a test can drive the Changes-pane
+        # disclosure caret + structured `unified_diff` render. nil by default.
+        diff: Map.get(diffs, {class, selector})
       }
     end)
     |> Enum.reverse()
+  end
+
+  @doc "Test helper: seed the net-vs-disk diff string for a `{class, selector}`."
+  def set_change_diff(class, selector, diff) when is_binary(diff) do
+    update(:change_diffs, fn diffs -> Map.put(diffs || %{}, {class, selector}, diff) end)
   end
 
   # BT-2590: the workspace `autoflush` flag, read at mount. Defaults to `false`
@@ -335,7 +348,15 @@ defmodule BtAttachWeb.StubWorkspaceClient do
     get(:git_log) || {:ok, []}
   end
 
-  def git_diff(path), do: record({:git_diff, path}) && {:ok, %{worktree: "", staged: ""}}
+  def git_diff(path) do
+    record({:git_diff, path})
+    # BT-2636: a seeded diff drives the Git-pane structured `unified_diff` render;
+    # the default empty result keeps the existing "No textual diff" empty state.
+    get(:git_diff_result) || {:ok, %{worktree: "", staged: ""}}
+  end
+
+  @doc "Test helper: seed the `git_diff/1` result (e.g. a unified-diff string)."
+  def set_git_diff(result), do: put(:git_diff_result, result)
   def git_stage(path), do: record({:git_stage, path}) && {:ok, nil}
   def git_unstage(path), do: record({:git_unstage, path}) && {:ok, nil}
   def git_commit(message), do: record({:git_commit, message}) && {:ok, nil}


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2636

## Summary

Replaces the flat verbatim-`<pre>` diff blob in the Changes and Git panes with a structured, colored, gutter-aligned diff view. Presentation-only — the diff text producers (`present_diff/1`, `beamtalk_git:git_diff/1`) are untouched.

## Key changes

- `parse_diff/1`: classifies a unified-diff string into `:add | :remove | :context | :hunk | :meta` lines, stripping the `+`/`-`/space marker off content. `--- `/`+++ ` headers are classified `:meta` **before** the bare `+`/`-` clauses so they aren't mis-read as add/remove.
- `unified_diff/1`: stateless function component rendering those lines with a fixed-width gutter for the marker (content left-aligned, no `+ `/`- ` jaggedness); **reused by both panes**.
- Changes table: leading LHS disclosure caret (`›`→`▼`, `toggle_change_diff` + an `expanded_changes` MapSet) expanding the structured diff in a full-width row beneath. Old in-`Change`-column `diff` summary removed; owner-only revert column and `:if={c[:diff]}` guard preserved.
- Git pane staged/worktree diffs switched to `<.unified_diff>`; "No textual diff" empty state kept.
- `app.css`: per-line classes (`.diff-add/.diff-del/.diff-ctx/.diff-hunk/.diff-meta`, `.diff-gutter`, `.diff-content`) using `--ok`/`--err`/muted tokens + subtle add/remove backgrounds; `max-height`/scroll preserved.
- Tests: `workspace_diff_parse_test.exs` (7 unit, incl. a `parseEtfBinary:`-style leading-whitespace case) + `workspace_diff_view_test.exs` (Changes caret toggle + colored lines, Git shared renderer, empty-diff note); stub client gains `set_change_diff/3` + `set_git_diff/1` seeds.

## Design notes

- Toggle uses an `expanded_changes` MapSet + event rather than CSS-only `<details>` — a `<details>` can't cleanly span table rows for a full-width diff body beneath the row.
- No surface-parity doc change: the Changes/Git diff ops are already `surface-specific`; this is rendering-only over identical underlying text.

## Verification

- `just build` ✓
- LiveView ExUnit — 316 passed (9 new) ✓; `mix compile --warnings-as-errors` ✓; `mix format --check-formatted` ✓; `just clippy` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_