### PR TITLE
Tighten loose isNil assertions in source_file_reload_test.bt

### DIFF
--- a/stdlib/test/source_file_reload_test.bt
+++ b/stdlib/test/source_file_reload_test.bt
@@ -15,15 +15,15 @@ TestCase subclass: SourceFileReloadTest
 
   testStdlibClassSourceFileIsNil =>
     // Stdlib classes have no user-supplied source file
-    self assert: Integer sourceFile isNil
-    self assert: String sourceFile isNil
-    self assert: Object sourceFile isNil
-    self assert: Boolean sourceFile isNil
-    self assert: Actor sourceFile isNil
+    self assert: Integer sourceFile equals: nil
+    self assert: String sourceFile equals: nil
+    self assert: Object sourceFile equals: nil
+    self assert: Boolean sourceFile equals: nil
+    self assert: Actor sourceFile equals: nil
 
   testBootstrapBehaviourSourceFileIsNil =>
     // Behaviour itself is a stdlib class — no source file
-    self assert: Behaviour sourceFile isNil
+    self assert: Behaviour sourceFile equals: nil
 
   testStdlibReloadRaisesNoSourceFile =>
     // Reloading a stdlib class raises no_source_file
@@ -35,7 +35,7 @@ TestCase subclass: SourceFileReloadTest
     // sourceFile is a sealed method defined in Behaviour (class protocol)
     self assert: (Behaviour includesSelector: #sourceFile)
     // Sending sourceFile to any class object returns nil or a path (no DNU)
-    self assert: Integer sourceFile isNil
+    self assert: Integer sourceFile equals: nil
 
   testReloadMethodExists =>
     // reload is a sealed method defined in Behaviour (class protocol)


### PR DESCRIPTION
## Summary

- Replace 6 `self assert: X isNil` with `self assert: X equals: nil` in `stdlib/test/source_file_reload_test.bt`
- Both forms are logically equivalent; `assert:equals:` produces a useful failure message ("expected nil but got '/some/path'") instead of the opaque "expected true but got false" from the predicate form

## Test plan

- [x] `just test-bunit` — 2589 tests, 0 failures, SourceFileReloadTest passes
- [x] Pre-push hook: clippy, fmt-check, dialyzer all pass

Closes #2733

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wu49xdPF39bUusR2to9nd

---
_Generated by [Claude Code](https://claude.ai/code/session_013wu49xdPF39bUusR2to9nd)_