### PR TITLE
LiveView IDE: disambiguate new-method tab label + &quot;Add a method…&quot; action (BT-2613)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4688,7 +4688,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # for the same selector. A no-op for ordinary method/def tabs (the guard only
   # matches `new: true`). When a canonical method tab for the selector is already
   # open, the scratch tab is dropped and that existing tab is focused (no duplicate,
-  # no stale "Class ▸ new" left behind). `focus_tab_keep_banner/3` refreshes the
+  # no stale "Class ▸ (new method)" left behind). `focus_tab_keep_banner/3` refreshes the
   # edit assigns so the now-hidden selector reflects the saved name.
   defp promote_new_method_tab(socket, tab_id, saved_class, selector) do
     case find_tab(socket, tab_id) do
@@ -4710,7 +4710,7 @@ defmodule BtAttachWeb.WorkspaceLive do
           existing ->
             # A canonical method tab for this selector is already open: drop the
             # redundant scratch tab and focus the existing one, rather than leaving
-            # a stale "Class ▸ new" tab alongside it. Re-base that tab on the body
+            # a stale "Class ▸ (new method)" tab alongside it. Re-base that tab on the body
             # just compiled (same post-compile treatment `compile_clean/3` gives the
             # in-place path) so the editor shows the saved source, not its browse
             # snapshot.
@@ -4763,11 +4763,11 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp breadcrumb(%{kind: :def, class: class}), do: {class, nil, "class definition"}
   # A new-method tab has no stored selector yet (BT-2606): derive it live from the
   # body the author is typing so the breadcrumb names the method as soon as a
-  # recognizable signature appears, falling back to the `new method` placeholder
-  # until then.
+  # recognizable signature appears, falling back to the `(new method)` placeholder
+  # until then (parenthesised so it can't be mistaken for a real selector — BT-2613).
   defp breadcrumb(%{new: true, class: class, side: side, source: source}) do
     case parse_method_signature_selector(source) do
-      "" -> {class, side, "new method"}
+      "" -> {class, side, "(new method)"}
       selector -> {class, side, selector}
     end
   end
@@ -6561,7 +6561,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # The class whose *definition* tab is focused (or nil) — highlights the "class
   # definition" entry when the editor is showing this class's definition.
   attr :active_def, :string, default: nil
-  # The viewer's role — the "new method" authoring entry is owner-only (Observers
+  # The viewer's role — the "Add a method…" authoring entry is owner-only (Observers
   # get a read-only browser).
   attr :role, :atom, required: true
 
@@ -6598,8 +6598,8 @@ defmodule BtAttachWeb.WorkspaceLive do
               <span class="twig" style="color: var(--accent);">▸</span>
               <span class="mname mono">class definition</span>
             </div>
-            <%!-- new method entry (owner-only): opens a blank :method tab for the
-                 selected class so a brand-new method can be authored on demand —
+            <%!-- "Add a method…" entry (owner-only): opens a blank :method tab for
+                 the selected class so a brand-new method can be authored on demand —
                  the role the starter tab used to play before the editor opened
                  empty. --%>
             <div
@@ -6609,7 +6609,7 @@ defmodule BtAttachWeb.WorkspaceLive do
               phx-value-class={@selected_class}
             >
               <span class="twig" style="color: var(--accent);">+</span>
-              <span class="mname mono">new method</span>
+              <span class="mname mono">Add a method…</span>
             </div>
           </div>
           <%!-- protocol filter row: ∗ "all" + one row per protocol --%>
@@ -7674,7 +7674,11 @@ defmodule BtAttachWeb.WorkspaceLive do
                     <span class="tab-label mono">
                       {cond do
                         t.kind == :def -> t.class <> " ▸ def"
-                        t.new -> t.class <> " ▸ new"
+                        # Placeholder label for an unsaved new-method tab. Parens
+                        # keep it from being read as a real `new` selector tab,
+                        # which renders as plain "new" via the branch below
+                        # (BT-2613).
+                        t.new -> t.class <> " ▸ (new method)"
                         true -> t.selector
                       end}
                     </span>

--- a/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_flush_badge_test.exs
@@ -273,12 +273,13 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
         |> element(~s(div[phx-click="new_method"][phx-value-class="Counter"]))
         |> render_click()
 
-      # A new-method tab is open: the breadcrumb reads "new method" (no selector
-      # exists yet). There is no separate selector input anymore (BT-2606) — the
-      # author writes the full method in the body.
-      assert opened =~ "new method"
+      # A new-method tab is open: the breadcrumb/tab read "(new method)" (no
+      # selector exists yet — parenthesised so it can't be read as a real `new`
+      # selector tab, BT-2613). There is no separate selector input anymore
+      # (BT-2606) — the author writes the full method in the body.
+      assert opened =~ "(new method)"
       refute opened =~ "new-method-selector"
-      assert opened =~ "Counter ▸ new"
+      assert opened =~ "Counter ▸ (new method)"
 
       # Authoring + saving drives the same write-surface `save` as any method. The
       # form posts no real selector (there is no input); the save handler parses it
@@ -300,7 +301,7 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
       # selector input is gone — so the author's selector survives and a second
       # ⌘S doesn't trip the empty-selector guard (the BT-review regression).
       assert saved =~ "greet"
-      refute saved =~ "Counter ▸ new"
+      refute saved =~ "Counter ▸ (new method)"
       refute saved =~ "new-method-selector"
     end
 
@@ -404,7 +405,7 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
 
       # Author the new method under a selector that is *already* open. On save the
       # scratch new-method tab is dropped and the existing `increment` tab focused —
-      # no duplicate, no stale "Counter ▸ new" — and the save banner still shows.
+      # no duplicate, no stale "Counter ▸ (new method)" — and the save banner still shows.
       saved =
         view
         |> form("form[phx-submit='save_method']")
@@ -416,7 +417,7 @@ defmodule BtAttachWeb.WorkspaceFlushBadgeTest do
         })
 
       assert saved =~ "Saved increment on Counter"
-      refute saved =~ "Counter ▸ new"
+      refute saved =~ "Counter ▸ (new method)"
       refute saved =~ "new-method-selector"
     end
   end


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2613

## Summary

The new-method placeholder tab was labelled `Class ▸ new`, ambiguous with a real (class-side constructor) `new` selector — so `Counter ▸ new` could be either the placeholder or a tab editing an actual `new` method.

## Key changes

- Tab-label `cond`: the `t.new` branch now renders **`Class ▸ (new method)`** (parentheses disambiguate); a real `new` selector tab still renders as plain `new` via the fall-through branch.
- System Browser authoring entry: **"new method" → "Add a method…"** (entry text + comment + role attr comment).
- `breadcrumb/1` new-method clause: placeholder fallback now `(new method)`, consistent with the tab.
- Tests: `workspace_flush_badge_test.exs` assertions updated (`Counter ▸ new` → `Counter ▸ (new method)`, breadcrumb wording).

Implemented standalone (no dependency on BT-2606). Optional muted/italic styling skipped — the parentheses already make it unambiguous (AC marked styling optional). Once a method is saved, the tab shows the real selector as before.

## Verification

- `just build` ✓
- LiveView ExUnit — 316 passed ✓; `mix compile --warnings-as-errors` ✓; `mix format --check-formatted` ✓; `just clippy` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_