### PR TITLE
docs(contributing): clarify where SSH-signing steps run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,25 +87,32 @@ authenticates via OAuth — no API token required.
 
 ### Commit Signing (SSH)
 
-For verified commits, configure SSH signing:
+For verified commits, configure SSH signing. Steps 1–2 set up the key on the
+host; steps 3–4 run **wherever you actually commit** — see the note below if
+that's inside the devcontainer.
 
 ```bash
 # 1. Generate a signing key (on the host)
 ssh-keygen -t ed25519 -C "you@example.com" -f ~/.ssh/id_ed25519_signing
 
-# 2. Add the public key to GitHub as a *Signing Key*
+# 2. Add the public key to GitHub as a *Signing Key* (on the host)
 #    (Settings → SSH and GPG keys → New SSH key → key type: Signing Key)
 cat ~/.ssh/id_ed25519_signing.pub
 
-# 3. Configure git (inside the container)
+# 3. Configure git in the environment you commit from (host or container)
 git config --global gpg.format ssh
 git config --global user.signingkey ~/.ssh/id_ed25519_signing
 git config --global commit.gpgsign true
 
-# 4. Add the private key to the SSH agent
+# 4. Load the key into the SSH agent in that same environment
 eval "$(ssh-agent -s)"
 ssh-add ~/.ssh/id_ed25519_signing
 ```
+
+> **Committing from inside the devcontainer?** The key generated in step 1 lives
+> on the host, so the container can't see `~/.ssh/id_ed25519_signing` by default.
+> Enable [SSH agent forwarding](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials)
+> into the container (or mount/copy the key in) before running steps 3–4 there.
 
 ## Building & Testing
 


### PR DESCRIPTION
## Summary

Follow-up to the review nit on #2770. The SSH commit-signing steps in `CONTRIBUTING.md` were ambiguous about *where* each step runs:

- Steps 1–2 said "on the host", step 3 said "inside the container", but **step 4** (`ssh-agent` / `ssh-add`) carried no label.
- Since the signing key is generated on the host in step 1, a contributor running step 4 inside the devcontainer would find the key file absent.

This change:
- Labels each step's environment (steps 3–4 now read "wherever you actually commit (host or container)").
- Adds a note that committing from inside the devcontainer requires SSH agent forwarding (or mounting/copying the key in), since the host-generated key isn't visible to the container by default.

## Test plan
- Docs-only change; no code paths affected.
- Renders cleanly; the new link points to VS Code's documented agent-forwarding guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSXCtyTYCJPiQaBSHvq78J)_