### PR TITLE
test: tighten 3 placeholder assertions in native_package.btscript

### DIFF
--- a/tests/repl-protocol/cases/native_package.btscript
+++ b/tests/repl-protocol/cases/native_package.btscript
@@ -45,7 +45,7 @@ NativeCalc version
 
 // Save the path to the native .erl file for modification
 erlPath := "tests/repl-protocol/fixtures/native_package_project/native/native_calc.erl"
-// => _
+// => tests/repl-protocol/fixtures/native_package_project/native/native_calc.erl
 
 // Save original content so we can restore it after the test
 originalContent := (File readAll: erlPath) unwrap
@@ -56,7 +56,7 @@ modifiedContent := originalContent replaceAll: "version() -> 1." with: "version(
 // => _
 
 File writeAll: erlPath contents: modifiedContent
-// => _
+// => Result ok: nil
 
 // Reload the class — demand-driven compilation detects the stale .erl
 :reload NativeCalc
@@ -79,4 +79,4 @@ NativeCalc add: 10 with: 20
 // (1 second on most filesystems) can prevent stale detection when the
 // restore and reload happen within the same second.
 File writeAll: erlPath contents: originalContent
-// => _
+// => Result ok: nil


### PR DESCRIPTION
## Summary

Replaces three `// => _` wildcards in `tests/repl-protocol/cases/native_package.btscript` with concrete expected values, making the test a stricter regression gate.

- **`erlPath :=` string assignment** → asserts the path string value. Pattern proven by `workspace_native_api.btscript` (strings display without quotes in REPL output, e.g. `ReloadCounter sourceFile // => tests/repl-protocol/fixtures/reload_counter.bt`).
- **`File writeAll: erlPath contents: modifiedContent`** → asserts `Result ok: nil`. Proven by `workspace_flush_roundtrip.btscript` lines 163 and 278.
- **`File writeAll: erlPath contents: originalContent`** (restore) → asserts `Result ok: nil`. Same proof.

The two legitimately non-deterministic expressions (file content reads and the string mutation result) retain `// => _`.

## Why it's safe

Tightening `// => _` to a real value makes a test *more* strict, never less — it's a regression gate upgrade. No test intent changes; the operations still verify the same things, now also checking the return value format. `just test-repl-protocol` passes with all three changes in place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvJeLqkbQQvVj5S5hUspBz)_