### PR TITLE
test+docs: empty-collection coverage and doc nits for BT-2703 enumeration folds

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/enumeration_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/enumeration_ops.rs
@@ -172,6 +172,9 @@ impl CoreErlangGenerator {
                 ")}",
             ]);
         }
+        // Both callers (`try_generate_each_with_index` / `try_generate_do_separated_by`)
+        // build `inject_send` via `inject_into`, which always returns an
+        // `Expression::MessageSend`, so this destructure cannot fail.
         let Expression::MessageSend {
             receiver,
             selector,

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/mod.rs
@@ -17,6 +17,7 @@
 //! - [`search_ops`] — `detect:`, `anySatisfy:`, `allSatisfy:` codegen
 //! - [`transform_ops`] — `inject:into:`, `flatMap:`, `count:`, `takeWhile:`,
 //!   `dropWhile:`, `partition:`, `groupBy:`, `sort:` codegen
+//! - [`enumeration_ops`] — `eachWithIndex:`, `do:separatedBy:` desugar codegen (BT-2703)
 
 mod basic_ops;
 mod enumeration_ops;

--- a/stdlib/test/collection_mutations_test.bt
+++ b/stdlib/test/collection_mutations_test.bt
@@ -43,6 +43,19 @@ TestCase subclass: CollectionMutationsTest
     self assert: (counter joinSum: #(5)) equals: 5
     self assert: counter getTotal equals: 5
 
+  // BT-2703: empty collection — the fold body never runs, so `finalize_enumeration_fold`'s
+  // `element(2, EnumFold)` only works because the threaded inject seeds `foldl` with a
+  // `{Seed, State}` tuple (returned unchanged for `[]`), not a bare seed.
+  testActorEachWithIndexEmptyCollection =>
+    counter := CollectionMutationCounter spawn
+    self assert: (counter sumWithIndex: #()) equals: 0
+    self assert: counter getTotal equals: 0
+
+  testActorDoSeparatedByEmptyCollection =>
+    counter := CollectionMutationCounter spawn
+    self assert: (counter joinSum: #()) equals: 0
+    self assert: counter getTotal equals: 0
+
   // BT-2703: eachWithIndex: threading an outer local alongside a field write.
   testActorEachWithIndexLocalAndField =>
     counter := CollectionMutationCounter spawn


### PR DESCRIPTION
Follow-up to #2780 addressing the non-blocking review suggestions. **No behaviour change** — tests and docs only.

## Changes

- **Empty-collection regression tests** for the actor path of `eachWithIndex:` and `do:separatedBy:`. That path re-projects the fold via `erlang:element(2, EnumFold)`, which is safe only because the threaded `inject:into:` codegen seeds `lists:foldl` with a `{Seed, State}` tuple (returned unchanged when the list is empty) rather than a bare seed. With an empty collection the fold body never runs, so nothing else exercises this; these tests lock the invariant in so a regression to a bare seed (which would `badarg` on `[]`) is caught.
- **Doc index**: list `enumeration_ops` in the `list_ops` `# Submodule organisation` section.
- **Inline note** on the non-actor `unreachable!()` branch of `finalize_enumeration_fold` explaining why it can't be reached (the send is always built via `inject_into`).

Full BUnit suite green (2639 tests, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016UaA4TvJrq1pSsKXShFBmo)_