### PR TITLE
docs(ADR): reconcile status lines with shipped implementations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,6 @@ Beamtalk is a Smalltalk/Newspeak-inspired language compiling to BEAM via Rust. T
 - **Test assertions:** Every expression in test files needs a `// =>` assertion (even `// => _`) — no assertion means no execution.
 - **Cross-platform temp paths:** Never hardcode `/tmp/`. Use `File tempDirectory` (BT) / `beamtalk_file:'tempDirectory'()` (Erlang) and concatenate, or prefer relative temp filenames in runtime EUnit tests. See `docs/development/testing-strategy.md`.
 - **Generated files:** Before editing `.app.src` or other generated artifacts, check if a build step owns them — `build_stdlib.rs` generates `beamtalk_stdlib.app.src`, so edit the generator.
-- **Worktree stale builds:** Run `just build` after entering/creating a worktree before tests — stale BEAM artifacts cause false failures.
 - **REPL output:** Confirm with the user before changing any REPL display value, prompt format, or output behaviour — it's usually intentional and covered by e2e tests.
 - **Surface parity:** When adding/modifying operations on any surface (CLI, REPL, MCP, LSP), update `docs/development/surface-parity.md`. Operations not labelled `surface-specific` must produce equivalent output across surfaces.
 

--- a/docs/ADR/0056-native-erlang-backed-actors.md
+++ b/docs/ADR/0056-native-erlang-backed-actors.md
@@ -1,7 +1,7 @@
 # ADR 0056: Native Erlang-Backed Actors — `native:` and `self delegate`
 
 ## Status
-Accepted (partial, 2026-03-07) — revised from initial `@native` annotation design
+Accepted (2026-03-07) — revised from initial `@native` annotation design. Phases 1–2 Implemented (compiler `native:` support + stdlib migration, BT-1204–BT-1215); Phase 3 tooling (`gen-native`, LSP go-to-implementation/mismatch detection) outstanding
 
 ## Context
 

--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -1,7 +1,7 @@
 # ADR 0081: First-Class Session Object — Walkable Binding Layers
 
 ## Status
-Accepted (2026-06-01)
+Accepted (2026-06-01), Implemented — all 7 phases shipped (BT-2365–BT-2369)
 
 ## Context
 

--- a/docs/ADR/0091-remote-workspace-access-phoenix-authenticated-front.md
+++ b/docs/ADR/0091-remote-workspace-access-phoenix-authenticated-front.md
@@ -1,7 +1,7 @@
 # ADR 0091: Connection Security for Remote Workspace Access — Phoenix as Authenticated Front
 
 ## Status
-Accepted (2026-06-06)
+Accepted (2026-06-06), Implemented — OIDC front, RBAC op facade, transport hardening, deployment docs (BT-2417–BT-2424)
 
 Extends [ADR 0020 — Connection Security](0020-connection-security.md). Amends
 [ADR 0058 — Platform Security Model](0058-platform-security-model.md) Principle 6

--- a/docs/ADR/0094-object-string-representation-protocols.md
+++ b/docs/ADR/0094-object-string-representation-protocols.md
@@ -1,7 +1,7 @@
 # ADR 0094: Object String Representation Protocols (printString / displayString / inspect)
 
 ## Status
-Proposed (2026-06-07)
+Implemented (2026-06-07) — structural `printString`/`displayString` protocols, canonical `beamtalk_object_printer` renderer, kind-headed actor/supervisor labels (BT-2462, BT-2504)
 
 ## Context
 

--- a/docs/ADR/0096-system-browser-data-source.md
+++ b/docs/ADR/0096-system-browser-data-source.md
@@ -1,7 +1,7 @@
 # ADR 0096: System Browser Data Source — Class/Method Browse API for the LiveView IDE
 
 ## Status
-Proposed (2026-06-10)
+Implemented (2026-06-10) — four read-only browse ops in `beamtalk_repl_ops_browse` with origin/divergence metadata (BT-2482, BT-2488)
 
 ## Context
 

--- a/docs/ADR/0098-build-artifact-provenance.md
+++ b/docs/ADR/0098-build-artifact-provenance.md
@@ -1,7 +1,7 @@
 # ADR 0098: Build Artifact Provenance and Version-Based Staleness Invalidation
 
 ## Status
-Accepted (2026-06-23)
+Accepted (2026-06-23), Implemented — all 4 phases: project stamp, dependency provenance, self-describing modules, workspace attach gate (BT-2674–BT-2677)
 
 ## Context
 


### PR DESCRIPTION
## Summary

Status review of all **Accepted** / **Proposed** ADRs against the actual codebase. Several ADRs had completed (or substantially completed) implementations but stale status headers. This PR reconciles the headers; no code behaviour changes.

## Stale status corrected (work shipped, header lagged)

| ADR | Before → After | Evidence |
|---|---|---|
| **0081** First-Class Session Object | Accepted → **Implemented** | All 7 phases shipped — `Session.bt`, `BindingsView.bt`, `beamtalk_session_primitives.erl`, EUnit + e2e (BT-2365–2369) |
| **0091** Remote Workspace / Phoenix Front | Accepted → **Implemented** | Full `bt_attach` Phoenix app: OIDC, RBAC op facade, epmd hardening, deploy docs (BT-2417–2424) |
| **0094** Object String Representation | Proposed → **Implemented** | `beamtalk_object_printer` structural renderer, `printString`/`displayString`, actor/supervisor labels (BT-2462, BT-2504) |
| **0096** System Browser Data Source | Proposed → **Implemented** | Four browse ops in `beamtalk_repl_ops_browse` + tests + CHANGELOG (BT-2482, BT-2488) |
| **0098** Build Artifact Provenance | Accepted → **Implemented** | All 4 phases: project/dep stamps, self-describing modules, attach gate (BT-2674–2677) |
| **0056** Native Erlang-Backed Actors | clarified | Phases 1–2 implemented; Phase 3 tooling (`gen-native`, LSP) outstanding |

## CLAUDE.md

Removed the "run `just build` first in a worktree" caveat — ADR 0098's provenance stamping now self-heals stale worktree artifacts, and its migration path explicitly calls for retiring the caveat.

## Left untouched (status verified accurate)

0084 (in progress, capstone BT-2271 pending), 0090 & 0097 (not started), 0085 (mostly not started), 0017 Phase 3 (~70%), and the intentionally-not-implemented set (0030 Rejected, 0048/0049 Deferred, 0058 policy, 0074 deferral, 0075 Phase 2 deferred, 0088 Rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cf4EPk8KDZJYsYpw4JcS4U)_