### PR TITLE
LiveView IDE: New Class writes snake_case filename (BT-2646)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -3244,16 +3244,15 @@ defmodule BtAttachWeb.WorkspaceLive do
     end
   end
 
-  # Derive the in-project `.bt` path for a new class from its name (BT-2293):
-  # `Greeter` → `src/Greeter.bt`. The runtime's `newClass:at:` validation accepts
-  # an exact (`Greeter.bt`, the stdlib convention) basename match, so the
-  # PascalCase name maps cleanly. The name is already PascalCase-validated by the
-  # caller, so this always succeeds; it returns `{:ok, path}` to keep the
-  # call-site explicit.
-  #
-  # NOTE (BT-2646): the snake_case filename convention is OUT OF SCOPE here — this
-  # keeps the PascalCase basename behaviour unchanged so BT-2646 is a clean
-  # follow-up.
+  # Derive the in-project `.bt` path for a new class from its name (BT-2293,
+  # BT-2646): `Greeter` → `src/greeter.bt`, `EventStore` → `src/event_store.bt`.
+  # The basename is snake_cased to match the project convention (every file in a
+  # package `src/` is snake_case). The runtime's `newClass:at:` validation
+  # snake_case-normalises both the declared class name and the path basename
+  # (`beamtalk_repl_loader:validate_new_class/3` via `to_snake_case/1`), so a
+  # snake_case file maps cleanly to the PascalCase class. The name is already
+  # PascalCase-validated by the caller, so this always succeeds; it returns
+  # `{:ok, path}` to keep the call-site explicit.
   #
   # The `src/` prefix is assumed — it's the canonical package source dir the
   # runtime resolves (`resolve_package_module` tries `src/` then `test/`). A
@@ -3261,7 +3260,38 @@ defmodule BtAttachWeb.WorkspaceLive do
   # creation time (not silently on flush). If per-project source dirs ever land,
   # this is the spot to read the configured dir instead of hardcoding `src/`.
   defp derive_class_path(name) do
-    {:ok, "src/" <> name <> ".bt"}
+    {:ok, "src/" <> to_snake_case(name) <> ".bt"}
+  end
+
+  # Snake-case a PascalCase class name, mirroring the runtime's
+  # `beamtalk_repl_loader:to_snake_case/1` EXACTLY so the IDE-derived filename and
+  # the loader's basename normalisation agree (BT-2646). The rule: the first
+  # character is lowercased unconditionally; thereafter an uppercase letter gets a
+  # leading `_` ONLY when the previous character was a lowercase letter. This
+  # collapses acronyms (`HTTPServer` → `httpserver`) rather than splitting every
+  # capital — diverging from the runtime here would make the loader reject or
+  # mis-locate the created file. Digits and other characters pass through verbatim
+  # and do not count as "lowercase" for the boundary test.
+  defp to_snake_case(name) do
+    name
+    |> String.to_charlist()
+    |> snake_chars(false, [])
+  end
+
+  defp snake_chars([], _prev_was_lower?, acc), do: acc |> Enum.reverse() |> List.to_string()
+
+  defp snake_chars([c | rest], prev_was_lower?, acc) when c >= ?A and c <= ?Z do
+    lowered = c + 32
+
+    if prev_was_lower? do
+      snake_chars(rest, false, [lowered, ?_ | acc])
+    else
+      snake_chars(rest, false, [lowered | acc])
+    end
+  end
+
+  defp snake_chars([c | rest], _prev_was_lower?, acc) do
+    snake_chars(rest, c >= ?a and c <= ?z, [c | acc])
   end
 
   # Revert one pending method patch (BT-2293). On success the prior body is

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -563,10 +563,11 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
     suffix = System.unique_integer([:positive])
     class = "Greeter#{suffix}"
-    # The path is derived from the class name: `Greeter12` → its exact PascalCase
-    # basename `src/Greeter12.bt` (the stdlib convention the runtime's
-    # `newClass:at:` validation accepts as an exact match — snake_case is BT-2646).
-    path = "src/#{class}.bt"
+    # The path is derived from the class name, snake_cased to match the project
+    # convention (BT-2646): `Greeter12` → `src/greeter12.bt`. These names are a
+    # leading capital + digits, so `String.downcase/1` equals the runtime's
+    # `to_snake_case/1` here.
+    path = "src/#{String.downcase(class)}.bt"
 
     # Drive a real `newClass:at:` round-trip: modal fields (name + Object) →
     # synthesized `Object subclass: Greeter12` → derived path → `:new_class` facade
@@ -595,7 +596,7 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     view |> element(~s(button[phx-click="toggle_new_class"])) |> render_click()
     suffix = System.unique_integer([:positive])
     class = "Bar#{suffix}"
-    path = "src/#{class}.bt"
+    path = "src/#{String.downcase(class)}.bt"
 
     # Superclass `Actor` → synthesize `Actor subclass: Bar…`; the success path
     # must open + select the new class (`Bar…`), never the superclass (`Actor`).

--- a/editors/liveview/test/bt_attach_web/workspace_new_class_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_new_class_test.exs
@@ -165,9 +165,9 @@ defmodule BtAttachWeb.WorkspaceNewClassTest do
         |> form("#new-class-form")
         |> render_submit(%{"name" => "Foo", "superclass" => "Object"})
 
-      # `Foo` → `Object subclass: Foo` → `src/Foo.bt` (PascalCase basename; the
-      # snake_case convention is deferred to BT-2646).
-      assert html =~ "Created new class — src/Foo.bt"
+      # `Foo` → `Object subclass: Foo` → `src/foo.bt` (snake_case basename per the
+      # project convention — BT-2646).
+      assert html =~ "Created new class — src/foo.bt"
       # The modal closes after a successful create.
       refute html =~ ~s(id="new-class-modal")
       # The created class is opened (a `def:Foo` tab) and selected in the tree.
@@ -185,7 +185,7 @@ defmodule BtAttachWeb.WorkspaceNewClassTest do
         |> form("#new-class-form")
         |> render_submit(%{"name" => "Bar", "superclass" => "Actor"})
 
-      assert html =~ "Created new class — src/Bar.bt"
+      assert html =~ "Created new class — src/bar.bt"
       assert html =~ "def:Bar"
       refute html =~ "def:Actor"
     end
@@ -201,8 +201,52 @@ defmodule BtAttachWeb.WorkspaceNewClassTest do
         |> form("#new-class-form")
         |> render_submit(%{"name" => "Baz", "superclass" => "  "})
 
-      assert html =~ "Created new class — src/Baz.bt"
+      assert html =~ "Created new class — src/baz.bt"
       assert html =~ "def:Baz"
+    end
+
+    test "a multi-word PascalCase name snake_cases the filename (BT-2646)", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      open_modal(view)
+
+      # `EventStore` must land at `src/event_store.bt`, not `src/EventStore.bt`:
+      # the loader snake_case-normalises the basename, so the snake_case file maps
+      # cleanly back to the PascalCase class.
+      html =
+        view
+        |> form("#new-class-form")
+        |> render_submit(%{"name" => "EventStore", "superclass" => "Object"})
+
+      assert html =~ "Created new class — src/event_store.bt"
+      assert html =~ "def:EventStore"
+    end
+  end
+
+  describe "snake_case filename derivation (BT-2646)" do
+    # The IDE's snake_case derivation MUST match the runtime's
+    # `beamtalk_repl_loader:to_snake_case/1` so the loader's snake-normalised
+    # basename validation accepts the created file. These cases pin the exact
+    # rule, including the acronym-collapsing behaviour (`HTTPServer` → `httpserver`,
+    # NOT `h_t_t_p_server`) — diverging would make the loader reject the file.
+    for {name, expected} <- [
+          {"Foo", "src/foo.bt"},
+          {"EventStore", "src/event_store.bt"},
+          {"WorkflowEngine", "src/workflow_engine.bt"},
+          {"HTTPServer", "src/httpserver.bt"},
+          {"A", "src/a.bt"},
+          {"Counter2", "src/counter2.bt"}
+        ] do
+      test "#{name} → #{expected}", %{conn: conn} do
+        {:ok, view, _html} = live(owner_conn(conn), "/")
+        open_modal(view)
+
+        html =
+          view
+          |> form("#new-class-form")
+          |> render_submit(%{"name" => unquote(name), "superclass" => "Object"})
+
+        assert html =~ "Created new class — " <> unquote(expected)
+      end
     end
   end
 end


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2646

## Summary

New Class wrote `src/Foo.bt` (PascalCase), but the project convention is snake_case (every file in beamtalk-exdura `src/` is snake_case). Now `Foo → src/foo.bt`, `EventStore → src/event_store.bt`.

## Approach — Option 1 (client-side snake_case)

The `:new_class` op contract is `%{source, path}` and the loader validates the declared class name against the path basename. Option 2 (server-side path derivation) would need an invasive `newClass:at:` signature change — which the issue says to avoid — so Option 1 fits the existing contract cleanly. The loader already snake_case-normalises both sides of the basename check, so a snake_case file is fully accepted.

## Parity (load-bearing)

The new `to_snake_case/1` in the LiveView mirrors `beamtalk_repl_loader:to_snake_case/1` **exactly** — lowercase the first char, insert `_` before an uppercase letter only when the previous char was lowercase (acronyms collapse). Verified against the actual runtime function: `Foo→foo`, `EventStore→event_store`, `WorkflowEngine→workflow_engine`, `HTTPServer→httpserver`, `A→a`, `Counter2→counter2` — all match. (If the IDE and loader disagreed, the loader would reject/mis-locate the file — hence the explicit parity check.)

## Key changes

- `workspace_live.ex`: `derive_class_path/1` snake_cases the name; added `to_snake_case/1` + `snake_chars/3`.
- Tests: BT-2645 assertions updated to snake_case paths; added `EventStore → src/event_store.bt` integration test + a parameterised parity suite.

The created file, tree entry, and Changes/git path all flow from `derive_class_path/1`, so all three show the snake_case path. The BT-2645 modal flow (open+select, in-modal validation) is unchanged.

## Verification

- `just build` ✓
- LiveView ExUnit — 351 passed (new-class file 16/16) ✓; `mix compile --warnings-as-errors` ✓; `mix format --check-formatted` ✓; `just clippy` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_