### PR TITLE
LiveView IDE: the flush confirmation banner ("Flushed N change(s)…") is too tall (BT-2654)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -1039,9 +1039,9 @@ body.col-resizing .cockpit { transition: none; }
 /* result / output / error blocks */
 .io-block {
   display: flex; align-items: flex-start; gap: 8px;
-  margin: 0 0 8px 0; padding: 9px 12px; border: 1px solid var(--line);
-  border-radius: 7px; background: var(--code-bg); font-family: var(--code-font, ui-monospace, monospace);
-  font-size: 12.5px; white-space: pre-wrap; overflow-wrap: break-word; color: var(--ink);
+  margin: 0 0 6px 0; padding: 4px 10px; border: 1px solid var(--line);
+  border-radius: 6px; background: var(--code-bg); font-family: var(--code-font, ui-monospace, monospace);
+  font-size: 12.5px; line-height: 1.45; white-space: pre-wrap; overflow-wrap: break-word; color: var(--ink);
 }
 .io-block.ok  { background: color-mix(in oklab, var(--ok) 10%, var(--code-bg)); border-color: color-mix(in oklab, var(--ok) 35%, var(--line)); }
 .io-block.err { background: color-mix(in oklab, var(--err) 10%, var(--code-bg)); border-color: color-mix(in oklab, var(--err) 35%, var(--line)); color: var(--err); }


### PR DESCRIPTION
## Summary

The post-flush confirmation banner ("Flushed N change(s) across M file(s)") rendered as a tall block at the top of the editor pane, dominating the layout for a single line of text. This trims the shared `.io-block` transient-notice styling so the flush banner — and every sibling notice in that slot (save/error/warn) — becomes a compact, single-line transient notice.

Linear: https://linear.app/beamtalk/issue/BT-2654

## Changes

- `editors/liveview/assets/css/app.css` — `.io-block` shared notice rule:
  - vertical padding `9px 12px` → `4px 10px`
  - bottom margin `8px` → `6px`
  - border-radius `7px` → `6px`
  - added explicit `line-height: 1.45`

The fix is on the shared component (`.io-block` rendered by the `notice/1` LiveComponent), so it applies consistently to `flush_result`, `flush_error`, `save_result`, `save_error`, and the other notices rather than a one-off.

## Preserved

- Message text and `format_flush_summary/1` output unchanged (display value only, per REPL-output caution).
- The × dismiss control and its `phx-click`/`phx-value-key` wiring are untouched and still work.
- `white-space: pre-wrap` retained, so multi-line REPL `@output` blocks still wrap correctly.

## Testing

- 73 LiveView tests pass (`workspace_test.exs`, `workspace_dismiss_notice_test.exs`, `workspace_flush_badge_test.exs`). No test asserts on CSS pixel values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_