### PR TITLE
Replace duplicated temp-dir helpers with beamtalk_file:tempDirectory in runtime tests

### DIFF
--- a/runtime/apps/beamtalk_compiler/test/beamtalk_build_worker_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_build_worker_tests.erl
@@ -180,21 +180,8 @@ handle_read_specs_crash_caught_test() ->
 %%% ---------------------------------------------------------------
 
 setup_temp_dir() ->
-    TmpBase =
-        case os:getenv("TMPDIR") of
-            false ->
-                case os:getenv("TEMP") of
-                    false -> "/tmp";
-                    "" -> "/tmp";
-                    WinDir -> WinDir
-                end;
-            "" ->
-                "/tmp";
-            Dir ->
-                Dir
-        end,
     TmpDir = filename:join([
-        TmpBase,
+        binary_to_list(beamtalk_file:'tempDirectory'()),
         "beamtalk_build_worker_test_" ++
             integer_to_list(erlang:unique_integer([positive]))
     ]),

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_spec_reader_tests.erl
@@ -1450,13 +1450,8 @@ map_type_remote_type_no_context_resolves_test() ->
 %%% ---------------------------------------------------------------
 
 make_tmp_dir() ->
-    TmpBase =
-        case os:getenv("TMPDIR") of
-            false -> "/tmp";
-            Dir -> Dir
-        end,
     TmpDir = filename:join(
-        TmpBase,
+        binary_to_list(beamtalk_file:'tempDirectory'()),
         "bt_spec_reader_test_" ++ integer_to_list(erlang:unique_integer([positive]))
     ),
     ok = filelib:ensure_dir(filename:join(TmpDir, "x")),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_module_activation_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_module_activation_tests.erl
@@ -737,16 +737,7 @@ create_temp_dir() ->
     Base.
 
 -doc "Platform-agnostic temp directory.".
-get_tmp_base() ->
-    case os:getenv("TMPDIR") of
-        false ->
-            case os:getenv("TEMP") of
-                false -> "/tmp";
-                Dir -> Dir
-            end;
-        Dir ->
-            Dir
-    end.
+get_tmp_base() -> binary_to_list(beamtalk_file:'tempDirectory'()).
 
 remove_temp_dir(Dir) ->
     case file:list_dir(Dir) of

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
@@ -15,17 +15,7 @@ Tests expression evaluation, file loading, and compilation.
 %% Helpers
 %%====================================================================
 
-%% Cross-platform temp directory (TMPDIR on Unix, TEMP on Windows)
-temp_dir() ->
-    case os:getenv("TMPDIR") of
-        false ->
-            case os:getenv("TEMP") of
-                false -> "/tmp";
-                Dir -> Dir
-            end;
-        Dir ->
-            Dir
-    end.
+temp_dir() -> binary_to_list(beamtalk_file:'tempDirectory'()).
 
 %%====================================================================
 %% Tests

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
@@ -11,16 +11,7 @@
 %% Helpers
 %%====================================================================
 
-temp_dir() ->
-    case os:getenv("TMPDIR") of
-        false ->
-            case os:getenv("TEMP") of
-                false -> "/tmp";
-                Dir -> Dir
-            end;
-        Dir ->
-            Dir
-    end.
+temp_dir() -> binary_to_list(beamtalk_file:'tempDirectory'()).
 
 %%====================================================================
 %% is_stdlib_path/1

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_bootstrap_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_bootstrap_tests.erl
@@ -616,16 +616,7 @@ find_bt_modules_skips_invalid_names_test() ->
 %% Test helpers for temp directories
 %%====================================================================
 
-get_temp_dir() ->
-    case os:getenv("TMPDIR") of
-        false ->
-            case os:getenv("TEMP") of
-                false -> "/tmp";
-                Temp -> Temp
-            end;
-        TmpDir ->
-            TmpDir
-    end.
+get_temp_dir() -> binary_to_list(beamtalk_file:'tempDirectory'()).
 
 make_temp_beam_dir(FileNames) ->
     Dir = filename:join(

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_interface_primitives_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_interface_primitives_tests.erl
@@ -35,22 +35,7 @@ Tests the Phase 2 dispatch/3 interface for WorkspaceInterface primitives:
 fake_self(Pid) ->
     {beamtalk_object, 'WorkspaceInterface', 'bt@stdlib@workspace_interface', Pid}.
 
-%% Cross-platform temporary directory (Windows has no /tmp).
-tmp_dir() ->
-    case os:type() of
-        {win32, _} ->
-            case os:getenv("TEMP") of
-                false ->
-                    case os:getenv("TMP") of
-                        false -> ".";
-                        Tmp -> Tmp
-                    end;
-                Temp ->
-                    Temp
-            end;
-        _ ->
-            "/tmp"
-    end.
+tmp_dir() -> binary_to_list(beamtalk_file:'tempDirectory'()).
 
 %% Create a unique empty directory under tmp_dir().
 make_empty_tmp_dir(Prefix) ->


### PR DESCRIPTION
## Summary

Seven test files across `beamtalk_runtime`, `beamtalk_workspace`, and `beamtalk_compiler` each implemented their own 9–20 line OS environment-variable scan to locate the system temp directory, with `/tmp` hardcoded as the Unix fallback. This pattern violates the CLAUDE.md rule *"Never hardcode `/tmp/`. Use `beamtalk_file:'tempDirectory'()` (Erlang)"*.

- Replace every local helper body with a one-liner delegating to `beamtalk_file:'tempDirectory'/0`, the canonical cross-platform API in `beamtalk_stdlib`
- Helpers that returned charlists call `binary_to_list/1` to preserve their return type
- Helpers that also created the directory (e.g. `setup_temp_dir/0`, `make_tmp_dir/0`) keep that logic; only the base-path detection is removed
- Net: −77 lines / +7 lines across 7 files

## Files changed

| File | Helper replaced |
|---|---|
| `beamtalk_runtime/test/beamtalk_module_activation_tests.erl` | `get_tmp_base/0` |
| `beamtalk_workspace/test/beamtalk_workspace_bootstrap_tests.erl` | `get_temp_dir/0` |
| `beamtalk_workspace/test/beamtalk_repl_eval_tests.erl` | `temp_dir/0` |
| `beamtalk_workspace/test/beamtalk_repl_loader_tests.erl` | `temp_dir/0` |
| `beamtalk_workspace/test/beamtalk_workspace_interface_primitives_tests.erl` | `tmp_dir/0` |
| `beamtalk_compiler/test/beamtalk_build_worker_tests.erl` | `setup_temp_dir/0` (base-path only) |
| `beamtalk_compiler/test/beamtalk_spec_reader_tests.erl` | `make_tmp_dir/0` (base-path only) |

## Test plan

- [x] `just test-runtime` — 5165 + 1582 tests, 0 failures
- [x] `just fmt` — all files pass erlfmt check
- [x] Pre-push hooks — clippy, Rust fmt, Dialyzer, Erlang fmt all green

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWV2bbJZbR7H4gkHij3Exg)_