### PR TITLE
test: extract actor spawn to setUp/tearDown in ActorSelfCallStateTest

### DIFF
--- a/stdlib/test/actor_self_call_state_test.bt
+++ b/stdlib/test/actor_self_call_state_test.bt
@@ -7,39 +7,37 @@
 // Fixtures: stdlib/test/fixtures/self_call_state_actor.bt
 
 TestCase subclass: ActorSelfCallStateTest
+  field: a = nil
+
+  setUp => self withA: SelfCallStateActor spawn
+
+  tearDown => self.a isNil ifFalse: [self.a stop]
 
   // Core regression test: self-call mutates state, caller reads it
   testSelfCallStateMutationVisible =>
-    a := SelfCallStateActor spawn
-    self assert: a callSetupThenRead equals: 42
+    self assert: self.a callSetupThenRead equals: 42
 
   // Multiple sequential self-calls each mutate state
   testMultipleSelfCallsMutateState =>
-    a := SelfCallStateActor spawn
-    self assert: a callThreeIncrements equals: 3
+    self assert: self.a callThreeIncrements equals: 3
 
   // Self-call as last expression threads state back to gen_server
   testSelfCallAsLastExpressionThreadsState =>
-    a := SelfCallStateActor spawn
-    a callSetupAsLast
-    self assert: a getValue equals: 42
+    self.a callSetupAsLast
+    self assert: self.a getValue equals: 42
 
   // Self-call mutation followed by field assignment
   testSelfCallThenFieldAssignment =>
-    a := SelfCallStateActor spawn
-    self assert: a callSetupThenAssignField equals: 52
+    self assert: self.a callSetupThenAssignField equals: 52
 
   // BT-1421: Assignment RHS self-send returns the value, not the dispatch tuple
   testAssignmentRhsSelfSendReturnsValue =>
-    a := SelfCallStateActor spawn
-    self assert: a callBumpAndCapture equals: 1
+    self assert: self.a callBumpAndCapture equals: 1
 
   // BT-1421: Assignment RHS self-send threads state correctly
   testAssignmentRhsSelfSendThreadsState =>
-    a := SelfCallStateActor spawn
-    self assert: a callBumpAndReadState equals: 1
+    self assert: self.a callBumpAndReadState equals: 1
 
   // BT-1421: Multiple assignment RHS self-sends accumulate state
   testMultipleAssignmentRhsSelfSends =>
-    a := SelfCallStateActor spawn
-    self assert: a callDoubleBumpAndCapture equals: 3
+    self assert: self.a callDoubleBumpAndCapture equals: 3


### PR DESCRIPTION
## Summary

- All 7 test methods in `ActorSelfCallStateTest` opened with identical `a := SelfCallStateActor spawn` and never stopped the actor
- Extracted to `field: a = nil` + `setUp` + `tearDown`, following the pattern already established in `actor_conditional_mutations_test.bt`
- Fixes a resource leak (OTP actor process never stopped after each test)

## Test plan

- [x] `just test-bunit` passes: 2589 tests, 0 failures
- [x] Pre-push hooks pass: Clippy, fmt, Dialyzer, erlfmt all clean
- [x] No assertions changed — purely structural refactor

Closes #2759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aE5cPeBhX2tDKn8kMFTW8

---
_Generated by [Claude Code](https://claude.ai/code/session_011aE5cPeBhX2tDKn8kMFTW8)_