### PR TITLE
test: tighten placeholder assertion in lazy_name_resolution.btscript

### DIFF
--- a/tests/repl-protocol/cases/lazy_name_resolution.btscript
+++ b/tests/repl-protocol/cases/lazy_name_resolution.btscript
@@ -21,7 +21,7 @@ Transcript
 
 // Singleton receiver dispatch still works (binding-aware class send).
 Transcript show: "hi"
-// => _
+// => Actor(TranscriptStream, _)
 
 // ===========================================================================
 // SHADOWING: a session local shadows a workspace binding of the same name


### PR DESCRIPTION
## Summary

Replace one `// => _` wildcard in `tests/repl-protocol/cases/lazy_name_resolution.btscript` with a concrete expected value:

- `Transcript show: "hi"` (line 23): `// => _` → `// => Actor(TranscriptStream, _)`

The return value is deterministic — async actor sends on Transcript return `self` (the `TranscriptStream` actor). This is confirmed by at least three independent tests in the suite: `workspace_bindings.btscript` (line 22-23), and `transcript.btscript` (lines 23-24, 27-28, 40-41). The tighter assertion would catch any regression in the return-self contract of async Transcript sends within the lazy-resolution codepath.

The other wildcards in this file remain as `// => _`: `Transcript` standalone (no prior test covers its direct REPL display), and the `do:` loop (List `do:` returns `ok` from Erlang `lists:foreach`, which differs from ByteArray/Set/Stream returning `nil` — the test's intent is to verify no `{badkey,_}` crash, not the return value).

## Test plan

- [x] `just test-repl-protocol` — 1830/1830 assertions pass (confirmed locally)
- [x] Pre-push hook: clippy, fmt, dialyzer, spec validation all pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01Se63BD2wZhjmKP78CLqNqh)_