### PR TITLE
System Browser: show greyed context ancestors in filtered Hierarchy view (BT-2649)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -310,6 +310,15 @@
 .cat-row { color: var(--muted); font-weight: 600; font-size: 11px; letter-spacing: .03em; text-transform: uppercase; cursor: default; }
 .cat-row:hover, .row:hover { background: var(--hover); }
 .row.sel, .cat-row.sel { background: var(--sel); color: var(--sel-ink); }
+/* Context ancestor rows (BT-2649): superclass spine surfaced only to connect
+   filtered matches up to a root in the Hierarchy view. Dimmed and non-interactive
+   — no pointer cursor, no hover highlight — so they read as secondary, immutable
+   context rather than selectable classes. */
+.row.context {
+  color: var(--faint); cursor: default; opacity: 0.7;
+}
+.row.context:hover { background: transparent; }
+.row.context .cls { color: var(--faint); font-style: italic; }
 .row .twig { color: var(--faint); width: 12px; flex: none; text-align: center; }
 /* The class name takes the flexible space and truncates with an ellipsis so the
    trailing badges (BT-2610) are pushed into a consistent right-pinned column and

--- a/editors/liveview/lib/bt_attach_web/live/class_tree.ex
+++ b/editors/liveview/lib/bt_attach_web/live/class_tree.ex
@@ -56,4 +56,59 @@ defmodule BtAttachWeb.ClassTree do
       walk_hierarchy(by_parent, Map.get(class, "name"), indent + 1, acc)
     end)
   end
+
+  @doc """
+  The Hierarchy view's rows under an active source filter (BT-2649), as an
+  ordered list of `{class_row, indent, context?}`.
+
+  `all_classes` is the **full** browse set (every loaded class, unfiltered);
+  `visible_names` is the `MapSet` of class names that survive the active filter
+  (the matching classes). The tree is walked over the *display set* = the visible
+  names plus the transitive in-set superclass ancestors needed to connect each
+  matching class up to a root. Those connecting ancestors render as **context
+  rows** (`context? = true`) — dimmed, non-interactive spine — so the filtered
+  view keeps its real shape (e.g. a project `ActorSnapshot` still nests under
+  `Actor → Object`) instead of flattening every match to the root.
+
+  A row's `context?` is `true` iff its name is **not** in `visible_names`.
+  Indents and ordering match `hierarchy_rows/1` over the display set. A matching
+  class whose ancestors are entirely absent from `all_classes` still renders as a
+  root (no context rows synthesised — we only ever surface ancestors that already
+  exist in the full set, never the whole stdlib tree).
+  """
+  @spec hierarchy_rows_with_context([class_row()], MapSet.t(String.t())) ::
+          [{class_row(), non_neg_integer(), boolean()}]
+  def hierarchy_rows_with_context(all_classes, visible_names) do
+    super_of =
+      Map.new(all_classes, fn c -> {Map.get(c, "name"), Map.get(c, "superclass")} end)
+
+    display_names =
+      Enum.reduce(all_classes, MapSet.new(), fn c, acc ->
+        name = Map.get(c, "name")
+
+        if MapSet.member?(visible_names, name),
+          do: add_ancestors(name, super_of, acc),
+          else: acc
+      end)
+
+    all_classes
+    |> Enum.filter(fn c -> MapSet.member?(display_names, Map.get(c, "name")) end)
+    |> hierarchy_rows()
+    |> Enum.map(fn {class, indent} ->
+      {class, indent, not MapSet.member?(visible_names, Map.get(class, "name"))}
+    end)
+  end
+
+  # Add `name` and its transitive in-set superclass ancestors to `acc`. Stops at
+  # the first ancestor not present in the full set (its superclass is unknown), so
+  # we only ever connect matches up through classes that actually exist. Guards
+  # against a superclass cycle by not revisiting a name already in `acc`.
+  defp add_ancestors(name, super_of, acc) do
+    cond do
+      name == nil -> acc
+      MapSet.member?(acc, name) -> acc
+      not Map.has_key?(super_of, name) -> acc
+      true -> add_ancestors(Map.get(super_of, name), super_of, MapSet.put(acc, name))
+    end
+  end
 end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -4515,13 +4515,19 @@ defmodule BtAttachWeb.WorkspaceLive do
   # spike's two levels, so a cap collapsed everything onto one indent and read as
   # flat). `class_rows/1` scales the visible indent from this depth.
   # Category groups by the class annotation, each group a `{category, rows}` pair.
-  # Both return `{row, indent}` tuples so the template renders one branch.
+  # Both feed `class_rows/1` `{row, indent, context?}` tuples so the template
+  # renders one branch — Category rows are always `context? = false`; only the
+  # filtered Hierarchy view (BT-2649) emits dimmed `context? = true` ancestor rows.
 
-  # Hierarchy: a flat, ordered list of `{class_row, indent}` walking the
-  # superclass tree from roots down — see `BtAttachWeb.ClassTree.hierarchy_rows/1`
-  # for the (unit-tested) layout logic. `indent` is the true superclass depth
-  # (BT-2637: uncapped) and `class_rows/1` scales the visible left-indent from it.
-  defp hierarchy_rows(classes), do: BtAttachWeb.ClassTree.hierarchy_rows(classes)
+  # Hierarchy under an active source filter (BT-2649). Builds the tree from the
+  # *full* class set so the transitive superclass ancestors connecting each
+  # matching class to a root are kept as dimmed, non-interactive "context" rows —
+  # otherwise the filtered set flattens (every match at indent 0). Returns
+  # `{class_row, indent, context?}`; a context row's name is not in `visible_names`.
+  # For the `all` filter every class is visible, so this emits zero context rows —
+  # identical shape to `hierarchy_rows/1` plus a `false` context flag.
+  defp hierarchy_rows_with_context(all_classes, visible_names),
+    do: BtAttachWeb.ClassTree.hierarchy_rows_with_context(all_classes, visible_names)
 
   # Category: `{category, [class_row]}` groups, each group's classes sorted by
   # name, the groups themselves sorted by category. A class with no category falls
@@ -6922,14 +6928,23 @@ defmodule BtAttachWeb.WorkspaceLive do
                 <div :for={{category, rows} <- category_groups(@visible_classes)} class="cat-group">
                   <div class="cat-row">{category}</div>
                   <.class_rows
-                    rows={Enum.map(rows, &{&1, 1})}
+                    rows={Enum.map(rows, &{&1, 1, false})}
                     selected_class={@selected_class}
                     browser_side={@browser_side}
                   />
                 </div>
               <% else %>
+                <%!-- BT-2649: build the Hierarchy tree from the *full* class set so
+                     the superclass ancestors connecting filtered matches up to a
+                     root survive as dimmed, non-interactive context rows. Under
+                     `all`, every class is visible, so no context rows are emitted. --%>
                 <.class_rows
-                  rows={hierarchy_rows(@visible_classes)}
+                  rows={
+                    hierarchy_rows_with_context(
+                      @browser_classes,
+                      MapSet.new(@visible_classes, &Map.get(&1, "name"))
+                    )
+                  }
                   selected_class={@selected_class}
                   browser_side={@browser_side}
                 />
@@ -7002,41 +7017,60 @@ defmodule BtAttachWeb.WorkspaceLive do
     """
   end
 
-  # Render a list of `{class_row, indent}` tuples — shared by the Hierarchy and
-  # Category views. The selected class is highlighted; an indented row reads as a
-  # subclass. A runtime-only class is badged; the class-side selection shows a
-  # `class` pill so the side is visible in the tree.
+  # Render a list of `{class_row, indent, context?}` tuples — shared by the
+  # Hierarchy and Category views. The selected class is highlighted; an indented
+  # row reads as a subclass. A runtime-only class is badged; the class-side
+  # selection shows a `class` pill so the side is visible in the tree. A
+  # `context? = true` row (BT-2649) is a filter's connecting superclass ancestor:
+  # dimmed and non-interactive, with no selection/badges.
+  #
+  # Public (not `defp`) so the dimmed/non-interactive context rendering is
+  # unit-testable via `render_component/2` in the non-workspace lane (BT-2649).
   attr :rows, :list, required: true
   attr :selected_class, :string, default: nil
   attr :browser_side, :string, required: true
 
-  defp class_rows(assigns) do
+  def class_rows(assigns) do
     ~H"""
+    <%!-- BT-2649: a `context?` row is a superclass ancestor surfaced only to keep
+         the filtered Hierarchy spine intact. It renders dimmed (`context` class),
+         carries no `phx-click`/selection and no origin/runtime badges, and is
+         skipped as a tab stop — a clearly secondary, non-interactive marker. --%>
     <div
-      :for={{class, indent} <- @rows}
+      :for={{class, indent, context?} <- @rows}
       class={[
         "row",
         indent > 0 && "subclass",
-        @selected_class == class["name"] && "sel"
+        context? && "context",
+        not context? && @selected_class == class["name"] && "sel"
       ]}
       style={class_row_indent(indent)}
-      phx-click="browser_select_class"
-      phx-value-class={class["name"]}
+      phx-click={not context? && "browser_select_class"}
+      phx-value-class={not context? && class["name"]}
+      aria-disabled={context? && "true"}
+      tabindex={context? && "-1"}
       title={class["name"]}
     >
       <span class="twig">{if class["superclass"], do: "→", else: "●"}</span>
       <span class="cls">{class["name"]}</span>
       <span
-        :if={class["source_origin"] && class["source_origin"] != "project"}
+        :if={not context? && class["source_origin"] && class["source_origin"] != "project"}
         class={"source-origin-tag #{source_origin_class(class)}"}
         title={source_origin_title(class)}
       >
         {source_origin_label(class)}
       </span>
-      <span :if={runtime_only?(class)} class="runtime-tag" title="runtime-only (not on disk)">
+      <span
+        :if={not context? && runtime_only?(class)}
+        class="runtime-tag"
+        title="runtime-only (not on disk)"
+      >
         ⚡
       </span>
-      <span :if={@selected_class == class["name"] and @browser_side == "class"} class="pill">
+      <span
+        :if={(not context? && @selected_class == class["name"]) and @browser_side == "class"}
+        class="pill"
+      >
         class
       </span>
     </div>

--- a/editors/liveview/test/bt_attach_web/class_rows_render_test.exs
+++ b/editors/liveview/test/bt_attach_web/class_rows_render_test.exs
@@ -1,0 +1,66 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.ClassRowsRenderTest do
+  @moduledoc """
+  Render tests for the System Browser class-tree rows (BT-2649). Exercises the
+  `class_rows/1` function component directly via `render_component/2`, so it runs
+  in the bare `mix test` lane (no workspace node, no browser).
+  """
+  use ExUnit.Case, async: true
+  import Phoenix.LiveViewTest
+
+  defp row(name, superclass), do: %{"name" => name, "superclass" => superclass}
+
+  defp render_rows(rows) do
+    render_component(&BtAttachWeb.WorkspaceLive.class_rows/1,
+      rows: rows,
+      selected_class: nil,
+      browser_side: "instance"
+    )
+  end
+
+  test "a matching row is interactive: it carries the select click + class value" do
+    html = render_rows([{row("ActorSnapshot", "Actor"), 2, false}])
+
+    assert html =~ ~s(phx-click="browser_select_class")
+    assert html =~ ~s(phx-value-class="ActorSnapshot")
+    assert html =~ "ActorSnapshot"
+    refute html =~ ~s(class="row subclass context")
+  end
+
+  test "a context ancestor row is dimmed and non-interactive" do
+    html = render_rows([{row("Object", nil), 0, true}])
+
+    # Dimmed via the `context` class.
+    assert html =~ "context"
+    # Non-interactive: no select click, no class value, marked disabled + untabbable.
+    refute html =~ ~s(phx-click="browser_select_class")
+    refute html =~ ~s(phx-value-class)
+    assert html =~ ~s(aria-disabled="true")
+    assert html =~ ~s(tabindex="-1")
+    # The name is still shown so the spine reads.
+    assert html =~ "Object"
+  end
+
+  test "a context ancestor carries no origin/runtime badges" do
+    cls =
+      "Object"
+      |> row(nil)
+      |> Map.merge(%{"source_origin" => "stdlib", "origin" => "runtime"})
+
+    html = render_rows([{cls, 0, true}])
+
+    refute html =~ "source-origin-tag"
+    refute html =~ "runtime-tag"
+  end
+
+  test "a matching stdlib row still carries its origin badge (no regression)" do
+    cls = Map.put(row("Number", "Object"), "source_origin", "stdlib")
+
+    html = render_rows([{cls, 1, false}])
+
+    assert html =~ "source-origin-tag"
+    assert html =~ "stdlib"
+  end
+end

--- a/editors/liveview/test/bt_attach_web/class_tree_test.exs
+++ b/editors/liveview/test/bt_attach_web/class_tree_test.exs
@@ -17,6 +17,9 @@ defmodule BtAttachWeb.ClassTreeTest do
   # Reduce the `{row, indent}` output to the `{name, indent}` pairs we assert on.
   defp names(rows), do: Enum.map(rows, fn {c, i} -> {c["name"], i} end)
 
+  # Reduce the `{row, indent, context?}` output to `{name, indent, context?}`.
+  defp names_ctx(rows), do: Enum.map(rows, fn {c, i, ctx} -> {c["name"], i, ctx} end)
+
   describe "hierarchy_rows/1" do
     test "nests a chain Object -> Actor -> ActorSnapshot at increasing indents" do
       classes = [
@@ -106,6 +109,113 @@ defmodule BtAttachWeb.ClassTreeTest do
       ]
 
       assert names(ClassTree.hierarchy_rows(classes)) == [{"A", 0}, {"B", 0}]
+    end
+  end
+
+  describe "hierarchy_rows_with_context/2 (BT-2649)" do
+    test "all classes visible emits zero context rows (= `all` filter, today's behaviour)" do
+      classes = [
+        row("ActorSnapshot", "Actor"),
+        row("Actor", "Object"),
+        row("Object", nil)
+      ]
+
+      visible = MapSet.new(["ActorSnapshot", "Actor", "Object"])
+
+      assert names_ctx(ClassTree.hierarchy_rows_with_context(classes, visible)) == [
+               {"Object", 0, false},
+               {"Actor", 1, false},
+               {"ActorSnapshot", 2, false}
+             ]
+    end
+
+    test "keeps the superclass spine as dimmed context rows under a Proj-style filter" do
+      # Only the project class matches; its Actor -> Object ancestors live in the
+      # full set and must be surfaced as context so the spine stays intact rather
+      # than flattening ActorSnapshot to the root.
+      classes = [
+        row("ActorSnapshot", "Actor"),
+        row("Actor", "Object"),
+        row("Object", nil)
+      ]
+
+      visible = MapSet.new(["ActorSnapshot"])
+
+      assert names_ctx(ClassTree.hierarchy_rows_with_context(classes, visible)) == [
+               {"Object", 0, true},
+               {"Actor", 1, true},
+               {"ActorSnapshot", 2, false}
+             ]
+    end
+
+    test "includes only the ancestors needed to connect matches, not the whole tree" do
+      # Number/Integer are loaded siblings but irrelevant to the visible match, so
+      # they are not surfaced as context.
+      classes = [
+        row("Object", nil),
+        row("Actor", "Object"),
+        row("ActorSnapshot", "Actor"),
+        row("Number", "Object"),
+        row("Integer", "Number")
+      ]
+
+      visible = MapSet.new(["ActorSnapshot"])
+
+      assert names_ctx(ClassTree.hierarchy_rows_with_context(classes, visible)) == [
+               {"Object", 0, true},
+               {"Actor", 1, true},
+               {"ActorSnapshot", 2, false}
+             ]
+    end
+
+    test "two matches sharing a spine emit each connecting ancestor once" do
+      classes = [
+        row("Object", nil),
+        row("Actor", "Object"),
+        row("ActorSnapshot", "Actor"),
+        row("Reactor", "Actor")
+      ]
+
+      visible = MapSet.new(["ActorSnapshot", "Reactor"])
+
+      assert names_ctx(ClassTree.hierarchy_rows_with_context(classes, visible)) == [
+               {"Object", 0, true},
+               {"Actor", 1, true},
+               {"ActorSnapshot", 2, false},
+               {"Reactor", 2, false}
+             ]
+    end
+
+    test "a match whose ancestors are absent from the full set renders as a root" do
+      # Actor's superclass Object is not in the full set, so no context row exists
+      # to synthesise — the matching class is its own root (edge case, no change).
+      classes = [
+        row("ActorSnapshot", "Actor"),
+        row("Actor", "Object")
+      ]
+
+      visible = MapSet.new(["Actor"])
+
+      assert names_ctx(ClassTree.hierarchy_rows_with_context(classes, visible)) == [
+               {"Actor", 0, false}
+             ]
+    end
+
+    test "a matching intermediate keeps both an ancestor context row and a descendant context-free" do
+      # Actor matches; Object (ancestor) is context, ActorSnapshot (descendant,
+      # not matching) is NOT pulled in — only ancestors connect upward.
+      classes = [
+        row("Object", nil),
+        row("Actor", "Object"),
+        row("ActorSnapshot", "Actor")
+      ]
+
+      visible = MapSet.new(["Actor"])
+
+      assert names_ctx(ClassTree.hierarchy_rows_with_context(classes, visible)) == [
+               {"Object", 0, true},
+               {"Actor", 1, false}
+             ]
     end
   end
 end


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2649

## Summary

Under the **Proj/Deps** source filter, the Hierarchy view flattened because the tree was built from the already-filtered set, dropping non-matching superclass ancestors before the walk (so e.g. project `ActorSnapshot` lost its `Actor → Object` spine). Now the connecting ancestors are surfaced as **dimmed, non-interactive context rows** so the spine stays intact.

## Key changes

- `class_tree.ex`: new pure `hierarchy_rows_with_context/2` — takes the **full** class list + the visible-name set, computes the display set = visible ∪ transitive in-set superclass ancestors, walks via the existing `hierarchy_rows/1`, and tags `context? = true` iff a row's name isn't visible. Cycle-guarded `add_ancestors/3` stops at ancestors absent from the full set (so an absent-ancestor match still renders as a root).
- `workspace_live.ex`: Hierarchy passes full `@browser_classes` + visible-name set to the new builder; Category passes plain `{row, 1, false}`; `class_rows/1` renders context rows dimmed/non-interactive (no `phx-click`, no select/badges, `aria-disabled`, `tabindex="-1"`).
- `app.css`: `.row.context` muted variant.
- Tests: 6 new ClassTree cases (order/indents/context flag, ancestor scoping, shared-spine dedup, absent-ancestor root, all-visible = no context) + a new `class_rows_render_test.exs` (dimmed/non-interactive context rows; matching rows keep clicks/badges).

## Scope

`All` filter (every class visible → zero context rows) and Category view are unchanged. Pure presentation — no runtime/browse-op change (full class set is already client-side). Doesn't regress BT-2637 nesting, the "Tests" bucket, or BT-2641/2642 badges.

## Verification

- `just build` ✓
- LiveView ExUnit — 369 passed (16 new) ✓; `mix compile --warnings-as-errors` ✓; `mix format --check-formatted` ✓; `just clippy` ✓

(The `:workspace`-gated integration tests are excluded in the bare lane; the new logic is covered by the ClassTree unit tests + the render-component test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_