### PR TITLE
Cockpit: async-ify the Tests pane list_tests discovery read (BT-2599)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -420,6 +420,11 @@ defmodule BtAttachWeb.WorkspaceLive do
       # `phx-disable-with` alone reverts as soon as the (now-immediate) event
       # handler re-renders, since the work moved off-socket to `start_async`.
       |> assign(:tests_running, false)
+      # BT-2599: a transient flag for the off-socket `:test_discover` catalogue
+      # discovery — true only while a partial-load re-discovery is in flight so
+      # `handle_async(:test_discover, …)` keeps the partial-load `tests_error`
+      # banner across a successful re-discovery (see `apply_test_classes/3`).
+      |> assign(:tests_discover_keep_error, false)
       # REPL tab (BT-2543): a classic TUI request→response scrollback with the
       # input pinned at the bottom. `:repl` is the scrollback stream (so long
       # history never bloats the assigns/diff); `:repl_seq` mints stable entry
@@ -956,10 +961,16 @@ defmodule BtAttachWeb.WorkspaceLive do
   # catalogue); running tests is `:execute` (Owner-only, it evaluates code), so
   # the run controls are owner-gated in the template, mirroring the eval form.
 
-  # Re-discover the test catalogue (the "refresh" affordance + lazy first load).
+  # Re-discover the test catalogue (the "refresh" affordance). The discovery is a
+  # `:read` reflection op, but it is still a blocking workspace RPC — so it runs
+  # off-socket via `discover_test_classes/1` (`:test_discover` `start_async`,
+  # BT-2599) rather than stalling the LiveView process against a slow node. We
+  # reset `test_classes` to the nil sentinel so the pane shows its "discovering"
+  # state (not the misleading "No TestCase subclasses" empty-state) until the
+  # `handle_async(:test_discover, …)` fold resolves.
   @impl true
   def handle_event("tests_refresh", _params, socket) do
-    {:noreply, assign_test_classes(socket)}
+    {:noreply, socket |> assign(:test_classes, nil) |> discover_test_classes()}
   end
 
   # Run every loaded TestCase subclass (`test-all`).
@@ -2242,6 +2253,43 @@ defmodule BtAttachWeb.WorkspaceLive do
        tests_running: false,
        test_results: nil,
        tests_error: "The test run failed unexpectedly."
+     )}
+  end
+
+  # BT-2599: the off-socket test-catalogue discovery (`discover_test_classes/1` →
+  # `list_tests`, `:read`) completed. We fold the raw dispatch outcome onto the
+  # socket through the pure `apply_test_classes/3` helper — the same path the
+  # load-tests re-discovery uses — so the async and sync callers agree. The
+  # `keep_error?` flag (set by the partial-load re-discovery) rides a transient
+  # assign so a *successful* re-discovery doesn't clear a partial-load banner.
+  def handle_async(:test_discover, {:ok, result}, socket) do
+    keep_error? = socket.assigns[:tests_discover_keep_error] || false
+
+    {:noreply,
+     socket
+     |> apply_test_classes(result, keep_error?)
+     |> assign(:tests_discover_keep_error, false)}
+  end
+
+  # A newer discovery (rapid double-refresh / open-then-refresh) `cancel_async`-ed
+  # this one — a no-op, mirroring the `:git_load` / `:test_op` cancellation. The
+  # replacement task already reset `test_classes` to the nil sentinel, so the
+  # pane stays in its "discovering" state until that newer result lands.
+  def handle_async(:test_discover, {:exit, :cancelled}, socket), do: {:noreply, socket}
+
+  # The discovery task crashed/exited. Degrade to a `tests_error` rather than
+  # taking down the socket (matching the `:git_load` / `:test_op` crash handlers).
+  # Leave `test_classes` at the nil sentinel so the pane shows only the error —
+  # not the misleading "No TestCase subclasses" empty-state — and retries on the
+  # next open/refresh.
+  def handle_async(:test_discover, {:exit, reason}, socket) do
+    Logger.error("test discovery crashed: #{inspect(reason)}", domain: [:beamtalk, :liveview])
+
+    {:noreply,
+     assign(socket,
+       test_classes: nil,
+       tests_error: "Couldn't discover tests — the discovery failed unexpectedly.",
+       tests_discover_keep_error: false
      )}
   end
 
@@ -3874,25 +3922,59 @@ defmodule BtAttachWeb.WorkspaceLive do
   # the tab keeps the already-loaded list — use `tests_refresh` to re-discover.
   defp ensure_test_classes(socket) do
     if is_nil(socket.assigns.test_classes),
-      do: assign_test_classes(socket),
+      do: discover_test_classes(socket),
       else: socket
   end
 
   # Discover the live image's TestCase subclasses + selectors (`list_tests`,
-  # `:read`). A dispatch failure / RBAC denial renders a `tests_error` rather
-  # than crashing the pane, mirroring `assign_changes/1`.
-  defp assign_test_classes(socket) do
-    case Facade.dispatch(:list_tests, %{}, ctx(socket)) do
-      {:ok, classes} when is_list(classes) ->
-        assign(socket, test_classes: classes, tests_error: nil)
+  # `:read`). Although `:read` reflection is usually fast, it is still a blocking
+  # workspace RPC: against a slow/unresponsive node the ~5s timeout would stall
+  # the LiveView process (first Tests-tab open / every manual Refresh). So it
+  # runs off-socket in a `:test_discover` `start_async` task, mirroring the test
+  # run/load `:test_op` (BT-2597) and the git panel's `:git_load` (BT-2590). A
+  # rapid double-refresh / open-then-refresh `cancel_async`-es the prior probe so
+  # only the latest result wins; the result lands in
+  # `handle_async(:test_discover, …)`. The `test_classes` nil sentinel is
+  # preserved meanwhile so the pane shows its "discovering" state rather than the
+  # misleading "No TestCase subclasses" empty-state.
+  # `keep_error?` is set by the load-tests re-discovery path: a partial load has
+  # already populated `tests_error` with its compile-error summary, and a
+  # *successful* discovery must NOT clear it (it would swallow the partial-load
+  # banner). The flag rides a transient assign that `handle_async/3` consumes.
+  defp discover_test_classes(socket, keep_error? \\ false) do
+    ctx = ctx(socket)
 
-      {:error, reason} ->
-        # Leave the catalogue as the nil sentinel (not []) so the pane shows only
-        # the error — not the misleading "No TestCase subclasses" empty-state —
-        # and so re-opening the tab retries discovery (a transient failure heals).
-        assign(socket, test_classes: nil, tests_error: facade_error(reason))
-    end
+    socket
+    |> assign(:tests_discover_keep_error, keep_error?)
+    |> cancel_async(:test_discover, :cancelled)
+    |> start_async(:test_discover, fn ->
+      # Off the LiveView process — capture only `ctx`, never `socket`.
+      Facade.dispatch(:list_tests, %{}, ctx)
+    end)
   end
+
+  # Apply a completed `list_tests` dispatch to the socket. Pure (no dispatch);
+  # shared by `handle_async(:test_discover, …)` so the async path and the
+  # load-tests re-discovery agree (mirrors `apply_test_result/2` and
+  # `apply_git_status/2`). A dispatch failure / RBAC denial renders a
+  # `tests_error` rather than crashing the pane, mirroring `apply_changes/2`.
+  #
+  # On success we normally clear `tests_error` (a stale failure heals), but when
+  # `keep_error?` is true (a partial load is showing its compile-error summary)
+  # we leave `tests_error` intact so the banner survives the re-discovery.
+  defp apply_test_classes(socket, {:ok, classes}, keep_error?) when is_list(classes) do
+    socket = assign(socket, :test_classes, classes)
+    if keep_error?, do: socket, else: assign(socket, :tests_error, nil)
+  end
+
+  defp apply_test_classes(socket, {:error, reason}, _keep_error?),
+    # Leave the catalogue as the nil sentinel (not []) so the pane shows only the
+    # error — not the misleading "No TestCase subclasses" empty-state — and so
+    # re-opening the tab retries discovery (a transient failure heals).
+    do: assign(socket, test_classes: nil, tests_error: facade_error(reason))
+
+  defp apply_test_classes(socket, _other, _keep_error?),
+    do: assign(socket, test_classes: nil, tests_error: facade_error(:unexpected_test_result))
 
   # Run all tests (`class` = nil) or a single class (`run_tests`, `:execute`).
   #
@@ -3945,16 +4027,25 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   # Apply a completed `load_tests` dispatch: refresh the catalogue to show
   # whatever loaded, surfacing partial compile errors as `tests_error`. The
-  # `assign_test_classes/1` re-discovery is a lightweight `:read` reflection (not
-  # the heavy compile), so it stays synchronous here.
+  # re-discovery is kicked off via the off-socket `:test_discover` task
+  # (`discover_test_classes/2`) so the fold never blocks the LiveView process.
+  #
+  # We reset `test_classes` to the nil sentinel so the catalogue shows its
+  # "discovering" state until the off-socket re-discovery resolves with the
+  # freshly-loaded classes, and pass `keep_error?: true` so the later
+  # `handle_async(:test_discover, …)` fold doesn't clear this partial-load
+  # banner on a successful re-discovery.
   defp apply_test_load(socket, {:ok, %{"errors" => [_ | _] = errors}}),
-    do: socket |> assign_test_classes() |> assign(tests_error: load_tests_error(errors))
+    do:
+      socket
+      |> assign(test_classes: nil, tests_error: load_tests_error(errors))
+      |> discover_test_classes(true)
 
-  # `assign_test_classes/1` already clears `tests_error` on a successful
-  # re-discovery and sets it on failure — so it is the last writer, with no
-  # trailing `assign(tests_error: nil)` that would swallow a re-discovery error.
+  # A clean load simply re-discovers the catalogue off-socket; the
+  # `handle_async(:test_discover, …)` fold clears any stale `tests_error` on
+  # success (via `apply_test_classes/3`) and sets it on failure.
   defp apply_test_load(socket, {:ok, _result}),
-    do: assign_test_classes(socket)
+    do: socket |> assign(test_classes: nil) |> discover_test_classes()
 
   defp apply_test_load(socket, {:error, reason}),
     do: assign(socket, tests_error: facade_error(reason))
@@ -8385,10 +8476,12 @@ defmodule BtAttachWeb.WorkspaceLive do
                       >
                         Load tests
                       </button>
-                      <%!-- BT-2597: also gated by `@tests_running` — a manual
-                           refresh mid-load issues a synchronous `list_tests`
-                           that would race the in-flight load's own re-discovery
-                           (`apply_test_load`) and could flash a stale catalogue. --%>
+                      <%!-- BT-2597/BT-2599: also gated by `@tests_running` — a
+                           manual refresh mid-load kicks off a `:test_discover`
+                           probe (`tests_refresh`) that would race the in-flight
+                           load's own re-discovery (`apply_test_load`) and could
+                           flash a stale catalogue. (Discovery itself is now
+                           off-socket via `start_async`, BT-2599.) --%>
                       <button
                         type="button"
                         class="btn ghost"

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -106,8 +106,12 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
       {:ok, view, _html} = live(observer_conn(conn), "/")
 
       # Discovery (`list_tests`) is :read — opening the Tests tab lists the
-      # catalogue without an authorization refusal.
-      listed = render_hook(view, "dock_tab", %{"tab" => "tests"})
+      # catalogue without an authorization refusal. BT-2599: discovery now runs
+      # off-socket (`start_async`), so await it; this also ensures the discovery
+      # success fold settles *before* the run below, so it can't clear the
+      # run-refusal error (`tests_error`) out from under the assertion.
+      render_hook(view, "dock_tab", %{"tab" => "tests"})
+      listed = render_async(view, 30_000)
       refute listed =~ "Not authorized"
 
       # Running (`run_tests`) is :execute — the Run controls are owner-gated away,

--- a/editors/liveview/test/bt_attach_web/workspace_tests_pane_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_tests_pane_test.exs
@@ -16,6 +16,11 @@ defmodule BtAttachWeb.WorkspaceTestsPaneTest do
       `handle_async`; an error degrades to a `tests_error` rather than crashing.
     * F2 — switching to a source filter that hides the selected class clears the
       selection (and its method pane).
+    * F4 — (BT-2599) catalogue discovery (`list_tests`) runs off-socket via
+      `start_async(:test_discover, …)`: the pane shows a "discovering" state
+      (nil sentinel, not the empty-state) until it resolves, an error / crash
+      degrades to a `tests_error` rather than taking down the socket, and a
+      partial-load compile-error banner survives the off-socket re-discovery.
   """
   use BtAttachWeb.ConnCase, async: false
 
@@ -145,6 +150,128 @@ defmodule BtAttachWeb.WorkspaceTestsPaneTest do
       html = render_async(view)
 
       assert html =~ "unexpected_test_result"
+      assert Process.alive?(view.pid)
+    end
+  end
+
+  describe "F4: non-blocking catalogue discovery (start_async, BT-2599)" do
+    test "opening the Tests tab discovers off-socket and renders the catalogue", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # The first open seeds the nil sentinel ("Loading tests…") and kicks off the
+      # `:test_discover` async task; the catalogue lands once it resolves.
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+      html = render_async(view)
+
+      assert html =~ "StubDemoTest"
+      refute html =~ "No TestCase subclasses"
+      assert Process.alive?(view.pid)
+    end
+
+    test "Refresh re-discovers off-socket without blocking the socket", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+      assert render_async(view) =~ "StubDemoTest"
+
+      # Manual refresh kicks off another `:test_discover` and returns immediately;
+      # the refreshed catalogue fills in from handle_async.
+      render_click(view, "tests_refresh")
+      html = render_async(view)
+
+      assert html =~ "StubDemoTest"
+      assert Process.alive?(view.pid)
+    end
+
+    test "shows a discovering state, not the empty state, until discovery resolves",
+         %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # Immediately after opening the tab (before render_async drains the task),
+      # the pane shows the nil-sentinel "Loading tests…" — not the misleading
+      # "No TestCase subclasses" empty-state that [] would render.
+      html = render_click(view, "dock_tab", %{"tab" => "tests"})
+
+      assert html =~ "Loading tests…"
+      refute html =~ "No TestCase subclasses"
+      assert Process.alive?(view.pid)
+    end
+
+    test "a discovery error degrades to a pane error, not a LiveView crash", %{conn: conn} do
+      # The async dispatch returns an error; `apply_test_classes/3` folds it into
+      # `tests_error` and leaves `test_classes` at the nil sentinel — so the pane
+      # shows the error, not the empty-state.
+      StubWorkspaceClient.set_test_classes({:error, :workspace_unreachable})
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+      html = render_async(view)
+
+      refute html =~ "StubDemoTest"
+      refute html =~ "No TestCase subclasses"
+      assert Process.alive?(view.pid)
+    end
+
+    test "an unexpected discovery reply shape degrades, not crashes", %{conn: conn} do
+      # A non-{:ok,list}/{:error,_} reply must hit the total `apply_test_classes/3`
+      # clause rather than crashing handle_async on an unmatched shape.
+      StubWorkspaceClient.set_test_classes(:bogus)
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+      html = render_async(view)
+
+      assert html =~ "unexpected_test_result"
+      assert Process.alive?(view.pid)
+    end
+
+    test "a discovery crash degrades to tests_error, not a LiveView crash", %{conn: conn} do
+      # The discovery task itself raises, so `handle_async(:test_discover, {:exit, …})`
+      # runs — degrade to a pane error rather than taking down the socket.
+      StubWorkspaceClient.set_list_tests_raise(true)
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+      html = render_async(view)
+
+      assert html =~ "discovery failed unexpectedly"
+      refute html =~ "No TestCase subclasses"
+      assert Process.alive?(view.pid)
+    end
+
+    test "a clean Load tests re-discovers the freshly-loaded catalogue", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+      assert render_async(view) =~ "StubDemoTest"
+
+      # Load (a `:test_op` async) then its `apply_test_load` kicks off the
+      # `:test_discover` re-discovery; render_async drains both. No error banner.
+      render_click(view, "load_tests")
+      html = render_async(view)
+
+      assert html =~ "StubDemoTest"
+      refute html =~ "failed to load"
+      assert Process.alive?(view.pid)
+    end
+
+    test "a partial Load tests keeps the compile-error banner across re-discovery",
+         %{conn: conn} do
+      # A partial load returns compile errors; `apply_test_load` surfaces them as
+      # `tests_error` and passes keep_error?: true so the *successful* off-socket
+      # re-discovery doesn't swallow the banner.
+      StubWorkspaceClient.set_load_tests(
+        {:ok, %{"errors" => [%{"path" => "test/foo.bt", "message" => "boom"}]}}
+      )
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      render_click(view, "dock_tab", %{"tab" => "tests"})
+      assert render_async(view) =~ "StubDemoTest"
+
+      render_click(view, "load_tests")
+      html = render_async(view)
+
+      assert html =~ "failed to load"
+      # The catalogue still re-discovers (banner sits beside the catalogue).
+      assert html =~ "StubDemoTest"
       assert Process.alive?(view.pid)
     end
   end

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -404,6 +404,11 @@ defmodule BtAttachWeb.StubWorkspaceClient do
 
   def list_tests do
     record({:list_tests})
+
+    # BT-2599: simulate a discovery crash so the `:test_discover` async task hits
+    # its `{:exit, …}` clause (degrade-to-error rather than crash the socket).
+    if get(:list_tests_raise), do: raise("simulated list_tests crash")
+
     get(:test_classes) || {:ok, default_test_classes()}
   end
 
@@ -419,6 +424,9 @@ defmodule BtAttachWeb.StubWorkspaceClient do
 
   @doc "Test helper: seed the simulated `list_tests` result."
   def set_test_classes(result), do: put(:test_classes, result)
+
+  @doc "Test helper: make `list_tests` raise (drives the `:test_discover` `{:exit, …}` path)."
+  def set_list_tests_raise(flag), do: put(:list_tests_raise, flag)
 
   @doc "Test helper: seed the simulated `run_tests` result."
   def set_run_tests(result), do: put(:run_tests_result, result)


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2599

## Summary

The Tests pane's `list_tests` discovery read was the only Tests-pane workspace call still synchronous on the LiveView process (BT-2597 already async-ified `run_tests`/`load_tests`). Against a slow/unresponsive node the ~5s RPC timeout stalled the first Tests-tab open and every manual refresh. This moves discovery off-socket via `start_async`, mirroring the existing `:test_op` / `:git_load` pattern.

## Key changes

- `workspace_live.ex`: replaced synchronous `assign_test_classes/1` with `discover_test_classes/2` — `cancel_async`-es any prior `:test_discover` then `start_async`-es `Facade.dispatch(:list_tests, …)` (captures only `ctx`). Extracted a pure `apply_test_classes/3` (mirrors `apply_test_result/2` / `apply_git_status/2`) shared by the async fold and load-tests re-discovery; handles `{:ok, list}`, `{:error, _}`, and an unexpected-shape catch-all. Added `handle_async(:test_discover, …)`: `{:ok}` folds; `{:exit, :cancelled}` no-op; `{:exit, reason}` logs + degrades to `tests_error` (socket survives). `tests_refresh` + `ensure_test_classes` now go through the async path.
- Tests: new F4 group in `workspace_tests_pane_test.exs` (incl. the `{:exit, …}` crash path via a new `set_list_tests_raise/1` stub).

## Preserved behaviour

- **nil/[] discovering-vs-empty distinction**: callers reset `test_classes` to `nil` before discovery, so the render shows "Loading tests…" (nil) until `handle_async` resolves, vs "No TestCase subclasses" ([]). Error/exit paths leave it `nil` (not `[]`) so the pane shows only the error and retries on next open/refresh.
- A partial-load compile-error banner survives a successful off-socket re-discovery via a transient `tests_discover_keep_error` flag (the async ordering would otherwise clear `tests_error`).
- Refresh-disabled-while-running guard kept.

## Verification

- `just build` ✓; `just clippy` ✓
- LiveView ExUnit — 396 passed (tests-pane file 18) ✓; `mix compile --warnings-as-errors` ✓; `mix format --check-formatted` ✓
- (The crash test emits expected `[error]` log lines from the simulated crash + the defensive log — intentional.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_