### PR TITLE
Unify FFI proxy: wrap error:* by default, propagate exit/throw (BT-2722)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_erlang_proxy.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_erlang_proxy.erl
@@ -38,9 +38,18 @@ for reserved selectors (class, ==, /=, self, etc.).
 See: ADR 0028 §1 (Module Proxy Pattern)
 """.
 
--export([coerce_result/1, direct_call/3, dispatch/3, has_method/1, new/1]).
+-export([coerce_result/1, direct_call/3, dispatch/3, has_method/1, native_call/4, new/1]).
 
 -include("beamtalk.hrl").
+
+%%% Error-reporting context for the unified apply path (ADR 0101 Part 2).
+%%%
+%%% - `none` — inline `(Erlang module)` FFI. Wrapped errors report the
+%%%   Erlang-facing `'ErlangModule'` class and the original selector.
+%%% - `{Class, Selector}` — a `native:` Object delegation (BT-2720). Wrapped
+%%%   errors report the Beamtalk class/selector so they read `Stream>>take:`
+%%%   rather than the bare Erlang MFA.
+-type error_context() :: none | {atom(), atom()}.
 
 -doc "Create a new ErlangModule proxy for the given module atom.".
 -spec new(atom()) -> map().
@@ -158,8 +167,10 @@ of calling `call 'M':'F'(args)` directly. This enables:
 - Automatic binary→charlist coercion on badarg (BT-1127)
 - Charlist→binary result coercion for consistent string types
 
-Unlike `validate_and_apply/4`, this does NOT wrap exit/throw exceptions —
-those propagate naturally so `Erlang erlang exit: 1` behaves as expected.
+Wrapping policy is unified across all apply paths via `apply_with_coercion/5`
+(ADR 0101 Part 2): `error:*` is converted to a structured `#beamtalk_error{}`,
+while `exit:*` and `throw:*` propagate naturally so `Erlang erlang exit: 1`
+behaves as expected and foreign throws stay throws.
 """.
 -spec direct_call(atom(), atom(), list()) -> term().
 direct_call(Module, FunName, Args) ->
@@ -170,7 +181,7 @@ direct_call(Module, FunName, Args) ->
         {ok, Exports} ->
             case lists:member({FunName, Arity}, Exports) of
                 true ->
-                    apply_with_coercion(Module, FunName, Args, FunName);
+                    apply_with_coercion(Module, FunName, Args, FunName, none);
                 false ->
                     raise_function_or_arity_error(
                         Module, FunName, Arity, FunName, Exports
@@ -179,41 +190,113 @@ direct_call(Module, FunName, Args) ->
     end.
 
 -doc """
-Call Module:FunName(Args), retrying with charlist-coerced args on badarg.
+Entry point for `native:` Object delegation (ADR 0101 Part 1, BT-2720).
 
-Only catches badarg (for coercion retry). All other exceptions (exit, throw,
-and other errors) propagate naturally — this preserves the semantics of
-direct calls like `Erlang erlang exit: 1`.
+`native:` Object methods lower to
+`beamtalk_erlang_proxy:native_call(Mod, Fn, [Self | Args], {Class, Sel})`.
+Unlike `direct_call/3`/`validate_and_apply/4` this **skips the proactive
+`get_exports`/arity pre-check** — codegen guarantees the call shape at compile
+time, so the check is pure overhead. It still routes through the shared
+`apply_with_coercion/5`, so it gets the **same** `error:*` → `#beamtalk_error{}`
+wrapping and ADR 0076 ok/error → `Result` coercion as inline FFI.
+
+The `{Class, Sel}` context makes wrapped errors read `Stream>>take:` instead of
+the bare Erlang MFA. Crucially, `error:undef` is still caught (the compile-time
+guarantee does not survive **hot code reload** — a backing function can be
+swapped between compile and call) and surfaced as a structured
+`does_not_understand` carrying `{Class, Sel}`.
 """.
--spec apply_with_coercion(atom(), atom(), list(), atom()) -> term().
-apply_with_coercion(Module, FunName, Args, OrigSelector) ->
+-spec native_call(atom(), atom(), list(), {atom(), atom()}) -> term().
+native_call(Module, FunName, Args, {Class, Selector}) ->
+    apply_with_coercion(Module, FunName, Args, FunName, {Class, Selector}).
+
+-doc """
+The single, unified apply path for all FFI (ADR 0101 Part 2).
+
+Calls `Module:FunName(Args)`, coercing ok/error → `Result` (ADR 0076) on the
+happy path and retrying with charlist-coerced args on `badarg` (BT-1127).
+
+Exception policy — converged across `direct_call/3`, `validate_and_apply/4`,
+and `native_call/4`:
+- `error:#beamtalk_error{}` (already wrapped) → re-raised unchanged
+- `error:undef` → structured `does_not_understand` (hot-reload TOCTOU)
+- `error:badarg` → charlist retry, else `type_error`
+- `error:function_clause` → `arity_mismatch`
+- `error:badarith` → `type_error`
+- any other `error:Reason` → `runtime_error` (this is the catch-all that makes
+  casual FFI safe by default — previously `direct_call` leaked these)
+- `exit:*` → **propagates** (not caught)
+- `throw:*` → **passes through** (not caught)
+
+`Context` selects the class/selector reported on wrapped errors — see
+`error_context()`. The wrapping helpers (`ensure_wrapped`-style) run only on the
+error path; the happy path pays nothing beyond the `try` frame + coercion.
+""".
+-spec apply_with_coercion(atom(), atom(), list(), atom(), error_context()) -> term().
+apply_with_coercion(Module, FunName, Args, OrigSelector, Context) ->
     try
-        Result = erlang:apply(Module, FunName, Args),
-        coerce_ffi_result(Module, Result)
+        coerce_ffi_result(Module, erlang:apply(Module, FunName, Args))
     catch
-        error:#{error := #beamtalk_error{}} = Wrapped:WrappedStack ->
-            erlang:raise(error, Wrapped, WrappedStack);
-        error:undef:_Stack ->
-            %% TOCTOU: function unloaded between export check and apply
-            raise_undef_error(Module, FunName, length(Args), OrigSelector);
         error:badarg:Stack ->
-            CoercedArgs = coerce_binaries_to_charlists(Args),
-            case CoercedArgs =/= Args of
-                true ->
-                    try
-                        RetryResult = erlang:apply(Module, FunName, CoercedArgs),
-                        coerce_ffi_result(Module, RetryResult)
-                    catch
-                        error:badarg:Stack2 ->
-                            raise_badarg_error(Module, FunName, OrigSelector, Stack2);
-                        error:#{error := #beamtalk_error{}} = Wrapped2:WrappedStack2 ->
-                            erlang:raise(error, Wrapped2, WrappedStack2);
-                        error:undef:_Stack2 ->
-                            raise_undef_error(Module, FunName, length(CoercedArgs), OrigSelector)
-                    end;
-                false ->
-                    raise_badarg_error(Module, FunName, OrigSelector, Stack)
-            end
+            maybe_retry_badarg(Module, FunName, Args, OrigSelector, Context, Stack);
+        error:#{error := #beamtalk_error{}} = Wrapped:WrappedStack ->
+            %% Re-raise already-wrapped Beamtalk exceptions unchanged
+            %% (e.g. from Beamtalk code reached via Erlang). Idempotent.
+            erlang:raise(error, Wrapped, WrappedStack);
+        error:#beamtalk_error{} = Rec:RecStack ->
+            %% A bare #beamtalk_error{} record raised by an Erlang shim
+            %% (e.g. error(#beamtalk_error{kind = type_error, …})) is already
+            %% classified — wrap it into the map form *preserving its kind*
+            %% (idempotent); do not reclassify it as a generic runtime_error.
+            erlang:raise(error, beamtalk_exception_handler:wrap(Rec), RecStack);
+        error:undef:_Stack ->
+            %% TOCTOU / hot code reload: function unloaded between check and apply
+            raise_undef_error(Module, FunName, length(Args), OrigSelector, Context);
+        error:function_clause:Stack ->
+            raise_function_clause_error(Module, FunName, OrigSelector, Context, Stack);
+        error:badarith:Stack ->
+            raise_badarith_error(Module, FunName, OrigSelector, Context, Stack);
+        error:Reason:Stack ->
+            raise_generic_error(Module, FunName, OrigSelector, Context, Reason, Stack)
+        %% exit:* and throw:* are deliberately NOT caught — they propagate
+        %% (ADR 0101 Part 2: process exit and foreign throws are semantically
+        %% meaningful and must not be flattened into #beamtalk_error{}).
+    end.
+
+-doc """
+BT-1127: auto-coerce binary args to charlists and retry once on `badarg`.
+
+Many Erlang functions (os:cmd/1, file:read_file/1, …) expect charlists but
+Beamtalk strings are binaries. Applies the same unified catch policy on the
+retry; if the retry still fails (or no binary args were coercible) the error is
+wrapped per `apply_with_coercion/5`.
+""".
+-spec maybe_retry_badarg(atom(), atom(), list(), atom(), error_context(), list()) -> term().
+maybe_retry_badarg(Module, FunName, Args, OrigSelector, Context, Stack) ->
+    CoercedArgs = coerce_binaries_to_charlists(Args),
+    case CoercedArgs =/= Args of
+        true ->
+            try
+                coerce_ffi_result(Module, erlang:apply(Module, FunName, CoercedArgs))
+            catch
+                error:#{error := #beamtalk_error{}} = Wrapped:WrappedStack ->
+                    erlang:raise(error, Wrapped, WrappedStack);
+                error:#beamtalk_error{} = Rec:RecStack ->
+                    erlang:raise(error, beamtalk_exception_handler:wrap(Rec), RecStack);
+                error:badarg:Stack2 ->
+                    raise_badarg_error(Module, FunName, OrigSelector, Context, Stack2);
+                error:undef:_Stack2 ->
+                    raise_undef_error(Module, FunName, length(CoercedArgs), OrigSelector, Context);
+                error:function_clause:Stack2 ->
+                    raise_function_clause_error(Module, FunName, OrigSelector, Context, Stack2);
+                error:badarith:Stack2 ->
+                    raise_badarith_error(Module, FunName, OrigSelector, Context, Stack2);
+                error:Reason2:Stack2 ->
+                    raise_generic_error(Module, FunName, OrigSelector, Context, Reason2, Stack2)
+                %% exit:* / throw:* propagate (see apply_with_coercion/5)
+            end;
+        false ->
+            raise_badarg_error(Module, FunName, OrigSelector, Context, Stack)
     end.
 
 %%% ============================================================================
@@ -280,6 +363,11 @@ Validate function existence and arity, then apply.
 
 Checks module_info(exports) before calling erlang:apply/3 to provide
 actionable error messages (BT-679). No caching — hot code reload must work.
+
+Once validated, delegates to the unified `apply_with_coercion/5` so the
+`call:args:` / dispatch path shares the **same** exception policy as inline FFI
+(ADR 0101 Part 2): `error:*` wrapped, `exit:*`/`throw:*` propagated. This rolls
+back the former `exit`→`erlang_exit` / `throw`→`erlang_throw` wrapping.
 """.
 -spec validate_and_apply(atom(), atom(), list(), atom()) -> term().
 validate_and_apply(Module, FunName, Args, OrigSelector) ->
@@ -290,153 +378,7 @@ validate_and_apply(Module, FunName, Args, OrigSelector) ->
         {ok, Exports} ->
             case lists:member({FunName, Arity}, Exports) of
                 true ->
-                    %% Exact match — call directly
-                    try
-                        coerce_ffi_result(Module, erlang:apply(Module, FunName, Args))
-                    catch
-                        error:#{error := #beamtalk_error{}} = Wrapped:_Stack ->
-                            %% Re-raise already-wrapped Beamtalk exceptions
-                            %% (e.g., from Beamtalk code called via Erlang)
-                            error(Wrapped);
-                        error:undef:Stack ->
-                            %% Unlikely with export validation (BT-679), but
-                            %% possible during hot code reload race conditions
-                            Error0 = beamtalk_error:new(does_not_understand, 'ErlangModule'),
-                            Error1 = beamtalk_error:with_selector(Error0, OrigSelector),
-                            Error2 = beamtalk_error:with_hint(
-                                Error1,
-                                erlang_error_hint(Module, FunName, undef)
-                            ),
-                            beamtalk_error:raise(
-                                beamtalk_error:with_details(
-                                    Error2,
-                                    #{
-                                        erlang_error => undef,
-                                        erlang_stacktrace => Stack
-                                    }
-                                )
-                            );
-                        error:badarg:Stack ->
-                            %% BT-1127: Auto-coerce binary args to charlists and retry.
-                            %% Many Erlang functions (os:cmd/1, file:read_file/1, etc.)
-                            %% expect charlists but Beamtalk strings are binaries.
-                            CoercedArgs = coerce_binaries_to_charlists(Args),
-                            case CoercedArgs =/= Args of
-                                true ->
-                                    try
-                                        Result = erlang:apply(Module, FunName, CoercedArgs),
-                                        coerce_ffi_result(Module, Result)
-                                    catch
-                                        error:badarg:Stack2 ->
-                                            raise_badarg_error(
-                                                Module, FunName, OrigSelector, Stack2
-                                            );
-                                        error:#{error := #beamtalk_error{}} = Wrapped:_Stack2 ->
-                                            error(Wrapped);
-                                        error:undef:_Stack2 ->
-                                            raise_undef_error(
-                                                Module,
-                                                FunName,
-                                                length(CoercedArgs),
-                                                OrigSelector
-                                            )
-                                    end;
-                                false ->
-                                    raise_badarg_error(Module, FunName, OrigSelector, Stack)
-                            end;
-                        error:function_clause:Stack ->
-                            Error0 = beamtalk_error:new(arity_mismatch, 'ErlangModule'),
-                            Error1 = beamtalk_error:with_selector(Error0, OrigSelector),
-                            Error2 = beamtalk_error:with_hint(
-                                Error1,
-                                erlang_error_hint(Module, FunName, function_clause)
-                            ),
-                            beamtalk_error:raise(
-                                beamtalk_error:with_details(
-                                    Error2,
-                                    #{
-                                        erlang_error => function_clause,
-                                        erlang_stacktrace => Stack
-                                    }
-                                )
-                            );
-                        error:badarith:Stack ->
-                            Error0 = beamtalk_error:new(type_error, 'ErlangModule'),
-                            Error1 = beamtalk_error:with_selector(Error0, OrigSelector),
-                            Error2 = beamtalk_error:with_hint(
-                                Error1,
-                                erlang_error_hint(Module, FunName, badarith)
-                            ),
-                            beamtalk_error:raise(
-                                beamtalk_error:with_details(
-                                    Error2,
-                                    #{
-                                        erlang_error => badarith,
-                                        erlang_stacktrace => Stack
-                                    }
-                                )
-                            );
-                        error:Reason:Stack ->
-                            Error0 = beamtalk_error:new(runtime_error, 'ErlangModule'),
-                            Error1 = beamtalk_error:with_selector(Error0, OrigSelector),
-                            Error2 = beamtalk_error:with_hint(
-                                Error1,
-                                erlang_error_hint(Module, FunName, Reason)
-                            ),
-                            beamtalk_error:raise(
-                                beamtalk_error:with_details(
-                                    Error2,
-                                    #{
-                                        erlang_error => Reason,
-                                        erlang_stacktrace => Stack
-                                    }
-                                )
-                            );
-                        exit:Reason:Stack ->
-                            Error0 = beamtalk_error:new(erlang_exit, 'ErlangModule'),
-                            Error1 = beamtalk_error:with_selector(Error0, OrigSelector),
-                            ReasonBin = iolist_to_binary(io_lib:format("~p", [Reason])),
-                            Hint = iolist_to_binary([
-                                <<"Erlang process exit in ">>,
-                                atom_to_binary(Module, utf8),
-                                <<":">>,
-                                atom_to_binary(FunName, utf8),
-                                <<": ">>,
-                                ReasonBin
-                            ]),
-                            Error2 = beamtalk_error:with_hint(Error1, Hint),
-                            beamtalk_error:raise(
-                                beamtalk_error:with_details(
-                                    Error2,
-                                    #{
-                                        erlang_exit_reason => Reason,
-                                        erlang_stacktrace => Stack
-                                    }
-                                )
-                            );
-                        throw:Value:Stack ->
-                            Error0 = beamtalk_error:new(erlang_throw, 'ErlangModule'),
-                            Error1 = beamtalk_error:with_selector(Error0, OrigSelector),
-                            ValueBin = iolist_to_binary(io_lib:format("~p", [Value])),
-                            Hint = iolist_to_binary([
-                                <<"Erlang throw in ">>,
-                                atom_to_binary(Module, utf8),
-                                <<":">>,
-                                atom_to_binary(FunName, utf8),
-                                <<": ">>,
-                                ValueBin
-                            ]),
-                            Error2 = beamtalk_error:with_hint(Error1, Hint),
-                            beamtalk_error:raise(
-                                beamtalk_error:with_details(
-                                    Error2,
-                                    #{
-                                        erlang_throw_value => Value,
-                                        erlang_stacktrace => Stack
-                                    }
-                                )
-                            )
-                    end;
+                    apply_with_coercion(Module, FunName, Args, OrigSelector, none);
                 false ->
                     raise_function_or_arity_error(
                         Module, FunName, Arity, OrigSelector, Exports
@@ -498,12 +440,29 @@ raise_function_or_arity_error(Module, FunName, Arity, OrigSelector, Exports) ->
     end.
 
 -doc """
+Resolve the `{Class, Selector}` to attach to a wrapped FFI error.
+
+Inline FFI (`Context = none`) reports the Erlang-facing `'ErlangModule'` class
+and the original selector — preserving the long-standing error contract.
+A `native:` delegation (`Context = {Class, Sel}`) reports the Beamtalk
+class/selector so errors read `Stream>>take:` (ADR 0101 Part 2).
+""".
+-spec error_class_selector(error_context(), atom()) -> {atom(), atom()}.
+error_class_selector(none, OrigSelector) -> {'ErlangModule', OrigSelector};
+error_class_selector({Class, Selector}, _OrigSelector) -> {Class, Selector}.
+
+-doc """
 Raise a structured undef error (TOCTOU: function unloaded between check and apply).
 
 Pass the actual arity so the error message is accurate (not "0 arguments").
+
+For inline FFI (`Context = none`) this re-checks exports to distinguish
+"missing function" from "wrong arity". For a `native:` delegation
+(`Context = {Class, Sel}`) the pre-check was skipped by design, so surface a
+`does_not_understand` carrying the Beamtalk `{Class, Sel}` directly.
 """.
--spec raise_undef_error(atom(), atom(), non_neg_integer(), atom()) -> no_return().
-raise_undef_error(Module, FunName, Arity, OrigSelector) ->
+-spec raise_undef_error(atom(), atom(), non_neg_integer(), atom(), error_context()) -> no_return().
+raise_undef_error(Module, FunName, Arity, OrigSelector, none) ->
     case get_exports(Module) of
         {error, not_loaded} ->
             raise_module_not_loaded(Module, OrigSelector);
@@ -511,22 +470,93 @@ raise_undef_error(Module, FunName, Arity, OrigSelector) ->
             raise_function_or_arity_error(
                 Module, FunName, Arity, OrigSelector, Exports
             )
-    end.
-
--doc "Raise a structured badarg error.".
--spec raise_badarg_error(atom(), atom(), atom(), list()) -> no_return().
-raise_badarg_error(Module, FunName, OrigSelector, Stack) ->
-    Error0 = beamtalk_error:new(type_error, 'ErlangModule'),
-    Error1 = beamtalk_error:with_selector(Error0, OrigSelector),
+    end;
+raise_undef_error(Module, FunName, Arity, _OrigSelector, {Class, Selector}) ->
+    Error0 = beamtalk_error:new(does_not_understand, Class),
+    Error1 = beamtalk_error:with_selector(Error0, Selector),
     Error2 = beamtalk_error:with_hint(
         Error1,
-        erlang_error_hint(Module, FunName, badarg)
+        erlang_error_hint(Module, FunName, undef)
+    ),
+    beamtalk_error:raise(
+        beamtalk_error:with_details(Error2, #{
+            module => Module,
+            function => FunName,
+            arity => Arity,
+            erlang_error => undef
+        })
+    ).
+
+-doc "Raise a structured badarg error (type_error).".
+-spec raise_badarg_error(atom(), atom(), atom(), error_context(), list()) -> no_return().
+raise_badarg_error(Module, FunName, OrigSelector, Context, Stack) ->
+    raise_wrapped_error(type_error, badarg, Module, FunName, OrigSelector, Context, Stack).
+
+-doc "Raise a structured function_clause error (arity_mismatch).".
+-spec raise_function_clause_error(atom(), atom(), atom(), error_context(), list()) -> no_return().
+raise_function_clause_error(Module, FunName, OrigSelector, Context, Stack) ->
+    raise_wrapped_error(
+        arity_mismatch, function_clause, Module, FunName, OrigSelector, Context, Stack
+    ).
+
+-doc "Raise a structured badarith error (type_error).".
+-spec raise_badarith_error(atom(), atom(), atom(), error_context(), list()) -> no_return().
+raise_badarith_error(Module, FunName, OrigSelector, Context, Stack) ->
+    raise_wrapped_error(type_error, badarith, Module, FunName, OrigSelector, Context, Stack).
+
+-doc """
+Catch-all wrapper for any other `error:Reason` (ADR 0101 Part 2).
+
+This is what makes casual FFI safe by default: any `error:*` not handled by a
+specific clause above becomes a structured `#beamtalk_error{}` rather than
+leaking a raw Erlang fault to the user/REPL.
+
+Delegates to the canonical classifier `beamtalk_exception_handler:ensure_wrapped/4`
+(AC: "via ensure_wrapped"), so unclassified BEAM shapes get readable, bucketed
+messages: `{badkey, K}` → key_error "key not found: K", `{badmap, M}`,
+`{badmatch, V}`, `noproc`, `timeout`, … (BT-2704/2707). The `{Class, Selector}`
+breadcrumb locates the message (e.g. `Stream>>take:`). This reuses the existing
+classifier rather than re-deriving FFI error text in the proxy.
+""".
+-spec raise_generic_error(atom(), atom(), atom(), error_context(), term(), list()) -> no_return().
+raise_generic_error(_Module, _FunName, OrigSelector, Context, Reason, Stack) ->
+    Ctx = generic_error_context(Context, OrigSelector),
+    Wrapped = beamtalk_exception_handler:ensure_wrapped(error, Reason, Stack, Ctx),
+    erlang:raise(error, Wrapped, Stack).
+
+-doc """
+Build the dispatch breadcrumb map (`#{class, selector}`) handed to
+`ensure_wrapped/4` so a generically-wrapped FFI error is located. Inline FFI
+reports `'ErlangModule'` + the Erlang function; `native:` reports the Beamtalk
+class/selector.
+""".
+-spec generic_error_context(error_context(), atom()) -> map().
+generic_error_context(none, OrigSelector) ->
+    #{class => 'ErlangModule', selector => OrigSelector};
+generic_error_context({Class, Selector}, _OrigSelector) ->
+    #{class => Class, selector => Selector}.
+
+-doc """
+Shared builder for a wrapped `error:*` FFI exception.
+
+Attaches `{Class, Selector}` per `error_class_selector/2`, an actionable hint,
+and the original Erlang error + stacktrace in details.
+""".
+-spec raise_wrapped_error(atom(), term(), atom(), atom(), atom(), error_context(), list()) ->
+    no_return().
+raise_wrapped_error(Kind, ErlangError, Module, FunName, OrigSelector, Context, Stack) ->
+    {ErrClass, ErrSelector} = error_class_selector(Context, OrigSelector),
+    Error0 = beamtalk_error:new(Kind, ErrClass),
+    Error1 = beamtalk_error:with_selector(Error0, ErrSelector),
+    Error2 = beamtalk_error:with_hint(
+        Error1,
+        erlang_error_hint(Module, FunName, ErlangError)
     ),
     beamtalk_error:raise(
         beamtalk_error:with_details(
             Error2,
             #{
-                erlang_error => badarg,
+                erlang_error => ErlangError,
                 erlang_stacktrace => Stack
             }
         )

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_erlang_proxy.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_erlang_proxy.erl
@@ -205,6 +205,12 @@ the bare Erlang MFA. Crucially, `error:undef` is still caught (the compile-time
 guarantee does not survive **hot code reload** — a backing function can be
 swapped between compile and call) and surfaced as a structured
 `does_not_understand` carrying `{Class, Sel}`.
+
+**Codegen-only.** This entry deliberately omits the proactive
+`get_exports`/arity pre-check that `direct_call/3` and `validate_and_apply/4`
+run, so it must only be called with the exact `{Mod, Fn, Args}` shape codegen
+emits. Hand-written code wanting export validation up front should use
+`direct_call/3` (or the `(Erlang module)` FFI surface) instead.
 """.
 -spec native_call(atom(), atom(), list(), {atom(), atom()}) -> term().
 native_call(Module, FunName, Args, {Class, Selector}) ->
@@ -237,8 +243,9 @@ apply_with_coercion(Module, FunName, Args, OrigSelector, Context) ->
     try
         coerce_ffi_result(Module, erlang:apply(Module, FunName, Args))
     catch
-        error:badarg:Stack ->
-            maybe_retry_badarg(Module, FunName, Args, OrigSelector, Context, Stack);
+        %% Clause order mirrors maybe_retry_badarg/6 for readability. The patterns
+        %% are mutually exclusive (distinct atoms vs map vs record), so order only
+        %% matters for the trailing catch-all, which must stay last.
         error:#{error := #beamtalk_error{}} = Wrapped:WrappedStack ->
             %% Re-raise already-wrapped Beamtalk exceptions unchanged
             %% (e.g. from Beamtalk code reached via Erlang). Idempotent.
@@ -249,6 +256,8 @@ apply_with_coercion(Module, FunName, Args, OrigSelector, Context) ->
             %% classified — wrap it into the map form *preserving its kind*
             %% (idempotent); do not reclassify it as a generic runtime_error.
             erlang:raise(error, beamtalk_exception_handler:wrap(Rec), RecStack);
+        error:badarg:Stack ->
+            maybe_retry_badarg(Module, FunName, Args, OrigSelector, Context, Stack);
         error:undef:_Stack ->
             %% TOCTOU / hot code reload: function unloaded between check and apply
             raise_undef_error(Module, FunName, length(Args), OrigSelector, Context);

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_erlang_proxy_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_erlang_proxy_tests.erl
@@ -231,35 +231,31 @@ erlang_proxy_with_args_raises_arity_mismatch_test() ->
 
 %%% ===================================================================
 %%% ===================================================================
-%%% Exception mapping — BT-678
+%%% Exception mapping — BT-678 / ADR 0101 Part 2
+%%%
+%%% ADR 0101 unifies both apply paths: `exit:*` propagates and `throw:*`
+%%% passes through (rolling back the former erlang_exit / erlang_throw
+%%% wrapping in validate_and_apply). `error:*` is still wrapped.
 %%% ===================================================================
 
-dispatch_exit_wraps_as_exit_error_test() ->
-    %% exit:Reason should be caught and wrapped as erlang_exit
+dispatch_exit_propagates_test() ->
+    %% ADR 0101: exit must propagate, NOT be wrapped as erlang_exit
     Proxy = beamtalk_erlang_proxy:new(erlang),
     try
         beamtalk_erlang_proxy:dispatch('exit:', [killed], Proxy),
         ?assert(false)
     catch
-        error:#{error := Inner} ->
-            ?assertEqual(erlang_exit, Inner#beamtalk_error.kind),
-            ?assertEqual('ErlangModule', Inner#beamtalk_error.class),
-            ?assert(is_binary(Inner#beamtalk_error.hint)),
-            ?assertNotEqual(undefined, Inner#beamtalk_error.hint)
+        exit:killed -> ok
     end.
 
-dispatch_throw_wraps_as_throw_error_test() ->
-    %% throw:Value should be caught and wrapped as erlang_throw
+dispatch_throw_passes_through_test() ->
+    %% ADR 0101: throw must pass through unchanged, NOT be wrapped as erlang_throw
     Proxy = beamtalk_erlang_proxy:new(erlang),
     try
         beamtalk_erlang_proxy:dispatch('throw:', [oops], Proxy),
         ?assert(false)
     catch
-        error:#{error := Inner} ->
-            ?assertEqual(erlang_throw, Inner#beamtalk_error.kind),
-            ?assertEqual('ErlangModule', Inner#beamtalk_error.class),
-            ?assert(is_binary(Inner#beamtalk_error.hint)),
-            ?assertNotEqual(undefined, Inner#beamtalk_error.hint)
+        throw:oops -> ok
     end.
 
 dispatch_badarith_wraps_as_type_error_test() ->
@@ -277,58 +273,24 @@ dispatch_badarith_wraps_as_type_error_test() ->
             ?assertEqual(badarith, maps:get(erlang_error, Details))
     end.
 
-dispatch_exit_preserves_details_test() ->
-    %% exit errors should preserve the original reason and stacktrace in details
+dispatch_exit_preserves_reason_test() ->
+    %% ADR 0101: the exit propagates with its original reason intact
     Proxy = beamtalk_erlang_proxy:new(erlang),
     try
-        beamtalk_erlang_proxy:dispatch('exit:', [normal], Proxy),
+        beamtalk_erlang_proxy:dispatch('exit:', [{shutdown, restart}], Proxy),
         ?assert(false)
     catch
-        error:#{error := Inner} ->
-            ?assertEqual(erlang_exit, Inner#beamtalk_error.kind),
-            Details = Inner#beamtalk_error.details,
-            ?assertEqual(normal, maps:get(erlang_exit_reason, Details)),
-            ?assert(is_list(maps:get(erlang_stacktrace, Details)))
+        exit:{shutdown, restart} -> ok
     end.
 
-dispatch_throw_preserves_details_test() ->
-    %% throw errors should preserve the original value and stacktrace in details
+dispatch_throw_preserves_value_test() ->
+    %% ADR 0101: the throw passes through with its original value intact
     Proxy = beamtalk_erlang_proxy:new(erlang),
     try
         beamtalk_erlang_proxy:dispatch('throw:', [{custom, value}], Proxy),
         ?assert(false)
     catch
-        error:#{error := Inner} ->
-            ?assertEqual(erlang_throw, Inner#beamtalk_error.kind),
-            Details = Inner#beamtalk_error.details,
-            ?assertEqual({custom, value}, maps:get(erlang_throw_value, Details)),
-            ?assert(is_list(maps:get(erlang_stacktrace, Details)))
-    end.
-
-dispatch_exit_hint_includes_module_test() ->
-    %% Hint should include module and function name
-    Proxy = beamtalk_erlang_proxy:new(erlang),
-    try
-        beamtalk_erlang_proxy:dispatch('exit:', [killed], Proxy),
-        ?assert(false)
-    catch
-        error:#{error := Inner} ->
-            Hint = Inner#beamtalk_error.hint,
-            ?assertNotEqual(nomatch, binary:match(Hint, <<"erlang">>)),
-            ?assertNotEqual(nomatch, binary:match(Hint, <<"exit">>))
-    end.
-
-dispatch_throw_hint_includes_module_test() ->
-    %% Hint should include module and function name
-    Proxy = beamtalk_erlang_proxy:new(erlang),
-    try
-        beamtalk_erlang_proxy:dispatch('throw:', [oops], Proxy),
-        ?assert(false)
-    catch
-        error:#{error := Inner} ->
-            Hint = Inner#beamtalk_error.hint,
-            ?assertNotEqual(nomatch, binary:match(Hint, <<"erlang">>)),
-            ?assertNotEqual(nomatch, binary:match(Hint, <<"throw">>))
+        throw:{custom, value} -> ok
     end.
 
 dispatch_badarg_from_binary_to_atom_preserves_details_test() ->
@@ -421,20 +383,37 @@ dispatch_reraises_beamtalk_exceptions_test() ->
     end.
 
 dispatch_generic_error_maps_to_runtime_error_test() ->
-    %% Generic error:Reason should map to runtime_error and preserve details
+    %% ADR 0101: a generic error:Reason is wrapped via ensure_wrapped (the
+    %% canonical classifier). An unclassified reason maps to runtime_error,
+    %% located on the ErlangModule breadcrumb, preserving the reason in details.
     Proxy = beamtalk_erlang_proxy:new(erlang),
     try
-        %% erlang:error/1 with a custom reason triggers generic error handler
+        %% erlang:error/1 with a custom reason triggers the generic catch-all
         beamtalk_erlang_proxy:dispatch('error:', [{custom_reason, 42}], Proxy),
         ?assert(false)
     catch
         error:#{error := Inner} ->
             ?assertEqual(runtime_error, Inner#beamtalk_error.kind),
             ?assertEqual('ErlangModule', Inner#beamtalk_error.class),
-            ?assert(is_binary(Inner#beamtalk_error.hint)),
+            ?assertEqual('error:', Inner#beamtalk_error.selector),
+            ?assert(is_binary(Inner#beamtalk_error.message)),
             Details = Inner#beamtalk_error.details,
-            ?assertEqual({custom_reason, 42}, maps:get(erlang_error, Details)),
-            ?assert(is_list(maps:get(erlang_stacktrace, Details)))
+            ?assertEqual({custom_reason, 42}, maps:get(reason, Details))
+    end.
+
+dispatch_badkey_is_readable_key_error_test() ->
+    %% ADR 0101 / BT-932: a {badkey, K} BEAM error from FFI is wrapped by default
+    %% via ensure_wrapped into a readable key_error (not a raw leak).
+    Proxy = beamtalk_erlang_proxy:new(maps),
+    try
+        beamtalk_erlang_proxy:dispatch('get:with:', [missingKey, #{other => 1}], Proxy),
+        ?assert(false)
+    catch
+        error:#{error := Inner} ->
+            ?assertEqual(key_error, Inner#beamtalk_error.kind),
+            Msg = Inner#beamtalk_error.message,
+            ?assert(is_binary(Msg)),
+            ?assertNotEqual(nomatch, binary:match(Msg, <<"key not found">>))
     end.
 
 %%% ===================================================================
@@ -901,3 +880,197 @@ dispatch_ok_tuple_coerced_to_result_test() ->
     ?assertEqual(true, maps:get('isOk', Result)),
     %% BT-1879: charlist inside Result should be coerced to binary
     ?assert(is_binary(maps:get('okValue', Result))).
+
+%%% ===================================================================
+%%% ADR 0101 Part 2 — unified wrap-by-default on the inline-FFI boundary
+%%%
+%%% direct_call/3 previously leaked function_clause / generic error:* (it only
+%%% caught badarg/undef). The unified apply path now wraps all error:* while
+%%% propagating exit/throw. These cover each exception class on the inline path.
+%%% ===================================================================
+
+direct_call_function_clause_wraps_as_arity_mismatch_test() ->
+    %% lists:nth(0, [a]) raises function_clause — previously leaked from direct_call
+    try
+        beamtalk_erlang_proxy:direct_call(lists, nth, [0, [a]]),
+        ?assert(false)
+    catch
+        error:#{error := Inner} ->
+            ?assertEqual(arity_mismatch, Inner#beamtalk_error.kind),
+            ?assertEqual('ErlangModule', Inner#beamtalk_error.class),
+            Details = Inner#beamtalk_error.details,
+            ?assertEqual(function_clause, maps:get(erlang_error, Details))
+    end.
+
+direct_call_generic_error_wraps_as_runtime_error_test() ->
+    %% erlang:error/1 with a custom reason — previously leaked raw from direct_call,
+    %% now wrapped via ensure_wrapped into a structured runtime_error.
+    try
+        beamtalk_erlang_proxy:direct_call(erlang, error, [{custom_reason, 42}]),
+        ?assert(false)
+    catch
+        error:#{error := Inner} ->
+            ?assertEqual(runtime_error, Inner#beamtalk_error.kind),
+            ?assertEqual('ErlangModule', Inner#beamtalk_error.class),
+            Details = Inner#beamtalk_error.details,
+            ?assertEqual({custom_reason, 42}, maps:get(reason, Details))
+    end.
+
+direct_call_beamtalk_error_passthrough_test() ->
+    %% An already-#beamtalk_error{} must re-raise unchanged (idempotent)
+    OrigError = beamtalk_error:new(type_error, 'Integer'),
+    OrigError1 = beamtalk_error:with_selector(OrigError, '+:'),
+    Wrapped = beamtalk_exception_handler:wrap(OrigError1),
+    try
+        beamtalk_erlang_proxy:direct_call(erlang, error, [Wrapped]),
+        ?assert(false)
+    catch
+        error:#{error := Inner} ->
+            ?assertEqual(type_error, Inner#beamtalk_error.kind),
+            ?assertEqual('Integer', Inner#beamtalk_error.class),
+            ?assertEqual('+:', Inner#beamtalk_error.selector)
+    end.
+
+direct_call_bare_beamtalk_error_record_passthrough_test() ->
+    %% A bare #beamtalk_error{} record (e.g. error(#beamtalk_error{...}) from an
+    %% Erlang shim like beamtalk_tracing) must be wrapped into the map form while
+    %% PRESERVING its kind — not reclassified as a generic runtime_error.
+    BareRecord = beamtalk_error:with_selector(
+        beamtalk_error:new(type_error, 'Tracing'), 'hotMethods:'
+    ),
+    try
+        %% erlang:error/1 raises the bare record directly (not the map form)
+        beamtalk_erlang_proxy:direct_call(erlang, error, [BareRecord]),
+        ?assert(false)
+    catch
+        error:#{error := Inner} ->
+            ?assertEqual(type_error, Inner#beamtalk_error.kind),
+            ?assertEqual('Tracing', Inner#beamtalk_error.class),
+            ?assertEqual('hotMethods:', Inner#beamtalk_error.selector)
+    end.
+
+%%% ===================================================================
+%%% ADR 0101 Part 1/2 — native_call/4 boundary (consumed by BT-2720)
+%%%
+%%% native_call skips the export pre-check but routes through the same
+%%% apply_with_coercion/5 — same error:* wrapping + 0076 Result coercion as
+%%% inline FFI, carrying {Class, Sel} so errors read e.g. Stream>>take:.
+%%% ===================================================================
+
+native_call_returns_plain_value_test() ->
+    %% Happy path: a non-tuple return is passed through with self-as-first-arg
+    %% (lists:reverse(Self) where Self = [1,2,3])
+    ?assertEqual(
+        [3, 2, 1],
+        beamtalk_erlang_proxy:native_call(lists, reverse, [[1, 2, 3]], {'Stream', 'asList'})
+    ).
+
+native_call_ok_tuple_coerced_to_result_test() ->
+    %% ADR 0076: {ok, V} return is coerced to a Result value (orthogonal to wrapping)
+    Result = beamtalk_erlang_proxy:native_call(file, get_cwd, [], {'File', 'cwd'}),
+    ?assertEqual('Result', maps:get('$beamtalk_class', Result)),
+    ?assertEqual(true, maps:get('isOk', Result)),
+    ?assert(is_binary(maps:get('okValue', Result))).
+
+native_call_error_tuple_coerced_to_result_test() ->
+    %% ADR 0076: {error, R} return is coerced to a Result error value
+    Result = beamtalk_erlang_proxy:native_call(
+        file, read_file, [<<"/nonexistent_file_xyz_12345">>], {'File', 'readAll:'}
+    ),
+    ?assertEqual('Result', maps:get('$beamtalk_class', Result)),
+    ?assertEqual(false, maps:get('isOk', Result)).
+
+native_call_undef_is_does_not_understand_with_context_test() ->
+    %% Hot-reload TOCTOU: a since-removed backing function must surface a
+    %% structured does_not_understand carrying the Beamtalk {Class, Sel}.
+    try
+        beamtalk_erlang_proxy:native_call(
+            lists, nonexistent_fn_xyz, [foo], {'Stream', 'take:'}
+        ),
+        ?assert(false)
+    catch
+        error:#{error := Inner} ->
+            ?assertEqual(does_not_understand, Inner#beamtalk_error.kind),
+            ?assertEqual('Stream', Inner#beamtalk_error.class),
+            ?assertEqual('take:', Inner#beamtalk_error.selector)
+    end.
+
+native_call_badarg_wraps_with_context_test() ->
+    %% error:badarg → type_error, but carrying the Beamtalk class/selector
+    try
+        beamtalk_erlang_proxy:native_call(erlang, abs, [not_a_number], {'Math', 'abs'}),
+        ?assert(false)
+    catch
+        error:#{error := Inner} ->
+            ?assertEqual(type_error, Inner#beamtalk_error.kind),
+            ?assertEqual('Math', Inner#beamtalk_error.class),
+            ?assertEqual('abs', Inner#beamtalk_error.selector),
+            Details = Inner#beamtalk_error.details,
+            ?assertEqual(badarg, maps:get(erlang_error, Details))
+    end.
+
+native_call_function_clause_wraps_with_context_test() ->
+    %% error:function_clause → arity_mismatch, carrying the Beamtalk class/selector
+    try
+        beamtalk_erlang_proxy:native_call(lists, nth, [0, [a]], {'List', 'at:'}),
+        ?assert(false)
+    catch
+        error:#{error := Inner} ->
+            ?assertEqual(arity_mismatch, Inner#beamtalk_error.kind),
+            ?assertEqual('List', Inner#beamtalk_error.class),
+            ?assertEqual('at:', Inner#beamtalk_error.selector)
+    end.
+
+native_call_generic_error_wraps_with_context_test() ->
+    %% any other error:Reason → runtime_error, carrying the Beamtalk class/selector
+    try
+        beamtalk_erlang_proxy:native_call(
+            erlang, error, [{custom_reason, 7}], {'Stream', 'collect:'}
+        ),
+        ?assert(false)
+    catch
+        error:#{error := Inner} ->
+            ?assertEqual(runtime_error, Inner#beamtalk_error.kind),
+            ?assertEqual('Stream', Inner#beamtalk_error.class),
+            ?assertEqual('collect:', Inner#beamtalk_error.selector)
+    end.
+
+native_call_exit_propagates_test() ->
+    %% ADR 0101: exit propagates unchanged, even with native context
+    try
+        beamtalk_erlang_proxy:native_call(erlang, exit, [killed], {'Stream', 'take:'}),
+        ?assert(false)
+    catch
+        exit:killed -> ok
+    end.
+
+native_call_throw_passes_through_test() ->
+    %% ADR 0101: throw passes through unchanged, even with native context
+    try
+        beamtalk_erlang_proxy:native_call(erlang, throw, [oops], {'Stream', 'take:'}),
+        ?assert(false)
+    catch
+        throw:oops -> ok
+    end.
+
+native_call_beamtalk_error_passthrough_test() ->
+    %% An already-#beamtalk_error{} re-raises unchanged (innermost wins)
+    OrigError = beamtalk_error:new(does_not_understand, 'TestClass'),
+    OrigError1 = beamtalk_error:with_selector(OrigError, 'foo'),
+    Wrapped = beamtalk_exception_handler:wrap(OrigError1),
+    try
+        beamtalk_erlang_proxy:native_call(erlang, error, [Wrapped], {'Stream', 'take:'}),
+        ?assert(false)
+    catch
+        error:#{error := Inner} ->
+            ?assertEqual(does_not_understand, Inner#beamtalk_error.kind),
+            ?assertEqual('TestClass', Inner#beamtalk_error.class),
+            ?assertEqual('foo', Inner#beamtalk_error.selector)
+    end.
+
+native_call_charlist_coercion_retry_test() ->
+    %% BT-1127: native: path also retries binary→charlist on badarg.
+    %% os:cmd/1 expects a charlist; a binary self/arg must be coerced.
+    Result = beamtalk_erlang_proxy:native_call(os, cmd, [<<"echo hello">>], {'Os', 'cmd:'}),
+    ?assert(is_binary(Result)),
+    ?assertEqual(<<"hello">>, string:trim(Result, trailing)).

--- a/stdlib/bootstrap-test/erlang_exceptions.btscript
+++ b/stdlib/bootstrap-test/erlang_exceptions.btscript
@@ -89,6 +89,8 @@
 [Erlang erlang throw: 1] on: Error do: [:e | e message]
 // => 1
 
-// Erlang error still caught by Error handler (no regression)
-[Erlang erlang error: 1] on: Error do: [:e | e message]
-// => 1
+// Erlang error still caught by Error handler, now wrapped by default as a
+// structured #beamtalk_error{} at the FFI boundary (ADR 0101 Part 2). The raw
+// error:* no longer leaks; it is caught as a runtime_error rather than message "1".
+[Erlang erlang error: 1] on: Error do: [:e | e kind]
+// => runtime_error

--- a/stdlib/test/error_message_test.bt
+++ b/stdlib/test/error_message_test.bt
@@ -16,8 +16,9 @@ TestCase subclass: ErrorMessageTest
     self assert: result failed equals: 1
     failures := result failures
     errorMsg := (failures first) at: #error
-    // Should say "not found in dictionary" instead of raw {badkey,...}
-    self assert: (errorMsg includesSubstring: "not found in dictionary")
+    // ADR 0101: FFI {badkey,_} is now wrapped by default at the proxy boundary
+    // into a readable key_error ("key not found: ...") instead of leaking raw.
+    self assert: (errorMsg includesSubstring: "key not found")
 
   testBadarithMessageIsReadable =>
     result := TestRunner run: ErrorMessageHelperTest method: #triggerBadarith

--- a/stdlib/test/tracing_test.bt
+++ b/stdlib/test/tracing_test.bt
@@ -220,17 +220,20 @@ TestCase subclass: TracingTest
     self assert: ((health at: "run_queue") >= 0)
 
   // === Type error validation ===
+  // ADR 0101: these shims raise a #beamtalk_error{kind = type_error}; the unified
+  // FFI proxy now preserves that classification (idempotent pass-through) instead
+  // of the former clobbering to runtime_error.
   testSlowMethodsRequiresPositiveInteger =>
-    self should: [Tracing slowMethods: 0] raise: #runtime_error
+    self should: [Tracing slowMethods: 0] raise: #type_error
 
   testHotMethodsRequiresPositiveInteger =>
-    self should: [Tracing hotMethods: -1] raise: #runtime_error
+    self should: [Tracing hotMethods: -1] raise: #type_error
 
   testErrorMethodsRequiresPositiveInteger =>
-    self should: [Tracing errorMethods: 0] raise: #runtime_error
+    self should: [Tracing errorMethods: 0] raise: #type_error
 
   testBottlenecksRequiresPositiveInteger =>
-    self should: [Tracing bottlenecks: 0] raise: #runtime_error
+    self should: [Tracing bottlenecks: 0] raise: #type_error
 
   testMaxEventsRequiresPositiveInteger =>
-    self should: [Tracing maxEvents: 0] raise: #runtime_error
+    self should: [Tracing maxEvents: 0] raise: #type_error


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2722

## Summary

ADR 0101 Part 2 (Phase 2 of 4 — foundation). Converges the two inconsistent FFI apply paths (`direct_call/3` which leaked most `error:*`, and `validate_and_apply/4` which over-wrapped `exit`/`throw`) onto a single exception policy via a shared `apply_with_coercion/5`, and adds the `native_call/4` boundary that BT-2720 will lower through.

## Exception policy (unified across direct_call, validate_and_apply, native_call)

- `error:*` → structured `#beamtalk_error{}` (safe by default; casual FFI no longer leaks raw faults)
  - named clauses: `badarg`→type_error (+charlist retry), `function_clause`→arity_mismatch, `badarith`→type_error, `undef`→does_not_understand
  - generic catch-all delegates to `beamtalk_exception_handler:ensure_wrapped` (the canonical classifier) → readable bucketed messages for `{badkey,K}`, `{badmap,M}`, `noproc`, `timeout`, …
- `exit:*` → **propagates** (rolls back `validate_and_apply`'s `erlang_exit` wrapping) — `(Erlang erlang) exit: 1` still propagates
- `throw:*` → **passes through** (rolls back `erlang_throw` wrapping); `on:do:` still catches foreign throws (unchanged, out of scope)
- already-`#beamtalk_error{}` (both wrapped-map and bare-record forms) → idempotent pass-through preserving kind

## native: boundary (consumed by BT-2720)

`native_call(Mod, Fn, [Self|Args], {Class, Sel})` threads the Beamtalk `{Class, Sel}` context through the **existing** `apply_with_coercion` (not a parallel path), so errors read e.g. `Stream>>take:`. It skips the proactive `get_exports`/arity pre-check (codegen guarantees the shape) but **still catches `error:undef`** (hot-reload TOCTOU) and surfaces a structured `does_not_understand` with `{Class, Sel}`. Same ADR 0076 ok/error→`Result` coercion as inline FFI.

## Key changes

- `runtime/.../beamtalk_erlang_proxy.erl` — unify the apply paths; `apply_with_coercion/5` + `maybe_retry_badarg/6`; export `native_call/4`; context-aware error helpers
- EUnit covering each exception class on the inline-FFI and `native:` boundaries (badarg/function_clause/undef/exit/throw/already-wrapped) + `native:` 0076 `Result` coercion and `does_not_understand`-on-undef
- Updated `erlang_exceptions.btscript`, `tracing_test.bt`, `error_message_test.bt` expectations to the wrap-by-default contract (the bare-record pass-through now correctly preserves the shim's `type_error` instead of clobbering to `runtime_error`)

No codegen change needed this issue (codegen still emits `direct_call`/`validate_and_apply`; `native_call` is wired up by BT-2720).

## Testing

- `just build`, `just clippy`, `just fmt-check`, `just dialyzer` — clean
- Rust + stdlib + BUnit + runtime tests green (pre-push CI passed)
- Pre-existing unrelated: 5 `beamtalk_erlang_proxy_tests` `'Erlang'` class-object failures only appear under the standalone `rebar3 eunit --module=` runner (compiled stdlib `Erlang` class not loaded there); they pass in the full harness. Flaky supervision BUnit test filed as BT-2729 (reproduced on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)