### PR TITLE
E2E btscript + docs for the unified interop model (BT-2727)

### DIFF
--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -753,13 +753,18 @@ proxy strong_rand_bytes: 16            // => random binary
 The `(Erlang module)` pattern is used throughout the stdlib to wrap Erlang functions as Beamtalk class methods:
 
 ```beamtalk
-// How File.readAll: is implemented — a thin wrapper
+// How File.readAll: is implemented — a thin wrapper.
+// The `{ok, _} | {error, _}` tuples beamtalk_file returns become a Result
+// at the FFI boundary (see "Result conversion" below), so the return type
+// is Result(String, Error), not a bare String.
 Object subclass: File
-  class readAll: path :: String -> String =>
+  class readAll: path :: String -> Result(String, Error) =>
     (Erlang beamtalk_file) readAll: path
 ```
 
-**Keyword mapping:** Beamtalk keyword selectors map to Erlang function names by joining with underscores. `Erlang maps merge: a with: b` calls `maps:merge_with(A, B)`. Unary selectors map directly: `Erlang erlang node` calls `erlang:node()`.
+> A class that delegates *wholesale* to one Erlang module can declare the module on `subclass:` and replace each body with `=> self delegate` instead of hand-writing the FFI call — see [`native:` for stateless Objects](beamtalk-native-erlang.md#native-stateless-objects--native-for-object). `Stream` (`native: beamtalk_stream`) is the worked example.
+
+**Keyword mapping:** The Erlang function name is taken from the **first keyword** (with its colon removed); the remaining keyword *values* follow as positional arguments. `Erlang maps merge: a with: b` calls `maps:merge(A, B)` (not `maps:merge_with` — only the first keyword names the function). Unary selectors map directly: `Erlang erlang node` calls `erlang:node()`.
 
 **Result conversion (ADR 0076):** Erlang functions that return `{ok, Value}` or `{error, Reason}` tuples are automatically converted to `Result` objects at the FFI boundary. This means FFI calls use the same error-handling idiom as native Beamtalk code:
 
@@ -824,13 +829,28 @@ result ifOk: [:content | content] ifError: [:e | "error"]
 result value  // raises on error
 ```
 
-**Error handling:** Errors from Erlang calls are wrapped as `BEAMError`, `ExitError`, or `ThrowError` — catchable with `on:do:`. The handler block parameter is typed from the exception class argument, so `e` in `on: BEAMError do: [:e | ...]` is inferred as `BEAMError` (not `Dynamic`):
+**Error handling — wrap by default (ADR 0101):** every FFI call is *safe by default*. The boundary treats the two channels a BEAM function can use independently, and they are mutually exclusive per call (a function either returns or raises):
+
+| Outcome of the call | Channel | Beamtalk result | Handle with |
+|---------------------|---------|-----------------|-------------|
+| *returns* `{ok, V}` / `{error, R}` | return value | a `Result(V, R)` **value** | `isOk` / `value` / `andThen:` |
+| *raises* `error:Reason` (`badarg`, `{badkey,_}`, `function_clause`, …) | exception | a **raised** `#beamtalk_error{}` | `on:do:` / `ensure:`, or bubbles to the REPL |
+| *raises* `exit:Reason` | exception | **propagates** unwrapped (an enclosing `on:do:` catches it as `erlang_exit`) | supervision / let-it-crash |
+| *raises* `throw:Term` | exception | **passes through** unchanged | `^` / Beamtalk exceptions |
+
+The guarantee: **a user never sees a raw Erlang error tuple.** A `badarg` becomes a structured `#beamtalk_error{}` (kind `type_error`) with a hint, not a bare `{badarg, [...]}` — most visible at the REPL, where the abstraction is most exposed. `exit:`/`throw:` are deliberately *not* wrapped, so `(Erlang erlang) exit: #killed` still terminates the process with reason `killed`.
+
+**Same function, both channels.** Because the channels are orthogonal, one function can use both: `File readAll:` *returns* a `Result error:` for the modeled missing-file case, but *raises* a `#beamtalk_error{}` if called with a non-String path. The rule is **`Result` for expected/recoverable outcomes the API models, exceptions for misuse/faults.** Wrapping changes no return type — a raised `#beamtalk_error{}` is invisible to the type system, so `Result` stays the only type-visible error channel.
+
+A raised FFI error is catchable as `BEAMError`, `ExitError`, or `ThrowError`. The handler block parameter is typed from the exception class argument, so `e` in `on: BEAMError do: [:e | ...]` is inferred as `BEAMError` (not `Dynamic`):
 
 ```beamtalk
 [Erlang erlang error: #badarg] on: BEAMError do: [:e | e message]
 // => "badarg"
 // e is typed as BEAMError — `e message` type-checks without warnings
 ```
+
+A `native:` method's wrapped error carries the Beamtalk `Class`/selector (e.g. `Type error in 'take:' on Stream`), whereas inline `(Erlang …)` FFI carries the Erlang-facing `ErlangModule` context (e.g. `Type error in 'atom_to_list' on ErlangModule`) — a documented limitation, since the proxy knows the MFA but not the calling class.
 
 ### Type Specs for Native Modules
 
@@ -4423,6 +4443,8 @@ hash => @intrinsic hash
 ```
 
 The full list of structural intrinsics: `actorSpawn`, `actorSpawnWith`, `blockValue`, `blockValue1`–`blockValue3`, `whileTrue`, `whileFalse`, `repeat`, `onDo`, `ensure`, `timesRepeat`, `toDo`, `toByDo`, `basicNew`, `basicNewWith`, `hash`, `respondsTo`, `fieldNames`, `fieldAt`, `fieldAtPut`, `dynamicSend`, `dynamicSendWithArgs`, `error`.
+
+**Relationship to `native:` (ADR 0101).** `@primitive` and `@intrinsic` cover native BEAM *value types* and compiler *substrate*. A third mechanism, the class-level `native:` declaration with `=> self delegate` bodies, covers whole-class **delegation** to a single Erlang module (a stateless `Object` such as `Stream`, or an `Actor` gen_server). Pick by what the method needs: guarded dispatch + the open-world extension registry → `@primitive`; the dispatch act itself (`==`, `class`, `perform:`, actor lifecycle) → `@intrinsic`; pure pass-through to one module → `native:`. See [`native:` for stateless Objects](beamtalk-native-erlang.md#native-stateless-objects--native-for-object).
 
 ---
 

--- a/docs/beamtalk-native-erlang.md
+++ b/docs/beamtalk-native-erlang.md
@@ -11,10 +11,12 @@ There are three mechanisms for integrating Erlang code with Beamtalk, each suite
 | Mechanism | Use case | Declared in |
 |-----------|----------|-------------|
 | `(Erlang module)` FFI | Call any Erlang function from a method body | Per-method |
-| `native:` + `self delegate` | Actor backed by a hand-written gen_server | Class declaration |
+| `native:` + `self delegate` | A class wholesale-backed by a hand-written Erlang module (a stateless `Object` *or* an `Actor` gen_server) | Class declaration |
 | `[native.dependencies]` | Use hex.pm packages from native Erlang code | `beamtalk.toml` |
 
-These mechanisms are complementary. A single package might use all three — FFI for simple utility calls, `native:` for actors that need direct OTP control, and hex dependencies for ecosystem libraries like `gun` or `cowboy`.
+These mechanisms are complementary. A single package might use all three — FFI for simple utility calls, `native:` for classes that delegate wholesale to one Erlang module, and hex dependencies for ecosystem libraries like `gun` or `cowboy`.
+
+> **Unified model (ADR 0101).** `native:` is the universal "this class is backed by a named Erlang module" declaration; the **class kind selects the lowering** — a `native:` `Object` delegates with an in-process synchronous call, while a `native:` `Actor` delegates across a process boundary via `gen_server:call`. Both share the same boundary, so all FFI is **safe by default**: `error:*` exceptions become structured `#beamtalk_error{}` values (a user never sees a raw Erlang tuple at the REPL), while `exit:*`/`throw:*` still propagate. See [Native Stateless Objects](#native-stateless-objects--native-for-object) and [Wrap-by-Default Error Handling](#wrap-by-default-error-handling).
 
 ## Directory Layout
 
@@ -96,6 +98,94 @@ FFI is the right choice when:
 - You need to call a handful of Erlang functions
 - The Erlang module is stateless or manages its own state externally
 - You want explicit control over which Erlang function each method calls
+
+## Wrap-by-Default Error Handling
+
+All Erlang calls — inline `(Erlang …)` FFI, `native:` `Object` delegation, and `native:` `Actor` delegation — share one error boundary (ADR 0101 Part 2). The boundary handles the two channels a BEAM function can use independently:
+
+| Outcome of the Erlang call | Channel | Beamtalk result | How you handle it |
+|----------------------------|---------|-----------------|-------------------|
+| *returns* `{ok, V}` / `{error, R}` | return value | a `Result(V, R)` **value** (ADR 0076) | `isOk` / `value` / `andThen:` |
+| *raises* `error:Reason` | exception | a **raised** `#beamtalk_error{}` | `on:do:` / `ensure:`, or it bubbles to the REPL |
+| *raises* `exit:Reason` | exception | **propagates** unwrapped (caught by an enclosing `on:do:` as `erlang_exit`, else process death) | supervision / let-it-crash |
+| *raises* `throw:Term` | exception | **passes through** unchanged | `^` and Beamtalk exceptions are throw/catch |
+
+The key guarantee: **a user never sees a raw Erlang error tuple at the REPL.** A `badarg`, `{badkey, K}`, `function_clause`, etc. is converted to a structured `#beamtalk_error{}` with a `kind`, a hint, and a `Class`/`selector` breadcrumb — not a bare `{badarg, [...]}`.
+
+`exit:`/`throw:` are deliberately **not** wrapped: process exit and foreign throws are semantically meaningful (intentional `erlang:exit/1`, `{noproc, _}` from a dead actor, control-flow throws) and must not be flattened into `#beamtalk_error{}`. So `(Erlang erlang) exit: #killed` still terminates the process with reason `killed`.
+
+### Same function, both channels
+
+The return channel (`Result`) and the exception channel (`#beamtalk_error{}`) are orthogonal and mutually exclusive *per call* — a function either returns or raises — so the **same** function can use both:
+
+```beamtalk
+// File readAll: -> Result(String, Error)
+
+// Modeled, recoverable failure → a RETURNED Result error: value
+File readAll: "missing.txt"        // => Result error: File 'readAll:': file not found
+
+// Misuse / fault (a non-String path) → a RAISED #beamtalk_error{}
+File readAll: 12345                 // raises: Type error in 'readAll:' on File
+```
+
+The split is principled: **`Result` for expected/recoverable outcomes the API models, exceptions for misuse/faults.** Wrap-by-default changes no return type — a raised `#beamtalk_error{}` is invisible to the type system, so `Result` remains the only type-visible error channel.
+
+### Error context: `Class` + selector vs Erlang MFA
+
+A wrapped `native:` error carries the Beamtalk `Class` and selector, so it reads `Stream` / `take:` rather than the backing `beamtalk_stream:take`:
+
+```beamtalk
+(Stream from: 1) take: -1          // raises Type error in 'take:' on Stream
+```
+
+Inline `(Erlang …)` FFI has a documented limitation: the proxy knows the Erlang MFA, not the Beamtalk class, so an inline-FFI error carries the `ErlangModule` context (e.g. `Type error in 'atom_to_list' on ErlangModule`). It is still structured — just less specific than a `native:` method's breadcrumb. Prefer `native:` for whole-class delegation precisely so errors name your class.
+
+## Native Stateless Objects — `native:` for `Object`
+
+`native:` is not limited to actors. A stateless `Object` that delegates wholesale to a single Erlang module declares the module on `subclass:` and uses `=> self delegate` bodies — **identical surface** to a native Actor, but the lowering is an in-process synchronous call rather than a gen_server round-trip (the class kind selects the lowering). `Stream` is the worked example:
+
+```beamtalk
+sealed typed Object subclass: Stream(E) native: beamtalk_stream
+
+  class sealed from: start :: Integer -> Stream(Integer) => self delegate   // ⇒ beamtalk_stream:from(Start)
+  select: predicate :: Block -> Stream(E)                => self delegate   // ⇒ beamtalk_stream:select(Self, Predicate)
+  take: count :: Integer -> List(E)                      => self delegate   // ⇒ beamtalk_stream:take(Self, Count)
+  asList -> List(E)                                       => self delegate   // ⇒ beamtalk_stream:asList(Self)
+```
+
+A class may freely mix `self delegate` methods with full-bodied Beamtalk methods.
+
+### Object vs Actor delegation
+
+| | `native:` `Object` | `native:` `Actor` |
+|---|---|---|
+| `self delegate` lowers to | `beamtalk_erlang_proxy:native_call(Mod, Fn, [Self\|Args], {Class, Sel})` | `beamtalk_actor:sync_send(Pid, Sel, Args)` |
+| Receiver (`self`) | first positional arg | the actor pid |
+| Call shape | in-process, synchronous — cannot block, time out, or raise `noproc` | crosses a process boundary — can block, time out, raise `noproc`, cross nodes |
+| State | none (`state:` is for Actors) | lives in the gen_server |
+
+> **Caution (leaky abstraction).** Because both kinds read `self delegate`, switching a delegation class between `Object subclass:` and `Actor subclass:` silently flips the lowering (in-process call ⇄ cross-process `sync_send`) with no type error. The class kind one line above is the only signal of the failure/performance profile.
+
+### The naming rule (normative)
+
+The Erlang function name is the **first keyword with its colon removed**; the remaining keyword *values* follow as positional args. Self-threading is inferred from the declaration side:
+
+- **Instance methods prepend `self`**: `take: count` → `mod:take(Self, Count)`; `inject: i into: b` → `mod:inject(Self, I, B)`; unary `asList` → `mod:asList(Self)`.
+- **Class methods omit `self`**: `class from: start` → `mod:from(Start)`.
+
+This is the same first-keyword convention as inline FFI (`(Erlang mod) do: x with: y` → `mod:do(X, Y)`).
+
+### The `delegate` sentinel
+
+`self delegate` typechecks because the `Object`/`Value` base (and `Object class`, for class-side constructors) defines a `delegate` sentinel — exactly mirroring the `delegate` sentinel ADR 0056 added to `Actor`. On a `native:` class, codegen rewrites `self delegate` to the real call before the sentinel runs; on a non-`native:` class the sentinel raises, catching the misuse. `delegate` is therefore a **reserved selector** on the Object protocol.
+
+### Inheritance
+
+`native:` delegation follows the class declaration, **not** inheritance. A subclass that does not redeclare `native:` inherits no backing module and cannot add `self delegate` methods of its own; a subclass that redeclares `native: other_mod` uses `other_mod` only for the `self delegate` methods it declares.
+
+### Reserved-word constraint
+
+If a method's first keyword is an Erlang reserved word (`after and andalso band begin bnot bor bsl bsr bxor case catch cond div end fun if let not of or orelse receive rem try when xor`), codegen emits a compile error rather than producing invalid output like `mod:receive(Self, X)`. Use inline FFI with an explicitly-named function for those (rare) cases.
 
 ## Native Actors — `native:` and `self delegate`
 
@@ -569,8 +659,9 @@ beamtalk test
 | Need | Use |
 |------|-----|
 | Call a stateless Erlang function | `(Erlang module)` FFI in method body |
-| Wrap a utility library as class methods | `Object subclass:` with FFI calls |
-| Actor with OTP gen_server control | `native:` + `self delegate` |
+| Stateless `Object` delegating wholesale to one module | `Object subclass: … native: module` + `self delegate` |
+| Wrap a few utility functions as class methods | `Object subclass:` with inline FFI calls |
+| Actor with OTP gen_server control | `Actor subclass: … native: module` + `self delegate` |
 | Actor with Beamtalk-only logic | Standard `Actor subclass:` (no `native:`) |
 | Hex.pm package dependency | `[native.dependencies]` in `beamtalk.toml` |
 | Port, NIF, or raw process | Per-method `(Erlang module)` FFI |
@@ -598,3 +689,4 @@ Use `self delegate` for operations that modify state or need gen_server guarante
 - [ADR 0055](ADR/0055-erlang-backed-class-authoring-protocol.md) -- Erlang-backed class authoring protocol
 - [ADR 0056](ADR/0056-native-erlang-backed-actors.md) -- Native actors design decisions
 - [ADR 0072](ADR/0072-user-erlang-sources-in-packages.md) -- User Erlang sources in packages
+- [ADR 0101](ADR/0101-unified-erlang-interop-native-objects.md) -- Unified interop: `native:` for stateless Objects, wrap-by-default FFI

--- a/tests/repl-protocol/cases/native_object_interop.btscript
+++ b/tests/repl-protocol/cases/native_object_interop.btscript
@@ -1,0 +1,108 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E (REPL-protocol) tests for the unified Erlang interop model (ADR 0101).
+//
+// This file validates, end-to-end from the REPL, the four guarantees of the
+// unified model that EUnit/BUnit alone cannot catch:
+//
+//   1. `native:` Object delegation — a stateless `Object` backed by an Erlang
+//      module (`Stream` → `beamtalk_stream`) dispatches `self delegate` methods
+//      through the shared FFI boundary and returns ordinary values.
+//   2. The dual error channel — the SAME class uses BOTH channels: a modeled
+//      failure *returns* a `Result error:` value, while a misuse fault *raises*
+//      a structured `#beamtalk_error{}` (return-vs-raise, ADR 0101 Part 2 /
+//      ADR 0076).
+//   3. `native:` errors carry `Class`+`selector` context (e.g. `Stream` /
+//      `take:`), not a bare Erlang MFA (`beamtalk_stream:take`).
+//   4. `(Erlang erlang) exit:` still propagates raw — it is NOT flattened into
+//      a `#beamtalk_error{}`.
+//   5. A user NEVER sees a raw Erlang error tuple at the REPL — every faulting
+//      FFI call surfaces a structured error, never `{badarg, ...}`.
+//
+// Lower-level coverage lives in:
+//   runtime/apps/beamtalk_runtime/test/beamtalk_erlang_proxy_tests.erl (native_call/4)
+//   stdlib/test/*.bt (per-class BUnit)
+
+// ===========================================================================
+// 1. native: OBJECT DELEGATION (Stream → beamtalk_stream)
+// ===========================================================================
+
+// `class from:` is a class-side `self delegate` → beamtalk_stream:from(Start)
+// `take:` is an instance-side `self delegate` → beamtalk_stream:take(Self, 5)
+(Stream from: 1) take: 5
+// => [1,2,3,4,5]
+
+// `on:` (class-side) + `asList` (instance-side) delegate correctly
+(Stream on: #(1, 2, 3)) asList
+// => [1,2,3]
+
+// Chained delegation: select: returns a Stream, take: forces it to a List
+((Stream from: 1) select: [:n | n isEven]) take: 3
+// => [2,4,6]
+
+// Delegation persists across REPL turns via a workspace binding
+s := (Stream on: #(10, 20, 30)) collect: [:n | n + 1]
+// => _
+
+s asList
+// => [11,21,31]
+
+// ===========================================================================
+// 2. DUAL ERROR CHANNEL — SAME FUNCTION, BOTH CHANNELS
+// (File readAll: -> Result(String, Error))
+// ===========================================================================
+
+// Modeled failure (missing file) is a RETURNED Result error: value — not raised.
+File readAll: "bt_definitely_nonexistent_file_xyz.txt"
+// => Result error: _
+
+// It is an ordinary value the program can branch on.
+(File readAll: "bt_definitely_nonexistent_file_xyz.txt") isError
+// => true
+
+// Misuse fault (a non-String path) is RAISED as a structured #beamtalk_error{},
+// not returned as a Result. Same function, different channel (ADR 0101 Part 2).
+File readAll: 12345
+// => ERROR: Type error in 'readAll:' on File
+
+// ===========================================================================
+// 3. native: ERROR CARRIES Class + selector CONTEXT (not a bare Erlang MFA)
+// ===========================================================================
+
+// `take: -1` reaches beamtalk_stream:take/2 with a valid Integer, so it passes
+// any arg typing and faults *inside* the Erlang module. native_call wraps it
+// carrying the Beamtalk {Class, Selector}, so the surfaced error names
+// `Stream` / `take:` — NOT `beamtalk_stream:take`.
+(Stream from: 1) take: -1
+// => ERROR: Type error in 'take:' on Stream
+
+// The context is the Beamtalk class, never the backing module name.
+(Stream from: 1) take: -1
+// => ERROR: on Stream
+
+// ===========================================================================
+// 4. (Erlang erlang) exit: STILL PROPAGATES (not wrapped)
+// ===========================================================================
+
+// `exit:` is deliberately NOT caught by the FFI proxy — it propagates raw so
+// process exit / supervision semantics are preserved. The surfaced reason is
+// the bare exit term `killed`, not a `Type error`/wrapped #beamtalk_error{}.
+(Erlang erlang) exit: #killed
+// => ERROR: killed
+
+// ===========================================================================
+// 5. WRAP-BY-DEFAULT — NO RAW ERLANG TUPLE EVER REACHES THE REPL
+// ===========================================================================
+
+// Inline `(Erlang ...)` FFI: a badarg is wrapped into a structured
+// #beamtalk_error{} (kind = type_error). The user sees a readable message,
+// never a raw `{badarg, ...}` tuple. (Inline FFI carries the Erlang-facing
+// `ErlangModule` context — the documented limitation vs `native:` methods.)
+Erlang erlang atom_to_list: 42
+// => ERROR: Type error in 'atom_to_list' on ErlangModule
+
+// First-keyword naming rule: `merge: a with: b` calls `maps:merge/2`
+// (first keyword only, args positional) — NOT `maps:merge_with/3`.
+Erlang maps merge: #{#a => 1} with: #{#b => 2}
+// => #{#a => 1, #b => 2}

--- a/tests/repl-protocol/cases/native_object_interop.btscript
+++ b/tests/repl-protocol/cases/native_object_interop.btscript
@@ -72,22 +72,22 @@ File readAll: 12345
 
 // `take: -1` reaches beamtalk_stream:take/2 with a valid Integer, so it passes
 // any arg typing and faults *inside* the Erlang module. native_call wraps it
-// carrying the Beamtalk {Class, Selector}, so the surfaced error names
-// `Stream` / `take:` — NOT `beamtalk_stream:take`.
+// carrying the Beamtalk {Class, Selector}, so the surfaced error names the
+// Beamtalk class `Stream` and selector `take:` — NOT the backing module
+// function `beamtalk_stream:take`.
 (Stream from: 1) take: -1
 // => ERROR: Type error in 'take:' on Stream
-
-// The context is the Beamtalk class, never the backing module name.
-(Stream from: 1) take: -1
-// => ERROR: on Stream
 
 // ===========================================================================
 // 4. (Erlang erlang) exit: STILL PROPAGATES (not wrapped)
 // ===========================================================================
 
-// `exit:` is deliberately NOT caught by the FFI proxy — it propagates raw so
-// process exit / supervision semantics are preserved. The surfaced reason is
-// the bare exit term `killed`, not a `Type error`/wrapped #beamtalk_error{}.
+// `exit:` is deliberately NOT caught by the FFI proxy: it propagates past the
+// boundary with its exit reason intact (`killed`), rather than being converted
+// into a structured `type_error` the way an `error:*` fault like `badarg` is
+// (ADR 0101 Part 2). The surfaced value is the exit reason, not a `Type error`.
+// (If caught by an enclosing `on:do:` it classifies as kind `erlang_exit` — it
+// is never flattened into a generic FFI error.)
 (Erlang erlang) exit: #killed
 // => ERROR: killed
 
@@ -95,10 +95,11 @@ File readAll: 12345
 // 5. WRAP-BY-DEFAULT — NO RAW ERLANG TUPLE EVER REACHES THE REPL
 // ===========================================================================
 
-// Inline `(Erlang ...)` FFI: a badarg is wrapped into a structured
-// #beamtalk_error{} (kind = type_error). The user sees a readable message,
-// never a raw `{badarg, ...}` tuple. (Inline FFI carries the Erlang-facing
-// `ErlangModule` context — the documented limitation vs `native:` methods.)
+// Inline FFI (`Erlang <module> <selector>`): a badarg is wrapped into a
+// structured #beamtalk_error{} (kind = type_error). The user sees a readable
+// message, never a raw `{badarg, ...}` tuple. (Inline FFI carries the
+// Erlang-facing `ErlangModule` context — the documented limitation vs the
+// Beamtalk-class context a `native:` method gets.)
 Erlang erlang atom_to_list: 42
 // => ERROR: Type error in 'atom_to_list' on ErlangModule
 


### PR DESCRIPTION
Closes [BT-2727](https://linear.app/beamtalk/issue/BT-2727). Phase 4 of 4 of ADR 0101 (Epic BT-2719) — the E2E validation + docs pass for the unified Erlang interop model.

## Summary

Adds an end-to-end REPL-protocol btscript exercising the now-live unified model (native: for stateless Objects, wrap-by-default FFI, the {Class,Sel} boundary, dual error channel) and brings the user docs in line with the shipped behaviour.

> **Note on path:** the issue references `tests/e2e/cases/`; that directory was renamed to `tests/repl-protocol/cases/` (BT-2085), so the new case lives there.

## Key changes

- **`tests/repl-protocol/cases/native_object_interop.btscript`** (new) — validates from the REPL:
  - native: Object delegation (`Stream` → `beamtalk_stream`): `take:`, `asList`, chained `select:`+`take:`, cross-turn binding;
  - dual error channel — `File readAll:` *returns* `Result error:` for a missing file but *raises* a structured `#beamtalk_error{}` for a non-String path (same function, both channels);
  - native: error carries `Class`+selector context (`Type error in 'take:' on Stream`), not a bare Erlang MFA;
  - `(Erlang erlang) exit: #killed` still propagates raw (not wrapped);
  - inline FFI `badarg` wraps to a structured error — no raw Erlang tuple ever reaches the REPL.
- **`docs/beamtalk-native-erlang.md`** — new sections: Wrap-by-Default Error Handling (return-vs-raise table, "same function both channels", Class+selector vs MFA context) and Native Stateless Objects (`native:` for Object: class-kind lowering, first-keyword naming rule, `delegate` sentinel, inheritance, reserved-word constraint); overview + quick-reference tables updated.
- **`docs/beamtalk-language-features.md`** — wrap-by-default + dual channel in the FFI section; **fixed a keyword-mapping bug** (docs claimed underscore-join `maps:merge_with`; the real rule is first-keyword-only `maps:merge/2`, confirmed empirically); `File.readAll:` now typed `Result(String, Error)`; `@primitive`/`@intrinsic`/`native:` relationship note.
- **`docs/development/surface-parity.md`** — reviewed, no change needed (no new surface op; error output unchanged since BT-2722).

## Testing

`just test-repl-protocol` — 1831/1831 e2e tests pass (the new file's assertions were derived empirically from REPL output). Full CI ran green via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)