### PR TITLE
test(codegen): snapshot tests for enumeration_ops.rs eachWithIndex/do:separatedBy desugar

### DIFF
--- a/test-package-compiler/cases/actor_enumeration_ops/main.bt
+++ b/test-package-compiler/cases/actor_enumeration_ops/main.bt
@@ -1,0 +1,43 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Snapshot test for BT-2703 enumeration desugar codegen (enumeration_ops.rs),
+// actor context.
+//
+// `eachWithIndex:` and `do:separatedBy:` are desugared to `inject:into:` when
+// a block mutates state. Without snapshot tests the entire enumeration_ops.rs
+// was at 0% Rust coverage despite BUnit tests exercising the runtime behaviour
+// (BUnit runs via `beamtalk test`, not `cargo test`).
+//
+// In an actor method, finalize_enumeration_fold re-projects the fold's
+// {Acc, NewState} tuple to {'nil', element(2, EnumFold)}.
+//
+// Covers:
+//   try_generate_each_with_index   — field mutation → desugar fires
+//   try_generate_do_separated_by   — element-block mutation
+//                                    separator-block-only mutation (outer local)
+//   finalize_enumeration_fold      — actor re-projection path
+
+Actor subclass: EnumerationActor
+  state: total :: Integer = 0
+
+  // try_generate_each_with_index: field mutation in block → desugar fires.
+  // Accumulates item * 1-based-index into self.total; returns the updated total.
+  sumWithIndex: coll =>
+    coll eachWithIndex: [:item :i | self.total := self.total + (item * i)]
+    self.total
+
+  // try_generate_do_separated_by: element block mutates field → desugar fires.
+  // The separator block also mutates the field (adds 100 per gap between elements).
+  joinSum: coll =>
+    coll do: [:item |
+      self.total := self.total + item
+    ] separatedBy: [self.total := self.total + 100]
+    self.total
+
+  // try_generate_do_separated_by: only the separator block mutates an outer local.
+  // The element block is pure; separator increments `gaps` per gap.
+  gapCount: coll =>
+    gaps := 0
+    coll do: [:item | item] separatedBy: [gaps := gaps + 1]
+    gaps

--- a/test-package-compiler/cases/value_enumeration_ops/main.bt
+++ b/test-package-compiler/cases/value_enumeration_ops/main.bt
@@ -1,0 +1,22 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Snapshot test for BT-2703 enumeration desugar codegen (enumeration_ops.rs),
+// value-type context.
+//
+// In a value-type method, finalize_enumeration_fold takes the non-actor
+// (passthrough) branch: the fold result is the un-annotated inject:into: send,
+// and the outer call-site annotation is the only one.
+//
+// Covers:
+//   try_generate_each_with_index  — local variable mutation in a Value context
+//   finalize_enumeration_fold     — non-actor passthrough path
+
+Value subclass: EnumerationValue
+
+  // try_generate_each_with_index: captured-local mutation → desugar fires.
+  // finalize_enumeration_fold takes the non-actor (passthrough) branch here.
+  sumWithIndex: coll =>
+    sum := 0
+    coll eachWithIndex: [:item :i | sum := sum + (item * i)]
+    sum

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_codegen.snap
@@ -1,0 +1,377 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: core_erlang
+---
+module 'actor_enumeration_ops' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2, 'handle_cast'/2, 'handle_call'/3, 'handle_info'/2, 'code_change'/3, 'terminate'/2, 'dispatch'/4, 'safe_dispatch'/3, 'method_table'/0, 'has_method'/1, 'class_name'/0, 'spawn'/0, 'spawn'/1, 'new'/0, 'new'/1, 'superclass'/0, '__beamtalk_meta'/0, 'class_supervisionSpec'/2, 'register_class'/0]
+  attributes ['behaviour' = ['gen_server'], 'on_load' = [{'register_class', 0}],
+     'beamtalk_class' = [{'EnumerationActor', 'Actor'}]]
+
+'start_link'/1 = fun (InitArgs) ->
+    call 'gen_server':'start_link'('actor_enumeration_ops', InitArgs, [])
+
+
+'start_link'/2 = fun (ServerName, InitArgs) ->
+    call 'gen_server':'start_link'(ServerName, 'actor_enumeration_ops', InitArgs, [])
+
+
+'spawn'/0 = fun () ->
+    case call 'beamtalk_actor':'safe_spawn'('actor_enumeration_ops', ~{}~) of
+        <{'ok', Pid}> when 'true' ->
+            let _InstReg = try call 'beamtalk_object_instances':'register'('EnumerationActor', Pid)
+                of _RegOk -> _RegOk
+                catch <_RegT, _RegE, _RegS> -> 'ok'
+            in
+            {'beamtalk_object', 'EnumerationActor', 'actor_enumeration_ops', Pid}
+        <{'error', Reason}> when 'true' ->
+            let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', 'EnumerationActor') in
+            let SpawnErr1 = call 'beamtalk_error':'with_selector'(SpawnErr0, 'spawn') in
+            let SpawnErr2 = call 'beamtalk_error':'with_hint'(SpawnErr1, Reason) in
+            call 'beamtalk_error':'raise'(SpawnErr2)
+    end
+
+
+'spawn'/1 = fun (InitArgs) ->
+    case call 'erlang':'is_map'(InitArgs) of
+        <'false'> when 'true' ->
+            let TypeErr0 = call 'beamtalk_error':'new'('type_error', 'EnumerationActor') in
+            let TypeErr1 = call 'beamtalk_error':'with_selector'(TypeErr0, 'spawnWith:') in
+            let TypeErr2 = call 'beamtalk_error':'with_hint'(TypeErr1, #{#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<68>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']])}#) in
+            call 'beamtalk_error':'raise'(TypeErr2)
+        <'true'> when 'true' ->
+            case call 'beamtalk_actor':'safe_spawn'('actor_enumeration_ops', InitArgs) of
+                <{'ok', Pid}> when 'true' ->
+                    let _InstReg = try call 'beamtalk_object_instances':'register'('EnumerationActor', Pid)
+                        of _RegOk -> _RegOk
+                        catch <_RegT, _RegE, _RegS> -> 'ok'
+                    in
+                    {'beamtalk_object', 'EnumerationActor', 'actor_enumeration_ops', Pid}
+                <{'error', Reason}> when 'true' ->
+                    let SpawnErr0 = call 'beamtalk_error':'new'('instantiation_error', 'EnumerationActor') in
+                    let SpawnErr1 = call 'beamtalk_error':'with_selector'(SpawnErr0, 'spawnWith:') in
+                    let SpawnErr2 = call 'beamtalk_error':'with_hint'(SpawnErr1, Reason) in
+                    call 'beamtalk_error':'raise'(SpawnErr2)
+            end
+    end
+
+
+'new'/0 = fun () ->
+    let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in
+    let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new') in
+    let Error2 = call 'beamtalk_error':'with_hint'(Error1, #{#<85>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']])}#) in
+    call 'beamtalk_error':'raise'(Error2)
+
+'new'/1 = fun (_InitArgs) ->
+    let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in
+    let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new:') in
+    let Error2 = call 'beamtalk_error':'with_hint'(Error1, #{#<85>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']])}#) in
+    call 'beamtalk_error':'raise'(Error2)
+
+'superclass'/0 = fun () -> 'Actor'
+
+
+'class_name'/0 = fun () -> 'EnumerationActor'
+
+
+'init'/1 = fun (InitArgs) ->
+    let _Marker = case call 'maps':'get'('__skip_initialize__', InitArgs, 'false') of
+        <'true'> when 'true' -> 'skipped'
+        <'false'> when 'true' ->
+            call 'erlang':'put'('$beamtalk_actor', 'actor_enumeration_ops')
+    end in
+    let DefaultState = ~{
+        '__class_mod__' => 'actor_enumeration_ops'
+        , 'total' => 0
+    }~
+    in let FinalState = call 'maps':'merge'(DefaultState, InitArgs)
+    in case call 'maps':'get'('__skip_initialize__', InitArgs, 'false') of
+        <'true'> when 'true' ->
+            let CleanState = call 'maps':'remove'('__skip_initialize__', FinalState) in
+            {'ok', CleanState}
+        <'false'> when 'true' ->
+            let _TelPid = call 'erlang':'self'() in
+            let _TelStart = call 'beamtalk_actor':'maybe_execute_telemetry'(['beamtalk', 'actor', 'lifecycle', 'start'], ~{}~, ~{'pid' => _TelPid, 'class' => 'actor_enumeration_ops'}~) in
+            {'ok', FinalState}
+    end
+
+
+'handle_continue'/2 = fun (Continue, State) ->
+    case Continue of
+        <'initialize'> when 'true' ->
+            let InitNewState = State in
+            {'noreply', InitNewState}
+        <_> when 'true' -> {'noreply', State}
+    end
+
+
+'handle_cast'/2 = fun (Msg, State) ->
+    case Msg of
+        <{'cast', CastSelector, CastArgs, CastPropCtx}> when 'true' ->
+            let _CastCtxOk = call 'beamtalk_actor':'restore_propagated_ctx'(CastPropCtx) in
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _CastDispatchResult = call 'actor_enumeration_ops':'safe_dispatch'(CastSelector, CastArgs, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _CastDispatchResult of
+                <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
+                    {'noreply', CastNewState}
+                <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
+                    let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
+                    let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+                <{'error', CastError, _CastState2}> when 'true' ->
+                    let CastErrMsg2 = call 'beamtalk_error':'format_safe'(CastError) in
+                    let _ = call 'logger':'warning'(CastErrMsg2, ~{'selector' => CastSelector, 'reason' => CastError, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+            end
+        <{'cast', CastSelector, CastArgs}> when 'true' ->
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _CastDispatchResult = call 'actor_enumeration_ops':'safe_dispatch'(CastSelector, CastArgs, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _CastDispatchResult of
+                <{'reply', _CastResult, CastNewState}> when 'true' ->
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
+                    {'noreply', CastNewState}
+                <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
+                    let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
+                    let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+                <{'error', CastError, _CastState2}> when 'true' ->
+                    let CastErrMsg2 = call 'beamtalk_error':'format_safe'(CastError) in
+                    let _ = call 'logger':'warning'(CastErrMsg2, ~{'selector' => CastSelector, 'reason' => CastError, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
+                    in {'noreply', State}
+            end
+        <_> when 'true' -> {'noreply', State}
+    end
+
+
+'handle_call'/3 = fun (Msg, _From, State) ->
+    case Msg of
+        <{Selector, Args, PropCtx}> when 'true' ->
+            let _CtxOk = call 'beamtalk_actor':'restore_propagated_ctx'(PropCtx) in
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _DispatchResult = call 'actor_enumeration_ops':'safe_dispatch'(Selector, Args, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _DispatchResult of
+                <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
+                    {'reply', {'ok', Result}, NewState}
+                <{'error', Error, ErrState}> when 'true' ->
+                    {'reply', {'error', Error}, ErrState}
+            end
+        <{Selector, Args}> when 'true' ->
+            let _OldState = call 'erlang':'get'('$bt_actor_state') in
+            let _PutOk = call 'erlang':'put'('$bt_actor_state', State) in
+            let _DispatchResult = call 'actor_enumeration_ops':'safe_dispatch'(Selector, Args, State) in
+            let _RestoreOk = case _OldState of
+                <'undefined'> when 'true' ->
+                    call 'erlang':'erase'('$bt_actor_state')
+                <_Prev> when 'true' ->
+                    call 'erlang':'put'('$bt_actor_state', _Prev)
+            end in
+            let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
+            case _DispatchResult of
+                <{'reply', Result, NewState}> when 'true' ->
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
+                    {'reply', {'ok', Result}, NewState}
+                <{'error', Error, ErrState}> when 'true' ->
+                    {'reply', {'error', Error}, ErrState}
+            end
+    end
+
+
+'handle_info'/2 = fun (Msg, State) ->
+    call 'beamtalk_actor':'handle_info'(Msg, State)
+
+
+'code_change'/3 = fun (OldVsn, State, Extra) ->
+    call 'beamtalk_hot_reload':'code_change'(OldVsn, State, Extra)
+
+
+'terminate'/2 = fun (Reason, State) ->
+    let _TelPid = call 'erlang':'self'() in
+    let _TelStop = call 'beamtalk_actor':'maybe_execute_telemetry'(['beamtalk', 'actor', 'lifecycle', 'stop'], ~{}~, ~{'pid' => _TelPid, 'class' => 'actor_enumeration_ops', 'reason' => Reason}~) in
+    %% Call terminate: method if defined — exceptions must not prevent shutdown
+    let Self = call 'beamtalk_actor':'make_self'(State) in
+    let _TermDisp = try call 'actor_enumeration_ops':'dispatch'('terminate:', [Reason], Self, State)
+        of _TermOk -> 'ok'
+        catch <_TermT, _TermE, _TermS> -> 'ok'
+    in 'ok'
+
+
+'safe_dispatch'/3 = fun (Selector, Args, State) ->
+    let Self = call 'beamtalk_actor':'make_self'(State) in
+    try call 'actor_enumeration_ops':'dispatch'(Selector, Args, Self, State)
+    of Result -> Result
+    catch <Type, Error, Stacktrace> -> {'error', {Type, Error, Stacktrace}, State}
+
+
+'dispatch'/4 = fun (Selector, Args, Self, State) ->
+    case Selector of
+        <'sumWithIndex:'> when 'true' ->
+            case Args of
+                <[_coll1]> when 'true' ->
+                    let _Tuple2 = let _EnumFold17 = let _temp3 = _coll1 in let _temp4 = case call 'erlang':'is_list'(_temp3) of <'true'> when 'true' -> _temp3 <'false'> when 'true' -> call 'beamtalk_collection':'to_list'(_temp3) end in let _temp5 = 1 in let _temp6 = fun (Item, _AccSt7) -> let Acc = call 'erlang':'element'(1, _AccSt7) in let StateAcc = call 'erlang':'element'(2, _AccSt7) in let _Val8 = call 'erlang':'+'(call 'maps':'get'('total', StateAcc), let _BinLeft9 = Item in let _BinRight10 = Acc in case call 'erlang':'is_number'(_BinLeft9) of <'true'> when 'true' -> call 'erlang':'*'(_BinLeft9, _BinRight10) <'false'> when 'true' -> call 'beamtalk_message_dispatch':'send'(_BinLeft9, '*', [_BinRight10]) end) in let StateAcc1 = call 'maps':'put'('total', _Val8, StateAcc) in let _AccOut11 = let _BinLeft12 = Acc in let _BinRight13 = 1 in case call 'erlang':'is_number'(_BinLeft12) of <'true'> when 'true' -> call 'erlang':'+'(_BinLeft12, _BinRight13) <'false'> when 'true' -> call 'beamtalk_message_dispatch':'send'(_BinLeft12, '+', [_BinRight13]) end in {_AccOut11, StateAcc1} in let _temp14 = call 'lists':'foldl'(_temp6, {_temp5, State}, _temp4) in let _AccOut15 = call 'erlang':'element'(1, _temp14) in let _StOut16 = call 'erlang':'element'(2, _temp14) in {_AccOut15, _StOut16} in {'nil', call 'erlang':'element'(2, _EnumFold17)} in let State1 = call 'erlang':'element'(2, _Tuple2) in let _Result = call 'maps':'get'('total', State1) in {'reply', _Result, State1}
+                <_> when 'true' -> {'reply', {'error', 'bad_arity'}, State}
+            end
+        <'joinSum:'> when 'true' ->
+            case Args of
+                <[_coll18]> when 'true' ->
+                    let _Tuple19 = let _EnumFold34 = let _temp21 = _coll18 in let _temp22 = case call 'erlang':'is_list'(_temp21) of <'true'> when 'true' -> _temp21 <'false'> when 'true' -> call 'beamtalk_collection':'to_list'(_temp21) end in let _temp23 = 'true' in let _temp24 = fun (Item, _AccSt25) -> let Acc = call 'erlang':'element'(1, _AccSt25) in let StateAcc = call 'erlang':'element'(2, _AccSt25) in let _CondResult26 = let _Cond27 = Acc in case _Cond27 of <'true'> when 'true' -> {'nil', StateAcc} <'false'> when 'true' -> let StateAcc = StateAcc in let _Val28 = call 'erlang':'+'(call 'maps':'get'('total', StateAcc), 100) in let StateAcc1 = call 'maps':'put'('total', _Val28, StateAcc) in {_Val28, StateAcc1} end in let StateAcc1 = call 'erlang':'element'(2, _CondResult26) in let _Val29 = call 'erlang':'+'(call 'maps':'get'('total', StateAcc1), Item) in let StateAcc2 = call 'maps':'put'('total', _Val29, StateAcc1) in let _AccOut30 = 'false' in {_AccOut30, StateAcc2} in let _temp31 = call 'lists':'foldl'(_temp24, {_temp23, State}, _temp22) in let _AccOut32 = call 'erlang':'element'(1, _temp31) in let _StOut33 = call 'erlang':'element'(2, _temp31) in {_AccOut32, _StOut33} in {'nil', call 'erlang':'element'(2, _EnumFold34)} in let State1 = call 'erlang':'element'(2, _Tuple19) in let _Result = call 'maps':'get'('total', State1) in {'reply', _Result, State1}
+                <_> when 'true' -> {'reply', {'error', 'bad_arity'}, State}
+            end
+        <'gapCount:'> when 'true' ->
+            case Args of
+                <[_coll35]> when 'true' ->
+                    let Gaps = 0 in let _Tuple36 = let _EnumFold54 = let _Packed43 = call 'maps':'put'('__local__gaps', Gaps, State) in let _temp38 = _coll35 in let _temp39 = case call 'erlang':'is_list'(_temp38) of <'true'> when 'true' -> _temp38 <'false'> when 'true' -> call 'beamtalk_collection':'to_list'(_temp38) end in let _temp40 = 'true' in let _temp41 = fun (Item, _AccSt42) -> let Acc = call 'erlang':'element'(1, _AccSt42) in let StateAcc = call 'erlang':'element'(2, _AccSt42) in let Gaps = call 'maps':'get'('__local__gaps', StateAcc) in let _CondResult44 = let _SeededState46 = call 'maps':'put'('__local__gaps', Gaps, StateAcc) in let _Cond45 = Acc in case _Cond45 of <'true'> when 'true' -> {'nil', _SeededState46} <'false'> when 'true' -> let StateAcc = _SeededState46 in let _Val47 = let _BinLeft48 = Gaps in let _BinRight49 = 1 in case call 'erlang':'is_number'(_BinLeft48) of <'true'> when 'true' -> call 'erlang':'+'(_BinLeft48, _BinRight49) <'false'> when 'true' -> call 'beamtalk_message_dispatch':'send'(_BinLeft48, '+', [_BinRight49]) end in let StateAcc1 = call 'maps':'put'('__local__gaps', _Val47, StateAcc) in {_Val47, StateAcc1} end in let StateAcc1 = call 'erlang':'element'(2, _CondResult44) in let _ = Item in let _AccOut50 = 'false' in {_AccOut50, StateAcc1} in let _temp51 = call 'lists':'foldl'(_temp41, {_temp40, _Packed43}, _temp39) in let _AccOut52 = call 'erlang':'element'(1, _temp51) in let _StOut53 = call 'erlang':'element'(2, _temp51) in let Gaps = call 'maps':'get'('__local__gaps', _StOut53) in {_AccOut52, _StOut53} in {'nil', call 'erlang':'element'(2, _EnumFold54)} in let State1 = call 'erlang':'element'(2, _Tuple36) in let Gaps = call 'maps':'get'('__local__gaps', State1) in let _Result = Gaps in {'reply', _Result, State1}
+                <_> when 'true' -> {'reply', {'error', 'bad_arity'}, State}
+            end
+        <OtherSelector> when 'true' ->
+            %% BT-229/ADR 0005: Check extension registry before hierarchy walk
+            let ExtLookup = try call 'beamtalk_extensions':'lookup'('EnumerationActor', OtherSelector)
+                of ExtLookupResult -> ExtLookupResult
+                catch <_EType, _EReason, _EStack> -> 'not_found'
+            in
+            case ExtLookup of
+                <{'ok', ExtFun, _ExtOwner}> when 'true' ->
+                    %% BT-1512/BT-2250: Invoke via the runtime helper, which
+                    %% accepts both the 3-arity actor shape
+                    %% (fun(Args, Self, State) -> {Result, NewState}) and the
+                    %% 2-arity value shape (fun(Args, Self) -> Result), so a
+                    %% foreign extension whose codegen-time arity could not be
+                    %% resolved still dispatches correctly. Returns {reply, _, _}.
+                    call 'beamtalk_dispatch':'invoke_extension'(ExtFun, Args, Self, State)
+                <'not_found'> when 'true' ->
+                    %% ADR 0006: Try hierarchy walk before DNU
+                    case call 'beamtalk_dispatch':'super'(OtherSelector, Args, Self, State, 'EnumerationActor') of
+                        <{'reply', InheritedResult, InheritedState}> when 'true' ->
+                            {'reply', InheritedResult, InheritedState}
+                        <{'error', _DispatchError}> when 'true' ->
+                            %% Not in hierarchy - try doesNotUnderstand:args: (BT-29)
+                            let DnuSelector = 'doesNotUnderstand:args:' in
+                            let Methods = call 'actor_enumeration_ops':'method_table'() in
+                            case call 'maps':'is_key'(DnuSelector, Methods) of
+                                <'true'> when 'true' ->
+                                    call 'actor_enumeration_ops':'dispatch'(DnuSelector, [OtherSelector, Args], Self, State)
+                                <'false'> when 'true' ->
+                                    %% No DNU handler - return #beamtalk_error{} record
+                                    let ClassName = 'EnumerationActor' in
+                                    let Error0 = call 'beamtalk_error':'new'('does_not_understand', ClassName) in
+                                    let Error1 = call 'beamtalk_error':'with_selector'(Error0, OtherSelector) in
+                                    let HintMsg = #{#<67>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<107>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<39>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<84>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<39>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<118>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']])}# in
+                                    let Error = call 'beamtalk_error':'with_hint'(Error1, HintMsg) in
+                                    {'error', Error, State}
+                            end
+                    end
+            end
+    end
+
+
+'method_table'/0 = fun () ->
+    ~{'sumWithIndex:' => 1, 'joinSum:' => 1, 'gapCount:' => 1}~
+
+
+'has_method'/1 = fun (Selector) ->
+    call 'lists':'member'(Selector, ['sumWithIndex:', 'joinSum:', 'gapCount:'])
+
+
+'class_supervisionSpec'/2 = fun (ClassSelf, ClassVars) ->
+    let CMR = call 'bt@stdlib@actor':'class_supervisionPolicy'(ClassSelf, ClassVars) in
+    case CMR of
+      <{'class_var_result', Policy, NewClassVars}> when 'true' ->
+        let Spec0 = call 'bt@stdlib@supervision_spec':'new'() in
+        let Spec1 = call 'bt@stdlib@supervision_spec':'withActorClass:'(Spec0, ClassSelf) in
+        let Spec2 = call 'bt@stdlib@supervision_spec':'withRestart:'(Spec1, Policy) in
+        {'class_var_result', Spec2, NewClassVars}
+      <Policy> when 'true' ->
+        let Spec0 = call 'bt@stdlib@supervision_spec':'new'() in
+        let Spec1 = call 'bt@stdlib@supervision_spec':'withActorClass:'(Spec0, ClassSelf) in
+        call 'bt@stdlib@supervision_spec':'withRestart:'(Spec1, Policy)
+    end
+
+'__beamtalk_meta'/0 = fun () ->
+    ~{'class' => 'EnumerationActor',
+      'superclass' => 'Actor',
+      'package' => 'none',
+      'kind' => 'actor',
+      'fields' => ['total'],
+      'class_fields' => [],
+      'is_sealed' => 'false',
+      'is_abstract' => 'false',
+      'is_value' => 'false',
+      'is_typed' => 'false',
+      'is_internal' => 'false',
+      'visibility' => 'public',
+      'type_params' => [],
+      'field_types' => ~{'total' => 'Integer'}~,
+      'field_has_default' => ~{'total' => 'true'}~,
+      'method_info' => ~{'sumWithIndex:' => ~{'arity' => 1, 'param_types' => ['none'], 'return_type' => 'Integer', 'is_sealed' => 'false', 'visibility' => 'public'}~, 'joinSum:' => ~{'arity' => 1, 'param_types' => ['none'], 'return_type' => 'Integer', 'is_sealed' => 'false', 'visibility' => 'public'}~, 'gapCount:' => ~{'arity' => 1, 'param_types' => ['none'], 'return_type' => 'Integer', 'is_sealed' => 'false', 'visibility' => 'public'}~}~,
+      'class_method_info' => ~{'supervisionSpec' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'SupervisionSpec', 'is_sealed' => 'false', 'visibility' => 'public'}~}~
+    }~
+
+'register_class'/0 = fun () ->
+    try
+        let _BuilderState0 = ~{
+            'className' => 'EnumerationActor',
+            'superclassRef' => 'Actor',
+            'moduleName' => 'actor_enumeration_ops',
+            'methodSource' => ~{'sumWithIndex:' => #{#<115>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<45>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<91>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<124>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<43>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<40>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<42>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<41>(8,1,'integer',['unsigned'|['big']]),#<93>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']])}#, 'joinSum:' => #{#<106>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<83>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<45>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<91>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<124>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<43>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<93>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<66>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<91>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<43>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<49>(8,1,'integer',['unsigned'|['big']]),#<48>(8,1,'integer',['unsigned'|['big']]),#<48>(8,1,'integer',['unsigned'|['big']]),#<93>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<46>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']])}#, 'gapCount:' => #{#<103>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<67>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<45>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<48>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<91>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<124>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<93>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<66>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<91>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<43>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<49>(8,1,'integer',['unsigned'|['big']]),#<93>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']])}#}~,
+            'classMethodSource' => ~{}~,
+            'methodSignatures' => ~{'sumWithIndex:' => #{#<115>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<45>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']])}#, 'joinSum:' => #{#<106>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<83>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<45>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']])}#, 'gapCount:' => #{#<103>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<67>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<45>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']])}#}~,
+            'classMethodSignatures' => ~{}~,
+            'methodXref' => [~{'class_side' => 'false', 'selector' => 'sumWithIndex:', 'line' => 1, 'sends' => [~{'selector' => 'eachWithIndex:', 'line' => 2, 'recv_kind' => 'other'}~, ~{'selector' => '+', 'line' => 2, 'recv_kind' => 'other'}~, ~{'selector' => '*', 'line' => 2, 'recv_kind' => 'other'}~], 'references' => [~{'class' => 'Integer', 'line' => 1}~], 'source_status' => 'indexed'}~, ~{'class_side' => 'false', 'selector' => 'joinSum:', 'line' => 1, 'sends' => [~{'selector' => 'do:separatedBy:', 'line' => 2, 'recv_kind' => 'other'}~, ~{'selector' => '+', 'line' => 3, 'recv_kind' => 'other'}~, ~{'selector' => '+', 'line' => 4, 'recv_kind' => 'other'}~], 'references' => [~{'class' => 'Integer', 'line' => 1}~], 'source_status' => 'indexed'}~, ~{'class_side' => 'false', 'selector' => 'gapCount:', 'line' => 1, 'sends' => [~{'selector' => 'do:separatedBy:', 'line' => 3, 'recv_kind' => 'other'}~, ~{'selector' => '+', 'line' => 3, 'recv_kind' => 'other'}~], 'references' => [~{'class' => 'Integer', 'line' => 1}~], 'source_status' => 'indexed'}~, ~{'class_side' => 'true', 'selector' => 'new', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~, ~{'class_side' => 'true', 'selector' => 'new:', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~, ~{'class_side' => 'true', 'selector' => 'spawn', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~, ~{'class_side' => 'true', 'selector' => 'spawn:', 'line' => 1, 'sends' => [], 'references' => [], 'source_status' => 'synthetic', 'synthetic_origin' => 1}~],
+            'classState' => ~{}~,
+            'classDoc' => 'none',
+            'methodDocs' => ~{}~,
+            'classMethodDocs' => ~{}~,
+            'meta' => ~{'class' => 'EnumerationActor',
+      'superclass' => 'Actor',
+      'package' => 'none',
+      'kind' => 'actor',
+      'fields' => ['total'],
+      'class_fields' => [],
+      'is_sealed' => 'false',
+      'is_abstract' => 'false',
+      'is_value' => 'false',
+      'is_typed' => 'false',
+      'is_internal' => 'false',
+      'visibility' => 'public',
+      'type_params' => [],
+      'field_types' => ~{'total' => 'Integer'}~,
+      'field_has_default' => ~{'total' => 'true'}~,
+      'method_info' => ~{'sumWithIndex:' => ~{'arity' => 1, 'param_types' => ['none'], 'return_type' => 'Integer', 'is_sealed' => 'false', 'visibility' => 'public'}~, 'joinSum:' => ~{'arity' => 1, 'param_types' => ['none'], 'return_type' => 'Integer', 'is_sealed' => 'false', 'visibility' => 'public'}~, 'gapCount:' => ~{'arity' => 1, 'param_types' => ['none'], 'return_type' => 'Integer', 'is_sealed' => 'false', 'visibility' => 'public'}~}~,
+      'class_method_info' => ~{'supervisionSpec' => ~{'arity' => 0, 'param_types' => [], 'return_type' => 'SupervisionSpec', 'is_sealed' => 'false', 'visibility' => 'public'}~}~
+    }~,
+            'isConstructible' => 'false'
+        }~
+        in let _Reg0 = case call 'beamtalk_class_builder':'register'(_BuilderState0) of
+            <{'ok', _Pid0}> when 'true' -> 'ok'
+            <{'error', _Err0}> when 'true' -> {'error', _Err0}
+        end
+
+        in _Reg0
+
+    of _ClassRegResult -> _ClassRegResult
+    catch <CatchType, CatchError, CatchStack> -> primop 'raw_raise'(CatchType, CatchError, CatchStack)
+
+end

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_lexer.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_lexer.snap
@@ -1,0 +1,99 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+Token { kind: Identifier("Actor"), span: Span { start: 895, end: 900 }, leading_trivia: [LineComment("// Copyright 2026 James Casey"), Whitespace("\n"), LineComment("// SPDX-License-Identifier: Apache-2.0"), Whitespace("\n\n"), LineComment("// Snapshot test for BT-2703 enumeration desugar codegen (enumeration_ops.rs),"), Whitespace("\n"), LineComment("// actor context."), Whitespace("\n"), LineComment("//"), Whitespace("\n"), LineComment("// `eachWithIndex:` and `do:separatedBy:` are desugared to `inject:into:` when"), Whitespace("\n"), LineComment("// a block mutates state. Without snapshot tests the entire enumeration_ops.rs"), Whitespace("\n"), LineComment("// was at 0% Rust coverage despite BUnit tests exercising the runtime behaviour"), Whitespace("\n"), LineComment("// (BUnit runs via `beamtalk test`, not `cargo test`)."), Whitespace("\n"), LineComment("//"), Whitespace("\n"), LineComment("// In an actor method, finalize_enumeration_fold re-projects the fold's"), Whitespace("\n"), LineComment("// {Acc, NewState} tuple to {'nil', element(2, EnumFold)}."), Whitespace("\n"), LineComment("//"), Whitespace("\n"), LineComment("// Covers:"), Whitespace("\n"), LineComment("//   try_generate_each_with_index   — field mutation → desugar fires"), Whitespace("\n"), LineComment("//   try_generate_do_separated_by   — element-block mutation"), Whitespace("\n"), LineComment("//                                    separator-block-only mutation (outer local)"), Whitespace("\n"), LineComment("//   finalize_enumeration_fold      — actor re-projection path"), Whitespace("\n\n")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("subclass:"), span: Span { start: 901, end: 910 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("EnumerationActor"), span: Span { start: 911, end: 927 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("state:"), span: Span { start: 930, end: 936 }, leading_trivia: [Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("total"), span: Span { start: 937, end: 942 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: DoubleColon, span: Span { start: 943, end: 945 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("Integer"), span: Span { start: 946, end: 953 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("="), span: Span { start: 954, end: 955 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("0"), span: Span { start: 956, end: 957 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("sumWithIndex:"), span: Span { start: 1121, end: 1134 }, leading_trivia: [Whitespace("\n\n  "), LineComment("// try_generate_each_with_index: field mutation in block → desugar fires."), Whitespace("\n  "), LineComment("// Accumulates item * 1-based-index into self.total; returns the updated total."), Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("coll"), span: Span { start: 1135, end: 1139 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 1140, end: 1142 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("coll"), span: Span { start: 1147, end: 1151 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("eachWithIndex:"), span: Span { start: 1152, end: 1166 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftBracket, span: Span { start: 1167, end: 1168 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Colon, span: Span { start: 1168, end: 1169 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("item"), span: Span { start: 1169, end: 1173 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Colon, span: Span { start: 1174, end: 1175 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("i"), span: Span { start: 1175, end: 1176 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Pipe, span: Span { start: 1177, end: 1178 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("self"), span: Span { start: 1179, end: 1183 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1183, end: 1184 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("total"), span: Span { start: 1184, end: 1189 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 1190, end: 1192 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("self"), span: Span { start: 1193, end: 1197 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1197, end: 1198 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("total"), span: Span { start: 1198, end: 1203 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("+"), span: Span { start: 1204, end: 1205 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftParen, span: Span { start: 1206, end: 1207 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("item"), span: Span { start: 1207, end: 1211 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("*"), span: Span { start: 1212, end: 1213 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("i"), span: Span { start: 1214, end: 1215 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: RightParen, span: Span { start: 1215, end: 1216 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: RightBracket, span: Span { start: 1216, end: 1217 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("self"), span: Span { start: 1222, end: 1226 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1226, end: 1227 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("total"), span: Span { start: 1227, end: 1232 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("joinSum:"), span: Span { start: 1403, end: 1411 }, leading_trivia: [Whitespace("\n\n  "), LineComment("// try_generate_do_separated_by: element block mutates field → desugar fires."), Whitespace("\n  "), LineComment("// The separator block also mutates the field (adds 100 per gap between elements)."), Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("coll"), span: Span { start: 1412, end: 1416 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 1417, end: 1419 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("coll"), span: Span { start: 1424, end: 1428 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("do:"), span: Span { start: 1429, end: 1432 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftBracket, span: Span { start: 1433, end: 1434 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Colon, span: Span { start: 1434, end: 1435 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("item"), span: Span { start: 1435, end: 1439 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Pipe, span: Span { start: 1440, end: 1441 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("self"), span: Span { start: 1448, end: 1452 }, leading_trivia: [Whitespace("\n      ")], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1452, end: 1453 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("total"), span: Span { start: 1453, end: 1458 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 1459, end: 1461 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("self"), span: Span { start: 1462, end: 1466 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1466, end: 1467 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("total"), span: Span { start: 1467, end: 1472 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("+"), span: Span { start: 1473, end: 1474 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("item"), span: Span { start: 1475, end: 1479 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: RightBracket, span: Span { start: 1484, end: 1485 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("separatedBy:"), span: Span { start: 1486, end: 1498 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftBracket, span: Span { start: 1499, end: 1500 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("self"), span: Span { start: 1500, end: 1504 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1504, end: 1505 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("total"), span: Span { start: 1505, end: 1510 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 1511, end: 1513 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("self"), span: Span { start: 1514, end: 1518 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1518, end: 1519 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("total"), span: Span { start: 1519, end: 1524 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("+"), span: Span { start: 1525, end: 1526 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("100"), span: Span { start: 1527, end: 1530 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: RightBracket, span: Span { start: 1530, end: 1531 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("self"), span: Span { start: 1536, end: 1540 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Period, span: Span { start: 1540, end: 1541 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("total"), span: Span { start: 1541, end: 1546 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("gapCount:"), span: Span { start: 1703, end: 1712 }, leading_trivia: [Whitespace("\n\n  "), LineComment("// try_generate_do_separated_by: only the separator block mutates an outer local."), Whitespace("\n  "), LineComment("// The element block is pure; separator increments `gaps` per gap."), Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("coll"), span: Span { start: 1713, end: 1717 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 1718, end: 1720 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("gaps"), span: Span { start: 1725, end: 1729 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 1730, end: 1732 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("0"), span: Span { start: 1733, end: 1734 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("coll"), span: Span { start: 1739, end: 1743 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("do:"), span: Span { start: 1744, end: 1747 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftBracket, span: Span { start: 1748, end: 1749 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Colon, span: Span { start: 1749, end: 1750 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("item"), span: Span { start: 1750, end: 1754 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Pipe, span: Span { start: 1755, end: 1756 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("item"), span: Span { start: 1757, end: 1761 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: RightBracket, span: Span { start: 1761, end: 1762 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("separatedBy:"), span: Span { start: 1763, end: 1775 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftBracket, span: Span { start: 1776, end: 1777 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("gaps"), span: Span { start: 1777, end: 1781 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 1782, end: 1784 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("gaps"), span: Span { start: 1785, end: 1789 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("+"), span: Span { start: 1790, end: 1791 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("1"), span: Span { start: 1792, end: 1793 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: RightBracket, span: Span { start: 1793, end: 1794 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("gaps"), span: Span { start: 1799, end: 1803 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Eof, span: Span { start: 1804, end: 1804 }, leading_trivia: [Whitespace("\n")], trailing_trivia: [] }

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_parser.snap
@@ -1,0 +1,1096 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+AST:
+Module {
+    classes: [
+        ClassDefinition {
+            name: Identifier {
+                name: "EnumerationActor",
+                span: Span {
+                    start: 911,
+                    end: 927,
+                },
+            },
+            superclass: Some(
+                Identifier {
+                    name: "Actor",
+                    span: Span {
+                        start: 895,
+                        end: 900,
+                    },
+                },
+            ),
+            superclass_package: None,
+            class_kind: Actor,
+            is_abstract: false,
+            is_sealed: false,
+            is_typed: false,
+            is_internal: false,
+            supervisor_kind: None,
+            state: [
+                StateDeclaration {
+                    name: Identifier {
+                        name: "total",
+                        span: Span {
+                            start: 937,
+                            end: 942,
+                        },
+                    },
+                    type_annotation: Some(
+                        Simple(
+                            Identifier {
+                                name: "Integer",
+                                span: Span {
+                                    start: 946,
+                                    end: 953,
+                                },
+                            },
+                        ),
+                    ),
+                    default_value: Some(
+                        Literal(
+                            Integer(
+                                0,
+                            ),
+                            Span {
+                                start: 956,
+                                end: 957,
+                            },
+                        ),
+                    ),
+                    declared_keyword: State,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 930,
+                        end: 957,
+                    },
+                },
+            ],
+            methods: [
+                MethodDefinition {
+                    selector: Keyword(
+                        [
+                            KeywordPart {
+                                keyword: "sumWithIndex:",
+                                span: Span {
+                                    start: 1121,
+                                    end: 1134,
+                                },
+                            },
+                        ],
+                    ),
+                    parameters: [
+                        ParameterDefinition {
+                            name: Identifier {
+                                name: "coll",
+                                span: Span {
+                                    start: 1135,
+                                    end: 1139,
+                                },
+                            },
+                            type_annotation: None,
+                        },
+                    ],
+                    body: [
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: MessageSend {
+                                receiver: Identifier(
+                                    Identifier {
+                                        name: "coll",
+                                        span: Span {
+                                            start: 1147,
+                                            end: 1151,
+                                        },
+                                    },
+                                ),
+                                selector: Keyword(
+                                    [
+                                        KeywordPart {
+                                            keyword: "eachWithIndex:",
+                                            span: Span {
+                                                start: 1152,
+                                                end: 1166,
+                                            },
+                                        },
+                                    ],
+                                ),
+                                arguments: [
+                                    Block(
+                                        Block {
+                                            parameters: [
+                                                BlockParameter {
+                                                    name: "item",
+                                                    span: Span {
+                                                        start: 1169,
+                                                        end: 1173,
+                                                    },
+                                                },
+                                                BlockParameter {
+                                                    name: "i",
+                                                    span: Span {
+                                                        start: 1175,
+                                                        end: 1176,
+                                                    },
+                                                },
+                                            ],
+                                            body: [
+                                                ExpressionStatement {
+                                                    comments: CommentAttachment {
+                                                        leading: [],
+                                                        trailing: None,
+                                                    },
+                                                    expression: Assignment {
+                                                        target: FieldAccess {
+                                                            receiver: Identifier(
+                                                                Identifier {
+                                                                    name: "self",
+                                                                    span: Span {
+                                                                        start: 1179,
+                                                                        end: 1183,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            field: Identifier {
+                                                                name: "total",
+                                                                span: Span {
+                                                                    start: 1184,
+                                                                    end: 1189,
+                                                                },
+                                                            },
+                                                            span: Span {
+                                                                start: 1179,
+                                                                end: 1189,
+                                                            },
+                                                        },
+                                                        value: MessageSend {
+                                                            receiver: FieldAccess {
+                                                                receiver: Identifier(
+                                                                    Identifier {
+                                                                        name: "self",
+                                                                        span: Span {
+                                                                            start: 1193,
+                                                                            end: 1197,
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                field: Identifier {
+                                                                    name: "total",
+                                                                    span: Span {
+                                                                        start: 1198,
+                                                                        end: 1203,
+                                                                    },
+                                                                },
+                                                                span: Span {
+                                                                    start: 1193,
+                                                                    end: 1203,
+                                                                },
+                                                            },
+                                                            selector: Binary(
+                                                                "+",
+                                                            ),
+                                                            arguments: [
+                                                                Parenthesized {
+                                                                    expression: MessageSend {
+                                                                        receiver: Identifier(
+                                                                            Identifier {
+                                                                                name: "item",
+                                                                                span: Span {
+                                                                                    start: 1207,
+                                                                                    end: 1211,
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                        selector: Binary(
+                                                                            "*",
+                                                                        ),
+                                                                        arguments: [
+                                                                            Identifier(
+                                                                                Identifier {
+                                                                                    name: "i",
+                                                                                    span: Span {
+                                                                                        start: 1214,
+                                                                                        end: 1215,
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_cast: false,
+                                                                        span: Span {
+                                                                            start: 1207,
+                                                                            end: 1215,
+                                                                        },
+                                                                    },
+                                                                    span: Span {
+                                                                        start: 1206,
+                                                                        end: 1216,
+                                                                    },
+                                                                },
+                                                            ],
+                                                            is_cast: false,
+                                                            span: Span {
+                                                                start: 1193,
+                                                                end: 1216,
+                                                            },
+                                                        },
+                                                        type_annotation: None,
+                                                        span: Span {
+                                                            start: 1179,
+                                                            end: 1216,
+                                                        },
+                                                    },
+                                                    preceding_blank_line: false,
+                                                },
+                                            ],
+                                            span: Span {
+                                                start: 1167,
+                                                end: 1217,
+                                            },
+                                        },
+                                    ),
+                                ],
+                                is_cast: false,
+                                span: Span {
+                                    start: 1147,
+                                    end: 1217,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: FieldAccess {
+                                receiver: Identifier(
+                                    Identifier {
+                                        name: "self",
+                                        span: Span {
+                                            start: 1222,
+                                            end: 1226,
+                                        },
+                                    },
+                                ),
+                                field: Identifier {
+                                    name: "total",
+                                    span: Span {
+                                        start: 1227,
+                                        end: 1232,
+                                    },
+                                },
+                                span: Span {
+                                    start: 1222,
+                                    end: 1232,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                    ],
+                    return_type: None,
+                    is_sealed: false,
+                    is_internal: false,
+                    is_class_method: false,
+                    kind: Primary,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [
+                            Comment {
+                                content: "try_generate_each_with_index: field mutation in block → desugar fires.",
+                                span: Span {
+                                    start: 1121,
+                                    end: 1134,
+                                },
+                                kind: Line,
+                                preceding_blank_line: true,
+                            },
+                            Comment {
+                                content: "Accumulates item * 1-based-index into self.total; returns the updated total.",
+                                span: Span {
+                                    start: 1121,
+                                    end: 1134,
+                                },
+                                kind: Line,
+                                preceding_blank_line: false,
+                            },
+                        ],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 1121,
+                        end: 1232,
+                    },
+                },
+                MethodDefinition {
+                    selector: Keyword(
+                        [
+                            KeywordPart {
+                                keyword: "joinSum:",
+                                span: Span {
+                                    start: 1403,
+                                    end: 1411,
+                                },
+                            },
+                        ],
+                    ),
+                    parameters: [
+                        ParameterDefinition {
+                            name: Identifier {
+                                name: "coll",
+                                span: Span {
+                                    start: 1412,
+                                    end: 1416,
+                                },
+                            },
+                            type_annotation: None,
+                        },
+                    ],
+                    body: [
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: MessageSend {
+                                receiver: Identifier(
+                                    Identifier {
+                                        name: "coll",
+                                        span: Span {
+                                            start: 1424,
+                                            end: 1428,
+                                        },
+                                    },
+                                ),
+                                selector: Keyword(
+                                    [
+                                        KeywordPart {
+                                            keyword: "do:",
+                                            span: Span {
+                                                start: 1429,
+                                                end: 1432,
+                                            },
+                                        },
+                                        KeywordPart {
+                                            keyword: "separatedBy:",
+                                            span: Span {
+                                                start: 1486,
+                                                end: 1498,
+                                            },
+                                        },
+                                    ],
+                                ),
+                                arguments: [
+                                    Block(
+                                        Block {
+                                            parameters: [
+                                                BlockParameter {
+                                                    name: "item",
+                                                    span: Span {
+                                                        start: 1435,
+                                                        end: 1439,
+                                                    },
+                                                },
+                                            ],
+                                            body: [
+                                                ExpressionStatement {
+                                                    comments: CommentAttachment {
+                                                        leading: [],
+                                                        trailing: None,
+                                                    },
+                                                    expression: Assignment {
+                                                        target: FieldAccess {
+                                                            receiver: Identifier(
+                                                                Identifier {
+                                                                    name: "self",
+                                                                    span: Span {
+                                                                        start: 1448,
+                                                                        end: 1452,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            field: Identifier {
+                                                                name: "total",
+                                                                span: Span {
+                                                                    start: 1453,
+                                                                    end: 1458,
+                                                                },
+                                                            },
+                                                            span: Span {
+                                                                start: 1448,
+                                                                end: 1458,
+                                                            },
+                                                        },
+                                                        value: MessageSend {
+                                                            receiver: FieldAccess {
+                                                                receiver: Identifier(
+                                                                    Identifier {
+                                                                        name: "self",
+                                                                        span: Span {
+                                                                            start: 1462,
+                                                                            end: 1466,
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                field: Identifier {
+                                                                    name: "total",
+                                                                    span: Span {
+                                                                        start: 1467,
+                                                                        end: 1472,
+                                                                    },
+                                                                },
+                                                                span: Span {
+                                                                    start: 1462,
+                                                                    end: 1472,
+                                                                },
+                                                            },
+                                                            selector: Binary(
+                                                                "+",
+                                                            ),
+                                                            arguments: [
+                                                                Identifier(
+                                                                    Identifier {
+                                                                        name: "item",
+                                                                        span: Span {
+                                                                            start: 1475,
+                                                                            end: 1479,
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            is_cast: false,
+                                                            span: Span {
+                                                                start: 1462,
+                                                                end: 1479,
+                                                            },
+                                                        },
+                                                        type_annotation: None,
+                                                        span: Span {
+                                                            start: 1448,
+                                                            end: 1479,
+                                                        },
+                                                    },
+                                                    preceding_blank_line: false,
+                                                },
+                                            ],
+                                            span: Span {
+                                                start: 1433,
+                                                end: 1485,
+                                            },
+                                        },
+                                    ),
+                                    Block(
+                                        Block {
+                                            parameters: [],
+                                            body: [
+                                                ExpressionStatement {
+                                                    comments: CommentAttachment {
+                                                        leading: [],
+                                                        trailing: None,
+                                                    },
+                                                    expression: Assignment {
+                                                        target: FieldAccess {
+                                                            receiver: Identifier(
+                                                                Identifier {
+                                                                    name: "self",
+                                                                    span: Span {
+                                                                        start: 1500,
+                                                                        end: 1504,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            field: Identifier {
+                                                                name: "total",
+                                                                span: Span {
+                                                                    start: 1505,
+                                                                    end: 1510,
+                                                                },
+                                                            },
+                                                            span: Span {
+                                                                start: 1500,
+                                                                end: 1510,
+                                                            },
+                                                        },
+                                                        value: MessageSend {
+                                                            receiver: FieldAccess {
+                                                                receiver: Identifier(
+                                                                    Identifier {
+                                                                        name: "self",
+                                                                        span: Span {
+                                                                            start: 1514,
+                                                                            end: 1518,
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                field: Identifier {
+                                                                    name: "total",
+                                                                    span: Span {
+                                                                        start: 1519,
+                                                                        end: 1524,
+                                                                    },
+                                                                },
+                                                                span: Span {
+                                                                    start: 1514,
+                                                                    end: 1524,
+                                                                },
+                                                            },
+                                                            selector: Binary(
+                                                                "+",
+                                                            ),
+                                                            arguments: [
+                                                                Literal(
+                                                                    Integer(
+                                                                        100,
+                                                                    ),
+                                                                    Span {
+                                                                        start: 1527,
+                                                                        end: 1530,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            is_cast: false,
+                                                            span: Span {
+                                                                start: 1514,
+                                                                end: 1530,
+                                                            },
+                                                        },
+                                                        type_annotation: None,
+                                                        span: Span {
+                                                            start: 1500,
+                                                            end: 1530,
+                                                        },
+                                                    },
+                                                    preceding_blank_line: false,
+                                                },
+                                            ],
+                                            span: Span {
+                                                start: 1499,
+                                                end: 1531,
+                                            },
+                                        },
+                                    ),
+                                ],
+                                is_cast: false,
+                                span: Span {
+                                    start: 1424,
+                                    end: 1531,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: FieldAccess {
+                                receiver: Identifier(
+                                    Identifier {
+                                        name: "self",
+                                        span: Span {
+                                            start: 1536,
+                                            end: 1540,
+                                        },
+                                    },
+                                ),
+                                field: Identifier {
+                                    name: "total",
+                                    span: Span {
+                                        start: 1541,
+                                        end: 1546,
+                                    },
+                                },
+                                span: Span {
+                                    start: 1536,
+                                    end: 1546,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                    ],
+                    return_type: None,
+                    is_sealed: false,
+                    is_internal: false,
+                    is_class_method: false,
+                    kind: Primary,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [
+                            Comment {
+                                content: "try_generate_do_separated_by: element block mutates field → desugar fires.",
+                                span: Span {
+                                    start: 1403,
+                                    end: 1411,
+                                },
+                                kind: Line,
+                                preceding_blank_line: true,
+                            },
+                            Comment {
+                                content: "The separator block also mutates the field (adds 100 per gap between elements).",
+                                span: Span {
+                                    start: 1403,
+                                    end: 1411,
+                                },
+                                kind: Line,
+                                preceding_blank_line: false,
+                            },
+                        ],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 1403,
+                        end: 1546,
+                    },
+                },
+                MethodDefinition {
+                    selector: Keyword(
+                        [
+                            KeywordPart {
+                                keyword: "gapCount:",
+                                span: Span {
+                                    start: 1703,
+                                    end: 1712,
+                                },
+                            },
+                        ],
+                    ),
+                    parameters: [
+                        ParameterDefinition {
+                            name: Identifier {
+                                name: "coll",
+                                span: Span {
+                                    start: 1713,
+                                    end: 1717,
+                                },
+                            },
+                            type_annotation: None,
+                        },
+                    ],
+                    body: [
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: Assignment {
+                                target: Identifier(
+                                    Identifier {
+                                        name: "gaps",
+                                        span: Span {
+                                            start: 1725,
+                                            end: 1729,
+                                        },
+                                    },
+                                ),
+                                value: Literal(
+                                    Integer(
+                                        0,
+                                    ),
+                                    Span {
+                                        start: 1733,
+                                        end: 1734,
+                                    },
+                                ),
+                                type_annotation: None,
+                                span: Span {
+                                    start: 1725,
+                                    end: 1734,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: MessageSend {
+                                receiver: Identifier(
+                                    Identifier {
+                                        name: "coll",
+                                        span: Span {
+                                            start: 1739,
+                                            end: 1743,
+                                        },
+                                    },
+                                ),
+                                selector: Keyword(
+                                    [
+                                        KeywordPart {
+                                            keyword: "do:",
+                                            span: Span {
+                                                start: 1744,
+                                                end: 1747,
+                                            },
+                                        },
+                                        KeywordPart {
+                                            keyword: "separatedBy:",
+                                            span: Span {
+                                                start: 1763,
+                                                end: 1775,
+                                            },
+                                        },
+                                    ],
+                                ),
+                                arguments: [
+                                    Block(
+                                        Block {
+                                            parameters: [
+                                                BlockParameter {
+                                                    name: "item",
+                                                    span: Span {
+                                                        start: 1750,
+                                                        end: 1754,
+                                                    },
+                                                },
+                                            ],
+                                            body: [
+                                                ExpressionStatement {
+                                                    comments: CommentAttachment {
+                                                        leading: [],
+                                                        trailing: None,
+                                                    },
+                                                    expression: Identifier(
+                                                        Identifier {
+                                                            name: "item",
+                                                            span: Span {
+                                                                start: 1757,
+                                                                end: 1761,
+                                                            },
+                                                        },
+                                                    ),
+                                                    preceding_blank_line: false,
+                                                },
+                                            ],
+                                            span: Span {
+                                                start: 1748,
+                                                end: 1762,
+                                            },
+                                        },
+                                    ),
+                                    Block(
+                                        Block {
+                                            parameters: [],
+                                            body: [
+                                                ExpressionStatement {
+                                                    comments: CommentAttachment {
+                                                        leading: [],
+                                                        trailing: None,
+                                                    },
+                                                    expression: Assignment {
+                                                        target: Identifier(
+                                                            Identifier {
+                                                                name: "gaps",
+                                                                span: Span {
+                                                                    start: 1777,
+                                                                    end: 1781,
+                                                                },
+                                                            },
+                                                        ),
+                                                        value: MessageSend {
+                                                            receiver: Identifier(
+                                                                Identifier {
+                                                                    name: "gaps",
+                                                                    span: Span {
+                                                                        start: 1785,
+                                                                        end: 1789,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            selector: Binary(
+                                                                "+",
+                                                            ),
+                                                            arguments: [
+                                                                Literal(
+                                                                    Integer(
+                                                                        1,
+                                                                    ),
+                                                                    Span {
+                                                                        start: 1792,
+                                                                        end: 1793,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            is_cast: false,
+                                                            span: Span {
+                                                                start: 1785,
+                                                                end: 1793,
+                                                            },
+                                                        },
+                                                        type_annotation: None,
+                                                        span: Span {
+                                                            start: 1777,
+                                                            end: 1793,
+                                                        },
+                                                    },
+                                                    preceding_blank_line: false,
+                                                },
+                                            ],
+                                            span: Span {
+                                                start: 1776,
+                                                end: 1794,
+                                            },
+                                        },
+                                    ),
+                                ],
+                                is_cast: false,
+                                span: Span {
+                                    start: 1739,
+                                    end: 1794,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: Identifier(
+                                Identifier {
+                                    name: "gaps",
+                                    span: Span {
+                                        start: 1799,
+                                        end: 1803,
+                                    },
+                                },
+                            ),
+                            preceding_blank_line: false,
+                        },
+                    ],
+                    return_type: None,
+                    is_sealed: false,
+                    is_internal: false,
+                    is_class_method: false,
+                    kind: Primary,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [
+                            Comment {
+                                content: "try_generate_do_separated_by: only the separator block mutates an outer local.",
+                                span: Span {
+                                    start: 1703,
+                                    end: 1712,
+                                },
+                                kind: Line,
+                                preceding_blank_line: true,
+                            },
+                            Comment {
+                                content: "The element block is pure; separator increments `gaps` per gap.",
+                                span: Span {
+                                    start: 1703,
+                                    end: 1712,
+                                },
+                                kind: Line,
+                                preceding_blank_line: false,
+                            },
+                        ],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 1703,
+                        end: 1803,
+                    },
+                },
+            ],
+            class_methods: [],
+            class_variables: [],
+            comments: CommentAttachment {
+                leading: [
+                    Comment {
+                        content: "Copyright 2026 James Casey",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "Snapshot test for BT-2703 enumeration desugar codegen (enumeration_ops.rs),",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: true,
+                    },
+                    Comment {
+                        content: "actor context.",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "`eachWithIndex:` and `do:separatedBy:` are desugared to `inject:into:` when",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "a block mutates state. Without snapshot tests the entire enumeration_ops.rs",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "was at 0% Rust coverage despite BUnit tests exercising the runtime behaviour",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "(BUnit runs via `beamtalk test`, not `cargo test`).",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "In an actor method, finalize_enumeration_fold re-projects the fold's",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "{Acc, NewState} tuple to {'nil', element(2, EnumFold)}.",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "Covers:",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "  try_generate_each_with_index   — field mutation → desugar fires",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "  try_generate_do_separated_by   — element-block mutation",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "                                   separator-block-only mutation (outer local)",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "  finalize_enumeration_fold      — actor re-projection path",
+                        span: Span {
+                            start: 895,
+                            end: 900,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                ],
+                trailing: None,
+            },
+            doc_comment: None,
+            backing_module: None,
+            type_params: [],
+            superclass_type_args: [],
+            span: Span {
+                start: 895,
+                end: 1803,
+            },
+        },
+    ],
+    method_definitions: [],
+    protocols: [],
+    expressions: [],
+    span: Span {
+        start: 895,
+        end: 1803,
+    },
+    file_leading_comments: [],
+    file_trailing_comments: [],
+}

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_semantic.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_semantic.snap
@@ -1,0 +1,5 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+No semantic errors

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_codegen.snap
@@ -1,0 +1,148 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: core_erlang
+---
+module 'value_enumeration_ops' ['new'/0, 'new'/1, 'sumWithIndex:'/2, 'dispatch'/3, 'dispatch'/4, 'has_method'/1, 'superclass'/0, 'register_class'/0, '__beamtalk_meta'/0]
+  attributes ['on_load' = [{'register_class', 0}],
+     'beamtalk_class' = [{'EnumerationValue', 'Value'}],
+     'spec' =
+        [{{'sumWithIndex:', 2}, [{'type', 0, 'fun', [{'type', 0, 'product', [{'type', 0, 'map', 'any'}, {'type', 0, 'any', []}]}, {'type', 0, 'integer', []}]}]}]]
+
+'new'/0 = fun () ->
+    ~{'$beamtalk_class' => 'EnumerationValue'}~
+
+
+'new'/1 = fun (InitArgs) ->
+    let DefaultState = call 'value_enumeration_ops':'new'() in
+    call 'maps':'merge'(DefaultState, InitArgs)
+
+
+'sumWithIndex:'/2 = fun (Self, _coll1) ->
+    let Sum = 0 in
+    let _seq2 = let _InitMap8 = call 'maps':'new'() in let _Packed9 = call 'maps':'put'('__local__sum', Sum, _InitMap8) in let _temp3 = _coll1 in let _temp4 = case call 'erlang':'is_list'(_temp3) of <'true'> when 'true' -> _temp3 <'false'> when 'true' -> call 'beamtalk_collection':'to_list'(_temp3) end in let _temp5 = 1 in let _temp6 = fun (Item, _AccSt7) -> let Acc = call 'erlang':'element'(1, _AccSt7) in let StateAcc = call 'erlang':'element'(2, _AccSt7) in let Sum = call 'maps':'get'('__local__sum', StateAcc) in let _Val10 = let _BinLeft13 = Sum in let _BinRight14 = let _BinLeft11 = Item in let _BinRight12 = Acc in case call 'erlang':'is_number'(_BinLeft11) of <'true'> when 'true' -> call 'erlang':'*'(_BinLeft11, _BinRight12) <'false'> when 'true' -> call 'beamtalk_message_dispatch':'send'(_BinLeft11, '*', [_BinRight12]) end in case call 'erlang':'is_number'(_BinLeft13) of <'true'> when 'true' -> call 'erlang':'+'(_BinLeft13, _BinRight14) <'false'> when 'true' -> call 'beamtalk_message_dispatch':'send'(_BinLeft13, '+', [_BinRight14]) end in let StateAcc1 = call 'maps':'put'('__local__sum', _Val10, StateAcc) in let _AccOut15 = let _BinLeft16 = Acc in let _BinRight17 = 1 in case call 'erlang':'is_number'(_BinLeft16) of <'true'> when 'true' -> call 'erlang':'+'(_BinLeft16, _BinRight17) <'false'> when 'true' -> call 'beamtalk_message_dispatch':'send'(_BinLeft16, '+', [_BinRight17]) end in {_AccOut15, StateAcc1} in let _temp18 = call 'lists':'foldl'(_temp6, {_temp5, _Packed9}, _temp4) in let _AccOut19 = call 'erlang':'element'(1, _temp18) in let _StOut20 = call 'erlang':'element'(2, _temp18) in let Sum = call 'maps':'get'('__local__sum', _StOut20) in {_AccOut19, _StOut20} in
+    Sum
+
+'dispatch'/3 = fun (Selector, Args, Self) ->
+    case Selector of
+        <'class'> when 'true' ->
+            'EnumerationValue'
+        <'respondsTo:'> when 'true' ->
+            case Args of
+                <[RtSelector | _]> when 'true' -> call 'value_enumeration_ops':'has_method'(RtSelector)
+                <_> when 'true' -> 'false'
+            end
+        <'fieldNames'> when 'true' ->
+            call 'beamtalk_reflection':'field_names'(Self)
+        <'fieldAt:'> when 'true' ->
+            let <FaName> = call 'erlang':'hd'(Args) in
+            call 'beamtalk_reflection':'read_field'(FaName, Self)
+        <'fieldAt:put:'> when 'true' ->
+            let <ImmErr0> = call 'beamtalk_error':'new'('immutable_value', 'EnumerationValue') in
+            let <ImmErr1> = call 'beamtalk_error':'with_selector'(ImmErr0, 'fieldAt:put:') in
+            let <ImmErr2> = call 'beamtalk_error':'with_hint'(ImmErr1, #{#<67>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<102>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<118>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<121>(8,1,'integer',['unsigned'|['big']]),#<112>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<226>(8,1,'integer',['unsigned'|['big']]),#<128>(8,1,'integer',['unsigned'|['big']]),#<148>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<83>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<119>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']])}#) in
+            call 'beamtalk_error':'raise'(ImmErr2)
+        <'perform:'> when 'true' ->
+            let <PerfSel> = call 'erlang':'hd'(Args) in
+            call 'value_enumeration_ops':'dispatch'(PerfSel, [], Self)
+        <'perform:withArguments:'> when 'true' ->
+            let <PwaSel> = call 'erlang':'hd'(Args) in
+            let <PwaArgs> = call 'erlang':'hd'(call 'erlang':'tl'(Args)) in
+            call 'value_enumeration_ops':'dispatch'(PwaSel, PwaArgs, Self)
+        <'sumWithIndex:'> when 'true' ->
+            let <DispArg0> = call 'erlang':'hd'(Args) in
+            call 'value_enumeration_ops':'sumWithIndex:'(Self, DispArg0)
+        <_Other> when 'true' ->
+            case call 'beamtalk_extensions':'lookup'('EnumerationValue', Selector) of
+                <{'ok', ExtFun, _ExtOwner}> when 'true' ->
+                    apply ExtFun(Args, Self)
+                <'not_found'> when 'true' ->
+                    call 'bt@stdlib@value':'dispatch'(Selector, Args, Self)
+            end
+    end
+
+
+'dispatch'/4 = fun (Selector, Args, Self, State) ->
+    try call 'value_enumeration_ops':'dispatch'(Selector, Args, Self)
+    of <D4Result> -> {'reply', D4Result, State}
+    catch <_D4Type, D4Error, _D4Stack> -> {'error', D4Error, State}
+
+
+'has_method'/1 = fun (Selector) ->
+    case call 'lists':'member'(Selector, ['class', 'respondsTo:', 'fieldNames', 'fieldAt:', 'fieldAt:put:', 'perform:', 'perform:withArguments:', 'sumWithIndex:']) of
+        <'true'> when 'true' -> 'true'
+        <'false'> when 'true' ->
+            case call 'beamtalk_extensions':'has'('EnumerationValue', Selector) of
+                <'true'> when 'true' -> 'true'
+                <'false'> when 'true' -> call 'bt@stdlib@value':'has_method'(Selector)
+            end
+    end
+
+
+'superclass'/0 = fun () -> 'Value'
+
+'register_class'/0 = fun () ->
+    try
+        let _BuilderState0 = ~{
+            'className' => 'EnumerationValue',
+            'superclassRef' => 'Value',
+            'moduleName' => 'value_enumeration_ops',
+            'methodSource' => ~{'sumWithIndex:' => #{#<115>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<45>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<48>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<97>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<91>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<124>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<61>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<43>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<40>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<42>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<41>(8,1,'integer',['unsigned'|['big']]),#<93>(8,1,'integer',['unsigned'|['big']]),#<10>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<115>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']])}#}~,
+            'classMethodSource' => ~{}~,
+            'methodSignatures' => ~{'sumWithIndex:' => #{#<115>(8,1,'integer',['unsigned'|['big']]),#<117>(8,1,'integer',['unsigned'|['big']]),#<109>(8,1,'integer',['unsigned'|['big']]),#<87>(8,1,'integer',['unsigned'|['big']]),#<105>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<104>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<100>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<120>(8,1,'integer',['unsigned'|['big']]),#<58>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<99>(8,1,'integer',['unsigned'|['big']]),#<111>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<108>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<45>(8,1,'integer',['unsigned'|['big']]),#<62>(8,1,'integer',['unsigned'|['big']]),#<32>(8,1,'integer',['unsigned'|['big']]),#<73>(8,1,'integer',['unsigned'|['big']]),#<110>(8,1,'integer',['unsigned'|['big']]),#<116>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<103>(8,1,'integer',['unsigned'|['big']]),#<101>(8,1,'integer',['unsigned'|['big']]),#<114>(8,1,'integer',['unsigned'|['big']])}#}~,
+            'classMethodSignatures' => ~{}~,
+            'methodXref' => [~{'class_side' => 'false', 'selector' => 'sumWithIndex:', 'line' => 1, 'sends' => [~{'selector' => 'eachWithIndex:', 'line' => 3, 'recv_kind' => 'other'}~, ~{'selector' => '+', 'line' => 3, 'recv_kind' => 'other'}~, ~{'selector' => '*', 'line' => 3, 'recv_kind' => 'other'}~], 'references' => [~{'class' => 'Integer', 'line' => 1}~], 'source_status' => 'indexed'}~],
+            'classState' => ~{}~,
+            'classDoc' => 'none',
+            'methodDocs' => ~{}~,
+            'classMethodDocs' => ~{}~,
+            'meta' => ~{'class' => 'EnumerationValue',
+      'superclass' => 'Value',
+      'package' => 'none',
+      'kind' => 'value',
+      'fields' => [],
+      'class_fields' => [],
+      'is_sealed' => 'false',
+      'is_abstract' => 'false',
+      'is_value' => 'true',
+      'is_typed' => 'false',
+      'is_internal' => 'false',
+      'visibility' => 'public',
+      'type_params' => [],
+      'field_types' => ~{}~,
+      'field_has_default' => ~{}~,
+      'method_info' => ~{'sumWithIndex:' => ~{'arity' => 1, 'param_types' => ['none'], 'return_type' => 'Integer', 'is_sealed' => 'false', 'visibility' => 'public'}~}~,
+      'class_method_info' => ~{}~
+    }~
+        }~
+        in let _Reg0 = case call 'beamtalk_class_builder':'register'(_BuilderState0) of
+            <{'ok', _Pid0}> when 'true' -> 'ok'
+            <{'error', _Err0}> when 'true' -> {'error', _Err0}
+        end
+
+        in _Reg0
+
+    of _ClassRegResult -> _ClassRegResult
+    catch <CatchType, CatchError, CatchStack> -> primop 'raw_raise'(CatchType, CatchError, CatchStack)
+
+
+'__beamtalk_meta'/0 = fun () ->
+    ~{'class' => 'EnumerationValue',
+      'superclass' => 'Value',
+      'package' => 'none',
+      'kind' => 'value',
+      'fields' => [],
+      'class_fields' => [],
+      'is_sealed' => 'false',
+      'is_abstract' => 'false',
+      'is_value' => 'true',
+      'is_typed' => 'false',
+      'is_internal' => 'false',
+      'visibility' => 'public',
+      'type_params' => [],
+      'field_types' => ~{}~,
+      'field_has_default' => ~{}~,
+      'method_info' => ~{'sumWithIndex:' => ~{'arity' => 1, 'param_types' => ['none'], 'return_type' => 'Integer', 'is_sealed' => 'false', 'visibility' => 'public'}~}~,
+      'class_method_info' => ~{}~
+    }~
+
+end

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_lexer.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_lexer.snap
@@ -1,0 +1,33 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+Token { kind: Identifier("Value"), span: Span { start: 546, end: 551 }, leading_trivia: [LineComment("// Copyright 2026 James Casey"), Whitespace("\n"), LineComment("// SPDX-License-Identifier: Apache-2.0"), Whitespace("\n\n"), LineComment("// Snapshot test for BT-2703 enumeration desugar codegen (enumeration_ops.rs),"), Whitespace("\n"), LineComment("// value-type context."), Whitespace("\n"), LineComment("//"), Whitespace("\n"), LineComment("// In a value-type method, finalize_enumeration_fold takes the non-actor"), Whitespace("\n"), LineComment("// (passthrough) branch: the fold result is the un-annotated inject:into: send,"), Whitespace("\n"), LineComment("// and the outer call-site annotation is the only one."), Whitespace("\n"), LineComment("//"), Whitespace("\n"), LineComment("// Covers:"), Whitespace("\n"), LineComment("//   try_generate_each_with_index  — local variable mutation in a Value context"), Whitespace("\n"), LineComment("//   finalize_enumeration_fold     — non-actor passthrough path"), Whitespace("\n\n")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("subclass:"), span: Span { start: 552, end: 561 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("EnumerationValue"), span: Span { start: 562, end: 578 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Keyword("sumWithIndex:"), span: Span { start: 738, end: 751 }, leading_trivia: [Whitespace("\n\n  "), LineComment("// try_generate_each_with_index: captured-local mutation → desugar fires."), Whitespace("\n  "), LineComment("// finalize_enumeration_fold takes the non-actor (passthrough) branch here."), Whitespace("\n  ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("coll"), span: Span { start: 752, end: 756 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: FatArrow, span: Span { start: 757, end: 759 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("sum"), span: Span { start: 764, end: 767 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 768, end: 770 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Integer("0"), span: Span { start: 771, end: 772 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("coll"), span: Span { start: 777, end: 781 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Keyword("eachWithIndex:"), span: Span { start: 782, end: 796 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftBracket, span: Span { start: 797, end: 798 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Colon, span: Span { start: 798, end: 799 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("item"), span: Span { start: 799, end: 803 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Colon, span: Span { start: 804, end: 805 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("i"), span: Span { start: 805, end: 806 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Pipe, span: Span { start: 807, end: 808 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("sum"), span: Span { start: 809, end: 812 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Assign, span: Span { start: 813, end: 815 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("sum"), span: Span { start: 816, end: 819 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("+"), span: Span { start: 820, end: 821 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: LeftParen, span: Span { start: 822, end: 823 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("item"), span: Span { start: 823, end: 827 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: BinarySelector("*"), span: Span { start: 828, end: 829 }, leading_trivia: [], trailing_trivia: [Whitespace(" ")] }
+Token { kind: Identifier("i"), span: Span { start: 830, end: 831 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: RightParen, span: Span { start: 831, end: 832 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: RightBracket, span: Span { start: 832, end: 833 }, leading_trivia: [], trailing_trivia: [] }
+Token { kind: Identifier("sum"), span: Span { start: 838, end: 841 }, leading_trivia: [Whitespace("\n    ")], trailing_trivia: [] }
+Token { kind: Eof, span: Span { start: 842, end: 842 }, leading_trivia: [Whitespace("\n")], trailing_trivia: [] }

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_parser.snap
@@ -1,0 +1,420 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+AST:
+Module {
+    classes: [
+        ClassDefinition {
+            name: Identifier {
+                name: "EnumerationValue",
+                span: Span {
+                    start: 562,
+                    end: 578,
+                },
+            },
+            superclass: Some(
+                Identifier {
+                    name: "Value",
+                    span: Span {
+                        start: 546,
+                        end: 551,
+                    },
+                },
+            ),
+            superclass_package: None,
+            class_kind: Value,
+            is_abstract: false,
+            is_sealed: false,
+            is_typed: false,
+            is_internal: false,
+            supervisor_kind: None,
+            state: [],
+            methods: [
+                MethodDefinition {
+                    selector: Keyword(
+                        [
+                            KeywordPart {
+                                keyword: "sumWithIndex:",
+                                span: Span {
+                                    start: 738,
+                                    end: 751,
+                                },
+                            },
+                        ],
+                    ),
+                    parameters: [
+                        ParameterDefinition {
+                            name: Identifier {
+                                name: "coll",
+                                span: Span {
+                                    start: 752,
+                                    end: 756,
+                                },
+                            },
+                            type_annotation: None,
+                        },
+                    ],
+                    body: [
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: Assignment {
+                                target: Identifier(
+                                    Identifier {
+                                        name: "sum",
+                                        span: Span {
+                                            start: 764,
+                                            end: 767,
+                                        },
+                                    },
+                                ),
+                                value: Literal(
+                                    Integer(
+                                        0,
+                                    ),
+                                    Span {
+                                        start: 771,
+                                        end: 772,
+                                    },
+                                ),
+                                type_annotation: None,
+                                span: Span {
+                                    start: 764,
+                                    end: 772,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: MessageSend {
+                                receiver: Identifier(
+                                    Identifier {
+                                        name: "coll",
+                                        span: Span {
+                                            start: 777,
+                                            end: 781,
+                                        },
+                                    },
+                                ),
+                                selector: Keyword(
+                                    [
+                                        KeywordPart {
+                                            keyword: "eachWithIndex:",
+                                            span: Span {
+                                                start: 782,
+                                                end: 796,
+                                            },
+                                        },
+                                    ],
+                                ),
+                                arguments: [
+                                    Block(
+                                        Block {
+                                            parameters: [
+                                                BlockParameter {
+                                                    name: "item",
+                                                    span: Span {
+                                                        start: 799,
+                                                        end: 803,
+                                                    },
+                                                },
+                                                BlockParameter {
+                                                    name: "i",
+                                                    span: Span {
+                                                        start: 805,
+                                                        end: 806,
+                                                    },
+                                                },
+                                            ],
+                                            body: [
+                                                ExpressionStatement {
+                                                    comments: CommentAttachment {
+                                                        leading: [],
+                                                        trailing: None,
+                                                    },
+                                                    expression: Assignment {
+                                                        target: Identifier(
+                                                            Identifier {
+                                                                name: "sum",
+                                                                span: Span {
+                                                                    start: 809,
+                                                                    end: 812,
+                                                                },
+                                                            },
+                                                        ),
+                                                        value: MessageSend {
+                                                            receiver: Identifier(
+                                                                Identifier {
+                                                                    name: "sum",
+                                                                    span: Span {
+                                                                        start: 816,
+                                                                        end: 819,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            selector: Binary(
+                                                                "+",
+                                                            ),
+                                                            arguments: [
+                                                                Parenthesized {
+                                                                    expression: MessageSend {
+                                                                        receiver: Identifier(
+                                                                            Identifier {
+                                                                                name: "item",
+                                                                                span: Span {
+                                                                                    start: 823,
+                                                                                    end: 827,
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                        selector: Binary(
+                                                                            "*",
+                                                                        ),
+                                                                        arguments: [
+                                                                            Identifier(
+                                                                                Identifier {
+                                                                                    name: "i",
+                                                                                    span: Span {
+                                                                                        start: 830,
+                                                                                        end: 831,
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        is_cast: false,
+                                                                        span: Span {
+                                                                            start: 823,
+                                                                            end: 831,
+                                                                        },
+                                                                    },
+                                                                    span: Span {
+                                                                        start: 822,
+                                                                        end: 832,
+                                                                    },
+                                                                },
+                                                            ],
+                                                            is_cast: false,
+                                                            span: Span {
+                                                                start: 816,
+                                                                end: 832,
+                                                            },
+                                                        },
+                                                        type_annotation: None,
+                                                        span: Span {
+                                                            start: 809,
+                                                            end: 832,
+                                                        },
+                                                    },
+                                                    preceding_blank_line: false,
+                                                },
+                                            ],
+                                            span: Span {
+                                                start: 797,
+                                                end: 833,
+                                            },
+                                        },
+                                    ),
+                                ],
+                                is_cast: false,
+                                span: Span {
+                                    start: 777,
+                                    end: 833,
+                                },
+                            },
+                            preceding_blank_line: false,
+                        },
+                        ExpressionStatement {
+                            comments: CommentAttachment {
+                                leading: [],
+                                trailing: None,
+                            },
+                            expression: Identifier(
+                                Identifier {
+                                    name: "sum",
+                                    span: Span {
+                                        start: 838,
+                                        end: 841,
+                                    },
+                                },
+                            ),
+                            preceding_blank_line: false,
+                        },
+                    ],
+                    return_type: None,
+                    is_sealed: false,
+                    is_internal: false,
+                    is_class_method: false,
+                    kind: Primary,
+                    expect: None,
+                    comments: CommentAttachment {
+                        leading: [
+                            Comment {
+                                content: "try_generate_each_with_index: captured-local mutation → desugar fires.",
+                                span: Span {
+                                    start: 738,
+                                    end: 751,
+                                },
+                                kind: Line,
+                                preceding_blank_line: true,
+                            },
+                            Comment {
+                                content: "finalize_enumeration_fold takes the non-actor (passthrough) branch here.",
+                                span: Span {
+                                    start: 738,
+                                    end: 751,
+                                },
+                                kind: Line,
+                                preceding_blank_line: false,
+                            },
+                        ],
+                        trailing: None,
+                    },
+                    doc_comment: None,
+                    span: Span {
+                        start: 738,
+                        end: 841,
+                    },
+                },
+            ],
+            class_methods: [],
+            class_variables: [],
+            comments: CommentAttachment {
+                leading: [
+                    Comment {
+                        content: "Copyright 2026 James Casey",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "SPDX-License-Identifier: Apache-2.0",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "Snapshot test for BT-2703 enumeration desugar codegen (enumeration_ops.rs),",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: true,
+                    },
+                    Comment {
+                        content: "value-type context.",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "In a value-type method, finalize_enumeration_fold takes the non-actor",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "(passthrough) branch: the fold result is the un-annotated inject:into: send,",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "and the outer call-site annotation is the only one.",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "Covers:",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "  try_generate_each_with_index  — local variable mutation in a Value context",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                    Comment {
+                        content: "  finalize_enumeration_fold     — non-actor passthrough path",
+                        span: Span {
+                            start: 546,
+                            end: 551,
+                        },
+                        kind: Line,
+                        preceding_blank_line: false,
+                    },
+                ],
+                trailing: None,
+            },
+            doc_comment: None,
+            backing_module: None,
+            type_params: [],
+            superclass_type_args: [],
+            span: Span {
+                start: 546,
+                end: 841,
+            },
+        },
+    ],
+    method_definitions: [],
+    protocols: [],
+    expressions: [],
+    span: Span {
+        start: 546,
+        end: 841,
+    },
+    file_leading_comments: [],
+    file_trailing_comments: [],
+}

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_semantic.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_semantic.snap
@@ -1,0 +1,5 @@
+---
+source: test-package-compiler/tests/compiler_tests.rs
+expression: output
+---
+No semantic errors


### PR DESCRIPTION
## Summary

`crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/enumeration_ops.rs` was at **0% Rust coverage** (0/169 executable lines) despite the BT-2703 `eachWithIndex:`/`do:separatedBy:` desugar being fully implemented and BUnit-tested. The gap exists because BUnit tests run via `beamtalk test` (not `cargo test`), so they never exercise the Rust codegen paths that `cargo llvm-cov` measures.

This PR adds two snapshot test cases to `test-package-compiler/cases/` that run the desugar through the Rust compiler under `cargo test`, closing the coverage gap.

### What's covered by the new cases

**`actor_enumeration_ops/main.bt`** — Actor context (`enumeration_threads_actor_state → true`):
- `sumWithIndex:` — `try_generate_each_with_index` with field mutation; `finalize_enumeration_fold` actor re-projection path (`{'nil', element(2, EnumFold)}`)
- `joinSum:` — `try_generate_do_separated_by` with field mutation in both element and separator blocks
- `gapCount:` — `try_generate_do_separated_by` where only the separator block mutates an outer local

**`value_enumeration_ops/main.bt`** — Value-type context (`enumeration_threads_actor_state → false`):
- `sumWithIndex:` — `try_generate_each_with_index` with captured-local mutation; `finalize_enumeration_fold` non-actor passthrough path

Both `_compiles` tests pass (generated Core Erlang is accepted by `erlc +from_core`), confirming the desugar output is syntactically valid.

## Test plan

- [x] `cargo test -p test-package-compiler -- enumeration_ops` — 10/10 pass (lexer, parser, semantic, codegen, compiles × 2 cases)
- [x] `cargo test --all-targets` — 387 tests, 0 failures
- [x] `just test-stdlib` — 223 tests, 0 failures
- [x] `just test-bunit` — 2653 tests, 0 failures
- [x] Pre-push hook: clippy, fmt, dialyzer, erlfmt — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWnwAWXubwBJzHdiPD5N9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWnwAWXubwBJzHdiPD5N9Y)_