### PR TITLE
docs: refresh stale flat-namespace limitations (BT-2698)

### DIFF
--- a/docs/ADR/0031-flat-namespace-for-v01.md
+++ b/docs/ADR/0031-flat-namespace-for-v01.md
@@ -1,7 +1,9 @@
 # ADR 0031: Flat Namespace for v0.1
 
 ## Status
-Implemented (2026-02-18)
+Superseded by [ADR 0070](0070-package-namespaces-and-dependencies.md) (2026-03-24)
+
+Originally Implemented (2026-02-18). The flat global namespace shipped in v0.1 exactly as described below. [ADR 0070](0070-package-namespaces-and-dependencies.md) later added the package namespace and dependency system (`beamtalk.toml` dependencies, qualified `package@Class` names, collision-as-error), and [ADR 0071](0071-class-visibility-internal-modifier.md) added the `internal` visibility modifier. This ADR is preserved as the historical record of the v0.1 decision — its "v0.2 will introduce a module/import system" framing is now fulfilled by those ADRs.
 
 ## Context
 

--- a/docs/ADR/0070-package-namespaces-and-dependencies.md
+++ b/docs/ADR/0070-package-namespaces-and-dependencies.md
@@ -1,7 +1,7 @@
 # ADR 0070: Package Namespaces and Dependencies
 
 ## Status
-Implemented (2026-03-24)
+Implemented (2026-03-24). Supersedes [ADR 0031](0031-flat-namespace-for-v01.md) (Flat Namespace for v0.1).
 
 ## Context
 
@@ -54,7 +54,7 @@ http = { git = "https://github.com/someone/beamtalk-http", branch = "main" }
 
 Each dependency must point to a directory containing a `beamtalk.toml`. The compiler resolves dependencies transitively in topological order, compiles each, and places their `ebin/` on the BEAM code path.
 
-A **lockfile** (`beamtalk.lock`) pins exact commit SHAs for git dependencies, ensuring reproducible builds. It is generated on first resolve and updated explicitly via a future `beamtalk deps update` command (not yet implemented). Path deps are not locked — they resolve to whatever is on disk, so they are only reproducible within a single repository checkout.
+A **lockfile** (`beamtalk.lock`) pins exact commit SHAs for git dependencies, ensuring reproducible builds. It is generated on first resolve and updated explicitly via the `beamtalk deps update` command. Path deps are not locked — they resolve to whatever is on disk, so they are only reproducible within a single repository checkout.
 
 **Version policy:** Each package name may appear at most once in the resolved dependency graph. If two dependencies require different versions of the same transitive dependency, this is a **resolve error** — the user must align versions. This matches Hex.pm's single-version policy and avoids the complexity of multiple coexisting versions. Diamond dependency resolution with version ranges is deferred to the registry-based dependency phase.
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -57,7 +57,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0028](0028-beam-interop-strategy.md) | BEAM Interop Strategy | Implemented | 2026-02-17 |
 | [0029](0029-streaming-eval-output.md) | Streaming Eval Output | Implemented | 2026-02-18 |
 | [0030](0030-cargo-dist-evaluation.md) | cargo-dist Evaluation for Release Packaging | Rejected | 2026-02-18 |
-| [0031](0031-flat-namespace-for-v01.md) | Flat Namespace for v0.1 | Implemented | 2026-02-18 |
+| [0031](0031-flat-namespace-for-v01.md) | Flat Namespace for v0.1 | Superseded by 0070 | 2026-02-18 |
 | [0032](0032-early-class-protocol.md) | Early Class Protocol — Behaviour and Class in Beamtalk Stdlib | Implemented | 2026-02-24 |
 | [0033](0033-runtime-embedded-documentation.md) | Runtime-Embedded Documentation on Class and CompiledMethod | Implemented | 2026-02-24 |
 | [0034](0034-stdlib-self-hosting-in-beamtalk.md) | Stdlib Self-Hosting — Moving Logic from Erlang to Beamtalk | Implemented | 2026-02-24 |

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -3706,8 +3706,13 @@ Announcements (typed domain events you subscribe to in app logic):
 
 ## Namespace and Class Visibility
 
-Beamtalk uses a **flat global namespace** (ADR 0031). All classes are globally
-visible — no `import`, `export`, or namespace declaration is needed or available.
+Within a package (and the REPL workspace), Beamtalk uses a **flat namespace** — all
+classes are visible to each other, with no `import` or `export` declarations. Across
+packages, dependencies are declared in `beamtalk.toml` and a dependency's classes are
+referenced by their short name, with qualified `package@Class` names available to
+resolve collisions ([ADR 0070](ADR/0070-package-namespaces-and-dependencies.md)). The
+original v0.1 flat-global-namespace decision is [ADR 0031](ADR/0031-flat-namespace-for-v01.md)
+(superseded by ADR 0070).
 
 ### How loading works
 
@@ -3810,8 +3815,13 @@ Integer subclass: SafeInteger
 
 ### Namespace
 
-Class names must be globally unique. A package namespace and dependency system is designed ([ADR 0070](ADR/0070-package-namespaces-and-dependencies.md)) but not yet implemented. See [known-limitations.md](known-limitations.md) and
-[ADR 0031](ADR/0031-flat-namespace-for-v01.md) for details.
+Within a package, class names must be unique. Across packages, the namespace and
+dependency system ([ADR 0070](ADR/0070-package-namespaces-and-dependencies.md)) makes
+each declared dependency's classes available by their short name; collisions between
+dependencies are a compile error, resolved with qualified `package@Class` names. See the
+[Package Management guide](beamtalk-packages.md) for `beamtalk.toml`, dependencies, and
+qualified names. [ADR 0031](ADR/0031-flat-namespace-for-v01.md) (superseded by ADR 0070)
+records the original v0.1 flat-namespace decision.
 
 ### Visibility and Access Control (ADR 0071)
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -4,18 +4,15 @@ Beamtalk is under active development. This page documents features that are **no
 
 ## Language Features
 
-### No Module or Import System
+### Package Dependencies: Path and Git Only (No Registry Yet)
 
-Beamtalk uses a **flat global namespace**: all classes are globally visible with no `import`, `export`, or namespace syntax. This is an explicit design decision documented in [ADR 0031](ADR/0031-flat-namespace-for-v01.md).
+Beamtalk has a package namespace and dependency system ([ADR 0070](ADR/0070-package-namespaces-and-dependencies.md)): declare dependencies in `beamtalk.toml`, reference a dependency's classes by their short name, and disambiguate with qualified `package@Class` names when needed. Class-name collisions between dependencies are a **compile error** (not silent shadowing) — resolve them with the qualified name. There are no per-file `import`/`export` statements: within a package (and the REPL workspace) all classes share a flat namespace by design.
 
-- Class names must be unique across all loaded packages
-- When two packages define the same class name, the second `:load` hot-reloads the class and emits a warning: `Class 'X' redefined (was old_module, now new_module)`
-- ADR 0016 prevents Erlang-level module collisions under the hood via `bt@package@class` naming
-- A package namespace and dependency system is designed ([ADR 0070](ADR/0070-package-namespaces-and-dependencies.md)) but not yet implemented (see [BT-714](https://linear.app/beamtalk/issue/BT-714))
+The remaining gap is the **source** of dependencies: only `path` (local) and `git` dependencies are supported. Registry-based resolution (e.g. `json = "1.0"` via a Hex.pm-style registry) is deferred until the ecosystem warrants it.
 
-**Workaround:** Use distinctive, package-specific class names to avoid collisions (e.g. `MyAppCounter` instead of `Counter`).
+**Workaround:** Vendor a package via a `git` or `path` dependency instead of a registry name.
 
-**References:** [ADR 0031](ADR/0031-flat-namespace-for-v01.md), [ADR 0070](ADR/0070-package-namespaces-and-dependencies.md), [BT-714](https://linear.app/beamtalk/issue/BT-714)
+**References:** [ADR 0070](ADR/0070-package-namespaces-and-dependencies.md) (package namespaces + dependencies), [ADR 0031](ADR/0031-flat-namespace-for-v01.md) (superseded — the original v0.1 flat-namespace decision), [Package Management guide](beamtalk-packages.md)
 
 ### No `try`/`catch` Keywords
 


### PR DESCRIPTION
## Summary

Namespaces + dependencies shipped (ADR 0070, PR #1657) and the deps tooling landed (`beamtalk.toml`, `beamtalk deps add/list/update`, lockfiles, transitive compile order), but several docs still described Beamtalk as a flat global namespace with no import/dependency system. This refreshes those stale claims. Fixes BT-2698.

## Changes

- **`docs/known-limitations.md`** — Replaced "No Module or Import System" with an accurate "Package Dependencies: Path and Git Only (No Registry Yet)" limitation. Collision guidance now points to qualified `package@Class` names and compile-error-on-collision; dropped the stale BT-714-as-open reference.
- **`docs/ADR/0031-flat-namespace-for-v01.md`** — Marked **Superseded by ADR 0070** in the status header (preserved as historical record).
- **`docs/ADR/README.md`** — Updated the index row for 0031 to `Superseded by 0070`.
- **`docs/ADR/0070-package-namespaces-and-dependencies.md`** — Added a reciprocal "Supersedes ADR 0031" note, and corrected a stale "`beamtalk deps update` not yet implemented" parenthetical (the command ships — verified in `crates/beamtalk-cli/src/commands/deps/cli.rs`).
- **`docs/beamtalk-language-features.md`** — Reworded the "Namespace and Class Visibility" intro and "Namespace" subsection to reflect per-package flat namespace + cross-package deps with qualified names.

## Acceptance criteria

- [x] `known-limitations.md` no longer says the namespace/dep system is unimplemented; collision guidance reflects qualified names
- [x] ADR 0031 marked superseded-by-0070 (preserved as history)
- [x] ADR 0070 confirmed accurate to shipped behaviour
- [x] No remaining doc claims that contradict shipped namespaces + deps (grep clean in user-facing docs)
- [x] CLAUDE.md not affected — docs-only

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVHZwX3QX9WDFDuL4qN2cE)_