### PR TITLE
Remove unused core2 git patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,3 @@ undocumented_unsafe_blocks = "warn"
 # Allow some pedantic lints that are too noisy
 module_name_repetitions = "allow"
 must_use_candidate = "allow"
-
-# Patch yanked transitive dependency (core2 0.4.0 was yanked from crates.io)
-[patch.crates-io]
-core2 = { git = "https://github.com/bbqsrc/core2", rev = "545e84bcb0f2" }


### PR DESCRIPTION
## Summary

Removes the `[patch.crates-io]` entry that pinned `core2` to a git rev (added because `core2 0.4.0` was yanked from crates.io). The patch is no longer needed.

## Why it's safe to remove

- **`core2` is gone from the dependency graph.** Resolving the workspace to latest compatible versions yields **313 packages with zero `core2`**. A `[patch.crates-io]` only takes effect if the patched crate is in the graph — it isn't, so the patch is inert.
- **Confirmed true negative.** Scanned all in-tree packages against the crates.io sparse index: none has *any* published version that depends on `core2`. The crates.io reverse-dependency API for `core2` is also empty — the ecosystem migrated off it.
- **Nothing to bump to.** Every published `core2` version (through 0.4.0) is yanked upstream with no replacement, so removal — not re-pinning — is the correct fix. The git source it pointed at is an abandoned repo.

## Verification

- `cargo build --workspace` ✅
- `cargo clippy --workspace --all-targets` ✅ (warnings-as-errors, clean)
- Resolves cleanly to 313 packages, no `core2` in the lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtbX7iRdxJ5KXrwhf2Xs6i)_