### PR TITLE
refactor: move parse_repl_port/parse_repl_workspace_id into beamtalk-workspace

### DIFF
--- a/crates/beamtalk-mcp/src/workspace.rs
+++ b/crates/beamtalk-mcp/src/workspace.rs
@@ -76,21 +76,14 @@ pub fn discover_port(workspace_id: Option<&str>) -> Option<u16> {
 ///
 /// Expects a line like: `Connected to REPL backend on port 12345.`
 pub fn parse_repl_port(stdout: &str) -> Option<u16> {
-    stdout.lines().find_map(|line| {
-        line.strip_prefix("Connected to REPL backend on port ")
-            .and_then(|rest| rest.trim_end_matches('.').trim().parse().ok())
-    })
+    beamtalk_workspace::parse_repl_port(stdout)
 }
 
 /// Parse the workspace ID from `beamtalk repl` stdout.
 ///
 /// Expects a line like: `  Workspace: abc123def456 (new)`
 pub fn parse_workspace_id(stdout: &str) -> Option<String> {
-    stdout.lines().find_map(|line| {
-        line.strip_prefix("  Workspace: ")
-            .and_then(|rest| rest.split_whitespace().next())
-            .map(std::string::ToString::to_string)
-    })
+    beamtalk_workspace::parse_repl_workspace_id(stdout)
 }
 
 /// Find any running workspace and return its port, cookie, and workspace ID.
@@ -272,57 +265,6 @@ mod tests {
         let dir = beamtalk_workspace::workspace_dir("abc123def456");
         assert!(dir.is_ok());
         assert!(dir.unwrap().ends_with("abc123def456"));
-    }
-
-    #[test]
-    fn test_parse_repl_port_typical() {
-        // Mirrors real `beamtalk repl` output order: the Workspace line is
-        // printed before the port line (repl/mod.rs). Parsing is order-agnostic,
-        // but the fixture matches reality so it can't mislead a maintainer.
-        let stdout = "Welcome to beamtalk REPL\n  Workspace: abc123def456 (new)\nConnected to REPL backend on port 9876.\n";
-        assert_eq!(parse_repl_port(stdout), Some(9876));
-    }
-
-    #[test]
-    fn test_parse_repl_port_missing() {
-        assert_eq!(parse_repl_port("some other output\n"), None);
-        assert_eq!(parse_repl_port(""), None);
-    }
-
-    #[test]
-    fn test_parse_repl_port_malformed() {
-        assert_eq!(
-            parse_repl_port("Connected to REPL backend on port notanumber.\n"),
-            None
-        );
-    }
-
-    #[test]
-    fn test_parse_workspace_id_typical() {
-        // Real output order: Workspace line precedes the port line (repl/mod.rs).
-        let stdout = "  Workspace: abc123def456 (new)\nConnected to REPL backend on port 9876.\n";
-        assert_eq!(parse_workspace_id(stdout), Some("abc123def456".to_string()));
-    }
-
-    #[test]
-    fn test_parse_workspace_id_missing() {
-        assert_eq!(parse_workspace_id("no workspace line\n"), None);
-        assert_eq!(parse_workspace_id(""), None);
-    }
-
-    #[test]
-    fn test_parse_workspace_id_bare() {
-        assert_eq!(
-            parse_workspace_id("  Workspace: deadbeef1234\n"),
-            Some("deadbeef1234".to_string())
-        );
-    }
-
-    #[test]
-    fn test_parse_workspace_id_empty_prefix() {
-        // "  Workspace: " present but no ID — must return None, not Some("")
-        assert_eq!(parse_workspace_id("  Workspace: \n"), None);
-        assert_eq!(parse_workspace_id("  Workspace: "), None);
     }
 
     #[test]

--- a/crates/beamtalk-parity-tests/src/pool.rs
+++ b/crates/beamtalk-parity-tests/src/pool.rs
@@ -6,11 +6,6 @@
 //! The harness starts at most one workspace per process. The same workspace is
 //! reused by every REPL and MCP case in a run — this is the key contributor
 //! to keeping the parity suite's wall-clock under the e2e suite's ~50s.
-//!
-//! Borrowed from `crates/beamtalk-mcp/src/client.rs::tests` (the only other
-//! place in the repo that auto-starts a workspace from a test binary). The
-//! logic is copied rather than re-exported because the MCP test fixture is
-//! not a public API.
 
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -108,12 +103,12 @@ fn start_workspace() -> Result<SharedRepl, String> {
     let _ = std::fs::remove_file(&stderr_path);
     drop(child);
 
-    let port = parse_port_line(&combined).ok_or_else(|| {
+    let port = beamtalk_workspace::parse_repl_port(&combined).ok_or_else(|| {
         format!(
             "`beamtalk repl` did not report a port within 45s.\nstdout:\n{combined}\nstderr:\n{stderr_text}"
         )
     })?;
-    let workspace_id = parse_workspace_id(&combined).ok_or_else(|| {
+    let workspace_id = beamtalk_workspace::parse_repl_workspace_id(&combined).ok_or_else(|| {
         format!(
             "`beamtalk repl` did not report a workspace id.\nstdout:\n{combined}\nstderr:\n{stderr_text}"
         )
@@ -159,21 +154,6 @@ pub fn beamtalk_binary(name: &str) -> Result<PathBuf, String> {
     ))
 }
 
-fn parse_port_line(stdout: &str) -> Option<u16> {
-    stdout.lines().find_map(|line| {
-        line.strip_prefix("Connected to REPL backend on port ")
-            .and_then(|rest| rest.trim_end_matches('.').trim().parse().ok())
-    })
-}
-
-fn parse_workspace_id(stdout: &str) -> Option<String> {
-    stdout.lines().find_map(|line| {
-        line.strip_prefix("  Workspace: ")
-            .and_then(|rest| rest.split_whitespace().next())
-            .map(str::to_string)
-    })
-}
-
 fn wait_for_tcp_ready(port: u16, timeout: Duration) -> Result<(), String> {
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
@@ -191,21 +171,4 @@ fn wait_for_tcp_ready(port: u16, timeout: Duration) -> Result<(), String> {
         "TCP port {port} did not accept connections within {}s",
         timeout.as_secs()
     ))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_port_line_extracts_number() {
-        let s = "  starting...\nConnected to REPL backend on port 12345.\nready";
-        assert_eq!(parse_port_line(s), Some(12345));
-    }
-
-    #[test]
-    fn parse_workspace_id_extracts_first_token() {
-        let s = "  Workspace: deadbeef1234 (new)\n";
-        assert_eq!(parse_workspace_id(s).as_deref(), Some("deadbeef1234"));
-    }
 }

--- a/crates/beamtalk-workspace/src/lib.rs
+++ b/crates/beamtalk-workspace/src/lib.rs
@@ -140,6 +140,27 @@ pub fn read_cookie_file(workspace_id: &str) -> Result<Option<String>> {
     }
 }
 
+/// Parse the REPL port from `beamtalk repl` stdout.
+///
+/// Expects a line like: `Connected to REPL backend on port 12345.`
+pub fn parse_repl_port(stdout: &str) -> Option<u16> {
+    stdout.lines().find_map(|line| {
+        line.strip_prefix("Connected to REPL backend on port ")
+            .and_then(|rest| rest.trim_end_matches('.').trim().parse().ok())
+    })
+}
+
+/// Parse the workspace ID from `beamtalk repl` stdout.
+///
+/// Expects a line like: `  Workspace: abc123def456 (new)`
+pub fn parse_repl_workspace_id(stdout: &str) -> Option<String> {
+    stdout.lines().find_map(|line| {
+        line.strip_prefix("  Workspace: ")
+            .and_then(|rest| rest.split_whitespace().next())
+            .map(std::string::ToString::to_string)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -283,5 +304,54 @@ mod tests {
         assert_eq!(result, None, "Empty cookie file should return None");
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_parse_repl_port_typical() {
+        let stdout = "Welcome to beamtalk REPL\n  Workspace: abc123def456 (new)\nConnected to REPL backend on port 9876.\n";
+        assert_eq!(parse_repl_port(stdout), Some(9876));
+    }
+
+    #[test]
+    fn test_parse_repl_port_missing() {
+        assert_eq!(parse_repl_port("some other output\n"), None);
+        assert_eq!(parse_repl_port(""), None);
+    }
+
+    #[test]
+    fn test_parse_repl_port_malformed() {
+        assert_eq!(
+            parse_repl_port("Connected to REPL backend on port notanumber.\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_repl_workspace_id_typical() {
+        let stdout = "  Workspace: abc123def456 (new)\nConnected to REPL backend on port 9876.\n";
+        assert_eq!(
+            parse_repl_workspace_id(stdout),
+            Some("abc123def456".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_repl_workspace_id_missing() {
+        assert_eq!(parse_repl_workspace_id("no workspace line\n"), None);
+        assert_eq!(parse_repl_workspace_id(""), None);
+    }
+
+    #[test]
+    fn test_parse_repl_workspace_id_bare() {
+        assert_eq!(
+            parse_repl_workspace_id("  Workspace: deadbeef1234\n"),
+            Some("deadbeef1234".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_repl_workspace_id_empty_prefix() {
+        assert_eq!(parse_repl_workspace_id("  Workspace: \n"), None);
+        assert_eq!(parse_repl_workspace_id("  Workspace: "), None);
     }
 }


### PR DESCRIPTION
## Summary

- `parse_repl_port` and `parse_workspace_id` were duplicated between `beamtalk-mcp/src/workspace.rs` (public, with tests) and `beamtalk-parity-tests/src/pool.rs` (private copy, with its own tests). The pool.rs comment even acknowledged the copy.
- Moved both functions to `beamtalk-workspace/src/lib.rs` — the right home since both callers already depend on it, and workspace already owns all other port/cookie file I/O.
- Renamed to `parse_repl_workspace_id` in the workspace crate to be unambiguous at the call site.
- Reduced `beamtalk-mcp/src/workspace.rs` to thin delegating wrappers (preserving the existing public API for MCP callers).
- Migrated the comprehensive test suite from both files into `beamtalk-workspace`; deleted the duplicated tests.

## Files changed

- `crates/beamtalk-workspace/src/lib.rs` — add `parse_repl_port`, `parse_repl_workspace_id`, and 7 unit tests
- `crates/beamtalk-mcp/src/workspace.rs` — delegate to `beamtalk_workspace::*`, remove 8 now-duplicate tests
- `crates/beamtalk-parity-tests/src/pool.rs` — use `beamtalk_workspace::*`, remove private copies and their 2 tests

**Net:** 3 files, −25 lines. No logic change. No Cargo.toml changes needed.

## Test plan

- [x] `cargo test -p beamtalk-workspace` — 21 unit tests + 4 integration tests pass
- [x] `cargo test -p beamtalk-mcp --tests` — 91 tests pass (workspace tests still green)
- [x] `cargo clippy -p beamtalk-workspace -p beamtalk-mcp -p beamtalk-parity-tests -- -D warnings` — clean
- [x] `just fmt` — no changes
- [x] All pre-push hooks pass (clippy, dialyzer, erlfmt, biome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ahy4LCuWh7DZLUdKnaK24M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ahy4LCuWh7DZLUdKnaK24M)_