### PR TITLE
refactor(test): use assert:/deny: idioms in printable_protocol_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ What's in the cockpit:
 
 - **System Browser** — a four-pane Smalltalk navigator (classes → protocols →
   methods → source) over the live image, including stdlib and runtime classes.
-- **Method editor** — open any method as an editable tab with CodeMirror syntax
+- **Method editor** — open any method as an editable tab with `CodeMirror` syntax
   highlighting; *Compile* redefines it on the running system (live code reload),
   with *Senders* / *Implementors* navigation and *Save All to Disk*.
 - **Workspace** — a *Do it / Print it / Inspect it* eval pane returning live

--- a/stdlib/test/printable_protocol_test.bt
+++ b/stdlib/test/printable_protocol_test.bt
@@ -9,80 +9,80 @@ TestCase subclass: PrintableProtocolTest
 
   // --- Protocol registration ---
   testPrintableIsRegistered =>
-    self assert: (Protocol isProtocol: #Printable) equals: true
+    self assert: (Protocol isProtocol: #Printable)
 
   testRequiredMethods =>
     methods := Protocol requiredMethods: #Printable
     self assert: methods size equals: 2
-    self assert: (methods includes: #asString) equals: true
-    self assert: (methods includes: #printString) equals: true
+    self assert: (methods includes: #asString)
+    self assert: (methods includes: #printString)
 
   testAllProtocolsIncludesPrintable =>
-    self assert: (Protocol allProtocols includes: #Printable) equals: true
+    self assert: (Protocol allProtocols includes: #Printable)
 
   // --- Conforming classes (have both asString and printString) ---
   testIntegerConforms =>
-    self assert: (Integer conformsTo: #Printable) equals: true
+    self assert: (Integer conformsTo: #Printable)
 
-  testFloatConforms => self assert: (Float conformsTo: #Printable) equals: true
+  testFloatConforms => self assert: (Float conformsTo: #Printable)
 
   testStringConforms =>
-    self assert: (String conformsTo: #Printable) equals: true
+    self assert: (String conformsTo: #Printable)
 
   testCharacterConforms =>
-    self assert: (Character conformsTo: #Printable) equals: true
+    self assert: (Character conformsTo: #Printable)
 
   testSymbolConforms =>
-    self assert: (Symbol conformsTo: #Printable) equals: true
+    self assert: (Symbol conformsTo: #Printable)
 
   testDateTimeConforms =>
-    self assert: (DateTime conformsTo: #Printable) equals: true
+    self assert: (DateTime conformsTo: #Printable)
 
-  testListConforms => self assert: (List conformsTo: #Printable) equals: true
+  testListConforms => self assert: (List conformsTo: #Printable)
 
-  testArrayConforms => self assert: (Array conformsTo: #Printable) equals: true
+  testArrayConforms => self assert: (Array conformsTo: #Printable)
 
   testDictionaryConforms =>
-    self assert: (Dictionary conformsTo: #Printable) equals: true
+    self assert: (Dictionary conformsTo: #Printable)
 
-  testSetConforms => self assert: (Set conformsTo: #Printable) equals: true
+  testSetConforms => self assert: (Set conformsTo: #Printable)
 
-  testBagConforms => self assert: (Bag conformsTo: #Printable) equals: true
+  testBagConforms => self assert: (Bag conformsTo: #Printable)
 
-  testTupleConforms => self assert: (Tuple conformsTo: #Printable) equals: true
+  testTupleConforms => self assert: (Tuple conformsTo: #Printable)
 
   testBinaryConforms =>
-    self assert: (Binary conformsTo: #Printable) equals: true
+    self assert: (Binary conformsTo: #Printable)
 
-  testPidConforms => self assert: (Pid conformsTo: #Printable) equals: true
+  testPidConforms => self assert: (Pid conformsTo: #Printable)
 
-  testPortConforms => self assert: (Port conformsTo: #Printable) equals: true
+  testPortConforms => self assert: (Port conformsTo: #Printable)
 
   testReferenceConforms =>
-    self assert: (Reference conformsTo: #Printable) equals: true
+    self assert: (Reference conformsTo: #Printable)
 
   testCompiledMethodConforms =>
-    self assert: (CompiledMethod conformsTo: #Printable) equals: true
+    self assert: (CompiledMethod conformsTo: #Printable)
 
   testCollectionConforms =>
-    self assert: (Collection conformsTo: #Printable) equals: true
+    self assert: (Collection conformsTo: #Printable)
 
   // --- Conformance via protocols method ---
   testIntegerProtocolsIncludesPrintable =>
-    self assert: (Integer protocols includes: #Printable) equals: true
+    self assert: (Integer protocols includes: #Printable)
 
   testStringProtocolsIncludesPrintable =>
-    self assert: (String protocols includes: #Printable) equals: true
+    self assert: (String protocols includes: #Printable)
 
   // --- Classes with auto-generated asString (codegen-synthesized) ---
-  testTrueConforms => self assert: (True conformsTo: #Printable) equals: true
+  testTrueConforms => self assert: (True conformsTo: #Printable)
 
-  testFalseConforms => self assert: (False conformsTo: #Printable) equals: true
+  testFalseConforms => self assert: (False conformsTo: #Printable)
 
   testUndefinedObjectConforms =>
-    self assert: (UndefinedObject conformsTo: #Printable) equals: true
+    self assert: (UndefinedObject conformsTo: #Printable)
 
   // --- Non-conforming class (no asString in hierarchy) ---
   testBooleanDoesNotConform =>
     // Boolean has printString (from Object) but no asString
-    self assert: (Boolean conformsTo: #Printable) equals: false
+    self deny: (Boolean conformsTo: #Printable)

--- a/stdlib/test/printable_protocol_test.bt
+++ b/stdlib/test/printable_protocol_test.bt
@@ -8,8 +8,7 @@
 TestCase subclass: PrintableProtocolTest
 
   // --- Protocol registration ---
-  testPrintableIsRegistered =>
-    self assert: (Protocol isProtocol: #Printable)
+  testPrintableIsRegistered => self assert: (Protocol isProtocol: #Printable)
 
   testRequiredMethods =>
     methods := Protocol requiredMethods: #Printable
@@ -21,29 +20,23 @@ TestCase subclass: PrintableProtocolTest
     self assert: (Protocol allProtocols includes: #Printable)
 
   // --- Conforming classes (have both asString and printString) ---
-  testIntegerConforms =>
-    self assert: (Integer conformsTo: #Printable)
+  testIntegerConforms => self assert: (Integer conformsTo: #Printable)
 
   testFloatConforms => self assert: (Float conformsTo: #Printable)
 
-  testStringConforms =>
-    self assert: (String conformsTo: #Printable)
+  testStringConforms => self assert: (String conformsTo: #Printable)
 
-  testCharacterConforms =>
-    self assert: (Character conformsTo: #Printable)
+  testCharacterConforms => self assert: (Character conformsTo: #Printable)
 
-  testSymbolConforms =>
-    self assert: (Symbol conformsTo: #Printable)
+  testSymbolConforms => self assert: (Symbol conformsTo: #Printable)
 
-  testDateTimeConforms =>
-    self assert: (DateTime conformsTo: #Printable)
+  testDateTimeConforms => self assert: (DateTime conformsTo: #Printable)
 
   testListConforms => self assert: (List conformsTo: #Printable)
 
   testArrayConforms => self assert: (Array conformsTo: #Printable)
 
-  testDictionaryConforms =>
-    self assert: (Dictionary conformsTo: #Printable)
+  testDictionaryConforms => self assert: (Dictionary conformsTo: #Printable)
 
   testSetConforms => self assert: (Set conformsTo: #Printable)
 
@@ -51,21 +44,18 @@ TestCase subclass: PrintableProtocolTest
 
   testTupleConforms => self assert: (Tuple conformsTo: #Printable)
 
-  testBinaryConforms =>
-    self assert: (Binary conformsTo: #Printable)
+  testBinaryConforms => self assert: (Binary conformsTo: #Printable)
 
   testPidConforms => self assert: (Pid conformsTo: #Printable)
 
   testPortConforms => self assert: (Port conformsTo: #Printable)
 
-  testReferenceConforms =>
-    self assert: (Reference conformsTo: #Printable)
+  testReferenceConforms => self assert: (Reference conformsTo: #Printable)
 
   testCompiledMethodConforms =>
     self assert: (CompiledMethod conformsTo: #Printable)
 
-  testCollectionConforms =>
-    self assert: (Collection conformsTo: #Printable)
+  testCollectionConforms => self assert: (Collection conformsTo: #Printable)
 
   // --- Conformance via protocols method ---
   testIntegerProtocolsIncludesPrintable =>


### PR DESCRIPTION
## Summary

- Replace 27 verbose `assert: X equals: true` calls with `assert: X` throughout `stdlib/test/printable_protocol_test.bt`
- Replace the one `assert: X equals: false` call with `deny: X`
- Apply bt-fmt inline style (single-expression methods on one line)
- Fix pre-existing clippy `doc_markdown` lint in README.md (`CodeMirror` → `` `CodeMirror` ``)

No semantic change — the assertions express the same conditions using the idiomatic BUnit forms documented in `docs/development/testing-strategy.md`.

Closes #2775

## Test plan

- [x] `just test-bunit` — 2614 tests, 0 failures
- [x] Pre-push hook: clippy, fmt-check, dialyzer, Beamtalk fmt-check all green

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVbTMocmrgP4d65G9m1oz6)_