### PR TITLE
Post-merge review nits from PR #2810 (ADR 0101 interop)

### DIFF
--- a/docs/ADR/0081-first-class-session-object.md
+++ b/docs/ADR/0081-first-class-session-object.md
@@ -58,21 +58,19 @@ There is **no injected `Session` binding** at the shell level; the class is reac
 ### API
 
 ```beamtalk
-sealed typed Object subclass: Session
+sealed typed Object subclass: Session native: beamtalk_session_primitives
 
   // ─── Class-side: factory methods only ───
 
   /// The calling process's session as a value. Returns `nil` outside a
   /// REPL eval context (compiled program code has no session), matching
   /// `Workspace currentSession`.
-  class current -> Session | Nil =>
-    (Erlang beamtalk_session_primitives) current
+  class current -> Session | Nil => self delegate
 
   /// Look up a session by its protocol session ID. Returns `nil` if no
   /// such session exists or it is no longer alive. Used for cross-session
   /// access — see "Cross-session access (LSP, VS Code)" below.
-  class withId: aSessionId :: String -> Session | Nil =>
-    (Erlang beamtalk_session_primitives) withId: aSessionId
+  class withId: aSessionId :: String -> Session | Nil => self delegate
 
   // ─── Instance-side: all operations live here ───
 
@@ -81,8 +79,7 @@ sealed typed Object subclass: Session
   /// session state (write-through, for the calling session only).
   /// (There is no `globals` here — globals are workspace-owned;
   /// use `Workspace globals`.)
-  bindings -> BindingsView =>
-    (Erlang beamtalk_session_primitives) bindingsViewFor: self
+  bindings -> BindingsView => self delegate
 
   /// Resolve a name exactly the way bare-name lookup does, returning the
   /// first match or nil. Order: session locals → workspace globals
@@ -90,23 +87,23 @@ sealed typed Object subclass: Session
   /// tool: answers "where does this name resolve from?" interactively.
   /// Uses the one shared resolver (see "Binding storage model"), so it can
   /// never disagree with how the name actually resolves.
-  resolve: aName :: Symbol -> Object =>
-    (Erlang beamtalk_session_primitives) resolveFor: self name: aName
+  resolve: aName :: Symbol -> Object => self delegate
 
   /// Clear this session's local bindings. Workspace globals remain.
-  clear -> Nil =>
-    (Erlang beamtalk_session_primitives) clearFor: self
+  clear -> Nil => self delegate
 
   /// Stable session identifier (matches the protocol session ID).
-  id -> String =>
-    (Erlang beamtalk_session_primitives) idOf: self
+  id -> String => self delegate
 ```
 
-> **Note (ADR 0101 / BT-2731):** the backing primitives shown here were later
-> renamed to their first-keyword form and `Session` / `BindingsView` migrated to
-> `native:` `self delegate` (`bindings`, `resolve`, `clear`, `id`, `at`, `keys`,
-> `size`, …). The design below is unchanged; only the Erlang function names and
-> the delegation mechanism differ. See ADR 0101 Resolved Decision 5.
+> **Note (ADR 0101 / BT-2731):** the example above reflects the shipped form —
+> `Session` / `BindingsView` are `native: beamtalk_session_primitives` and each
+> method is a `self delegate`. The original design expressed these as inline
+> `(Erlang beamtalk_session_primitives) bindingsViewFor: self` etc.; the backing
+> primitives were later renamed to their first-keyword form (`bindings`,
+> `resolve`, `clear`, `id`, `at`, `keys`, `size`, …). The design is unchanged;
+> only the Erlang function names and the delegation mechanism differ. See ADR
+> 0101 Resolved Decision 5.
 
 The common idiom is `Session current bindings keys`; for another session, `(Session withId: "…") bindings keys`. Binding a session to a temp (`s := Session current`) works too, but note `s` then becomes a session-local and will appear in `s bindings keys` — so the inline form is cleaner for one-off inspection.
 

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_erlang_proxy.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_erlang_proxy.erl
@@ -334,7 +334,7 @@ Policy (ADR 0101 Part 2), matching the doc on `apply_with_coercion/5`:
 %% (`maybe_retry_badarg/6`) can *return* the charlist-coerced retry result on
 %% success. That value flows back through here to `apply_with_coercion/5`.
 -spec classify_ffi_exception(
-    atom(),
+    error | exit | throw,
     term(),
     list(),
     atom(),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_erlang_proxy_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_erlang_proxy_tests.erl
@@ -14,6 +14,17 @@ error wrapping, and printString formatting.
 -include_lib("eunit/include/eunit.hrl").
 -include("beamtalk.hrl").
 
+%% Exported so the proxy can `erlang:apply/3` them (external call). Fixtures for
+%% the charlist-retry exit/throw tests: raise `badarg` on a binary arg (to
+%% trigger the retry) then `exit`/`throw` on the charlist-coerced retry arg.
+-export([retry_then_exit/1, retry_then_throw/1]).
+
+retry_then_exit(Arg) when is_binary(Arg) -> erlang:error(badarg);
+retry_then_exit(Arg) when is_list(Arg) -> exit(retry_exit_reason).
+
+retry_then_throw(Arg) when is_binary(Arg) -> erlang:error(badarg);
+retry_then_throw(Arg) when is_list(Arg) -> throw(retry_throw_value).
+
 %%% ===================================================================
 %%% Proxy construction
 %%% ===================================================================
@@ -1063,6 +1074,33 @@ native_call_throw_passes_through_test() ->
         ?assert(false)
     catch
         throw:oops -> ok
+    end.
+
+%%% BT-2730 review follow-up: exit/throw raised on the charlist-coercion RETRY
+%%% (the inner try in maybe_retry_badarg/6, not the first apply) must still
+%%% propagate unchanged. The retry routes through the same classify_ffi_exception/9
+%%% catch-all as the first pass, so these guard the shared classifier's retry arm.
+native_call_retry_exit_propagates_test() ->
+    %% First apply on the binary arg raises badarg → retry with the charlist-coerced
+    %% arg, which exits. The exit must propagate, not become a #beamtalk_error{}.
+    try
+        beamtalk_erlang_proxy:native_call(
+            ?MODULE, retry_then_exit, [<<"x">>], {'Stream', 'take:'}
+        ),
+        ?assert(false)
+    catch
+        exit:retry_exit_reason -> ok
+    end.
+
+native_call_retry_throw_passes_through_test() ->
+    %% Same, but the charlist retry throws — the throw must pass through unchanged.
+    try
+        beamtalk_erlang_proxy:native_call(
+            ?MODULE, retry_then_throw, [<<"x">>], {'Stream', 'take:'}
+        ),
+        ?assert(false)
+    catch
+        throw:retry_throw_value -> ok
     end.
 
 native_call_beamtalk_error_passthrough_test() ->


### PR DESCRIPTION
## Summary

Three non-blocking follow-ups the Claude review bot raised on the now-merged **PR #2810** (BT-2730 / BT-2731, ADR 0101 unified Erlang interop). All are comment/spec/test/doc-only — **no behavior change**.

1. **`classify_ffi_exception/9` — tighten the `Class` param type.** Narrowed from `atom()` to `error | exit | throw` (the only exception classes a `catch` can bind), giving Dialyzer more precision.

2. **Cover the charlist-retry exit/throw path.** The refactor's shared classifier is exercised on the first apply for exit/throw, but the *retry* arm inside `maybe_retry_badarg/6` was untested. Added `native_call_retry_exit_propagates_test` and `native_call_retry_throw_passes_through_test`: they drive a binary arg that raises `badarg` on first apply (triggering the charlist retry) then `exit`/`throw` on the coerced retry arg, so the retry's inner catch → the classifier's catch-all is now covered. Adds two small exported test fixtures.

3. **ADR 0081 — refresh the `Session` example.** It still showed the pre-rename inline-FFI primitive names (`bindingsViewFor:`, `resolveFor:name:`, …); updated it to the shipped `native: beamtalk_session_primitives` + `self delegate` form and reworked the accompanying ADR-0101 note.

## Context

Follow-up to the merged BT-2730 / BT-2731 work (PR #2810), part of epic BT-2719 (ADR 0101). These are the leftover non-blocking suggestions/nits from that PR's final review pass.

## Testing

- `just build` — clean
- `just dialyzer` — clean (confirms the tightened `Class` type)
- `just test-runtime` — **5184 tests, 0 failures** (the two new retry tests included)
- `just fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTYDiDZxRdbxoSHwJoMvXW)_