### PR TITLE
docs(adr): mark ADR 0098 Accepted + fix Phase 4 concurrency rationale (BT-2673)

### DIFF
--- a/docs/ADR/0098-build-artifact-provenance.md
+++ b/docs/ADR/0098-build-artifact-provenance.md
@@ -1,7 +1,7 @@
 # ADR 0098: Build Artifact Provenance and Version-Based Staleness Invalidation
 
 ## Status
-Proposed (2026-06-23)
+Accepted (2026-06-23)
 
 ## Context
 
@@ -356,10 +356,12 @@ the stamp is build-local and the lockfile is committed.
   dep) complete *before* any `code:load_file/1` calls begin, so a "source
   unavailable" failure always leaves the code server in its pre-attach state —
   no partial loads to roll back. Concurrent attaches fall under the same
-  last-write-wins accepted race as §1: two sessions that both recompile a stale
-  dep still produce a valid stamp, and OTP's code server serializes
-  `code:load_file/1`, so no lock is needed. Test: an old-toolchain fixture (no
-  meta keys) recompiles on attach.
+  last-write-wins accepted race as §1: both sessions compile from identical
+  source to identical output, so last-write-wins on the `.beam` files still
+  yields a valid module; OTP's code server additionally serializes each
+  `code:load_file/1` call, so the load step is safe regardless of order. No lock
+  is needed at either step. Test: an old-toolchain fixture (no meta keys)
+  recompiles on attach.
 
 ## Migration Path
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -124,7 +124,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0095](0095-rich-navigable-inspector.md) | Rich Navigable Inspector — Drillable, Live-Refreshing Object Views | Accepted | 2026-06-11 |
 | [0096](0096-system-browser-data-source.md) | System Browser Data Source — Class/Method Browse API for the LiveView IDE | Proposed | 2026-06-10 |
 | [0097](0097-desktop-attach-client-node-per-workspace.md) | Desktop Attach Client — One Front Node per Workspace | Proposed | 2026-06-13 |
-| [0098](0098-build-artifact-provenance.md) | Build Artifact Provenance and Version-Based Staleness Invalidation | Proposed | 2026-06-23 |
+| [0098](0098-build-artifact-provenance.md) | Build Artifact Provenance and Version-Based Staleness Invalidation | Accepted | 2026-06-23 |
 
 > ADR 0086 was originally numbered 0069 (a collision with *Actor Observability and Tracing*) and was renumbered on 2026-05-25.
 


### PR DESCRIPTION
## Summary

Follow-up to #2747. Promotes **ADR 0098** from *Proposed* to **Accepted** now that the design is settled, and corrects one technical inaccuracy spotted in review after #2747 merged.

## Changes
- **Status → Accepted** in `docs/ADR/0098-build-artifact-provenance.md` and the `docs/ADR/README.md` index row.
- **Phase 4 concurrency rationale fix:** the concurrent-attach paragraph previously credited `code:load_file/1` serialization for *compile-step* safety. Compile-step safety actually comes from the §1 identical-source / last-write-wins guarantee on `.beam` files; code-server serialization covers only the *load* step. Reworded to keep the two risks distinct.

## Test plan
Docs-only; no build/test impact.

Implementation tracked under BT-2673 (phase sub-issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tj95bwJGXFGL2sYv3tkoWd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tj95bwJGXFGL2sYv3tkoWd)_