### PR TITLE
feat(types): resolve singleton receivers via Symbol + narrow undefined/enum FFI specs (BT-2647)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1325,6 +1325,11 @@ impl TypeChecker {
                 return elem_ty;
             }
 
+            // Validation routes ALL singleton receivers (including binary sends)
+            // through `Symbol` — that is fine: `Symbol` understands `=:=`/`=`, so
+            // no spurious DNU, and the BT-2631 impossible-comparison hint fires
+            // via the Dynamic fall-through below, not via validation. Only the
+            // *inference* redirect (`resolve_class`) excludes binary sends.
             self.check_instance_selector(class_name, &selector_name, span, hierarchy);
             // BT-2647: a non-union singleton receiver (`#text`) is a subtype of
             // `Symbol` but not itself in the hierarchy, so method lookup and

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1333,7 +1333,18 @@ impl TypeChecker {
             // its protocol through `Symbol`, mirroring the singleton-union member
             // handling from BT-2624. `class_name` (`#text`) is still used for
             // `Self` returns and user-facing messages.
-            let resolve_class: EcoString = if class_name.starts_with('#') {
+            //
+            // `!contains('|')` keeps this symmetric with `check_instance_selector`
+            // (a `Known` is never a union today, but a future `Known { "#a | #b" }`
+            // must not silently route here while validation leaves it untouched).
+            // Binary sends are excluded: an equality op on a singleton receiver
+            // (`#west =:= unionVar`) must fall through to the BT-2631
+            // statically-decidable-comparison hint below rather than
+            // short-circuiting on `Symbol`'s `=:=`.
+            let resolve_class: EcoString = if class_name.starts_with('#')
+                && !class_name.contains('|')
+                && !matches!(selector, MessageSelector::Binary(_))
+            {
                 EcoString::from("Symbol")
             } else {
                 class_name.clone()

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1326,11 +1326,23 @@ impl TypeChecker {
             }
 
             self.check_instance_selector(class_name, &selector_name, span, hierarchy);
+            // BT-2647: a non-union singleton receiver (`#text`) is a subtype of
+            // `Symbol` but not itself in the hierarchy, so method lookup and
+            // argument/return-type inference would otherwise fall through to
+            // Dynamic — losing the inference it had when typed `Symbol`. Resolve
+            // its protocol through `Symbol`, mirroring the singleton-union member
+            // handling from BT-2624. `class_name` (`#text`) is still used for
+            // `Self` returns and user-facing messages.
+            let resolve_class: EcoString = if class_name.starts_with('#') {
+                EcoString::from("Symbol")
+            } else {
+                class_name.clone()
+            };
             // Skip argument type check for binary messages — check_binary_operand_types
             // already provides more specific warnings for arithmetic/comparison/concat.
             if !matches!(selector, MessageSelector::Binary(_)) {
                 self.check_argument_types(
-                    class_name,
+                    &resolve_class,
                     &selector_name,
                     &arg_types,
                     span,
@@ -1342,7 +1354,7 @@ impl TypeChecker {
             }
 
             // Infer return type from method info
-            if let Some(method) = hierarchy.find_method(class_name, &selector_name) {
+            if let Some(method) = hierarchy.find_method(&resolve_class, &selector_name) {
                 if let Some(ref ret_ty) = method.return_type {
                     // `Self` resolves to the static receiver class (with type args)
                     if ret_ty.as_str() == "Self" {
@@ -1365,7 +1377,10 @@ impl TypeChecker {
                     // `find_class_method`. Pre-0083 this returned `Dynamic`
                     // (BT-1952).
                     if ret_ty.as_str() == "Self class" {
-                        return InferredType::meta(class_name.clone());
+                        // BT-2647: for a singleton receiver, `resolve_class` is
+                        // `Symbol` so `#text class` is `Symbol class` (`#text` is a
+                        // Symbol at runtime), not a phantom `Meta("#text")`.
+                        return InferredType::meta(resolve_class.clone());
                     }
                     // ADR 0083: `X class` — the method returns the metatype of a
                     // specific named class (BT-2034 annotation `X class`).
@@ -1384,7 +1399,7 @@ impl TypeChecker {
                     // if the method is inherited (ADR 0068 Phase 1b, BT-1577)
                     let subst = Self::build_inherited_substitution_map(
                         hierarchy,
-                        class_name,
+                        &resolve_class,
                         type_args,
                         &method.defined_in,
                     );

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
@@ -861,16 +861,21 @@ fn bt2647_singleton_resolves_inherited_symbol_method() {
     );
 }
 
-/// BT-2647: a selector `Symbol` does not understand on a non-union singleton is a
-/// definite DNU — a Warning, not the silently-Dynamic non-result it was before.
+/// BT-2647: a selector `Symbol` does not understand on a non-union singleton now
+/// produces a DNU diagnostic — previously the send fell through silently to
+/// Dynamic. Instance-selector DNUs are emitted at Hint severity (matching every
+/// other known-class instance send, via `emit_unknown_selector_warning`).
 #[test]
-fn bt2647_singleton_genuine_nonresponder_warns() {
+fn bt2647_singleton_genuine_nonresponder_hints() {
     let (_ty, diags) = infer_singleton_send(MessageSelector::Unary("frobnicate".into()), vec![]);
     let dnu: Vec<_> = diags.iter().filter(|d| d.contains("understand")).collect();
     assert_eq!(dnu.len(), 1, "expected one DNU diagnostic, got: {diags:?}");
+    // The `"Symbol"` substring is the load-bearing invariant: it proves the
+    // singleton routed through Symbol's protocol on the *negative* path (the
+    // positive path is covered by `bt2647_singleton_resolves_inherited_symbol_method`).
     assert!(
-        dnu[0].starts_with("Warning:") && dnu[0].contains("Symbol"),
-        "singleton DNU should warn and resolve via Symbol: {dnu:?}"
+        dnu[0].starts_with("Hint:") && dnu[0].contains("Symbol"),
+        "singleton DNU should hint and resolve via Symbol: {dnu:?}"
     );
 }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
@@ -813,3 +813,71 @@ fn bt2624_union_singleton_class_resolves_to_symbol_metatype() {
     );
     assert_eq!(ty, InferredType::meta("Symbol"), "got: {ty:?}");
 }
+
+// ── BT-2647: non-union singleton receivers resolve against Symbol ─────────
+
+/// Infer `x <selector>` where `x :: #infinity` (a *non-union* singleton),
+/// returning the inferred type and rendered diagnostics.
+fn infer_singleton_send(
+    selector: MessageSelector,
+    args: Vec<Expression>,
+) -> (InferredType, Vec<String>) {
+    let module = Module::new(
+        vec![ExpressionStatement::bare(msg_send(
+            Expression::Identifier(ident("x")),
+            selector,
+            args,
+        ))],
+        span(),
+    );
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local("x", InferredType::known("#infinity"));
+    let ty = checker.infer_expr(
+        &module.expressions[0].expression,
+        &hierarchy,
+        &mut env,
+        false,
+    );
+    let diags = checker
+        .diagnostics()
+        .iter()
+        .map(|d| format!("{:?}: {}", d.severity, d.message))
+        .collect();
+    (ty, diags)
+}
+
+/// BT-2647: a non-union singleton (`#infinity`) is a subtype of `Symbol`, so a
+/// method `Symbol` understands (`asString`) infers a concrete type — not the
+/// `Dynamic` it fell through to before this fix — with no DNU warning.
+#[test]
+fn bt2647_singleton_resolves_inherited_symbol_method() {
+    let (ty, diags) = infer_singleton_send(MessageSelector::Unary("asString".into()), vec![]);
+    assert_eq!(ty, InferredType::known("String"));
+    assert!(
+        diags.iter().all(|d| !d.contains("understand")),
+        "asString resolves on Symbol, got: {diags:?}"
+    );
+}
+
+/// BT-2647: a selector `Symbol` does not understand on a non-union singleton is a
+/// definite DNU — a Warning, not the silently-Dynamic non-result it was before.
+#[test]
+fn bt2647_singleton_genuine_nonresponder_warns() {
+    let (_ty, diags) = infer_singleton_send(MessageSelector::Unary("frobnicate".into()), vec![]);
+    let dnu: Vec<_> = diags.iter().filter(|d| d.contains("understand")).collect();
+    assert_eq!(dnu.len(), 1, "expected one DNU diagnostic, got: {diags:?}");
+    assert!(
+        dnu[0].starts_with("Warning:") && dnu[0].contains("Symbol"),
+        "singleton DNU should warn and resolve via Symbol: {dnu:?}"
+    );
+}
+
+/// BT-2647: `#infinity class` resolves through `Symbol`, so the metatype is
+/// `Symbol class` (`Meta("Symbol")`), not a phantom `Meta("#infinity")`.
+#[test]
+fn bt2647_singleton_class_resolves_to_symbol_metatype() {
+    let (ty, _diags) = infer_singleton_send(MessageSelector::Unary("class".into()), vec![]);
+    assert_eq!(ty, InferredType::meta("Symbol"), "got: {ty:?}");
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -460,6 +460,20 @@ impl TypeChecker {
         span: Span,
         hierarchy: &ClassHierarchy,
     ) {
+        // BT-2647: a singleton type (`#text`) is a subtype of `Symbol` but is not
+        // itself a class in the hierarchy. Resolve its selectors through
+        // `Symbol`'s protocol so DNU validation still applies — narrowing a getter
+        // from `Symbol` to a singleton (e.g. `#text | #json`, then a single
+        // member) would otherwise silently drop the selector checking it had.
+        // Mirrors the singleton-union inference handling from BT-2624. The
+        // "Symbol does not understand …" message matches the pre-narrowing text.
+        let symbol: EcoString;
+        let class_name: &EcoString = if class_name.starts_with('#') && !class_name.contains('|') {
+            symbol = EcoString::from("Symbol");
+            &symbol
+        } else {
+            class_name
+        };
         if !hierarchy.has_class(class_name) {
             // BT-1833: If the type is a protocol (from respondsTo: narrowing),
             // validate the selector against the protocol's required methods.

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
@@ -949,16 +949,21 @@ extract_beamtalk_class([_ | Rest]) ->
     extract_beamtalk_class(Rest).
 
 -doc """
-Classify union branches and emit Result(T, E) for ok/error patterns.
+Map a union type to a Beamtalk type string.
 
-Recognizes these patterns in union types (ADR 0076 Phase 2):
-  - {ok, T} | {error, E}  → Result(T, E)
-  - ok | {error, E}       → Result(Nil, E)    (bare ok atom)
-  - {ok, T} alone         → Result(T, Dynamic) (no error branch)
-  - {error, E} alone      → Result(Dynamic, E) (no ok branch)
-  - 3+ branch union with ok/error → Result(T, E) | Other
-
-Non-ok/error unions fall through to standard type mapping.
+Dispatch order (BT-2647):
+  1. Narrow pure-atom enum first — a union of only plain literal atoms with at
+     least one atom beyond `ok`/`error` becomes a singleton union (`#a | #b`),
+     even if it contains a bare `ok`/`error` (e.g. `emergency | error | info`).
+  2. Otherwise `map_union_result/1` applies ADR-0076 ok/error Result recognition,
+     falling back to standard branch-by-branch mapping:
+       - {ok, T} | {error, E}  → Result(T, E)
+       - ok | {error, E}       → Result(Nil, E)    (bare ok atom)
+       - {ok, T} alone         → Result(T, Dynamic) (no error branch)
+       - {error, E} alone      → Result(Dynamic, E) (no ok branch)
+       - 3+ branch union with ok/error → Result(T, E) | Other
+       - bare `ok | error` (subset of {ok, error}) → Result(Nil, Nil)
+       - non-ok/error unions → each branch mapped via map_type
 """.
 -spec map_union([tuple()], term()) -> binary().
 map_union(Branches, _Line) ->

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
@@ -872,6 +872,15 @@ map_type({atom, _, false}) ->
     <<"False">>;
 map_type({atom, _, nil}) ->
     <<"Nil">>;
+%% BT-2647: `undefined` is deliberately NOT mapped to `Nil`. Beamtalk's canonical
+%% Nil is the `nil` atom (class `UndefinedObject`); `undefined` is a distinct
+%% atom. The FFI boundary does not coerce `undefined` -> `nil`
+%% (`beamtalk_erlang_proxy:coerce_result/1` passes it through unchanged), so an
+%% FFI call returning `undefined` yields the Beamtalk Symbol `#undefined`, which
+%% `ifNil:` does not match. A lone `undefined` therefore maps to `Symbol` here,
+%% and inside a small pure-atom union it narrows to the singleton `#undefined`
+%% (see `singleton_binary/1`) — the honest type for the runtime value. Mapping it
+%% to `Nil` would be unsound.
 map_type({atom, _, _}) ->
     <<"Symbol">>;
 %% Catch-all types that map to Dynamic
@@ -953,6 +962,40 @@ Non-ok/error unions fall through to standard type mapping.
 """.
 -spec map_union([tuple()], term()) -> binary().
 map_union(Branches, _Line) ->
+    %% BT-2647: a pure-atom enumeration that contains atoms beyond `ok`/`error`
+    %% (e.g. the log levels `emergency | … | error | … | none`) is a genuine
+    %% enum, not a Result — even though it contains the bare atom `error`. Let the
+    %% singleton-union path win over ADR-0076 bare ok/error Result recognition in
+    %% that case, so the enum narrows to `#emergency | … | #none`. A union whose
+    %% atoms are *only* `ok`/`error` (subset of `{ok, error}`) stays a Result to
+    %% preserve ADR-0076 semantics. Tuple-form Result recognition is unaffected:
+    %% any tuple branch makes `singleton_union_members/1` return
+    %% `not_singleton_union`, so this guard never fires.
+    case singleton_union_members(Branches) of
+        {ok, Members} ->
+            case has_non_result_atom(Branches) of
+                true -> iolist_to_binary(lists:join(<<" | ">>, Members));
+                false -> map_union_result(Branches)
+            end;
+        not_singleton_union ->
+            map_union_result(Branches)
+    end.
+
+%% Whether a union of plain literal atoms contains an atom other than `ok`/`error`.
+%% Only called when `singleton_union_members/1` has already confirmed every branch
+%% is a plain literal atom, so the match on `{atom, _, A}` is total.
+-spec has_non_result_atom([tuple()]) -> boolean().
+has_non_result_atom(Branches) ->
+    lists:any(
+        fun({atom, _, A}) -> A =/= ok andalso A =/= error end,
+        Branches
+    ).
+
+%% Map a union via ADR-0076 ok/error Result recognition, falling back to a
+%% branch-by-branch standard mapping (including the singleton-union enumeration
+%% for pure ok/error-free atom unions).
+-spec map_union_result([tuple()]) -> binary().
+map_union_result(Branches) ->
     {OkTypes, ErrTypes, OtherBranches} = classify_union_branches(Branches),
     case {OkTypes, ErrTypes} of
         {[], []} ->

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
@@ -999,21 +999,16 @@ map_union_result(Branches) ->
     {OkTypes, ErrTypes, OtherBranches} = classify_union_branches(Branches),
     case {OkTypes, ErrTypes} of
         {[], []} ->
-            %% No ok/error branches — standard union. A union of *only* plain
-            %% literal atoms (e.g. `text | json`, `info | debug | error`) is a
-            %% narrow enumeration: map it to a Beamtalk singleton union
-            %% (`#text | #json`) rather than collapsing every atom to `Symbol`
-            %% (BT-2632). Mixed unions still map each branch via map_type, so a
-            %% lone atom branch keeps its existing `Symbol` mapping.
-            case singleton_union_members(Branches) of
-                {ok, Members} ->
-                    iolist_to_binary(lists:join(<<" | ">>, Members));
-                not_singleton_union ->
-                    Mapped = dedup_types([map_type(B) || B <- Branches]),
-                    case Mapped of
-                        [Single] -> Single;
-                        Multiple -> iolist_to_binary(lists:join(<<" | ">>, Multiple))
-                    end
+            %% No ok/error branches — standard union. `map_union/1` already tried
+            %% the narrow pure-atom singleton enumeration first (BT-2632/BT-2647)
+            %% and only delegates here when the union is *not* such an enum, so a
+            %% re-check would always be `not_singleton_union`. Map each branch via
+            %% map_type: a lone atom keeps its `Symbol` mapping; mixed unions map
+            %% each member.
+            Mapped = dedup_types([map_type(B) || B <- Branches]),
+            case Mapped of
+                [Single] -> Single;
+                Multiple -> iolist_to_binary(lists:join(<<" | ">>, Multiple))
             end;
         _ ->
             %% At least one ok or error branch — emit Result(T, E)

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
@@ -989,7 +989,7 @@ map_union(Branches, _Line) ->
 %% Whether a union of plain literal atoms contains an atom other than `ok`/`error`.
 %% Only called when `singleton_union_members/1` has already confirmed every branch
 %% is a plain literal atom, so the match on `{atom, _, A}` is total.
--spec has_non_result_atom([tuple()]) -> boolean().
+-spec has_non_result_atom([{atom, term(), atom()}]) -> boolean().
 has_non_result_atom(Branches) ->
     lists:any(
         fun({atom, _, A}) -> A =/= ok andalso A =/= error end,

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl
@@ -999,7 +999,7 @@ map_union_result(Branches) ->
     {OkTypes, ErrTypes, OtherBranches} = classify_union_branches(Branches),
     case {OkTypes, ErrTypes} of
         {[], []} ->
-            %% No ok/error branches — standard union. `map_union/1` already tried
+            %% No ok/error branches — standard union. `map_union/2` already tried
             %% the narrow pure-atom singleton enumeration first (BT-2632/BT-2647)
             %% and only delegates here when the union is *not* such an enum, so a
             %% re-check would always be `not_singleton_union`. Map each branch via

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
@@ -368,16 +368,15 @@ map_type_singleton_union_too_wide_falls_back_test() ->
         beamtalk_spec_reader:map_type({type, 0, union, Branches})
     ).
 
-%% Documented limitation (BT-2632): a pure-atom enumeration that *contains* the
-%% bare atom `error` (or `ok`) is intercepted by ADR-0076 ok/error Result
-%% recognition before the singleton-union path runs, so it does NOT become a
-%% singleton union. This locks in the current behaviour for `logLevel/0`'s
-%% `... | error | ...` spec; tightening it is deferred to BT-2647. The
-%% user-facing `Beamtalk logLevel` type is carried by the source annotation, not
-%% this inferred type.
-map_type_singleton_union_with_error_atom_is_result_not_singleton_test() ->
+%% BT-2647: a pure-atom enumeration that *contains* the bare atom `error` (or
+%% `ok`) but also has atoms beyond `ok`/`error` is a genuine enum, so the
+%% singleton-union path now wins over ADR-0076 ok/error Result recognition. This
+%% gives `logLevel/0`'s `... | error | ...` spec its narrow singleton union via
+%% FFI inference (previously `Result(Dynamic, Nil) | Symbol`, a documented
+%% BT-2632 limitation).
+map_type_singleton_union_with_error_atom_is_singleton_test() ->
     ?assertEqual(
-        <<"Result(Dynamic, Nil) | Symbol">>,
+        <<"#emergency | #error | #info | #debug">>,
         beamtalk_spec_reader:map_type(
             {type, 0, union, [
                 {atom, 0, emergency},
@@ -386,6 +385,52 @@ map_type_singleton_union_with_error_atom_is_result_not_singleton_test() ->
                 {atom, 0, debug}
             ]}
         )
+    ).
+
+%% BT-2647: a union whose only atoms are `ok`/`error` stays a Result — ADR-0076
+%% bare ok/error semantics are preserved (`has_non_result_atom/1` is false).
+map_type_bare_ok_error_stays_result_test() ->
+    ?assertEqual(
+        <<"Result(Nil, Nil)">>,
+        beamtalk_spec_reader:map_type(
+            {type, 0, union, [{atom, 0, ok}, {atom, 0, error}]}
+        )
+    ).
+
+%% BT-2647: tuple-form Result recognition is unaffected by the enum precedence —
+%% a `{ok, T} | {error, E}` union with an extra plain atom is still a Result,
+%% because a tuple branch makes `singleton_union_members/1` reject the union.
+map_type_result_tuples_with_atom_stays_result_test() ->
+    ?assertEqual(
+        <<"Result(Integer, Symbol) | Symbol">>,
+        beamtalk_spec_reader:map_type(
+            {type, 0, union, [
+                {type, 0, tuple, [{atom, 0, ok}, {type, 0, integer, []}]},
+                {type, 0, tuple, [{atom, 0, error}, {type, 0, atom, []}]},
+                {atom, 0, pending}
+            ]}
+        )
+    ).
+
+%% BT-2647 (decision 1): `undefined` is NOT mapped to `Nil`. The runtime does not
+%% coerce Erlang `undefined` -> Beamtalk `nil` at the FFI boundary
+%% (`beamtalk_erlang_proxy:coerce_result/1` passes it through), so the honest
+%% type for a `value | undefined` enum is the singleton union `#value |
+%% #undefined`, not `... | Nil`. A consumer must exact-match `#undefined`.
+map_type_undefined_in_atom_union_is_singleton_not_nil_test() ->
+    ?assertEqual(
+        <<"#found | #undefined">>,
+        beamtalk_spec_reader:map_type(
+            {type, 0, union, [{atom, 0, found}, {atom, 0, undefined}]}
+        )
+    ).
+
+%% BT-2647 (decision 1): a lone `undefined` atom maps to `Symbol` (the runtime
+%% value is the atom `undefined`, a Beamtalk Symbol), never `Nil`.
+map_type_lone_undefined_is_symbol_test() ->
+    ?assertEqual(
+        <<"Symbol">>,
+        beamtalk_spec_reader:map_type({atom, 0, undefined})
     ).
 
 %% Duplicate atoms are deduped; a union that collapses to a single member is
@@ -1366,8 +1411,12 @@ resolve_remote_type_prim_file_preloaded_test() ->
         {_, Bin, _} ->
             case beam_lib:chunks(Bin, [abstract_code]) of
                 {ok, {_, [{abstract_code, {raw_abstract_v1, _}}]}} ->
+                    %% BT-2647: `prim_file:prim_file_name_error()` is the pure-atom
+                    %% enum `error | ignore | warning`. Although it contains the bare
+                    %% atom `error`, the enum precedence rule now narrows it to a
+                    %% singleton union (was `Result(Dynamic, Nil) | Symbol`).
                     ?assertEqual(
-                        <<"Result(Dynamic, Nil) | Symbol">>,
+                        <<"#error | #ignore | #warning">>,
                         beamtalk_spec_reader:map_type(
                             {remote_type, 0, [
                                 {atom, 0, prim_file},


### PR DESCRIPTION
## Summary

Resolves the two decisions deferred from BT-2632 (plus the ok/error sub-decision raised in the BT-2647 comment).

### 1. `undefined` in atom-union specs stays `#undefined` (not `Nil`)

The FFI boundary does **not** coerce Erlang `undefined` → Beamtalk `nil` — `beamtalk_erlang_proxy:coerce_result/1` passes it through unchanged, and every callsite that wants nil semantics converts `undefined -> nil` explicitly. So an FFI call returning `undefined` yields the Beamtalk Symbol `#undefined`, which `ifNil:` does not match. Mapping the type to `Nil` would be unsound. Documented in `map_type/1` with regression tests (`#found | #undefined` in a union; lone `undefined` → `Symbol`).

### 2. Singleton receivers resolve methods against `Symbol`

A non-union singleton (`#text`) is a subtype of `Symbol` but not itself in the class hierarchy, so message sends previously dropped DNU validation and return-type inference (falling through to `Dynamic`). `check_instance_selector` and the instance-send inference path now resolve such receivers through `Symbol`, mirroring the singleton-union member handling from BT-2624. `Self` returns and user-facing messages are unchanged.

### 3. Pure-atom enum precedence over bare `ok`/`error` Result recognition

A pure-atom enumeration containing atoms beyond `ok`/`error` (e.g. the log levels, `prim_file:prim_file_name_error()`) now narrows to a singleton union instead of `Result(...) | Symbol`. Bare `ok`/`error`-only unions and tuple-form Results are unaffected, preserving ADR-0076 semantics.

## Changes

- `beamtalk_spec_reader.erl`: enum-precedence rule in `map_union/1` (+ `has_non_result_atom/1`, `map_union_result/1`); `#undefined` documentation in `map_type/1`
- `validation.rs`: `check_instance_selector` resolves singleton receivers via `Symbol`
- `inference.rs`: instance-send inference resolves non-union singleton receivers via `Symbol`
- Tests: Erlang spec_reader regression tests (undefined, bare ok/error, tuple Results, enum precedence; updated `prim_file` + `logLevel` expectations); Rust `union_types` tests for non-union singleton receivers

## Test plan

- [x] Erlang: `beamtalk_spec_reader_tests` — 127 tests passing (compiled standalone with `-DTEST`)
- [ ] Rust type-checker tests — could not run locally (the `core2` git patch dependency is blocked by this environment's egress policy); relying on CI
- [ ] Full `just ci`

## References

- BT-2647 — the deferred decisions (this PR)
- BT-2632 — narrow singleton-union returns from atom-union FFI specs
- BT-2624 — singleton union members resolve via Symbol (inference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KwXVqQdz75pteVDznfNSY

---
_Generated by [Claude Code](https://claude.ai/code/session_013KwXVqQdz75pteVDznfNSY)_