### PR TITLE
Fix LiveView native-module editor UX bugs (BT-2733)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -403,8 +403,14 @@
    method opens it here). The highlighted-source overlay grows; the New File form
    and nav actions stay compact below it. */
 .editor-panel .panel-body { display: flex; flex-direction: column; }
-#method-editor-form { display: flex; flex-direction: column; flex: 1; min-height: 0; }
-#method-editor-form .cm-wrap { flex: 1; min-height: 6rem; }
+/* BT-2670: the editable native (.erl) editor tab reuses the method editor's
+   CodeMirror chrome under its own form id, so it needs the same fill rules —
+   without them its `.cm-wrap` (whose `.cm-host` is absolutely `inset: 0`)
+   collapses to zero height and the editor renders blank. */
+#method-editor-form,
+#native-editor-form { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+#method-editor-form .cm-wrap,
+#native-editor-form .cm-wrap { flex: 1; min-height: 6rem; }
 
 /* ============================================================================
    Tabbed method editor — write-surface tab strip + breadcrumb (BT-2494)

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -8570,7 +8570,16 @@ defmodule BtAttachWeb.WorkspaceLive do
                      re-renders the class tree inside it), but the SplitDrag hook's
                      own MutationObserver — not updated() — re-applies the saved size
                      when that happens. --%>
+                <%!-- BT-2733: the method browser (gutter + protocol/method list) is a
+                     Beamtalk-class surface — native `.erl` modules have no protocol
+                     browsing here (their clauses open in an editor tab). In Native
+                     mode we hide it so a stale `@selected_class` method list can't
+                     linger under the unrelated native-module list; `@selected_class`
+                     is left intact, so switching back to Classes restores it with no
+                     re-fetch. The remaining class/native panel then fills the column
+                     (the `.browser-split > .panel:last-of-type` flex rule). --%>
                 <div
+                  :if={@browser_mode != :native}
                   id="browser-split-gutter"
                   class="split-gutter split-gutter-y"
                   phx-hook="SplitDrag"
@@ -8587,6 +8596,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                 >
                 </div>
                 <.system_browser_methods
+                  :if={@browser_mode != :native}
                   browser_protocols={@browser_protocols}
                   selected_protocol={@selected_protocol}
                   selected_class={@selected_class}

--- a/editors/liveview/test/bt_attach_web/workspace_native_modules_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_native_modules_test.exs
@@ -93,6 +93,30 @@ defmodule BtAttachWeb.WorkspaceNativeModulesTest do
       assert html =~ ~s(aria-label="Class source filter")
     end
 
+    test "switching to Native hides the Beamtalk method browser; Classes restores it (BT-2733)",
+         %{conn: conn} do
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+
+      # Select a Beamtalk class so the lower method browser shows its protocol/method
+      # list (the `sb-classdef` "class definition" + owner-only "Add a method…" rows).
+      html = render_click(view, "browser_select_class", %{"class" => "Counter"})
+      assert html =~ ~s(class="tree sb-classdef")
+      assert html =~ "Add a method"
+
+      # BT-2733: switching to Native must NOT leave that class's method list showing
+      # beneath the unrelated native-module list — the whole method panel is hidden.
+      html = render_click(view, "browser_mode", %{"mode" => "native"})
+      assert html =~ ~s(phx-value-module="beamtalk_http_client")
+      refute html =~ ~s(class="tree sb-classdef")
+      refute html =~ "Add a method"
+
+      # `@selected_class` is left intact, so switching back to Classes restores the
+      # method list with no re-selection.
+      html = render_click(view, "browser_mode", %{"mode" => "classes"})
+      assert html =~ ~s(class="tree sb-classdef")
+      assert html =~ "Add a method"
+    end
+
     test "the native origin filter defaults to All when no module is project-origin", %{
       conn: conn
     } do


### PR DESCRIPTION
Two LiveView System Browser bugs found while exercising native (`.erl`) modules against a live workspace.

## Fixes

### 1. Editable native (`.erl`) editor rendered blank
The project-owned native module editor (BT-2670) mounts CodeMirror inside `#native-editor-form`, but the rule that sizes the editor wrapper was scoped only to `#method-editor-form`. Without it, `.cm-wrap` (whose `.cm-host` is `position: absolute; inset: 0`) collapsed to zero height, so an editable `.erl` tab showed a blank pane instead of its source. Extended the flex-fill + `min-height` rules to also cover `#native-editor-form`. Read-only native tabs use `.native-pre` and were unaffected.

### 2. Stale Beamtalk method list under the Native browser (BT-2733)
Switching the System Browser's `Classes | Native` toggle to Native swapped the class tree for the native-module list, but the lower method browser (`system_browser_methods`) was rendered unconditionally — so it kept showing the previously-selected Beamtalk class and its methods beneath the unrelated native list. Gated the split gutter + method panel on `browser_mode != :native`; `@selected_class` is left intact so switching back to Classes restores the selection with no re-fetch. The remaining class/native panel then fills the column via the existing `.browser-split > .panel:last-of-type` flex rule.

## Verification
- New regression test in `workspace_native_modules_test.exs` (present-in-classes → hidden-in-native → restored-on-return); full native-modules suite passes (22/22).
- Both fixes confirmed visually against a live workspace (editable `.erl` source now renders; Native mode shows only the module list filling the column).

## Linear
- https://linear.app/beamtalk/issue/BT-2733

Related follow-up filed during review: BT-2732 (native-module "Callers" should include ADR 0056 self-delegate callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)