### PR TITLE
feat(runtime): connected-mode Program exit: ends the session (BT-2688)

### DIFF
--- a/crates/beamtalk-repl-protocol/src/response.rs
+++ b/crates/beamtalk-repl-protocol/src/response.rs
@@ -48,6 +48,13 @@ pub struct ReplResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<Vec<String>>,
 
+    /// POSIX exit status from a connected-session `Program exit:` (BT-2688,
+    /// ADR 0099 §3). Present only on the `done` reply that ended the session; the
+    /// connecting client adopts it as its own process exit code. `None` for every
+    /// other response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<u8>,
+
     // --- Common payload ---
     /// Result value (eval, clear, kill, clone, etc.).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -307,6 +314,23 @@ mod tests {
         let resp: ReplResponse = serde_json::from_str(json).unwrap();
         assert!(resp.is_error());
         assert_eq!(resp.error_message(), Some("Something went wrong"));
+    }
+
+    #[test]
+    fn deserialize_script_exit_response() {
+        // BT-2688: connected-session `Program exit: 5` — a `done` reply (not an
+        // error) carrying the POSIX exit status the CLI adopts.
+        let json = r#"{"id":"msg-008","value":null,"status":["done"],"exit_code":5}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        assert!(!resp.is_error());
+        assert_eq!(resp.exit_code, Some(5));
+    }
+
+    #[test]
+    fn exit_code_absent_on_ordinary_response() {
+        let json = r#"{"id":"msg-009","value":42,"status":["done"]}"#;
+        let resp: ReplResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.exit_code, None);
     }
 
     #[test]

--- a/crates/beamtalk-repl-protocol/src/response.rs
+++ b/crates/beamtalk-repl-protocol/src/response.rs
@@ -49,9 +49,11 @@ pub struct ReplResponse {
     pub status: Option<Vec<String>>,
 
     /// POSIX exit status from a connected-session `Program exit:` (BT-2688,
-    /// ADR 0099 §3). Present only on the `done` reply that ended the session; the
-    /// connecting client adopts it as its own process exit code. `None` for every
-    /// other response.
+    /// ADR 0099 §3). Present only on the `done` reply that ended the session.
+    /// This is the wire contract a connecting client *will* adopt as its own
+    /// process exit code once connected-mode `beamtalk run` dispatch lands
+    /// (BT-2691); no consumer reads it yet, so it does not affect any CLI exit
+    /// code today. `None` for every other response.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<u8>,
 

--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -164,6 +164,14 @@ defmodule BtAttach.Workspace do
       so no shared `.hrl` is needed)
 
   `output` is captured stdout (`String.t/0`) and `warnings` is a list of strings.
+
+  > #### Connected exit (BT-2688) {: .info}
+  > A `Program exit:` in this connected session makes the op layer return a
+  > `{:script_exit, code, output, warnings}` term. It is **not consumed here yet**
+  > — it falls through to `{:error, {:unexpected_reply, _}, …}` below — matching
+  > the protocol field doc ("no consumer reads it yet"). Wiring this shape into a
+  > clean exit-code surface is part of **BT-2691** (connected-mode `beamtalk run`);
+  > add a `{:script_exit, …}` arm here when that lands.
   """
   def eval(session_pid, expression) when is_pid(session_pid) and is_binary(expression) do
     case dispatch_eval(session_pid, expression) do

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_program.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_program.erl
@@ -86,8 +86,9 @@ block that wraps `Program exit:` in an `on:do:` whose handler class matches
 re-raises after running cleanup, so the exit still propagates). The robust fix is
 to add this signal to the non-local-return passthrough the `on:do:` codegen
 already emits for `{'$bt_nlr', _}` (see `control_flow/exception_handling.rs`);
-that is a follow-up. In practice `Program exit:` is called at the top of a `main:`
-or as a bare REPL expression, neither of which is wrapped in such a handler.
+that is a follow-up (tracked on BT-2688). In practice `Program exit:` is called at
+the top of a `main:` or as a bare REPL expression, neither of which is wrapped in
+such a handler.
 """.
 -spec 'exit:'(integer()) -> no_return().
 'exit:'(Code) when is_integer(Code), Code >= 0, Code =< 255 ->

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_program.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_program.erl
@@ -64,19 +64,30 @@ End this program with status `Code` — the job-level, safe exit (ADR 0099 §3).
 
 In a **node-owning** context (run-mode / escript — the program *is* the node)
 this exits the node with `Code` via `erlang:halt/1` (which flushes the `io`
-layer). In a **shared/connected** context it must end only *this session's* job
-and leave the node up; that needs the `Session`-termination hook (BT-2688,
-ADR 0099 §3 / Phase 5) which is not yet wired, so it refuses loudly rather than
-halt a shared node.
+layer). In a **shared/connected** context (REPL / MCP / LSP / connected
+`beamtalk run`) it must end only *this session's* job and leave the node up; it
+raises a tagged `script_exit` signal carrying the status, which the session
+evaluator catches to report the status to the connecting client and terminate
+the session (BT-2688, ADR 0099 §3 / Phase 5).
 
 **Process boundary.** The run-mode/escript path is an immediate `erlang:halt/1`,
 so it is effective from *any* process — including a spawned/supervised Actor —
 because the node is dedicated to this one program; there is no harness throw to
 unwind, so the ADR 0099 §3 supervised-Actor-restart caveat does not apply here.
-That caveat is about the *connected-mode* path (Phase 5), which ends the session
-via a signal caught by the session evaluator and so is effective only from the
-entry method's own synchronous call chain; a spawned Actor there must return a
-status to the entry method and let *it* call `exit:`.
+That caveat *does* apply to the connected-mode path: the signal is caught by the
+session evaluator, so it is effective only from the entry method's own
+synchronous call chain; a spawned Actor there must return a status to the entry
+method and let *it* call `exit:`.
+
+**`on:do:` caveat (connected mode).** Because the connected exit is a `throw`, a
+block that wraps `Program exit:` in an `on:do:` whose handler class matches
+(`on: Error do:` / `on: Exception do:` / a catch-all) will intercept it as an
+`erlang_throw` rather than letting the session end. `ensure:` is unaffected (it
+re-raises after running cleanup, so the exit still propagates). The robust fix is
+to add this signal to the non-local-return passthrough the `on:do:` codegen
+already emits for `{'$bt_nlr', _}` (see `control_flow/exception_handling.rs`);
+that is a follow-up. In practice `Program exit:` is called at the top of a `main:`
+or as a bare REPL expression, neither of which is wrapped in such a handler.
 """.
 -spec 'exit:'(integer()) -> no_return().
 'exit:'(Code) when is_integer(Code), Code >= 0, Code =< 255 ->
@@ -84,7 +95,14 @@ status to the entry method and let *it* call `exit:`.
         true ->
             erlang:halt(Code);
         false ->
-            raise_connected_exit_unsupported(Code)
+            %% Connected/shared context: end only THIS session's job, not the
+            %% shared node. The tagged `script_exit` signal carries the status; the
+            %% session evaluator (`beamtalk_repl_eval`/`beamtalk_repl_shell`) catches
+            %% it, replies with the exit status, and stops the session shell
+            %% (BT-2688). `throw` (not `error`) keeps it distinct from a user-level
+            %% `#beamtalk_error{}`, so an ordinary `on:do:` handler does not swallow
+            %% it.
+            throw({beamtalk_script_exit, Code})
     end;
 'exit:'(Code) when is_integer(Code) ->
     %% Out of the POSIX range — a wrong *value*, not a wrong *type*. Validated
@@ -113,18 +131,3 @@ exit(Code) ->
 -spec node_owning() -> boolean().
 node_owning() ->
     application:get_env(beamtalk_runtime, node_owning, false) =:= true.
-
--spec raise_connected_exit_unsupported(integer()) -> no_return().
-raise_connected_exit_unsupported(Code) ->
-    Error0 = beamtalk_error:new(unsupported, 'Program'),
-    Error1 = beamtalk_error:with_selector(Error0, 'exit:'),
-    Error2 = beamtalk_error:with_details(Error1, #{requested_code => Code}),
-    Error3 = beamtalk_error:with_hint(
-        Error2,
-        <<
-            "Program exit: in a shared/connected workspace needs the Session-termination "
-            "hook (BT-2688), not yet available. Run the program with `beamtalk run` "
-            "(run-mode) to use Program exit:, or halt the whole node with System halt:."
-        >>
-    ),
-    beamtalk_error:raise(Error3).

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_program_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_program_tests.erl
@@ -1,0 +1,76 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_program_tests).
+
+-moduledoc """
+Unit tests for the `Program` class runtime (`beamtalk_program`), focused on the
+two-tier exit (ADR 0099 §3).
+
+The node-owning branch of `exit:` calls `erlang:halt/1` and so cannot be
+exercised under EUnit (it would kill the test VM); these tests pin the
+**connected-mode** branch — `Program exit: Code` raising the tagged `script_exit`
+signal the session evaluator catches (BT-2688) — and the value/type validation,
+which runs before the node-owning gate.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+%% Force the connected (non-node-owning) context so `exit:` raises the
+%% `script_exit` signal rather than halting the EUnit VM. Saved/restored around
+%% each test so a leaked `node_owning => true` cannot turn `Program exit:` into an
+%% `erlang:halt/1` that kills the runner.
+connected_setup() ->
+    Prev = application:get_env(beamtalk_runtime, node_owning),
+    application:set_env(beamtalk_runtime, node_owning, false),
+    Prev.
+
+connected_teardown(Prev) ->
+    case Prev of
+        {ok, V} -> application:set_env(beamtalk_runtime, node_owning, V);
+        undefined -> application:unset_env(beamtalk_runtime, node_owning)
+    end,
+    ok.
+
+%% BT-2688: in a connected/shared context, `Program exit: Code` raises the tagged
+%% `{beamtalk_script_exit, Code}` signal (caught by the session evaluator) instead
+%% of halting the node or raising the old `#unsupported` error.
+connected_exit_with_code_raises_script_exit_test_() ->
+    {setup, fun connected_setup/0, fun connected_teardown/1, fun(_) ->
+        [
+            ?_assertThrow({beamtalk_script_exit, 5}, beamtalk_program:'exit:'(5)),
+            ?_assertThrow({beamtalk_script_exit, 0}, beamtalk_program:'exit:'(0)),
+            ?_assertThrow({beamtalk_script_exit, 255}, beamtalk_program:'exit:'(255)),
+            %% Zero-arg `exit`/`exit:` shim both route through `exit:(0)`.
+            ?_assertThrow({beamtalk_script_exit, 0}, beamtalk_program:exit()),
+            ?_assertThrow({beamtalk_script_exit, 7}, beamtalk_program:exit(7))
+        ]
+    end}.
+
+%% Out-of-range is a wrong *value*, validated before the node-owning gate, so it
+%% raises a structured error in any context (consistent with `System halt:`).
+exit_out_of_range_raises_invalid_argument_test_() ->
+    {setup, fun connected_setup/0, fun connected_teardown/1, fun(_) ->
+        [
+            ?_assertError(
+                #{error := #beamtalk_error{kind = invalid_argument}},
+                beamtalk_program:'exit:'(999)
+            ),
+            ?_assertError(
+                #{error := #beamtalk_error{kind = invalid_argument}},
+                beamtalk_program:'exit:'(-1)
+            )
+        ]
+    end}.
+
+%% Non-integer is a wrong *type*, also validated before the node-owning gate.
+exit_non_integer_raises_type_error_test_() ->
+    {setup, fun connected_setup/0, fun connected_teardown/1, fun(_) ->
+        [
+            ?_assertError(
+                #{error := #beamtalk_error{kind = type_error}},
+                beamtalk_program:'exit:'(<<"two">>)
+            )
+        ]
+    end}.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
@@ -1195,7 +1195,13 @@ strip_internal_bindings(Bindings) ->
     maps:remove(?INTERNAL_REGISTRY_KEY, Stripped0).
 
 -doc "Inject captured output and warnings into an eval result tuple.".
--spec inject_output(tuple(), binary(), [binary()]) -> tuple().
+-spec inject_output(
+    {ok, term(), beamtalk_repl_state:state()}
+    | {error, term(), beamtalk_repl_state:state()}
+    | {script_exit, non_neg_integer(), beamtalk_repl_state:state()},
+    binary(),
+    [binary()]
+) -> eval_result().
 inject_output({ok, Result, State}, Output, Warnings) ->
     {ok, Result, Output, Warnings, State};
 inject_output({error, Reason, State}, Output, Warnings) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
@@ -76,19 +76,27 @@ module loading to beamtalk_repl_loader (BT-863).
 -define(INTERNAL_REGISTRY_KEY, '__repl_actor_registry__').
 -define(WORKSPACE_BINDINGS_KEY, '__workspace_user_bindings__').
 
+-doc """
+Result of evaluating an expression. The `script_exit` shape (BT-2688) carries the
+status of a connected-session `Program exit: Code` so the shell can report it and
+terminate the session; `ok`/`error` are the ordinary value/failure shapes.
+""".
+-type eval_result() ::
+    {ok, term(), binary(), [binary()], beamtalk_repl_state:state()}
+    | {error, term(), binary(), [binary()], beamtalk_repl_state:state()}
+    | {script_exit, non_neg_integer(), binary(), [binary()], beamtalk_repl_state:state()}.
+
+-export_type([eval_result/0]).
+
 %%% Public API
 
 -doc "Evaluate a Beamtalk expression.".
--spec do_eval(string(), beamtalk_repl_state:state()) ->
-    {ok, term(), binary(), [binary()], beamtalk_repl_state:state()}
-    | {error, term(), binary(), [binary()], beamtalk_repl_state:state()}.
+-spec do_eval(string(), beamtalk_repl_state:state()) -> eval_result().
 do_eval(Expression, State) ->
     do_eval(Expression, State, undefined).
 
 -doc "Evaluate with optional streaming subscriber (BT-696).".
--spec do_eval(string(), beamtalk_repl_state:state(), pid() | undefined) ->
-    {ok, term(), binary(), [binary()], beamtalk_repl_state:state()}
-    | {error, term(), binary(), [binary()], beamtalk_repl_state:state()}.
+-spec do_eval(string(), beamtalk_repl_state:state(), pid() | undefined) -> eval_result().
 do_eval(Expression, State, Subscriber) ->
     Counter = beamtalk_repl_state:get_eval_counter(State),
     % elp:fixme W0023 intentional atom creation
@@ -843,8 +851,7 @@ first_token(SelectorBin) ->
     pid() | undefined,
     pid() | undefined
 ) ->
-    {ok, term(), binary(), [binary()], beamtalk_repl_state:state()}
-    | {error, term(), binary(), [binary()], beamtalk_repl_state:state()}.
+    eval_result().
 handle_class_definition(
     ClassInfo, Warnings, Expression, MergedBindings, State, RegistryPid, Subscriber
 ) ->
@@ -961,14 +968,20 @@ maybe_register_protocol_class(ModuleName) ->
     [binary()],
     beamtalk_repl_state:state()
 ) ->
-    {ok, term(), binary(), [binary()], beamtalk_repl_state:state()}
-    | {error, term(), binary(), [binary()], beamtalk_repl_state:state()}.
+    eval_result().
 eval_loaded_module(ModuleName, Expression, Bindings, RegistryPid, Subscriber, Warnings, State) ->
     CaptureRef = beamtalk_io_capture:start(Subscriber),
     EvalResult =
         try
             execute_and_process(ModuleName, Expression, Bindings, RegistryPid, State)
         catch
+            throw:{beamtalk_script_exit, Code} ->
+                %% BT-2688: `Program exit: Code` evaluated in a connected session
+                %% (ADR 0099 §3 / Phase 5). This is the job-level exit signal raised
+                %% by `beamtalk_program:'exit:'/1`, not a user error — surface the
+                %% status so the shell reports it and terminates the session. Caught
+                %% ahead of the generic clause so it is never wrapped as an error.
+                {script_exit, Code, State};
             Class:Reason:Stacktrace ->
                 CaughtExObj = beamtalk_exception_handler:ensure_wrapped(Class, Reason, Stacktrace),
                 CaughtBindings = Bindings#{'_error' => CaughtExObj},
@@ -1176,7 +1189,11 @@ strip_internal_bindings(Bindings) ->
 inject_output({ok, Result, State}, Output, Warnings) ->
     {ok, Result, Output, Warnings, State};
 inject_output({error, Reason, State}, Output, Warnings) ->
-    {error, Reason, Output, Warnings, State}.
+    {error, Reason, Output, Warnings, State};
+%% BT-2688: connected-session `Program exit:` — carry the status alongside any
+%% output captured before the exit signal fired.
+inject_output({script_exit, Code, State}, Output, Warnings) ->
+    {script_exit, Code, Output, Warnings, State}.
 
 -doc "Wrap a compile error as a structured #beamtalk_error{} result tuple.".
 -spec wrap_compile_err(term(), beamtalk_repl_state:state()) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
@@ -152,7 +152,8 @@ or `{error, Reason, Output, Warnings, State}' on failure.
 """.
 -spec do_eval_trace(string(), beamtalk_repl_state:state()) ->
     {ok, [{binary(), term()}], binary(), [binary()], beamtalk_repl_state:state()}
-    | {error, term(), binary(), [binary()], beamtalk_repl_state:state()}.
+    | {error, term(), binary(), [binary()], beamtalk_repl_state:state()}
+    | {script_exit, non_neg_integer(), binary(), [binary()], beamtalk_repl_state:state()}.
 do_eval_trace(Expression, State) ->
     Counter = beamtalk_repl_state:get_eval_counter(State),
     % elp:fixme W0023 intentional atom creation
@@ -221,6 +222,13 @@ do_eval_trace(Expression, State) ->
                                     {ok, AwaitedSteps, FinalState}
                             end
                         catch
+                            throw:{beamtalk_script_exit, Code} ->
+                                %% BT-2688: `Program exit: Code` inside a traced eval.
+                                %% Honour it like the non-trace path
+                                %% (eval_loaded_module) instead of letting the generic
+                                %% clause wrap it as an error, so the shell reports the
+                                %% status and terminates the session consistently.
+                                {script_exit, Code, NewState};
                             Class:Reason:Stacktrace ->
                                 CaughtExObj = beamtalk_exception_handler:ensure_wrapped(
                                     Class, Reason, Stacktrace
@@ -237,6 +245,8 @@ do_eval_trace(Expression, State) ->
                     case EvalResult of
                         {ok, Steps2, FinalState2} ->
                             {ok, Steps2, Output, Warnings, FinalState2};
+                        {script_exit, ExitCode, ScState} ->
+                            {script_exit, ExitCode, Output, Warnings, ScState};
                         {error, ErrorReason, ErrorState} ->
                             WrappedReason = beamtalk_repl_errors:ensure_structured_error(
                                 ErrorReason

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops.erl
@@ -42,6 +42,7 @@ leak compiler/runtime internals.
 |-----|-------|-------------|
 | result | `{ok, Value, Output, Warnings}` | `eval`, `unload`, `clone`, tracing read ops |
 | trace | `{trace, Steps, Output, Warnings}` | `eval` (trace mode) |
+| script_exit | `{script_exit, Code, Output, Warnings}` | `eval` (connected `Program exit:`, BT-2688) |
 | actors | `{actors, [ActorMeta]}` | `actors` |
 | inspect | `{inspect, map() \| binary()}` | `inspect` |
 | status | `{status, ok}` | `kill`, `interrupt`, `close`, `shutdown` |
@@ -98,6 +99,7 @@ tagged terms; `encode/2` is the only thing that turns them into JSON.
 -type op_result() ::
     {ok, Value :: term(), Output :: binary(), Warnings :: [binary()]}
     | {trace, Steps :: [term()], Output :: binary(), Warnings :: [binary()]}
+    | {script_exit, Code :: non_neg_integer(), Output :: binary(), Warnings :: [binary()]}
     | {actors, [map()]}
     | {inspect, map() | binary()}
     | {status, ok}
@@ -222,6 +224,11 @@ encode({trace, Steps, Output, Warnings}, Msg) ->
     beamtalk_repl_protocol:encode_trace_result(
         Steps, Msg, fun beamtalk_repl_json:term_to_json/1, Output, Warnings
     );
+encode({script_exit, Code, Output, Warnings}, Msg) ->
+    %% BT-2688: connected-session `Program exit: Code`. Carries the POSIX exit
+    %% status in a dedicated `exit_code` field; the session shell has already
+    %% terminated by the time this reply is encoded.
+    beamtalk_repl_protocol:encode_script_exit(Code, Msg, Output, Warnings);
 encode({actors, Actors}, Msg) ->
     beamtalk_repl_protocol:encode_actors(Actors, Msg, fun beamtalk_repl_json:term_to_json/1);
 encode({inspect, Map}, Msg) when is_map(Map) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
@@ -55,6 +55,10 @@ handle_term(<<"eval">>, Params, _Msg, SessionPid) ->
             case beamtalk_repl_shell:eval_trace(SessionPid, Code) of
                 {ok, Steps, Output, Warnings} ->
                     {trace, Steps, Output, Warnings};
+                {script_exit, Code2, Output, Warnings} ->
+                    %% BT-2688: `Program exit: Code2` inside a traced eval — same
+                    %% connected-exit handling as the non-trace branch.
+                    {script_exit, Code2, Output, Warnings};
                 {error, ErrorReason, Output, Warnings} ->
                     WrappedReason = beamtalk_repl_errors:ensure_structured_error(ErrorReason),
                     {error, WrappedReason, Output, Warnings}

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_eval.erl
@@ -31,7 +31,9 @@ handle(<<"eval">>, Params, Msg, SessionPid) ->
 
 -doc """
 Term-returning eval handler. Returns `{ok, Value, Output, Warnings}` on success,
-`{trace, Steps, Output, Warnings}` in trace mode, or
+`{trace, Steps, Output, Warnings}` in trace mode,
+`{script_exit, Code, Output, Warnings}` when the expression called
+`Program exit: Code` in this connected session (BT-2688), or
 `{error, #beamtalk_error{}}` / `{error, #beamtalk_error{}, Output, Warnings}` on
 failure. No JSON in this path — dist-attached clients consume the term directly.
 """.
@@ -61,6 +63,9 @@ handle_term(<<"eval">>, Params, _Msg, SessionPid) ->
             case beamtalk_repl_shell:eval(SessionPid, Code) of
                 {ok, Result, Output, Warnings} ->
                     {ok, Result, Output, Warnings};
+                {script_exit, Code2, Output, Warnings} ->
+                    %% BT-2688: `Program exit: Code2` ended this connected session.
+                    {script_exit, Code2, Output, Warnings};
                 {error, ErrorReason, Output, Warnings} ->
                     WrappedReason = beamtalk_repl_errors:ensure_structured_error(ErrorReason),
                     {error, WrappedReason, Output, Warnings}

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_protocol.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_protocol.erl
@@ -25,6 +25,7 @@ Legacy format (backward compatible):
     decode/1,
     parse_request/1,
     encode_result/3, encode_result/4, encode_result/5,
+    encode_script_exit/4,
     encode_error/3, encode_error/4, encode_error/5, encode_error/6,
     encode_status/3,
     encode_out/3,
@@ -228,6 +229,39 @@ encode_result(Value, Msg, TermToJson, Output, Warnings) ->
         false ->
             Base = base_response(Msg),
             Full = Base#{<<"value">> => JsonValue, <<"status">> => [<<"done">>]},
+            iolist_to_binary(
+                json:encode(maybe_add_warnings(maybe_add_output(Full, Output), Warnings))
+            )
+    end.
+
+-doc """
+Encode a connected-session `Program exit:` response (BT-2688, ADR 0099 §3).
+
+A successful `done` response (NOT an error) that additionally carries the POSIX
+exit status in a dedicated `exit_code` field, so the connecting client can adopt
+it as its own process exit code. `value` is `null` — `Program exit:` does not
+return a value. The session shell has already terminated by the time this is
+encoded; the shared node stays up.
+""".
+-spec encode_script_exit(non_neg_integer(), protocol_msg(), binary(), [binary()]) -> binary().
+encode_script_exit(Code, Msg, Output, Warnings) ->
+    case Msg#protocol_msg.legacy of
+        true ->
+            %% Legacy protocol has no status array; surface the exit code alongside
+            %% the result envelope so legacy clients can still read it.
+            Base = #{
+                <<"type">> => <<"result">>, <<"value">> => null, <<"exit_code">> => Code
+            },
+            iolist_to_binary(
+                json:encode(maybe_add_warnings(maybe_add_output(Base, Output), Warnings))
+            );
+        false ->
+            Base = base_response(Msg),
+            Full = Base#{
+                <<"value">> => null,
+                <<"status">> => [<<"done">>],
+                <<"exit_code">> => Code
+            },
             iolist_to_binary(
                 json:encode(maybe_add_warnings(maybe_add_output(Full, Output), Warnings))
             )

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
@@ -100,13 +100,19 @@ Returns `{ok, Steps, Output, Warnings}' or `{error, Reason, Output, Warnings}'.
 """.
 -spec eval_trace(pid(), string()) ->
     {ok, [{binary(), term()}], binary(), [binary()]}
-    | {error, term(), binary(), [binary()]}.
+    | {error, term(), binary(), [binary()]}
+    | {script_exit, non_neg_integer(), binary(), [binary()]}.
 eval_trace(SessionPid, Expression) ->
     gen_server:call(SessionPid, {eval_trace, Expression}, 30000).
 
 -doc """
 Evaluate an expression with streaming subscriber (BT-696).
-Subscriber receives {eval_out, Chunk} messages during eval.
+
+Subscriber receives `{eval_out, Chunk}` messages during eval, then one terminal
+message: `{eval_done, Value, Output, Warnings}`, `{eval_error, Reason, Output,
+Warnings}`, or — when the expression called `Program exit:` in this connected
+session — `{eval_script_exit, Code, Output, Warnings}` (BT-2688), after which the
+session shell stops.
 """.
 -spec eval_async(pid(), string(), pid()) -> ok.
 eval_async(SessionPid, Expression, Subscriber) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
@@ -79,9 +79,18 @@ start_link(SessionId, Meta) when is_map(Meta) ->
 stop(SessionPid) ->
     gen_server:stop(SessionPid, normal, 5000).
 
--doc "Evaluate an expression in this session.".
+-doc """
+Evaluate an expression in this session.
+
+The `{script_exit, Code, Output, Warnings}` reply (BT-2688) signals a
+connected-session `Program exit: Code`: the shell sends it, then terminates this
+session (the caller surfaces the status to the connecting client). The shared
+node is unaffected.
+""".
 -spec eval(pid(), string()) ->
-    {ok, term(), binary(), [binary()]} | {error, term(), binary(), [binary()]}.
+    {ok, term(), binary(), [binary()]}
+    | {error, term(), binary(), [binary()]}
+    | {script_exit, non_neg_integer(), binary(), [binary()]}.
 eval(SessionPid, Expression) ->
     gen_server:call(SessionPid, {eval, Expression}, 30000).
 
@@ -489,7 +498,16 @@ handle_info({eval_result, WorkerPid, Result}, {SessionId, ShellState, {WorkerPid
             %% must not wipe every local because the line after `clear` failed.
             MergedState0 = apply_pending_removals(ShellState, WorkerState),
             MergedState = apply_pending_mutations_no_clear(ShellState, MergedState0, SessionId),
-            {noreply, {SessionId, MergedState, undefined}}
+            {noreply, {SessionId, MergedState, undefined}};
+        {script_exit, Code, Output, Warnings, _WorkerState} ->
+            %% BT-2688 (ADR 0099 §3 / Phase 5): `Program exit: Code` in this
+            %% connected session. Reply with the exit status, then stop this
+            %% session's shell so the job ends while the shared node stays up. The
+            %% shell is a `temporary` child of `beamtalk_session_sup`, so it is not
+            %% restarted. Pending session-local mutations are dropped — the session
+            %% is ending, so there is nothing left to read them back.
+            reply_eval(From, {eval_script_exit, Code, Output, Warnings}),
+            {stop, normal, {SessionId, ShellState, undefined}}
     end;
 %% Worker process crashed (BT-666)
 handle_info(
@@ -737,4 +755,8 @@ reply_eval({async, Subscriber}, Msg) ->
 reply_eval(From, {eval_done, Value, Output, Warnings}) ->
     gen_server:reply(From, {ok, Value, Output, Warnings});
 reply_eval(From, {eval_error, Reason, Output, Warnings}) ->
-    gen_server:reply(From, {error, Reason, Output, Warnings}).
+    gen_server:reply(From, {error, Reason, Output, Warnings});
+%% BT-2688: connected-session `Program exit:` — surface the status to the caller,
+%% which encodes it for the connecting client before the session shell stops.
+reply_eval(From, {eval_script_exit, Code, Output, Warnings}) ->
+    gen_server:reply(From, {script_exit, Code, Output, Warnings}).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
@@ -147,12 +147,31 @@ websocket_info(
         io_capture_pid = undefined,
         stdin_ref = undefined
     }};
+%% BT-2688: connected-session `Program exit:` under a streaming eval. Surface the
+%% exit-status reply (parity with the synchronous op path) so the subscriber gets
+%% a terminal message rather than waiting forever; the session shell has already
+%% stopped. Rare in practice — `Program exit:` is documented for `main:` / bare
+%% expressions, not streaming contexts.
+websocket_info(
+    {eval_script_exit, Code, Output, Warnings},
+    State = #ws_state{authenticated = true, pending_eval = Msg}
+) when
+    Msg =/= undefined
+->
+    Response = beamtalk_repl_protocol:encode_script_exit(Code, Msg, Output, Warnings),
+    {[{text, Response}], State#ws_state{
+        pending_eval = undefined,
+        io_capture_pid = undefined,
+        stdin_ref = undefined
+    }};
 %% BT-696: Late streaming messages after eval completed — drop silently
 websocket_info({eval_out, _Chunk}, State = #ws_state{pending_eval = undefined}) ->
     {ok, State};
 websocket_info({eval_done, _, _, _}, State = #ws_state{pending_eval = undefined}) ->
     {ok, State};
 websocket_info({eval_error, _, _, _}, State = #ws_state{pending_eval = undefined}) ->
+    {ok, State};
+websocket_info({eval_script_exit, _, _, _}, State = #ws_state{pending_eval = undefined}) ->
     {ok, State};
 %% Transcript push — forwarded from beamtalk_transcript_stream subscriber (ADR 0017)
 websocket_info({transcript_output, Text}, State = #ws_state{authenticated = true}) ->

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
@@ -157,6 +157,15 @@ do_eval_preserves_bindings_on_error_test() ->
     %% New binding should NOT be there (eval failed)
     ?assertEqual(false, maps:is_key(z, FinalBindings)).
 
+%%% BT-2688: connected-session Program exit: result plumbing
+
+inject_output_script_exit_test() ->
+    %% inject_output/3 threads captured output + warnings into the script_exit
+    %% shape so the shell can report the exit status (ADR 0099 §3 / Phase 5).
+    State = beamtalk_repl_state:new(undefined, 0),
+    Result = beamtalk_repl_eval:inject_output({script_exit, 7, State}, <<"out">>, [<<"w">>]),
+    ?assertEqual({script_exit, 7, <<"out">>, [<<"w">>], State}, Result).
+
 %%% rebuild_bindings_from_steps tests (BT-1261)
 
 rebuild_bindings_from_steps_simple_assignment_test() ->

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_protocol_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_protocol_tests.erl
@@ -193,6 +193,35 @@ encode_sessions_new_format_test() ->
     SessionList = maps:get(<<"sessions">>, Decoded),
     ?assertEqual(2, length(SessionList)).
 
+%% BT-2688: connected-session `Program exit:` reply carries the POSIX exit status
+%% in `exit_code`, alongside a `done` status and a null value — NOT an error.
+encode_script_exit_new_format_test() ->
+    Msg = make_msg(<<"eval">>, <<"msg-exit-1">>, <<"alice">>, false),
+    Result = beamtalk_repl_protocol:encode_script_exit(5, Msg, <<>>, []),
+    Decoded = json:decode(Result),
+    ?assertEqual(<<"msg-exit-1">>, maps:get(<<"id">>, Decoded)),
+    ?assertEqual(<<"alice">>, maps:get(<<"session">>, Decoded)),
+    ?assertEqual(5, maps:get(<<"exit_code">>, Decoded)),
+    ?assertEqual(null, maps:get(<<"value">>, Decoded)),
+    ?assertEqual([<<"done">>], maps:get(<<"status">>, Decoded)),
+    %% Crucially a success, not an error: no "error" flag in status.
+    ?assertNot(lists:member(<<"error">>, maps:get(<<"status">>, Decoded))).
+
+encode_script_exit_with_output_test() ->
+    Msg = make_msg(<<"eval">>, <<"msg-exit-2">>, undefined, false),
+    Result = beamtalk_repl_protocol:encode_script_exit(0, Msg, <<"bye\n">>, []),
+    Decoded = json:decode(Result),
+    ?assertEqual(0, maps:get(<<"exit_code">>, Decoded)),
+    ?assertEqual(<<"bye\n">>, maps:get(<<"output">>, Decoded)).
+
+encode_script_exit_legacy_format_test() ->
+    Msg = make_msg(<<"eval">>, undefined, undefined, true),
+    Result = beamtalk_repl_protocol:encode_script_exit(3, Msg, <<>>, []),
+    Decoded = json:decode(Result),
+    ?assertEqual(<<"result">>, maps:get(<<"type">>, Decoded)),
+    ?assertEqual(3, maps:get(<<"exit_code">>, Decoded)),
+    ?assertEqual(null, maps:get(<<"value">>, Decoded)).
+
 %%% Encode tests (legacy format)
 
 encode_result_legacy_format_test() ->

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_shell_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_shell_tests.erl
@@ -719,7 +719,9 @@ script_exit_replies_and_terminates_session_test_() ->
                 after 2000 ->
                     ?assert(false)
                 end,
-                ?assertNot(is_process_alive(Pid))
+                ?assertNot(is_process_alive(Pid)),
+                %% Tidy up the stand-in worker (harmless if already gone).
+                exit(FakeWorkerPid, kill)
             end)
         ]
     end}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_shell_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_shell_tests.erl
@@ -674,6 +674,56 @@ worker_state_with_bindings(Bindings) ->
     State = beamtalk_repl_state:new(undefined, 0),
     beamtalk_repl_state:set_bindings(Bindings, State).
 
+%%====================================================================
+%% BT-2688: connected-session Program exit: (ADR 0099 §3 / Phase 5)
+%%====================================================================
+
+%% A {script_exit, Code, Output, Warnings} eval result surfaces the exit status to
+%% the caller and then terminates the session shell (normal stop), leaving the
+%% shared node up. Mirrors the BT-2366 worker-injection pattern: a fake worker +
+%% an {async, self()} From so reply_eval sends us a message we can match.
+script_exit_replies_and_terminates_session_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                {ok, Pid} = beamtalk_repl_shell:start_link(<<"test-script-exit-1">>),
+                MonRef = erlang:monitor(process, Pid),
+                FakeWorkerPid = spawn(fun() ->
+                    receive
+                        _ -> ok
+                    end
+                end),
+                %% Capture the test pid here: the replace_state fun runs in the
+                %% gen_server process, so `self()` inside it would be the shell.
+                Self = self(),
+                sys:replace_state(Pid, fun({SId, State, _W}) ->
+                    {SId, State, {FakeWorkerPid, make_ref(), {async, Self}}}
+                end),
+                %% The worker→shell result is the 5-tuple
+                %% {script_exit, Code, Output, Warnings, WorkerState}.
+                WorkerState = worker_state_with_bindings(#{}),
+                Pid ! {eval_result, FakeWorkerPid, {script_exit, 5, <<>>, [], WorkerState}},
+                %% The shell surfaces the exit status to the caller...
+                receive
+                    {eval_script_exit, Code, Output, Warnings} ->
+                        ?assertEqual(5, Code),
+                        ?assertEqual(<<>>, Output),
+                        ?assertEqual([], Warnings)
+                after 2000 ->
+                    ?assert(false)
+                end,
+                %% ...and then ends the session with a normal stop.
+                receive
+                    {'DOWN', MonRef, process, Pid, Reason} ->
+                        ?assertEqual(normal, Reason)
+                after 2000 ->
+                    ?assert(false)
+                end,
+                ?assertNot(is_process_alive(Pid))
+            end)
+        ]
+    end}.
+
 unload_module_in_use_returns_error_test_() ->
     {setup, fun setup/0, fun teardown/1, fun(_) ->
         [

--- a/stdlib/test/program_test.bt
+++ b/stdlib/test/program_test.bt
@@ -32,8 +32,9 @@ TestCase subclass: ProgramTest
     // gate), consistent with System halt:.
     self should: [Program exit: 999] raise: #invalid_argument
 
-  testExitInSharedWorkspaceRefuses =>
-    // The test workspace is not node-owning, so Program exit: refuses (pending
-    // the connected-mode Session-termination hook, BT-2688) rather than ending a
-    // shared node. (If this ever halts the runner, node_owning leaked into tests.)
-    self should: [Program exit: 0] raise: #unsupported
+// NOTE: connected-mode `Program exit: N` (non-node-owning) no longer raises an
+// error — it raises a tagged `script_exit` signal that the session evaluator
+// catches to end the session and report exit code N to the connecting client
+// (BT-2688, ADR 0099 §3 / Phase 5). That behaviour needs a live session shell,
+// so it is covered by the EUnit test `beamtalk_repl_shell_tests` (a BUnit block
+// here has no session evaluator to catch the signal).


### PR DESCRIPTION
ADR 0099 §3 / **Phase 5** of epic BT-2684, follow-up to the now-merged #2768. Implements the **connected-mode** half of `Program exit:` (the part Phase 3 gated with `#unsupported`).

In a **connected session** (REPL / MCP / LSP), `Program exit: N` now ends only *that session's* job and reports the status to the connecting client, instead of raising `#unsupported`. Run-mode / escript still halt the node via `erlang:halt/1` (unchanged).

## What changed

- **`beamtalk_program`** — the connected branch of `exit:` raises a tagged `{beamtalk_script_exit, N}` signal instead of `raise_connected_exit_unsupported/1` (gate removed).
- **`beamtalk_repl_eval`** — the eval worker catches the signal *ahead of* the generic handler → `{script_exit, N, …}` (a success shape, not an error).
- **`beamtalk_repl_shell`** — replies with the exit status, then stops the session shell (a `temporary` child of `beamtalk_session_sup`), leaving the node and every other session running.
- **Protocol** — a new `{script_exit, …}` op_result + `encode_script_exit/4` emit a `done` reply carrying a dedicated **`exit_code`** field (`value: null`); the Rust `ReplResponse` gains `exit_code: Option<u8>`.
- Range/type validation (`Program exit: 999` → `#invalid_argument`, `Program exit: "x"` → `#type_error`) and `System halt:` are unchanged.

## Testing

- **EUnit:** `beamtalk_program` (signal raised in connected mode + validation), `beamtalk_repl_shell` (reply + session termination, node stays up), `beamtalk_repl_protocol` (`encode_script_exit` new/legacy), `beamtalk_repl_eval` (`inject_output`).
- **Rust:** `ReplResponse` deserializes `exit_code`; absent on ordinary replies.
- `program_test.bt`'s old `#unsupported` expectation removed — the connected-exit behaviour now needs a live session shell, so it is covered in EUnit (a BUnit block has no session evaluator to catch the signal).
- Local: full `test-runtime` (5133 + 1541), BUnit (2608), Rust protocol tests, `clippy`, `dialyzer` — all green.

## Known limitation (documented in `beamtalk_program`)

A connected `Program exit:` wrapped in a *matching* `on:do:` (`on: Error do:` / `on: Exception do:` / catch-all) is intercepted as an `erlang_throw`. `ensure:` is unaffected (re-raises after cleanup), as are the common top-level / REPL paths. The robust fix is adding this signal to the `{'$bt_nlr', _}` non-local-return passthrough the `on:do:` codegen already emits — tracked as a follow-up.

## Follow-ups
- **BT-2690** — UAT test in `beamtalk-uat`.
- **BT-2691** — connected-mode `beamtalk run` script dispatch (the CLI consumer that turns `exit_code` into a process exit; `needs-spec`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFJR7WPxr75jwuT5vjyW5c)_