### PR TITLE
Cache git repo toplevel per project path in beamtalk_git (BT-2621)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_git.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_git.erl
@@ -252,12 +252,17 @@ mutate(Selector, Args, FailMsg) ->
 %% coincide; when it is a subdirectory (e.g. `examples/getting-started` inside
 %% the `beamtalk` repo) this prevents the path from being re-prefixed and
 %% matching nothing (BT-2608).
+%%
+%% The toplevel is static for a given project path, so it is resolved once and
+%% cached in beamtalk_workspace_meta (keyed by project path), removing the
+%% per-op `rev-parse` spawn on the hot read path (BT-2621). The cache
+%% self-invalidates when the project path changes (the keyed lookup misses).
 -spec run_git(atom(), [binary()]) ->
     {ok, binary(), non_neg_integer()} | {error, #beamtalk_error{}}.
 run_git(Selector, Args) ->
     case project_dir() of
         {ok, Dir} ->
-            case repo_toplevel(Selector, Dir) of
+            case cached_repo_toplevel(Selector, Dir) of
                 {ok, Toplevel} ->
                     run_git_in(Selector, Args, Toplevel);
                 {error, _} = Err ->
@@ -265,6 +270,27 @@ run_git(Selector, Args) ->
             end;
         {error, _} = Err ->
             Err
+    end.
+
+%% Resolve the repo toplevel for the project dir, consulting the per-project-path
+%% cache in beamtalk_workspace_meta first (BT-2621). On a cache miss the toplevel
+%% is resolved via `git rev-parse --show-toplevel` (one subprocess) and the
+%% successful result is cached for subsequent ops. Error results (not a git
+%% repository, git absent) are deliberately left uncached so they are re-detected
+%% cheaply and a later `git init` is picked up without a stale negative entry.
+-spec cached_repo_toplevel(atom(), binary()) -> {ok, binary()} | {error, #beamtalk_error{}}.
+cached_repo_toplevel(Selector, Dir) ->
+    case beamtalk_workspace_meta:get_git_toplevel(Dir) of
+        {ok, Toplevel} ->
+            {ok, Toplevel};
+        miss ->
+            case repo_toplevel(Selector, Dir) of
+                {ok, Toplevel} = Ok ->
+                    beamtalk_workspace_meta:set_git_toplevel(Dir, Toplevel),
+                    Ok;
+                {error, _} = Err ->
+                    Err
+            end
     end.
 
 %% Resolve the git repository toplevel for the workspace project directory.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
@@ -31,6 +31,9 @@ and can be queried by other components (e.g., idle monitor).
 -export([get_package_name/0]).
 %% ADR 0082 Phase 4 (BT-2290): workspace-scoped boolean settings (autoflush).
 -export([get_setting/2, set_setting/2]).
+%% BT-2621: per-project-path cache of the git repository toplevel, so beamtalk_git
+%% resolves `git rev-parse --show-toplevel` at most once per project path.
+-export([get_git_toplevel/1, set_git_toplevel/2]).
 % Alias for get_metadata/0
 -export([get/0]).
 
@@ -47,6 +50,11 @@ and can be queried by other components (e.g., idle monitor).
 -define(WORKSPACE_META_TABLE, beamtalk_workspace_registry).
 % Debounce disk writes to every 2 seconds
 -define(PERSIST_DELAY_MS, 2000).
+%% BT-2621: ETS row key for the cached git repo toplevel. Stored as a separate
+%% small row (`{?GIT_TOPLEVEL_KEY, ProjectPath, Toplevel}`) rather than inside
+%% the mirrored #state{} so the git hot path reads only this tuple, not a copy
+%% of the whole state (which carries class sources and loaded modules).
+-define(GIT_TOPLEVEL_KEY, git_toplevel).
 
 -record(state, {
     workspace_id :: binary(),
@@ -336,6 +344,45 @@ set_setting(Key, Value) when is_atom(Key) ->
             ok
     end.
 
+-doc """
+Read the cached git repository toplevel for `ProjectPath` (BT-2621).
+
+Returns `{ok, Toplevel}` only when a toplevel was previously cached for *exactly*
+this project path; otherwise `miss` (never resolved, the project path changed
+since caching, or the server is not running). Reads straight from ETS so the git
+hot path (`git_status` on every panel refresh) pays no gen_server round-trip.
+""".
+-spec get_git_toplevel(binary()) -> {ok, binary()} | miss.
+get_git_toplevel(ProjectPath) when is_binary(ProjectPath) ->
+    case ets:whereis(?WORKSPACE_META_TABLE) of
+        undefined ->
+            miss;
+        _ ->
+            case ets:lookup(?WORKSPACE_META_TABLE, ?GIT_TOPLEVEL_KEY) of
+                [{?GIT_TOPLEVEL_KEY, ProjectPath, Toplevel}] ->
+                    {ok, Toplevel};
+                _ ->
+                    miss
+            end
+    end.
+
+-doc """
+Cache the resolved git repository toplevel for `ProjectPath` (BT-2621).
+
+Stores a single `{ProjectPath, Toplevel}` entry; a later lookup for a different
+project path misses and forces re-resolution, so the cache self-invalidates when
+the workspace switches projects. Best-effort (a cast): a no-op when the server
+is not running.
+""".
+-spec set_git_toplevel(binary(), binary()) -> ok.
+set_git_toplevel(ProjectPath, Toplevel) when is_binary(ProjectPath), is_binary(Toplevel) ->
+    try
+        gen_server:cast(?MODULE, {set_git_toplevel, ProjectPath, Toplevel})
+    catch
+        exit:{noproc, _} ->
+            ok
+    end.
+
 %%% gen_server callbacks
 
 init(InitialMetadata) ->
@@ -508,6 +555,16 @@ handle_cast({remove_file_mtime, FilePath}, State) ->
     State2 = State#state{file_mtimes = maps:remove(FilePath, Mtimes)},
     store_state_in_ets(State2),
     {noreply, State2};
+handle_cast({set_git_toplevel, ProjectPath, Toplevel}, State) ->
+    %% BT-2621: cache the resolved toplevel in its own ETS row (single entry,
+    %% overwritten on project switch). Derived state — not persisted to disk, and
+    %% it dies with the table when the server stops, so it is never restored stale
+    %% across restarts (or across machines, where the path would not exist).
+    case ets:whereis(?WORKSPACE_META_TABLE) of
+        undefined -> ok;
+        _ -> ets:insert(?WORKSPACE_META_TABLE, {?GIT_TOPLEVEL_KEY, ProjectPath, Toplevel})
+    end,
+    {noreply, State};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_git_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_git_tests.erl
@@ -458,6 +458,69 @@ repo_toplevel_outside_repo_errors_test() ->
     end.
 
 %%% ============================================================================
+%%% Repo toplevel caching through beamtalk_workspace_meta (BT-2621)
+%%%
+%%% These route real git ops through run_git/2 (which reads project_path from the
+%%% workspace_meta gen_server) to prove the toplevel is resolved once and cached,
+%%% with no behavioural regression vs BT-2608 (subdir status still correct).
+%%% ============================================================================
+
+%% A git op populates the per-project-path toplevel cache and subsequent ops
+%% reuse it, while status still reports the modified subdir file under its
+%% repo-root-relative path.
+git_status_populates_toplevel_cache_test() ->
+    with_subdir_repo(fun(Top, ProjectDir, RelFile) ->
+        stop_meta_if_running(),
+        {ok, Pid} = beamtalk_workspace_meta:start_link(#{
+            workspace_id => <<"git_cache_test">>,
+            project_path => ProjectDir,
+            created_at => erlang:system_time(second),
+            repl => false
+        }),
+        try
+            %% Cold cache: nothing stored for this project path yet.
+            ?assertEqual(miss, beamtalk_workspace_meta:get_git_toplevel(ProjectDir)),
+
+            %% First status resolves + caches the toplevel and still lists the
+            %% modified file under its repo-root-relative path (BT-2608 contract).
+            {ok, Status1} = beamtalk_git:git_status(),
+            Paths1 = [maps:get(path, F) || F <- maps:get(files, Status1)],
+            ?assert(lists:member(RelFile, Paths1)),
+
+            %% Barrier: a synchronous call flushes the set_git_toplevel cast that
+            %% run_git/2 emitted (sent before this call from the same process).
+            {ok, _} = beamtalk_workspace_meta:get_metadata(),
+
+            %% The cache now holds the resolved repo toplevel.
+            ?assertEqual(
+                {ok, canonical(Top)},
+                cache_canonical(beamtalk_workspace_meta:get_git_toplevel(ProjectDir))
+            ),
+
+            %% A second status reuses the cache and behaves identically.
+            {ok, Status2} = beamtalk_git:git_status(),
+            Paths2 = [maps:get(path, F) || F <- maps:get(files, Status2)],
+            ?assert(lists:member(RelFile, Paths2))
+        after
+            gen_server:stop(Pid)
+        end
+    end).
+
+stop_meta_if_running() ->
+    case whereis(beamtalk_workspace_meta) of
+        undefined ->
+            ok;
+        Pid ->
+            gen_server:stop(Pid),
+            timer:sleep(10)
+    end.
+
+%% Canonicalise the toplevel inside an {ok, _} cache result so it compares equal
+%% to canonical(Top) across symlinked temp dirs (macOS /tmp → /private/tmp).
+cache_canonical({ok, Top}) -> {ok, canonical(Top)};
+cache_canonical(Other) -> Other.
+
+%%% ============================================================================
 %%% Helpers
 %%% ============================================================================
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_meta_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_meta_tests.erl
@@ -875,6 +875,77 @@ settings_int_and_binary_survive_restart_test() ->
         _ = file:delete(MetaFile)
     end.
 
+%%% BT-2621: git repo toplevel cache (set/get, project-path invalidation)
+
+git_toplevel_cache_roundtrips_test() ->
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+
+    %% Never-set ⇒ miss.
+    ?assertEqual(miss, beamtalk_workspace_meta:get_git_toplevel(<<"/bt_test/proj">>)),
+
+    %% After caching, the exact project path resolves to the stored toplevel.
+    ok = beamtalk_workspace_meta:set_git_toplevel(<<"/bt_test/proj">>, <<"/bt_test/repo">>),
+    timer:sleep(50),
+    ?assertEqual(
+        {ok, <<"/bt_test/repo">>},
+        beamtalk_workspace_meta:get_git_toplevel(<<"/bt_test/proj">>)
+    ),
+
+    %% A different project path misses — the cache self-invalidates on project
+    %% switch rather than returning a stale toplevel.
+    ?assertEqual(miss, beamtalk_workspace_meta:get_git_toplevel(<<"/bt_test/other">>)),
+
+    %% Re-caching under a new project path overwrites the single entry.
+    ok = beamtalk_workspace_meta:set_git_toplevel(<<"/bt_test/other">>, <<"/bt_test/other_repo">>),
+    timer:sleep(50),
+    ?assertEqual(
+        {ok, <<"/bt_test/other_repo">>},
+        beamtalk_workspace_meta:get_git_toplevel(<<"/bt_test/other">>)
+    ),
+    ?assertEqual(miss, beamtalk_workspace_meta:get_git_toplevel(<<"/bt_test/proj">>)),
+
+    gen_server:stop(Pid).
+
+git_toplevel_cache_not_persisted_test() ->
+    %% The toplevel cache is derived state living only in ETS — it must never be
+    %% written to metadata.json, so it cannot be restored stale across restarts
+    %% (or across machines, where the cached path would not exist).
+    stop_if_running(),
+    WsId = <<"gittop_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+    MetaFile = metadata_path_for(WsId),
+    _ = file:delete(MetaFile),
+    try
+        Init = #{
+            workspace_id => WsId,
+            project_path => <<"/bt_test/gittop">>,
+            created_at => erlang:system_time(second)
+        },
+        {ok, Pid} = beamtalk_workspace_meta:start_link(Init),
+        %% Distinctive token unlikely to occur elsewhere in the metadata blob.
+        ok = beamtalk_workspace_meta:set_git_toplevel(
+            <<"/bt_test/gittop">>, <<"/bt_test/repo_toplevel_token">>
+        ),
+        %% terminate/2 persists synchronously on stop.
+        gen_server:stop(Pid),
+        timer:sleep(50),
+        ?assert(filelib:is_file(MetaFile)),
+        {ok, Bin} = file:read_file(MetaFile),
+        ?assertEqual(nomatch, binary:match(Bin, <<"repo_toplevel_token">>))
+    after
+        _ = file:delete(MetaFile)
+    end.
+
+git_toplevel_cache_miss_when_not_started_test() ->
+    stop_if_running(),
+    %% No server: lookup gracefully misses rather than crashing.
+    ?assertEqual(miss, beamtalk_workspace_meta:get_git_toplevel(<<"/x">>)).
+
+set_git_toplevel_when_not_started_test() ->
+    stop_if_running(),
+    %% No server: the cast helper returns ok without spawning a server.
+    ?assertEqual(ok, beamtalk_workspace_meta:set_git_toplevel(<<"/x">>, <<"/y">>)).
+
 %%% Class source persistence round-trip (covers class_sources restore branch)
 
 class_source_survives_restart_test() ->


### PR DESCRIPTION
## Summary

BT-2608 made `beamtalk_git:run_git/2` resolve the git repository toplevel (`git rev-parse --show-toplevel`) from the project dir before **every** git op, so each op spawned two subprocesses. On the hot read path (`git_status` on every IDE git-panel refresh, `git_diff`) this doubled the subprocess round-trips.

The toplevel is static for a given project path, so this resolves it once and caches it.

## What changed

**`beamtalk_git.erl`** — `run_git/2` now calls a new `cached_repo_toplevel/2` instead of `repo_toplevel/2` directly. On a cache hit it skips the `rev-parse` subprocess; on a miss it resolves once and caches the result. Error results (not-a-repo, git absent) are deliberately left uncached so a later `git init` is picked up without a stale negative entry.

**`beamtalk_workspace_meta.erl`** — added `get_git_toplevel/1` (ETS read) and `set_git_toplevel/2` (cast). The cache is a single ETS row `{git_toplevel, ProjectPath, Toplevel}`:
- Stored as its own small row (**not** in `#state{}`), so the hot read path copies only a 3-tuple instead of the whole meta state (which carries class sources and loaded modules).
- Read straight from ETS — no gen_server round-trip on `git_status`/`git_diff`.
- Keyed by project path → self-invalidates on project switch (a lookup for a different path misses and forces re-resolution).
- Derived state — never written to `metadata.json`.

## Acceptance criteria (BT-2621)

- [x] `beamtalk_git` resolves the repo toplevel at most once per project path (cached).
- [x] Cache is invalidated/recomputed when `project_path` changes.
- [x] `git rev-parse` is not re-spawned on every `git_status`/`git_diff`/mutating op.
- [x] No behavioural regression vs BT-2608 (subdir-project revert/stage/unstage still correct).

## Testing

- Full `beamtalk_workspace` eunit: **2380 tests, 0 failures**, including 5 new tests: cache round-trip, project-path invalidation, no-disk-persistence, not-started graceful handling, and an end-to-end caching test through a real subdirectory git repo.
- `just build`, `rebar3 fmt --check`, and `just dialyzer` (no warnings) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTBGFZh28WjGduDoqgenJa)_