### PR TITLE
test: tighten Erlang node/0 assertion to check Symbol type

### DIFF
--- a/stdlib/test/erlang_object_inheritance_test.bt
+++ b/stdlib/test/erlang_object_inheritance_test.bt
@@ -40,7 +40,8 @@ TestCase subclass: ErlangObjectInheritanceTest
   testErlangModuleKeywordDispatch =>
     self assert: (self.proxy reverse: #(3, 2, 1)) equals: #(1, 2, 3)
 
-  testErlangModuleUnaryDispatch => self assert: ((Erlang erlang) node isKindOf: Symbol)
+  testErlangModuleUnaryDispatch =>
+    self assert: ((Erlang erlang) node isKindOf: Symbol)
 
   // === Erlang: Object-inherited methods ===
   // Note: Must use dynamic dispatch (via variable or perform:) because

--- a/stdlib/test/erlang_object_inheritance_test.bt
+++ b/stdlib/test/erlang_object_inheritance_test.bt
@@ -40,7 +40,7 @@ TestCase subclass: ErlangObjectInheritanceTest
   testErlangModuleKeywordDispatch =>
     self assert: (self.proxy reverse: #(3, 2, 1)) equals: #(1, 2, 3)
 
-  testErlangModuleUnaryDispatch => self assert: (Erlang erlang) node notNil
+  testErlangModuleUnaryDispatch => self assert: ((Erlang erlang) node isKindOf: Symbol)
 
   // === Erlang: Object-inherited methods ===
   // Note: Must use dynamic dispatch (via variable or perform:) because


### PR DESCRIPTION
## Summary

`testErlangModuleUnaryDispatch` in `stdlib/test/erlang_object_inheritance_test.bt` asserted only that `(Erlang erlang) node` was non-nil. `erlang:node/0` is documented to return a Symbol (Erlang atom), and the parallel test in `erlang_interop_test.bt` already asserts `class equals: Symbol` for the same call. The `notNil` assertion would silently pass even if the return type regressed to an integer or string.

**Change:** replace `notNil` with `isKindOf: Symbol`, matching the file's own pattern for typed dispatch tests (`hash isKindOf: Integer`, `displayString isKindOf: String`, `inspect isKindOf: Inspector`).

## Test plan

- [x] `just test-bunit` — 2655 tests, 0 failures
- [x] All pre-push lint hooks pass (Clippy, fmt, Dialyzer, Beamtalk formatter, Biome)
- [x] No other files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrLKxo248zbEU5L66zKhgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrLKxo248zbEU5L66zKhgx)_