### PR TITLE
test(workspace): add edge-case tests for beamtalk_erlang_help

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_erlang_help_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_erlang_help_tests.erl
@@ -166,3 +166,52 @@ find_function_arities_returns_sorted_arities_test() ->
 
 find_function_arities_returns_empty_for_nonexistent_test() ->
     ?assertEqual([], beamtalk_erlang_help:find_function_arities(lists, zzz_nonexistent_fn_xyz)).
+
+find_function_arities_nonexistent_module_returns_empty_test() ->
+    %% Module does not exist — catch clause returns []
+    ?assertEqual([], beamtalk_erlang_help:find_function_arities(zzz_nonexistent_module_xyz, foo)).
+
+%%====================================================================
+%% format_function_help/2 — preloaded module (erlang)
+%%====================================================================
+
+format_function_help_for_preloaded_module_function_test() ->
+    %% erlang is a preloaded module; exercises the preloaded branch in
+    %% format_function_help/2 and format_function_with_docs/3
+    {ok, Text} = beamtalk_erlang_help:format_function_help(erlang, abs),
+    ?assertNotEqual(nomatch, binary:match(Text, <<"erlang:abs">>)).
+
+format_function_help_nonexistent_fn_in_preloaded_module_test() ->
+    %% Preloaded module, function not found — exercises find_types_in_beam preloaded branch
+    ?assertEqual(
+        {error, not_found},
+        beamtalk_erlang_help:format_function_help(erlang, zzz_nonexistent_fn_xyz)
+    ).
+
+%%====================================================================
+%% format_exports_list/1
+%%====================================================================
+
+format_exports_list_nonexistent_module_returns_fallback_test() ->
+    %% Module not loaded — catch clause returns fallback string
+    Result = beamtalk_erlang_help:format_exports_list(zzz_nonexistent_module_xyz),
+    ?assertEqual(<<"(no export information available)\n">>, Result).
+
+%%====================================================================
+%% dedupe_keyword_aliases/1 — empty name
+%%====================================================================
+
+dedupe_empty_name_spec_is_kept_test() ->
+    %% Empty binary name: is_keyword_name(<<>>) -> false, so no dedup occurs
+    Result = beamtalk_erlang_help:dedupe_keyword_aliases([#{name => <<>>, arity => 0}]),
+    ?assertEqual(1, length(Result)).
+
+%%====================================================================
+%% format_beamtalk_signature/3 — empty param name fallback
+%%====================================================================
+
+signature_empty_param_name_uses_arg_fallback_test() ->
+    %% format_param_name(<<>>) -> <<"arg">>
+    Params = [#{name => <<>>, type => <<"Integer">>}],
+    Result = beamtalk_erlang_help:format_beamtalk_signature(<<"test:">>, Params, <<"String">>),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"arg">>)).


### PR DESCRIPTION
## Summary

- Add 6 new EUnit tests to `beamtalk_erlang_help_tests` covering previously uncovered branches
- Module was at 71% (156/219 lines) in the 2026-06-25 CI coverage run; expected improvement to ~76-78%

## New tests

| Test | Lines covered |
|------|--------------|
| `format_function_help_for_preloaded_module_function_test` | preloaded branch in `format_function_help/2` + `format_function_with_docs/3` (lines 78, 186, 219, 237-241, 261) |
| `format_function_help_nonexistent_fn_in_preloaded_module_test` | `find_types_in_beam(preloaded, _) -> {error, no_debug_info}` (line 332) |
| `format_exports_list_nonexistent_module_returns_fallback_test` | catch fallback `"(no export information available)\n"` (line 400) |
| `dedupe_empty_name_spec_is_kept_test` | `is_keyword_name(<<>>) -> false` (line 546) |
| `signature_empty_param_name_uses_arg_fallback_test` | `format_param_name(<<>>) -> <<"arg">>` (line 602) |
| `find_function_arities_nonexistent_module_returns_empty_test` | module error catch `-> []` (line 613) |

## Test plan

- [x] `cd runtime && rebar3 eunit --module=beamtalk_erlang_help_tests` — all 28 tests pass
- [x] `erlfmt --check` — no formatting violations
- [x] Pre-push hook (clippy, dialyzer, fmt) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5UFn1rzpF6Ljuwo2qh2VU

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5UFn1rzpF6Ljuwo2qh2VU)_