### PR TITLE
runtime: classify raw errors on the runtime-only actor method path (BT-2704 follow-up)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -2132,7 +2132,7 @@ wrap_method_error(Selector, State, Class, Reason, Stacktrace) ->
         stacktrace => Stacktrace,
         domain => [beamtalk, runtime]
     }),
-    Error0 = beamtalk_error:new(runtime_error, ClassName, Selector),
+    Error0 = beamtalk_error:new(method_error_kind(Class, Reason), ClassName, Selector),
     Error1 = beamtalk_error:with_message(Error0, Message),
     Error = beamtalk_error:with_details(Error1, #{
         original_class => Class,
@@ -2140,6 +2140,15 @@ wrap_method_error(Selector, State, Class, Reason, Stacktrace) ->
         erlang_stacktrace => Stacktrace
     }),
     {error, Error, State}.
+
+%% Classify the kind for a raw method-dispatch failure on the runtime-only
+%% (`__methods__`) path, mirroring the compiled path (BT-2704): error-class
+%% reasons run through the shared classifier so a raw error surfaces as the same
+%% kind whether the method was compiled or runtime-defined. exit/throw stay
+%% runtime_error here. The richer MFA message is kept regardless.
+-spec method_error_kind(atom(), term()) -> atom().
+method_error_kind(error, Reason) -> beamtalk_exception_handler:classify_kind(Reason);
+method_error_kind(_Class, _Reason) -> runtime_error.
 
 -doc "Format a human-readable error message from a method dispatch failure.".
 -spec format_method_error_message(atom(), atom(), term(), term(), list()) -> binary().
@@ -2205,7 +2214,9 @@ wrap_dnu_handler_error(Selector, State, Class, Reason, Stacktrace) ->
         stacktrace => Stacktrace,
         domain => [beamtalk, runtime]
     }),
-    Error0 = beamtalk_error:new(runtime_error, ClassName, 'doesNotUnderstand:args:'),
+    Error0 = beamtalk_error:new(
+        method_error_kind(Class, Reason), ClassName, 'doesNotUnderstand:args:'
+    ),
     Error1 = beamtalk_error:with_message(Error0, Message),
     Error = beamtalk_error:with_details(Error1, #{
         original_class => Class,

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_exception_handler.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_exception_handler.erl
@@ -56,6 +56,7 @@ helpers called by that generated code: `wrap/1` and `matches_class/2`.
     class_signal_message/2,
     kind_to_class/1,
     class_to_kind/1,
+    classify_kind/1,
     is_exception_class/1
 ]).
 
@@ -212,6 +213,40 @@ wrap(Other) ->
     wrap_raw(Other).
 
 -doc """
+Map a raw Erlang error reason to its Beamtalk error kind (BT-2707).
+
+The single source of truth for raw-error classification. `wrap_raw/2` uses it to
+pick the kind for the error it builds; the runtime-only actor method-error path
+(`beamtalk_actor:wrap_method_error/5`) borrows it to classify the kind while
+keeping its own richer MFA message — so a raw error surfaces as the *same* kind
+regardless of whether the failing method was compiled or runtime-defined.
+
+Buckets: A user-input (`type_error`/`key_error`/`argument_error`), B internal
+bugs (`internal_error`), C resource/env (`resource_error`/`process_not_found`/
+`timeout_error`); anything unrecognised stays `runtime_error`.
+""".
+-spec classify_kind(term()) -> atom().
+%% Bucket A — user-input
+classify_kind(badarith) -> type_error;
+classify_kind({badmap, _}) -> type_error;
+classify_kind({badkey, _}) -> key_error;
+classify_kind(badarg) -> argument_error;
+%% Bucket B — internal bugs
+classify_kind(function_clause) -> internal_error;
+classify_kind(if_clause) -> internal_error;
+classify_kind({case_clause, _}) -> internal_error;
+classify_kind({badmatch, _}) -> internal_error;
+classify_kind({try_clause, _}) -> internal_error;
+%% Bucket C — resource/environment
+classify_kind(system_limit) -> resource_error;
+classify_kind(noproc) -> process_not_found;
+classify_kind({noproc, _}) -> process_not_found;
+classify_kind(timeout) -> timeout_error;
+classify_kind({timeout, _}) -> timeout_error;
+%% Fallback
+classify_kind(_) -> runtime_error.
+
+-doc """
 Wrap a raw Erlang error into a classified Exception tagged map.
 
 Equivalent to `wrap_raw/2` with no dispatch context. See `wrap_raw/2`.
@@ -262,18 +297,18 @@ wrap_raw(badarith, Context) ->
     Message = located(Sel, Cls, <<"bad arithmetic operation">>),
     Hint =
         <<"Arithmetic requires numbers; check for a non-numeric operand or division by zero.">>,
-    wrap_classified(type_error, Cls, Sel, Message, Hint, #{reason => badarith});
+    wrap_classified(classify_kind(badarith), Cls, Sel, Message, Hint, #{reason => badarith});
 wrap_raw({badkey, Key}, Context) ->
     {Sel, Cls} = breadcrumb(Context),
     Core = iolist_to_binary(io_lib:format("key not found: ~tp", [Key])),
     Message = located(Sel, Cls, Core),
     Hint = <<"Use 'includesKey:' to test first, or 'at:ifAbsent:' to supply a default.">>,
-    wrap_classified(key_error, Cls, Sel, Message, Hint, #{key => Key});
+    wrap_classified(classify_kind({badkey, Key}), Cls, Sel, Message, Hint, #{key => Key});
 wrap_raw({badmap, Value}, Context) ->
     {Sel, Cls} = breadcrumb(Context),
     Message = located(Sel, Cls, <<"expected a Dictionary but got a non-map value">>),
     Hint = <<"This message is only understood by Dictionary values.">>,
-    wrap_classified(type_error, Cls, Sel, Message, Hint, #{value => Value});
+    wrap_classified(classify_kind({badmap, Value}), Cls, Sel, Message, Hint, #{value => Value});
 wrap_raw(badarg, Context) ->
     %% `badarg` is overloaded (user mistake vs internal misuse) and the bare
     %% error can't tell which. With a dispatch breadcrumb we can locate it as a
@@ -282,7 +317,7 @@ wrap_raw(badarg, Context) ->
     {Sel, Cls} = breadcrumb(Context),
     Message = located(Sel, Cls, <<"invalid argument">>),
     Hint = <<"Check the argument types and values for this message.">>,
-    wrap_classified(argument_error, Cls, Sel, Message, Hint, #{reason => badarg});
+    wrap_classified(classify_kind(badarg), Cls, Sel, Message, Hint, #{reason => badarg});
 %%% --- Bucket B: internal bugs --------------------------------------------
 wrap_raw(Reason, Context) when
     Reason =:= function_clause orelse
@@ -302,13 +337,13 @@ wrap_raw(Reason, Context) when
         )
     ),
     Hint = <<"Please report this with the code that triggered it; it should not happen.">>,
-    wrap_classified(internal_error, Cls, Sel, Message, Hint, #{reason => Reason});
+    wrap_classified(classify_kind(Reason), Cls, Sel, Message, Hint, #{reason => Reason});
 %%% --- Bucket C: resource/environment -------------------------------------
 wrap_raw(system_limit, Context) ->
     {Sel, Cls} = breadcrumb(Context),
     Message = located(Sel, Cls, <<"a system limit was reached">>),
     Hint = <<"The VM hit a hard limit (e.g. too many processes, atoms, or ports).">>,
-    wrap_classified(resource_error, Cls, Sel, Message, Hint, #{reason => system_limit});
+    wrap_classified(classify_kind(system_limit), Cls, Sel, Message, Hint, #{reason => system_limit});
 wrap_raw(Reason, Context) when
     Reason =:= noproc orelse
         (is_tuple(Reason) andalso tuple_size(Reason) >= 1 andalso element(1, Reason) =:= noproc)
@@ -316,7 +351,7 @@ wrap_raw(Reason, Context) when
     {Sel, Cls} = breadcrumb(Context),
     Message = located(Sel, Cls, <<"the target process no longer exists">>),
     Hint = <<"The actor or process may have already terminated.">>,
-    wrap_classified(process_not_found, Cls, Sel, Message, Hint, #{reason => Reason});
+    wrap_classified(classify_kind(Reason), Cls, Sel, Message, Hint, #{reason => Reason});
 wrap_raw(Reason, Context) when
     Reason =:= timeout orelse
         (is_tuple(Reason) andalso tuple_size(Reason) >= 1 andalso element(1, Reason) =:= timeout)
@@ -324,12 +359,12 @@ wrap_raw(Reason, Context) when
     {Sel, Cls} = breadcrumb(Context),
     Message = located(Sel, Cls, <<"the operation timed out">>),
     Hint = <<"The operation did not complete within its time limit.">>,
-    wrap_classified(timeout_error, Cls, Sel, Message, Hint, #{reason => Reason});
+    wrap_classified(classify_kind(Reason), Cls, Sel, Message, Hint, #{reason => Reason});
 %%% --- Fallback: unclassified ---------------------------------------------
 wrap_raw(Other, Context) ->
     {Sel, Cls} = breadcrumb(Context),
     wrap_classified(
-        runtime_error,
+        classify_kind(Other),
         Cls,
         Sel,
         iolist_to_binary(io_lib:format("~p", [Other])),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
@@ -2328,7 +2328,11 @@ method_badarg_error_test() ->
     %% Trigger a badarg error in a method to cover format_method_error_message badarg path
     {ok, Actor} = test_badarg_actor:start_link(),
     Result = gen_server:call(Actor, {triggerBadarg, []}),
-    ?assertMatch({error, #beamtalk_error{kind = runtime_error, selector = triggerBadarg}}, Result),
+    %% BT-2704: the runtime-only method path now classifies the kind (badarg ->
+    %% argument_error) the same as the compiled path, keeping its MFA message.
+    ?assertMatch(
+        {error, #beamtalk_error{kind = argument_error, selector = triggerBadarg}}, Result
+    ),
     %% Message should contain "Bad argument"
     {error, Err} = Result,
     ?assertNotEqual(nomatch, binary:match(Err#beamtalk_error.message, <<"Bad argument">>)),
@@ -2338,8 +2342,9 @@ method_badarith_error_test() ->
     %% Trigger a badarith error to cover format_method_error_message badarith path
     {ok, Actor} = test_badarg_actor:start_link(),
     Result = gen_server:call(Actor, {triggerBadarith, []}),
+    %% BT-2704: badarith -> type_error, matching the compiled path.
     ?assertMatch(
-        {error, #beamtalk_error{kind = runtime_error, selector = triggerBadarith}}, Result
+        {error, #beamtalk_error{kind = type_error, selector = triggerBadarith}}, Result
     ),
     {error, Err} = Result,
     ?assertNotEqual(nomatch, binary:match(Err#beamtalk_error.message, <<"Arithmetic error">>)),
@@ -2358,8 +2363,9 @@ method_function_clause_error_test() ->
     %% Trigger a function_clause error to cover that path
     {ok, Actor} = test_badarg_actor:start_link(),
     Result = gen_server:call(Actor, {triggerFunctionClause, []}),
+    %% BT-2704: function_clause is an internal bug -> internal_error.
     ?assertMatch(
-        {error, #beamtalk_error{kind = runtime_error, selector = triggerFunctionClause}}, Result
+        {error, #beamtalk_error{kind = internal_error, selector = triggerFunctionClause}}, Result
     ),
     {error, Err} = Result,
     ?assertNotEqual(nomatch, binary:match(Err#beamtalk_error.message, <<"No matching clause">>)),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_exception_handler_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_exception_handler_tests.erl
@@ -704,6 +704,64 @@ wrap_raw_unknown_stays_runtime_error_test() ->
     Inner = classify({some_unknown_reason, 1, 2}),
     ?assertEqual(runtime_error, Inner#beamtalk_error.kind).
 
+%%% --- classify_kind/1 — canonical raw-reason -> kind map (BT-2704 follow-up) ---
+
+classify_kind_buckets_test() ->
+    C = fun beamtalk_exception_handler:classify_kind/1,
+    %% Bucket A — user-input
+    ?assertEqual(type_error, C(badarith)),
+    ?assertEqual(type_error, C({badmap, #{}})),
+    ?assertEqual(key_error, C({badkey, missing})),
+    ?assertEqual(argument_error, C(badarg)),
+    %% Bucket B — internal bugs
+    ?assertEqual(internal_error, C(function_clause)),
+    ?assertEqual(internal_error, C(if_clause)),
+    ?assertEqual(internal_error, C({case_clause, x})),
+    ?assertEqual(internal_error, C({badmatch, x})),
+    ?assertEqual(internal_error, C({try_clause, x})),
+    %% Bucket C — resource/environment
+    ?assertEqual(resource_error, C(system_limit)),
+    ?assertEqual(process_not_found, C(noproc)),
+    ?assertEqual(process_not_found, C({noproc, {gen_server, call, []}})),
+    ?assertEqual(timeout_error, C(timeout)),
+    ?assertEqual(timeout_error, C({timeout, ref})),
+    %% Fallback — undef and unknown terms stay generic
+    ?assertEqual(runtime_error, C(undef)),
+    ?assertEqual(runtime_error, C({weird, term})).
+
+%% The kind wrap_raw/2 produces must equal classify_kind/1 for every reason —
+%% they share one taxonomy, so the runtime-only method path (which borrows
+%% classify_kind directly) cannot drift from the dispatch-boundary path.
+classify_kind_agrees_with_wrap_raw_test() ->
+    Reasons = [
+        badarith,
+        {badmap, #{}},
+        {badkey, missing},
+        badarg,
+        function_clause,
+        if_clause,
+        {case_clause, x},
+        {badmatch, x},
+        {try_clause, x},
+        system_limit,
+        noproc,
+        {noproc, mfa},
+        timeout,
+        {timeout, ref},
+        undef,
+        {weird, term}
+    ],
+    lists:foreach(
+        fun(Reason) ->
+            #{error := Inner} = beamtalk_exception_handler:wrap_raw(Reason),
+            ?assertEqual(
+                beamtalk_exception_handler:classify_kind(Reason),
+                Inner#beamtalk_error.kind
+            )
+        end,
+        Reasons
+    ).
+
 %%% --- BT-2705: breadcrumb produces located messages ---
 
 wrap_raw_badarith_with_breadcrumb_is_located_test() ->


### PR DESCRIPTION
Follow-up to #2783, closing the classification **parity gap** the review surfaced.

## Problem

A raw Erlang error from a *runtime-defined* actor method (the `__methods__` / `beamtalk_actor:handle_call/3` path used by builder/REPL-defined actors) was always wrapped as `runtime_error`, while the **same** error from a *compiled* method classified into `type_error` / `argument_error` / `internal_error` (via #2783). So `1 / 0` inside a runtime-defined method was catchable only as `RuntimeError`, but as `TypeError` from a compiled method — a surface inconsistency for identical errors.

## Fix

- Extract **`beamtalk_exception_handler:classify_kind/1`** as the single source of truth for raw-reason → kind. `wrap_raw/2` now sources its kind from it (no more per-clause literal kinds), and the runtime-only method path borrows it directly — so the taxonomy can't drift between the two paths.
- `beamtalk_actor:wrap_method_error/5` and `wrap_dnu_handler_error/5` classify the kind via `method_error_kind/2` (`error`-class reasons → `classify_kind`; `exit`/`throw` stay `runtime_error`), while **keeping their richer MFA messages** unchanged (e.g. `"Arithmetic error in Counter>>compute (called erlang:'/'/2 at line 5)"`).

## Tests

- `classify_kind` bucket coverage + a **consistency test** asserting `wrap_raw` agrees with `classify_kind` for every reason (locks the two paths to one taxonomy).
- Updated the three runtime-only method-error tests: `badarg` → `argument_error`, `badarith` → `type_error`, `function_clause` → `internal_error` (`undef` stays `runtime_error`).

Local: runtime EUnit (5165 + 1582), stdlib (223), dialyzer, erlfmt — all green. The `wrap_raw` refactor is behavior-preserving (identical kinds), so stdlib/BUnit/REPL output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ht695CKaQPhVXGvjZ2X5W)_