### PR TITLE
docs: daily refresh 2026-07-03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
 - **Cockpit: System Browser native-class Erlang source** — `native:` classes show a read-only "Erlang backend" pane on the class-definition tab, with jump-to-implementation from a `self delegate` facade method to the corresponding `handle_call` clause in the backing `.erl` module (BT-2578).
 - **Cockpit: collapsible method-editor doc block** — the method-editor doc block is now collapsed by default (signature line visible as expand/collapse toggle), removing the duplicated doc-comment display between the rendered block and the editable source (BT-2558).
 - **Cockpit: New Class form in System Browser** — the create-a-class widget moves from the method-editor panel into the System Browser header as a collapsed-by-default form; the target path `src/<ClassName>.bt` is derived automatically from the declared class name (BT-2293).
+- Fix LiveView System Browser: editable native (`.erl`) editor rendered blank (CSS sizing rules scoped only to the method editor form); stale Beamtalk method list shown when switching to Native browser mode (BT-2733, #2817).
 - Fix LiveView IDE System Browser not showing stdlib class definitions — class definitions are now synthesized from reflection for every loaded class, independent of a disk source file. The method editor opens to an empty tab strip with a "new method" entry for creating methods directly in the browser (#2637, #2634).
 - Fix LiveView IDE method-editor false `expected expression, found ⇒` diagnostics — the `diagnostics` op now accepts a `mode` parameter so the System Browser parses bare method bodies with `parse_method` instead of the full-module grammar (BT-2569).
 - Fix LiveView IDE method-editor doc block rendering template whitespace — `white-space: pre-wrap` on doc-block spans no longer inherits into toggle/signature elements (#2633).
@@ -159,6 +160,7 @@
 
 ### Internal
 
+- Collapse `beamtalk_error:new/2` + `with_selector/2` chains to `new/3` across 12 runtime modules — 36 call sites, no behavior change (#2814).
 - Consolidate zero-param dispatch BIFs to use `leaf::atom` pattern (BT-2498).
 - Add codegen unit tests for Actor initialize chain (BT-2499).
 - Replace placeholder assertions in `value_objects.btscript` with explicit expected values (BT-2500).

--- a/docs/agents/expanded.md
+++ b/docs/agents/expanded.md
@@ -166,7 +166,7 @@ The beamtalk codebase follows strict architectural principles for code organizat
 - Validate file paths and buffer boundaries
 - Document unsafe code with `// SAFETY:` comment explaining invariants
 - Run `cargo audit` before releases
-- **Use structured errors at public API boundaries** - `beamtalk_error:new/with_selector/with_hint` for all user-facing error paths
+- **Use structured errors at public API boundaries** - `beamtalk_error:new/3` + `with_hint`/`with_details` for all user-facing error paths
 
 See full guide: [docs/development/architecture-principles.md](../docs/development/architecture-principles.md)
 
@@ -196,10 +196,9 @@ All errors use `#beamtalk_error{}` records defined in `runtime/include/beamtalk.
 Use `beamtalk_error` module helpers:
 
 ```erlang
-Error0 = beamtalk_error:new(does_not_understand, 'Integer'),
-Error1 = beamtalk_error:with_selector(Error0, 'foo'),
-Error2 = beamtalk_error:with_hint(Error1, <<"Check spelling">>),
-error(Error2)
+Error0 = beamtalk_error:new(does_not_understand, 'Integer', 'foo'),
+Error1 = beamtalk_error:with_hint(Error0, <<"Check spelling">>),
+error(Error1)
 ```
 
 ### In Generated Core Erlang Code
@@ -211,10 +210,9 @@ Codegen MUST use `beamtalk_error` calls:
 call 'erlang':'error'({'some_error', 'message'})
 
 %% ✅ RIGHT - structured error
-let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in
-let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new') in
-let Error2 = call 'beamtalk_error':'with_hint'(Error1, <<"Use spawn instead">>) in
-call 'erlang':'error'(Error2)
+let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor', 'new') in
+let Error1 = call 'beamtalk_error':'with_hint'(Error0, <<"Use spawn instead">>) in
+call 'erlang':'error'(Error1)
 ```
 
 ### Error Kinds

--- a/docs/development/erlang-guidelines.md
+++ b/docs/development/erlang-guidelines.md
@@ -151,11 +151,10 @@ All Beamtalk errors use `#beamtalk_error{}` records from `runtime/include/beamta
 -include("beamtalk.hrl").
 
 %% Creating errors in runtime Erlang code
-Error0 = beamtalk_error:new(does_not_understand, 'Integer'),
-Error1 = beamtalk_error:with_selector(Error0, 'foo'),
-Error2 = beamtalk_error:with_hint(Error1, <<"Check spelling">>),
-Error3 = beamtalk_error:with_details(Error2, #{arity => 0}),
-error(Error3).
+Error0 = beamtalk_error:new(does_not_understand, 'Integer', 'foo'),
+Error1 = beamtalk_error:with_hint(Error0, <<"Check spelling">>),
+Error2 = beamtalk_error:with_details(Error1, #{arity => 0}),
+error(Error2).
 ```
 
 ### Generated Core Erlang Errors
@@ -168,10 +167,9 @@ call 'erlang':'error'({'some_error', 'message'})
 call 'erlang':'error'('simple_atom')
 
 %% ✅ RIGHT - structured error
-let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor') in
-let Error1 = call 'beamtalk_error':'with_selector'(Error0, 'new') in
-let Error2 = call 'beamtalk_error':'with_hint'(Error1, <<"Use spawn instead">>) in
-call 'erlang':'error'(Error2)
+let Error0 = call 'beamtalk_error':'new'('instantiation_error', 'Actor', 'new') in
+let Error1 = call 'beamtalk_error':'with_hint'(Error0, <<"Use spawn instead">>) in
+call 'erlang':'error'(Error1)
 ```
 
 ### Error Kinds
@@ -712,9 +710,8 @@ build_error(Kind, Class) ->
 %% All immutable_primitive_error functions
 -spec immutable_primitive_error(atom(), term()) -> beamtalk_error:error().
 immutable_primitive_error(Class, FieldName) ->
-    Error0 = beamtalk_error:new(immutable_primitive, Class),
-    Error1 = beamtalk_error:with_selector(Error0, 'fieldAt:put:'),
-    beamtalk_error:with_hint(Error1, <<"Use assignment instead">>).
+    Error0 = beamtalk_error:new(immutable_primitive, Class, 'fieldAt:put:'),
+    beamtalk_error:with_hint(Error0, <<"Use assignment instead">>).
 ```
 
 **When to be vague:**


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 5 commits merged to `main` in the last 24 hours.

## Commits reviewed

| SHA | Title | Classification | Doc change |
|-----|-------|---------------|------------|
| `bcccbde` | Fix LiveView native-module editor UX bugs (BT-2733) | Tooling bug fix | CHANGELOG entry |
| `a279c3c` | docs: fix ConsoleEcho doc/code mismatch + de-dup destructuring tests (BT-2715) | Self-contained doc fix | Skipped — already applied |
| `55e55d2` | test: tighten placeholder assertion in lazy_name_resolution.btscript | Test-only | Excluded (purely `tests/`) |
| `355f514` | refactor(runtime): collapse new/2 + with_selector chains to new/3 | Internal refactor | CHANGELOG entry + dev doc updates |
| `531fb79` | docs: refresh stale flat-namespace limitations (BT-2698) | Already a doc refresh | Skipped — already applied |

## Changes

- **CHANGELOG.md** — Added Tooling entry for LiveView System Browser native-module fixes (bcccbde); added Internal entry for `beamtalk_error:new/2` + `with_selector/2` → `new/3` collapse (355f514).
- **docs/development/erlang-guidelines.md** — Updated three error-construction examples from the old `new/2` + `with_selector/2` chain to the canonical `new/3` form, matching the codebase after #2814.
- **docs/agents/expanded.md** — Updated two error-construction examples and the API reference line to match `new/3`.

## Skipped

- **a279c3c** — Already a doc fix PR; the ConsoleEcho doc correction and test dedup are self-contained.
- **55e55d2** — Test-only commit (purely under `tests/`); excluded per refresh rules.
- **531fb79** — Already a doc refresh PR updating namespace/dependency docs; no further changes needed.

## Needs human judgment

None — all commits had clear doc impact (or lack thereof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eVXNT1hkKs6HGUf8VAnq2

---
_Generated by [Claude Code](https://claude.ai/code/session_017eVXNT1hkKs6HGUf8VAnq2)_