### PR TITLE
test(repl): add EUnit tests for beamtalk_repl_ops_eval uncovered paths

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
@@ -29,7 +29,7 @@ Covers:
 make_msg(Op) ->
     {protocol_msg, Op, <<"id-1">>, undefined, #{}, false}.
 
-setup() ->
+setup(SessionId) ->
     application:ensure_all_started(compiler),
     application:ensure_all_started(beamtalk_runtime),
     case application:ensure_all_started(beamtalk_compiler) of
@@ -38,7 +38,7 @@ setup() ->
     end,
     %% Allow the runtime to register its bootstrap classes before compiling.
     timer:sleep(300),
-    {ok, SessionPid} = beamtalk_repl_shell:start_link(<<"test-eval-ops">>),
+    {ok, SessionPid} = beamtalk_repl_shell:start_link(SessionId),
     SessionPid.
 
 teardown(SessionPid) ->
@@ -64,72 +64,83 @@ handle_term_empty_code_returns_empty_expression_error_test() ->
 %%====================================================================
 
 handle_term_non_empty_eval_success_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(SessionPid) ->
-        [
-            ?_test(begin
-                Msg = make_msg(<<"eval">>),
-                Result = beamtalk_repl_ops_eval:handle_term(
-                    <<"eval">>, #{<<"code">> => <<"1 + 2">>}, Msg, SessionPid
-                ),
-                ?assertMatch({ok, 3, _, _}, Result)
-            end)
-        ]
-    end}.
+    {setup,
+        fun() -> setup(<<"test-eval-ops-success">>) end,
+        fun teardown/1,
+        fun(SessionPid) ->
+            [
+                ?_test(begin
+                    Msg = make_msg(<<"eval">>),
+                    Result = beamtalk_repl_ops_eval:handle_term(
+                        <<"eval">>, #{<<"code">> => <<"1 + 2">>}, Msg, SessionPid
+                    ),
+                    ?assertMatch({ok, 3, _, _}, Result)
+                end)
+            ]
+        end}.
 
 handle_term_eval_error_wraps_in_beamtalk_error_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(SessionPid) ->
-        [
-            ?_test(begin
-                Msg = make_msg(<<"eval">>),
-                %% Unary message not understood by Integer → does_not_understand.
-                Result = beamtalk_repl_ops_eval:handle_term(
-                    <<"eval">>, #{<<"code">> => <<"1 unknownMsg">>}, Msg, SessionPid
-                ),
-                ?assertMatch({error, #beamtalk_error{}, _, _}, Result)
-            end)
-        ]
-    end}.
+    {setup,
+        fun() -> setup(<<"test-eval-ops-error">>) end,
+        fun teardown/1,
+        fun(SessionPid) ->
+            [
+                ?_test(begin
+                    Msg = make_msg(<<"eval">>),
+                    %% Unary message not understood by Integer → does_not_understand.
+                    Result = beamtalk_repl_ops_eval:handle_term(
+                        <<"eval">>, #{<<"code">> => <<"1 unknownMsg">>}, Msg, SessionPid
+                    ),
+                    ?assertMatch({error, #beamtalk_error{}, _, _}, Result)
+                end)
+            ]
+        end}.
 
 %%====================================================================
 %% handle_term/4 — trace mode
 %%====================================================================
 
 handle_term_trace_mode_returns_trace_shape_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(SessionPid) ->
-        [
-            ?_test(begin
-                Msg = make_msg(<<"eval">>),
-                Result = beamtalk_repl_ops_eval:handle_term(
-                    <<"eval">>,
-                    #{<<"code">> => <<"1 + 2">>, <<"trace">> => true},
-                    Msg,
-                    SessionPid
-                ),
-                ?assertMatch({trace, _, _, _}, Result)
-            end)
-        ]
-    end}.
+    {setup,
+        fun() -> setup(<<"test-eval-ops-trace">>) end,
+        fun teardown/1,
+        fun(SessionPid) ->
+            [
+                ?_test(begin
+                    Msg = make_msg(<<"eval">>),
+                    Result = beamtalk_repl_ops_eval:handle_term(
+                        <<"eval">>,
+                        #{<<"code">> => <<"1 + 2">>, <<"trace">> => true},
+                        Msg,
+                        SessionPid
+                    ),
+                    ?assertMatch({trace, _, _, _}, Result)
+                end)
+            ]
+        end}.
 
 %%====================================================================
 %% handle/4 — WebSocket edge wrapper
 %%====================================================================
 
 handle_websocket_encodes_eval_result_to_json_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun(SessionPid) ->
-        [
-            ?_test(begin
-                Msg = make_msg(<<"eval">>),
-                Result = beamtalk_repl_ops_eval:handle(
-                    <<"eval">>, #{<<"code">> => <<"1 + 2">>}, Msg, SessionPid
-                ),
-                ?assert(is_binary(Result)),
-                Decoded = json:decode(Result),
-                %% WebSocket edge always encodes op_result to a JSON object:
-                %% {"value": ...} on success or {"error": ...} on failure.
-                ?assert(is_map(Decoded)),
-                ?assert(
-                    maps:is_key(<<"value">>, Decoded) orelse maps:is_key(<<"error">>, Decoded)
-                )
-            end)
-        ]
-    end}.
+    {setup,
+        fun() -> setup(<<"test-eval-ops-ws">>) end,
+        fun teardown/1,
+        fun(SessionPid) ->
+            [
+                ?_test(begin
+                    Msg = make_msg(<<"eval">>),
+                    Result = beamtalk_repl_ops_eval:handle(
+                        <<"eval">>, #{<<"code">> => <<"1 + 2">>}, Msg, SessionPid
+                    ),
+                    ?assert(is_binary(Result)),
+                    Decoded = json:decode(Result),
+                    ?assert(is_map(Decoded)),
+                    ?assert(
+                        maps:is_key(<<"value">>, Decoded) orelse maps:is_key(<<"error">>, Decoded)
+                    ),
+                    ?assertEqual(3, maps:get(<<"value">>, Decoded, undefined))
+                end)
+            ]
+        end}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
@@ -64,83 +64,71 @@ handle_term_empty_code_returns_empty_expression_error_test() ->
 %%====================================================================
 
 handle_term_non_empty_eval_success_test_() ->
-    {setup,
-        fun() -> setup(<<"test-eval-ops-success">>) end,
-        fun teardown/1,
-        fun(SessionPid) ->
-            [
-                ?_test(begin
-                    Msg = make_msg(<<"eval">>),
-                    Result = beamtalk_repl_ops_eval:handle_term(
-                        <<"eval">>, #{<<"code">> => <<"1 + 2">>}, Msg, SessionPid
-                    ),
-                    ?assertMatch({ok, 3, _, _}, Result)
-                end)
-            ]
-        end}.
+    {setup, fun() -> setup(<<"test-eval-ops-success">>) end, fun teardown/1, fun(SessionPid) ->
+        [
+            ?_test(begin
+                Msg = make_msg(<<"eval">>),
+                Result = beamtalk_repl_ops_eval:handle_term(
+                    <<"eval">>, #{<<"code">> => <<"1 + 2">>}, Msg, SessionPid
+                ),
+                ?assertMatch({ok, 3, _, _}, Result)
+            end)
+        ]
+    end}.
 
 handle_term_eval_error_wraps_in_beamtalk_error_test_() ->
-    {setup,
-        fun() -> setup(<<"test-eval-ops-error">>) end,
-        fun teardown/1,
-        fun(SessionPid) ->
-            [
-                ?_test(begin
-                    Msg = make_msg(<<"eval">>),
-                    %% Unary message not understood by Integer → does_not_understand.
-                    Result = beamtalk_repl_ops_eval:handle_term(
-                        <<"eval">>, #{<<"code">> => <<"1 unknownMsg">>}, Msg, SessionPid
-                    ),
-                    ?assertMatch({error, #beamtalk_error{}, _, _}, Result)
-                end)
-            ]
-        end}.
+    {setup, fun() -> setup(<<"test-eval-ops-error">>) end, fun teardown/1, fun(SessionPid) ->
+        [
+            ?_test(begin
+                Msg = make_msg(<<"eval">>),
+                %% Unary message not understood by Integer → does_not_understand.
+                Result = beamtalk_repl_ops_eval:handle_term(
+                    <<"eval">>, #{<<"code">> => <<"1 unknownMsg">>}, Msg, SessionPid
+                ),
+                ?assertMatch({error, #beamtalk_error{}, _, _}, Result)
+            end)
+        ]
+    end}.
 
 %%====================================================================
 %% handle_term/4 — trace mode
 %%====================================================================
 
 handle_term_trace_mode_returns_trace_shape_test_() ->
-    {setup,
-        fun() -> setup(<<"test-eval-ops-trace">>) end,
-        fun teardown/1,
-        fun(SessionPid) ->
-            [
-                ?_test(begin
-                    Msg = make_msg(<<"eval">>),
-                    Result = beamtalk_repl_ops_eval:handle_term(
-                        <<"eval">>,
-                        #{<<"code">> => <<"1 + 2">>, <<"trace">> => true},
-                        Msg,
-                        SessionPid
-                    ),
-                    ?assertMatch({trace, _, _, _}, Result)
-                end)
-            ]
-        end}.
+    {setup, fun() -> setup(<<"test-eval-ops-trace">>) end, fun teardown/1, fun(SessionPid) ->
+        [
+            ?_test(begin
+                Msg = make_msg(<<"eval">>),
+                Result = beamtalk_repl_ops_eval:handle_term(
+                    <<"eval">>,
+                    #{<<"code">> => <<"1 + 2">>, <<"trace">> => true},
+                    Msg,
+                    SessionPid
+                ),
+                ?assertMatch({trace, _, _, _}, Result)
+            end)
+        ]
+    end}.
 
 %%====================================================================
 %% handle/4 — WebSocket edge wrapper
 %%====================================================================
 
 handle_websocket_encodes_eval_result_to_json_test_() ->
-    {setup,
-        fun() -> setup(<<"test-eval-ops-ws">>) end,
-        fun teardown/1,
-        fun(SessionPid) ->
-            [
-                ?_test(begin
-                    Msg = make_msg(<<"eval">>),
-                    Result = beamtalk_repl_ops_eval:handle(
-                        <<"eval">>, #{<<"code">> => <<"1 + 2">>}, Msg, SessionPid
-                    ),
-                    ?assert(is_binary(Result)),
-                    Decoded = json:decode(Result),
-                    ?assert(is_map(Decoded)),
-                    ?assert(
-                        maps:is_key(<<"value">>, Decoded) orelse maps:is_key(<<"error">>, Decoded)
-                    ),
-                    ?assertEqual(3, maps:get(<<"value">>, Decoded, undefined))
-                end)
-            ]
-        end}.
+    {setup, fun() -> setup(<<"test-eval-ops-ws">>) end, fun teardown/1, fun(SessionPid) ->
+        [
+            ?_test(begin
+                Msg = make_msg(<<"eval">>),
+                Result = beamtalk_repl_ops_eval:handle(
+                    <<"eval">>, #{<<"code">> => <<"1 + 2">>}, Msg, SessionPid
+                ),
+                ?assert(is_binary(Result)),
+                Decoded = json:decode(Result),
+                ?assert(is_map(Decoded)),
+                ?assert(
+                    maps:is_key(<<"value">>, Decoded) orelse maps:is_key(<<"error">>, Decoded)
+                ),
+                ?assertEqual(3, maps:get(<<"value">>, Decoded, undefined))
+            end)
+        ]
+    end}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
@@ -125,10 +125,8 @@ handle_websocket_encodes_eval_result_to_json_test_() ->
                 ?assert(is_binary(Result)),
                 Decoded = json:decode(Result),
                 ?assert(is_map(Decoded)),
-                ?assert(
-                    maps:is_key(<<"value">>, Decoded) orelse maps:is_key(<<"error">>, Decoded)
-                ),
-                ?assertEqual(3, maps:get(<<"value">>, Decoded, undefined))
+                ?assert(maps:is_key(<<"value">>, Decoded)),
+                ?assertEqual(3, maps:get(<<"value">>, Decoded))
             end)
         ]
     end}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
@@ -30,12 +30,23 @@ make_msg(Op) ->
     {protocol_msg, Op, <<"id-1">>, undefined, #{}, false}.
 
 setup() ->
+    application:ensure_all_started(compiler),
     application:ensure_all_started(beamtalk_runtime),
+    case application:ensure_all_started(beamtalk_compiler) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    %% Allow the runtime to register its bootstrap classes before compiling.
+    timer:sleep(300),
     {ok, SessionPid} = beamtalk_repl_shell:start_link(<<"test-eval-ops">>),
     SessionPid.
 
 teardown(SessionPid) ->
-    catch beamtalk_repl_shell:stop(SessionPid).
+    catch beamtalk_repl_shell:stop(SessionPid),
+    %% Restore baseline "compiler not running" state so subsequent test modules
+    %% that test no-compiler error paths see the expected initial state.
+    _ = application:stop(beamtalk_compiler),
+    ok.
 
 %%====================================================================
 %% handle_term/4 — empty code (no session required)

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
@@ -1,0 +1,124 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_repl_ops_eval_tests).
+
+%%% **DDD Context:** REPL Session Context
+
+-moduledoc """
+EUnit tests for `beamtalk_repl_ops_eval` — the `eval` op handler (BT-2399,
+ADR 0017 Phase 3).
+
+Covers:
+* empty code → `{error, #beamtalk_error{kind=empty_expression}}` (no session
+  needed — short-circuits before touching the session pid);
+* non-empty expression that succeeds → `{ok, Value, Output, Warnings}`;
+* non-empty expression that fails at runtime → `{error, #beamtalk_error{}, Output, Warnings}`
+  (verify `beamtalk_repl_errors:ensure_structured_error/1` wrapping);
+* trace mode → `{trace, Steps, Output, Warnings}`;
+* `handle/4` WebSocket edge wrapper → encodes the term result to a JSON binary.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+make_msg(Op) ->
+    {protocol_msg, Op, <<"id-1">>, undefined, #{}, false}.
+
+setup() ->
+    application:ensure_all_started(beamtalk_runtime),
+    {ok, SessionPid} = beamtalk_repl_shell:start_link(<<"test-eval-ops">>),
+    SessionPid.
+
+teardown(SessionPid) ->
+    catch beamtalk_repl_shell:stop(SessionPid).
+
+%%====================================================================
+%% handle_term/4 — empty code (no session required)
+%%====================================================================
+
+handle_term_empty_code_returns_empty_expression_error_test() ->
+    Msg = make_msg(<<"eval">>),
+    Result = beamtalk_repl_ops_eval:handle_term(
+        <<"eval">>, #{<<"code">> => <<>>}, Msg, self()
+    ),
+    ?assertMatch({error, #beamtalk_error{kind = empty_expression}}, Result).
+
+%%====================================================================
+%% handle_term/4 — non-empty eval paths (session required)
+%%====================================================================
+
+handle_term_non_empty_eval_success_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(SessionPid) ->
+        [
+            ?_test(begin
+                Msg = make_msg(<<"eval">>),
+                Result = beamtalk_repl_ops_eval:handle_term(
+                    <<"eval">>, #{<<"code">> => <<"1 + 2">>}, Msg, SessionPid
+                ),
+                ?assertMatch({ok, 3, _, _}, Result)
+            end)
+        ]
+    end}.
+
+handle_term_eval_error_wraps_in_beamtalk_error_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(SessionPid) ->
+        [
+            ?_test(begin
+                Msg = make_msg(<<"eval">>),
+                %% Unary message not understood by Integer → does_not_understand.
+                Result = beamtalk_repl_ops_eval:handle_term(
+                    <<"eval">>, #{<<"code">> => <<"1 unknownMsg">>}, Msg, SessionPid
+                ),
+                ?assertMatch({error, #beamtalk_error{}, _, _}, Result)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% handle_term/4 — trace mode
+%%====================================================================
+
+handle_term_trace_mode_returns_trace_shape_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(SessionPid) ->
+        [
+            ?_test(begin
+                Msg = make_msg(<<"eval">>),
+                Result = beamtalk_repl_ops_eval:handle_term(
+                    <<"eval">>,
+                    #{<<"code">> => <<"1 + 2">>, <<"trace">> => true},
+                    Msg,
+                    SessionPid
+                ),
+                ?assertMatch({trace, _, _, _}, Result)
+            end)
+        ]
+    end}.
+
+%%====================================================================
+%% handle/4 — WebSocket edge wrapper
+%%====================================================================
+
+handle_websocket_encodes_eval_result_to_json_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(SessionPid) ->
+        [
+            ?_test(begin
+                Msg = make_msg(<<"eval">>),
+                Result = beamtalk_repl_ops_eval:handle(
+                    <<"eval">>, #{<<"code">> => <<"1 + 2">>}, Msg, SessionPid
+                ),
+                ?assert(is_binary(Result)),
+                Decoded = json:decode(Result),
+                %% WebSocket edge always encodes op_result to a JSON object:
+                %% {"value": ...} on success or {"error": ...} on failure.
+                ?assert(is_map(Decoded)),
+                ?assert(
+                    maps:is_key(<<"value">>, Decoded) orelse maps:is_key(<<"error">>, Decoded)
+                )
+            end)
+        ]
+    end}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
@@ -30,12 +30,9 @@ make_msg(Op) ->
     {protocol_msg, Op, <<"id-1">>, undefined, #{}, false}.
 
 setup(SessionId) ->
-    application:ensure_all_started(compiler),
-    application:ensure_all_started(beamtalk_runtime),
-    case application:ensure_all_started(beamtalk_compiler) of
-        {ok, _} -> ok;
-        {error, {already_started, _}} -> ok
-    end,
+    {ok, _} = application:ensure_all_started(compiler),
+    {ok, _} = application:ensure_all_started(beamtalk_runtime),
+    {ok, _} = application:ensure_all_started(beamtalk_compiler),
     %% Allow the runtime to register its bootstrap classes before compiling.
     timer:sleep(300),
     {ok, SessionPid} = beamtalk_repl_shell:start_link(SessionId),


### PR DESCRIPTION
## Summary

- `beamtalk_repl_ops_eval` had only 4/13 lines covered (30.8%) — the `handle/4` WebSocket wrapper and the entire non-empty eval dispatch (success, error-wrapping, trace) were never exercised directly
- All existing tests that evaluate code call `beamtalk_repl_shell:eval` directly, bypassing this module entirely
- Add `beamtalk_repl_ops_eval_tests` covering the 5 paths: empty code, eval success, eval error with structured-error wrapping, trace mode, and WebSocket JSON encoding

Projected coverage: **30.8% → ~84.6%** (11/13 lines; trace error path remains as future work).

## Test plan

- [ ] `handle_term_empty_code_returns_empty_expression_error_test` — no session required, short-circuits before eval
- [ ] `handle_term_non_empty_eval_success_test_` — starts a REPL session, evals `1 + 2`, asserts `{ok, 3, _, _}`
- [ ] `handle_term_eval_error_wraps_in_beamtalk_error_test_` — evals `1 unknownMsg` (DNU), asserts `ensure_structured_error` wrapping produces `{error, #beamtalk_error{}, _, _}`
- [ ] `handle_term_trace_mode_returns_trace_shape_test_` — evals with `trace: true`, asserts `{trace, Steps, Output, Warnings}`
- [ ] `handle_websocket_encodes_eval_result_to_json_test_` — calls `handle/4`, asserts the result is a valid JSON binary with either a `"value"` or `"error"` key

Session-dependent tests follow the `{setup, fun setup/0, fun teardown/1, ...}` pattern from `beamtalk_repl_shell_tests.erl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD8Hdud1p9ztQz9LceZcSL

---
_Generated by [Claude Code](https://claude.ai/code/session_01YD8Hdud1p9ztQz9LceZcSL)_