### PR TITLE
Add Actor-boundary tests for threaded_expr.rs (BT-2378)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -964,3 +964,66 @@ fn test_vt_nested_loop_in_conditional_assign_rhs_threads_local() {
         "Nested loop inside a conditional assign-RHS branch must thread 'sum'. Got:\n{code}"
     );
 }
+
+#[test]
+fn test_actor_conditional_last_expr_lower_actor_threaded_last() {
+    // BT-2378: When the LAST expression of an Actor method is a conditional with
+    // field mutations, `lower_actor_threaded_last` must bind element 1 of the
+    // {Value, NewState} tuple as the reply value and element 2 as the new
+    // gen_server State, then emit {'reply', ReplyValue, NewState}.
+    //
+    // All prior Actor conditional-mutation tests read `self.count` AFTER the
+    // conditional, so the conditional was never in last position. This exercises
+    // the `lower_actor_threaded_last` path that was completely uncovered.
+    let src = "Actor subclass: Ctr\n  state: count = 0\n\n  setByFlag: flag =>\n    flag ifTrue: [self.count := 1] ifFalse: [self.count := -1]\n";
+    let code = codegen(src);
+    eprintln!("Generated code for actor conditional-as-last:\n{code}");
+
+    // lower_actor_threaded_last binds element 1 (reply value) and element 2 (State).
+    assert!(
+        code.contains("'erlang':'element'(1,"),
+        "Last-position conditional must extract reply value via element(1, ...). Got:\n{code}"
+    );
+    assert!(
+        code.contains("'erlang':'element'(2,"),
+        "Last-position conditional must extract new State via element(2, ...). Got:\n{code}"
+    );
+    // The gen_server reply tuple must carry the State extracted from element 2.
+    assert!(
+        code.contains("{'reply',"),
+        "Actor method must return a gen_server reply tuple. Got:\n{code}"
+    );
+    // The conditional compiles to an inline case.
+    assert!(
+        code.contains("case "),
+        "Conditional must compile to an inline case expression. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_actor_conditional_assign_rhs_emit_actor_threaded_assign_rhs() {
+    // BT-2378: `result := flag ifTrue: [...] ifFalse: [...]` with local variable
+    // mutations in an Actor method must route through `emit_actor_threaded_assign_rhs`:
+    //   - bind element 1 of the {Value, NewState} tuple → assignment target
+    //   - bind element 2 → next gen_server State version
+    //   - rebind sibling outer locals (here `x`) from the new State map
+    let src = "Actor subclass: Ctr\n  state: count = 0\n\n  compute: flag =>\n    x := 0\n    result := flag ifTrue: [x := 1. x] ifFalse: [x := -1. x]\n    result\n";
+    let code = codegen(src);
+    eprintln!("Generated code for actor conditional assign-RHS:\n{code}");
+
+    // emit_actor_threaded_assign_rhs must extract value (element 1) and State (element 2).
+    assert!(
+        code.contains("'erlang':'element'(1,") && code.contains("'erlang':'element'(2,"),
+        "Conditional assign-RHS must extract value (element 1) and new State (element 2). Got:\n{code}"
+    );
+    // The sibling local `x` must be rebound from the updated State map.
+    assert!(
+        code.contains("'__local__x'"),
+        "Sibling local 'x' must be rebound from the updated State map. Got:\n{code}"
+    );
+    // The conditional compiles to an inline case.
+    assert!(
+        code.contains("case "),
+        "Conditional must compile to an inline case expression. Got:\n{code}"
+    );
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -1013,8 +1013,12 @@ fn test_actor_conditional_assign_rhs_emit_actor_threaded_assign_rhs() {
 
     // emit_actor_threaded_assign_rhs must extract value (element 1) and State (element 2).
     assert!(
-        code.contains("'erlang':'element'(1,") && code.contains("'erlang':'element'(2,"),
-        "Conditional assign-RHS must extract value (element 1) and new State (element 2). Got:\n{code}"
+        code.contains("'erlang':'element'(1,"),
+        "Conditional assign-RHS must extract value via element(1, ...). Got:\n{code}"
+    );
+    assert!(
+        code.contains("'erlang':'element'(2,"),
+        "Conditional assign-RHS must extract new State via element(2, ...). Got:\n{code}"
     );
     // The sibling local `x` must be rebound from the updated State map.
     assert!(


### PR DESCRIPTION
## Summary

- Add two unit tests in `control_flow.rs` covering the two completely-uncovered Actor-boundary functions in `threaded_expr.rs` (file was at 55.9% per CI artifact from 2026-06-30)
- `test_actor_conditional_last_expr_lower_actor_threaded_last`: exercises `lower_actor_threaded_last` (lines 191–225) — triggered when a conditional with field mutations is the **last** expression of an Actor method
- `test_actor_conditional_assign_rhs_emit_actor_threaded_assign_rhs`: exercises `emit_actor_threaded_assign_rhs` (lines 300–361) — triggered when `result := flag ifTrue: [...] ifFalse: [...]` with local-variable mutations appears in an Actor method; also covers the sibling-local rebinding loop via `__local__x`

## Why these were uncovered

All prior Actor conditional-mutation tests (`actor_conditional_field_mutations/main.bt`, `test_if_true_with_field_mutation_generates_inline_case`, etc.) read `self.count` **after** the conditional, making the conditional non-last. The Actor boundary `lower_actor_threaded_last` path fires only when the conditional IS the final expression. Similarly, no test had `var := <conditional-with-mutations>` in Actor context.

## Test plan

- [x] `cargo test -p beamtalk-core -- test_actor_conditional` — both tests pass
- [x] `cargo test -p beamtalk-core` — all 4,297 tests pass, 0 failed
- [x] `just clippy` — clean
- [x] `just fmt-check` — clean
- [x] Pre-push hook (full CI including dialyzer) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kaafPLnEmEsrsTmUhHDy6

---
_Generated by [Claude Code](https://claude.ai/code/session_014kaafPLnEmEsrsTmUhHDy6)_