### PR TITLE
refactor(cli): extract spawn_build_worker_node to deduplicate erl startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ What's in the cockpit:
 
 - **System Browser** — a four-pane Smalltalk navigator (classes → protocols →
   methods → source) over the live image, including stdlib and runtime classes.
-- **Method editor** — open any method as an editable tab with CodeMirror syntax
+- **Method editor** — open any method as an editable tab with `CodeMirror` syntax
   highlighting; *Compile* redefines it on the running system (live code reload),
   with *Senders* / *Implementors* navigation and *Save All to Disk*.
 - **Workspace** — a *Do it / Print it / Inspect it* eval pane returning live

--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -283,29 +283,7 @@ impl BeamCompiler {
         // -mode minimal: only loads kernel+stdlib, skips scanning other -pa dirs at boot
         // -boot no_dot_erlang: skips .erlang config file
         debug!("Spawning BEAM node with beamtalk_build_worker");
-        let temp_dir = std::env::temp_dir();
-        let mut child = Command::new("erl")
-            .arg("-noshell")
-            .arg("-mode")
-            .arg("minimal")
-            .arg("-boot")
-            .arg("no_dot_erlang")
-            // Redirect OTP default logger to stderr (BT-1431). Without this,
-            // logger output goes to stdout and mixes into the compilation
-            // protocol, causing parse failures or ugly error messages.
-            .arg("-kernel")
-            .arg("logger")
-            .arg(beamtalk_cli::repl_startup::KERNEL_LOGGER_STDERR)
-            .args(&pa_args)
-            .arg("-s")
-            .arg("beamtalk_build_worker")
-            .arg("main")
-            .current_dir(&temp_dir)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .into_diagnostic()
+        let mut child = spawn_build_worker_node(&pa_args)
             .wrap_err("Failed to start BEAM node for compilation.\nIs Erlang/OTP installed?")?;
 
         // From here, the protocol is identical to the escript backend
@@ -1646,6 +1624,36 @@ fn extract_specs_from_child(
     read_specs_protocol(stdout, stderr)
 }
 
+/// Spawns a `beamtalk_build_worker` BEAM node with the given `-pa` path arguments.
+///
+/// Applies the standard boot flags (`-noshell -mode minimal -boot no_dot_erlang`) and
+/// the kernel logger redirect (BT-1431).  Callers supply the variable `-pa` paths and
+/// add a context-specific `wrap_err` message on the returned `Result`.
+fn spawn_build_worker_node(pa_args: &[String]) -> Result<std::process::Child> {
+    use beamtalk_cli::repl_startup;
+    Command::new("erl")
+        .arg("-noshell")
+        .arg("-mode")
+        .arg("minimal")
+        .arg("-boot")
+        .arg("no_dot_erlang")
+        // Redirect OTP default logger to stderr (BT-1431). Without this, logger
+        // output goes to stdout and mixes into the compilation protocol.
+        .arg("-kernel")
+        .arg("logger")
+        .arg(repl_startup::KERNEL_LOGGER_STDERR)
+        .args(pa_args)
+        .arg("-s")
+        .arg("beamtalk_build_worker")
+        .arg("main")
+        .current_dir(std::env::temp_dir())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .into_diagnostic()
+}
+
 /// Spawns a `beamtalk_build_worker` BEAM node for spec extraction.
 fn spawn_build_worker_for_specs() -> Result<std::process::Child> {
     use beamtalk_cli::repl_startup;
@@ -1694,28 +1702,7 @@ fn spawn_build_worker_for_specs() -> Result<std::process::Child> {
             pa_args.push(ebin.display().to_string());
         }
     }
-    let temp_dir = std::env::temp_dir();
-
-    Command::new("erl")
-        .arg("-noshell")
-        .arg("-mode")
-        .arg("minimal")
-        .arg("-boot")
-        .arg("no_dot_erlang")
-        .arg("-kernel")
-        .arg("logger")
-        .arg(repl_startup::KERNEL_LOGGER_STDERR)
-        .args(&pa_args)
-        .arg("-s")
-        .arg("beamtalk_build_worker")
-        .arg("main")
-        .current_dir(&temp_dir)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .into_diagnostic()
-        .wrap_err("Failed to start BEAM node for spec extraction")
+    spawn_build_worker_node(&pa_args).wrap_err("Failed to start BEAM node for spec extraction")
 }
 
 /// Reads the `beamtalk-specs-module:` protocol lines from the build worker's stdout.


### PR DESCRIPTION
## Summary

`beam_compiler.rs` contained two near-identical `Command::new("erl")` blocks — one in `compile_batch_port` and one in `spawn_build_worker_for_specs` — that both launched a `beamtalk_build_worker` BEAM node with the same 7-argument flag sequence:

```
-noshell -mode minimal -boot no_dot_erlang -kernel logger <STDERR> <pa_args> -s beamtalk_build_worker main
```

This PR extracts a shared private helper `spawn_build_worker_node(pa_args: &[String])` that owns the common flags and the BT-1431 logger redirect. Each call site now supplies only its variable `-pa` paths and its own `wrap_err` context message.

Also fixes a pre-existing `clippy::doc_markdown` lint in `README.md` (missing backticks around `CodeMirror`) that the pre-push hook caught.

## Changes

- `crates/beamtalk-cli/src/beam_compiler.rs`: extract `spawn_build_worker_node`, replace both call sites (−45 lines, +32 lines net)
- `README.md`: add backticks around `CodeMirror` to satisfy `clippy::doc_markdown`

## Test plan

- [x] `cargo build -p beamtalk-cli` — clean build
- [x] Pre-push hook: clippy ✅, fmt ✅, dialyzer ✅, stdlib build ✅, Erlang fmt ✅
- [ ] CI green on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyUas2unXr3BZmvzTE5GRQ)_