### PR TITLE
refactor(tests): extract setUp/tearDown in FutureAutoAwaitTest

### DIFF
--- a/stdlib/test/future_auto_await_test.bt
+++ b/stdlib/test/future_auto_await_test.bt
@@ -8,38 +8,38 @@
 // beamtalk_future:maybe_await/1 for backward compatibility during migration
 
 TestCase subclass: FutureAutoAwaitTest
+  field: a = nil
+
+  setUp => self.a := ActorChainingFixture spawn
+
+  tearDown => self.a isNil ifFalse: [self.a stop]
 
   // Equality: actor method result used in == comparison
   testEqualityWithActorMethod =>
-    a := ActorChainingFixture spawn
-    self assert: (a getValue == 0) equals: true
+    self assert: (self.a getValue == 0) equals: true
 
   // Arithmetic: actor method result used in + operation
   testArithmeticAddWithActorMethod =>
-    a := ActorChainingFixture spawn
-    self assert: (a getValue + 1) equals: 1
+    self assert: (self.a getValue + 1) equals: 1
 
   // Comparison: actor method result used in > comparison
   testGreaterThanWithActorMethod =>
-    a := ActorChainingFixture spawn
-    a increment
-    self assert: (a getValue > 0) equals: true
+    self.a increment
+    self assert: (self.a getValue > 0) equals: true
 
   // Comparison: actor method result used in < comparison
   testLessThanWithActorMethod =>
-    a := ActorChainingFixture spawn
-    self assert: (a getValue < 10) equals: true
+    self assert: (self.a getValue < 10) equals: true
 
   // Arithmetic: actor method result used in * operation
   testArithmeticAfterIncrement =>
-    a := ActorChainingFixture spawn
-    a increment
-    a increment
-    self assert: (a getValue * 3) equals: 6
+    self.a increment
+    self.a increment
+    self assert: (self.a getValue * 3) equals: 6
 
   // Both operands are actor method results
   testBothOperandsAreActorResults =>
-    a := ActorChainingFixture spawn
     b := ActorChainingFixture spawn
-    a increment
-    self assert: (a getValue + b getValue) equals: 1
+    self.a increment
+    self assert: (self.a getValue + b getValue) equals: 1
+    b stop


### PR DESCRIPTION
## Summary

- `stdlib/test/future_auto_await_test.bt` had `a := ActorChainingFixture spawn` repeated inline at the top of every test method (6 tests, 7 total spawn calls), with no corresponding `stop` calls — actor processes were leaked after each test.
- The sibling file `actor_message_chaining_test.bt` uses this same fixture correctly with `setUp`/`tearDown`.
- Extracted the repeated spawn to `setUp`/`tearDown` following the established BUnit pattern.

## Changes

- Add `field: a = nil` declaration
- Add `setUp => self.a := ActorChainingFixture spawn`
- Add `tearDown => self.a isNil ifFalse: [self.a stop]`
- Remove 5 duplicate inline spawns; rename `a` → `self.a` throughout
- In `testBothOperandsAreActorResults`: keep inline `b` spawn (that test needs two actors), add `b stop`

## Safety

No behavioral change — each test still receives a fresh `ActorChainingFixture` instance via `setUp`. BUnit creates a new TestCase instance per test method and runs `setUp` before each.

**Verified:** `just test-bunit` — 2666 tests, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_0193NZ4eJu6daDWP9gMVKnJS)_