### PR TITLE
test(codegen): cover type-annotation paths in gen_server/callbacks.rs

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -4294,3 +4294,282 @@ fn test_init_parent_actor_subclass_calls_parent_init() {
         "ChildFields must include the child's own logCount state field. Got:\n{code}"
     );
 }
+
+// ── Type-annotation codegen coverage ─────────────────────────────────────────
+//
+// Target: gen_server/callbacks.rs — is_nilable_type Union branch (line 589),
+// type_annotation_display Singleton/Generic/FalseOr/SelfType/SelfClass/ClassOf
+// variants (lines 604-620), user_defined_initialize_chain fallback when
+// class_hierarchy is None (lines 643-655), and inherited_typed_no_default_fields
+// fallback (lines 711-733).
+//
+// Strategy:
+// - Tests 1-6: generate_module with actor having one typed-no-default field per
+//   TypeAnnotation variant; coverage comes from the hierarchy path (lines 748-763)
+//   that calls is_nilable_type and type_annotation_display.
+// - Tests 7-12: direct CoreErlangGenerator unit tests (class_hierarchy = None)
+//   to exercise the no-hierarchy fallback paths in both functions.
+
+/// Shared helper: a single-class Actor Module with one typed-no-default state field.
+fn make_actor_typed_no_default(field_name: &str, ty: TypeAnnotation) -> Module {
+    let s = Span::new(0, 0);
+    let class = ClassDefinition {
+        name: Identifier::new("TestActor", s),
+        superclass: Some(Identifier::new("Actor", s)),
+        superclass_package: None,
+        class_kind: ClassKind::Actor,
+        is_abstract: false,
+        is_sealed: false,
+        is_typed: false,
+        is_internal: false,
+        supervisor_kind: None,
+        state: vec![StateDeclaration {
+            name: Identifier::new(field_name, s),
+            type_annotation: Some(ty),
+            default_value: None,
+            expect: None,
+            comments: CommentAttachment::default(),
+            doc_comment: None,
+            declared_keyword: DeclaredKeyword::default(),
+            span: s,
+        }],
+        methods: vec![],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        superclass_type_args: vec![],
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        backing_module: None,
+        span: s,
+    };
+    Module {
+        classes: vec![class],
+        method_definitions: Vec::new(),
+        protocols: Vec::new(),
+        expressions: Vec::new(),
+        span: s,
+        file_leading_comments: vec![],
+        file_trailing_comments: Vec::new(),
+    }
+}
+
+#[test]
+fn test_actor_typed_union_nil_field_is_nilable() {
+    // is_nilable_type Union branch (line 589): Union([Integer, Nil]) is nilable.
+    // The field is excluded from typed-no-default so no initialize continuation emitted.
+    let s = Span::new(0, 0);
+    let union_nil = TypeAnnotation::union(
+        vec![
+            TypeAnnotation::simple("Integer", s),
+            TypeAnnotation::simple("Nil", s),
+        ],
+        s,
+    );
+    let module = make_actor_typed_no_default("optValue", union_nil);
+    let result = generate_module(&module, CodegenOptions::new("bt@test_actor"));
+    assert!(result.is_ok(), "Codegen should succeed: {result:?}");
+    let code = result.unwrap();
+    assert!(
+        !code.contains("{'continue', 'initialize'}"),
+        "Nil-union field is nilable so no initialize continuation is needed. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_actor_typed_union_non_nil_field_triggers_validation() {
+    // is_nilable_type Union branch: Union([Integer, String]) is not nilable → included.
+    // type_annotation_display Union branch (lines 599-603) also exercised.
+    let s = Span::new(0, 0);
+    let union_no_nil = TypeAnnotation::union(
+        vec![
+            TypeAnnotation::simple("Integer", s),
+            TypeAnnotation::simple("String", s),
+        ],
+        s,
+    );
+    let module = make_actor_typed_no_default("combo", union_no_nil);
+    let result = generate_module(&module, CodegenOptions::new("bt@test_actor"));
+    assert!(result.is_ok(), "Codegen should succeed: {result:?}");
+    let code = result.unwrap();
+    assert!(
+        code.contains("'uninitialized_state_error'"),
+        "Non-nil Union field should trigger typed-no-default validation. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_actor_typed_singleton_field_triggers_validation() {
+    // type_annotation_display Singleton branch (line 604).
+    let s = Span::new(0, 0);
+    let singleton = TypeAnnotation::Singleton {
+        name: "ok".into(),
+        span: s,
+    };
+    let module = make_actor_typed_no_default("status", singleton);
+    let result = generate_module(&module, CodegenOptions::new("bt@test_actor"));
+    assert!(result.is_ok(), "Codegen should succeed: {result:?}");
+    let code = result.unwrap();
+    assert!(
+        code.contains("'uninitialized_state_error'"),
+        "Singleton-typed field should trigger typed-no-default validation. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_actor_typed_generic_field_triggers_validation() {
+    // type_annotation_display Generic branch (lines 605-613).
+    let s = Span::new(0, 0);
+    let generic = TypeAnnotation::generic(
+        Identifier::new("Collection", s),
+        vec![TypeAnnotation::simple("Integer", s)],
+        s,
+    );
+    let module = make_actor_typed_no_default("items", generic);
+    let result = generate_module(&module, CodegenOptions::new("bt@test_actor"));
+    assert!(result.is_ok(), "Codegen should succeed: {result:?}");
+    let code = result.unwrap();
+    assert!(
+        code.contains("'uninitialized_state_error'"),
+        "Generic-typed field should trigger typed-no-default validation. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_actor_typed_false_or_field_triggers_validation() {
+    // type_annotation_display FalseOr branch (lines 615-616).
+    let s = Span::new(0, 0);
+    let false_or = TypeAnnotation::false_or(TypeAnnotation::simple("Integer", s), s);
+    let module = make_actor_typed_no_default("result", false_or);
+    let result = generate_module(&module, CodegenOptions::new("bt@test_actor"));
+    assert!(result.is_ok(), "Codegen should succeed: {result:?}");
+    let code = result.unwrap();
+    assert!(
+        code.contains("'uninitialized_state_error'"),
+        "FalseOr-typed field should trigger typed-no-default validation. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_actor_typed_class_of_field_triggers_validation() {
+    // type_annotation_display ClassOf branch (line 620).
+    let s = Span::new(0, 0);
+    let class_of = TypeAnnotation::ClassOf {
+        class_name: Identifier::new("Actor", s),
+        span: s,
+    };
+    let module = make_actor_typed_no_default("actorClass", class_of);
+    let result = generate_module(&module, CodegenOptions::new("bt@test_actor"));
+    assert!(result.is_ok(), "Codegen should succeed: {result:?}");
+    let code = result.unwrap();
+    assert!(
+        code.contains("'uninitialized_state_error'"),
+        "ClassOf-typed field should trigger typed-no-default validation. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_user_defined_initialize_chain_fallback_with_initialize() {
+    // user_defined_initialize_chain fallback (lines 643-655): class_hierarchy is
+    // None, actor defines initialize → fallback returns chain containing the leaf.
+    let src = concat!(
+        "Actor subclass: TestActor\n",
+        "  state: value = 0\n\n",
+        "  initialize =>\n",
+        "    self.value := 42\n",
+    );
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _) = crate::source_analysis::parse(tokens);
+    let generator = crate::codegen::core_erlang::CoreErlangGenerator::new("bt@test_actor");
+    let chain = generator.user_defined_initialize_chain(&module, "TestActor");
+    assert_eq!(chain.len(), 1, "Fallback should return one entry for the initialize method");
+    assert_eq!(
+        chain[0].class_name, "TestActor",
+        "Chain entry should name the leaf class"
+    );
+}
+
+#[test]
+fn test_user_defined_initialize_chain_fallback_without_initialize() {
+    // user_defined_initialize_chain fallback (lines 643-655): class_hierarchy is
+    // None, no initialize method → fallback returns empty chain.
+    let src = concat!(
+        "Actor subclass: TestActor\n",
+        "  state: value = 0\n",
+        "  getValue => self.value\n",
+    );
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _) = crate::source_analysis::parse(tokens);
+    let generator = crate::codegen::core_erlang::CoreErlangGenerator::new("bt@test_actor");
+    let chain = generator.user_defined_initialize_chain(&module, "TestActor");
+    assert!(
+        chain.is_empty(),
+        "No initialize method should produce an empty fallback chain"
+    );
+}
+
+#[test]
+fn test_inherited_typed_no_default_fallback_union_nil_excluded() {
+    // inherited_typed_no_default_fields fallback (line 721): Union([Integer, Nil])
+    // is nilable → field excluded from the typed-no-default list.
+    let s = Span::new(0, 0);
+    let union_nil = TypeAnnotation::union(
+        vec![
+            TypeAnnotation::simple("Integer", s),
+            TypeAnnotation::simple("Nil", s),
+        ],
+        s,
+    );
+    let module = make_actor_typed_no_default("optValue", union_nil);
+    let generator = crate::codegen::core_erlang::CoreErlangGenerator::new("bt@test_actor");
+    let fields = generator.inherited_typed_no_default_fields(&module, "TestActor");
+    assert!(
+        fields.is_empty(),
+        "Nil-union field is nilable so it should be excluded from typed-no-default"
+    );
+}
+
+#[test]
+fn test_inherited_typed_no_default_fallback_singleton_type_display() {
+    // inherited_typed_no_default_fields fallback (lines 726-728): Singleton type
+    // annotation → type_annotation_display returns "#ok" → field included with
+    // the correct display name.
+    let s = Span::new(0, 0);
+    let singleton = TypeAnnotation::Singleton {
+        name: "ok".into(),
+        span: s,
+    };
+    let module = make_actor_typed_no_default("status", singleton);
+    let generator = crate::codegen::core_erlang::CoreErlangGenerator::new("bt@test_actor");
+    let fields = generator.inherited_typed_no_default_fields(&module, "TestActor");
+    assert_eq!(fields.len(), 1, "Singleton field should appear in typed-no-default");
+    assert_eq!(fields[0].field_name, "status");
+    assert_eq!(fields[0].type_name, "#ok", "Singleton display should be '#ok'");
+}
+
+#[test]
+fn test_inherited_typed_no_default_fallback_self_type_display() {
+    // type_annotation_display SelfType branch (line 618).
+    let s = Span::new(0, 0);
+    let self_type = TypeAnnotation::SelfType { span: s };
+    let module = make_actor_typed_no_default("selfRef", self_type);
+    let generator = crate::codegen::core_erlang::CoreErlangGenerator::new("bt@test_actor");
+    let fields = generator.inherited_typed_no_default_fields(&module, "TestActor");
+    assert_eq!(fields.len(), 1, "SelfType field should appear in typed-no-default");
+    assert_eq!(fields[0].type_name, "Self", "SelfType display should be 'Self'");
+}
+
+#[test]
+fn test_inherited_typed_no_default_fallback_self_class_display() {
+    // type_annotation_display SelfClass branch (line 619).
+    let s = Span::new(0, 0);
+    let self_class = TypeAnnotation::SelfClass { span: s };
+    let module = make_actor_typed_no_default("classRef", self_class);
+    let generator = crate::codegen::core_erlang::CoreErlangGenerator::new("bt@test_actor");
+    let fields = generator.inherited_typed_no_default_fields(&module, "TestActor");
+    assert_eq!(fields.len(), 1, "SelfClass field should appear in typed-no-default");
+    assert_eq!(
+        fields[0].type_name, "Self class",
+        "SelfClass display should be 'Self class'"
+    );
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -4482,7 +4482,11 @@ fn test_user_defined_initialize_chain_fallback_with_initialize() {
     let (module, _) = crate::source_analysis::parse(tokens);
     let generator = crate::codegen::core_erlang::CoreErlangGenerator::new("bt@test_actor");
     let chain = generator.user_defined_initialize_chain(&module, "TestActor");
-    assert_eq!(chain.len(), 1, "Fallback should return one entry for the initialize method");
+    assert_eq!(
+        chain.len(),
+        1,
+        "Fallback should return one entry for the initialize method"
+    );
     assert_eq!(
         chain[0].class_name, "TestActor",
         "Chain entry should name the leaf class"
@@ -4542,9 +4546,16 @@ fn test_inherited_typed_no_default_fallback_singleton_type_display() {
     let module = make_actor_typed_no_default("status", singleton);
     let generator = crate::codegen::core_erlang::CoreErlangGenerator::new("bt@test_actor");
     let fields = generator.inherited_typed_no_default_fields(&module, "TestActor");
-    assert_eq!(fields.len(), 1, "Singleton field should appear in typed-no-default");
+    assert_eq!(
+        fields.len(),
+        1,
+        "Singleton field should appear in typed-no-default"
+    );
     assert_eq!(fields[0].field_name, "status");
-    assert_eq!(fields[0].type_name, "#ok", "Singleton display should be '#ok'");
+    assert_eq!(
+        fields[0].type_name, "#ok",
+        "Singleton display should be '#ok'"
+    );
 }
 
 #[test]
@@ -4555,8 +4566,15 @@ fn test_inherited_typed_no_default_fallback_self_type_display() {
     let module = make_actor_typed_no_default("selfRef", self_type);
     let generator = crate::codegen::core_erlang::CoreErlangGenerator::new("bt@test_actor");
     let fields = generator.inherited_typed_no_default_fields(&module, "TestActor");
-    assert_eq!(fields.len(), 1, "SelfType field should appear in typed-no-default");
-    assert_eq!(fields[0].type_name, "Self", "SelfType display should be 'Self'");
+    assert_eq!(
+        fields.len(),
+        1,
+        "SelfType field should appear in typed-no-default"
+    );
+    assert_eq!(
+        fields[0].type_name, "Self",
+        "SelfType display should be 'Self'"
+    );
 }
 
 #[test]
@@ -4567,7 +4585,11 @@ fn test_inherited_typed_no_default_fallback_self_class_display() {
     let module = make_actor_typed_no_default("classRef", self_class);
     let generator = crate::codegen::core_erlang::CoreErlangGenerator::new("bt@test_actor");
     let fields = generator.inherited_typed_no_default_fields(&module, "TestActor");
-    assert_eq!(fields.len(), 1, "SelfClass field should appear in typed-no-default");
+    assert_eq!(
+        fields.len(),
+        1,
+        "SelfClass field should appear in typed-no-default"
+    );
     assert_eq!(
         fields[0].type_name, "Self class",
         "SelfClass display should be 'Self class'"


### PR DESCRIPTION
## Summary

- Adds 12 focused Rust unit tests to `crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs` targeting previously-uncovered branches in `gen_server/callbacks.rs`
- No production code changes — pure test additions

## Coverage targets

| Function | Branch | Lines | Test strategy |
|---|---|---|---|
| `is_nilable_type` | `Union` variant | 589 | `generate_module` with `Union([Integer, Nil])` field |
| `type_annotation_display` | `Union` | 599-603 | `generate_module` with `Union([Integer, String])` field |
| `type_annotation_display` | `Singleton` | 604 | `generate_module` + fallback assertion (display = `"#ok"`) |
| `type_annotation_display` | `Generic` | 605-613 | `generate_module` with `Collection(Integer)` field |
| `type_annotation_display` | `FalseOr` | 615-616 | `generate_module` with `Integer \| False` field |
| `type_annotation_display` | `ClassOf` | 620 | `generate_module` with `Actor class` field |
| `type_annotation_display` | `SelfType` | 618 | Direct `CoreErlangGenerator` fallback test |
| `type_annotation_display` | `SelfClass` | 619 | Direct `CoreErlangGenerator` fallback test |
| `user_defined_initialize_chain` | fallback (no hierarchy) | 643-655 | Direct generator, with and without `initialize` method |
| `inherited_typed_no_default_fields` | fallback (no hierarchy) | 711-733 | Direct generator, Union-Nil exclusion + Singleton display |

## Test strategy

Two orthogonal approaches:

**generate_module tests (1–6):** Compile a full actor module; coverage fires through the hierarchy path (`lines 748-763`) which calls `is_nilable_type` and `type_annotation_display` the same way as the fallback. Assertions verify `'uninitialized_state_error'` appears in output (proves the validation codepath was reached) or that no initialize continuation is emitted (for the nilable Union case).

**Direct CoreErlangGenerator tests (7–12):** Construct a generator with `class_hierarchy = None` and call `user_defined_initialize_chain` / `inherited_typed_no_default_fields` directly, exercising the fallback paths that `generate_module` can never reach (it always builds a hierarchy). These tests also directly inspect return values to assert the correct type display strings.

## Test plan

- [x] All 12 new tests pass: `cargo test -p beamtalk-core --lib -- test_actor_typed test_user_defined_initialize_chain test_inherited_typed_no_default`
- [x] `cargo fmt` clean (pre-push hook verified)
- [x] `cargo clippy` clean (pre-push hook verified)
- [x] Dialyzer clean (pre-push hook verified)
- [ ] Full `just test` (running in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKjsmybB8fFj2m6oEABFRi

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKjsmybB8fFj2m6oEABFRi)_