### PR TITLE
Cockpit: don't let the async mount fold clobber a fresher live push (BT-2619)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -634,6 +634,21 @@ defmodule BtAttachWeb.WorkspaceLive do
       |> assign(:changes, [])
       |> assign(:changes_error, nil)
       |> assign(:autoflush, false)
+      # BT-2619 (race): per-surface "loaded" flags gating the async mount fold so a
+      # live push that lands BEFORE the mount load resolves is not clobbered by the
+      # (staler) mount snapshot. `:source_loaded` covers the source-dependent pair
+      # (browser_classes + changes — they always refresh together via
+      # `:do_source_refresh`); `:bindings_loaded` covers the bindings pane. Both
+      # start `false` and are set `true` ONLY by a *successful* push refresh (see
+      # `:do_source_refresh` / `:BindingChanged`); `handle_async(:mount_load, …)`
+      # then applies a surface's mount read only while its flag is still `false`.
+      # Success-only gating is the crux of the edge case: an early push that ERRORED
+      # leaves the flag `false`, so the later-completing mount load's *successful*
+      # data still folds in (no lingering error flash). A remount = new process =
+      # fresh `false` flags, so reconnect/resume re-loads normally. `autoflush` has
+      # no competing push, so it always folds in (no flag).
+      |> assign(:source_loaded, false)
+      |> assign(:bindings_loaded, false)
       |> start_mount_load(pid)
       # Git panel (BT-2586): the post-flush VCS surface. Loaded lazily the first
       # time the Git tab is opened (and refreshed after flush/save), so a page
@@ -1985,8 +2000,8 @@ defmodule BtAttachWeb.WorkspaceLive do
     # carries `sessionId` (BT-2530); a nil/unknown origin falls back to a refresh so a
     # session-less event can never silently freeze the pane.
     case Map.get(event, :sessionId) do
-      ^session_id -> {:noreply, assign_bindings(socket, pid)}
-      nil -> {:noreply, assign_bindings(socket, pid)}
+      ^session_id -> {:noreply, mark_bindings_loaded(assign_bindings(socket, pid))}
+      nil -> {:noreply, mark_bindings_loaded(assign_bindings(socket, pid))}
       _other_session -> {:noreply, socket}
     end
   end
@@ -2013,7 +2028,13 @@ defmodule BtAttachWeb.WorkspaceLive do
   # burst — re-pull the source-dependent surfaces ONCE for the whole burst, then
   # clear the pending flag so the next burst schedules afresh.
   def handle_info(:do_source_refresh, socket) do
-    {:noreply, refresh_after_source_change(assign(socket, source_refresh_pending: false))}
+    socket =
+      socket
+      |> assign(source_refresh_pending: false)
+      |> refresh_after_source_change()
+      |> mark_source_loaded()
+
+    {:noreply, socket}
   end
 
   # Per-object change push (BT-2492, backend BT-2489): the watched actor committed
@@ -2143,18 +2164,33 @@ defmodule BtAttachWeb.WorkspaceLive do
   # BT-2619 (race): a `BindingChanged`/`classes` live push (or any post-mount
   # action) can land *before* this mount load resolves and populate `bindings` /
   # `browser_classes` / `changes` with fresher data. This fold is the *mount-
-  # initial* state, so blindly overwriting could clobber that fresher push with
-  # staler mount data. We avoid the cheap-to-avoid cases here — when an assign has
-  # already moved off its empty mount default we keep the fresher value rather
-  # than overwrite — and leave the fully race-safe sequencing (e.g. a generation
-  # token) to BT-2619. `autoflush` is a stable settings probe with no live push,
-  # so it always folds in.
+  # initial* state, so blindly overwriting would clobber that fresher push with
+  # staler mount data.
+  #
+  # We gate each surface on its per-surface "loaded" flag (`:source_loaded` for
+  # the browser_classes + changes pair, `:bindings_loaded` for bindings): a flag
+  # is set `true` ONLY by a *successful* push refresh (see `:do_source_refresh` /
+  # `:BindingChanged`), so we apply a surface's mount read only while its flag is
+  # still `false`, then set it `true` so a later sync refresh path stays the source
+  # of truth.
+  #
+  # Success-only gating is what handles the "early push errored, mount succeeded"
+  # edge case: a push refresh that fired before this fold and itself failed (e.g.
+  # `ClassLoaded` while the workspace was momentarily unreachable → `changes_error`
+  # set, list still empty) leaves the flag `false` — so this fold's *successful*
+  # mount data still folds in and the pane shows real data rather than getting
+  # stuck on the transient error until the next push. A genuinely-empty workspace
+  # (no push at all) keeps both flags `false`, so the empty-but-successful mount
+  # read still applies and the panes render their empty state.
+  #
+  # `autoflush` is a stable settings probe with no live push, so it always folds in.
   def handle_async(:mount_load, {:ok, result}, socket) do
     socket =
       socket
-      |> fold_mount_read(:browser_classes, result.browser_classes, &apply_browser_classes/2)
-      |> fold_mount_read(:bindings, result.bindings, &apply_bindings/2)
-      |> fold_mount_read(:changes, result.changes, &apply_changes/2)
+      |> fold_mount_read(:source_loaded, result.browser_classes, &apply_browser_classes/2)
+      |> fold_mount_read(:bindings_loaded, result.bindings, &apply_bindings/2)
+      |> fold_mount_read(:source_loaded, result.changes, &apply_changes/2)
+      |> assign(source_loaded: true, bindings_loaded: true)
       # autoflush has no competing live push — always apply the mount read.
       |> apply_autoflush(result.autoflush)
 
@@ -3800,22 +3836,36 @@ defmodule BtAttachWeb.WorkspaceLive do
     end)
   end
 
-  # BT-2619 (partial): fold one mount read into its assign only if a fresher live
-  # push hasn't already populated it. We detect "already populated" cheaply: the
-  # assign still holds its empty mount default (`[]`) AND no error has been set
-  # for it. If a `BindingChanged`/`classes` push (or a post-mount action) has
-  # already filled the pane, we keep that fresher value rather than overwrite it
-  # with potentially-staler mount data. This deliberately does NOT solve the full
-  # race (a push that arrives *between* this check and a concurrent fold, or one
-  # that legitimately produces an empty list) — that hardening is BT-2619; here we
-  # only ensure the mount-initial fold never *worsens* the race.
-  defp fold_mount_read(socket, key, read, apply_fun) do
-    error_key = :"#{key}_error"
+  # BT-2619: fold one mount read into its surface's assigns only if a *successful*
+  # live push hasn't already loaded that surface. `loaded_key` is the per-surface
+  # flag (`:source_loaded` / `:bindings_loaded`): it is `true` only when a push
+  # refresh succeeded, so a `false` flag means either no push landed yet OR a push
+  # landed but errored — in both cases the mount read (which carries real,
+  # successful data here) should win. We do NOT clear the flag here; the caller
+  # sets all flags `true` after the fold so the post-mount sync refresh path
+  # remains the source of truth.
+  defp fold_mount_read(socket, loaded_key, read, apply_fun) do
+    if socket.assigns[loaded_key], do: socket, else: apply_fun.(socket, read)
+  end
 
-    already_fresh? =
-      socket.assigns[key] != [] or not is_nil(socket.assigns[error_key])
+  # BT-2619: mark the source-dependent surfaces (browser_classes + changes) as
+  # loaded by a push — but ONLY when the push refresh actually succeeded (neither
+  # surface holds an error). An errored push leaves the flag `false` so a
+  # later-completing mount fold's successful data can still replace the transient
+  # error (no lingering error flash). Idempotent: re-marking after a later success
+  # just re-affirms `true`.
+  defp mark_source_loaded(socket) do
+    if is_nil(socket.assigns.browser_error) and is_nil(socket.assigns.changes_error),
+      do: assign(socket, :source_loaded, true),
+      else: socket
+  end
 
-    if already_fresh?, do: socket, else: apply_fun.(socket, read)
+  # BT-2619: mark the bindings surface as loaded by a push — only on a successful
+  # refresh (no `bindings_error`), mirroring `mark_source_loaded/1`.
+  defp mark_bindings_loaded(socket) do
+    if is_nil(socket.assigns.bindings_error),
+      do: assign(socket, :bindings_loaded, true),
+      else: socket
   end
 
   # ── Test-runner pane data source (BT-2557) ──────────────────────────────────

--- a/editors/liveview/test/bt_attach_web/workspace_mount_load_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_mount_load_test.exs
@@ -136,15 +136,13 @@ defmodule BtAttachWeb.WorkspaceMountLoadTest do
     end
   end
 
-  describe "BT-2619 partial race guard (BT-2591)" do
+  describe "BT-2619 post-load stability (BT-2591)" do
     test "a bindings push that populated the pane is not blanked by a re-fold", %{conn: conn} do
       # NOTE: this is the *post-load* stability scenario — `render_async` resolves
       # the mount load before the push, so `handle_async(:mount_load, …)` has
-      # already run and this exercises "live pushes update the pane and the value
-      # sticks", not the concurrent race the guard ultimately protects against
-      # (a push landing *before* the fold). That truly-concurrent case — and the
-      # "early push errored, mount succeeded" variant — is deterministically
-      # testable only with the generation-token hardening in BT-2619; covered there.
+      # already run. This exercises "live pushes update the pane and the value
+      # sticks" after the fold. The truly-concurrent push-before-fold race is
+      # covered deterministically below via the stub's one-shot mount gate.
       {:ok, view, _html} = live(owner_conn(conn), "/")
       assert render_async(view, 5_000) =~ "Counter"
 
@@ -158,6 +156,152 @@ defmodule BtAttachWeb.WorkspaceMountLoadTest do
       # The fresher push value survives subsequent re-renders — the mount fold's
       # guard never overwrites a populated pane with the (now-staler) mount read.
       refute_eventually(fn -> not (render(view) =~ name) end)
+      assert Process.alive?(view.pid)
+    end
+  end
+
+  describe "BT-2619 push-before-fold race (deterministic via the mount gate)" do
+    # The stub's one-shot mount gate (`arm_mount_gate/0`) blocks the async mount
+    # load's FIRST read (`browse_classes`) until `release_mount_gate/0`, so the
+    # test can deliver a live push and let the LiveView handle it BEFORE the async
+    # mount fold runs — the exact concurrency BT-2619 protects against.
+
+    test "a bindings push landing before the fold is not clobbered by the mount read",
+         %{conn: conn} do
+      # Mount snapshot would carry NO bindings ([] default); the push carries one.
+      # With success-only loaded-flag gating the push value must survive the fold.
+      StubWorkspaceClient.put_bindings([])
+      :ok = StubWorkspaceClient.arm_mount_gate()
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # The mount-load task is now blocked on `browse_classes`. Deliver a fresher
+      # bindings push; the LiveView handles it (sets bindings + bindings_loaded)
+      # while the fold is still pending.
+      pushed = "preFoldVar#{System.unique_integer([:positive])}"
+      StubWorkspaceClient.put_bindings([{pushed, 99}])
+      send(view.pid, {:beamtalk_announcement, make_ref(), :BindingChanged, :handler, %{}})
+      assert eventually(fn -> render(view) =~ pushed end)
+
+      # Make the mount snapshot STALER than the push: when the gate releases, the
+      # mount task's `list_bindings` read will see an empty workspace. Without the
+      # loaded-flag guard the fold would blank the pushed binding to []; with the
+      # guard (bindings_loaded set true by the push) the fold skips this surface.
+      StubWorkspaceClient.put_bindings([])
+
+      :ok = StubWorkspaceClient.release_mount_gate()
+      _ = render_async(view, 5_000)
+
+      assert render(view) =~ pushed
+      assert Process.alive?(view.pid)
+    end
+
+    test "a source (ClassLoaded) push landing before the fold is not clobbered",
+         %{conn: conn} do
+      # A user-defined class appears via eval; the ClassLoaded push refreshes the
+      # browser surface BEFORE the fold and marks source_loaded. We then make the
+      # mount snapshot STALER (drop the class) before releasing the gate: without
+      # the loaded-flag guard the fold would revert the class tree to the staler
+      # snapshot; with the guard the fold skips the already-loaded source surface.
+      :ok = StubWorkspaceClient.arm_mount_gate()
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # Define a class so the push's browse includes it, then deliver the
+      # ClassLoaded push BEFORE the fold. The push refresh (`browse_classes`) is not
+      # gated (the gate is one-shot, consumed by the mount task's first read).
+      {:ok, _r, _o, _w} = StubWorkspaceClient.eval(self(), "Actor subclass: RaceClass")
+
+      send(
+        view.pid,
+        {:beamtalk_announcement, make_ref(), :ClassLoaded, :handler, %{}}
+      )
+
+      assert eventually(fn -> render(view) =~ "RaceClass" end)
+
+      # Make the mount snapshot staler than the push, then release the gate.
+      StubWorkspaceClient.clear_defined_classes()
+      :ok = StubWorkspaceClient.release_mount_gate()
+      _ = render_async(view, 5_000)
+
+      # The push-loaded class must remain visible (the fold did not revert the
+      # source surface to the staler mount snapshot).
+      assert render(view) =~ "RaceClass"
+      assert render(view) =~ "Counter"
+      assert Process.alive?(view.pid)
+    end
+
+    test "an errored early bindings push does NOT lock out a successful mount fold",
+         %{conn: conn} do
+      # The edge case: an early push refresh that FAILS (sets bindings_error, list
+      # stays empty) must NOT set bindings_loaded — so the later-completing mount
+      # load's SUCCESSFUL data still folds in (no lingering error flash).
+      :ok = StubWorkspaceClient.arm_mount_gate()
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # The mount load is blocked. Seed the mount snapshot to carry a real binding,
+      # but make the in-flight push refresh FAIL by handing the bindings re-read an
+      # error result. We model the error by sending the push while bindings return
+      # an error shape: drive it through the stub's error path.
+      mounted = "mountVar#{System.unique_integer([:positive])}"
+      StubWorkspaceClient.put_bindings([{mounted, 1}])
+      # Force the push refresh's `list_bindings` to error.
+      StubWorkspaceClient.fail_bindings(true)
+
+      send(view.pid, {:beamtalk_announcement, make_ref(), :BindingChanged, :handler, %{}})
+      # The push refresh errored: the pane shows its error, not the binding yet.
+      assert eventually(fn -> render(view) =~ "bindings-panel" end)
+
+      # Stop failing so the mount read succeeds, then release the gate. Because the
+      # errored push did NOT set bindings_loaded, the mount fold's successful data
+      # applies — the real binding shows, replacing the transient error.
+      StubWorkspaceClient.fail_bindings(false)
+      :ok = StubWorkspaceClient.release_mount_gate()
+      _ = render_async(view, 5_000)
+
+      assert eventually(fn -> render(view) =~ mounted end)
+      assert Process.alive?(view.pid)
+    end
+  end
+
+  describe "BT-2619 empty workspace + autoflush" do
+    test "a genuinely-empty workspace still shows its empty state after mount", %{conn: conn} do
+      # No push occurs, so both loaded flags stay false and the (empty-but-success)
+      # mount read still folds in — the empty state must render, not stay blank
+      # forever.
+      StubWorkspaceClient.put_bindings([])
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      html = render_async(view, 5_000)
+      assert html =~ "bindings-panel"
+      # Browser classes still fold in from the stub default (no push gated them).
+      assert html =~ "Counter"
+      assert Process.alive?(view.pid)
+    end
+
+    test "autoflush always folds in even after a source push (no competing push)",
+         %{conn: conn} do
+      # autoflush has no live push, so the mount fold must apply it unconditionally
+      # — even when a source push set source_loaded. We seed autoflush true and
+      # assert the post-save git refresh gate sees it (a save shells out to git).
+      StubWorkspaceClient.set_autoflush(true)
+      :ok = StubWorkspaceClient.arm_mount_gate()
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      send(view.pid, {:beamtalk_announcement, make_ref(), :ClassLoaded, :handler, %{}})
+      assert eventually(fn -> render(view) =~ "Counter" end)
+
+      :ok = StubWorkspaceClient.release_mount_gate()
+      _ = render_async(view, 5_000)
+
+      # The mount fold applied autoflush despite the source push: assert the LiveView
+      # is alive and rendered (autoflush itself is internal state; its application is
+      # exercised by the git-refresh-on-save tests — here we assert the fold ran and
+      # did not crash applying autoflush after a push).
+      assert render(view) =~ "Counter"
       assert Process.alive?(view.pid)
     end
   end

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -54,6 +54,14 @@ defmodule BtAttachWeb.StubWorkspaceClient do
               # surfaced by `change_history` so the Changes-pane disclosure caret +
               # structured diff render can be driven without a real workspace.
               change_diffs: %{},
+              # BT-2619: a one-shot barrier for the async mount-load reads. When a
+              # test arms the gate (`arm_mount_gate/0`), the FIRST `browse_classes`
+              # call (the mount-load task's first read) blocks until the test calls
+              # `release_mount_gate/0` — letting the test deterministically deliver a
+              # live push BEFORE the async mount fold runs, the BT-2619 race. The gate
+              # disarms itself on first use, so the subsequent push-refresh reads (and
+              # the now-released mount reads) never block.
+              mount_gate: nil,
               calls: []
   end
 
@@ -117,10 +125,26 @@ defmodule BtAttachWeb.StubWorkspaceClient do
     end
   end
 
-  def list_bindings(_pid), do: get(:bindings) || []
+  @doc """
+  Test helper (BT-2619): drop all eval-defined classes so a subsequent
+  `browse_classes` returns only the canned base rows. Lets a test make the mount
+  load's source read STALER than a fresher live push.
+  """
+  def clear_defined_classes, do: put(:defined_classes, MapSet.new())
+
+  def list_bindings(_pid) do
+    if get(:fail_bindings), do: {:error, :unreachable}, else: get(:bindings) || []
+  end
 
   @doc "Test helper (BT-2634): seed the workspace bindings the bindings pane reads."
   def put_bindings(pairs) when is_list(pairs), do: put(:bindings, pairs)
+
+  @doc """
+  Test helper (BT-2619): force `list_bindings/1` to return `{:error, :unreachable}`
+  so a test can drive the bindings push-refresh ERROR path (the "errored early push
+  must not lock out a successful mount fold" edge case).
+  """
+  def fail_bindings(flag) when is_boolean(flag), do: put(:fail_bindings, flag)
 
   # BT-2634: a supervisor's inspection content is its children / supervision tree
   # (drillable child handles), not actor instance vars. The stub keys variants off
@@ -425,7 +449,60 @@ defmodule BtAttachWeb.StubWorkspaceClient do
 
   # ── Browse ops ───────────────────────────────────────────────────────────
 
+  @doc """
+  Test helper (BT-2619): arm the one-shot mount-load barrier. The next
+  `browse_classes` call (the async mount-load task's first read) will block until
+  `release_mount_gate/0` is called, so a test can deliver a live push BEFORE the
+  async mount fold runs and assert the fold does not clobber it.
+  """
+  def arm_mount_gate do
+    {:ok, gate} = Agent.start(fn -> false end)
+    put(:mount_gate, gate)
+    put(:mount_gate_consumed, false)
+    :ok
+  end
+
+  @doc "Test helper (BT-2619): release the armed mount-load barrier (see `arm_mount_gate/0`)."
+  def release_mount_gate do
+    case get(:mount_gate) do
+      nil -> :ok
+      gate -> if Process.alive?(gate), do: Agent.update(gate, fn _ -> true end), else: :ok
+    end
+  end
+
+  # Block on the armed gate (if any). Only the FIRST read to reach the gate waits;
+  # `:mount_gate_consumed` marks it spent so later reads (the push refresh, the
+  # released mount reads) pass straight through. The gate ref itself is kept until
+  # the test releases it, so `release_mount_gate/0` can find it.
+  defp await_mount_gate do
+    case get(:mount_gate) do
+      nil ->
+        :ok
+
+      gate ->
+        consumed = get(:mount_gate_consumed)
+
+        if consumed do
+          :ok
+        else
+          put(:mount_gate_consumed, true)
+          wait_for_release(gate)
+        end
+    end
+  end
+
+  defp wait_for_release(gate) do
+    if Process.alive?(gate) and Agent.get(gate, & &1) == false do
+      Process.sleep(5)
+      wait_for_release(gate)
+    else
+      :ok
+    end
+  end
+
   def browse_classes do
+    await_mount_gate()
+
     base = [
       # BT-2642: project rows carry the project package name (`project_package_name/0`
       # in the backend), so the editor header's project package badge can be reached

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -62,6 +62,7 @@ defmodule BtAttachWeb.StubWorkspaceClient do
               # disarms itself on first use, so the subsequent push-refresh reads (and
               # the now-released mount reads) never block.
               mount_gate: nil,
+              mount_gate_consumed: false,
               calls: []
   end
 
@@ -456,7 +457,9 @@ defmodule BtAttachWeb.StubWorkspaceClient do
   async mount fold runs and assert the fold does not clobber it.
   """
   def arm_mount_gate do
-    {:ok, gate} = Agent.start(fn -> false end)
+    # `start_link` (not `start`) so the gate is linked to the test process and dies
+    # with it — no orphaned Agent accumulating across the suite.
+    {:ok, gate} = Agent.start_link(fn -> false end)
     put(:mount_gate, gate)
     put(:mount_gate_consumed, false)
     :ok


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2619

## Summary

BT-2591's async mount load could clobber a fresher live push: if a `ClassLoaded`/`ClassRemoved` or `bindings_changed` push was handled before the `:mount_load` task completed, the async fold reverted the pane to the older mount snapshot (window largest when the workspace is slow). This replaces BT-2591's interim `fold_mount_read` heuristic with a correct, success-gated mechanism.

## Gating rule — per-surface success-only "loaded" flags

- `:source_loaded` (covers browser_classes + changes, which refresh together via `:do_source_refresh`) and `:bindings_loaded` init `false` at mount.
- A push-refresh handler sets its flag `true` **only on the success branch** — `mark_source_loaded/1` iff `browser_error` and `changes_error` are both nil; `mark_bindings_loaded/1` iff `bindings_error` is nil.
- `handle_async(:mount_load, …)` applies each surface's mount read only while its flag is still `false` (`fold_mount_read/4` is now a one-line flag check), then sets all flags `true` so the sync refresh path stays source-of-truth. `autoflush` has no competing push → always folds.
- A remount = new process = fresh `false` flags → reconnect/resume unaffected.

## Edge case (documented on the issue): early *errored* push must not lock out a successful mount

Because the flag is set true only on a **successful** push, an early push that errored leaves the flag `false`, so the later-completing mount fold's successful data still applies over the transient error — no lingering error flash. A genuinely-empty workspace (no push) keeps both flags `false`, so the empty-but-successful mount read still folds in.

## Key changes

- `workspace_live.ex`: flags + `mark_source_loaded/1` / `mark_bindings_loaded/1`; rewritten `fold_mount_read/4`; push handlers + fold updated; interim heuristic removed.
- `stub_workspace_client.ex`: one-shot mount gate (`arm_mount_gate/0` / `release_mount_gate/0`), `fail_bindings/1`, `clear_defined_classes/0` for deterministic race tests.
- `workspace_mount_load_test.exs`: deterministic push-before-fold race tests (source + bindings), errored-early-push, empty-workspace, autoflush.

## Verification

- `just build` ✓; `just clippy` ✓
- LiveView ExUnit — 388 passed (mount-load file 10/10) ✓; `mix compile --warnings-as-errors` ✓; `mix format --check-formatted` ✓
- Mutation-checked: source + bindings race tests fail with the guard removed; the errored-push test fails under naive (always-set-loaded) gating and passes under success-only gating.

The low-priority error-render-RPC-on-socket note from the issue was left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_