### PR TITLE
codegen: thread actor state through eachWithIndex: / do:separatedBy: (BT-2703)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/enumeration_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/enumeration_ops.rs
@@ -1,0 +1,289 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! BT-2703: Actor state threading for `eachWithIndex:` and `do:separatedBy:`.
+//!
+//! **DDD Context:** Compilation — Code Generation
+//!
+//! Unlike the foldl list-ops in the sibling modules, these two enumeration
+//! selectors are *self-hosted* in `Collection.bt` on top of `inject:into:`. A
+//! plain dispatch to those methods cannot thread an actor's `State` back out of the
+//! block, so a mutating block silently lost its writes — and, once the selectors
+//! were classified as state-threading, the block was emitted as a stateful
+//! `{Value, State}`-tuple fun whose arity no longer matched the un-threaded
+//! `Collection.bt` method, crashing with `badarity`.
+//!
+//! Rather than re-derive the full `lists:foldl` threading machinery for two more
+//! selectors (and, for `do:separatedBy:`, a *second* block), we desugar each call
+//! — whenever a block actually needs mutation threading — into the equivalent
+//! `inject:into:` fold and reuse its codegen. The desugar fires in *every* context
+//! so the stateful block is always consumed by the fold (never dispatched at the
+//! wrong arity). `inject:into:` already threads field/local mutations (including
+//! those nested in the separator's conditional) and seeds the index / "first
+//! element" accumulator without needing a statement before the loop:
+//!
+//! ```text
+//! coll eachWithIndex: [:x :i | BODY]
+//!   ⇒  coll inject: 1 into: [:i :x | BODY. i + 1]
+//!
+//! coll do: [:x | BODY] separatedBy: [SEP]
+//!   ⇒  coll inject: true into: [:first :x | first ifFalse: [SEP]. BODY. false]
+//! ```
+//!
+//! Making the index / "first" accumulator a genuine block *parameter* (rather than a
+//! synthetic local) means it correctly shadows any outer local of the same name. A
+//! single synthetic `inject:into:` send keeps this to one annotated message send, so
+//! the result composes with the enclosing method-body threading without the
+//! double-parenthesised Core Erlang a nested `[ … ] value` would produce. In an actor
+//! method we additionally re-project the fold's `{Acc, NewState}` tuple to
+//! `{'nil', NewState}` so the selectors honour their `-> Nil` contract while keeping
+//! the threaded `State` (see [`CoreErlangGenerator::finalize_enumeration_fold`]).
+//!
+//! Non-mutating calls return `None` here and fall through to the ordinary dispatch
+//! to the `Collection.bt` method, preserving existing behaviour.
+
+use super::super::super::document::{Document, leaf};
+use super::super::super::{CodeGenContext, CoreErlangGenerator, Result, block_analysis};
+use crate::ast::{
+    Block, BlockParameter, Expression, ExpressionStatement, Identifier, KeywordPart, Literal,
+    MessageSelector,
+};
+use crate::docvec;
+use crate::source_analysis::Span;
+
+// ── Synthetic AST builders ──────────────────────────────────────────────────
+// These construct the desugared `inject:into:` tree. Spans are inherited from the
+// originating block so diagnostics point back at user source.
+
+fn ident(name: &str, span: Span) -> Expression {
+    Expression::Identifier(Identifier::new(name, span))
+}
+
+fn int_lit(n: i64, span: Span) -> Expression {
+    Expression::Literal(Literal::Integer(n), span)
+}
+
+fn binary(receiver: Expression, op: &str, arg: Expression, span: Span) -> Expression {
+    Expression::MessageSend {
+        receiver: Box::new(receiver),
+        selector: MessageSelector::Binary(op.into()),
+        arguments: vec![arg],
+        is_cast: false,
+        span,
+    }
+}
+
+fn if_false(receiver: Expression, false_block: Expression, span: Span) -> Expression {
+    Expression::MessageSend {
+        receiver: Box::new(receiver),
+        selector: MessageSelector::Keyword(vec![KeywordPart::new("ifFalse:", span)]),
+        arguments: vec![false_block],
+        is_cast: false,
+        span,
+    }
+}
+
+/// Builds `receiver inject: <initial> into: <inject_block>`.
+fn inject_into(
+    receiver: Expression,
+    initial: Expression,
+    inject_block: Expression,
+    span: Span,
+) -> Expression {
+    Expression::MessageSend {
+        receiver: Box::new(receiver),
+        selector: MessageSelector::Keyword(vec![
+            KeywordPart::new("inject:", span),
+            KeywordPart::new("into:", span),
+        ]),
+        arguments: vec![initial, inject_block],
+        is_cast: false,
+        span,
+    }
+}
+
+fn block_expr(params: &[&str], body: Vec<Expression>, span: Span) -> Expression {
+    Expression::Block(Block::new(
+        params
+            .iter()
+            .map(|p| BlockParameter::new(*p, span))
+            .collect(),
+        body.into_iter().map(ExpressionStatement::bare).collect(),
+        span,
+    ))
+}
+
+/// Clones a block's statements as bare expressions for inlining into the
+/// synthetic `inject:into:` body (comment attachments are irrelevant to codegen).
+fn inlined_body(body: &[ExpressionStatement]) -> Vec<Expression> {
+    body.iter().map(|s| s.expression.clone()).collect()
+}
+
+impl CoreErlangGenerator {
+    /// Returns `true` if `block` mutates field/local state in a way that requires
+    /// threading (and so cannot be served by a plain dispatch to the `Collection.bt`
+    /// method). Mirrors the per-block analysis in `control_flow_has_mutations`.
+    fn enumeration_block_needs_threading(&self, block: &Block) -> bool {
+        let analysis = block_analysis::analyze_block(block);
+        self.needs_mutation_threading(&analysis)
+            || self.body_has_list_op_cross_scope_mutations(block)
+    }
+
+    /// Returns `true` when the desugared fold threads actor `State`: an actor
+    /// (`gen_server`) method body not inside a direct-params counted loop.
+    ///
+    /// The desugar itself fires in *every* context (so the stateful block is consumed
+    /// by the fold and never dispatched as a mismatched-arity fun to the un-threaded
+    /// `Collection.bt` method). But only an actor fold yields the `{Acc, NewState}`
+    /// reply-tuple shape that [`Self::finalize_enumeration_fold`]'s `{'nil', NewState}`
+    /// re-projection and the `get_control_flow_threaded_vars` `__local__` extraction
+    /// rely on. Value types, class methods and the REPL thread captured locals through
+    /// different fold shapes, and a fold nested in a direct-params loop yields an open
+    /// let-chain rather than a tuple, so those keep the plain fold result.
+    pub(in crate::codegen::core_erlang) fn enumeration_threads_actor_state(&self) -> bool {
+        matches!(self.context, CodeGenContext::Actor) && !self.in_direct_params_loop
+    }
+
+    /// Lowers a synthetic `inject:into:` send (already threading state) to the value
+    /// the enumeration methods actually return.
+    ///
+    /// In an actor the fold yields a `{Acc, NewState}` tuple whose element 2 is the
+    /// threaded `State` map, so we bind the *annotated* fold (its parentheses make a
+    /// safe `let`-value) and re-project `{'nil', NewState}` — honouring the methods'
+    /// `-> Nil` contract while keeping the threaded state. The `let`-chain also breaks
+    /// up the parentheses so the enclosing `eachWithIndex:`/`do:separatedBy:`
+    /// annotation does not produce the invalid `( ( … ) )` two-deep parenthesisation
+    /// that `core_parse` rejects.
+    ///
+    /// Elsewhere the fold is emitted as the *un-annotated* message send (the caller's
+    /// own send annotation is then the only one, matching a hand-written
+    /// `inject:into:`), and its accumulator value stands as the result.
+    fn finalize_enumeration_fold(&mut self, inject_send: &Expression) -> Result<Document<'static>> {
+        if self.enumeration_threads_actor_state() {
+            let inject_doc = self.expression_doc(inject_send)?;
+            let tuple_var = self.fresh_temp_var("EnumFold");
+            return Ok(docvec![
+                "let ",
+                leaf::var(tuple_var.clone()),
+                " = ",
+                inject_doc,
+                " in {'nil', call 'erlang':'element'(2, ",
+                leaf::var(tuple_var),
+                ")}",
+            ]);
+        }
+        let Expression::MessageSend {
+            receiver,
+            selector,
+            arguments,
+            ..
+        } = inject_send
+        else {
+            unreachable!(
+                "finalize_enumeration_fold is only called with a synthetic inject:into: send"
+            );
+        };
+        self.generate_message_send(receiver, selector, arguments)
+    }
+
+    /// BT-2703: Desugars `receiver eachWithIndex: [:elem :idx | body]` into a
+    /// threaded `inject:into:` fold when the block mutates state. Returns `None`
+    /// (so the caller dispatches to the `Collection.bt` method as before) for
+    /// non-literal callables, the wrong block arity, or a non-mutating block.
+    pub(in crate::codegen::core_erlang) fn try_generate_each_with_index(
+        &mut self,
+        receiver: &Expression,
+        block_arg: &Expression,
+    ) -> Result<Option<Document<'static>>> {
+        let Expression::Block(user_block) = block_arg else {
+            return Ok(None);
+        };
+        // eachWithIndex: takes a 2-arg block `[:elem :idx | …]`.
+        if user_block.parameters.len() != 2 {
+            return Ok(None);
+        }
+        if !self.enumeration_block_needs_threading(user_block) {
+            return Ok(None);
+        }
+
+        let span = user_block.span;
+        let elem_name = user_block.parameters[0].name.to_string();
+        let idx_name = user_block.parameters[1].name.to_string();
+        // Degenerate `[:x :x | …]` — leave it to the normal path's diagnostics.
+        if elem_name == idx_name {
+            return Ok(None);
+        }
+
+        // The 1-based index *is* the fold accumulator (seeded to 1), so the user's
+        // index parameter becomes the inject block's accumulator parameter — a genuine
+        // block parameter that correctly shadows any outer local of the same name,
+        // rather than a synthetic local that would clobber it. The body runs with the
+        // current index, then `idx + 1` is the next accumulator.
+        let mut inject_body = inlined_body(&user_block.body);
+        inject_body.push(binary(ident(&idx_name, span), "+", int_lit(1, span), span));
+
+        let inject_send = inject_into(
+            receiver.clone(),
+            int_lit(1, span),
+            block_expr(&[idx_name.as_str(), elem_name.as_str()], inject_body, span),
+            span,
+        );
+        Ok(Some(self.finalize_enumeration_fold(&inject_send)?))
+    }
+
+    /// BT-2703: Desugars `receiver do: [:elem | body] separatedBy: [sep]` into a
+    /// threaded `inject:into:` fold when either block mutates state, threading the
+    /// "between elements" flag through the accumulator. Returns `None` (so the
+    /// caller dispatches to the `Collection.bt` method as before) for non-literal
+    /// callables, the wrong block arities, or two non-mutating blocks.
+    pub(in crate::codegen::core_erlang) fn try_generate_do_separated_by(
+        &mut self,
+        receiver: &Expression,
+        element_arg: &Expression,
+        separator_arg: &Expression,
+    ) -> Result<Option<Document<'static>>> {
+        let (Expression::Block(element_block), Expression::Block(separator_block)) =
+            (element_arg, separator_arg)
+        else {
+            return Ok(None);
+        };
+        // `do:` block is 1-arg `[:elem | …]`, separator is 0-arg `[…]`.
+        if element_block.parameters.len() != 1 || !separator_block.parameters.is_empty() {
+            return Ok(None);
+        }
+        if !self.enumeration_block_needs_threading(element_block)
+            && !self.enumeration_block_needs_threading(separator_block)
+        {
+            return Ok(None);
+        }
+
+        let span = element_block.span;
+        let elem_name = element_block.parameters[0].name.to_string();
+        // The accumulator is the "is this the first element?" flag (`true` initially,
+        // `false` thereafter). A fresh name keeps it clear of user identifiers.
+        let first_name = self.fresh_temp_var("BtSepFirst");
+
+        // inject:into: body: `first ifFalse: [sep]` (separator runs *between* elements,
+        // so it is skipped on the first), the user body, then `false` as the new acc.
+        let separator = block_expr(
+            &[],
+            inlined_body(&separator_block.body),
+            separator_block.span,
+        );
+        let mut inject_body = vec![if_false(ident(&first_name, span), separator, span)];
+        inject_body.extend(inlined_body(&element_block.body));
+        inject_body.push(ident("false", span));
+
+        let inject_send = inject_into(
+            receiver.clone(),
+            ident("true", span),
+            block_expr(
+                &[first_name.as_str(), elem_name.as_str()],
+                inject_body,
+                span,
+            ),
+            span,
+        );
+        Ok(Some(self.finalize_enumeration_fold(&inject_send)?))
+    }
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/mod.rs
@@ -19,6 +19,7 @@
 //!   `dropWhile:`, `partition:`, `groupBy:`, `sort:` codegen
 
 mod basic_ops;
+mod enumeration_ops;
 mod filter_ops;
 mod search_ops;
 mod transform_ops;

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -2994,6 +2994,12 @@ impl CoreErlangGenerator {
                         format!("State{}", self.state_version())
                     };
 
+                    // BT-2703: Rebind the local to the freshly-written value so a later
+                    // read *within the same iteration* (`idx := idx + 1` … `x * idx`) sees
+                    // the new value instead of the stale iteration-start `maps:get` binding.
+                    // Mirrors the tuple-acc path (`generate_direct_var_update_in_loop`).
+                    self.bind_var(&id.name, &val_var);
+
                     // BT-1053: Return val_var so callers (e.g. generate_conditional_branch_inline)
                     // can use it as the branch result.
                     return Ok((
@@ -3040,6 +3046,9 @@ impl CoreErlangGenerator {
                 // BT-1397: If the RHS produced an open scope (class method self-send),
                 // emit the open scope first, then bind the variable to the result.
                 if let Some(open_scope_result) = open_scope {
+                    // BT-2703: see note below — rebind so later same-iteration reads
+                    // observe the freshly-written value.
+                    self.bind_var(&id.name, &val_var);
                     return Ok((
                         docvec![
                             value_code,
@@ -3060,6 +3069,12 @@ impl CoreErlangGenerator {
                         val_var,
                     ));
                 }
+
+                // BT-2703: Rebind the local to the freshly-written value so a later read
+                // *within the same iteration* sees the new value rather than the stale
+                // iteration-start `maps:get` binding (the map-acc analogue of the
+                // tuple-acc rebind in `generate_direct_var_update_in_loop`).
+                self.bind_var(&id.name, &val_var);
 
                 // BT-1053: Return val_var so callers (e.g. generate_conditional_branch_inline)
                 // can use it as the branch result.

--- a/crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs
@@ -597,6 +597,17 @@ impl CoreErlangGenerator {
                         let doc = self.generate_list_sort(receiver, &arguments[0])?;
                         Ok(Some(doc))
                     }
+                    // BT-2703: `eachWithIndex:`/`do:separatedBy:` are self-hosted in
+                    // Collection.bt. In an actor method that mutates state, desugar to a
+                    // stateful `inject:into:` fold so the mutation threads; otherwise
+                    // return `None` and let the ordinary dispatch reach the Collection.bt
+                    // method.
+                    "eachWithIndex:" if arguments.len() == 1 => {
+                        self.try_generate_each_with_index(receiver, &arguments[0])
+                    }
+                    "do:separatedBy:" if arguments.len() == 2 => {
+                        self.try_generate_do_separated_by(receiver, &arguments[0], &arguments[1])
+                    }
                     _ => Ok(None),
                 }
             }

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -2887,6 +2887,20 @@ impl CoreErlangGenerator {
             "inject:into:" if arguments.len() == 2 => {
                 self.threaded_locals_of_loop_body(arguments.get(1))
             }
+            // BT-2703: `eachWithIndex:`/`do:separatedBy:` desugar to an `inject:into:`
+            // fold (see `enumeration_ops`), packing the block's outer-local mutations
+            // into the same `__local__` StateAcc keys. The element block is the first
+            // argument; `do:separatedBy:`'s separator (the second block) runs in the
+            // fold too, so its outer-local writes are unioned in as well. Gated on
+            // `enumeration_threads_actor_state`: only the actor fold packs those keys
+            // into a `{Acc, State}` reply tuple, so outside it (value types, REPL, a
+            // direct-params loop) there is no `__local__` StateAcc to extract from.
+            "eachWithIndex:" if arguments.len() == 1 && self.enumeration_threads_actor_state() => {
+                self.threaded_locals_of_loop_body(arguments.first())
+            }
+            "do:separatedBy:" if arguments.len() == 2 && self.enumeration_threads_actor_state() => {
+                Self::non_empty(self.conditional_threaded_locals(&Self::block_args(arguments)))
+            }
             // BT-2355: conditionals thread outer-local mutations through the StateAcc
             // map under `__local__` keys (see generate_*_with_mutations, which also seed
             // those keys so extraction is safe even when the taken branch did not write

--- a/crates/beamtalk-core/src/state_threading_selectors.rs
+++ b/crates/beamtalk-core/src/state_threading_selectors.rs
@@ -59,6 +59,8 @@ pub(crate) fn is_state_threading_keyword_selector(sel: &str) -> bool {
             | "partition:"
             | "sort:"
             | "inject:into:"
+            | "eachWithIndex:"
+            | "do:separatedBy:"
             | "doWithKey:"
             | "keysAndValuesDo:"
             | "ensure:"
@@ -125,6 +127,9 @@ mod tests {
         assert!(is_state_threading_keyword_selector("groupBy:"));
         assert!(is_state_threading_keyword_selector("partition:"));
         assert!(is_state_threading_keyword_selector("sort:"));
+        // BT-2703: enumeration helpers self-hosted on inject:into:
+        assert!(is_state_threading_keyword_selector("eachWithIndex:"));
+        assert!(is_state_threading_keyword_selector("do:separatedBy:"));
         assert!(!is_state_threading_keyword_selector("perform:"));
     }
 

--- a/stdlib/test/collection_mutations_test.bt
+++ b/stdlib/test/collection_mutations_test.bt
@@ -22,3 +22,45 @@ TestCase subclass: CollectionMutationsTest
       #c => 30
     })) equals: 60
     self assert: counter3 getTotal equals: 60
+
+  // BT-2703: eachWithIndex: threads actor state through the block.
+  testActorEachWithIndexMutation =>
+    counter := CollectionMutationCounter spawn
+    // 10*1 + 20*2 + 30*3 = 10 + 40 + 90 = 140
+    self assert: (counter sumWithIndex: #(10, 20, 30)) equals: 140
+    self assert: counter getTotal equals: 140
+
+  // BT-2703: do:separatedBy: threads actor state through both blocks.
+  testActorDoSeparatedByMutation =>
+    counter := CollectionMutationCounter spawn
+    // elements 1+2+3 = 6; two separators between them = 200; total = 206
+    self assert: (counter joinSum: #(1, 2, 3)) equals: 206
+    self assert: counter getTotal equals: 206
+
+  // BT-2703: do:separatedBy: with a single element runs no separator.
+  testActorDoSeparatedBySingleElement =>
+    counter := CollectionMutationCounter spawn
+    self assert: (counter joinSum: #(5)) equals: 5
+    self assert: counter getTotal equals: 5
+
+  // BT-2703: eachWithIndex: threading an outer local alongside a field write.
+  testActorEachWithIndexLocalAndField =>
+    counter := CollectionMutationCounter spawn
+    // returns the outer local `seen` (one per element); field gets 10*1+20*2+30*3
+    self assert: (counter countWithIndex: #(10, 20, 30)) equals: 3
+    self assert: counter getTotal equals: 140
+
+  // BT-2703: do:separatedBy: threading an outer local mutated only in the separator.
+  testActorDoSeparatedByLocalSeparator =>
+    counter := CollectionMutationCounter spawn
+    // 3 elements -> 2 gaps; field accumulates 1+2+3 = 6
+    self assert: (counter gapCount: #(1, 2, 3)) equals: 2
+    self assert: counter getTotal equals: 6
+
+  // BT-2703: regression guard — in a value type these selectors with a mutating
+  // block must not crash with `badarity`. The captured-local write is lost here
+  // (pre-existing, out-of-scope value-type behaviour), so the result is the initial 0.
+  testValueTypeEnumerationDoesNotCrash =>
+    vt := EnumerationValueType new
+    self assert: (vt eachWithIndexSum: #(10, 20, 30)) equals: 0
+    self assert: (vt doSeparatedBySum: #(1, 2, 3)) equals: 0

--- a/stdlib/test/fixtures/collection_mutation_counter.bt
+++ b/stdlib/test/fixtures/collection_mutation_counter.bt
@@ -26,3 +26,38 @@ Actor subclass: CollectionMutationCounter
         acc + val
       ]
     self.total
+
+  // BT-2703: eachWithIndex: with field mutation. The 1-based index threads
+  // through the block while self.total is mutated as a side effect.
+  sumWithIndex: aColl =>
+    aColl eachWithIndex: [:item :i | self.total := self.total + (item * i)]
+    self.total
+
+  // BT-2703: do:separatedBy: with field mutation in BOTH blocks. The element
+  // block and the separator block each mutate self.total; the separator runs
+  // between consecutive elements only.
+  joinSum: aColl =>
+    aColl do: [:item |
+      self.total := self.total + item
+    ] separatedBy: [self.total := self.total + 100]
+    self.total
+
+  // BT-2703: eachWithIndex: mixing an outer local (`seen`) with a field write.
+  // Returns the outer local, which must be threaded back out of the loop.
+  countWithIndex: aColl =>
+    seen := 0
+    aColl
+      eachWithIndex: [:item :i |
+        seen := seen + 1
+        self.total := self.total + (item * i)
+      ]
+    seen
+
+  // BT-2703: do:separatedBy: where the separator mutates an outer local (counts
+  // the gaps between elements) while the element block mutates the field.
+  gapCount: aColl =>
+    gaps := 0
+    aColl do: [:item |
+      self.total := self.total + item
+    ] separatedBy: [gaps := gaps + 1]
+    gaps

--- a/stdlib/test/fixtures/enumeration_value_type.bt
+++ b/stdlib/test/fixtures/enumeration_value_type.bt
@@ -1,0 +1,23 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2703: regression guard for the non-actor path of eachWithIndex:/do:separatedBy:.
+// In a value type the desugar still fires (so the mutating block is consumed by the
+// fold rather than dispatched at the wrong arity to the Collection.bt method). The
+// captured-local mutation does not escape the fold here — that is pre-existing,
+// out-of-scope value-type behaviour — but it must compile and run without the
+// `badarity` crash that the state-threading classification would otherwise cause.
+
+Value subclass: EnumerationValueType
+
+  eachWithIndexSum: aColl =>
+    sum := 0
+    aColl eachWithIndex: [:item :i | sum := sum + (item * i)]
+    sum
+
+  doSeparatedBySum: aColl =>
+    total := 0
+    aColl do: [:item |
+      total := total + item
+    ] separatedBy: [total := total + 100]
+    total


### PR DESCRIPTION
## Summary

`eachWithIndex:` and `do:separatedBy:` are self-hosted in `Collection.bt` on top of `inject:into:`. A plain dispatch to those methods can't thread an actor's `State` back out of a mutating block, so they were excluded from the state-threading registry — mutating actor fields inside their blocks failed to compile (`unbound_var` / unsafe-mutation diagnostic).

This adds both selectors to `is_state_threading_keyword_selector` and, whenever a block needs mutation threading, desugars the call to the equivalent `inject:into:` fold — reusing the existing, well-tested inject threading codegen instead of re-deriving foldl machinery for a second, two-block selector:

```
coll eachWithIndex: [:x :i | BODY]
  ⇒  coll inject: 1 into: [:i :x | BODY. i + 1]
coll do: [:x | BODY] separatedBy: [SEP]
  ⇒  coll inject: true into: [:first :x | first ifFalse: [SEP]. BODY. false]
```

## Details

- **Index / "first" accumulator is a real block parameter**, not a synthetic local, so it correctly shadows an outer local of the same name (no clobbering).
- **Actor `-> Nil` contract preserved**: the fold's `{Acc, NewState}` tuple is re-projected to `{'nil', NewState}`, keeping the threaded `State`. A single synthetic `inject:into:` send avoids the double-annotation that would otherwise emit invalid `( ( … ) )` Core Erlang.
- **Outer locals rebound**: `get_control_flow_threaded_vars` learns both selectors so locals mutated alongside fields are extracted after the loop (gated on `enumeration_threads_actor_state`).
- **Desugar fires in every context** (not just actors): classifying the selectors as state-threading makes their block emit as a stateful `{Value, State}`-tuple fun, which would otherwise be dispatched at the wrong arity to the un-threaded `Collection.bt` method and crash with `badarity`. Desugaring everywhere keeps the stateful block inside the fold; the actor-only `{nil, State}` projection and `__local__` extraction stay gated to actor context.
- **Latent threading bug fix** (general, beyond these selectors): a threaded local read *after* being written in the same map-accumulator loop iteration (`idx := idx + 1` … `x * idx`) read the stale iteration-start binding because `generate_local_var_assignment_in_loop` never rebound it — the tuple-acc path already did. Fixed across all three return paths.

## Scope

Actor state threading (the issue's focus) is fully correct. Non-actor contexts (value types, REPL) fall through to the un-threaded `Collection.bt` behaviour for captured-local mutations — pre-existing and out of scope — but now compile and run without crashing.

## Tests

Actor BUnit coverage for field, mixed field+local, and separator-only local mutations through both selectors, plus a value-type regression guard that they compile and run without the `badarity` crash. Registry unit test updated. Full suite green (Rust, stdlib, BUnit `2628` tests, runtime); clippy/dialyzer/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016UaA4TvJrq1pSsKXShFBmo)_