### PR TITLE
Extract shared is_valid_class_name to beamtalk-core

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/mod.rs
@@ -63,3 +63,57 @@ pub use parser::{
 pub use span::Span;
 pub use summary::{DiagnosticSummary, SeverityCounts, category_name};
 pub use token::{Token, TokenKind, Trivia};
+
+/// Returns `true` if `name` is a valid Beamtalk class name.
+///
+/// A valid class name:
+/// - is non-empty
+/// - starts with an ASCII uppercase letter
+/// - contains only ASCII alphanumeric characters and underscores
+///
+/// This is the canonical definition; tools that validate user-supplied class
+/// names (LSP, MCP, CLI) must delegate their boolean check here so the rule
+/// stays in one place.
+pub fn is_valid_class_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.starts_with(|c: char| c.is_ascii_uppercase())
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+#[cfg(test)]
+mod naming_tests {
+    use super::*;
+
+    #[test]
+    fn valid_simple() {
+        assert!(is_valid_class_name("Counter"));
+        assert!(is_valid_class_name("FooBarBaz"));
+        assert!(is_valid_class_name("X123"));
+        assert!(is_valid_class_name("X_y"));
+        assert!(is_valid_class_name("A"));
+    }
+
+    #[test]
+    fn invalid_empty() {
+        assert!(!is_valid_class_name(""));
+    }
+
+    #[test]
+    fn invalid_lowercase_start() {
+        assert!(!is_valid_class_name("counter"));
+        assert!(!is_valid_class_name("myClass"));
+    }
+
+    #[test]
+    fn invalid_bad_chars() {
+        assert!(!is_valid_class_name("With Space"));
+        assert!(!is_valid_class_name("Bad!"));
+        assert!(!is_valid_class_name("Has-Hyphen"));
+        assert!(!is_valid_class_name("Has.Dot"));
+    }
+
+    #[test]
+    fn invalid_digit_start() {
+        assert!(!is_valid_class_name("123Foo"));
+    }
+}

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -2801,26 +2801,28 @@ fn expect_string_arg(
 /// flush expression. Tight on purpose — Beamtalk class names are a closed
 /// alphabet.
 fn validate_class_name(name: &str) -> std::result::Result<(), String> {
+    if beamtalk_core::source_analysis::is_valid_class_name(name) {
+        return Ok(());
+    }
     if name.is_empty() {
         return Err("class name must not be empty".to_string());
     }
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_uppercase() => {}
-        _ => {
-            return Err(format!(
-                "class name '{name}' must start with an uppercase letter"
-            ));
-        }
+    if !name.starts_with(|c: char| c.is_ascii_uppercase()) {
+        return Err(format!(
+            "class name '{name}' must start with an uppercase letter"
+        ));
     }
-    for c in chars {
-        if !(c.is_ascii_alphanumeric() || c == '_') {
-            return Err(format!(
-                "class name '{name}' contains invalid character '{c}' (allowed: letters, digits, underscore)"
-            ));
-        }
+    if let Some(c) = name
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || *c == '_'))
+    {
+        return Err(format!(
+            "class name '{name}' contains invalid character '{c}' (allowed: letters, digits, underscore)"
+        ));
     }
-    Ok(())
+    Err(format!(
+        "class name '{name}' is not a valid Beamtalk identifier"
+    ))
 }
 
 fn workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -2817,7 +2817,9 @@ fn validate_class_name(name: &str) -> std::result::Result<(), String> {
     let c = name
         .chars()
         .find(|c| !(c.is_ascii_alphanumeric() || *c == '_'))
-        .unwrap();
+        .expect(
+            "invariant: is_valid_class_name=false, non-empty, starts-uppercase → must have bad char",
+        );
     Err(format!(
         "class name '{name}' contains invalid character '{c}' (allowed: letters, digits, underscore)"
     ))

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -2812,16 +2812,14 @@ fn validate_class_name(name: &str) -> std::result::Result<(), String> {
             "class name '{name}' must start with an uppercase letter"
         ));
     }
-    if let Some(c) = name
+    // is_valid_class_name returned false, name is non-empty with uppercase start,
+    // so there must be at least one disallowed character.
+    let c = name
         .chars()
         .find(|c| !(c.is_ascii_alphanumeric() || *c == '_'))
-    {
-        return Err(format!(
-            "class name '{name}' contains invalid character '{c}' (allowed: letters, digits, underscore)"
-        ));
-    }
+        .unwrap();
     Err(format!(
-        "class name '{name}' is not a valid Beamtalk identifier"
+        "class name '{name}' contains invalid character '{c}' (allowed: letters, digits, underscore)"
     ))
 }
 

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -148,10 +148,7 @@ fn error_result(msg: impl Into<String>) -> CallToolResult {
 
 /// Validate that a string is a valid Beamtalk class name (uppercase-starting identifier).
 fn validate_class_name(name: &str) -> Result<(), rmcp::ErrorData> {
-    if name.is_empty()
-        || !name.starts_with(|c: char| c.is_ascii_uppercase())
-        || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-    {
+    if !beamtalk_core::source_analysis::is_valid_class_name(name) {
         return Err(rmcp::ErrorData::invalid_params(
             format!("Invalid class name: '{name}'. Must be an uppercase-starting identifier."),
             None,


### PR DESCRIPTION
## Summary

`validate_class_name` was duplicated between `beamtalk-lsp` and `beamtalk-mcp` with slightly diverging implementations. This PR extracts the canonical boolean check to `beamtalk_core::source_analysis::is_valid_class_name` so the naming rule lives once in the correct DDD bounded context (Source Analysis → Language Service).

## Changes

- **`crates/beamtalk-core/src/source_analysis/mod.rs`**: Add `pub fn is_valid_class_name(name: &str) -> bool` — non-empty, starts with ASCII uppercase, all chars alphanumeric or `_`. Includes 5 unit tests.
- **`crates/beamtalk-lsp/src/server.rs`**: `validate_class_name` delegates the structural check to `is_valid_class_name`; keeps its detailed per-character error messages for the LSP `Result<(), String>` type.
- **`crates/beamtalk-mcp/src/server.rs`**: `validate_class_name` delegates directly to `is_valid_class_name`; keeps its `rmcp::ErrorData` error type.

No behaviour change — both implementations agreed on which names are valid. No new crate dependencies (both LSP and MCP already depend on beamtalk-core).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwkUfbC6GxqYB8VVaNm7Eu)_