### PR TITLE
test(codegen): add snapshot tests for actor inheritance init paths

### DIFF
--- a/test-package-compiler/cases/initializing_counter/main.bt
+++ b/test-package-compiler/cases/initializing_counter/main.bt
@@ -1,0 +1,19 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Test: Actor subclass with an initialize method.
+// module name "initializing_counter" matches class InitializingCounter via to_module_name,
+// so current_class is resolved and has_initialize = true, exercising
+// init_initialize_guarded_doc and generate_handle_continue in gen_server/callbacks.rs.
+
+Actor subclass: InitializingCounter
+  state: value = 0
+  state: initialized = false
+
+  initialize =>
+    self.value := 100
+    self.initialized := true
+
+  getValue => self.value
+
+  isInitialized => self.initialized

--- a/test-package-compiler/cases/logging_counter/main.bt
+++ b/test-package-compiler/cases/logging_counter/main.bt
@@ -1,0 +1,16 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Test: Actor subclass inheriting from a non-Actor/Object class.
+// module name "logging_counter" matches class LoggingCounter via to_module_name,
+// so current_class is resolved and has_parent_init = true, exercising the
+// parent-init merge branch in gen_server/callbacks.rs.
+
+Counter subclass: LoggingCounter
+  state: logCount = 0
+
+  increment =>
+    self.logCount := self.logCount + 1
+    super increment
+
+  getLogCount => self.logCount

--- a/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_codegen.snap
@@ -1,0 +1,390 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: core_erlang
+---
+module 'initializing_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2, 'handle_cast'/2, 'handle_call'/3, 'handle_info'/2, 'code_change'/3, 'terminate'/2, 'dispatch'/4, 'safe_dispatch'/3, 'method_table'/0, 'has_method'/1, 'class_name'/0, 'spawn'/0, 'spawn'/1, 'new'/0, 'new'/1, 'superclass'/0, '__beamtalk_meta'/0, 'class_supervisionSpec'/2, 'register_class'/0]
+  attributes ['behaviour' = ['gen_server'], 'on_load' = [{'register_class', 0}],
+     'beamtalk_class' = [{'InitializingCounter', 'Actor'}]]
+
+'start_link'/1 = fun (InitArgs) ->
+    call 'gen_server':'start_link'('initializing_counter', InitArgs, [])
+
+
+'start_link'/2 = fun (ServerName, InitArgs) ->
+    call 'gen_server':'start_link'(ServerName, 'initializing_counter', InitArgs, [])
+
+
+'spawn'/0 = fun () ->
+    case call 'beamtalk_actor':'safe_spawn'('initializing_counter', ~{}~) of
+        <{'ok', Pid}> when 'true' ->
+            let _InstReg = try call 'beamtalk_object_instances':'register'('InitializingCounter', Pid)
+                of _RegOk -> _RegOk
+                catch <_RegT, _RegE, _RegS> -> 'ok'
+            in
+            {'beamtalk_object', 'InitializingCounter', 'initializing_counter', Pid}
+        <{'error', Reason}> when 'true' ->
+            let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', 'InitializingCounter') in
+            let SpawnErr1 = call 'beamtalk_error':'with_selector'(SpawnErr0, 'spawn') in
+            let SpawnErr2 = call 'beamtalk_error':'with_hint'(SpawnErr1, Reason) in
+            call 'beamtalk_error':'raise'(SpawnErr2)
+    end
+
+
+'spawn'/1 = fun (InitArgs) ->
+    case call 'erlang':'is_map'(InitArgs) of
+        <'false'> when 'true' ->
+            let TypeErr0 = call 'beamtalk_error':'new'('type_error', 'InitializingCounter') in
+            let TypeErr1 = call 'beamtalk_error':'with_selector'(TypeErr0, 'spawnWith:') in
+            let TypeErr2 = call 'beamtalk_error':'with_hint'(TypeErr1, #{#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<68>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']])}#) in
+            call 'beamtalk_error':'raise'(TypeErr2)
+        <'true'> when 'true' ->
+            case call 'beamtalk_actor':'safe_spawn'('initializing_counter', InitArgs) of
+                <{'ok', Pid}> when 'true' ->
+                    let _InstReg = try call 'beamtalk_object_instances':'register'('InitializingCounter', Pid)
+                        of _RegOk -> _RegOk
+                        catch <_RegT, _RegE, _RegS> -> 'ok'
+                    in
+                    {'beamtalk_object', 'InitializingCounter', 'initializing_counter', Pid}
+                <{'error', Reason}> when 'true' ->
+                    let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', 'InitializingCounter') in
+                    let SpawnErr1 = call 'beamtalk_error':'with_selector'(SpawnErr0, 'spawnWith:') in
+                    let SpawnErr2 = call 'beamtalk_error':'with_hint'(SpawnErr1, Reason) in
+                    call 'beamtalk_error':'raise'(SpawnErr2)
+            end
+    end
+
+
+'new'/0 = fun () ->
+    let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in
+    let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new') in
+    let Error2 = call 'beamtalk_error':'with_hint'(Error1, #{#<85>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']])}#) in
+    call 'beamtalk_error':'raise'(Error2)
+
+'new'/1 = fun (_InitArgs) ->
+    let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in
+    let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new:') in
+    let Error2 = call 'beamtalk_error':'with_hint'(Error1, #{#<85>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']])}#) in
+    call 'beamtalk_error':'raise'(Error2)
+
+'superclass'/0 = fun () -> 'Actor'
+
+
+'class_name'/0 = fun () -> 'InitializingCounter'
+
+
+'init'/1 = fun (InitArgs) ->
+    let _Marker = case call 'maps':'get'('__skip_initialize__', InitArgs, 'false') of
+        <'true'> when 'true' -> 'skipped'
+        <'false'> when 'true' ->
+            call 'erlang':'put'('$beamtalk_actor', 'InitializingCounter')
+    end in
+    let DefaultState = ~{
+        '__class_mod__' => 'initializing_counter'
+        , 'value' => 0
+        , 'initialized' => 'false'
+    }~
+    in let FinalState = call 'maps':'merge'(DefaultState, InitArgs)
+    %% BT-1417/BT-1541: Defer initialize to handle_continue unless called as a parent helper
+    in case call 'maps':'get'('__skip_initialize__', InitArgs, 'false') of
+        <'true'> when 'true' ->
+            let CleanState = call 'maps':'remove'('__skip_initialize__', FinalState) in
+            {'ok', CleanState}
+        <'false'> when 'true' ->
+            let CleanState1 = call 'maps':'remove'('__skip_initialize__', FinalState) in
+            let _TelPid = call 'erlang':'self'() in
+            let _TelStart = call 'beamtalk_actor':'maybe_execute_telemetry'(['beamtalk', 'actor', 'lifecycle', 'start'], ~{}~, ~{'pid' => _TelPid, 'class' => 'InitializingCounter'}~) in
+            {'ok', CleanState1, {'continue', 'initialize'}}
+    end
+
+
+'handle_continue'/2 = fun (Continue, State) ->
+    case Continue of
+        <'initialize'> when 'true' ->
+            let _OldPdict0 = call 'erlang':'get'('$bt_actor_state') in
+            let _PutPdict0 = call 'erlang':'put'('$bt_actor_state', State) in
+            let _InitResult0 = call 'bt@initializing_counter':'safe_dispatch'('initialize', [], State) in
+            let _RestorePdict0 = case _OldPdict0 of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack0 = call 'erlang':'erase'('$bt_call_stack') in
+            case _InitResult0 of
+                <{'reply', _InitRet0, InitNewState}> when 'true' ->
+                    {'noreply', InitNewState}
+                <{'error', {_InitType0, _InitReason0, _InitStack0}, _InitErrState0}> when 'true' ->
+                    let _InitErrMsg0 = call 'beamtalk_error':'format_safe'({_InitType0, _InitReason0}, _InitStack0) in
+                    let _InitErrClass0 = call 'bt@initializing_counter':'class_name'() in
+                    let _ = call 'logger':'error'(_InitErrMsg0, ~{'class' => _InitErrClass0, 'reason' => {_InitType0, _InitReason0}, 'stacktrace' => _InitStack0, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
+                    {'stop', {_InitType0, _InitReason0, _InitStack0}, _InitErrState0}
+                <{'error', _InitError0, _InitErrState0b}> when 'true' ->
+                    let _InitErrMsg0b = call 'beamtalk_error':'format_safe'(_InitError0) in
+                    let _InitErrClass0b = call 'bt@initializing_counter':'class_name'() in
+                    let _ = call 'logger':'error'(_InitErrMsg0b, ~{'class' => _InitErrClass0b, 'reason' => _InitError0, 'domain' => ['beamtalk'|['runtime'|[]]]}~) in
+                    {'stop', _InitError0, _InitErrState0b}
+            end
+        <_> when 'true' -> {'noreply', State}
+    end
+
+
+'handle_cast'/2 = fun (Msg, State) ->
+    case Msg of
+        <{'cast', CastSelector, CastArgs, CastPropCtx}> when 'true' ->
+            let _CastCtxOk = call 'beamtalk_actor':'restore_propagated_ctx'(CastPropCtx) in
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _CastDispatchResult = call 'initializing_counter':'safe_dispatch'(CastSelector, CastArgs, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _CastDispatchResult of
+                <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
+                    {'noreply', CastNewState}
+                <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
+                    let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
+                    let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+                <{'error', CastError, _CastState2}> when 'true' ->
+                    let CastErrMsg2 = call 'beamtalk_error':'format_safe'(CastError) in
+                    let _ = call 'logger':'warning'(CastErrMsg2, ~{'selector' => CastSelector, 'reason' => CastError, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+            end
+        <{'cast', CastSelector, CastArgs}> when 'true' ->
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _CastDispatchResult = call 'initializing_counter':'safe_dispatch'(CastSelector, CastArgs, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _CastDispatchResult of
+                <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
+                    {'noreply', CastNewState}
+                <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
+                    let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
+                    let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+                <{'error', CastError, _CastState2}> when 'true' ->
+                    let CastErrMsg2 = call 'beamtalk_error':'format_safe'(CastError) in
+                    let _ = call 'logger':'warning'(CastErrMsg2, ~{'selector' => CastSelector, 'reason' => CastError, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+            end
+        <_> when 'true' -> {'noreply', State}
+    end
+
+
+'handle_call'/3 = fun (Msg, _From, State) ->
+    case Msg of
+        <{Selector, Args, PropCtx}> when 'true' ->
+            let _CtxOk = call 'beamtalk_actor':'restore_propagated_ctx'(PropCtx) in
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _DispatchResult = call 'initializing_counter':'safe_dispatch'(Selector, Args, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _DispatchResult of
+                <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
+                    {'reply', {'ok', Result}, NewState}
+                <{'error', Error, ErrState}> when 'true' ->
+                    {'reply', {'error', Error}, ErrState}
+            end
+        <{Selector, Args}> when 'true' ->
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _DispatchResult = call 'initializing_counter':'safe_dispatch'(Selector, Args, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _DispatchResult of
+                <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
+                    {'reply', {'ok', Result}, NewState}
+                <{'error', Error, ErrState}> when 'true' ->
+                    {'reply', {'error', Error}, ErrState}
+            end
+    end
+
+
+'handle_info'/2 = fun (Msg, State) ->
+    call 'beamtalk_actor':'handle_info'(Msg, State)
+
+
+'code_change'/3 = fun (OldVsn, State, Extra) ->
+    call 'beamtalk_hot_reload':'code_change'(OldVsn, State, Extra)
+
+
+'terminate'/2 = fun (Reason, State) ->
+    let _TelPid = call 'erlang':'self'() in
+    let _TelStop = call 'beamtalk_actor':'maybe_execute_telemetry'(['beamtalk', 'actor', 'lifecycle', 'stop'], ~{}~, ~{'pid' => _TelPid, 'class' => 'InitializingCounter', 'reason' => Reason}~) in
+    %% Call terminate: method if defined — exceptions must not prevent shutdown
+    let Self = call 'beamtalk_actor':'make_self'(State) in
+    let _TermDisp = try call 'initializing_counter':'dispatch'('terminate:', [Reason], Self, State)
+        of _TermOk -> 'ok'
+        catch <_TermT, _TermE, _TermS> -> 'ok'
+    in 'ok'
+
+
+'safe_dispatch'/3 = fun (Selector, Args, State) ->
+    let Self = call 'beamtalk_actor':'make_self'(State) in
+    try call 'initializing_counter':'dispatch'(Selector, Args, Self, State)
+    of Result -> Result
+    catch <Type, Error, Stacktrace> -> {'error', {Type, Error, Stacktrace}, State}
+
+
+'dispatch'/4 = fun (Selector, Args, Self, State) ->
+    case Selector of
+        <'initialize'> when 'true' ->
+            let _Val1 = 100 in let State1 = call 'maps':'put'('value', _Val1, State) in let _Val2 = 'true' in let State2 = call 'maps':'put'('initialized', _Val2, State1) in {'reply', _Val2, State2}
+        <'getValue'> when 'true' ->
+            let _Result = call 'maps':'get'('value', State) in {'reply', _Result, State}
+        <'isInitialized'> when 'true' ->
+            let _Result = call 'maps':'get'('initialized', State) in {'reply', _Result, State}
+        <OtherSelector> when 'true' ->
+            %% BT-229/ADR 0005: Check extension registry before hierarchy walk
+            let ExtLookup = try call 'beamtalk_extensions':'lookup'('InitializingCounter', OtherSelector)
+                of ExtLookupResult -> ExtLookupResult
+                catch <_EType, _EReason, _EStack> -> 'not_found'
+            in
+            case ExtLookup of
+                <{'ok', ExtFun, _ExtOwner}> when 'true' ->
+                    %% BT-1512/BT-2250: Invoke via the runtime helper, which
+                    %% accepts both the 3-arity actor shape
+                    %% (fun(Args, Self, State) -> {Result, NewState}) and the
+                    %% 2-arity value shape (fun(Args, Self) -> Result), so a
+                    %% foreign extension whose codegen-time arity could not be
+                    %% resolved still dispatches correctly. Returns {reply, _, _}.
+                    call 'beamtalk_dispatch':'invoke_extension'(ExtFun, Args, Self, State)
+                <'not_found'> when 'true' ->
+                    %% ADR 0006: Try hierarchy walk before DNU
+                    case call 'beamtalk_dispatch':'super'(OtherSelector, Args, Self, State, 'InitializingCounter') of
+                        <{'reply', InheritedResult, InheritedState}> when 'true' ->
+                            {'reply', InheritedResult, InheritedState}
+                        <{'error', _DispatchError}> when 'true' ->
+                            %% Not in hierarchy - try doesNotUnderstand:args: (BT-29)
+                            let DnuSelector = 'doesNotUnderstand:args:' in
+                            let Methods = call 'initializing_counter':'method_table'() in
+                            case call 'maps':'is_key'(DnuSelector, Methods) of
+                                <'true'> when 'true' ->
+                                    call 'initializing_counter':'dispatch'(DnuSelector, [OtherSelector, Args], Self, State)
+                                <'false'> when 'true' ->
+                                    %% No DNU handler - return #beamtalk_error{} record
+                                    let ClassName = 'InitializingCounter' in
+                                    let Error0 = call 'beamtalk_error':'new'('does_not_understand', ClassName) in
+                                    let Error1 = call 'beamtalk_error':'with_selector'(Error0, OtherSelector) in
+                                    let HintMsg = #{#<67>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<107>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<39>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<84>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<39>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<118>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']])}# in
+                                    let Error = call 'beamtalk_error':'with_hint'(Error1, HintMsg) in
+                                    {'error', Error, State}
+                            end
+                    end
+            end
+    end
+
+
+'method_table'/0 = fun () ->
+    ~{'initialize' => 0, 'getValue' => 0, 'isInitialized' => 0}~
+
+
+'has_method'/1 = fun (Selector) ->
+    call 'lists':'member'(Selector, ['initialize', 'getValue', 'isInitialized'])
+
+
+'class_supervisionSpec'/2 = fun (ClassSelf, ClassVars) ->
+    let CMR = call 'bt@stdlib@actor':'class_supervisionPolicy'(ClassSelf, ClassVars) in
+    case CMR of
+      <{'class_var_result', Policy, NewClassVars}> when 'true' ->
+        let Spec0 = call 'bt@stdlib@supervision_spec':'new'() in
+        let Spec1 = call 'bt@stdlib@supervision_spec':'withActorClass:'(Spec0, ClassSelf) in
+        let Spec2 = call 'bt@stdlib@supervision_spec':'withRestart:'(Spec1, Policy) in
+        {'class_var_result', Spec2, NewClassVars}
+      <Policy> when 'true' ->
+        let Spec0 = call 'bt@stdlib@supervision_spec':'new'() in
+        let Spec1 = call 'bt@stdlib@supervision_spec':'withActorClass:'(Spec0, ClassSelf) in
+        call 'bt@stdlib@supervision_spec':'withRestart:'(Spec1, Policy)
+    end
+
+'__beamtalk_meta'/0 = fun () ->
+    ~{'class' => 'InitializingCounter',
+      'superclass' => 'Actor',
+      'package' => 'none',
+      'kind' => 'actor',
+      'fields' => ['value', 'initialized'],
+      'class_fields' => [],
+      'is_sealed' => 'false',
+      'is_abstract' => 'false',
+      'is_value' => 'false',
+      'is_typed' => 'false',
+      'is_internal' => 'false',
+      'visibility' => 'public',
+      'type_params' => [],
+      'field_types' => ~{'value' => 'none', 'initialized' => 'none'}~,
+      'field_has_default' => ~{'value' => 'true', 'initialized' => 'true'}~,
+      'method_info' => ~{'initialize' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'Boolean', 'is_sealed' => 'false', 'visibility' => 'public'}~, 'getValue' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'none', 'is_sealed' => 'false', 'visibility' => 'public'}~, 'isInitialized' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'none', 'is_sealed' => 'false', 'visibility' => 'public'}~}~,
+      'class_method_info' => ~{'supervisionSpec' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'SupervisionSpec', 'is_sealed' => 'false', 'visibility' => 'public'}~}~
+    }~
+
+'register_class'/0 = fun () ->
+    try
+        let _BuilderState0 = ~{
+            'className' => 'InitializingCounter',
+            'superclassRef' => 'Actor',
+            'moduleName' => 'initializing_counter',
+            'methodSource' => ~{'initialize' => #{#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<122>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<45>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<66>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<118>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<49>(8,1,'integer',['unsigned'|['big']]),#<48>(8,1,'integer',['unsigned'|['big']]),#<48>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<122>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']])}#, 'getValue' => #{#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<86>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<118>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']])}#, 'isInitialized' => #{#<105>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<122>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<122>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']])}#}~,
+            'classMethodSource' => ~{}~,
+            'methodSignatures' => ~{'initialize' => #{#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<122>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<45>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<66>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']])}#, 'getValue' => #{#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<86>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']])}#, 'isInitialized' => #{#<105>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<122>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']])}#}~,
+            'classMethodSignatures' => ~{}~,
+            'methodXref' => [~{'class_side' => 'false', 'selector' => 'initialize', 'line' => 1, 'sends' => [], 'references' => [~{'class' => 'Boolean', 'line' => 1}~], 'source_status' => 'indexed'}~, ~{'class_side' => 'false', 'selector' => 'getValue', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'indexed'}~, ~{'class_side' => 'false', 'selector' => 'isInitialized', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'indexed'}~, ~{'class_side' => 'true', 'selector' => 'new', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~, ~{'class_side' => 'true', 'selector' => 'new:', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~, ~{'class_side' => 'true', 'selector' => 'spawn', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~, ~{'class_side' => 'true', 'selector' => 'spawn:', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~],
+            'classState' => ~{}~,
+            'classDoc' => 'none',
+            'methodDocs' => ~{}~,
+            'classMethodDocs' => ~{}~,
+            'meta' => ~{'class' => 'InitializingCounter',
+      'superclass' => 'Actor',
+      'package' => 'none',
+      'kind' => 'actor',
+      'fields' => ['value', 'initialized'],
+      'class_fields' => [],
+      'is_sealed' => 'false',
+      'is_abstract' => 'false',
+      'is_value' => 'false',
+      'is_typed' => 'false',
+      'is_internal' => 'false',
+      'visibility' => 'public',
+      'type_params' => [],
+      'field_types' => ~{'value' => 'none', 'initialized' => 'none'}~,
+      'field_has_default' => ~{'value' => 'true', 'initialized' => 'true'}~,
+      'method_info' => ~{'initialize' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'Boolean', 'is_sealed' => 'false', 'visibility' => 'public'}~, 'getValue' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'none', 'is_sealed' => 'false', 'visibility' => 'public'}~, 'isInitialized' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'none', 'is_sealed' => 'false', 'visibility' => 'public'}~}~,
+      'class_method_info' => ~{'supervisionSpec' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'SupervisionSpec', 'is_sealed' => 'false', 'visibility' => 'public'}~}~
+    }~,
+            'isConstructible' => 'false'
+        }~
+        in let _Reg0 = case call 'beamtalk_class_builder':'register'(_BuilderState0) of
+            <{'ok', _Pid0}> when 'true' -> 'ok'
+            <{'error', _Err0}> when 'true' -> {'error', _Err0}
+        end
+
+        in _Reg0
+
+    of _ClassRegResult -> _ClassRegResult
+    catch <CatchType, CatchError, CatchStack> -> primop 'raw_raise'(CatchType, CatchError, CatchStack)
+
+end

--- a/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_lexer.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_lexer.snap
@@ -1,0 +1,38 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+Token { kind: Identifier("Actor"), span: Span { start: 372, end: 377 }, leading_trivia: [LineComment("// Copyright 2026 James Casey"), Whitespace("\n"), LineComment("// SPDX-License-Identifier: Apache-2.0"), Whitespace("\n\n"), LineComment("// Test: Actor subclass with an initialize method."), Whitespace("\n"), LineComment("// module name \"initializing_counter\" matches class InitializingCounter via to_module_name,"), Whitespace("\n"), LineComment("// so current_class is resolved and has_initialize = true, exercising"), Whitespace("\n"), LineComment("// init_initialize_guarded_doc and generate_handle_continue in gen_server/callbacks.rs."), Whitespace("\n\n")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("subclass:"), span: Span { start: 378, end: 387 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("InitializingCounter"), span: Span { start: 388, end: 407 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("state:"), span: Span { start: 410, end: 416 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("value"), span: Span { start: 417, end: 422 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("="), span: Span { start: 423, end: 424 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("0"), span: Span { start: 425, end: 426 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("state:"), span: Span { start: 429, end: 435 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("initialized"), span: Span { start: 436, end: 447 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("="), span: Span { start: 448, end: 449 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("false"), span: Span { start: 450, end: 455 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("initialize"), span: Span { start: 459, end: 469 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 470, end: 472 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("self"), span: Span { start: 477, end: 481 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 481, end: 482 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("value"), span: Span { start: 482, end: 487 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 488, end: 490 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("100"), span: Span { start: 491, end: 494 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("self"), span: Span { start: 499, end: 503 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 503, end: 504 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("initialized"), span: Span { start: 504, end: 515 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 516, end: 518 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("true"), span: Span { start: 519, end: 523 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("getValue"), span: Span { start: 527, end: 535 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 536, end: 538 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("self"), span: Span { start: 539, end: 543 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 543, end: 544 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("value"), span: Span { start: 544, end: 549 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("isInitialized"), span: Span { start: 553, end: 566 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 567, end: 569 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("self"), span: Span { start: 570, end: 574 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 574, end: 575 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("initialized"), span: Span { start: 575, end: 586 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Eof, span: Span { start: 587, end: 587 }, leading_trivia: [Whitespace("\n")], trailing_trivia: [] }

--- a/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_parser.snap
@@ -1,0 +1,397 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+AST:
+Module {
+    classes: [
+        ClassDefinition {
+            name: Identifier {
+                name: "InitializingCounter",
+                span: Span {
+                    start: 388,
+                    end: 407,
+                },
+            },
+            superclass: Some(
+                Identifier {
+                    name: "Actor",
+                    span: Span {
+                        start: 372,
+                        end: 377,
+                    },
+                },
+            ),
+            superclass_package: None,
+            class_kind: Actor,
+            is_abstract: false,
+            is_sealed: false,
+            is_typed: false,
+            is_internal: false,
+            supervisor_kind: None,
+            state: [
+                StateDeclaration {
+                    name: Identifier {
+                        name: "value",
+                        span: Span {
+                            start: 417,
+                            end: 422,
+                        },
+                    },
+                    type_annotation: None,
+                    default_value: Some(
+                        Literal(
+                            Integer(
+                                0,
+                            ),
+                            Span {
+                                start: 425,
+                                end: 426,
+                            },
+                        ),
+                    ),
+                    declared_keyword: State,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 410,
+                        end: 426,
+                    },
+                },
+                StateDeclaration {
+                    name: Identifier {
+                        name: "initialized",
+                        span: Span {
+                            start: 436,
+                            end: 447,
+                        },
+                    },
+                    type_annotation: None,
+                    default_value: Some(
+                        Identifier(
+                            Identifier {
+                                name: "false",
+                                span: Span {
+                                    start: 450,
+                                    end: 455,
+                                },
+                            },
+                        ),
+                    ),
+                    declared_keyword: State,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 429,
+                        end: 455,
+                    },
+                },
+            ],
+            methods: [
+                MethodDefinition {
+                    selector: Unary(
+                        "initialize",
+                    ),
+                    parameters: [],
+                    body: [
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: Assignment {
+                                target: FieldAccess {
+                                    receiver: Identifier(
+                                        Identifier {
+                                            name: "self",
+                                            span: Span {
+                                                start: 477,
+                                                end: 481,
+                                            },
+                                        },
+                                    ),
+                                    field: Identifier {
+                                        name: "value",
+                                        span: Span {
+                                            start: 482,
+                                            end: 487,
+                                        },
+                                    },
+                                    span: Span {
+                                        start: 477,
+                                        end: 487,
+                                    },
+                                },
+                                value: Literal(
+                                    Integer(
+                                        100,
+                                    ),
+                                    Span {
+                                        start: 491,
+                                        end: 494,
+                                    },
+                                ),
+                                type_annotation: None,
+                                span: Span {
+                                    start: 477,
+                                    end: 494,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: Assignment {
+                                target: FieldAccess {
+                                    receiver: Identifier(
+                                        Identifier {
+                                            name: "self",
+                                            span: Span {
+                                                start: 499,
+                                                end: 503,
+                                            },
+                                        },
+                                    ),
+                                    field: Identifier {
+                                        name: "initialized",
+                                        span: Span {
+                                            start: 504,
+                                            end: 515,
+                                        },
+                                    },
+                                    span: Span {
+                                        start: 499,
+                                        end: 515,
+                                    },
+                                },
+                                value: Identifier(
+                                    Identifier {
+                                        name: "true",
+                                        span: Span {
+                                            start: 519,
+                                            end: 523,
+                                        },
+                                    },
+                                ),
+                                type_annotation: None,
+                                span: Span {
+                                    start: 499,
+                                    end: 523,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                    ],
+                    return_type: None,
+                    is_sealed: false,
+                    is_internal: false,
+                    is_class_method: false,
+                    kind: Primary,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 459,
+                        end: 523,
+                    },
+                },
+                MethodDefinition {
+                    selector: Unary(
+                        "getValue",
+                    ),
+                    parameters: [],
+                    body: [
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: FieldAccess {
+                                receiver: Identifier(
+                                    Identifier {
+                                        name: "self",
+                                        span: Span {
+                                            start: 539,
+                                            end: 543,
+                                        },
+                                    },
+                                ),
+                                field: Identifier {
+                                    name: "value",
+                                    span: Span {
+                                        start: 544,
+                                        end: 549,
+                                    },
+                                },
+                                span: Span {
+                                    start: 539,
+                                    end: 549,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                    ],
+                    return_type: None,
+                    is_sealed: false,
+                    is_internal: false,
+                    is_class_method: false,
+                    kind: Primary,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 527,
+                        end: 549,
+                    },
+                },
+                MethodDefinition {
+                    selector: Unary(
+                        "isInitialized",
+                    ),
+                    parameters: [],
+                    body: [
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: FieldAccess {
+                                receiver: Identifier(
+                                    Identifier {
+                                        name: "self",
+                                        span: Span {
+                                            start: 570,
+                                            end: 574,
+                                        },
+                                    },
+                                ),
+                                field: Identifier {
+                                    name: "initialized",
+                                    span: Span {
+                                        start: 575,
+                                        end: 586,
+                                    },
+                                },
+                                span: Span {
+                                    start: 570,
+                                    end: 586,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                    ],
+                    return_type: None,
+                    is_sealed: false,
+                    is_internal: false,
+                    is_class_method: false,
+                    kind: Primary,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 553,
+                        end: 586,
+                    },
+                },
+            ],
+            class_methods: [],
+            class_variables: [],
+            comments: CommentAttachment {
+                leading: [
+                    Comment {
+                        content: "Copyright 2026 James Casey",
+                        span: Span {
+                            start: 372,
+                            end: 377,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 372,
+                            end: 377,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "Test: Actor subclass with an initialize method.",
+                        span: Span {
+                            start: 372,
+                            end: 377,
+                        },
+                        kind: Line,
+                        preceding_blank_line: true,
+                    },
+                    Comment {
+                        content: "module name \"initializing_counter\" matches class InitializingCounter via to_module_name,",
+                        span: Span {
+                            start: 372,
+                            end: 377,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "so current_class is resolved and has_initialize = true, exercising",
+                        span: Span {
+                            start: 372,
+                            end: 377,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "init_initialize_guarded_doc and generate_handle_continue in gen_server/callbacks.rs.",
+                        span: Span {
+                            start: 372,
+                            end: 377,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                ],
+                trailing: None,
+            },
+            doc_comment: None,
+            backing_module: None,
+            type_params: [],
+            superclass_type_args: [],
+            span: Span {
+                start: 372,
+                end: 586,
+            },
+        },
+    ],
+    method_definitions: [],
+    protocols: [],
+    expressions: [],
+    span: Span {
+        start: 372,
+        end: 586,
+    },
+    file_leading_comments: [],
+    file_trailing_comments: [],
+}

--- a/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_semantic.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_semantic.snap
@@ -1,0 +1,5 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+No semantic errors

--- a/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_codegen.snap
@@ -1,0 +1,373 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: core_erlang
+---
+module 'logging_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2, 'handle_cast'/2, 'handle_call'/3, 'handle_info'/2, 'code_change'/3, 'terminate'/2, 'dispatch'/4, 'safe_dispatch'/3, 'method_table'/0, 'has_method'/1, 'class_name'/0, 'spawn'/0, 'spawn'/1, 'new'/0, 'new'/1, 'superclass'/0, '__beamtalk_meta'/0, 'class_supervisionSpec'/2, 'register_class'/0]
+  attributes ['behaviour' = ['gen_server'], 'on_load' = [{'register_class', 0}],
+     'beamtalk_class' = [{'LoggingCounter', 'Counter'}]]
+
+'start_link'/1 = fun (InitArgs) ->
+    call 'gen_server':'start_link'('logging_counter', InitArgs, [])
+
+
+'start_link'/2 = fun (ServerName, InitArgs) ->
+    call 'gen_server':'start_link'(ServerName, 'logging_counter', InitArgs, [])
+
+
+'spawn'/0 = fun () ->
+    case call 'beamtalk_actor':'safe_spawn'('logging_counter', ~{}~) of
+        <{'ok', Pid}> when 'true' ->
+            let _InstReg = try call 'beamtalk_object_instances':'register'('LoggingCounter', Pid)
+                of _RegOk -> _RegOk
+                catch <_RegT, _RegE, _RegS> -> 'ok'
+            in
+            {'beamtalk_object', 'LoggingCounter', 'logging_counter', Pid}
+        <{'error', Reason}> when 'true' ->
+            let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', 'LoggingCounter') in
+            let SpawnErr1 = call 'beamtalk_error':'with_selector'(SpawnErr0, 'spawn') in
+            let SpawnErr2 = call 'beamtalk_error':'with_hint'(SpawnErr1, Reason) in
+            call 'beamtalk_error':'raise'(SpawnErr2)
+    end
+
+
+'spawn'/1 = fun (InitArgs) ->
+    case call 'erlang':'is_map'(InitArgs) of
+        <'false'> when 'true' ->
+            let TypeErr0 = call 'beamtalk_error':'new'('type_error', 'LoggingCounter') in
+            let TypeErr1 = call 'beamtalk_error':'with_selector'(TypeErr0, 'spawnWith:') in
+            let TypeErr2 = call 'beamtalk_error':'with_hint'(TypeErr1, #{#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<68>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']])}#) in
+            call 'beamtalk_error':'raise'(TypeErr2)
+        <'true'> when 'true' ->
+            case call 'beamtalk_actor':'safe_spawn'('logging_counter', InitArgs) of
+                <{'ok', Pid}> when 'true' ->
+                    let _InstReg = try call 'beamtalk_object_instances':'register'('LoggingCounter', Pid)
+                        of _RegOk -> _RegOk
+                        catch <_RegT, _RegE, _RegS> -> 'ok'
+                    in
+                    {'beamtalk_object', 'LoggingCounter', 'logging_counter', Pid}
+                <{'error', Reason}> when 'true' ->
+                    let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', 'LoggingCounter') in
+                    let SpawnErr1 = call 'beamtalk_error':'with_selector'(SpawnErr0, 'spawnWith:') in
+                    let SpawnErr2 = call 'beamtalk_error':'with_hint'(SpawnErr1, Reason) in
+                    call 'beamtalk_error':'raise'(SpawnErr2)
+            end
+    end
+
+
+'new'/0 = fun () ->
+    let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in
+    let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new') in
+    let Error2 = call 'beamtalk_error':'with_hint'(Error1, #{#<85>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']])}#) in
+    call 'beamtalk_error':'raise'(Error2)
+
+'new'/1 = fun (_InitArgs) ->
+    let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in
+    let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new:') in
+    let Error2 = call 'beamtalk_error':'with_hint'(Error1, #{#<85>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']])}#) in
+    call 'beamtalk_error':'raise'(Error2)
+
+'superclass'/0 = fun () -> 'Counter'
+
+
+'class_name'/0 = fun () -> 'LoggingCounter'
+
+
+'init'/1 = fun (InitArgs) ->
+    let _Marker = case call 'maps':'get'('__skip_initialize__', InitArgs, 'false') of
+        <'true'> when 'true' -> 'skipped'
+        <'false'> when 'true' ->
+            call 'erlang':'put'('$beamtalk_actor', 'LoggingCounter')
+    end in
+    %% Call parent init to get inherited state fields
+    let _ParentArgs = call 'maps':'put'('__skip_initialize__', 'true', InitArgs) in
+    case call 'bt@counter':'init'(_ParentArgs) of
+        <{'ok', ParentState}> when 'true' ->
+            %% Merge parent state with this class's fields
+            let ChildFields = ~{
+                '__class_mod__' => 'logging_counter'
+                , 'logCount' => 0
+            }~
+            in let MergedState = call 'maps':'merge'(ParentState, ChildFields)
+            in let FinalState = call 'maps':'merge'(MergedState, InitArgs)
+            in case call 'maps':'get'('__skip_initialize__', InitArgs, 'false') of
+                <'true'> when 'true' ->
+                    let CleanState = call 'maps':'remove'('__skip_initialize__', FinalState) in
+                    {'ok', CleanState}
+                <'false'> when 'true' ->
+                    let _TelPid = call 'erlang':'self'() in
+                    let _TelStart = call 'beamtalk_actor':'maybe_execute_telemetry'(['beamtalk', 'actor', 'lifecycle', 'start'], ~{}~, ~{'pid' => _TelPid, 'class' => 'LoggingCounter'}~) in
+                    {'ok', FinalState}
+            end
+        <{'error', Reason}> when 'true' ->
+            %% Propagate parent init error
+            {'error', Reason}
+    end
+
+
+'handle_continue'/2 = fun (Continue, State) ->
+    case Continue of
+        <'initialize'> when 'true' ->
+            let InitNewState = State in
+            {'noreply', InitNewState}
+        <_> when 'true' -> {'noreply', State}
+    end
+
+
+'handle_cast'/2 = fun (Msg, State) ->
+    case Msg of
+        <{'cast', CastSelector, CastArgs, CastPropCtx}> when 'true' ->
+            let _CastCtxOk = call 'beamtalk_actor':'restore_propagated_ctx'(CastPropCtx) in
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _CastDispatchResult = call 'logging_counter':'safe_dispatch'(CastSelector, CastArgs, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _CastDispatchResult of
+                <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
+                    {'noreply', CastNewState}
+                <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
+                    let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
+                    let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+                <{'error', CastError, _CastState2}> when 'true' ->
+                    let CastErrMsg2 = call 'beamtalk_error':'format_safe'(CastError) in
+                    let _ = call 'logger':'warning'(CastErrMsg2, ~{'selector' => CastSelector, 'reason' => CastError, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+            end
+        <{'cast', CastSelector, CastArgs}> when 'true' ->
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _CastDispatchResult = call 'logging_counter':'safe_dispatch'(CastSelector, CastArgs, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _CastDispatchResult of
+                <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
+                    {'noreply', CastNewState}
+                <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
+                    let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
+                    let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+                <{'error', CastError, _CastState2}> when 'true' ->
+                    let CastErrMsg2 = call 'beamtalk_error':'format_safe'(CastError) in
+                    let _ = call 'logger':'warning'(CastErrMsg2, ~{'selector' => CastSelector, 'reason' => CastError, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+            end
+        <_> when 'true' -> {'noreply', State}
+    end
+
+
+'handle_call'/3 = fun (Msg, _From, State) ->
+    case Msg of
+        <{Selector, Args, PropCtx}> when 'true' ->
+            let _CtxOk = call 'beamtalk_actor':'restore_propagated_ctx'(PropCtx) in
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _DispatchResult = call 'logging_counter':'safe_dispatch'(Selector, Args, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _DispatchResult of
+                <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
+                    {'reply', {'ok', Result}, NewState}
+                <{'error', Error, ErrState}> when 'true' ->
+                    {'reply', {'error', Error}, ErrState}
+            end
+        <{Selector, Args}> when 'true' ->
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _DispatchResult = call 'logging_counter':'safe_dispatch'(Selector, Args, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _DispatchResult of
+                <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
+                    {'reply', {'ok', Result}, NewState}
+                <{'error', Error, ErrState}> when 'true' ->
+                    {'reply', {'error', Error}, ErrState}
+            end
+    end
+
+
+'handle_info'/2 = fun (Msg, State) ->
+    call 'beamtalk_actor':'handle_info'(Msg, State)
+
+
+'code_change'/3 = fun (OldVsn, State, Extra) ->
+    call 'beamtalk_hot_reload':'code_change'(OldVsn, State, Extra)
+
+
+'terminate'/2 = fun (Reason, State) ->
+    let _TelPid = call 'erlang':'self'() in
+    let _TelStop = call 'beamtalk_actor':'maybe_execute_telemetry'(['beamtalk', 'actor', 'lifecycle', 'stop'], ~{}~, ~{'pid' => _TelPid, 'class' => 'LoggingCounter', 'reason' => Reason}~) in
+    %% Call terminate: method if defined — exceptions must not prevent shutdown
+    let Self = call 'beamtalk_actor':'make_self'(State) in
+    let _TermDisp = try call 'logging_counter':'dispatch'('terminate:', [Reason], Self, State)
+        of _TermOk -> 'ok'
+        catch <_TermT, _TermE, _TermS> -> 'ok'
+    in 'ok'
+
+
+'safe_dispatch'/3 = fun (Selector, Args, State) ->
+    let Self = call 'beamtalk_actor':'make_self'(State) in
+    try call 'logging_counter':'dispatch'(Selector, Args, Self, State)
+    of Result -> Result
+    catch <Type, Error, Stacktrace> -> {'error', {Type, Error, Stacktrace}, State}
+
+
+'dispatch'/4 = fun (Selector, Args, Self, State) ->
+    case Selector of
+        <'increment'> when 'true' ->
+            let _Val1 = call 'erlang':'+'(call 'maps':'get'('logCount', State), 1) in let State1 = call 'maps':'put'('logCount', _Val1, State) in let _SuperTuple = call 'beamtalk_dispatch':'super'('increment', [], Self, State1, 'LoggingCounter') in let _Result = call 'erlang':'element'(2, _SuperTuple) in let _NewState = call 'erlang':'element'(3, _SuperTuple) in {'reply', _Result, _NewState}
+        <'getLogCount'> when 'true' ->
+            let _Result = call 'maps':'get'('logCount', State) in {'reply', _Result, State}
+        <OtherSelector> when 'true' ->
+            %% BT-229/ADR 0005: Check extension registry before hierarchy walk
+            let ExtLookup = try call 'beamtalk_extensions':'lookup'('LoggingCounter', OtherSelector)
+                of ExtLookupResult -> ExtLookupResult
+                catch <_EType, _EReason, _EStack> -> 'not_found'
+            in
+            case ExtLookup of
+                <{'ok', ExtFun, _ExtOwner}> when 'true' ->
+                    %% BT-1512/BT-2250: Invoke via the runtime helper, which
+                    %% accepts both the 3-arity actor shape
+                    %% (fun(Args, Self, State) -> {Result, NewState}) and the
+                    %% 2-arity value shape (fun(Args, Self) -> Result), so a
+                    %% foreign extension whose codegen-time arity could not be
+                    %% resolved still dispatches correctly. Returns {reply, _, _}.
+                    call 'beamtalk_dispatch':'invoke_extension'(ExtFun, Args, Self, State)
+                <'not_found'> when 'true' ->
+                    %% ADR 0006: Try hierarchy walk before DNU
+                    case call 'beamtalk_dispatch':'super'(OtherSelector, Args, Self, State, 'LoggingCounter') of
+                        <{'reply', InheritedResult, InheritedState}> when 'true' ->
+                            {'reply', InheritedResult, InheritedState}
+                        <{'error', _DispatchError}> when 'true' ->
+                            %% Not in hierarchy - try doesNotUnderstand:args: (BT-29)
+                            let DnuSelector = 'doesNotUnderstand:args:' in
+                            let Methods = call 'logging_counter':'method_table'() in
+                            case call 'maps':'is_key'(DnuSelector, Methods) of
+                                <'true'> when 'true' ->
+                                    call 'logging_counter':'dispatch'(DnuSelector, [OtherSelector, Args], Self, State)
+                                <'false'> when 'true' ->
+                                    %% No DNU handler - return #beamtalk_error{} record
+                                    let ClassName = 'LoggingCounter' in
+                                    let Error0 = call 'beamtalk_error':'new'('does_not_understand', ClassName) in
+                                    let Error1 = call 'beamtalk_error':'with_selector'(Error0, OtherSelector) in
+                                    let HintMsg = #{#<67>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<107>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<39>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<84>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<39>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<118>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']])}# in
+                                    let Error = call 'beamtalk_error':'with_hint'(Error1, HintMsg) in
+                                    {'error', Error, State}
+                            end
+                    end
+            end
+    end
+
+
+'method_table'/0 = fun () ->
+    ~{'increment' => 0, 'getLogCount' => 0}~
+
+
+'has_method'/1 = fun (Selector) ->
+    call 'lists':'member'(Selector, ['increment', 'getLogCount'])
+
+
+'class_supervisionSpec'/2 = fun (ClassSelf, ClassVars) ->
+    let CMR = call 'bt@stdlib@actor':'class_supervisionPolicy'(ClassSelf, ClassVars) in
+    case CMR of
+      <{'class_var_result', Policy, NewClassVars}> when 'true' ->
+        let Spec0 = call 'bt@stdlib@supervision_spec':'new'() in
+        let Spec1 = call 'bt@stdlib@supervision_spec':'withActorClass:'(Spec0, ClassSelf) in
+        let Spec2 = call 'bt@stdlib@supervision_spec':'withRestart:'(Spec1, Policy) in
+        {'class_var_result', Spec2, NewClassVars}
+      <Policy> when 'true' ->
+        let Spec0 = call 'bt@stdlib@supervision_spec':'new'() in
+        let Spec1 = call 'bt@stdlib@supervision_spec':'withActorClass:'(Spec0, ClassSelf) in
+        call 'bt@stdlib@supervision_spec':'withRestart:'(Spec1, Policy)
+    end
+
+'__beamtalk_meta'/0 = fun () ->
+    ~{'class' => 'LoggingCounter',
+      'superclass' => 'Counter',
+      'package' => 'none',
+      'kind' => 'object',
+      'fields' => ['logCount'],
+      'class_fields' => [],
+      'is_sealed' => 'false',
+      'is_abstract' => 'false',
+      'is_value' => 'false',
+      'is_typed' => 'false',
+      'is_internal' => 'false',
+      'visibility' => 'public',
+      'type_params' => [],
+      'field_types' => ~{'logCount' => 'none'}~,
+      'field_has_default' => ~{'logCount' => 'true'}~,
+      'method_info' => ~{'increment' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'none', 'is_sealed' => 'false', 'visibility' => 'public'}~, 'getLogCount' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'none', 'is_sealed' => 'false', 'visibility' => 'public'}~}~,
+      'class_method_info' => ~{'supervisionSpec' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'SupervisionSpec', 'is_sealed' => 'false', 'visibility' => 'public'}~}~
+    }~
+
+'register_class'/0 = fun () ->
+    try
+        let _BuilderState0 = ~{
+            'className' => 'LoggingCounter',
+            'superclassRef' => 'Counter',
+            'moduleName' => 'logging_counter',
+            'methodSource' => ~{'increment' => #{#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<67>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<67>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<43>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<49>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']])}#, 'getLogCount' => #{#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<76>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<67>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<67>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']])}#}~,
+            'classMethodSource' => ~{}~,
+            'methodSignatures' => ~{'increment' => #{#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']])}#, 'getLogCount' => #{#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<76>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<67>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']])}#}~,
+            'classMethodSignatures' => ~{}~,
+            'methodXref' => [~{'class_side' => 'false', 'selector' => 'increment', 'line' => 1, 'sends' => [~{'selector' => '+', 'line' => 2, 'recv_kind' => 'other'}~, ~{'selector' => 'increment', 'line' => 3, 'recv_kind' => 'super_recv'}~], 'references' => [], 'source_status' => 'indexed'}~, ~{'class_side' => 'false', 'selector' => 'getLogCount', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'indexed'}~, ~{'class_side' => 'true', 'selector' => 'new', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~, ~{'class_side' => 'true', 'selector' => 'new:', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~, ~{'class_side' => 'true', 'selector' => 'spawn', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~, ~{'class_side' => 'true', 'selector' => 'spawn:', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~],
+            'classState' => ~{}~,
+            'classDoc' => 'none',
+            'methodDocs' => ~{}~,
+            'classMethodDocs' => ~{}~,
+            'meta' => ~{'class' => 'LoggingCounter',
+      'superclass' => 'Counter',
+      'package' => 'none',
+      'kind' => 'object',
+      'fields' => ['logCount'],
+      'class_fields' => [],
+      'is_sealed' => 'false',
+      'is_abstract' => 'false',
+      'is_value' => 'false',
+      'is_typed' => 'false',
+      'is_internal' => 'false',
+      'visibility' => 'public',
+      'type_params' => [],
+      'field_types' => ~{'logCount' => 'none'}~,
+      'field_has_default' => ~{'logCount' => 'true'}~,
+      'method_info' => ~{'increment' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'none', 'is_sealed' => 'false', 'visibility' => 'public'}~, 'getLogCount' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'none', 'is_sealed' => 'false', 'visibility' => 'public'}~}~,
+      'class_method_info' => ~{'supervisionSpec' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'SupervisionSpec', 'is_sealed' => 'false', 'visibility' => 'public'}~}~
+    }~,
+            'isConstructible' => 'false'
+        }~
+        in let _Reg0 = case call 'beamtalk_class_builder':'register'(_BuilderState0) of
+            <{'ok', _Pid0}> when 'true' -> 'ok'
+            <{'error', _Err0}> when 'true' -> {'error', _Err0}
+        end
+
+        in _Reg0
+
+    of _ClassRegResult -> _ClassRegResult
+    catch <CatchType, CatchError, CatchStack> -> primop 'raw_raise'(CatchType, CatchError, CatchStack)
+
+end

--- a/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_lexer.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_lexer.snap
@@ -1,0 +1,30 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+Token { kind: Identifier("Counter"), span: Span { start: 350, end: 357 }, leading_trivia: [LineComment("// Copyright 2026 James Casey"), Whitespace("\n"), LineComment("// SPDX-License-Identifier: Apache-2.0"), Whitespace("\n\n"), LineComment("// Test: Actor subclass inheriting from a non-Actor/Object class."), Whitespace("\n"), LineComment("// module name \"logging_counter\" matches class LoggingCounter via to_module_name,"), Whitespace("\n"), LineComment("// so current_class is resolved and has_parent_init = true, exercising the"), Whitespace("\n"), LineComment("// parent-init merge branch in gen_server/callbacks.rs."), Whitespace("\n\n")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("subclass:"), span: Span { start: 358, end: 367 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("LoggingCounter"), span: Span { start: 368, end: 382 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("state:"), span: Span { start: 385, end: 391 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("logCount"), span: Span { start: 392, end: 400 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("="), span: Span { start: 401, end: 402 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("0"), span: Span { start: 403, end: 404 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("increment"), span: Span { start: 408, end: 417 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 418, end: 420 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("self"), span: Span { start: 425, end: 429 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 429, end: 430 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("logCount"), span: Span { start: 430, end: 438 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 439, end: 441 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("self"), span: Span { start: 442, end: 446 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 446, end: 447 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("logCount"), span: Span { start: 447, end: 455 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("+"), span: Span { start: 456, end: 457 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("1"), span: Span { start: 458, end: 459 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("super"), span: Span { start: 464, end: 469 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("increment"), span: Span { start: 470, end: 479 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("getLogCount"), span: Span { start: 483, end: 494 }, leading_trivia: [Whitespace("\n\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 495, end: 497 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("self"), span: Span { start: 498, end: 502 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 502, end: 503 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("logCount"), span: Span { start: 503, end: 511 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Eof, span: Span { start: 512, end: 512 }, leading_trivia: [Whitespace("\n")], trailing_trivia: [] }

--- a/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_parser.snap
@@ -1,0 +1,326 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+AST:
+Module {
+    classes: [
+        ClassDefinition {
+            name: Identifier {
+                name: "LoggingCounter",
+                span: Span {
+                    start: 368,
+                    end: 382,
+                },
+            },
+            superclass: Some(
+                Identifier {
+                    name: "Counter",
+                    span: Span {
+                        start: 350,
+                        end: 357,
+                    },
+                },
+            ),
+            superclass_package: None,
+            class_kind: Object,
+            is_abstract: false,
+            is_sealed: false,
+            is_typed: false,
+            is_internal: false,
+            supervisor_kind: None,
+            state: [
+                StateDeclaration {
+                    name: Identifier {
+                        name: "logCount",
+                        span: Span {
+                            start: 392,
+                            end: 400,
+                        },
+                    },
+                    type_annotation: None,
+                    default_value: Some(
+                        Literal(
+                            Integer(
+                                0,
+                            ),
+                            Span {
+                                start: 403,
+                                end: 404,
+                            },
+                        ),
+                    ),
+                    declared_keyword: State,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 385,
+                        end: 404,
+                    },
+                },
+            ],
+            methods: [
+                MethodDefinition {
+                    selector: Unary(
+                        "increment",
+                    ),
+                    parameters: [],
+                    body: [
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: Assignment {
+                                target: FieldAccess {
+                                    receiver: Identifier(
+                                        Identifier {
+                                            name: "self",
+                                            span: Span {
+                                                start: 425,
+                                                end: 429,
+                                            },
+                                        },
+                                    ),
+                                    field: Identifier {
+                                        name: "logCount",
+                                        span: Span {
+                                            start: 430,
+                                            end: 438,
+                                        },
+                                    },
+                                    span: Span {
+                                        start: 425,
+                                        end: 438,
+                                    },
+                                },
+                                value: MessageSend {
+                                    receiver: FieldAccess {
+                                        receiver: Identifier(
+                                            Identifier {
+                                                name: "self",
+                                                span: Span {
+                                                    start: 442,
+                                                    end: 446,
+                                                },
+                                            },
+                                        ),
+                                        field: Identifier {
+                                            name: "logCount",
+                                            span: Span {
+                                                start: 447,
+                                                end: 455,
+                                            },
+                                        },
+                                        span: Span {
+                                            start: 442,
+                                            end: 455,
+                                        },
+                                    },
+                                    selector: Binary(
+                                        "+",
+                                    ),
+                                    arguments: [
+                                        Literal(
+                                            Integer(
+                                                1,
+                                            ),
+                                            Span {
+                                                start: 458,
+                                                end: 459,
+                                            },
+                                        ),
+                                    ],
+                                    is_cast: false,
+                                    span: Span {
+                                        start: 442,
+                                        end: 459,
+                                    },
+                                },
+                                type_annotation: None,
+                                span: Span {
+                                    start: 425,
+                                    end: 459,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: MessageSend {
+                                receiver: Super(
+                                    Span {
+                                        start: 464,
+                                        end: 469,
+                                    },
+                                ),
+                                selector: Unary(
+                                    "increment",
+                                ),
+                                arguments: [],
+                                is_cast: false,
+                                span: Span {
+                                    start: 464,
+                                    end: 479,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                    ],
+                    return_type: None,
+                    is_sealed: false,
+                    is_internal: false,
+                    is_class_method: false,
+                    kind: Primary,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 408,
+                        end: 479,
+                    },
+                },
+                MethodDefinition {
+                    selector: Unary(
+                        "getLogCount",
+                    ),
+                    parameters: [],
+                    body: [
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: FieldAccess {
+                                receiver: Identifier(
+                                    Identifier {
+                                        name: "self",
+                                        span: Span {
+                                            start: 498,
+                                            end: 502,
+                                        },
+                                    },
+                                ),
+                                field: Identifier {
+                                    name: "logCount",
+                                    span: Span {
+                                        start: 503,
+                                        end: 511,
+                                    },
+                                },
+                                span: Span {
+                                    start: 498,
+                                    end: 511,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                    ],
+                    return_type: None,
+                    is_sealed: false,
+                    is_internal: false,
+                    is_class_method: false,
+                    kind: Primary,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 483,
+                        end: 511,
+                    },
+                },
+            ],
+            class_methods: [],
+            class_variables: [],
+            comments: CommentAttachment {
+                leading: [
+                    Comment {
+                        content: "Copyright 2026 James Casey",
+                        span: Span {
+                            start: 350,
+                            end: 357,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 350,
+                            end: 357,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "Test: Actor subclass inheriting from a non-Actor/Object class.",
+                        span: Span {
+                            start: 350,
+                            end: 357,
+                        },
+                        kind: Line,
+                        preceding_blank_line: true,
+                    },
+                    Comment {
+                        content: "module name \"logging_counter\" matches class LoggingCounter via to_module_name,",
+                        span: Span {
+                            start: 350,
+                            end: 357,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "so current_class is resolved and has_parent_init = true, exercising the",
+                        span: Span {
+                            start: 350,
+                            end: 357,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "parent-init merge branch in gen_server/callbacks.rs.",
+                        span: Span {
+                            start: 350,
+                            end: 357,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                ],
+                trailing: None,
+            },
+            doc_comment: None,
+            backing_module: None,
+            type_params: [],
+            superclass_type_args: [],
+            span: Span {
+                start: 350,
+                end: 511,
+            },
+        },
+    ],
+    method_definitions: [],
+    protocols: [],
+    expressions: [],
+    span: Span {
+        start: 350,
+        end: 511,
+    },
+    file_leading_comments: [],
+    file_trailing_comments: [],
+}

--- a/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_semantic.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_semantic.snap
@@ -1,0 +1,5 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+No semantic errors


### PR DESCRIPTION
## Summary

Closes a real measured coverage gap in `gen_server/callbacks.rs` (was 36% line coverage per CI artifact from run 27980417786).

The root cause: all existing snapshot test cases use names like `class_definition`, `actor_spawn`, etc. that don't match any class name via `to_module_name` / `module_matches_class`, so `current_class` was always `None`, which meant `has_parent_init` was always `false` and `has_initialize` was always `false`. Two entire codegen branches were never executed.

**New test cases:**

- `cases/logging_counter/` — `Counter subclass: LoggingCounter` with `super increment`. Module name `logging_counter` matches class `LoggingCounter` via snake_case conversion, so `current_class = Some(LoggingCounter)` and `has_parent_init = true`. Exercises the parent-init call (`bt@counter:init`), `maps:merge` state merge, and `__skip_initialize__` guard (callbacks.rs lines 156–250).

- `cases/initializing_counter/` — `Actor subclass: InitializingCounter` with an `initialize` method. `has_initialize = true` exercises `init_initialize_guarded_doc` (`{ok, State, {continue, initialize}}` return) and `generate_handle_continue` (callbacks.rs lines 405–447, 851+).

## Test plan

- [x] `cargo test -p test-package-compiler` — all 377 tests pass
- [x] Snapshots reviewed: `logging_counter_codegen` shows `bt@counter:init` call and `maps:merge`; `initializing_counter_codegen` shows `{continue, initialize}` return and `handle_continue` dispatch
- [x] Pre-push hooks pass (clippy, fmt)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5ukErwutvqjQTngMsmEMz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ukErwutvqjQTngMsmEMz)_