### PR TITLE
docs: ADR 0100 open-world diagnostic policy + ADR 0070 cross-package extensions (BT-2251)

### DIFF
--- a/docs/ADR/0070-package-namespaces-and-dependencies.md
+++ b/docs/ADR/0070-package-namespaces-and-dependencies.md
@@ -265,37 +265,68 @@ package boundaries.
 
 **Decision:** a package's compiled interface also records the **extensions it
 contributes**, through the same channel its classes already use — no new artifact
-(consistent with reusing existing machinery; see ADR 0026 / ADR 0098). The `.app`
-`{env, …}` metadata gains an `extensions` list, mirrored in the host class's
-`__beamtalk_meta/0` where one exists:
+(consistent with reusing existing machinery; see ADR 0026 / ADR 0098).
+
+**Single source of truth.** The contributing module's `__beamtalk_meta/0` is the
+**canonical** carrier — extension records gain an `extensions` key there, alongside
+the existing `method_info` (the same function the runtime xref index and class
+metadata already use, ADR 0050 / 0098). The `.app` `{env, …}` metadata carries only
+a lightweight **index** — *which modules contribute extensions to which target
+classes* — so the consumer's build knows which `__beamtalk_meta/0` functions to
+read; it does **not** duplicate the type signatures. This avoids the `.app`-vs-`.beam`
+divergence that an independent `.app` copy would invite (a partial recompile or
+hand-edited `.app` can disagree with the actual `register/5` calls in the module).
+Each extension record:
 
 ```erlang
-{env, [
-  {classes, [ ... ]},
-  {extensions, [
-    #{target   => 'String',        % class (or 'String class' for class-side)
-      selector => 'shoutLouder',
-      package  => 'shout',         % contributing package (ADR 0066 Owner)
-      arity    => 0,
-      param_types  => [],          % None => Dynamic (gradual)
-      return_type  => 'String'     % None => Dynamic
-    }
-  ]}
-]}
+% in the contributing module's __beamtalk_meta/0:
+extensions => [
+  #{target   => 'String',        % class (or 'String class' for class-side)
+    selector => 'shoutLouder',
+    package  => 'shout',         % contributing package (ADR 0066 Owner)
+    arity    => 0,
+    param_types  => [],          % [] here; None => Dynamic (gradual, ADR 0075)
+    return_type  => 'String'     % None => Dynamic
+  }
+]
 ```
 
-On dependency resolution the consumer's checker loads these alongside the
-dependency's `ClassInfo` and feeds them into the **same** `register_extensions`
-path used for intra-project extensions (BT-2251 WS1), so a dependency's extension
-becomes part of the target class's statically-visible method surface. Diagnostic
-severity for any still-unresolved selector follows ADR 0100 (open-world policy) —
-extensions add resolution; they do not change the severity rule.
+On dependency resolution the consumer's checker reads these records and feeds them
+into the **same** `register_extensions` path used for intra-project extensions
+(BT-2251 WS1) — carrying the contributing `package` as the ADR 0066 `Owner`, so a
+cross-package extension is never miscounted as project-owned (relevant once the §9
+visibility story lands). A dependency's extension thus becomes part of the target
+class's statically-visible method surface. Diagnostic severity for any
+still-unresolved selector follows ADR 0100 (open-world policy) — extensions add
+resolution; they do not change the severity rule.
 
 Scope and boundaries:
 
-- **Extensions are exported by default**, like classes (visibility is the ADR 0070
-  §9 follow-up; when it lands, extensions inherit the same export rules as their
-  contributing package's classes).
+- **Extensions are always exported — visibility cannot hide them from the runtime.**
+  Unlike a class (which a package may keep `internal`, ADR 0071), an extension adds
+  a method to a *target* class the contributing package does not own, and BEAM
+  dispatch makes that method callable by **any** caller at runtime. So the interface
+  exports every contributed extension unconditionally; there is no coherent
+  "package-private extension" (it would be a checker-only fiction the runtime does
+  not enforce). The §9 visibility follow-up may still choose to *hide an extension
+  from completion/checker suggestions*, but that is explicitly advisory — the method
+  is dispatchable regardless, and the ADR 0100 policy must not treat a hidden
+  extension's selector as a hard error.
+- **Conflicting extensions are surfaced, not silently merged.** If two dependencies
+  both contribute `String >> toJson`, the consumer's checker now holds two records
+  for the same `{target, side, selector}` key — the static analogue of ADR 0066's
+  runtime last-writer-wins. The checker MUST reuse the existing
+  `ExtensionConflictDetector` (ADR 0066 Phase 3) to report a cross-package extension
+  conflict diagnostic at the consumer's compile time (consistent with §3 treating
+  class collisions as errors, not silent shadowing), rather than arbitrarily picking
+  one signature. If the two signatures *differ*, the conflict is reported with both
+  so the divergence is visible; the runtime behaviour (which fun wins) remains
+  ADR 0066's load-order concern.
+- **An extension calling its own package's `internal` methods** (ADR 0071) still
+  works at runtime; the consumer sees only the extension's public signature, never
+  its body, so no cross-package reachability leak occurs — but any future
+  cross-package call-graph analysis must not treat such internal calls as public
+  edges.
 - **Protocol conformance stays use-site computed**, unchanged — the structural-
   conformance argument above still holds; only the *extension method surface* is
   serialised, not derived conformance facts.
@@ -303,6 +334,16 @@ Scope and boundaries:
   type signature; they are recorded with `Dynamic` param/return like any
   unannotated extension, consistent with the runtime xref index's
   known-present-but-unindexable handling (ADR 0087).
+- **Type encoding is not new.** Extension `param_types` / `return_type` use the
+  *same* serialization as class `method_info` (including generics / type params,
+  ADR 0068 / 0075). Extensions inherit whatever that encoding supports — no
+  separate type-serialization strategy is introduced, so a consumer unifies
+  extension and method signatures through one decoder.
+- **Sequencing (with ADR 0100 Rule 2).** Until a consumer's build actually loads a
+  dependency's extension records, a receiver of that dependency's type must stay
+  classified `Open`, not `ClosedComplete` — otherwise the checker emits a false
+  `Dnu` hint for a real cross-package extension. WS3 (this amendment) must therefore
+  precede removing the open-world suppression for cross-package receivers.
 - This is the **static** complement to the runtime write path (BT-2250) and the
   live xref index (ADR 0087 / BT-2228): the same extension facts, made visible to a
   *consumer's compiler* rather than only to the running image.

--- a/docs/ADR/0070-package-namespaces-and-dependencies.md
+++ b/docs/ADR/0070-package-namespaces-and-dependencies.md
@@ -307,7 +307,10 @@ use the same `{'generic', 'Base', [...]}` / `{'type_param', 'Name', Index}` tagg
 tuples (ADR 0068). Consumer and contributor therefore share one decoder.
 `length(param_types)` is authoritative for the parameter type information; `arity`
 is a convenience count carried for consistency with the `method_info` tuple
-encoding, and a decoder that finds the two disagreeing trusts `param_types`.
+encoding. A decoder that finds the two disagreeing MUST emit a build diagnostic
+(malformed extension record) rather than silently trusting either field — the only
+way they can disagree is a serialiser bug or the `.app`-vs-`.beam` divergence this
+design otherwise avoids, so it should surface loudly, not be papered over.
 
 On dependency resolution the consumer's checker reads these records and feeds them
 into the **same** `register_extensions` path used for intra-project extensions
@@ -332,7 +335,9 @@ Scope and boundaries:
   extension's selector as a hard error.
 - **Conflicting extensions are surfaced, not silently merged.** If two dependencies
   both contribute `String >> toJson`, the consumer's checker now holds two records
-  for the same `{target, side, selector}` key — the static analogue of ADR 0066's
+  for the same `{target, selector}` key — where instance vs class side is already
+  encoded in the `target` atom (`'String'` vs `'String class'`), not a separate
+  field — the static analogue of ADR 0066's
   runtime last-writer-wins. The checker MUST reuse the existing extension conflict
   detector (`detect_extension_conflicts` / `conflict_diagnostics` in
   `crates/beamtalk-core/src/compilation/extension_conflicts.rs`, ADR 0066) — today

--- a/docs/ADR/0070-package-namespaces-and-dependencies.md
+++ b/docs/ADR/0070-package-namespaces-and-dependencies.md
@@ -285,11 +285,26 @@ extensions => [
     selector => 'shoutLouder',
     package  => 'shout',         % contributing package (ADR 0066 Owner)
     arity    => 0,
-    param_types  => [],          % [] here; None => Dynamic (gradual, ADR 0075)
-    return_type  => 'String'     % None => Dynamic
+    param_types  => [],          % zero params (the list is empty)
+    return_type  => 'String'     % concrete type, as an atom
+  },
+  % a 1-arity, unannotated extension — "type unknown" is the atom 'none',
+  % NOT an empty list (which means zero params):
+  #{target   => 'Array',
+    selector => 'padTo:',
+    package  => 'shout',
+    arity    => 1,
+    param_types  => ['none'],    % one param, type unknown => 'none'
+    return_type  => 'none'       % return type unknown => 'none'
   }
 ]
 ```
+
+The unknown-type sentinel is the atom `'none'` — the *same* term `method_info`
+already emits (`MetaTypeRepr::None`,
+`codegen/core_erlang/gen_server/methods.rs`); generic and type-parameter signatures
+use the same `{'generic', 'Base', [...]}` / `{'type_param', 'Name', Index}` tagged
+tuples (ADR 0068). Consumer and contributor therefore share one decoder.
 
 On dependency resolution the consumer's checker reads these records and feeds them
 into the **same** `register_extensions` path used for intra-project extensions
@@ -315,13 +330,16 @@ Scope and boundaries:
 - **Conflicting extensions are surfaced, not silently merged.** If two dependencies
   both contribute `String >> toJson`, the consumer's checker now holds two records
   for the same `{target, side, selector}` key — the static analogue of ADR 0066's
-  runtime last-writer-wins. The checker MUST reuse the existing
-  `ExtensionConflictDetector` (ADR 0066 Phase 3) to report a cross-package extension
-  conflict diagnostic at the consumer's compile time (consistent with §3 treating
-  class collisions as errors, not silent shadowing), rather than arbitrarily picking
-  one signature. If the two signatures *differ*, the conflict is reported with both
-  so the divergence is visible; the runtime behaviour (which fun wins) remains
-  ADR 0066's load-order concern.
+  runtime last-writer-wins. The checker MUST reuse the existing extension conflict
+  detector (`detect_extension_conflicts` / `conflict_diagnostics` in
+  `crates/beamtalk-core/src/compilation/extension_conflicts.rs`, ADR 0066) — today
+  it runs over an intra-project `ExtensionIndex`; cross-package records are fed into
+  the same index and pass — to report a cross-package extension conflict diagnostic
+  at the consumer's compile time (consistent with §3 treating class collisions as
+  errors, not silent shadowing), rather than arbitrarily picking one signature. If
+  the two signatures *differ*, the conflict is reported with both so the divergence
+  is visible; the runtime behaviour (which fun wins) remains ADR 0066's load-order
+  concern.
 - **An extension calling its own package's `internal` methods** (ADR 0071) still
   works at runtime; the consumer sees only the extension's public signature, never
   its body, so no cross-package reachability leak occurs — but any future

--- a/docs/ADR/0070-package-namespaces-and-dependencies.md
+++ b/docs/ADR/0070-package-namespaces-and-dependencies.md
@@ -251,6 +251,62 @@ This allows the compiler to:
 - Check protocol conformance at use sites using method signatures from `__beamtalk_meta/0`
 - Provide chain completion and `:help` for dependency classes in the REPL and LSP
 
+#### Amendment (2026-06-27, BT-2251 WS3): extension contributions in the package interface
+
+The cross-package metadata above carries a package's **classes** but not its
+**open-class extensions** (ADR 0066, `TargetClass >> selector => …`). Extensions
+are discovered today only by scanning a package's own source ASTs at *its* compile
+time (`ExtensionIndex`), so a *consumer* package's type checker has no way to learn
+that a dependency adds `String >> shoutLouder`. The extension activates at runtime
+(its `register/5` call ships in the dependency's `.beam`), but a consumer that
+writes `someString shoutLouder` gets a false `Dnu` hint at compile time — the
+static-analysis analogue of the intra-project gap BT-2251 WS1 closes, now across
+package boundaries.
+
+**Decision:** a package's compiled interface also records the **extensions it
+contributes**, through the same channel its classes already use — no new artifact
+(consistent with reusing existing machinery; see ADR 0026 / ADR 0098). The `.app`
+`{env, …}` metadata gains an `extensions` list, mirrored in the host class's
+`__beamtalk_meta/0` where one exists:
+
+```erlang
+{env, [
+  {classes, [ ... ]},
+  {extensions, [
+    #{target   => 'String',        % class (or 'String class' for class-side)
+      selector => 'shoutLouder',
+      package  => 'shout',         % contributing package (ADR 0066 Owner)
+      arity    => 0,
+      param_types  => [],          % None => Dynamic (gradual)
+      return_type  => 'String'     % None => Dynamic
+    }
+  ]}
+]}
+```
+
+On dependency resolution the consumer's checker loads these alongside the
+dependency's `ClassInfo` and feeds them into the **same** `register_extensions`
+path used for intra-project extensions (BT-2251 WS1), so a dependency's extension
+becomes part of the target class's statically-visible method surface. Diagnostic
+severity for any still-unresolved selector follows ADR 0100 (open-world policy) —
+extensions add resolution; they do not change the severity rule.
+
+Scope and boundaries:
+
+- **Extensions are exported by default**, like classes (visibility is the ADR 0070
+  §9 follow-up; when it lands, extensions inherit the same export rules as their
+  contributing package's classes).
+- **Protocol conformance stays use-site computed**, unchanged — the structural-
+  conformance argument above still holds; only the *extension method surface* is
+  serialised, not derived conformance facts.
+- **Sourceless / computed extensions** (`register/4`, runtime-built funs) carry no
+  type signature; they are recorded with `Dynamic` param/return like any
+  unannotated extension, consistent with the runtime xref index's
+  known-present-but-unindexable handling (ADR 0087).
+- This is the **static** complement to the runtime write path (BT-2250) and the
+  live xref index (ADR 0087 / BT-2228): the same extension facts, made visible to a
+  *consumer's compiler* rather than only to the running image.
+
 ### 8. Package Reflection: The `Package` Class
 
 Packages are first-class objects, inspectable via messages like any other part of the system. The `Package` class ships with the package system — it is the Smalltalk answer to "where does this class come from?" and a core part of the tooling story for LSP, MCP, and AI agents.

--- a/docs/ADR/0070-package-namespaces-and-dependencies.md
+++ b/docs/ADR/0070-package-namespaces-and-dependencies.md
@@ -305,6 +305,9 @@ already emits (`MetaTypeRepr::None`,
 `codegen/core_erlang/gen_server/methods.rs`); generic and type-parameter signatures
 use the same `{'generic', 'Base', [...]}` / `{'type_param', 'Name', Index}` tagged
 tuples (ADR 0068). Consumer and contributor therefore share one decoder.
+`length(param_types)` is authoritative for the parameter type information; `arity`
+is a convenience count carried for consistency with the `method_info` tuple
+encoding, and a decoder that finds the two disagreeing trusts `param_types`.
 
 On dependency resolution the consumer's checker reads these records and feeds them
 into the **same** `register_extensions` path used for intra-project extensions
@@ -334,9 +337,10 @@ Scope and boundaries:
   detector (`detect_extension_conflicts` / `conflict_diagnostics` in
   `crates/beamtalk-core/src/compilation/extension_conflicts.rs`, ADR 0066) — today
   it runs over an intra-project `ExtensionIndex`; cross-package records are fed into
-  the same index and pass — to report a cross-package extension conflict diagnostic
-  at the consumer's compile time (consistent with §3 treating class collisions as
-  errors, not silent shadowing), rather than arbitrarily picking one signature. If
+  the same index, which is then run through the detector, reporting a cross-package
+  extension conflict diagnostic at the consumer's compile time (consistent with §3
+  treating class collisions as errors, not silent shadowing), rather than
+  arbitrarily picking one signature. If
   the two signatures *differ*, the conflict is reported with both so the divergence
   is visible; the runtime behaviour (which fun wins) remains ADR 0066's load-order
   concern.

--- a/docs/ADR/0100-open-world-diagnostic-policy.md
+++ b/docs/ADR/0100-open-world-diagnostic-policy.md
@@ -180,9 +180,11 @@ final disposition is resolved most-specific-wins, in this order:
 
 1. **Site-level `@expect dnu` / `@expect type`** (ADR 0077) — always wins; an
    explicit acknowledgement at the call site silences it regardless of any global
-   setting. (A site that resolves after WS1/WS2 makes its `@expect` *stale*; ADR
-   0077 already warns on stale directives, so improved resolution self-reports the
-   now-dead annotation — no new mechanism needed.)
+   setting. (A site that resolves after WS1/WS2 makes its `@expect` *stale*; the
+   existing stale-directive warning — BT-1412,
+   `queries/diagnostic_provider.rs` — already flags an `@expect` with no matching
+   diagnostic, so improved resolution self-reports the now-dead annotation with no
+   new mechanism.)
 2. **Per-category project table** (`beamtalk.toml`, future) — sets the category's
    base severity for the package (`ignore` / `hint` / `warn` / `error`).
 3. **Rule 1 default** — the completeness-ladder severity, when nothing above
@@ -431,8 +433,9 @@ transitions warrant care:
   by correcting the selector or adding `@expect dnu` where the send is intentionally
   dynamic.
 - **Stale `@expect` directives**: a site that becomes resolvable after WS1/WS2 has a
-  now-unnecessary `@expect`; ADR 0077's stale-directive warning flags these
-  automatically, so cleanup is mechanical and self-surfacing.
+  now-unnecessary `@expect`; the existing stale-directive warning (BT-1412,
+  `queries/diagnostic_provider.rs`) flags these automatically, so cleanup is
+  mechanical and self-surfacing.
 
 ## References
 - Related issues: BT-2251 (epic: project-scoped compilation & type-checking;

--- a/docs/ADR/0100-open-world-diagnostic-policy.md
+++ b/docs/ADR/0100-open-world-diagnostic-policy.md
@@ -1,0 +1,344 @@
+# ADR 0100: Open-World Diagnostic Policy for Unresolved Selectors and Classes
+
+## Status
+Proposed (2026-06-27)
+
+## Context
+
+### Problem statement
+
+Beamtalk is a dynamic, open-world language: any object may implement
+`doesNotUnderstand:`, selectors can be sent reflectively via `perform:`, classes
+can be extended at runtime (ADR 0066), and methods can be hot-reloaded while the
+system runs. In such a world a *statically unresolved* message send is **not**
+proof of a bug — the receiver may understand the message at runtime through a
+mechanism the checker cannot see.
+
+At the same time, the type checker *can* often prove that a send will fail (a
+concrete, closed receiver type whose whole method surface is known and does not
+include the selector). Reporting nothing in that case wastes a real signal —
+typos, renamed methods, and wrong receivers are exactly the errors a Smalltalker
+expects the tooling to catch.
+
+The tension is therefore not "should we report unresolved sends?" but **"with
+what severity, given how complete the checker's knowledge is?"** That question
+has never been written down. The behaviour exists in code, was assembled
+incrementally, and includes at least one workaround (suppressing diagnostics
+whenever a receiver has a cross-file parent) that is really a stand-in for "my
+static knowledge is incomplete here." The project-scoped compilation epic
+(BT-2251) is about to make that knowledge *complete* for the intra-project case,
+which forces the question: when the checker becomes more certain, does it become
+more severe? This ADR fixes the policy so that WS1/WS2 (project scope) and a
+future strict mode have a principled rule to build against, rather than each
+escalating severity ad hoc.
+
+### Current state (as of this ADR)
+
+Severity and category infrastructure already exists
+(`crates/beamtalk-core/src/source_analysis/parser/mod.rs`):
+
+- **Severities:** `Error` (blocks compile), `Warning`, `Lint` (shown by
+  `beamtalk lint`), `Hint` (informational note).
+- **Categories** (`DiagnosticCategory`): `Dnu`, `Type`, `UnresolvedClass`,
+  `UnresolvedFfi`, `ArityMismatch`, `Deprecation`, … — these let policy and
+  suppression target a class of diagnostic rather than a message string.
+
+The de-facto behaviour for an unresolved *selector*
+(`type_checker/validation.rs`, `type_checker/inference.rs`):
+
+| Receiver situation | Today |
+|---|---|
+| Unresolved selector on a **known, concrete** class | `Hint` (`Dnu`) |
+| Receiver is **Dynamic / unknown** | **Silent** (no diagnostic) |
+| **Union** where *no* member responds and there is no uncertainty | `Warning` |
+| Union, some members respond or membership is uncertain | `Hint` |
+| Class declares a `doesNotUnderstand:` override | Silent |
+| Class has a **cross-file parent** | Silent *(incompleteness workaround)* |
+
+Unresolved *classes* and *FFI* targets emit `Warning`
+(`UnresolvedClass` / `UnresolvedFfi`). `@expect dnu` / `@expect type` suppress at
+a site (ADR 0077). `--warnings-as-errors` promotes `Warning`/`Hint` to `Error`,
+but **excludes** `UnresolvedClass`, `UnresolvedFfi`, `ArityMismatch`, and
+`Deprecation` for gradual migration; `Dnu` is **not** excluded, so today
+`--warnings-as-errors` already makes unresolved selectors fatal.
+
+### Constraints
+
+- **The language guarantees the escape hatches** — `doesNotUnderstand:`,
+  `perform:`, runtime extensions, hot reload. A default that rejects code which
+  these make valid would break the language's contract (ADR 0066, ADR 0024).
+- **Reload and live development** (ADR 0024 static-first, live-augmented): a file
+  may not resolve in isolation yet resolve fine against the running image. The
+  static layer must not be more fatal than the live reality.
+- **Whatever the policy, it must be expressible per-category**, because the right
+  answer differs for "selector on a closed receiver" vs. "imported class does not
+  exist."
+
+## Decision
+
+**Severity is a function of how complete the checker's knowledge is, and
+escalation to a build-failing error is always opt-in — never the default.**
+
+Concretely, three rules:
+
+### Rule 1 — Knowledge gates severity (the "completeness ladder")
+
+Diagnose an unresolved selector only as severely as the checker's certainty
+warrants. Absence of evidence is not evidence of absence in an open world.
+
+| Checker's knowledge of the receiver | Default severity |
+|---|---|
+| **Unknown / `Dynamic`** — cannot enumerate the method surface | **Silent** |
+| **Open** — known class but with a `doesNotUnderstand:` handler, or an open extension point the checker can't close | **Silent** |
+| **Closed & complete** — concrete known class; full method surface known across the project *and* dependency interfaces; no DNU handler; not `Dynamic` | **`Hint`** (`Dnu`) |
+| **Provably failing union** — every member is closed and *none* responds, no uncertainty | **`Warning`** (`Dnu`) |
+| **Unresolved class / FFI target** — the *name* resolves to nothing | **`Warning`** (`UnresolvedClass` / `UnresolvedFfi`) |
+
+The default ceiling for a *send* the checker believes will fail is **`Hint`** —
+or `Warning` only when failure is *provable* (the union case). This mirrors
+Dialyzer's success-typing stance: complain only when a call can be *shown* to
+fail, stay quiet otherwise.
+
+### Rule 2 — Completeness improves accuracy, it does not raise severity
+
+When project-scoped compilation (BT-2251 WS1/WS2) gives the checker complete
+intra-project knowledge, it **replaces the incompleteness workarounds with real
+resolution** — but the *default severity is unchanged*. Specifically:
+
+- The "**cross-file parent → silent**" suppression is **removed**. It was a proxy
+  for "I can't see the parent's methods." Once the project hierarchy is assembled
+  (WS2) and project-wide extensions are registered (WS1), the checker *can* see
+  them, so it resolves the send for real instead of suppressing.
+- A same-project cross-file extension (`String >> shoutLouder` in another file)
+  that today produces a **false `Hint`** will simply **resolve** and produce
+  **nothing**. The number of `Hint`s goes *down*, not up.
+- A genuinely-unresolved selector on a now-fully-known closed receiver stays a
+  **`Hint`**. Knowing more makes the Hint *trustworthy*; it does not make it an
+  error.
+
+This is the crux: **project scope buys precision, not strictness.** Strictness is
+a separate, explicit choice (Rule 3).
+
+### Rule 3 — Escalation is opt-in and per-category
+
+Promotion of soft diagnostics to build-failing `Error`s is never the default. It
+is requested explicitly:
+
+- `--warnings-as-errors` keeps its current meaning (promote `Warning`/`Hint` to
+  `Error`), and keeps excluding the gradual-migration categories
+  (`UnresolvedClass`, `UnresolvedFfi`, `ArityMismatch`, `Deprecation`).
+- `@expect dnu` / `@expect type` (ADR 0077) remain the site-level *down*-grade
+  (acknowledge-and-silence) for the irreducibly-dynamic call.
+- A future per-category strictness table in `beamtalk.toml` (e.g. treat `Dnu` as
+  `Error` in a mature application package) is the intended home for project-level
+  escalation. This ADR reserves the policy seam but does not define the schema —
+  that is a follow-up once project scope lands and real false-positive rates are
+  known.
+
+### What a user sees
+
+REPL — a typo on a closed receiver is a soft, navigable hint, and the expression
+still runs (the runtime raises the real DNU if reached):
+
+```beamtalk
+"hello" reverssed
+// hint: 'String' does not appear to understand #reverssed (did you mean #reversed?)
+// => the expression still compiles and runs; runtime raises doesNotUnderstand: if evaluated
+```
+
+Dynamic receiver — silence, because the checker cannot know:
+
+```beamtalk
+x := someApi fetchThing.   // x : Dynamic
+x wobble                   // no diagnostic — open world, may be understood at runtime
+```
+
+Provable failure on a closed union — a `Warning`, the strongest soft signal:
+
+```beamtalk
+n := flag ifTrue: [1] ifFalse: [2.0].   // n : Integer | Float
+n frobnicate
+// warning: no member of 'Integer | Float' understands #frobnicate
+```
+
+Opt-in strict build — the same hint, now fatal, by explicit request:
+
+```text
+$ beamtalk build --warnings-as-errors
+error: 'String' does not appear to understand #reverssed   (Dnu, promoted)
+```
+
+## Prior Art
+
+- **Smalltalk (Pharo/Squeak):** no static selector checking at all — an unknown
+  send becomes `doesNotUnderstand:` *at runtime*, often a teachable moment (the
+  debugger offers to create the method). Pure open world. Beamtalk keeps the
+  open-world *default* but adds a static **hint** layer Pharo lacks, without
+  making it fatal.
+- **Erlang Dialyzer (success typings):** the guiding analog. Dialyzer never warns
+  unless it can *prove* a call cannot succeed — it tolerates anything it cannot
+  disprove. Rule 1's "Warning only on provable failure, Hint otherwise, silent
+  when unknown" is success-typing applied to message sends.
+- **Elixir (`mix xref` / compiler warnings):** unresolved remote calls are
+  *warnings*, not errors, and dynamic dispatch (`apply/3`) is exempt — the same
+  "soft by default, dynamic is invisible" posture.
+- **Gleam:** the opposite pole — sound static types, closed world, unresolved =
+  hard compile error. Deliberately *rejected* as a default here: it is incoherent
+  with `doesNotUnderstand:`, runtime extensions, and hot reload. It is, however,
+  what Rule 3's opt-in strict mode approximates for teams who want it.
+- **TypeScript:** gradual typing with **opt-in strictness flags**
+  (`noImplicitAny`, `strict`). Directly inspires Rule 3 — the language ships
+  permissive, and severity is dialled up per-project by explicit configuration,
+  not by the checker getting cleverer.
+
+What we adopt: Dialyzer's provability bar (Rule 1) and TypeScript's opt-in
+escalation (Rule 3). What we reject: Gleam's closed-world fatality as a default.
+
+## User Impact
+
+- **Newcomer (from Python/JS/Ruby):** gets a gentle, navigable hint on typos
+  ("did you mean #reversed?") without the build breaking — matches the
+  exploratory feel they expect, and the runtime still raises a clear DNU if they
+  run it. They are never blocked by the checker disagreeing with valid dynamic
+  code they copied from a tutorial.
+- **Smalltalk developer:** the open-world default is *familiar and correct* —
+  `doesNotUnderstand:` is sacred, and the checker never pretends a send is
+  illegal just because it can't see the implementor. The added static hint is a
+  bonus over Pharo, not a constraint.
+- **Erlang/BEAM developer:** the success-typing posture is exactly Dialyzer's,
+  which they already trust; "warn only when provably wrong" reads as correct and
+  low-noise. Opt-in `--warnings-as-errors` fits CI gating habits.
+- **Production operator:** no behavioural change to running code — diagnostics are
+  a build/edit-time concern. Hot reload and live patches are never blocked by a
+  stale static view, because the static layer is non-fatal by default and the
+  live image is authoritative (ADR 0024).
+- **Tooling developer (LSP/MCP):** a stable `(severity, category)` contract per
+  diagnostic, with `Dnu` clearly separated, makes it trivial to render hints
+  distinctly from errors and to offer "create method" / "did you mean" actions.
+
+### Discoverability
+
+The `did you mean` note rides the existing `hint`/`notes` fields on `Diagnostic`,
+so editors and the REPL surface the suggestion without new infrastructure. The
+`@expect` directive (ADR 0077) is the discoverable, in-source way to mark a send
+as intentionally dynamic.
+
+## Steelman Analysis
+
+### Option B — Escalate to Warning when statically complete
+
+- 🧑‍💻 **Newcomer:** "A yellow squiggle is more visible than a grey hint — I'd
+  notice my typo sooner."
+- 🎩 **Smalltalk purist:** "If you've *proven* the receiver is closed and lacks
+  the method, that's as real as a union failure — treat it the same."
+- ⚙️ **BEAM veteran:** "Dialyzer surfaces provable failures as warnings, not
+  notes; a complete closed receiver is provable, so Warning is the honest level."
+- 🏭 **Operator:** "Warnings show up in CI summaries; hints get lost."
+- 🎨 **Language designer:** "Severity tracking certainty argues that *maximum*
+  certainty (closed + complete) deserves the higher soft level."
+
+This is the strongest competitor and the tension is real: a *complete closed*
+receiver is arguably as provable as the union case that already warns. It was not
+chosen as the default because (a) a single concrete receiver still has the
+`perform:`/extension/hot-reload escape that a frozen union analysis less commonly
+hits in practice, (b) raising the floor the moment project-scope lands would make
+WS1/WS2 *feel* like a regression ("why did my hints become warnings?"), violating
+Rule 2's promise that precision ≠ strictness, and (c) anyone who wants this can
+get it per-category via Rule 3. If post-WS1 false-positive rates prove low, the
+default ceiling for the closed-complete case can be revisited — the policy seam
+(Rule 3) is where that lever lives.
+
+### Option C — Hard error when statically complete (Gleam-style)
+
+- 🧑‍💻 **Newcomer:** "Other languages I know just tell me it's wrong — no
+  ambiguity."
+- 🎩 **Smalltalk purist:** (cannot honestly steelman — fatal static rejection
+  contradicts `doesNotUnderstand:`; the strongest they'd offer is "for a *sealed*
+  Value class with no DNU handler, it truly cannot be understood.")
+- ⚙️ **BEAM veteran:** "A guaranteed-crash call is worth failing the build over."
+- 🏭 **Operator:** "I want CI red on provable bugs."
+- 🎨 **Language designer:** "Soundness where soundness is achievable."
+
+Rejected as a default: it breaks the language's open-world guarantee and the
+live-augmented model (a file that fails static checking in isolation may resolve
+against the running image). The legitimate piece of this — sealed `Value` classes
+with no DNU handler are a genuinely closed sub-world — is precisely the kind of
+narrow rule Rule 3's opt-in table can encode later, not a global default.
+
+### Tension points
+
+- **Hint vs Warning for the closed-complete case** is the one place reasonable
+  people disagree (Option B). Resolved in favour of Hint to keep Rule 2's
+  "project scope buys precision, not strictness" promise, with the escalation lever
+  explicitly preserved.
+- **BEAM veterans/operators lean stricter; Smalltalkers/newcomers lean softer.**
+  Rule 3 (opt-in per-category escalation) is the release valve that lets both
+  camps get what they want without a global default that hurts the other.
+
+## Alternatives Considered
+
+### Promote unresolved selectors to Warning/Error by default
+Covered as Options B/C above — rejected as defaults, preserved as opt-in (Rule 3).
+
+### Keep the cross-file-parent suppression permanently
+Rejected. It is an incompleteness workaround, not a policy: it silences *real*
+typos whenever a class happens to have an out-of-file parent. Project scope (WS2)
+removes the incompleteness, so the workaround should go with it (Rule 2), not
+calcify into the contract.
+
+### One global strictness flag only (no categories)
+Rejected. `UnresolvedClass`/`UnresolvedFfi`/`ArityMismatch` already need
+independent migration treatment (they are excluded from `--warnings-as-errors`
+today). A category-aware policy is already a de-facto requirement; this ADR names
+it rather than inventing it.
+
+## Consequences
+
+### Positive
+- A written, principled rule the project-scope work (WS1/WS2) and any future
+  strict mode build against, instead of escalating severity ad hoc.
+- Fewer false positives after WS1/WS2: same-project cross-file extensions resolve
+  for real, so today's false `Dnu` hints disappear (Rule 2).
+- The open-world contract (`doesNotUnderstand:`, `perform:`, extensions, hot
+  reload) is never violated by a default — preserving ADR 0024 and ADR 0066.
+- Clear `(severity, category)` semantics for LSP/MCP rendering and `@expect`.
+
+### Negative
+- A real typo on a closed receiver stays a *hint* by default — quieter than some
+  users (Option B/C steelman) would prefer. Mitigated by `did you mean` notes and
+  opt-in escalation.
+- Defers the per-category strictness schema to a follow-up, so "make `Dnu` fatal
+  for this package" is not yet expressible beyond the global flag.
+
+### Neutral
+- No change to runtime behaviour or generated code — purely a build/edit-time
+  diagnostic policy.
+- Largely codifies and rationalises existing behaviour; the only near-term code
+  change is removing the cross-file-parent suppression once WS2 lands.
+
+## Implementation
+
+This ADR is policy; the code changes ride the BT-2251 workstreams.
+
+- **Semantic analysis** (`crates/beamtalk-core/src/semantic_analysis/type_checker/`):
+  centralise the severity decision behind the completeness ladder (Rule 1) so
+  `validation.rs` / `inference.rs` consult one place rather than scattered
+  `Diagnostic::hint` / `::warning` calls. Introduce an explicit
+  "receiver knowledge" notion (`Dynamic` / `Open` / `ClosedComplete`) that the
+  send-checker switches on.
+- **Remove the cross-file-parent suppression** when project-wide hierarchy (WS2)
+  and project-wide extension registration (WS1) are in place — resolution
+  replaces suppression (Rule 2).
+- **Escalation** (`crates/beamtalk-cli/src/beam_compiler.rs`): no change to
+  `--warnings-as-errors` now; the `beamtalk.toml` per-category table (Rule 3) is a
+  separate, later issue.
+- **No runtime/codegen changes.**
+
+## References
+- Related issues: BT-2251 (epic: project-scoped compilation & type-checking;
+  WS5 is this policy), BT-2250, BT-2228
+- Related ADRs: ADR 0024 (static-first, live-augmented tooling), ADR 0066 (open
+  class extension methods), ADR 0077 (type coverage visibility / `@expect`),
+  ADR 0070 (package namespaces & dependencies — cross-package interface)
+- Prior art: Erlang Dialyzer success typings; TypeScript `strict` flags; Elixir
+  `mix xref`; Gleam (closed-world contrast)

--- a/docs/ADR/0100-open-world-diagnostic-policy.md
+++ b/docs/ADR/0100-open-world-diagnostic-policy.md
@@ -115,6 +115,13 @@ never misreported:
   dependency type whose *extension* metadata has not been loaded (pre-WS3, see
   ADR 0070 amendment). The checker must treat "I have the class but maybe not all
   its extensions" as `Open`, not `ClosedComplete` (see Rule 2 sequencing).
+  Note the scope this implies: because *any* class — including stdlib `String`,
+  `Integer`, `Array` — can be extended by a dependency, until WS3 loads
+  cross-package extension metadata the only receivers that reach `ClosedComplete`
+  are classes the checker can confirm are dependency-extension-free (in practice,
+  classes local to a package with no dependencies). So WS1/WS2 alone deliver the
+  `Hint` precision benefit only for local, dependency-free types; the full benefit
+  for stdlib and imported types waits on WS3. This is intentional, not a gap.
 
 Because severity hinges entirely on this classification, the
 `Dynamic`/`Open`/`ClosedComplete` decision MUST be made in **one shared place** so
@@ -192,10 +199,11 @@ final disposition is resolved most-specific-wins, in this order:
 
 `--warnings-as-errors` is a **final promotion pass**, not a competing base
 severity: after 1–3 resolve a diagnostic to `Warning`/`Hint`, the flag promotes it
-to `Error` (minus the gradual-migration exclusions). So `[lints] dnu = "ignore"`
-removes the diagnostic before the flag ever sees it, while `[lints] dnu = "warn"`
-plus `--warnings-as-errors` yields an error. This keeps the flag's meaning ("treat
-what remains as fatal") intact and orthogonal to the base policy.
+to `Error` (minus the gradual-migration exclusions). So a `dnu = "ignore"` table
+entry removes the diagnostic before the flag ever sees it, while `dnu = "warn"`
+plus `--warnings-as-errors` yields an error (the `beamtalk.toml` keys here are
+illustrative — the actual schema is deferred, per Rule 3). This keeps the flag's
+meaning ("treat what remains as fatal") intact and orthogonal to the base policy.
 
 ### What a user sees
 

--- a/docs/ADR/0100-open-world-diagnostic-policy.md
+++ b/docs/ADR/0100-open-world-diagnostic-policy.md
@@ -99,6 +99,28 @@ or `Warning` only when failure is *provable* (the union case). This mirrors
 Dialyzer's success-typing stance: complain only when a call can be *shown* to
 fail, stay quiet otherwise.
 
+**Classification is conservative — when in doubt, classify *down*.** A receiver is
+`ClosedComplete` only when the checker can enumerate its *entire* method surface
+with certainty. The following force a downgrade to `Open` (→ silent), so they are
+never misreported:
+
+- **Any `Dynamic` in a union** (`Integer | Dynamic`) downgrades the *whole* union
+  to `Open`. The checker does not emit per-arm hints on a mixed union — a partial
+  "hint on the `Integer` arm, silence on the `Dynamic` arm" is more confusing than
+  useful, and the `Dynamic` arm could be the one that flows at runtime.
+- **A receiver that is also the target of `perform:` / reflective dispatch** in
+  scope is `Open` for the reflectively-sent selectors — a typed receiver does not
+  become provably-closed just because it has a static type.
+- **A class whose method surface depends on data not yet loaded** — e.g. a
+  dependency type whose *extension* metadata has not been loaded (pre-WS3, see
+  ADR 0070 amendment). The checker must treat "I have the class but maybe not all
+  its extensions" as `Open`, not `ClosedComplete` (see Rule 2 sequencing).
+
+Because severity hinges entirely on this classification, the
+`Dynamic`/`Open`/`ClosedComplete` decision MUST be made in **one shared place** so
+`validation.rs` and `inference.rs` cannot disagree about the same call site
+(see Implementation).
+
 ### Rule 2 — Completeness improves accuracy, it does not raise severity
 
 When project-scoped compilation (BT-2251 WS1/WS2) gives the checker complete
@@ -119,6 +141,24 @@ resolution** — but the *default severity is unchanged*. Specifically:
 This is the crux: **project scope buys precision, not strictness.** Strictness is
 a separate, explicit choice (Rule 3).
 
+**Sequencing guard (important).** The incompleteness workarounds may be removed
+*only* once the knowledge that made them necessary actually exists — removing them
+early turns every previously-suppressed site into a fresh false positive. The
+binding order:
+
+1. The **cross-file-parent** suppression stays until project-wide hierarchy
+   assembly (WS2) is verified complete.
+2. A receiver whose class may carry **cross-package extensions** stays classified
+   `Open` (Rule 1) until cross-package extension metadata is loaded (WS3 / the
+   ADR 0070 amendment). Until then, a fully-known *intra-project* surface is **not**
+   sufficient to call such a receiver `ClosedComplete`, or the checker would emit a
+   `Hint` for a dependency-contributed method that genuinely exists.
+
+In other words: **suppression is removed per-receiver only when the checker can
+prove its surface is complete for *that* receiver**, not globally when "WS1 has
+landed." A feature flag gates the removal until the corresponding workstream is
+verified, so a partially-landed epic never regresses diagnostics.
+
 ### Rule 3 — Escalation is opt-in and per-category
 
 Promotion of soft diagnostics to build-failing `Error`s is never the default. It
@@ -134,6 +174,26 @@ is requested explicitly:
   escalation. This ADR reserves the policy seam but does not define the schema —
   that is a follow-up once project scope lands and real false-positive rates are
   known.
+
+**Precedence (so the sources never silently conflict).** A `Dnu` diagnostic's
+final disposition is resolved most-specific-wins, in this order:
+
+1. **Site-level `@expect dnu` / `@expect type`** (ADR 0077) — always wins; an
+   explicit acknowledgement at the call site silences it regardless of any global
+   setting. (A site that resolves after WS1/WS2 makes its `@expect` *stale*; ADR
+   0077 already warns on stale directives, so improved resolution self-reports the
+   now-dead annotation — no new mechanism needed.)
+2. **Per-category project table** (`beamtalk.toml`, future) — sets the category's
+   base severity for the package (`ignore` / `hint` / `warn` / `error`).
+3. **Rule 1 default** — the completeness-ladder severity, when nothing above
+   applies.
+
+`--warnings-as-errors` is a **final promotion pass**, not a competing base
+severity: after 1–3 resolve a diagnostic to `Warning`/`Hint`, the flag promotes it
+to `Error` (minus the gradual-migration exclusions). So `[lints] dnu = "ignore"`
+removes the diagnostic before the flag ever sees it, while `[lints] dnu = "warn"`
+plus `--warnings-as-errors` yields an error. This keeps the flag's meaning ("treat
+what remains as fatal") intact and orthogonal to the base policy.
 
 ### What a user sees
 
@@ -237,16 +297,26 @@ as intentionally dynamic.
 - 🎨 **Language designer:** "Severity tracking certainty argues that *maximum*
   certainty (closed + complete) deserves the higher soft level."
 
-This is the strongest competitor and the tension is real: a *complete closed*
-receiver is arguably as provable as the union case that already warns. It was not
-chosen as the default because (a) a single concrete receiver still has the
-`perform:`/extension/hot-reload escape that a frozen union analysis less commonly
-hits in practice, (b) raising the floor the moment project-scope lands would make
-WS1/WS2 *feel* like a regression ("why did my hints become warnings?"), violating
-Rule 2's promise that precision ≠ strictness, and (c) anyone who wants this can
-get it per-category via Rule 3. If post-WS1 false-positive rates prove low, the
-default ceiling for the closed-complete case can be revisited — the policy seam
-(Rule 3) is where that lever lives.
+This is the strongest competitor, and the tension is real — honestly, a complete
+closed receiver is *exactly as provable* as the union case that already warns. The
+distinction is **not** provability (claiming otherwise would be inconsistent: both
+rest on "every candidate class is closed and none responds"). The distinction is
+**blast radius and frequency**:
+
+- The "no union member responds" case is **rare** — it requires the user to have
+  written branching control flow whose arms disagree, then send a selector none of
+  them has. When it fires it is almost always a genuine bug, so `Warning` is
+  low-noise.
+- A bare send to a single concrete receiver is the **most common shape in the
+  language**. Making it `Warning`-by-default the instant WS1/WS2 land would convert
+  a large body of today's quiet hints into warnings overnight — the precise
+  "project scope feels like a regression" outcome Rule 2 promises to avoid.
+
+So the union `Warning` is retained as an existing, *narrow* aggressive case, and
+the common single-receiver case stays `Hint` — with escalation available
+per-category (Rule 3) for teams that want union-level strictness everywhere. If
+post-WS1 false-positive rates prove low, raising the closed-complete ceiling is a
+one-line change to that table, not a re-decision of this ADR.
 
 ### Option C — Hard error when statically complete (Gleam-style)
 
@@ -285,6 +355,18 @@ Rejected. It is an incompleteness workaround, not a policy: it silences *real*
 typos whenever a class happens to have an out-of-file parent. Project scope (WS2)
 removes the incompleteness, so the workaround should go with it (Rule 2), not
 calcify into the contract.
+
+### Route `Dnu` to the `Lint` channel instead of `Hint`
+A genuine option: emit unresolved-selector diagnostics at `Severity::Lint`
+(invisible in a normal `beamtalk build`, surfaced only by `beamtalk lint`) rather
+than `Hint` (always shown as an informational note). Lint gives a *stronger*
+opt-in separation than Hint — the default build is completely silent on
+unresolved sends. Rejected as the default because the typo-catching value of the
+hint is highest *in the editor, inline, as you type* (LSP surfaces `Hint`s;
+`Lint` implies a separate command run), and Smalltalkers expect the tool to point
+at a suspicious send immediately, not on a deferred lint pass. `Lint` remains
+available as a per-category choice under Rule 3 for teams who want unresolved
+sends out of the default build entirely.
 
 ### One global strictness flag only (no categories)
 Rejected. `UnresolvedClass`/`UnresolvedFfi`/`ArityMismatch` already need
@@ -333,6 +415,24 @@ This ADR is policy; the code changes ride the BT-2251 workstreams.
   `--warnings-as-errors` now; the `beamtalk.toml` per-category table (Rule 3) is a
   separate, later issue.
 - **No runtime/codegen changes.**
+
+## Migration Path
+
+This ADR mostly codifies existing behaviour, so most code needs no change. Two
+transitions warrant care:
+
+- **Teams already running `--warnings-as-errors`** will see *new* build failures
+  when WS1/WS2 land — not because their code changed, but because improved
+  resolution surfaces previously-*suppressed* true positives (e.g. a real typo on a
+  class that happened to have a cross-file parent). This is a genuine, if benign,
+  tightening. Mitigation: WS1/WS2 ship behind the Rule 2 sequencing flag, and the
+  workstream that flips it should call out the expected new diagnostics in its
+  changelog so CI breakage is anticipated, not mysterious. Affected sites are fixed
+  by correcting the selector or adding `@expect dnu` where the send is intentionally
+  dynamic.
+- **Stale `@expect` directives**: a site that becomes resolvable after WS1/WS2 has a
+  now-unnecessary `@expect`; ADR 0077's stale-directive warning flags these
+  automatically, so cleanup is mechanical and self-surfacing.
 
 ## References
 - Related issues: BT-2251 (epic: project-scoped compilation & type-checking;

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -126,6 +126,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0097](0097-desktop-attach-client-node-per-workspace.md) | Desktop Attach Client — One Front Node per Workspace | Proposed | 2026-06-13 |
 | [0098](0098-build-artifact-provenance.md) | Build Artifact Provenance and Version-Based Staleness Invalidation | Accepted | 2026-06-23 |
 | [0099](0099-cli-application-story.md) | CLI Application Story — Console, Arguments, Exit, and Packaging | Accepted | 2026-06-26 |
+| [0100](0100-open-world-diagnostic-policy.md) | Open-World Diagnostic Policy for Unresolved Selectors and Classes | Proposed | 2026-06-27 |
 
 > ADR 0086 was originally numbered 0069 (a collision with *Actor Observability and Tracing*) and was renumbered on 2026-05-25.
 


### PR DESCRIPTION
Part of epic [BT-2251](https://linear.app/beamtalk/issue/BT-2251) — project-scoped compilation & type-checking. Documents two of the epic's workstreams as architecture decisions before implementation.

## Summary

- **ADR 0100 (new, Proposed) — Open-World Diagnostic Policy** (WS5): codifies the severity policy for unresolved selectors/classes under Beamtalk's open world. Three rules: (1) knowledge gates severity — a completeness ladder from silent (Dynamic) → `Hint` (closed-complete) → `Warning` (provably-failing union); (2) project scope buys *precision, not strictness* — improved resolution removes false positives but does not raise default severity; (3) escalation to build-failing errors is always opt-in and per-category, with a defined precedence chain.
- **ADR 0070 §7 amendment (WS3) — cross-package extension interface**: a package's open-class extensions (ADR 0066) are exported to a consumer's type checker via the existing `__beamtalk_meta/0` channel (canonical) with a lightweight `.app` index — no new artifact. Includes a duplicate-extension conflict policy and corrects the visibility semantics (extensions always dispatch at runtime).

## Key changes

- `docs/ADR/0100-open-world-diagnostic-policy.md` — new ADR.
- `docs/ADR/0070-package-namespaces-and-dependencies.md` — amendment to §7.
- `docs/ADR/README.md` — index entry for 0100.

## Provenance / review

Both ADRs were factually verified against the current checker (`validation.rs`, `inference.rs`, `beam_compiler.rs`) and revised after an adversarial review pass: conservative receiver classification, a sequencing guard for suppression removal, a severity-source precedence chain, an explicit cross-package extension conflict policy, and a single-source-of-truth fix for the metadata channel.

Docs-only change; no code, runtime, or codegen impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMiYT4zdtpEssoLCw4oyEP)_