### PR TITLE
LiveView IDE: git revert refreshes the open editor tab in place (BT-2655)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -2434,6 +2434,18 @@ defmodule BtAttachWeb.WorkspaceLive do
         # `unflushed` badge before the re-read (which would otherwise preserve the
         # already-set divergence, mirroring `clear_disk_differs/2` after a flush).
         |> assign(:tabs, clear_disk_differs(socket.assigns.tabs, reloaded))
+        # BT-2655: re-read the reverted `:def` tabs' *editable* definition buffer so
+        # the visible editor shows the reverted header without a close/reopen.
+        # `refresh_after_source_change/1` below re-reads `:method` tab bodies on its
+        # own (and now bumps `editor_rev` to remount the editor — see
+        # `resync_active_tab/2`), but it deliberately leaves a `:def` tab's editable
+        # definition buffer untouched (a generic push must not clobber a concurrent
+        # edit). A revert is the safe exception: it is blocked for this path under
+        # pending edits (`path_has_pending_edits?/2`, BT-2598 d2), so overwriting the
+        # editable buffer for exactly the reloaded `:def` set is both safe and
+        # expected. Method tabs are intentionally left to the refresh below to avoid
+        # a redundant second `browse_method_source` round-trip per tab.
+        |> reload_reverted_def_buffers(reloaded)
         |> refresh_after_source_change()
         |> assign_git()
         # A clean revert whose reload failed surfaces its note in the shared
@@ -2482,6 +2494,49 @@ defmodule BtAttachWeb.WorkspaceLive do
         MapSet.member?(reloaded, elem(key, 0)),
         into: MapSet.new(),
         do: key
+  end
+
+  # BT-2655: re-read the editable *definition* buffer of every open clean `:def` tab
+  # whose disk key is in `reloaded` (the reverted class' def tabs), so the visible
+  # editor reflects the reverted class header without a close/reopen. This is the
+  # one piece the generic push refresh (`refresh_source_tab/2`) intentionally skips:
+  # it re-reads only the `:def` doc block, never the editable definition body, so a
+  # concurrent edit during another session's flush is not clobbered. A revert is the
+  # safe exception — blocked under pending edits for the reverted path
+  # (`path_has_pending_edits?/2`, BT-2598 d2), so no in-progress edit can be lost.
+  # A dirty tab is left untouched all the same (defence in depth); method tabs and
+  # tabs outside `reloaded` pass through and are handled by the refresh that follows.
+  defp reload_reverted_def_buffers(socket, reloaded) do
+    tabs =
+      Enum.map(socket.assigns.tabs, fn tab ->
+        if match?(%{kind: :def, dirty: false}, tab) and
+             MapSet.member?(reloaded, tab_disk_key(tab)) do
+          reread_reverted_def_buffer(socket, tab)
+        else
+          tab
+        end
+      end)
+
+    socket
+    |> assign(:tabs, tabs)
+    |> resync_active_tab(tabs)
+  end
+
+  # Re-read one reverted `:def` tab's editable definition skeleton (header + state)
+  # from the now-reverted live image. Only overwrite the editable buffer when the
+  # re-fetch actually returned a skeleton — `class_definition_info/2` yields `""` on
+  # a transient fetch failure, and blanking a tab the user is looking at would be
+  # worse than leaving the prior (about-to-be-correct) body until the next refresh.
+  defp reread_reverted_def_buffer(socket, tab) do
+    case class_definition_info(socket, tab.class) do
+      {"", _comment, _native_module, _class_modifiers, _is_protocol} ->
+        tab
+
+      {definition, _comment, _native_module, _class_modifiers, _is_protocol} ->
+        # Only the editable definition buffer is touched here; the doc block + badges
+        # are refreshed by `refresh_source_tab/2` in the follow-up push refresh.
+        %{tab | source: definition, base: definition, dirty: false, disk_differs: false}
+    end
   end
 
   # Whether the file `path` git is about to revert has unflushed in-memory
@@ -3773,8 +3828,26 @@ defmodule BtAttachWeb.WorkspaceLive do
   # entry. A dirty active tab is untouched above, so this never disturbs an edit.
   defp resync_active_tab(socket, tabs) do
     case Enum.find(tabs, &(&1.id == socket.assigns[:active_tab])) do
-      %{dirty: false} = active -> sync_active(socket, active)
-      _ -> socket
+      %{dirty: false} = active ->
+        # BT-2655: if the re-read changed the active tab's *body* (a git revert, a
+        # push reconcile), bump `editor_rev` so the `phx-update="ignore"` CodeMirror
+        # host is re-keyed and remounts with the new source. A no-op re-read (same
+        # body) leaves the rev — and thus the live editor instance — untouched, so a
+        # routine refresh of an unchanged tab never disturbs the editor.
+        socket
+        |> maybe_bump_editor_rev(active.source)
+        |> sync_active(active)
+
+      _ ->
+        socket
+    end
+  end
+
+  defp maybe_bump_editor_rev(socket, new_source) do
+    if new_source == socket.assigns[:edit_source] do
+      socket
+    else
+      assign(socket, :editor_rev, socket.assigns.editor_rev + 1)
     end
   end
 
@@ -5020,6 +5093,15 @@ defmodule BtAttachWeb.WorkspaceLive do
     socket
     |> assign(:tabs, [])
     |> assign(:active_tab, nil)
+    # BT-2655: a monotonically-bumped revision folded into the method-editor
+    # overlay's element id. The CmEditor (CodeMirror) host is `phx-update="ignore"`
+    # and seeds its doc from the hidden textarea only on mount, so the only way to
+    # push a NEW body into the focused tab's editor is to re-key the element so
+    # LiveView replaces it and the hook remounts. Switching tabs already re-keys on
+    # `@active_tab`; an *in-place* body re-read of the already-active tab (a git
+    # revert, a flush/push reconcile) keeps the same `@active_tab`, so we bump this
+    # to force the remount and surface the reverted source without a close/reopen.
+    |> assign(:editor_rev, 0)
   end
 
   defp find_tab(socket, id), do: Enum.find(socket.assigns.tabs, &(&1.id == id))
@@ -8995,7 +9077,12 @@ defmodule BtAttachWeb.WorkspaceLive do
                         <%!-- CodeMirror 6 editor (BT-2539). Re-keyed on the active
                            tab id (`@active_tab`) so switching tabs remounts the
                            CmEditor hook and the editor picks up the new tab's
-                           source. The hidden <textarea name="source"> stays the
+                           source. BT-2655: the key also carries `@editor_rev`, bumped
+                           when the active tab's body is re-read in place (a git
+                           revert / push reconcile) so the editor remounts and shows
+                           the new source even though `@active_tab` is unchanged — the
+                           `phx-update="ignore"` host otherwise never re-seeds.
+                           The hidden <textarea name="source"> stays the
                            posted form field (so save_method reads it) and is
                            phx-update="ignore" (hook-owned): the hook mirrors the
                            doc into it and fires `input`, driving the
@@ -9003,7 +9090,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                            300 ms debounce. Selection reports ride select_source
                            via data-select-event, kept in `:edit_selection`. --%>
                         <div
-                          id={"method-editor-overlay-" <> @active_tab}
+                          id={"method-editor-overlay-" <> @active_tab <> "-" <> to_string(@editor_rev)}
                           class="cm-wrap field"
                           phx-hook="CmEditor"
                           data-select-event="select_source"
@@ -9011,7 +9098,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                           data-lint-mode={if active_tab(assigns).kind == :method, do: "method"}
                         >
                           <textarea
-                            id={"method-editor-source-" <> @active_tab}
+                            id={"method-editor-source-" <> @active_tab <> "-" <> to_string(@editor_rev)}
                             class="cm-field"
                             name="source"
                             spellcheck="false"
@@ -9022,7 +9109,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                           ><%= @edit_source %></textarea>
                           <div
                             class="cm-host"
-                            id={"method-editor-cm-" <> @active_tab}
+                            id={"method-editor-cm-" <> @active_tab <> "-" <> to_string(@editor_rev)}
                             phx-update="ignore"
                           >
                           </div>

--- a/editors/liveview/test/bt_attach_web/workspace_git_revert_refresh_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_git_revert_refresh_test.exs
@@ -205,9 +205,11 @@ defmodule BtAttachWeb.WorkspaceGitRevertRefreshTest do
       {:ok, view, _html} = live(owner_conn(conn), "/")
 
       # The in-image method body diverges from disk (a `>>` recompile / external
-      # edit reloaded into the image). Seed it BEFORE opening so the tab's editable
-      # buffer is seeded with — and the editor renders — the diverged image body.
-      StubWorkspaceClient.seed_change("Counter", "increment")
+      # edit reloaded into the image). Use `seed_disk_differs/2` (not `seed_change`)
+      # so we model image≠disk WITHOUT a saved-but-unflushed ChangeLog entry — the
+      # latter would trip `path_has_pending_edits?` and block the revert, testing
+      # the wrong path.
+      StubWorkspaceClient.seed_disk_differs("Counter", "increment")
 
       StubWorkspaceClient.update_compiled_source(
         "Counter",

--- a/editors/liveview/test/bt_attach_web/workspace_git_revert_refresh_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_git_revert_refresh_test.exs
@@ -200,6 +200,80 @@ defmodule BtAttachWeb.WorkspaceGitRevertRefreshTest do
     end
   end
 
+  describe "BT-2655: revert updates the open editor BODY in place (no reopen)" do
+    test "an open method tab's editor body reflects the reverted source", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # The in-image method body diverges from disk (a `>>` recompile / external
+      # edit reloaded into the image). Seed it BEFORE opening so the tab's editable
+      # buffer is seeded with — and the editor renders — the diverged image body.
+      StubWorkspaceClient.seed_change("Counter", "increment")
+
+      StubWorkspaceClient.update_compiled_source(
+        "Counter",
+        "increment",
+        "increment => self.value := self.value + 99"
+      )
+
+      html = open_increment_tab(view)
+      assert html =~ "self.value := self.value + 99"
+
+      # Revert the file. The reload resets the image to disk (drops the override),
+      # and the revert re-reads the OPEN tab body in place + re-keys the editor — so
+      # the editor shows the reverted on-disk source WITHOUT a close/reopen.
+      render_hook(view, "git_revert", %{"path" => "src/counter.bt"})
+
+      assert eventually(fn -> render(view) =~ "self.value := self.value + 1" end)
+      refute render(view) =~ "self.value := self.value + 99"
+    end
+
+    test "an open class-definition tab's editor body reflects the reverted header", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # The in-image class skeleton diverges from the on-disk skeleton (a header
+      # recompile: a renamed superclass / changed state). Seed it BEFORE opening so
+      # the def tab's editable buffer is seeded with the diverged image body.
+      StubWorkspaceClient.seed_class_definition(
+        "Counter",
+        "Object subclass: Counter\n  state: total :: Integer = 0"
+      )
+
+      html = render_hook(view, "browser_open_definition", %{"class" => "Counter"})
+      assert html =~ "state: total :: Integer = 0"
+
+      # Revert the file. `reload_file` drops the in-image definition override (image
+      # == disk), and the revert re-reads the open :def tab's editable definition
+      # buffer in place — so the editor shows the reverted on-disk skeleton WITHOUT a
+      # close/reopen. (The generic push refresh deliberately leaves the :def buffer
+      # untouched; a revert is the safe exception — BT-2655.)
+      render_hook(view, "git_revert", %{"path" => "src/counter.bt"})
+
+      assert eventually(fn -> render(view) =~ "Object subclass: Counter" end)
+      refute render(view) =~ "state: total :: Integer = 0"
+    end
+
+    test "an unrelated open tab is NOT disturbed by a revert of a different file", %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # Open Counter#increment and keep it focused.
+      html = open_increment_tab(view)
+      assert html =~ "self.value := self.value + 1"
+
+      # Revert a DIFFERENT file (subprocess.bt). The Counter tab must be untouched —
+      # its body still renders the unchanged Counter source.
+      render_hook(view, "git_revert", %{"path" => "src/subprocess.bt"})
+
+      assert eventually(fn ->
+               Enum.any?(
+                 StubWorkspaceClient.calls(),
+                 &match?({:reload_file, "src/subprocess.bt"}, &1)
+               )
+             end)
+
+      assert render(view) =~ "self.value := self.value + 1"
+    end
+  end
+
   describe "AC5: class-change push refreshes open windows + browser" do
     test "a ClassLoaded push re-reads an open clean method tab", %{conn: conn} do
       {:ok, view, _html} = live(owner_conn(conn), "/")

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -23,6 +23,12 @@ defmodule BtAttachWeb.StubWorkspaceClient do
               # current *image* body, which after a `>>` compile is the compiled
               # body — so the stub serves this over the hardcoded on-disk body.
               compiled_sources: %{},
+              # BT-2655: an in-image class-definition skeleton override per class,
+              # recorded so a test can make the image's `browse_class_definition`
+              # body diverge from the hardcoded on-disk skeleton (modelling a `>>`
+              # header recompile / external edit). `reload_file/1` drops the override
+              # for the reverted class so the served body falls back to disk.
+              compiled_definitions: %{},
               # BT-2590: the simulated `autoflush` flag (default off) and seeded
               # git panel results, so a test can exercise the post-save refresh
               # gate and the async git load without a real workspace node.
@@ -319,6 +325,10 @@ defmodule BtAttachWeb.StubWorkspaceClient do
       sources |> Enum.reject(fn {{c, _sel}, _src} -> c == class end) |> Map.new()
     end)
 
+    # BT-2655: drop any in-image class-definition override for the reverted class so
+    # `browse_class_definition` serves the on-disk skeleton again (image == disk).
+    update(:compiled_definitions, fn defs -> Map.delete(defs, class) end)
+
     update(:changes, fn changes ->
       changes |> Enum.reject(fn {{c, _sel}, _file} -> c == class end) |> Map.new()
     end)
@@ -350,6 +360,16 @@ defmodule BtAttachWeb.StubWorkspaceClient do
   """
   def seed_change(class, selector) do
     update(:changes, &Map.put(&1, {class, selector}, "src/#{Macro.underscore(class)}.bt"))
+  end
+
+  @doc """
+  Test helper (BT-2655): override the in-image method body served by
+  `browse_method_source/3` for `{class, selector}` (modelling a `>>` recompile /
+  external edit reloaded into the image). `reload_file/1` drops it for the class so
+  a revert's reload serves the on-disk stub body again (image == disk).
+  """
+  def update_compiled_source(class, selector, source) when is_binary(source) do
+    update(:compiled_sources, &Map.put(&1, {class, selector}, source))
   end
 
   # `src/git_gate3.bt` -> "GitGate3": strip dir + extension, then CamelCase from the
@@ -655,11 +675,23 @@ defmodule BtAttachWeb.StubWorkspaceClient do
   @doc "BT-2605: force `browse_class_definition/1` to fail (transient-outage simulation)."
   def fail_class_definition(flag) when is_boolean(flag), do: put(:fail_class_definition, flag)
 
+  @doc """
+  Test helper (BT-2655): seed an in-image class-definition skeleton override for
+  `class` so `browse_class_definition/1` serves it over the hardcoded on-disk
+  skeleton (modelling a header recompile / external edit). `reload_file/1` drops
+  it, so a revert's reload makes the served body fall back to the on-disk skeleton.
+  """
+  def seed_class_definition(class, definition) when is_binary(definition) do
+    update(:compiled_definitions, &Map.put(&1, class, definition))
+  end
+
   defp browse_class_definition_ok(class) do
+    definition = Map.get(get(:compiled_definitions), class, "Object subclass: #{class}")
+
     {:value,
      %{
        "class" => class,
-       "definition" => "Object subclass: #{class}",
+       "definition" => definition,
        "comment" => "The #{class} class.\n\n## Overview\nA stubbed class comment.",
        # BT-2578: `Subprocess` / `Headless` stand in for native: classes (ADR
        # 0056) so the System Browser's "Erlang backend" badge + native pane can be


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2655

After a git revert from the GIT pane, the live image was reverted but the open editor tab kept showing pre-revert source until close/reopen. Fix:

- `git_revert_event/2` now calls `reload_reverted_def_buffers/2` to re-read the reverted `:def` tabs' editable definition buffer (the gap the generic push refresh skips); `:method` bodies stay handled by `refresh_after_source_change/1`.
- Added an `editor_rev` assign folded into the CodeMirror overlay/textarea/host element ids, bumped in `resync_active_tab/2` only when the active clean tab's body actually changed — forcing the `phx-update="ignore"` editor to remount with the reverted source. Also fixes the same latent stale-buffer rendering for flush/external-edit pushes.
- Unrelated tabs and tabs with genuine unflushed edits are untouched (revert stays blocked under pending edits).

Tests: 3 new LiveView tests (method body, `:def` body, unrelated-tab-untouched) + stub seams; full `mix test` 403 passed, format + `--warnings-as-errors` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4jUmKM5sQiy7NGu1QrRS2)_