### PR TITLE
LiveView IDE: New Class modal with name + superclass fields (BT-2645)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -925,22 +925,32 @@ body.col-resizing .cockpit { transition: none; }
 }
 .btn-link:hover { color: var(--accent); }
 
-/* New Class form (BT-2293): the System Browser's collapsible create-a-class
-   affordance under the panel head — a compact source box + submit. The `.bt`
-   path is derived from the class name server-side, so there is no path field. */
-.new-class-form {
-  display: grid; grid-template-columns: 1fr auto; gap: .5rem; flex: none;
-  padding: .6rem 10px; border-bottom: 1px solid var(--line); align-items: start;
-  background: var(--panel-2);
+/* New Class modal (BT-2293, BT-2645): the System Browser's owner-only
+   create-a-class wizard. A centered dialog over a dimming scrim with two explicit
+   fields — class name + superclass (default `Object`); the `.bt` path and the
+   `<Superclass> subclass: <Name>` definition are synthesized server-side. */
+.modal-scrim {
+  position: fixed; inset: 0; z-index: 100; display: flex;
+  align-items: center; justify-content: center;
+  background: rgba(0, 0, 0, .5);
 }
-.new-class-label { grid-column: 1 / -1; font-size: 12px; font-weight: 600; color: var(--ink); }
-.new-class-source {
-  border: 1px solid var(--line); background: var(--code-bg); border-radius: 6px;
-  padding: 6px 9px; font-size: 12.5px; color: var(--ink); outline: none;
-  grid-column: 1; resize: vertical;
+.modal-dialog {
+  width: min(420px, calc(100vw - 2rem));
+  background: var(--panel); border: 1px solid var(--line); border-radius: 10px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, .4); overflow: hidden;
 }
-.new-class-source:focus { border-color: var(--accent); }
-.new-class-form .btn { grid-column: 2; align-self: end; }
+.modal-head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: .6rem .9rem; border-bottom: 1px solid var(--line); background: var(--panel-2);
+}
+.modal-title { margin: 0; font-size: 13px; font-weight: 600; color: var(--ink); }
+.new-class-modal-form { display: grid; gap: .35rem; padding: .9rem; }
+.new-class-field-label { font-size: 12px; font-weight: 600; color: var(--ink); }
+.new-class-field-label:not(:first-child) { margin-top: .5rem; }
+.new-class-modal-form .field { width: 100%; box-sizing: border-box; }
+.new-class-modal-form .field:focus { border-color: var(--accent); }
+.new-class-error { margin: .4rem 0 0; font-size: 12px; color: var(--danger, #e5534b); }
+.modal-actions { display: flex; justify-content: flex-end; gap: .5rem; margin-top: .8rem; }
 
 .field {
   border: 1px solid var(--line); background: var(--code-bg); border-radius: 6px;

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -3131,12 +3131,12 @@ defmodule BtAttachWeb.WorkspaceLive do
     name = String.trim(name)
     superclass = trim_superclass(superclass)
 
-    case validate_new_class_name(socket, name) do
-      :ok ->
-        source = superclass <> " subclass: " <> name
-        {:ok, path} = derive_class_path(name)
-        dispatch_new_class(socket, name, superclass, source, path)
-
+    with :ok <- validate_new_class_name(socket, name),
+         :ok <- validate_superclass(superclass) do
+      source = superclass <> " subclass: " <> name
+      {:ok, path} = derive_class_path(name)
+      dispatch_new_class(socket, name, superclass, source, path)
+    else
       {:error, message} ->
         # Keep the in-flight field values so the re-rendered modal shows what the
         # owner typed, and route the error to the modal-local assign (never the
@@ -3158,6 +3158,18 @@ defmodule BtAttachWeb.WorkspaceLive do
       "" -> "Object"
       trimmed -> trimmed
     end
+  end
+
+  # Validate the superclass field the same way as the class name (BT-2645): a bare
+  # PascalCase identifier. The empty case is already normalised to `Object` by
+  # `trim_superclass/1`. This rejects a crafted payload (e.g. embedded newlines /
+  # syntax) locally, matching the name field rather than relying on the server
+  # parser to reject the synthesized source.
+  defp validate_superclass(superclass) do
+    if Regex.match?(~r/^[A-Z][A-Za-z0-9_]*$/, superclass),
+      do: :ok,
+      else:
+        {:error, "Superclass must be a class name starting with a capital letter, e.g. `Object`."}
   end
 
   # Validate a new class name locally (BT-2645): non-empty, PascalCase

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -522,10 +522,18 @@ defmodule BtAttachWeb.WorkspaceLive do
       # a second replaces this value, and `native_shown?/2` scopes display to the
       # active tab's class (per-tab pane state is intentionally not kept).
       |> assign(:native_view, nil)
-      # New Class form (BT-2293): the System Browser's owner-only create-a-class
-      # affordance, collapsed by default (it lives in the browser head's ＋ button)
-      # so it never crowds the class tree until wanted.
+      # New Class modal (BT-2293, BT-2645): the System Browser's owner-only
+      # create-a-class wizard, closed by default (it opens from the browser head's
+      # ＋ button). The owner types a plain class name + picks a superclass
+      # (default `Object`); the `<Superclass> subclass: <Name>` definition is
+      # synthesized server-side. `new_class_error` carries an in-modal validation
+      # / create error (kept off the method-editor's shared `save_error`);
+      # `new_class_name` / `new_class_super` retain the in-flight field values so a
+      # rejected submit re-renders the modal with what the owner typed.
       |> assign(:new_class_open, false)
+      |> assign(:new_class_error, nil)
+      |> assign(:new_class_name, "")
+      |> assign(:new_class_super, "Object")
       # Navigation aids (BT-2495, epic BT-2482 Phase 3): the top-bar omni search
       # and the method-editor Senders/Implementors popovers. Both ride thin
       # `:read` facade ops over the navigation channel (ADR 0096), so they work
@@ -1461,46 +1469,54 @@ defmodule BtAttachWeb.WorkspaceLive do
     {:noreply, flush_changes(socket)}
   end
 
-  # Toggle the System Browser's "New Class" form open/closed (BT-2293). Collapsed
-  # by default so it doesn't occupy the class tree's space until the owner wants
-  # to create a class; the ＋ button in the browser head flips it. Opening the
-  # form clears any stale validation/create status from a prior attempt so the
-  # user gets a clean slate.
+  # Toggle the System Browser's "New Class" modal open/closed (BT-2293, BT-2645).
+  # Closed by default; the ＋ button in the browser head flips it. Opening the
+  # modal resets the field values + clears any stale in-modal validation error
+  # from a prior attempt so the owner gets a clean slate (the superclass defaults
+  # back to `Object`).
   def handle_event("toggle_new_class", _params, socket) do
     opening? = !socket.assigns.new_class_open
 
-    # Clear the whole shared status area on open (all four assigns, matching
-    # `status_error/2`) so no stale save *or* flush banner lingers behind the
-    # freshly-opened form.
     socket =
-      if opening?,
-        do:
-          assign(socket,
-            save_error: nil,
-            save_result: nil,
-            flush_error: nil,
-            flush_result: nil
-          ),
-        else: socket
+      if opening? do
+        assign(socket,
+          new_class_open: true,
+          new_class_error: nil,
+          new_class_name: "",
+          new_class_super: "Object"
+        )
+      else
+        assign(socket, new_class_open: false, new_class_error: nil)
+      end
 
-    {:noreply, assign(socket, new_class_open: opening?)}
+    {:noreply, socket}
   end
 
-  # Create a brand-new class from the New Class form's source ("New Class",
-  # ADR 0082 Phase 5 `Workspace newClass:at:`, BT-2293). The target `.bt` path is
-  # *derived from the declared class name* (`Greeter` → `src/Greeter.bt`) rather
-  # than typed — the user thinks in classes, not files. A successful create logs
-  # a durable `new-class` ChangeLog entry (written to disk later on flush) and
-  # appears in the Changes pane.
-  def handle_event("new_class", %{"source" => source}, socket)
-      when is_binary(source) do
-    {:noreply, new_class(socket, source)}
+  # Close the New Class modal (Esc / close button / scrim click), discarding the
+  # in-flight fields without creating anything (BT-2645).
+  def handle_event("close_new_class", _params, socket) do
+    {:noreply, assign(socket, new_class_open: false, new_class_error: nil)}
   end
 
-  # Malformed payload (missing key / non-binary value): surface a validation
-  # error rather than letting a crafted event crash the LiveView.
+  # Create a brand-new class from the New Class modal's name + superclass fields
+  # (ADR 0082 Phase 5 `Workspace newClass:at:`, BT-2293, BT-2645). The owner types
+  # a plain PascalCase class name and picks a superclass (default `Object`); the
+  # `<Superclass> subclass: <Name>` definition is synthesized server-side — the
+  # user never types `subclass:`. The target `.bt` path is derived from the class
+  # name (`Greeter` → `src/Greeter.bt`); the user thinks in classes, not files. A
+  # successful create logs a durable `new-class` ChangeLog entry (written to disk
+  # later on flush), appears in the Changes pane, and opens + selects the new class.
+  def handle_event("new_class", %{"name" => name} = params, socket)
+      when is_binary(name) do
+    superclass = Map.get(params, "superclass", "Object")
+    superclass = if is_binary(superclass), do: superclass, else: "Object"
+    {:noreply, new_class(socket, name, superclass)}
+  end
+
+  # Malformed payload (missing key / non-binary value): surface an in-modal
+  # validation error rather than letting a crafted event crash the LiveView.
   def handle_event("new_class", _params, socket) do
-    {:noreply, status_error(socket, "Invalid new-class form payload.")}
+    {:noreply, assign(socket, new_class_error: "Invalid new-class form payload.")}
   end
 
   # Revert one pending in-memory method patch (ADR 0082 Phase 5 `Workspace
@@ -3103,47 +3119,99 @@ defmodule BtAttachWeb.WorkspaceLive do
     end
   end
 
-  # Create a new class from the New Class form (BT-2293). Empty source is a local
-  # validation error (no round-trip); a real create derives the target `.bt` path
-  # from the declared class name (so the user never types a file path), threads
-  # source + derived path straight to the workspace newClass chokepoint, refreshes
-  # the Changes pane so the durable `new-class` entry is visible (ChangeLog
-  # coherence), and collapses the form.
-  defp new_class(socket, source) do
-    # Trim up front so the emptiness guard and the dispatched payload see the same
-    # normalised value (whitespace around a class definition is never significant).
-    source = String.trim(source)
+  # Create a new class from the New Class modal's name + superclass (BT-2293,
+  # BT-2645). The owner supplies a plain PascalCase class name and a superclass
+  # (default `Object`); validation (PascalCase, non-empty, non-duplicate) runs
+  # locally — a rejected name surfaces an in-modal error and never round-trips.
+  # A valid name synthesizes the `<Superclass> subclass: <Name>` definition,
+  # derives the target `.bt` path from the name (so the user never types a file
+  # path), threads source + path to the workspace newClass chokepoint, refreshes
+  # the Changes pane (ChangeLog coherence), and opens + selects the new class.
+  defp new_class(socket, name, superclass) do
+    name = String.trim(name)
+    superclass = trim_superclass(superclass)
 
-    cond do
-      source == "" ->
-        status_error(socket, "Enter a class definition to create a class.")
+    case validate_new_class_name(socket, name) do
+      :ok ->
+        source = superclass <> " subclass: " <> name
+        {:ok, path} = derive_class_path(name)
+        dispatch_new_class(socket, name, source, path)
 
-      true ->
-        case derive_class_path(source) do
-          {:ok, path} ->
-            dispatch_new_class(socket, source, path)
-
-          :error ->
-            status_error(
-              socket,
-              "Couldn't find a class name — start with e.g. `Object subclass: Greeter`."
-            )
-        end
+      {:error, message} ->
+        # Keep the in-flight field values so the re-rendered modal shows what the
+        # owner typed, and route the error to the modal-local assign (never the
+        # method-editor's shared `save_error` — BT-2645).
+        assign(socket,
+          new_class_open: true,
+          new_class_name: name,
+          new_class_super: superclass,
+          new_class_error: message
+        )
     end
   end
 
-  defp dispatch_new_class(socket, source, path) do
+  # An empty / blank superclass falls back to the default `Object` — the modal's
+  # select defaults to it, but a crafted payload or cleared typeahead must not
+  # synthesize a headerless `subclass: Name`.
+  defp trim_superclass(superclass) do
+    case String.trim(superclass) do
+      "" -> "Object"
+      trimmed -> trimmed
+    end
+  end
+
+  # Validate a new class name locally (BT-2645): non-empty, PascalCase
+  # (`^[A-Z][A-Za-z0-9_]*$`), and not a duplicate of an existing class in the
+  # browse list. Returns `:ok` or `{:error, message}` for an in-modal error.
+  @new_class_name_re ~r/^[A-Z][A-Za-z0-9_]*$/
+  defp validate_new_class_name(socket, name) do
+    cond do
+      name == "" ->
+        {:error, "Enter a class name to create a class."}
+
+      not Regex.match?(@new_class_name_re, name) ->
+        {:error,
+         "Class name must be PascalCase — start with an uppercase letter, e.g. `Greeter`."}
+
+      class_name_taken?(socket, name) ->
+        {:error, "A class named #{name} already exists."}
+
+      true ->
+        :ok
+    end
+  end
+
+  # Is `name` already a class in the loaded browse list? Compared against the
+  # `"name"` field of every browse row (the same list the tree renders), so a
+  # duplicate is caught before any round-trip.
+  defp class_name_taken?(socket, name) do
+    Enum.any?(socket.assigns[:browser_classes] || [], fn row ->
+      Map.get(row, "name") == name
+    end)
+  end
+
+  defp dispatch_new_class(socket, name, source, path) do
     case Facade.dispatch(:new_class, %{source: source, path: path}, ctx(socket)) do
       {:ok, created_path} ->
         socket
+        |> assign_browser_classes()
+        |> assign_changes()
+        # Open + select the NEW class (`name`), not the superclass: the def tab
+        # focuses it and the tree highlights it (BT-2645). `open_definition`
+        # re-syncs the active-tab editor assigns (clearing `save_result`), so the
+        # success status is assigned *after* it — otherwise the "Created …" banner
+        # would be wiped by the very tab it opens.
+        |> open_definition(name)
         |> assign(
+          selected_class: name,
+          selected_protocol: nil,
           save_result: "Created new class — #{created_path}",
           save_error: nil,
           flush_result: nil,
           flush_error: nil,
-          new_class_open: false
+          new_class_open: false,
+          new_class_error: nil
         )
-        |> assign_changes()
         # BT-2586/BT-2590: a new class only writes its `.bt` file to disk when
         # autoflush is on (it is otherwise a durable in-memory ChangeLog entry,
         # written at the next flush — `maybe_autoflush(durable)` in
@@ -3153,28 +3221,34 @@ defmodule BtAttachWeb.WorkspaceLive do
         |> maybe_refresh_git_after_save()
 
       {:error, reason} ->
-        status_error(socket, facade_error(reason))
+        # Route a failed create to the in-modal error (keep fields + modal open),
+        # never the method-editor's `save_error` (BT-2645).
+        assign(socket,
+          new_class_open: true,
+          new_class_name: name,
+          new_class_error: facade_error(reason)
+        )
     end
   end
 
-  # Derive the in-project `.bt` path for a new class from its definition's
-  # declared name (BT-2293): `Object subclass: Greeter` → `src/Greeter.bt`. The
-  # runtime's `newClass:at:` validation accepts an exact (`Greeter.bt`, the stdlib
-  # convention) basename match, so the PascalCase name maps cleanly. Returns
-  # `:error` when no `… subclass: Name` header is present so the caller can surface
-  # a friendly "looks like a class definition?" message instead of a path error.
+  # Derive the in-project `.bt` path for a new class from its name (BT-2293):
+  # `Greeter` → `src/Greeter.bt`. The runtime's `newClass:at:` validation accepts
+  # an exact (`Greeter.bt`, the stdlib convention) basename match, so the
+  # PascalCase name maps cleanly. The name is already PascalCase-validated by the
+  # caller, so this always succeeds; it returns `{:ok, path}` to keep the
+  # call-site explicit.
+  #
+  # NOTE (BT-2646): the snake_case filename convention is OUT OF SCOPE here — this
+  # keeps the PascalCase basename behaviour unchanged so BT-2646 is a clean
+  # follow-up.
   #
   # The `src/` prefix is assumed — it's the canonical package source dir the
   # runtime resolves (`resolve_package_module` tries `src/` then `test/`). A
   # project with a different layout would get a `target_outside_project` error at
   # creation time (not silently on flush). If per-project source dirs ever land,
   # this is the spot to read the configured dir instead of hardcoding `src/`.
-  @new_class_name_re ~r/\bsubclass:\s*([A-Z][A-Za-z0-9_]*)/
-  defp derive_class_path(source) do
-    case Regex.run(@new_class_name_re, source) do
-      [_, name] -> {:ok, "src/" <> name <> ".bt"}
-      _ -> :error
-    end
+  defp derive_class_path(name) do
+    {:ok, "src/" <> name <> ".bt"}
   end
 
   # Revert one pending method patch (BT-2293). On success the prior body is
@@ -6504,11 +6578,16 @@ defmodule BtAttachWeb.WorkspaceLive do
   attr :browser_source, :string, default: "all"
   attr :selected_class, :string, default: nil
   attr :browser_error, :string, default: nil
-  # Owner-only "New Class" affordance (BT-2293): `role` gates the ＋ button (only
-  # the owner can `newClass:at:`); `new_class_open` is the collapsed/expanded
-  # state of the inline create form. Both default so read-only callers can omit.
+  # Owner-only "New Class" affordance (BT-2293, BT-2645): `role` gates the ＋
+  # button (only the owner can `newClass:at:`); `new_class_open` is the open/closed
+  # state of the create-a-class modal. `new_class_name` / `new_class_super` retain
+  # the in-flight field values; `new_class_error` is the in-modal validation /
+  # create error. All default so read-only callers can omit.
   attr :role, :atom, default: :observer
   attr :new_class_open, :boolean, default: false
+  attr :new_class_name, :string, default: ""
+  attr :new_class_super, :string, default: "Object"
+  attr :new_class_error, :string, default: nil
 
   defp system_browser_classes(assigns) do
     # BT-2557: filter the rows once, up front, so both the hierarchy and category
@@ -6574,8 +6653,9 @@ defmodule BtAttachWeb.WorkspaceLive do
           type="button"
           class={["panel-icon", @new_class_open && "on"]}
           phx-click="toggle_new_class"
+          aria-haspopup="dialog"
           aria-expanded={to_string(@new_class_open)}
-          aria-controls={if @new_class_open, do: "new-class-form"}
+          aria-controls={if @new_class_open, do: "new-class-modal"}
           aria-label="New class"
           title="New class"
         >
@@ -6591,33 +6671,86 @@ defmodule BtAttachWeb.WorkspaceLive do
           ×
         </button>
       </div>
-      <%!-- NEW CLASS (BT-2293, ADR 0082 Phase 5): create a brand-new class from a
-           source definition (`Workspace newClass:at:`). The target `.bt` path is
-           derived from the declared class name server-side, so the owner thinks in
-           classes, not files. Collapsed by default; the new-class entry appears in
-           the Changes pane and is written to disk on the next flush. --%>
-      <form
+      <%!-- NEW CLASS modal (BT-2293, BT-2645, ADR 0082 Phase 5): create a
+           brand-new class from two explicit fields — a plain PascalCase name and a
+           superclass (default `Object`, a datalist typeahead over existing
+           classes). The `<Superclass> subclass: <Name>` definition + `.bt` path
+           are synthesized server-side, so the owner thinks in classes, not files
+           or `subclass:` syntax. Validation errors render inline inside the modal
+           (never the method editor). The new-class entry appears in the Changes
+           pane and is written to disk on the next flush; the created class opens +
+           is selected on success. --%>
+      <div
         :if={@role == :owner and @new_class_open}
-        id="new-class-form"
-        phx-submit="new_class"
-        class="new-class-form"
+        id="new-class-modal"
+        class="modal-scrim"
+        phx-click="close_new_class"
+        phx-window-keydown="close_new_class"
+        phx-key="escape"
       >
-        <label class="new-class-label" for="new-class-source">
-          New Class
-          <span class="muted-note">— saved under <code>src/</code> as <code>ClassName.bt</code></span>
-        </label>
-        <textarea
-          id="new-class-source"
-          name="source"
-          class="new-class-source mono"
-          rows="2"
-          placeholder="Object subclass: Greeter"
-          phx-mounted={Phoenix.LiveView.JS.focus()}
-        ></textarea>
-        <button class="btn" type="submit" phx-disable-with="Creating…">
-          Create
-        </button>
-      </form>
+        <div
+          class="modal-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-label="New class"
+          phx-click-away="close_new_class"
+        >
+          <div class="modal-head">
+            <h2 class="modal-title">New Class</h2>
+            <button
+              type="button"
+              class="panel-close"
+              phx-click="close_new_class"
+              aria-label="Close New Class dialog"
+              title="Close"
+            >
+              ×
+            </button>
+          </div>
+          <form id="new-class-form" phx-submit="new_class" class="new-class-modal-form">
+            <label class="new-class-field-label" for="new-class-name">Class name</label>
+            <input
+              type="text"
+              id="new-class-name"
+              name="name"
+              class="field"
+              value={@new_class_name}
+              autocomplete="off"
+              spellcheck="false"
+              placeholder="Greeter"
+              aria-describedby={if @new_class_error, do: "new-class-error"}
+              aria-invalid={to_string(@new_class_error != nil)}
+              phx-mounted={Phoenix.LiveView.JS.focus()}
+            />
+            <label class="new-class-field-label" for="new-class-super">Superclass</label>
+            <input
+              type="text"
+              id="new-class-super"
+              name="superclass"
+              class="field"
+              value={@new_class_super}
+              list="new-class-super-options"
+              autocomplete="off"
+              spellcheck="false"
+              placeholder="Object"
+            />
+            <datalist id="new-class-super-options">
+              <option :for={row <- @browser_classes} value={Map.get(row, "name")}></option>
+            </datalist>
+            <p :if={@new_class_error} id="new-class-error" class="new-class-error" role="alert">
+              {@new_class_error}
+            </p>
+            <div class="modal-actions">
+              <button type="button" class="btn ghost" phx-click="close_new_class">
+                Cancel
+              </button>
+              <button class="btn primary" type="submit" phx-disable-with="Creating…">
+                Create
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
       <div class="panel-body" id="system-browser-tree" phx-hook="ScrollToSelected">
         <.notice
           :if={@browser_error}
@@ -7175,6 +7308,9 @@ defmodule BtAttachWeb.WorkspaceLive do
                   browser_error={@browser_error}
                   role={@role}
                   new_class_open={@new_class_open}
+                  new_class_name={@new_class_name}
+                  new_class_super={@new_class_super}
+                  new_class_error={@new_class_error}
                 />
                 <%!-- Draggable divider (BT-2576): rebalances the class tree vs.
                      the method list ("more class, less method"). --%>

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -3135,7 +3135,7 @@ defmodule BtAttachWeb.WorkspaceLive do
       :ok ->
         source = superclass <> " subclass: " <> name
         {:ok, path} = derive_class_path(name)
-        dispatch_new_class(socket, name, source, path)
+        dispatch_new_class(socket, name, superclass, source, path)
 
       {:error, message} ->
         # Keep the in-flight field values so the re-rendered modal shows what the
@@ -3190,7 +3190,7 @@ defmodule BtAttachWeb.WorkspaceLive do
     end)
   end
 
-  defp dispatch_new_class(socket, name, source, path) do
+  defp dispatch_new_class(socket, name, superclass, source, path) do
     case Facade.dispatch(:new_class, %{source: source, path: path}, ctx(socket)) do
       {:ok, created_path} ->
         socket
@@ -3226,6 +3226,7 @@ defmodule BtAttachWeb.WorkspaceLive do
         assign(socket,
           new_class_open: true,
           new_class_name: name,
+          new_class_super: superclass,
           new_class_error: facade_error(reason)
         )
     end
@@ -6684,7 +6685,6 @@ defmodule BtAttachWeb.WorkspaceLive do
         :if={@role == :owner and @new_class_open}
         id="new-class-modal"
         class="modal-scrim"
-        phx-click="close_new_class"
         phx-window-keydown="close_new_class"
         phx-key="escape"
       >

--- a/editors/liveview/test/bt_attach_web/workspace_git_panel_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_git_panel_test.exs
@@ -159,18 +159,12 @@ defmodule BtAttachWeb.WorkspaceGitPanelTest do
 
   # Drive the new-class save path (`dispatch_new_class`) — one of the two saves
   # BT-2590 gates the git refresh behind. We push the `new_class` event directly
-  # (the form lives behind a collapsed affordance), exercising the same handler.
+  # (the modal lives behind the ＋ affordance), exercising the same handler. The
+  # modal now carries a plain class name + superclass (BT-2645); the definition is
+  # synthesized server-side.
   defp define_a_class(view) do
     class = "GitGate#{System.unique_integer([:positive])}"
-
-    src = """
-    Actor subclass: #{class}
-      state: value = 0
-
-      value => self.value
-    """
-
-    render_hook(view, "new_class", %{"source" => src})
+    render_hook(view, "new_class", %{"name" => class, "superclass" => "Actor"})
   end
 
   # Assert that `fun` stays false across the retry window (the negative of

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -90,11 +90,11 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     test "the New Class affordance is hidden for an Observer (BT-2293)", %{conn: conn} do
       # `new_class` is an :execute op, so the System Browser's "New Class"
       # affordance is owner-gated in the template (same as the eval form) — an
-      # Observer must see neither the ＋ toggle nor the form it reveals.
+      # Observer must see neither the ＋ toggle nor the modal it opens.
       {:ok, _view, html} = live(observer_conn(conn), "/")
       assert html =~ "read-only (Observer)"
       refute html =~ ~s(phx-click="toggle_new_class")
-      refute html =~ ~s(id="new-class-form")
+      refute html =~ ~s(id="new-class-modal")
       refute html =~ ~s(phx-submit="new_class")
     end
 
@@ -486,81 +486,128 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     assert view |> form("#eval-form") |> render_submit(%{expr: "6 * 7"}) =~ "42"
   end
 
-  test "the New Class toggle is present on the owner's connected render (BT-2293)", %{conn: conn} do
+  test "the New Class toggle opens a modal with name + superclass fields (BT-2645)", %{conn: conn} do
     {:ok, view, html} = live(conn, "/")
 
-    # The System Browser's "New Class" affordance is collapsed by default (it must
+    # The System Browser's "New Class" affordance is closed by default (it must
     # not crowd the class tree): only the ＋ toggle shows on the connected render.
     assert html =~ ~s(phx-click="toggle_new_class")
-    refute html =~ ~s(id="new-class-form")
+    refute html =~ ~s(id="new-class-modal")
 
-    # Toggling it open reveals the source-only form (no path field — the `.bt`
-    # path is derived from the declared class name server-side).
+    # Toggling it open reveals a modal with two explicit fields — a plain class
+    # name and a superclass (default `Object`); the owner never types `subclass:`.
     opened = view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
-    assert opened =~ ~s(id="new-class-form")
+    assert opened =~ ~s(id="new-class-modal")
     assert opened =~ ~s(phx-submit="new_class")
-    assert opened =~ ~s(name="source")
-    refute opened =~ ~s(name="path")
+    assert opened =~ ~s(name="name")
+    assert opened =~ ~s(name="superclass")
+    # The superclass field defaults to `Object`.
+    assert opened =~ ~s(value="Object")
+    # No bare-definition textarea in the modal anymore (the def is synthesized
+    # server-side). `name="source"` still exists elsewhere as the method editor's
+    # hidden field, so scope the check to the modal's removed source textarea.
+    refute opened =~ ~s(id="new-class-source")
   end
 
-  test "New Class validates an empty source before any create (BT-2293)", %{conn: conn} do
+  test "New Class validates an empty name inside the modal (BT-2645)", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/")
     view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
 
     html =
       view
       |> form("#new-class-form")
-      |> render_submit(%{"source" => ""})
+      |> render_submit(%{"name" => "", "superclass" => "Object"})
 
-    assert html =~ "Enter a class definition"
+    assert html =~ "Enter a class name"
+    # The error stays inside the modal — never the method editor's save banner.
+    assert html =~ ~s(id="new-class-modal")
+    # No round-trip happened, so no "Created" status.
+    refute html =~ "Created new class"
   end
 
-  test "New Class rejects source with no class header (BT-2293)", %{conn: conn} do
+  test "New Class rejects a lowercase (non-PascalCase) name inside the modal (BT-2645)", %{
+    conn: conn
+  } do
     {:ok, view, _html} = live(conn, "/")
     view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
 
-    # No `… subclass: Name` header → there is no class name to derive a path from,
-    # so the LiveView surfaces a friendly hint rather than dispatching a doomed
-    # round-trip.
     html =
       view
       |> form("#new-class-form")
-      |> render_submit(%{"source" => "1 + 1"})
+      |> render_submit(%{"name" => "foo", "superclass" => "Object"})
 
-    # Match a non-apostrophe substring of "Couldn't find a class name …": the
-    # rendered HTML escapes the apostrophe (`Couldn&#39;t`), so asserting the
-    # literal contraction would spuriously fail.
-    assert html =~ "find a class name"
+    assert html =~ "PascalCase"
+    assert html =~ ~s(id="new-class-modal")
+    refute html =~ "Created new class"
   end
 
-  test "New Class creates a class end-to-end via newClass:at: (BT-2293)", %{conn: conn} do
+  test "New Class rejects a duplicate class name inside the modal (BT-2645)", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
+
+    # `Object` is always present in the browse list, so it is a duplicate.
+    html =
+      view
+      |> form("#new-class-form")
+      |> render_submit(%{"name" => "Object", "superclass" => "Object"})
+
+    assert html =~ "already exists"
+    assert html =~ ~s(id="new-class-modal")
+    refute html =~ "Created new class"
+  end
+
+  test "New Class creates a class with default Object superclass and opens it (BT-2645)", %{
+    conn: conn
+  } do
     {:ok, view, _html} = live(conn, "/")
     view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
     suffix = System.unique_integer([:positive])
     class = "Greeter#{suffix}"
-    # The path is derived from the declared class name: `Greeter12` → its exact
-    # PascalCase basename `src/Greeter12.bt` (the stdlib convention the runtime's
-    # `newClass:at:` validation accepts as an exact match).
+    # The path is derived from the class name: `Greeter12` → its exact PascalCase
+    # basename `src/Greeter12.bt` (the stdlib convention the runtime's
+    # `newClass:at:` validation accepts as an exact match — snake_case is BT-2646).
     path = "src/#{class}.bt"
 
-    # Drive a real `newClass:at:` round-trip — the success path the validation
-    # tests don't reach: form (source only) → derived path → `:new_class` facade
-    # op → workspace `beamtalk_repl_eval:new_class/2`. Phase 1 installs the class
-    # in memory and logs a durable new-class ChangeEntry; the `.bt` file is only
-    # written on flush, so this leaves no on-disk artifact. A derivation bug
-    # (wrong basename/case) would fail here, not just in validation.
+    # Drive a real `newClass:at:` round-trip: modal fields (name + Object) →
+    # synthesized `Object subclass: Greeter12` → derived path → `:new_class` facade
+    # op → workspace. The `.bt` file is only written on flush, so this leaves no
+    # on-disk artifact.
     html =
       view
       |> form("#new-class-form")
-      |> render_submit(%{"source" => "Object subclass: #{class}"})
+      |> render_submit(%{"name" => class, "superclass" => "Object"})
 
     assert html =~ "Created new class — #{path}"
     refute html =~ "beamtalk_error"
     refute html =~ "{:error"
     # ChangeLog coherence: the new-class entry is now in the Changes viewer.
     assert html =~ class
-    # The form collapses again after a successful create.
-    refute html =~ ~s(id="new-class-form")
+    # The modal closes again after a successful create.
+    refute html =~ ~s(id="new-class-modal")
+    # The created class is opened + selected: a def tab focuses it and the tree
+    # highlights it (the `def:` tab id is the open-definition signal).
+    assert html =~ "def:#{class}"
+  end
+
+  test "New Class with an explicit superclass opens the NEW class, not the superclass (BT-2645)",
+       %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
+    suffix = System.unique_integer([:positive])
+    class = "Bar#{suffix}"
+    path = "src/#{class}.bt"
+
+    # Superclass `Actor` → synthesize `Actor subclass: Bar…`; the success path
+    # must open + select the new class (`Bar…`), never the superclass (`Actor`).
+    html =
+      view
+      |> form("#new-class-form")
+      |> render_submit(%{"name" => class, "superclass" => "Actor"})
+
+    assert html =~ "Created new class — #{path}"
+    # Opens the NEW class's definition tab, not the superclass's.
+    assert html =~ "def:#{class}"
+    refute html =~ "def:Actor"
   end
 
   # ── Phase 1 JS hook foundation (BT-2485, BT-2539) ───────────────────────────

--- a/editors/liveview/test/bt_attach_web/workspace_new_class_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_new_class_test.exs
@@ -1,0 +1,208 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.WorkspaceNewClassTest do
+  @moduledoc """
+  Integration test for the System Browser's New Class modal (BT-2645): the ＋
+  affordance opens a modal/wizard with two explicit fields — a plain PascalCase
+  class name and a superclass (default `Object`, a datalist typeahead over
+  existing classes). The `<Superclass> subclass: <Name>` definition + the `.bt`
+  path are synthesized server-side, so the owner never types `subclass:` or a file
+  path. A valid create opens + selects the NEW class (not the superclass);
+  invalid input (empty / lowercase / duplicate) renders an in-modal error with no
+  round-trip and no method-editor banner.
+
+  Drives the LiveView against the fully-stubbed workspace client
+  (`BtAttachWeb.StubWorkspaceClient`), whose `new_class/2` returns the created
+  path and whose `browse_class_definition/1` answers for any class name. No
+  `:workspace` tag, so this runs in the bare `mix test` lane.
+  """
+  use BtAttachWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  setup do
+    Application.put_env(:bt_attach, :workspace_client, BtAttachWeb.StubWorkspaceClient)
+
+    Application.put_env(:bt_attach, :oidc, %{
+      issuer: "https://idp",
+      client_id: "id",
+      redirect_uri: "https://ide/callback",
+      groups_claim: "groups",
+      client_secret: "x",
+      roles: %{"owner" => ["beamtalk-owners"], "observer" => ["beamtalk-observers"]}
+    })
+
+    Application.put_env(:bt_attach, :session_ttl_secs, 3600)
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      Application.delete_env(:bt_attach, :oidc)
+      Application.delete_env(:bt_attach, :session_ttl_secs)
+      BtAttachWeb.StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    {:ok, _} = BtAttachWeb.StubWorkspaceClient.start_state()
+
+    :ok
+  end
+
+  defp owner_conn(conn) do
+    Plug.Test.init_test_session(conn, %{
+      "bt_user" => %{"sub" => "alice", "groups" => ["beamtalk-owners"]},
+      "bt_logged_in_at" => System.system_time(:second)
+    })
+  end
+
+  defp observer_conn(conn) do
+    Plug.Test.init_test_session(conn, %{
+      "bt_user" => %{"sub" => "bob", "groups" => ["beamtalk-observers"]},
+      "bt_logged_in_at" => System.system_time(:second)
+    })
+  end
+
+  defp open_modal(view) do
+    view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
+  end
+
+  describe "New Class modal affordance (BT-2645)" do
+    test "the ＋ toggle is hidden for an Observer", %{conn: conn} do
+      {:ok, _view, html} = live(observer_conn(conn), "/")
+      refute html =~ ~s(phx-click="toggle_new_class")
+      refute html =~ ~s(id="new-class-modal")
+    end
+
+    test "the ＋ toggle opens a modal with name + superclass fields", %{conn: conn} do
+      {:ok, view, html} = live(owner_conn(conn), "/")
+
+      # Closed by default — only the toggle shows.
+      assert html =~ ~s(phx-click="toggle_new_class")
+      refute html =~ ~s(id="new-class-modal")
+
+      opened = open_modal(view)
+      assert opened =~ ~s(id="new-class-modal")
+      assert opened =~ ~s(role="dialog")
+      assert opened =~ ~s(phx-submit="new_class")
+      assert opened =~ ~s(name="name")
+      assert opened =~ ~s(name="superclass")
+      # Superclass defaults to `Object`.
+      assert opened =~ ~s(value="Object")
+      # A datalist typeahead over existing classes (no bare-definition textarea).
+      assert opened =~ ~s(id="new-class-super-options")
+      # The modal form itself has no `source` definition field — the def is
+      # synthesized server-side. (`name="source"` still exists elsewhere as the
+      # method editor's hidden field, so we scope the check to the modal form.)
+      refute opened =~ ~s(id="new-class-source")
+    end
+  end
+
+  describe "in-modal validation (BT-2645)" do
+    test "an empty name is rejected inside the modal with no round-trip", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      open_modal(view)
+
+      html =
+        view
+        |> form("#new-class-form")
+        |> render_submit(%{"name" => "", "superclass" => "Object"})
+
+      assert html =~ "Enter a class name"
+      assert html =~ ~s(id="new-class-modal")
+      refute html =~ "Created new class"
+    end
+
+    test "a lowercase (non-PascalCase) name is rejected inside the modal", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      open_modal(view)
+
+      html =
+        view
+        |> form("#new-class-form")
+        |> render_submit(%{"name" => "foo", "superclass" => "Object"})
+
+      assert html =~ "PascalCase"
+      assert html =~ ~s(id="new-class-modal")
+      refute html =~ "Created new class"
+    end
+
+    test "a duplicate class name is rejected inside the modal", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      open_modal(view)
+
+      # `Counter` is always present in the stub's browse list.
+      html =
+        view
+        |> form("#new-class-form")
+        |> render_submit(%{"name" => "Counter", "superclass" => "Object"})
+
+      assert html =~ "already exists"
+      assert html =~ ~s(id="new-class-modal")
+      refute html =~ "Created new class"
+    end
+
+    test "a validation error never reaches the method-editor save banner", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      open_modal(view)
+
+      html =
+        view
+        |> form("#new-class-form")
+        |> render_submit(%{"name" => "foo", "superclass" => "Object"})
+
+      # The error renders inside the modal (its `role="alert"` block), not in the
+      # method editor's save-error area.
+      assert html =~ ~s(id="new-class-error")
+    end
+  end
+
+  describe "create + open the new class (BT-2645)" do
+    test "default Object superclass creates the class and opens + selects it", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      open_modal(view)
+
+      html =
+        view
+        |> form("#new-class-form")
+        |> render_submit(%{"name" => "Foo", "superclass" => "Object"})
+
+      # `Foo` → `Object subclass: Foo` → `src/Foo.bt` (PascalCase basename; the
+      # snake_case convention is deferred to BT-2646).
+      assert html =~ "Created new class — src/Foo.bt"
+      # The modal closes after a successful create.
+      refute html =~ ~s(id="new-class-modal")
+      # The created class is opened (a `def:Foo` tab) and selected in the tree.
+      assert html =~ "def:Foo"
+    end
+
+    test "an explicit superclass opens the NEW class, not the superclass", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      open_modal(view)
+
+      # Superclass `Actor` → `Actor subclass: Bar`; the success path must open the
+      # new class (`Bar`), never the superclass (`Actor`).
+      html =
+        view
+        |> form("#new-class-form")
+        |> render_submit(%{"name" => "Bar", "superclass" => "Actor"})
+
+      assert html =~ "Created new class — src/Bar.bt"
+      assert html =~ "def:Bar"
+      refute html =~ "def:Actor"
+    end
+
+    test "a blank superclass falls back to Object", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      open_modal(view)
+
+      # A cleared superclass field must not synthesize a headerless `subclass: Baz`;
+      # it falls back to `Object` and still creates.
+      html =
+        view
+        |> form("#new-class-form")
+        |> render_submit(%{"name" => "Baz", "superclass" => "  "})
+
+      assert html =~ "Created new class — src/Baz.bt"
+      assert html =~ "def:Baz"
+    end
+  end
+end


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2645

## Summary

Replaces the broken inline New Class textarea with an accessible **modal/wizard**: a **Class name** field + a **Superclass** field (default `Object`). The `<Superclass> subclass: <Name>` definition is synthesized server-side, the created class is opened and selected, and validation/create errors render **inside the modal** (never the method-editor header).

Fixes the four problems: bare names now work, the *new* class is focused (not its superclass), errors are in-modal, and the label/input mismatch is gone.

## Key changes

- `workspace_live.ex`: modal assigns (`new_class_open/error/name/super`); `toggle_new_class` reset + `close_new_class`; the `new_class` event now takes `name` + `superclass`; `new_class/3` does local PascalCase/empty/duplicate validation; `dispatch_new_class/4` opens+selects the new class and routes errors in-modal; `derive_class_path/1` is now name-keyed (path output unchanged). Inline form markup → modal (datalist superclass typeahead, aria-labeled dialog, Esc/close/scrim, inline error).
- `app.css`: modal scrim/dialog/field/error styles; removed the old `.new-class-form`.
- Tests: new stub-backed `workspace_new_class_test.exs` (9 tests); updated the real-workspace cases + a git-panel helper.

## Scope

- Server contract (`Workspace newClass:at:`) and the `src/<Name>.bt` path derivation are **unchanged** — snake_case filename is deferred to **BT-2646** (next).
- Bug found + fixed: `open_definition`'s `sync_active` clears `save_result`, so the "Created…" success banner is assigned *after* opening the new class. (Success still uses the existing `save_result` banner; only *errors* are modal-local, per the AC.)

## Verification

- `just build` ✓
- LiveView ExUnit — 344 passed (new file 9/9) ✓; `mix compile --warnings-as-errors` ✓; `mix format --check-formatted` ✓; `just clippy` ✓

(The real-workspace New Class cases are `:workspace`-tagged/excluded in the bare lane; the modal flow is fully covered by the stub-backed suite that runs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_