### PR TITLE
Polish singleton-receiver resolution (BT-2679)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
@@ -875,6 +875,12 @@ fn bt2647_singleton_genuine_nonresponder_hints() {
     let (_ty, diags) = infer_singleton_send(MessageSelector::Unary("frobnicate".into()), vec![]);
     let dnu: Vec<_> = diags.iter().filter(|d| d.contains("understand")).collect();
     assert_eq!(dnu.len(), 1, "expected one DNU diagnostic, got: {diags:?}");
+    // `check_instance_selector` still resolves the selector (and any "did you
+    // mean" suggestion) against `Symbol` — that routing is unchanged and proven
+    // by `bt2647_singleton_resolves_inherited_symbol_method` (positive path) and
+    // `bt2679_singleton_binary_send_bypasses_symbol_redirect` (the bypass pin).
+    // BT-2679 changed only the *display* name: the message must name `#infinity`,
+    // never the `Symbol` it resolved through.
     assert!(
         dnu[0].starts_with("Hint:") && dnu[0].contains("#infinity"),
         "singleton DNU should hint and name the singleton receiver: {dnu:?}"

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
@@ -865,17 +865,23 @@ fn bt2647_singleton_resolves_inherited_symbol_method() {
 /// produces a DNU diagnostic — previously the send fell through silently to
 /// Dynamic. Instance-selector DNUs are emitted at Hint severity (matching every
 /// other known-class instance send, via `emit_unknown_selector_warning`).
+///
+/// BT-2679: the message names the singleton the user wrote (`#infinity`), not
+/// the `Symbol` it resolves selectors against. Resolution still routes through
+/// `Symbol` — the positive path is covered by
+/// `bt2647_singleton_resolves_inherited_symbol_method`.
 #[test]
 fn bt2647_singleton_genuine_nonresponder_hints() {
     let (_ty, diags) = infer_singleton_send(MessageSelector::Unary("frobnicate".into()), vec![]);
     let dnu: Vec<_> = diags.iter().filter(|d| d.contains("understand")).collect();
     assert_eq!(dnu.len(), 1, "expected one DNU diagnostic, got: {diags:?}");
-    // The `"Symbol"` substring is the load-bearing invariant: it proves the
-    // singleton routed through Symbol's protocol on the *negative* path (the
-    // positive path is covered by `bt2647_singleton_resolves_inherited_symbol_method`).
     assert!(
-        dnu[0].starts_with("Hint:") && dnu[0].contains("Symbol"),
-        "singleton DNU should hint and resolve via Symbol: {dnu:?}"
+        dnu[0].starts_with("Hint:") && dnu[0].contains("#infinity"),
+        "singleton DNU should hint and name the singleton receiver: {dnu:?}"
+    );
+    assert!(
+        !dnu[0].contains("Symbol"),
+        "singleton DNU should name `#infinity`, not the `Symbol` it resolves via: {dnu:?}"
     );
 }
 
@@ -885,4 +891,46 @@ fn bt2647_singleton_genuine_nonresponder_hints() {
 fn bt2647_singleton_class_resolves_to_symbol_metatype() {
     let (ty, _diags) = infer_singleton_send(MessageSelector::Unary("class".into()), vec![]);
     assert_eq!(ty, InferredType::meta("Symbol"), "got: {ty:?}");
+}
+
+/// BT-2679: the `resolve_class` redirect deliberately excludes binary sends
+/// (`!matches!(selector, MessageSelector::Binary(_))`), so a singleton receiver
+/// in an (in)equality send is NOT routed through `Symbol`. This is load-bearing:
+/// `Symbol` understands `=:=`/`=`, so routing through it would short-circuit the
+/// result to `Boolean` and swallow the BT-2631 statically-decidable-comparison
+/// hint. Co-located with the BT-2647 redirect it guards (previously covered only
+/// indirectly by `bt2631_standalone_singleton_eq_union_on_right_emits_hint`).
+#[test]
+fn bt2679_singleton_binary_send_bypasses_symbol_redirect() {
+    // `#infinity =:= x` where `x :: Integer | String` can never be true — the
+    // union admits no singleton.
+    let expr = msg_send(
+        symbol_lit("infinity"),
+        MessageSelector::Binary("=:=".into()),
+        vec![var("x")],
+    );
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local("x", InferredType::simple_union(&["Integer", "String"]));
+    let ty = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+
+    // Had the singleton routed through `Symbol`, `=:=` would resolve to Boolean.
+    assert!(
+        !matches!(&ty, InferredType::Known { class_name, .. } if class_name == "Boolean"),
+        "binary send on a singleton must bypass the Symbol redirect, got: {ty:?}"
+    );
+
+    // The BT-2631 impossible-comparison hint must still fire.
+    let hints: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("can never be true") && d.message.contains("#infinity"))
+        .collect();
+    assert_eq!(
+        hints.len(),
+        1,
+        "expected the BT-2631 hint to fire, got: {:?}",
+        checker.diagnostics()
+    );
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -160,7 +160,9 @@ impl TypeChecker {
                 || is_implicit_constructor
                 || (is_factory_selector && hierarchy.resolves_selector(class_name, selector));
             if !has_class_chain_method {
-                self.emit_unknown_selector_warning(class_name, selector, span, hierarchy, true);
+                self.emit_unknown_selector_warning(
+                    class_name, class_name, selector, span, hierarchy, true,
+                );
             }
         }
 
@@ -465,24 +467,34 @@ impl TypeChecker {
         // `Symbol`'s protocol so DNU validation still applies — narrowing a getter
         // from `Symbol` to a singleton (e.g. `#text | #json`, then a single
         // member) would otherwise silently drop the selector checking it had.
-        // Mirrors the singleton-union inference handling from BT-2624. The
-        // "Symbol does not understand …" message matches the pre-narrowing text.
+        // Mirrors the singleton-union inference handling from BT-2624.
+        //
+        // BT-2679: `effective_class` is what we resolve selectors/suggestions
+        // against (`Symbol` for a singleton); `class_name` stays the type the user
+        // wrote so DNU messages name the singleton (e.g. `#infinity`) rather than
+        // `Symbol`.
         let symbol: EcoString;
-        let class_name: &EcoString = if class_name.starts_with('#') && !class_name.contains('|') {
-            symbol = EcoString::from("Symbol");
-            &symbol
-        } else {
-            class_name
-        };
-        if !hierarchy.has_class(class_name) {
+        let effective_class: &EcoString =
+            if class_name.starts_with('#') && !class_name.contains('|') {
+                symbol = EcoString::from("Symbol");
+                &symbol
+            } else {
+                class_name
+            };
+        if !hierarchy.has_class(effective_class) {
             // BT-1833: If the type is a protocol (from respondsTo: narrowing),
             // validate the selector against the protocol's required methods.
             if let Some(ref registry) = self.protocol_registry {
-                if let Some(proto_info) = registry.get(class_name) {
+                if let Some(proto_info) = registry.get(effective_class) {
                     let required = proto_info.all_required_selectors(registry);
                     if !required.iter().any(|s| s.as_str() == selector) {
                         self.emit_unknown_selector_warning(
-                            class_name, selector, span, hierarchy, false,
+                            class_name,
+                            effective_class,
+                            selector,
+                            span,
+                            hierarchy,
+                            false,
                         );
                     }
                 }
@@ -491,21 +503,28 @@ impl TypeChecker {
         }
 
         // ADR 0071 Phase 3 (BT-1702): E0403 — cross-package send to internal method
-        self.check_internal_method_access(class_name, selector, span, hierarchy, false);
+        self.check_internal_method_access(effective_class, selector, span, hierarchy, false);
 
         // Classes with instance-side doesNotUnderstand: override accept any message
-        if hierarchy.has_instance_dnu_override(class_name) {
+        if hierarchy.has_instance_dnu_override(effective_class) {
             return;
         }
 
         // Cross-file inheritance: if the parent class is not in the hierarchy,
         // we can't know the full method set — suppress false-positive DNU hints.
-        if hierarchy.has_cross_file_parent(class_name) {
+        if hierarchy.has_cross_file_parent(effective_class) {
             return;
         }
 
-        if !hierarchy.resolves_selector(class_name, selector) {
-            self.emit_unknown_selector_warning(class_name, selector, span, hierarchy, false);
+        if !hierarchy.resolves_selector(effective_class, selector) {
+            self.emit_unknown_selector_warning(
+                class_name,
+                effective_class,
+                selector,
+                span,
+                hierarchy,
+                false,
+            );
         }
     }
 
@@ -1724,8 +1743,13 @@ impl TypeChecker {
     }
 
     /// Emit a warning diagnostic for an unknown selector.
+    /// `display_name` is the type the user wrote (e.g. a singleton `#infinity`),
+    /// used only in the message text. `class_name` is the type we resolve
+    /// selectors and "did you mean" suggestions against (e.g. `Symbol` for a
+    /// singleton — BT-2679). They coincide for ordinary class receivers.
     fn emit_unknown_selector_warning(
         &mut self,
+        display_name: &EcoString,
         class_name: &EcoString,
         selector: &str,
         span: Span,
@@ -1734,7 +1758,7 @@ impl TypeChecker {
     ) {
         let side = if is_class_side { " class" } else { "" };
         let message: EcoString =
-            format!("{class_name}{side} does not understand '{selector}'").into();
+            format!("{display_name}{side} does not understand '{selector}'").into();
 
         let mut diag = Diagnostic::hint(message, span).with_category(DiagnosticCategory::Dnu);
 


### PR DESCRIPTION
Three small refinements to the singleton→Symbol resolution code from
BT-2647:

1. DNU diagnostics now name the singleton the user wrote (e.g. `#infinity`)
   rather than the `Symbol` it resolves selectors against. Threads a
   `display_name` through `emit_unknown_selector_warning` separate from the
   `class_name` used for selector lookup and "did you mean" suggestions.

2. Adds `bt2679_singleton_binary_send_bypasses_symbol_redirect`, a co-located
   test pinning the binary-send exclusion in `resolve_class`: a singleton
   (in)equality send must not route through `Symbol` (which would infer
   `Boolean`) and must still trigger the BT-2631 impossible-comparison hint.
   Previously covered only indirectly.

3. Renames the shadowed `class_name` rebinding in `check_instance_selector`
   to `effective_class` so the singleton→Symbol substitution reads clearly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016qQAYpFPxP3HKnEuRNo9qB