### PR TITLE
Actor codegen: strip __local__ threading temps from persisted state & watch notifications (BT-2717)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -1216,12 +1216,16 @@ impl CoreErlangGenerator {
                     nest(
                         INDENT,
                         docvec![
+                            // BT-2717: strip codegen-internal `__local__` threading
+                            // temporaries before persist + notify (see handle_call).
+                            line(),
+                            "let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in",
                             // BT-2524: same per-object change push as handle_call, for
                             // a state write committed via a fire-and-forget cast.
                             line(),
-                            "let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in",
+                            "let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in",
                             line(),
-                            "{'noreply', CastNewState}",
+                            "{'noreply', CleanCastNewState}",
                         ]
                     ),
                     line(),
@@ -1384,14 +1388,20 @@ impl CoreErlangGenerator {
                     nest(
                         INDENT,
                         docvec![
+                            // BT-2717: strip codegen-internal `__local__` threading
+                            // temporaries before persist + notify, so an outer local
+                            // threaded through a control-flow desugar never leaks into
+                            // the committed actor state or a watch notification.
+                            line(),
+                            "let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in",
                             // BT-2524: notify the per-object change substrate so a
                             // watched compiled actor's committed state write pushes
                             // {object_changed, …} to the live Inspector — the runtime
                             // beamtalk_actor path does this via log_dispatch_complete.
                             line(),
-                            "let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in",
+                            "let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in",
                             line(),
-                            "{'reply', {'ok', Result}, NewState}",
+                            "{'reply', {'ok', Result}, CleanNewState}",
                         ]
                     ),
                     // Error case: pass error (now includes stacktrace) opaquely to caller

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -568,8 +568,10 @@ impl CoreErlangGenerator {
                                 leaf::var(err_var1),
                                 ", 'domain' => ['beamtalk'|['runtime'|[]]]}~) in",
                                 line(),
-                                // BT-2717: terminating path — state is discarded, but keep
-                                // the cleaned binding for consistency with the success arm.
+                                // BT-2717: terminating path — the state flows to
+                                // terminate/2, not persistence, so no clean-up contract
+                                // applies; use the cleaned binding for consistency with
+                                // the success arm.
                                 "{'stop', ",
                                 leaf::var(fmt_var),
                                 ", InitCleanState}",

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -474,12 +474,22 @@ impl CoreErlangGenerator {
             .unwrap_or_default();
 
         if typed_no_default.is_empty() {
-            return docvec![line(), "{'noreply', InitNewState}"];
+            // BT-2717: strip codegen-internal `__local__` threading temps from the
+            // post-initialize committed state, the same outermost-boundary clean-up
+            // handle_call/handle_cast apply — an `initialize` that threads an outer
+            // local must not persist the temporary into the actor's first state.
+            return docvec![
+                line(),
+                "let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in",
+                line(),
+                "{'noreply', InitCleanState}",
+            ];
         }
 
         // Build nested checks: each field gets a case that either stops or continues.
-        // We build from the inside out — the innermost is {'noreply', InitNewState}.
-        let mut body: Document<'static> = docvec!["{'noreply', InitNewState}"];
+        // We build from the inside out — the innermost is the cleaned {'noreply', …}
+        // (BT-2717: __local__ threading temps stripped from the committed state).
+        let mut body: Document<'static> = docvec!["{'noreply', InitCleanState}"];
 
         for (i, field) in typed_no_default.iter().enumerate().rev() {
             let field_name = field.field_name.clone();
@@ -574,6 +584,10 @@ impl CoreErlangGenerator {
         }
 
         docvec![
+            line(),
+            // BT-2717: clean the committed state once before the field checks; the
+            // checks read user fields (never `__local__`) so they are unaffected.
+            "let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in",
             line(),
             "%% BT-1949/BT-1951: Verify typed-no-default fields (including inherited) were initialized",
             line(),

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -568,9 +568,11 @@ impl CoreErlangGenerator {
                                 leaf::var(err_var1),
                                 ", 'domain' => ['beamtalk'|['runtime'|[]]]}~) in",
                                 line(),
+                                // BT-2717: terminating path — state is discarded, but keep
+                                // the cleaned binding for consistency with the success arm.
                                 "{'stop', ",
                                 leaf::var(fmt_var),
-                                ", InitNewState}",
+                                ", InitCleanState}",
                             ]
                         ),
                         line(),
@@ -1487,7 +1489,19 @@ impl CoreErlangGenerator {
                             docvec![
                                 line(),
                                 "<{'reply', _Result, NewState}> when 'true' ->",
-                                nest(INDENT, docvec![line(), "{'noreply', NewState}",]),
+                                nest(
+                                    INDENT,
+                                    docvec![
+                                        // BT-2717: handle_info is an outermost state-commit
+                                        // boundary too — a Server `handleInfo:` that threads an
+                                        // outer local through a control-flow desugar must not
+                                        // persist `__local__` temps into the committed state.
+                                        line(),
+                                        "let CleanInfoNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in",
+                                        line(),
+                                        "{'noreply', CleanInfoNewState}",
+                                    ]
+                                ),
                                 line(),
                                 // BT-1822: Destructure error triple to log stacktrace
                                 "<{'error', {InfoType, InfoReason, InfoStacktrace}, _ErrState}> when 'true' ->",

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -2582,6 +2582,37 @@ Actor subclass: Counter
 }
 
 #[test]
+fn test_bt2717_handle_continue_strips_local_temps_from_init_state() {
+    // BT-2717: handle_continue is an outermost state-commit boundary (it persists
+    // the post-initialize state). An `initialize` that threads an outer local must
+    // not leave a `__local__` temp in the actor's first committed state, so the
+    // post-initialize path strips it before the {'noreply', …} reply — the same
+    // clean-up handle_call/handle_cast apply.
+    let src = "
+Actor subclass: Counter
+  state: value = 0
+  initialize => self.value := 1
+";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let code = generate_module_with_warnings(&module, CodegenOptions::new("counter"))
+        .expect("codegen should succeed")
+        .code;
+
+    assert!(
+        code.contains(
+            "let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in"
+        ),
+        "handle_continue must strip __local__ threading temps from the committed \
+         post-initialize state. Got:\n{code}"
+    );
+    assert!(
+        code.contains("{'noreply', InitCleanState}"),
+        "handle_continue must reply with the cleaned post-initialize state. Got:\n{code}"
+    );
+}
+
+#[test]
 fn test_bt1005_explicit_annotation_not_overwritten_by_writeback() {
     // BT-1005: An explicitly annotated method must NOT be changed by the writeback pass.
     let src = "

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -4487,6 +4487,20 @@ fn test_actor_typed_union_non_nil_field_triggers_validation() {
         code.contains("'uninitialized_state_error'"),
         "Non-nil Union field should trigger typed-no-default validation. Got:\n{code}"
     );
+    // BT-2717: the typed-no-default field-check path must also strip __local__
+    // threading temps from the committed post-initialize state — the `let
+    // InitCleanState = …` binding is emitted before the nested field-check case,
+    // and the success arm replies with it.
+    assert!(
+        code.contains(
+            "let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in"
+        ),
+        "typed-no-default post-init path must strip __local__ temps. Got:\n{code}"
+    );
+    assert!(
+        code.contains("{'noreply', InitCleanState}"),
+        "typed-no-default post-init success arm must reply with the cleaned state. Got:\n{code}"
+    );
 }
 
 #[test]

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -2613,6 +2613,42 @@ Actor subclass: Counter
 }
 
 #[test]
+fn test_bt2717_handle_info_strips_local_temps_for_server_subclass() {
+    // BT-2717: a Server subclass's handle_info is an outermost state-commit boundary
+    // too — a `handleInfo:` that threads an outer local through a control-flow desugar
+    // must not persist `__local__` temps into the committed gen_server state.
+    let src = "
+Server subclass: TickServer
+  state: count = 0
+  handleInfo: msg =>
+    msg == #tick ifTrue: [self.count := self.count + 1]
+";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let code = generate_module_with_warnings(&module, CodegenOptions::new("tick_server"))
+        .expect("codegen should succeed")
+        .code;
+
+    // Sanity: this is the Server-subclass handle_info (dispatches handleInfo:), not
+    // the plain Actor delegate stub.
+    assert!(
+        code.contains("'safe_dispatch'('handleInfo:', [Msg], State)"),
+        "expected a Server-subclass handle_info dispatching handleInfo:. Got:\n{code}"
+    );
+    assert!(
+        code.contains(
+            "let CleanInfoNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in"
+        ),
+        "handle_info must strip __local__ threading temps before committing the \
+         post-handleInfo: state. Got:\n{code}"
+    );
+    assert!(
+        code.contains("{'noreply', CleanInfoNewState}"),
+        "handle_info must commit the cleaned state. Got:\n{code}"
+    );
+}
+
+#[test]
 fn test_bt1005_explicit_annotation_not_overwritten_by_writeback() {
     // BT-1005: An explicitly annotated method must NOT be changed by the writeback pass.
     let src = "

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -2556,17 +2556,28 @@ Actor subclass: Counter
         .expect("codegen should succeed")
         .code;
 
-    // handle_call commits NewState; the hook fires before returning the reply.
+    // BT-2717: handle_call strips codegen-internal `__local__` threading temps from
+    // the committed state, then notifies + persists the cleaned state.
     assert!(
-        code.contains("'beamtalk_actor':'notify_state_change'(State, NewState)"),
-        "handle_call must notify the per-object change substrate after committing \
-         state. Got:\n{code}"
+        code.contains("let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in"),
+        "handle_call must strip __local__ threading temps before persist/notify. Got:\n{code}"
     );
-    // handle_cast (fire-and-forget) commits CastNewState; same hook.
     assert!(
-        code.contains("'beamtalk_actor':'notify_state_change'(State, CastNewState)"),
-        "handle_cast must notify the per-object change substrate after committing \
-         state. Got:\n{code}"
+        code.contains("'beamtalk_actor':'notify_state_change'(State, CleanNewState)"),
+        "handle_call must notify the per-object change substrate with the cleaned \
+         state after committing. Got:\n{code}"
+    );
+    // handle_cast (fire-and-forget) commits CastNewState; same strip + hook.
+    assert!(
+        code.contains(
+            "let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in"
+        ),
+        "handle_cast must strip __local__ threading temps before persist/notify. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'beamtalk_actor':'notify_state_change'(State, CleanCastNewState)"),
+        "handle_cast must notify the per-object change substrate with the cleaned \
+         state after committing. Got:\n{code}"
     );
 }
 

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -189,7 +189,9 @@ handle_getValue([], State) ->
 
 %% BT-2524: per-object change publish hook, called from compiled actor
 %% gen_server callbacks after a method commits new state.
--export([notify_state_change/2]).
+%% BT-2717: strip_local_temps/1 cleans codegen-internal `__local__` threading
+%% temporaries from committed state before the reply is emitted.
+-export([notify_state_change/2, strip_local_temps/1]).
 
 %% Named registration (ADR 0079, BT-1987)
 -export([
@@ -1830,17 +1832,55 @@ notify_state_change(OldState, NewState) ->
 
 -doc """
 Compute which user-visible state keys changed between two state maps.
-Excludes internal keys (__methods__, $beamtalk_class, __class_mod__).
+
+Excludes internal keys (__methods__, $beamtalk_class, __class_mod__) and, per
+BT-2717, `__local__`-prefixed control-flow threading temporaries: those are
+codegen-internal locals packed into the state map while threading an outer local
+through a desugared loop/conditional, never user-observable fields. Belt-and-braces
+alongside the codegen-side `strip_local_temps/1` so a stray `__local__` key from any
+leak path never surfaces as a watched-actor changed slot.
 """.
 -spec changed_state_keys(map(), map()) -> [atom()].
 changed_state_keys(OldState, NewState) ->
     InternalKeys = ['__methods__', beamtalk_tagged_map:class_key(), '__class_mod__'],
     AllKeys = lists:usort(maps:keys(OldState) ++ maps:keys(NewState)),
-    UserKeys = AllKeys -- InternalKeys,
+    UserKeys = [K || K <- AllKeys -- InternalKeys, not is_local_temp_key(K)],
     [
         K
      || K <- UserKeys, maps:get(K, OldState, '__absent__') =/= maps:get(K, NewState, '__absent__')
     ].
+
+-doc """
+Strip codegen-internal `__local__`-prefixed control-flow threading temporaries from
+an actor state map before it is persisted or its changes published (BT-2717).
+
+When an actor method threads an outer local through a desugared control-flow
+construct (`eachWithIndex:`, `do:separatedBy:`, conditionals, counted loops) the
+local is packed into the gen_server `State` map under a `__local__<name>` key. Those
+keys are a purely internal threading mechanism — they must not leak into the
+persisted actor state or be mistaken for user-observable fields by the watch
+notification path. Compiled actor `handle_call`/`handle_cast` callbacks call this on
+the committed `NewState` before replying, so the persisted state stays clean
+regardless of which codegen path packed the temporary.
+
+Returns the map unchanged (no rebuild) when it carries no such keys — the common
+case for a method that threads nothing.
+""".
+-spec strip_local_temps(map()) -> map().
+strip_local_temps(State) ->
+    case [K || K <- maps:keys(State), is_local_temp_key(K)] of
+        [] -> State;
+        LocalKeys -> maps:without(LocalKeys, State)
+    end.
+
+-spec is_local_temp_key(term()) -> boolean().
+is_local_temp_key(Key) when is_atom(Key) ->
+    case atom_to_binary(Key, utf8) of
+        <<"__local__", _/binary>> -> true;
+        _ -> false
+    end;
+is_local_temp_key(_Key) ->
+    false.
 
 -doc """
 Construct a Self reference (#beamtalk_object{}) from the actor's state.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
@@ -3636,3 +3636,71 @@ bt1990_wait_until_unregistered_loop(Name, Deadline) ->
                     bt1990_wait_until_unregistered_loop(Name, Deadline)
             end
     end.
+
+%%% BT-2717: `__local__` threading temporaries must not leak into persisted
+%%% actor state or watch-notification changed slots.
+%%%
+%%% When an actor method threads an outer local through a desugared control-flow
+%%% construct (eachWithIndex:/do:separatedBy:, conditionals, counted loops) the
+%%% local is packed into the gen_server State under a `__local__<name>` key. Those
+%%% codegen-internal temps must be stripped before the state is committed and its
+%%% changes published. `strip_local_temps/1` does the codegen-side strip (called
+%%% from generated handle_call/handle_cast); `changed_state_keys/2` excludes the
+%%% prefix as belt-and-braces for any residual leak on the notification path.
+
+strip_local_temps_removes_threading_temps_test() ->
+    %% Mirrors the gapCount: leak: a `__local__gaps` temp packed alongside a real
+    %% `total` field. All `__local__*` keys are dropped; user fields and the
+    %% internal `__class_mod__` survive.
+    State = #{
+        total => 5,
+        '__local__gaps' => 2,
+        '__local__i' => 9,
+        '__class_mod__' => some_mod
+    },
+    ?assertEqual(
+        #{total => 5, '__class_mod__' => some_mod},
+        beamtalk_actor:strip_local_temps(State)
+    ).
+
+strip_local_temps_noop_without_temps_test() ->
+    %% Common case: no threading temps → the same map is returned unchanged.
+    State = #{total => 5, '__class_mod__' => some_mod},
+    ?assertEqual(State, beamtalk_actor:strip_local_temps(State)).
+
+%% Watch-notification path: a watched actor whose committed NewState still carried
+%% a `__local__*` temp must publish no changed slot keyed on that temp. Drives the
+%% real beamtalk_object_watch substrate via notify_state_change/2.
+local_temp_not_published_as_changed_slot_test_() ->
+    {setup, fun bt2717_watch_setup/0, fun bt2717_watch_teardown/1, fun(_) ->
+        ?_test(begin
+            Self = self(),
+            ok = beamtalk_object_watch:subscribe(Self, Self),
+            _ = sys:get_state(beamtalk_object_watch),
+            ?assert(beamtalk_object_watch:is_watched(Self)),
+            OldState = #{'__class_mod__' => some_mod, total => 0},
+            %% `total` changes (a real field) and a `__local__gaps` temp appears —
+            %% as it would after gapCount: threads its outer local through the fold.
+            NewState = OldState#{total => 5, '__local__gaps' => 2},
+            ok = beamtalk_actor:notify_state_change(OldState, NewState),
+            Slots =
+                receive
+                    {object_changed, Self, S} -> S
+                after 1000 -> ?assert(false)
+                end,
+            ?assert(lists:member(total, Slots)),
+            ?assertNot(lists:member('__local__gaps', Slots)),
+            beamtalk_object_watch:unsubscribe(Self, Self)
+        end)
+    end}.
+
+bt2717_watch_setup() ->
+    case whereis(beamtalk_object_watch) of
+        undefined -> {ok, _} = beamtalk_object_watch:start_link();
+        _ -> ok
+    end,
+    [beamtalk_object_watch:unsubscribe(P, self()) || P <- beamtalk_object_watch:watched_pids()],
+    ok.
+
+bt2717_watch_teardown(_) ->
+    ok.

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_conditional_field_mutations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_conditional_field_mutations_codegen.snap
@@ -99,7 +99,8 @@ module 'actor_conditional_field_mutations' ['start_link'/1, 'start_link'/2, 'ini
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_conditional_field_mutations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_conditional_field_mutations_codegen.snap
@@ -120,8 +120,9 @@ module 'actor_conditional_field_mutations' ['start_link'/1, 'start_link'/2, 'ini
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -144,8 +145,9 @@ module 'actor_conditional_field_mutations' ['start_link'/1, 'start_link'/2, 'ini
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -175,8 +177,9 @@ module 'actor_conditional_field_mutations' ['start_link'/1, 'start_link'/2, 'ini
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -193,8 +196,9 @@ module 'actor_conditional_field_mutations' ['start_link'/1, 'start_link'/2, 'ini
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_codegen.snap
@@ -98,7 +98,8 @@ module 'actor_enumeration_ops' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_codegen.snap
@@ -119,8 +119,9 @@ module 'actor_enumeration_ops' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'actor_enumeration_ops' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'actor_enumeration_ops' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'actor_enumeration_ops' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_list_ops_no_mutation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_list_ops_no_mutation_codegen.snap
@@ -96,7 +96,8 @@ module 'actor_list_ops_no_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, '
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_list_ops_no_mutation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_list_ops_no_mutation_codegen.snap
@@ -117,8 +117,9 @@ module 'actor_list_ops_no_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'actor_list_ops_no_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'actor_list_ops_no_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'actor_list_ops_no_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_codegen.snap
@@ -118,8 +118,9 @@ module 'actor_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -142,8 +143,9 @@ module 'actor_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -173,8 +175,9 @@ module 'actor_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -191,8 +194,9 @@ module 'actor_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_codegen.snap
@@ -97,7 +97,8 @@ module 'actor_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_codegen.snap
@@ -118,8 +118,9 @@ module 'actor_spawn_with_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -142,8 +143,9 @@ module 'actor_spawn_with_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -173,8 +175,9 @@ module 'actor_spawn_with_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -191,8 +194,9 @@ module 'actor_spawn_with_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_codegen.snap
@@ -97,7 +97,8 @@ module 'actor_spawn_with_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_codegen.snap
@@ -118,8 +118,9 @@ module 'actor_state_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -142,8 +143,9 @@ module 'actor_state_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -173,8 +175,9 @@ module 'actor_state_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -191,8 +194,9 @@ module 'actor_state_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_codegen.snap
@@ -97,7 +97,8 @@ module 'actor_state_mutation' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_codegen.snap
@@ -96,7 +96,8 @@ module 'async_keyword_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_codegen.snap
@@ -117,8 +117,9 @@ module 'async_keyword_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'async_keyword_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'async_keyword_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'async_keyword_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_codegen.snap
@@ -96,7 +96,8 @@ module 'async_unary_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_codegen.snap
@@ -117,8 +117,9 @@ module 'async_unary_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'async_unary_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'async_unary_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'async_unary_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_codegen.snap
@@ -117,8 +117,9 @@ module 'async_with_await' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'async_with_await' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'async_with_await' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'async_with_await' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_codegen.snap
@@ -96,7 +96,8 @@ module 'async_with_await' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_codegen.snap
@@ -119,8 +119,9 @@ module 'binary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'binary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'binary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'binary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_codegen.snap
@@ -98,7 +98,8 @@ module 'binary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_codegen.snap
@@ -97,7 +97,8 @@ module 'blocks_no_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_codegen.snap
@@ -118,8 +118,9 @@ module 'blocks_no_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -142,8 +143,9 @@ module 'blocks_no_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -173,8 +175,9 @@ module 'blocks_no_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -191,8 +194,9 @@ module 'blocks_no_args' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_codegen.snap
@@ -117,8 +117,9 @@ module 'boundary_deeply_nested' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'boundary_deeply_nested' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'boundary_deeply_nested' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'boundary_deeply_nested' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_codegen.snap
@@ -96,7 +96,8 @@ module 'boundary_deeply_nested' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_codegen.snap
@@ -119,8 +119,9 @@ module 'boundary_long_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'boundary_long_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'boundary_long_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'boundary_long_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_codegen.snap
@@ -98,7 +98,8 @@ module 'boundary_long_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_codegen.snap
@@ -117,8 +117,9 @@ module 'boundary_mixed_errors' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'boundary_mixed_errors' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'boundary_mixed_errors' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'boundary_mixed_errors' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_codegen.snap
@@ -96,7 +96,8 @@ module 'boundary_mixed_errors' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_codegen.snap
@@ -117,8 +117,9 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1,
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1,
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1,
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1,
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_codegen.snap
@@ -96,7 +96,8 @@ module 'boundary_unicode_identifiers' ['start_link'/1, 'start_link'/2, 'init'/1,
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_codegen.snap
@@ -96,7 +96,8 @@ module 'cascade_complex' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_codegen.snap
@@ -117,8 +117,9 @@ module 'cascade_complex' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'cascade_complex' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'cascade_complex' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'cascade_complex' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascades_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascades_codegen.snap
@@ -96,7 +96,8 @@ module 'cascades' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascades_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascades_codegen.snap
@@ -117,8 +117,9 @@ module 'cascades' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'cascades' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'cascades' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'cascades' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue'/2
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__character_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__character_literals_codegen.snap
@@ -121,8 +121,9 @@ module 'character_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -145,8 +146,9 @@ module 'character_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -176,8 +178,9 @@ module 'character_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -194,8 +197,9 @@ module 'character_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__character_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__character_literals_codegen.snap
@@ -100,7 +100,8 @@ module 'character_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_definition_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_definition_codegen.snap
@@ -119,8 +119,9 @@ module 'class_definition' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'class_definition' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'class_definition' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'class_definition' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_definition_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_definition_codegen.snap
@@ -98,7 +98,8 @@ module 'class_definition' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
@@ -121,8 +121,9 @@ module 'class_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -145,8 +146,9 @@ module 'class_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -176,8 +178,9 @@ module 'class_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -194,8 +197,9 @@ module 'class_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_methods_codegen.snap
@@ -100,7 +100,8 @@ module 'class_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_codegen.snap
@@ -100,7 +100,8 @@ module 'comment_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_codegen.snap
@@ -121,8 +121,9 @@ module 'comment_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -145,8 +146,9 @@ module 'comment_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -176,8 +178,9 @@ module 'comment_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -194,8 +197,9 @@ module 'comment_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_codegen.snap
@@ -105,7 +105,8 @@ module 'control_flow_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_codegen.snap
@@ -126,8 +126,9 @@ module 'control_flow_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -150,8 +151,9 @@ module 'control_flow_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -181,8 +183,9 @@ module 'control_flow_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -199,8 +202,9 @@ module 'control_flow_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_codegen.snap
@@ -117,8 +117,9 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_codegen.snap
@@ -96,7 +96,8 @@ module 'control_flow_mutations_errors' ['start_link'/1, 'start_link'/2, 'init'/1
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_codegen.snap
@@ -117,8 +117,9 @@ module 'empty_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'empty_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'empty_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'empty_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_codegen.snap
@@ -96,7 +96,8 @@ module 'empty_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_codegen.snap
@@ -119,8 +119,9 @@ module 'empty_method_body' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'empty_method_body' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'empty_method_body' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'empty_method_body' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_codegen.snap
@@ -98,7 +98,8 @@ module 'empty_method_body' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_message_codegen.snap
@@ -118,8 +118,9 @@ module 'error_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -142,8 +143,9 @@ module 'error_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -173,8 +175,9 @@ module 'error_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -191,8 +194,9 @@ module 'error_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_message_codegen.snap
@@ -97,7 +97,8 @@ module 'error_message' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_codegen.snap
@@ -96,7 +96,8 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'start_link'/2, 'init'/1
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_codegen.snap
@@ -117,8 +117,9 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'error_recovery_invalid_syntax' ['start_link'/1, 'start_link'/2, 'init'/1
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_codegen.snap
@@ -96,7 +96,8 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'start_link'/2, 'init
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_codegen.snap
@@ -117,8 +117,9 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'start_link'/2, 'init
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'start_link'/2, 'init
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'start_link'/2, 'init
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'error_recovery_malformed_message' ['start_link'/1, 'start_link'/2, 'init
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_codegen.snap
@@ -96,7 +96,8 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'start_link'/2, 'in
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_codegen.snap
@@ -117,8 +117,9 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'start_link'/2, 'in
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'start_link'/2, 'in
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'start_link'/2, 'in
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'error_recovery_unterminated_string' ['start_link'/1, 'start_link'/2, 'in
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_codegen.snap
@@ -118,8 +118,9 @@ module 'expect_directive' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -142,8 +143,9 @@ module 'expect_directive' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -173,8 +175,9 @@ module 'expect_directive' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -191,8 +194,9 @@ module 'expect_directive' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_codegen.snap
@@ -97,7 +97,8 @@ module 'expect_directive' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__foreign_extension_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__foreign_extension_codegen.snap
@@ -96,7 +96,8 @@ module 'foreign_extension' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__foreign_extension_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__foreign_extension_codegen.snap
@@ -117,8 +117,9 @@ module 'foreign_extension' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'foreign_extension' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'foreign_extension' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'foreign_extension' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_codegen.snap
@@ -96,7 +96,8 @@ module 'future_pattern_matching' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_codegen.snap
@@ -117,8 +117,9 @@ module 'future_pattern_matching' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'future_pattern_matching' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'future_pattern_matching' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'future_pattern_matching' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_codegen.snap
@@ -124,8 +124,9 @@ module 'future_string_interpolation' ['start_link'/1, 'start_link'/2, 'init'/1, 
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -148,8 +149,9 @@ module 'future_string_interpolation' ['start_link'/1, 'start_link'/2, 'init'/1, 
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -179,8 +181,9 @@ module 'future_string_interpolation' ['start_link'/1, 'start_link'/2, 'init'/1, 
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -197,8 +200,9 @@ module 'future_string_interpolation' ['start_link'/1, 'start_link'/2, 'init'/1, 
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_codegen.snap
@@ -103,7 +103,8 @@ module 'future_string_interpolation' ['start_link'/1, 'start_link'/2, 'init'/1, 
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__hello_world_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__hello_world_codegen.snap
@@ -117,8 +117,9 @@ module 'hello_world' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'hello_world' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'hello_world' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'hello_world' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__hello_world_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__hello_world_codegen.snap
@@ -96,7 +96,8 @@ module 'hello_world' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continue
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_codegen.snap
@@ -112,7 +112,8 @@ module 'initializing_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack0 = call 'erlang':'erase'('$bt_call_stack') in
             case _InitResult0 of
                 <{'reply', _InitRet0, InitNewState}> when 'true' ->
-                    {'noreply', InitNewState}
+                    let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+                    {'noreply', InitCleanState}
                 <{'error', {_InitType0, _InitReason0, _InitStack0}, _InitErrState0}> when 'true' ->
                     let _InitErrMsg0 = call 'beamtalk_error':'format_safe'({_InitType0, _InitReason0}, _InitStack0) in
                     let _InitErrClass0 = call 'bt@initializing_counter':'class_name'() in

--- a/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_codegen.snap
@@ -144,8 +144,9 @@ module 'initializing_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -168,8 +169,9 @@ module 'initializing_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -199,8 +201,9 @@ module 'initializing_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -217,8 +220,9 @@ module 'initializing_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_codegen.snap
@@ -108,7 +108,8 @@ module 'logging_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_codegen.snap
@@ -129,8 +129,9 @@ module 'logging_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -153,8 +154,9 @@ module 'logging_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -184,8 +186,9 @@ module 'logging_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -202,8 +205,9 @@ module 'logging_counter' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__map_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__map_literals_codegen.snap
@@ -117,8 +117,9 @@ module 'map_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'map_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'map_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'map_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__map_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__map_literals_codegen.snap
@@ -96,7 +96,8 @@ module 'map_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_continu
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_codegen.snap
@@ -117,8 +117,9 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'start_link'/2, 'init'/1, '
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_codegen.snap
@@ -96,7 +96,8 @@ module 'multi_keyword_complex_args' ['start_link'/1, 'start_link'/2, 'init'/1, '
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_codegen.snap
@@ -96,7 +96,8 @@ module 'nested_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_codegen.snap
@@ -117,8 +117,9 @@ module 'nested_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'nested_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'nested_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'nested_blocks' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_codegen.snap
@@ -96,7 +96,8 @@ module 'nested_keyword_messages' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_codegen.snap
@@ -117,8 +117,9 @@ module 'nested_keyword_messages' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'nested_keyword_messages' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'nested_keyword_messages' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'nested_keyword_messages' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__string_operations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__string_operations_codegen.snap
@@ -122,8 +122,9 @@ module 'string_operations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -146,8 +147,9 @@ module 'string_operations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -177,8 +179,9 @@ module 'string_operations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -195,8 +198,9 @@ module 'string_operations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__string_operations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__string_operations_codegen.snap
@@ -101,7 +101,8 @@ module 'string_operations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_codegen.snap
@@ -98,7 +98,8 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_codegen.snap
@@ -119,8 +119,9 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'typed_class_warnings' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_codegen.snap
@@ -119,8 +119,9 @@ module 'typed_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'typed_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'typed_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'typed_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_codegen.snap
@@ -98,7 +98,8 @@ module 'typed_methods' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_codegen.snap
@@ -97,7 +97,8 @@ module 'unary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_codegen.snap
@@ -118,8 +118,9 @@ module 'unary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -142,8 +143,9 @@ module 'unary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -173,8 +175,9 @@ module 'unary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -191,8 +194,9 @@ module 'unary_operators' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_codegen.snap
@@ -121,8 +121,9 @@ module 'unicode_string_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -145,8 +146,9 @@ module 'unicode_string_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -176,8 +178,9 @@ module 'unicode_string_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -194,8 +197,9 @@ module 'unicode_string_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_codegen.snap
@@ -100,7 +100,8 @@ module 'unicode_string_literals' ['start_link'/1, 'start_link'/2, 'init'/1, 'han
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_codegen.snap
@@ -96,7 +96,8 @@ module 'while_true_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_codegen.snap
@@ -117,8 +117,9 @@ module 'while_true_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'while_true_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'while_true_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'while_true_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_codegen.snap
@@ -98,7 +98,8 @@ module 'whitespace_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_codegen.snap
@@ -119,8 +119,9 @@ module 'whitespace_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'whitespace_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'whitespace_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'whitespace_handling' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_codegen.snap
@@ -118,8 +118,9 @@ module 'workspace_binding_cascade' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -142,8 +143,9 @@ module 'workspace_binding_cascade' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -173,8 +175,9 @@ module 'workspace_binding_cascade' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -191,8 +194,9 @@ module 'workspace_binding_cascade' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_codegen.snap
@@ -97,7 +97,8 @@ module 'workspace_binding_cascade' ['start_link'/1, 'start_link'/2, 'init'/1, 'h
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_codegen.snap
@@ -118,8 +118,9 @@ module 'workspace_binding_send' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -142,8 +143,9 @@ module 'workspace_binding_send' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -173,8 +175,9 @@ module 'workspace_binding_send' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -191,8 +194,9 @@ module 'workspace_binding_send' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_codegen.snap
@@ -97,7 +97,8 @@ module 'workspace_binding_send' ['start_link'/1, 'start_link'/2, 'init'/1, 'hand
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_mutations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_mutations_codegen.snap
@@ -96,7 +96,8 @@ module 'ws_list_ops_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_mutations_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_mutations_codegen.snap
@@ -117,8 +117,9 @@ module 'ws_list_ops_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'ws_list_ops_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'ws_list_ops_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'ws_list_ops_mutations' ['start_link'/1, 'start_link'/2, 'init'/1, 'handl
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_search_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_search_codegen.snap
@@ -121,8 +121,9 @@ module 'ws_list_ops_search' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -145,8 +146,9 @@ module 'ws_list_ops_search' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -176,8 +178,9 @@ module 'ws_list_ops_search' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -194,8 +197,9 @@ module 'ws_list_ops_search' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_search_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_search_codegen.snap
@@ -100,7 +100,8 @@ module 'ws_list_ops_search' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_simple_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_simple_codegen.snap
@@ -117,8 +117,9 @@ module 'ws_list_ops_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'ws_list_ops_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'ws_list_ops_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'ws_list_ops_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_simple_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_simple_codegen.snap
@@ -96,7 +96,8 @@ module 'ws_list_ops_simple' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_c
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_codegen.snap
@@ -117,8 +117,9 @@ module 'ws_stdlib_array' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'ws_stdlib_array' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'ws_stdlib_array' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'ws_stdlib_array' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_codegen.snap
@@ -96,7 +96,8 @@ module 'ws_stdlib_array' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_codegen.snap
@@ -119,8 +119,9 @@ module 'ws_stdlib_block' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'ws_stdlib_block' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'ws_stdlib_block' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'ws_stdlib_block' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_codegen.snap
@@ -98,7 +98,8 @@ module 'ws_stdlib_block' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_cont
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_codegen.snap
@@ -96,7 +96,8 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_codegen.snap
@@ -117,8 +117,9 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'ws_stdlib_boolean' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_codegen.snap
@@ -117,8 +117,9 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_codegen.snap
@@ -96,7 +96,8 @@ module 'ws_stdlib_dictionary' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_codegen.snap
@@ -98,7 +98,8 @@ module 'ws_stdlib_integer' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_codegen.snap
@@ -119,8 +119,9 @@ module 'ws_stdlib_integer' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'ws_stdlib_integer' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'ws_stdlib_integer' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'ws_stdlib_integer' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_co
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_codegen.snap
@@ -117,8 +117,9 @@ module 'ws_stdlib_list' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'ws_stdlib_list' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'ws_stdlib_list' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'ws_stdlib_list' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_codegen.snap
@@ -96,7 +96,8 @@ module 'ws_stdlib_list' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_conti
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_codegen.snap
@@ -117,8 +117,9 @@ module 'ws_stdlib_nil' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'ws_stdlib_nil' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'ws_stdlib_nil' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'ws_stdlib_nil' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_codegen.snap
@@ -96,7 +96,8 @@ module 'ws_stdlib_nil' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_codegen.snap
@@ -101,7 +101,8 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_codegen.snap
@@ -122,8 +122,9 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -146,8 +147,9 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -177,8 +179,9 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -195,8 +198,9 @@ module 'ws_stdlib_nil_object' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_codegen.snap
@@ -117,8 +117,9 @@ module 'ws_stdlib_set' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -141,8 +142,9 @@ module 'ws_stdlib_set' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -172,8 +174,9 @@ module 'ws_stdlib_set' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -190,8 +193,9 @@ module 'ws_stdlib_set' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_codegen.snap
@@ -96,7 +96,8 @@ module 'ws_stdlib_set' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_contin
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_codegen.snap
@@ -98,7 +98,8 @@ module 'ws_stdlib_string' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
     case Continue of
         <'initialize'> when 'true' ->
             let InitNewState = State in
-            {'noreply', InitNewState}
+            let InitCleanState = call 'beamtalk_actor':'strip_local_temps'(InitNewState) in
+            {'noreply', InitCleanState}
         <_> when 'true' -> {'noreply', State}
     end
 

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_codegen.snap
@@ -119,8 +119,9 @@ module 'ws_stdlib_string' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -143,8 +144,9 @@ module 'ws_stdlib_string' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _CastDispatchResult of
                 <{'reply', _CastResult, CastNewState}> when 'true' ->
-                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CastNewState) in
-                    {'noreply', CastNewState}
+                    let CleanCastNewState = call 'beamtalk_actor':'strip_local_temps'(CastNewState) in
+                    let _CastStateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanCastNewState) in
+                    {'noreply', CleanCastNewState}
                 <{'error', {CastType, CastReason, CastStacktrace}, _CastState}> when 'true' ->
                     let CastErrMsg = call 'beamtalk_error':'format_safe'({CastType, CastReason}, CastStacktrace) in
                     let _ = call 'logger':'warning'(CastErrMsg, ~{'selector' => CastSelector, 'reason' => {CastType, CastReason}, 'stacktrace' => CastStacktrace, 'domain' => ['beamtalk'|['runtime'|[]]]}~)
@@ -174,8 +176,9 @@ module 'ws_stdlib_string' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end
@@ -192,8 +195,9 @@ module 'ws_stdlib_string' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle_con
             let _ClearStack = call 'erlang':'erase'('$bt_call_stack') in
             case _DispatchResult of
                 <{'reply', Result, NewState}> when 'true' ->
-                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, NewState) in
-                    {'reply', {'ok', Result}, NewState}
+                    let CleanNewState = call 'beamtalk_actor':'strip_local_temps'(NewState) in
+                    let _StateChanged = call 'beamtalk_actor':'notify_state_change'(State, CleanNewState) in
+                    {'reply', {'ok', Result}, CleanNewState}
                 <{'error', Error, ErrState}> when 'true' ->
                     {'reply', {'error', Error}, ErrState}
             end


### PR DESCRIPTION
## Summary

Fixes [BT-2717](https://linear.app/beamtalk/issue/BT-2717). Actor methods that thread an outer local through a desugared control-flow construct (`eachWithIndex:`/`do:separatedBy:`, conditionals, counted loops) pack the local into the gen_server `State` under a `__local__<name>` key. These codegen-internal temporaries leaked into the **persisted actor state** and, for a **watched** actor, surfaced as spurious `__local__*` state-change notification slots.

The leak is systemic across multiple codegen emitters with no single emitter-level chokepoint, so the fix strips at the **outermost state-commit boundaries** (where the gen_server actually persists `NewState`), plus a runtime belt-and-braces for the notification path.

## Changes

**Codegen** (`gen_server/callbacks.rs`)
- Generated `handle_call` and `handle_cast` strip `__local__*` keys from the committed `NewState` via `beamtalk_actor:strip_local_temps/1` before notifying the per-object change substrate and replying (covers both the 3-tuple `PropCtx` and 2-tuple message clauses).
- `handle_continue` (post-initialize commit) does the same for `InitNewState`, so an `initialize` that threads a local doesn't persist a temp into the actor's first state.

**Runtime** (`beamtalk_actor.erl`)
- New `strip_local_temps/1` (+ `is_local_temp_key/1`): removes all `__local__`-prefixed atom keys; returns the map unchanged (no rebuild) when there are none — cheap on the common path.
- `changed_state_keys/2` also excludes `__local__`-prefixed keys (belt-and-braces for the notification path, regardless of leak source).

**Tests**
- EUnit: `strip_local_temps/1` unit coverage + an end-to-end watch-notification test driving the real `beamtalk_object_watch` substrate (a `__local__gaps` temp produces no changed slot while a real field still does).
- Codegen: extended the BT-2524 callback test and added a `handle_continue` strip test.
- Regenerated 62 actor codegen snapshots.

## Why this placement
Stripping only at the outermost gen_server callback is correct: stripping inside `safe_dispatch`/self-sends would corrupt an outer method's in-flight local threading (the inner call's returned state still carries the outer method's live `__local__` keys). Locals are always seeded fresh in-method before use, so stripping persisted state never affects re-execution.

## Verification
Local: workspace Rust tests (44 suites), stdlib (223), BUnit (2653), runtime EUnit (267), clippy, `cargo fmt`, `rebar3 fmt`, `rebar3 dialyzer` — all green.

## Follow-up
- **BT-2718** (filed from code review): reserve the internal `__…__` state-key namespace with a semantic validator so a user field/var named `__local__*` (or `__methods__`, etc.) is rejected rather than silently stripped. Latent today — no existing `.bt` uses such names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011WUTHZTeNvGyRMKYcz5xZq)_