### PR TITLE
runtime: classify &amp; wrap raw Erlang runtime errors at the dispatch boundary (BT-2704)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -783,9 +783,13 @@ sync_send_remote(ActorPid, Selector, Args) ->
                             %% BT-1822: safe_dispatch caught an Erlang exception with stacktrace;
                             %% re-raise with full type/stacktrace context.
                             %% Guard prevents false-match on non-stacktrace 3-tuples.
+                            %% BT-2705: attach the active selector/class breadcrumb so a raw
+                            %% error escaping the method is classified *and* located.
                             error(
                                 beamtalk_exception_handler:ensure_wrapped(
-                                    ErlType, ErrorValue, Stacktrace
+                                    ErlType, ErrorValue, Stacktrace, #{
+                                        selector => Selector, class => Class
+                                    }
                                 )
                             );
                         {error, {ErlType, ErrorValue}} ->
@@ -866,9 +870,12 @@ sync_send(ActorPid, Selector, Args, Timeout) when
                                     {Result, Metadata#{outcome => ok}};
                                 {error, {ErlType, ErrorValue, Stacktrace}} ->
                                     %% BT-1822: safe_dispatch with stacktrace
+                                    %% BT-2705: attach selector/class breadcrumb (see sync_send/3).
                                     error(
                                         beamtalk_exception_handler:ensure_wrapped(
-                                            ErlType, ErrorValue, Stacktrace
+                                            ErlType, ErrorValue, Stacktrace, #{
+                                                selector => Selector, class => Class
+                                            }
                                         )
                                     );
                                 {error, {ErlType, ErrorValue}} ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
@@ -402,7 +402,10 @@ invoke_method(MethodOwner, ClassPid, Selector, Args, Self, State, Depth) ->
                                         domain => [beamtalk, runtime]
                                     }),
                                     Wrapped = beamtalk_exception_handler:ensure_wrapped(
-                                        Type, Reason, Stack
+                                        Type,
+                                        Reason,
+                                        Stack,
+                                        dispatch_context(Selector, Self, State, MethodOwner)
                                     ),
                                     #{error := BtError} = Wrapped,
                                     {error, BtError}
@@ -427,7 +430,10 @@ invoke_method(MethodOwner, ClassPid, Selector, Args, Self, State, Depth) ->
                                         domain => [beamtalk, runtime]
                                     }),
                                     Wrapped = beamtalk_exception_handler:ensure_wrapped(
-                                        Type, Reason, Stack
+                                        Type,
+                                        Reason,
+                                        Stack,
+                                        dispatch_context(Selector, Self, State, MethodOwner)
                                     ),
                                     #{error := BtError} = Wrapped,
                                     {error, BtError}
@@ -435,6 +441,14 @@ invoke_method(MethodOwner, ClassPid, Selector, Args, Self, State, Depth) ->
                     end
             end
     end.
+
+%% Build the dispatch breadcrumb (BT-2705) handed to the error-wrap boundary so
+%% raw Erlang errors escaping a compiled method are classified *and* located.
+%% Computed only on the error path; the receiver's actual class is preferred
+%% over the method owner so the breadcrumb names what the user sent to.
+-spec dispatch_context(selector(), bt_self(), state(), class_name()) -> map().
+dispatch_context(Selector, Self, State, MethodOwner) ->
+    #{selector => Selector, class => class_name_from(Self, State, MethodOwner)}.
 
 -doc """
 Continue hierarchy walk to superclass when current class can't dispatch.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_exception_handler.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_exception_handler.erl
@@ -39,9 +39,12 @@ helpers called by that generated code: `wrap/1` and `matches_class/2`.
 
 -export([
     wrap/1,
+    wrap_raw/1,
+    wrap_raw/2,
     ensure_wrapped/1,
     ensure_wrapped/2,
     ensure_wrapped/3,
+    ensure_wrapped/4,
     matches_class/2,
     dispatch/3,
     has_method/1,
@@ -80,6 +83,14 @@ kind_to_class(callback_failed) -> 'RuntimeError';
 kind_to_class(actor_dead) -> 'RuntimeError';
 kind_to_class(future_not_awaited) -> 'RuntimeError';
 kind_to_class(internal_error) -> 'RuntimeError';
+%% BT-2707: classified raw-error kinds (bucket A user-input, bucket C resource/env).
+%% No dedicated stdlib class exists for these yet, so they live under RuntimeError
+%% for catchability (a future KeyError/ResourceError hierarchy can refine this).
+kind_to_class(key_error) -> 'RuntimeError';
+kind_to_class(argument_error) -> 'RuntimeError';
+kind_to_class(resource_error) -> 'RuntimeError';
+kind_to_class(process_not_found) -> 'RuntimeError';
+kind_to_class(timeout_error) -> 'RuntimeError';
 kind_to_class(type_error) -> 'TypeError';
 kind_to_class(instantiation_error) -> 'InstantiationError';
 %% BEAM interop exceptions (ADR 0028 §1, BT-678)
@@ -201,10 +212,37 @@ wrap(Other) ->
     wrap_raw(Other).
 
 -doc """
-Wrap raw Erlang errors into structured beamtalk errors.
-Recognizes common Erlang error patterns and produces better messages.
+Wrap a raw Erlang error into a classified Exception tagged map.
+
+Equivalent to `wrap_raw/2` with no dispatch context. See `wrap_raw/2`.
 """.
-wrap_raw({badarity, {Fun, Args}}) when is_function(Fun), is_list(Args) ->
+-spec wrap_raw(term()) -> map().
+wrap_raw(Reason) ->
+    wrap_raw(Reason, #{}).
+
+-doc """
+Wrap a raw Erlang error into a well-classified `#beamtalk_error{}` (BT-2707).
+
+Raw Erlang errors (`badarith`, `{badkey,K}`, `function_clause`, …) are sorted
+into three buckets that are presented differently (BT-2704):
+
+* **Bucket A — user-input** (`type_error`/`key_error`/`argument_error`):
+  `badarith`, `{badkey,K}`, `{badmap,M}`, `badarg`. Carries selector + value
+  + an actionable hint.
+* **Bucket B — internal bugs** (`internal_error`): `function_clause`,
+  `case_clause`, `badmatch`, `if_clause`. Loud, "please report" — NOT dressed
+  up as a user mistake (mislabeling a bug as a user error misdirects debugging).
+* **Bucket C — resource/env** (`resource_error`/`process_not_found`/
+  `timeout_error`): `system_limit`, `noproc`, `timeout`.
+
+`Context` is the dispatch-layer breadcrumb (BT-2705): a map that may carry
+`selector` and `class` for the active send. It disambiguates the overloaded
+`badarg` and lets bucket-A errors render located messages
+(e.g. `Tuple>>sum: …`). It is consulted only on this (error) path, so it adds
+nothing to successful dispatch.
+""".
+-spec wrap_raw(term(), map()) -> map().
+wrap_raw({badarity, {Fun, Args}}, _Context) when is_function(Fun), is_list(Args) ->
     {arity, Expected} = erlang:fun_info(Fun, arity),
     Actual = length(Args),
     Message = iolist_to_binary(
@@ -215,25 +253,121 @@ wrap_raw({badarity, {Fun, Args}}) when is_function(Fun), is_list(Args) ->
     ),
     Hint =
         <<"Check that your block has the right number of parameters (e.g., [:x | ...] for 1 argument)">>,
+    wrap_classified(arity_mismatch, 'Block', undefined, Message, Hint, #{
+        expected_args => Expected, actual_args => Actual
+    });
+%%% --- Bucket A: user-input errors ----------------------------------------
+wrap_raw(badarith, Context) ->
+    {Sel, Cls} = breadcrumb(Context),
+    Message = located(Sel, Cls, <<"bad arithmetic operation">>),
+    Hint =
+        <<"Arithmetic requires numbers; check for a non-numeric operand or division by zero.">>,
+    wrap_classified(type_error, Cls, Sel, Message, Hint, #{reason => badarith});
+wrap_raw({badkey, Key}, Context) ->
+    {Sel, Cls} = breadcrumb(Context),
+    Core = iolist_to_binary(io_lib:format("key not found: ~tp", [Key])),
+    Message = located(Sel, Cls, Core),
+    Hint = <<"Use 'includesKey:' to test first, or 'at:ifAbsent:' to supply a default.">>,
+    wrap_classified(key_error, Cls, Sel, Message, Hint, #{key => Key});
+wrap_raw({badmap, Value}, Context) ->
+    {Sel, Cls} = breadcrumb(Context),
+    Message = located(Sel, Cls, <<"expected a Dictionary but got a non-map value">>),
+    Hint = <<"This message is only understood by Dictionary values.">>,
+    wrap_classified(type_error, Cls, Sel, Message, Hint, #{value => Value});
+wrap_raw(badarg, Context) ->
+    %% `badarg` is overloaded (user mistake vs internal misuse) and the bare
+    %% error can't tell which. With a dispatch breadcrumb we can locate it as a
+    %% user argument error; without one we still give it its own kind rather
+    %% than the generic runtime_error catch-all (BT-2707 floor).
+    {Sel, Cls} = breadcrumb(Context),
+    Message = located(Sel, Cls, <<"invalid argument">>),
+    Hint = <<"Check the argument types and values for this message.">>,
+    wrap_classified(argument_error, Cls, Sel, Message, Hint, #{reason => badarg});
+%%% --- Bucket B: internal bugs --------------------------------------------
+wrap_raw(Reason, Context) when
+    Reason =:= function_clause orelse
+        Reason =:= if_clause orelse
+        (is_tuple(Reason) andalso tuple_size(Reason) =:= 2 andalso
+            (element(1, Reason) =:= case_clause orelse
+                element(1, Reason) =:= badmatch orelse
+                element(1, Reason) =:= try_clause))
+->
+    {Sel, Cls} = breadcrumb(Context),
+    Tag = internal_reason_tag(Reason),
+    Message = located(
+        Sel,
+        Cls,
+        iolist_to_binary(
+            io_lib:format("internal error (~s) - this is a bug in Beamtalk", [Tag])
+        )
+    ),
+    Hint = <<"Please report this with the code that triggered it; it should not happen.">>,
+    wrap_classified(internal_error, Cls, Sel, Message, Hint, #{reason => Reason});
+%%% --- Bucket C: resource/environment -------------------------------------
+wrap_raw(system_limit, Context) ->
+    {Sel, Cls} = breadcrumb(Context),
+    Message = located(Sel, Cls, <<"a system limit was reached">>),
+    Hint = <<"The VM hit a hard limit (e.g. too many processes, atoms, or ports).">>,
+    wrap_classified(resource_error, Cls, Sel, Message, Hint, #{reason => system_limit});
+wrap_raw(noproc, Context) ->
+    {Sel, Cls} = breadcrumb(Context),
+    Message = located(Sel, Cls, <<"the target process no longer exists">>),
+    Hint = <<"The actor or process may have already terminated.">>,
+    wrap_classified(process_not_found, Cls, Sel, Message, Hint, #{reason => noproc});
+wrap_raw(Reason, Context) when
+    Reason =:= timeout orelse
+        (is_tuple(Reason) andalso tuple_size(Reason) >= 1 andalso element(1, Reason) =:= timeout)
+->
+    {Sel, Cls} = breadcrumb(Context),
+    Message = located(Sel, Cls, <<"the operation timed out">>),
+    Hint = <<"The operation did not complete within its time limit.">>,
+    wrap_classified(timeout_error, Cls, Sel, Message, Hint, #{reason => Reason});
+%%% --- Fallback: unclassified ---------------------------------------------
+wrap_raw(Other, Context) ->
+    {Sel, Cls} = breadcrumb(Context),
+    wrap_classified(
+        runtime_error,
+        Cls,
+        Sel,
+        iolist_to_binary(io_lib:format("~p", [Other])),
+        undefined,
+        #{reason => Other}
+    ).
+
+%% Build a classified Exception tagged map from explicit error parts.
+-spec wrap_classified(
+    atom(), atom() | undefined, atom() | undefined, binary(), binary() | undefined, map()
+) ->
+    map().
+wrap_classified(Kind, Class, Selector, Message, Hint, Details) ->
     GenError = #beamtalk_error{
-        kind = arity_mismatch,
-        class = 'Block',
-        selector = undefined,
+        kind = Kind,
+        class = Class,
+        selector = Selector,
         message = Message,
         hint = Hint,
-        details = #{expected_args => Expected, actual_args => Actual}
+        details = Details
     },
-    #{'$beamtalk_class' => kind_to_class(arity_mismatch), error => GenError};
-wrap_raw(Other) ->
-    GenError = #beamtalk_error{
-        kind = runtime_error,
-        class = undefined,
-        selector = undefined,
-        message = iolist_to_binary(io_lib:format("~p", [Other])),
-        hint = undefined,
-        details = #{reason => Other}
-    },
-    #{'$beamtalk_class' => kind_to_class(runtime_error), error => GenError}.
+    #{'$beamtalk_class' => kind_to_class(Kind), error => GenError}.
+
+%% Extract the {Selector, Class} breadcrumb from a dispatch context (BT-2705).
+-spec breadcrumb(map()) -> {atom() | undefined, atom() | undefined}.
+breadcrumb(Context) ->
+    {maps:get(selector, Context, undefined), maps:get(class, Context, undefined)}.
+
+%% Prefix a core error message with its location (class/selector) when known.
+-spec located(atom() | undefined, atom() | undefined, binary()) -> binary().
+located(undefined, _Class, Core) ->
+    Core;
+located(Selector, undefined, Core) ->
+    iolist_to_binary(io_lib:format("'~s': ~s", [Selector, Core]));
+located(Selector, Class, Core) ->
+    iolist_to_binary(io_lib:format("~s>>~s: ~s", [Class, Selector, Core])).
+
+%% Human-readable tag for a bucket-B internal reason.
+-spec internal_reason_tag(term()) -> atom().
+internal_reason_tag(Reason) when is_atom(Reason) -> Reason;
+internal_reason_tag(Reason) when is_tuple(Reason) -> element(1, Reason).
 
 -doc """
 Idempotent exception wrapper (ADR 0015).
@@ -341,6 +475,31 @@ ensure_wrapped(throw, Reason, Stacktrace) ->
 ensure_wrapped(_Type, Other, Stacktrace) ->
     Wrapped = wrap(Other),
     Wrapped#{stacktrace => beamtalk_stack_frame:wrap(Stacktrace)}.
+
+-doc """
+Idempotent exception wrapper with a dispatch breadcrumb (BT-2705).
+
+Like ensure_wrapped/3 but threads a dispatch `Context` (a map that may carry
+`selector` and `class` for the active send) into `wrap_raw/2`, so raw Erlang
+errors escaping a send are classified *and* located.
+
+The breadcrumb is consulted only here, on the error path, so successful
+dispatch is unaffected. Already-wrapped exceptions pass through untouched so
+the *innermost* frame's classification wins — an outer frame never overwrites a
+more specific inner one. `undef`, `exit`, `throw`, and `#beamtalk_error{}` keep
+their existing ensure_wrapped/3 handling.
+""".
+-spec ensure_wrapped(atom(), term(), list(), map()) -> map().
+ensure_wrapped(_Type, #{'$beamtalk_class' := _} = Already, _Stacktrace, _Context) ->
+    %% Innermost classification already applied — preserve it (and its stacktrace).
+    Already;
+ensure_wrapped(error, Reason, Stacktrace, Context) when
+    map_size(Context) > 0, Reason =/= undef, not is_record(Reason, beamtalk_error)
+->
+    Wrapped = wrap_raw(Reason, Context),
+    Wrapped#{stacktrace => beamtalk_stack_frame:wrap(Stacktrace)};
+ensure_wrapped(Type, Reason, Stacktrace, _Context) ->
+    ensure_wrapped(Type, Reason, Stacktrace).
 
 -doc """
 Dispatch a message to an Exception object.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_exception_handler.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_exception_handler.erl
@@ -309,11 +309,14 @@ wrap_raw(system_limit, Context) ->
     Message = located(Sel, Cls, <<"a system limit was reached">>),
     Hint = <<"The VM hit a hard limit (e.g. too many processes, atoms, or ports).">>,
     wrap_classified(resource_error, Cls, Sel, Message, Hint, #{reason => system_limit});
-wrap_raw(noproc, Context) ->
+wrap_raw(Reason, Context) when
+    Reason =:= noproc orelse
+        (is_tuple(Reason) andalso tuple_size(Reason) >= 1 andalso element(1, Reason) =:= noproc)
+->
     {Sel, Cls} = breadcrumb(Context),
     Message = located(Sel, Cls, <<"the target process no longer exists">>),
     Hint = <<"The actor or process may have already terminated.">>,
-    wrap_classified(process_not_found, Cls, Sel, Message, Hint, #{reason => noproc});
+    wrap_classified(process_not_found, Cls, Sel, Message, Hint, #{reason => Reason});
 wrap_raw(Reason, Context) when
     Reason =:= timeout orelse
         (is_tuple(Reason) andalso tuple_size(Reason) >= 1 andalso element(1, Reason) =:= timeout)
@@ -340,9 +343,20 @@ wrap_raw(Other, Context) ->
 ) ->
     map().
 wrap_classified(Kind, Class, Selector, Message, Hint, Details) ->
+    %% `Class` is the *receiver* breadcrumb (already baked into the located
+    %% Message). Do not store it as the error's class when it is itself an
+    %% exception class: matches_class_name/2 treats #beamtalk_error.class as
+    %% authoritative for hierarchy matching (BT-480), so a raw error that merely
+    %% occurred on an Exception-subclass receiver must not hijack catch matching.
+    %% Fall back to undefined there, letting the kind-derived class drive matching.
+    RecordClass =
+        case Class =/= undefined andalso is_exception_class(Class) of
+            true -> undefined;
+            false -> Class
+        end,
     GenError = #beamtalk_error{
         kind = Kind,
-        class = Class,
+        class = RecordClass,
         selector = Selector,
         message = Message,
         hint = Hint,
@@ -359,10 +373,12 @@ breadcrumb(Context) ->
 -spec located(atom() | undefined, atom() | undefined, binary()) -> binary().
 located(undefined, _Class, Core) ->
     Core;
+%% ~ts (not ~s): an error formatter must never itself crash, even on an
+%% interop-supplied class/selector atom carrying non-Latin1 codepoints.
 located(Selector, undefined, Core) ->
-    iolist_to_binary(io_lib:format("'~s': ~s", [Selector, Core]));
+    iolist_to_binary(io_lib:format("'~ts': ~ts", [Selector, Core]));
 located(Selector, Class, Core) ->
-    iolist_to_binary(io_lib:format("~s>>~s: ~s", [Class, Selector, Core])).
+    iolist_to_binary(io_lib:format("~ts>>~ts: ~ts", [Class, Selector, Core])).
 
 %% Human-readable tag for a bucket-B internal reason.
 -spec internal_reason_tag(term()) -> atom().
@@ -490,9 +506,14 @@ more specific inner one. `undef`, `exit`, `throw`, and `#beamtalk_error{}` keep
 their existing ensure_wrapped/3 handling.
 """.
 -spec ensure_wrapped(atom(), term(), list(), map()) -> map().
-ensure_wrapped(_Type, #{'$beamtalk_class' := _} = Already, _Stacktrace, _Context) ->
-    %% Innermost classification already applied — preserve it (and its stacktrace).
-    Already;
+ensure_wrapped(_Type, #{'$beamtalk_class' := _} = Already, Stacktrace, _Context) ->
+    %% Innermost classification already applied — preserve it and any stacktrace it
+    %% already carries. Backfill from this frame only when absent, so stacktrace
+    %% capture never regresses versus ensure_wrapped/3 (which always attached one).
+    case Already of
+        #{stacktrace := _} -> Already;
+        _ -> Already#{stacktrace => beamtalk_stack_frame:wrap(Stacktrace)}
+    end;
 ensure_wrapped(error, Reason, Stacktrace, Context) when
     map_size(Context) > 0, Reason =/= undef, not is_record(Reason, beamtalk_error)
 ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_exception_handler_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_exception_handler_tests.erl
@@ -29,12 +29,13 @@ ensure_wrapped_wraps_raw_error_test() ->
     #{error := Inner} = Result,
     ?assertEqual(type_error, Inner#beamtalk_error.kind).
 
-%% Raw Erlang terms get wrapped as runtime_error
+%% Raw Erlang terms get wrapped and classified (BT-2707): a bare badarg with no
+%% dispatch context becomes its own argument_error kind, not generic runtime_error.
 ensure_wrapped_wraps_raw_erlang_test() ->
     Result = beamtalk_exception_handler:ensure_wrapped(badarg),
     ?assertMatch(#{'$beamtalk_class' := _, error := _}, Result),
     #{error := Inner} = Result,
-    ?assertEqual(runtime_error, Inner#beamtalk_error.kind).
+    ?assertEqual(argument_error, Inner#beamtalk_error.kind).
 
 %% Double-wrapping doesn't happen
 ensure_wrapped_no_double_wrap_test() ->
@@ -617,6 +618,161 @@ wrap_raw_badarity_test() ->
     ?assert(is_binary(Inner#beamtalk_error.message)),
     ?assert(is_binary(Inner#beamtalk_error.hint)),
     #{expected_args := 1, actual_args := 3} = Inner#beamtalk_error.details.
+
+%%% ===================================================================
+%%% wrap_raw/2 — raw-error classification into buckets A/B/C (BT-2707)
+%%% ===================================================================
+
+%% Helper: classify a raw reason (no context) and return the inner error.
+classify(Reason) ->
+    #{error := Inner} = beamtalk_exception_handler:wrap_raw(Reason),
+    Inner.
+
+%% Helper: classify a raw reason with a dispatch breadcrumb.
+classify(Reason, Context) ->
+    #{error := Inner} = beamtalk_exception_handler:wrap_raw(Reason, Context),
+    Inner.
+
+%%% --- Bucket A: user-input errors ---
+
+wrap_raw_badarith_is_type_error_test() ->
+    Inner = classify(badarith),
+    ?assertEqual(type_error, Inner#beamtalk_error.kind),
+    ?assert(is_binary(Inner#beamtalk_error.hint)).
+
+wrap_raw_badarith_class_is_type_error_test() ->
+    #{'$beamtalk_class' := Class} = beamtalk_exception_handler:wrap_raw(badarith),
+    ?assertEqual('TypeError', Class).
+
+wrap_raw_badkey_is_key_error_test() ->
+    Inner = classify({badkey, <<"missing">>}),
+    ?assertEqual(key_error, Inner#beamtalk_error.kind),
+    ?assertEqual(#{key => <<"missing">>}, Inner#beamtalk_error.details).
+
+wrap_raw_badmap_is_type_error_test() ->
+    Inner = classify({badmap, 42}),
+    ?assertEqual(type_error, Inner#beamtalk_error.kind).
+
+wrap_raw_badarg_no_context_is_argument_error_test() ->
+    Inner = classify(badarg),
+    ?assertEqual(argument_error, Inner#beamtalk_error.kind),
+    %% Without a breadcrumb the message is unlocated.
+    ?assertEqual(<<"invalid argument">>, Inner#beamtalk_error.message).
+
+%%% --- Bucket B: internal bugs (loud, not dressed up as user errors) ---
+
+wrap_raw_function_clause_is_internal_error_test() ->
+    Inner = classify(function_clause),
+    ?assertEqual(internal_error, Inner#beamtalk_error.kind),
+    %% Internal bugs must read as "please report", never as a user mistake.
+    ?assertEqual('RuntimeError', kind_to_class_of(Inner)),
+    ?assertNotEqual(type_error, Inner#beamtalk_error.kind).
+
+wrap_raw_case_clause_is_internal_error_test() ->
+    Inner = classify({case_clause, some_value}),
+    ?assertEqual(internal_error, Inner#beamtalk_error.kind).
+
+wrap_raw_badmatch_is_internal_error_test() ->
+    Inner = classify({badmatch, []}),
+    ?assertEqual(internal_error, Inner#beamtalk_error.kind).
+
+wrap_raw_if_clause_is_internal_error_test() ->
+    Inner = classify(if_clause),
+    ?assertEqual(internal_error, Inner#beamtalk_error.kind).
+
+%%% --- Bucket C: resource/environment ---
+
+wrap_raw_system_limit_is_resource_error_test() ->
+    Inner = classify(system_limit),
+    ?assertEqual(resource_error, Inner#beamtalk_error.kind).
+
+wrap_raw_noproc_is_process_not_found_test() ->
+    Inner = classify(noproc),
+    ?assertEqual(process_not_found, Inner#beamtalk_error.kind).
+
+wrap_raw_timeout_is_timeout_error_test() ->
+    Inner = classify(timeout),
+    ?assertEqual(timeout_error, Inner#beamtalk_error.kind).
+
+wrap_raw_timeout_tuple_is_timeout_error_test() ->
+    Inner = classify({timeout, gen_server_call}),
+    ?assertEqual(timeout_error, Inner#beamtalk_error.kind).
+
+%%% --- Fallback ---
+
+wrap_raw_unknown_stays_runtime_error_test() ->
+    Inner = classify({some_unknown_reason, 1, 2}),
+    ?assertEqual(runtime_error, Inner#beamtalk_error.kind).
+
+%%% --- BT-2705: breadcrumb produces located messages ---
+
+wrap_raw_badarith_with_breadcrumb_is_located_test() ->
+    Inner = classify(badarith, #{selector => sum, class => 'Tuple'}),
+    ?assertEqual(type_error, Inner#beamtalk_error.kind),
+    ?assertEqual(sum, Inner#beamtalk_error.selector),
+    ?assertEqual('Tuple', Inner#beamtalk_error.class),
+    %% Message names the originating Class>>selector.
+    ?assertEqual(
+        match,
+        re:run(Inner#beamtalk_error.message, "Tuple>>sum", [{capture, none}])
+    ).
+
+wrap_raw_badarg_with_selector_only_is_located_test() ->
+    Inner = classify(badarg, #{selector => 'at:'}),
+    ?assertEqual('at:', Inner#beamtalk_error.selector),
+    ?assertEqual(
+        match,
+        re:run(Inner#beamtalk_error.message, "'at:'", [{capture, none}])
+    ).
+
+%%% --- ensure_wrapped/4: context-aware idempotent wrapper (BT-2705) ---
+
+ensure_wrapped_4_classifies_with_context_test() ->
+    Result = beamtalk_exception_handler:ensure_wrapped(
+        error, badarith, [], #{selector => sum, class => 'Tuple'}
+    ),
+    ?assertMatch(#{'$beamtalk_class' := 'TypeError', error := _, stacktrace := _}, Result),
+    #{error := Inner} = Result,
+    ?assertEqual(type_error, Inner#beamtalk_error.kind),
+    ?assertEqual(sum, Inner#beamtalk_error.selector).
+
+ensure_wrapped_4_already_wrapped_preserves_innermost_test() ->
+    %% Inner frame already classified the error with its selector; an outer frame
+    %% with a different breadcrumb must NOT overwrite it (innermost wins).
+    InnerWrapped = beamtalk_exception_handler:wrap_raw(badarith, #{
+        selector => sum, class => 'Tuple'
+    }),
+    Result = beamtalk_exception_handler:ensure_wrapped(
+        error, InnerWrapped, [], #{selector => 'do:', class => 'OuterThing'}
+    ),
+    ?assertEqual(InnerWrapped, Result).
+
+ensure_wrapped_4_empty_context_delegates_test() ->
+    %% No breadcrumb → identical to ensure_wrapped/3.
+    R3 = beamtalk_exception_handler:ensure_wrapped(error, badarith, []),
+    R4 = beamtalk_exception_handler:ensure_wrapped(error, badarith, [], #{}),
+    ?assertEqual(R3, R4).
+
+%% Helper: the exception class an inner error maps to.
+kind_to_class_of(#beamtalk_error{kind = Kind}) ->
+    beamtalk_exception_handler:kind_to_class(Kind).
+
+%%% kind_to_class/1 — new classified kinds (BT-2707)
+
+kind_to_class_key_error_test() ->
+    ?assertEqual('RuntimeError', beamtalk_exception_handler:kind_to_class(key_error)).
+
+kind_to_class_argument_error_test() ->
+    ?assertEqual('RuntimeError', beamtalk_exception_handler:kind_to_class(argument_error)).
+
+kind_to_class_resource_error_test() ->
+    ?assertEqual('RuntimeError', beamtalk_exception_handler:kind_to_class(resource_error)).
+
+kind_to_class_process_not_found_test() ->
+    ?assertEqual('RuntimeError', beamtalk_exception_handler:kind_to_class(process_not_found)).
+
+kind_to_class_timeout_error_test() ->
+    ?assertEqual('RuntimeError', beamtalk_exception_handler:kind_to_class(timeout_error)).
 
 %%% ===================================================================
 %%% signal_message/1 tests

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_exception_handler_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_exception_handler_tests.erl
@@ -738,14 +738,27 @@ ensure_wrapped_4_classifies_with_context_test() ->
 
 ensure_wrapped_4_already_wrapped_preserves_innermost_test() ->
     %% Inner frame already classified the error with its selector; an outer frame
-    %% with a different breadcrumb must NOT overwrite it (innermost wins).
+    %% with a different breadcrumb must NOT overwrite the classification (innermost
+    %% wins). A stacktrace may be backfilled when the inner map lacked one, so we
+    %% compare the classified error rather than full-map equality.
     InnerWrapped = beamtalk_exception_handler:wrap_raw(badarith, #{
         selector => sum, class => 'Tuple'
     }),
     Result = beamtalk_exception_handler:ensure_wrapped(
         error, InnerWrapped, [], #{selector => 'do:', class => 'OuterThing'}
     ),
-    ?assertEqual(InnerWrapped, Result).
+    ?assertEqual(maps:get(error, InnerWrapped), maps:get(error, Result)),
+    ?assertEqual('TypeError', maps:get('$beamtalk_class', Result)).
+
+ensure_wrapped_4_already_wrapped_with_stacktrace_kept_test() ->
+    %% When the inner map already carries a stacktrace, it is preserved verbatim.
+    InnerWrapped = (beamtalk_exception_handler:wrap_raw(badarith, #{selector => sum}))#{
+        stacktrace => [frame_a, frame_b]
+    },
+    Result = beamtalk_exception_handler:ensure_wrapped(error, InnerWrapped, [], #{
+        selector => 'do:'
+    }),
+    ?assertEqual([frame_a, frame_b], maps:get(stacktrace, Result)).
 
 ensure_wrapped_4_empty_context_delegates_test() ->
     %% No breadcrumb → identical to ensure_wrapped/3.

--- a/stdlib/bootstrap-test/exceptions.btscript
+++ b/stdlib/bootstrap-test/exceptions.btscript
@@ -28,9 +28,10 @@
 // EXCEPTION OBJECT FIELD ACCESS
 // ===========================================================================
 
-// Access exception message from caught error
+// Access exception message from caught error (BT-2707: raw badarith is
+// classified and given a readable message, not the bare Erlang atom)
 [1 / 0] on: Exception do: [:e | e message]
-// => badarith
+// => bad arithmetic operation
 
 // Access exception kind from caught error
 [42 noSuchMethod] on: Exception do: [:e | e kind]
@@ -48,9 +49,9 @@
 [42 noSuchMethod] on: Exception do: [:e | e printString]
 // => Integer does not understand 'noSuchMethod'\nHint: Check spelling or use 'respondsTo:' to verify method exists
 
-// Exception hint — nil when no hint available
+// Exception hint — BT-2707 classified arithmetic errors carry an actionable hint
 [1 / 0] on: Exception do: [:e | e hint]
-// => nil
+// => Arithmetic requires numbers; check for a non-numeric operand or division by zero.
 
 // ===========================================================================
 // BLOCK ensure: — CLEANUP HANDLING

--- a/stdlib/test/destructuring_test.bt
+++ b/stdlib/test/destructuring_test.bt
@@ -269,11 +269,21 @@ TestCase subclass: DestructuringTest
 
   testMapDestructuringMissingKeyRaisesError =>
     // Accessing a missing key raises a {badkey, Key} error via erlang:map_get/2.
+    // BT-2707 classifies it into a readable key_error (a RuntimeError subclass)
+    // instead of leaking the raw `badkey` term.
     result := [
       #{#missing => _val} := #{#present => 42}
       #did_not_raise
-    ] on: RuntimeError do: [:e | e message includesSubstring: "badkey"]
+    ] on: RuntimeError do: [:e | e message includesSubstring: "not found"]
     self assert: result equals: true
+
+  testMapDestructuringMissingKeyIsKeyError =>
+    // The classified missing-key error carries the key_error kind.
+    result := [
+      #{#missing => _val} := #{#present => 42}
+      #did_not_raise
+    ] on: RuntimeError do: [:e | e kind]
+    self assert: result equals: #key_error
 
   testMapDestructuringOnlyStatement =>
     // Map destructuring as the only statement in a method.

--- a/stdlib/test/fixtures/raw_error_actor.bt
+++ b/stdlib/test/fixtures/raw_error_actor.bt
@@ -1,0 +1,10 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2705: helper actor whose compiled method triggers a raw Erlang badarith,
+// used by raw_error_classification_test to verify the actor dispatch boundary
+// attaches the active selector/class breadcrumb to the wrapped error.
+
+Actor subclass: RawErrorActor
+
+  triggerBadArith => #(1, "x") sum

--- a/stdlib/test/raw_error_classification_test.bt
+++ b/stdlib/test/raw_error_classification_test.bt
@@ -1,0 +1,79 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-2704: raw Erlang runtime errors escaping a send are classified and wrapped
+// at the dispatch boundary (never leaked raw), the active selector/class is
+// threaded to compiled-method errors as a breadcrumb (BT-2705), AND the
+// error-only wrapping must not swallow throw-based control flow (^ / on:do:).
+
+// The RawErrorActor helper (a compiled method that triggers a raw Erlang
+// badarith) lives in fixtures/raw_error_actor.bt and is auto-loaded.
+
+TestCase subclass: RawErrorClassificationTest
+
+  // --- Bucket A: user-input errors are classified, not left generic ---
+  testNonNumericSumIsTypeError =>
+    // #(1, "x") sum raises a raw Erlang badarith inside the value-type
+    // dispatch path; it must surface as a catchable TypeError.
+    result := [#(1, "x") sum] on: TypeError do: [:e | e kind]
+    self assert: result equals: #type_error
+
+  testNonNumericSumCaughtByRuntimeErrorParent =>
+    // TypeError is under Error/Exception, but a non-numeric arith is a TypeError,
+    // so RuntimeError must NOT catch it (correct classification, not flattening).
+    result := [
+      [#(1, "x") sum] on: RuntimeError do: [:e | "wrong"]
+    ] on: TypeError do: [:e | "right"]
+    self assert: result equals: "right"
+
+  testActorMethodErrorCarriesSelectorBreadcrumb =>
+    // BT-2705: a raw error escaping a compiled method is located with the
+    // active selector threaded in at the actor dispatch boundary.
+    actor := RawErrorActor spawn
+    result := [actor triggerBadArith] on: TypeError do: [:e | e selector]
+    self assert: result equals: #triggerBadArith
+
+  testActorMethodErrorIsClassified =>
+    // The raw badarith inside the method still classifies as a TypeError.
+    actor := RawErrorActor spawn
+    result := [actor triggerBadArith] on: TypeError do: [:e | e kind]
+    self assert: result equals: #type_error
+
+  testNonNumericSumHasHint =>
+    // Bucket-A errors carry an actionable hint.
+    result := [#(1, "x") sum] on: TypeError do: [:e | e hint isNil]
+    self assert: result equals: false
+
+  testNonNumericSumMessageIsNotRawErlang =>
+    // The message must be a formatted string, never a raw `badarith` dump.
+    result := [
+      #(1, "x") sum
+    ] on: Exception do: [:e | e message includesSubstring: "badarith"]
+    self assert: result equals: false
+
+  // --- Control flow must be unaffected (only error: is wrapped, not throw:) ---
+  testNonLocalReturnThroughValueSendStillExits =>
+    // ^ inside a block passed to a value-type send (do:) must still exit the
+    // enclosing method. If the dispatch-boundary catch wrongly intercepted
+    // throw, this would return 0 instead of 2.
+    self assert: self firstEven equals: 2
+
+  firstEven =>
+    #(1, 2, 3, 4) do: [:x | x isEven ifTrue: [^x]]
+    ^0
+
+  testOnDoStillCatches =>
+    result := [#(1, "x") sum] on: Exception do: [:e | "caught"]
+    self assert: result equals: "caught"
+
+  testOnDoReRaisePropagates =>
+    // Re-raising a caught (wrapped) error from inside the handler must still
+    // propagate to the outer handler.
+    result := [
+      [#(1, "x") sum] on: TypeError do: [:e | e signal]
+    ] on: Exception do: [:e | "re-raised"]
+    self assert: result equals: "re-raised"
+
+  testSuccessfulValueSendUnaffected =>
+    // The wrapping wrapper must be transparent on the success path.
+    self assert: #(1, 2, 3) sum equals: 6

--- a/tests/repl-protocol/cases/error_binding.btscript
+++ b/tests/repl-protocol/cases/error_binding.btscript
@@ -51,9 +51,10 @@ _error kind
 // => does_not_understand
 
 // Trigger a new error (division by zero)
+// (BT-2707: raw badarith is classified as a type_error with a readable message)
 1 / 0
-// => ERROR: badarith
+// => ERROR: bad arithmetic
 
 // _error now holds the new error
 _error kind
-// => runtime_error
+// => type_error

--- a/tests/repl-protocol/cases/errors.btscript
+++ b/tests/repl-protocol/cases/errors.btscript
@@ -141,8 +141,9 @@ obj foo:
 // Multiple errors in one expression - parser should recover
 
 // Block with empty body evaluates to nil, then nil + 1 is arithmetic error
+// (BT-2707: raw badarith is classified into a readable arithmetic message)
 [:x :y | ] + 1
-// => ERROR: badarith
+// => ERROR: bad arithmetic
 
 // Multiple syntax errors in sequence
 ] + [ + )


### PR DESCRIPTION
Implements epic **BT-2704** (and its three sub-issues BT-2705/BT-2707/BT-2706) on one branch: raw Erlang runtime errors escaping a send are now classified and wrapped into a well-formed `#beamtalk_error{}` instead of falling through to a generic, contextless `runtime_error`.

## What changed

**BT-2707 — classification (`wrap_raw/2`).** Raw Erlang errors are sorted into three buckets, each presented differently, with selector + offending value + an actionable hint:

| Bucket | Errors | Kind |
| -- | -- | -- |
| **A — user-input** | `badarith`, `{badmap}` → `type_error`; `{badkey}` → `key_error`; `badarg` → `argument_error` | catchable type/key/argument errors |
| **B — internal bugs** | `function_clause`, `case_clause`, `badmatch`, `if_clause` | `internal_error` — loud, "please report", *not* dressed up as a user mistake |
| **C — resource/env** | `system_limit`, `noproc`, `timeout` | `resource_error` / `process_not_found` / `timeout_error` |

`{badarity}` keeps its existing handling; `undef` keeps its existing informative MFA message.

**BT-2705 — breadcrumb (`ensure_wrapped/4`).** The active selector/class is threaded to the wrap site so errors are *located* (e.g. `RawErrorActor>>triggerBadArith: bad arithmetic operation`). Applied at the actor dispatch boundary (`sync_send`, `invoke_method`) where the selector is already in scope — **error path only**, so successful dispatch (the hottest path) pays nothing. Idempotent wrapping means the innermost classification wins.

**BT-2706 — control-flow safety.** Only the `error:` class is ever wrapped; `throw:` (`^` non-local return, `on:do:`) is never intercepted, with regression tests proving it.

## Design note (BT-2705 was `needs-spec`)

The epic gives two hard constraints — *no measurable regression on the hottest path* and *wrap at the boundary, not low in the stack*. So this intentionally does **not** add a try/catch to the per-send value-type path (which would tax every `3 + 4` and reclassify errors before closer catchers like `should:raise:`). Classification instead lands at the boundaries that already wrap (`on:do:`, REPL eval, actor dispatch).

## Tests

- EUnit coverage for each bucket + the `wrap_raw/2`/`ensure_wrapped/4` breadcrumb path.
- New BUnit end-to-end test (`raw_error_classification_test.bt`) covering classification, the actor-boundary breadcrumb, and `^`/`on:do:` control-flow regressions.
- Updated existing tests whose raw-atom expectations the epic deliberately changes (REPL `1/0` and `on:do:` now surface classified, readable messages).

Local: `test-runtime` (5162 + 1582 EUnit), `test-stdlib` (223), `test-bunit` (2633), `test-repl-protocol` (1818), dialyzer, erlfmt, BT fmt — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ht695CKaQPhVXGvjZ2X5W)_