### PR TITLE
test: tighten testResultFailuresEmpty to assert actual empty list

### DIFF
--- a/stdlib/test/test_runner_test.bt
+++ b/stdlib/test/test_runner_test.bt
@@ -35,4 +35,4 @@ TestCase subclass: TestRunnerTest
 
   testResultFailuresEmpty =>
     result := TestRunner run: SampleTestCase
-    self assert: (result failures == nil) equals: false
+    self assert: result failures equals: #()


### PR DESCRIPTION
## Summary

- Replaces the confusing double-negation assertion `self assert: (result failures == nil) equals: false` with the tighter `self assert: result failures equals: #()`
- `TestResult>>failures` returns a `List` (typed `-> List`, docstring example: `failures // => []`), so when all tests pass the correct expected value is the empty list, not just "not nil"
- The test name `testResultFailuresEmpty` implies checking emptiness — the old assertion only verified non-nil, leaving a gap where a non-empty list would also pass

## What changed

`stdlib/test/test_runner_test.bt` — one line in `testResultFailuresEmpty`.

## Why it's safe

- `SampleTestCase` has 2 tests, both passing → `failures` is always `#()` at this point
- All 2589 BUnit tests pass (244 files, 0 failures)
- Linting and Dialyzer clean

## Test quality smell addressed

`assert: (x == nil) equals: false` is a loose double-negation: it gives a confusing failure message ("expected false, got true") instead of showing the actual value, and it doesn't verify the thing the test name claims to check (emptiness vs non-nil).

_Nightly test-quality pass — one smell, one file._

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjYqNtFF7AM6udaHHCpUom)_