### PR TITLE
test(runtime): cover announcements guard-fail clauses and stale-subscription deliver edge cases

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
@@ -1453,6 +1453,126 @@ heir_rearm_with_remote_subscriber_impl() ->
         end)}.
 
 %%====================================================================
+%% Guard-fail clauses and stale-subscription deliver edge cases
+%%====================================================================
+
+%% Guard-fail (non-reference / non-atom / non-map) clauses in the public API.
+%% These match before any ETS or gen_server call, so no bus is required.
+%%
+%% Covers:
+%%   unsubscribe/1        line 317 — non-reference arg → ok
+%%   is_active/1          line 373 — non-reference arg → false
+%%   system_unsubscribe/2 line 359 — non-atom/non-pid args → ok
+%%   isActiveRef/1        line 1591 — non-subscription term → false
+guard_fail_clauses_test_() ->
+    [
+        ?_assertEqual(ok, beamtalk_announcements:unsubscribe(not_a_ref)),
+        ?_assertEqual(false, beamtalk_announcements:is_active(42)),
+        ?_assertEqual(ok, beamtalk_announcements:system_unsubscribe(42, 42)),
+        ?_assertEqual(false, beamtalk_announcements:'isActiveRef'(not_a_map))
+    ].
+
+%% `run_handler/2` arity-0 fun form on the synchronous path (line 707).
+%% Subscribes with a `fun/0` handler and drives `announceAndWait/2`; the
+%% transient handler process calls `Handler()` with no argument and acks back.
+run_handler_arity0_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Sub = spawn_idle(),
+                try
+                    {ok, _SubRef} = beamtalk_announcements:subscribe(
+                        'Arity0HandlerEvent', Sub, fun() -> ok end, false
+                    ),
+                    ok = beamtalk_announcements:announceAndWait('Arity0HandlerEvent', payload)
+                after
+                    stop_idle(Sub)
+                end
+            end)
+        ]
+    end}.
+
+%% `run_handler/2` opaque / catch-all form on the synchronous path (lines 712–713).
+%% An opaque handler term that is neither a fun nor `{send, Sel, _}` is treated as
+%% a no-op success; the async path would deliver it as a raw message instead.
+run_handler_opaque_handler_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            ?_test(begin
+                Sub = spawn_idle(),
+                try
+                    {ok, _SubRef} = beamtalk_announcements:subscribe(
+                        'OpaqueHandlerEvent', Sub, opaque_term, false
+                    ),
+                    ok = beamtalk_announcements:announceAndWait('OpaqueHandlerEvent', payload)
+                after
+                    stop_idle(Sub)
+                end
+            end)
+        ]
+    end}.
+
+%% `deliver/3` and `do_announce_and_wait` with a stale ETS row whose subscriber
+%% pid is dead at delivery time. Rows are inserted directly (bypassing
+%% `subscribe/4`) so no monitor is armed and bus auto-prune cannot race with the
+%% dispatch call. Covers the `subscriber_alive → false` branch in both paths
+%% (async: line 603; sync: line 504).
+stale_dead_subscriber_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            %% Async path: announce/2 → deliver/3 → subscriber_alive false → ok
+            ?_test(begin
+                {DeadPid, Mon} = spawn_monitor(fun() -> ok end),
+                receive
+                    {'DOWN', Mon, process, DeadPid, _} -> ok
+                after 1000 ->
+                    ok
+                end,
+                _SubRef = insert_subscription_row('StaleDeadAsyncEvent', DeadPid, h, false),
+                ok = beamtalk_announcements:announce('StaleDeadAsyncEvent', payload)
+            end),
+            %% Sync path: announceAndWait/2 → do_announce_and_wait → subscriber_alive false → skip
+            ?_test(begin
+                {DeadPid2, Mon2} = spawn_monitor(fun() -> ok end),
+                receive
+                    {'DOWN', Mon2, process, DeadPid2, _} -> ok
+                after 1000 ->
+                    ok
+                end,
+                _SubRef2 = insert_subscription_row('StaleDeadSyncEvent', DeadPid2, h, false),
+                ok = beamtalk_announcements:announceAndWait('StaleDeadSyncEvent', payload)
+            end)
+        ]
+    end}.
+
+%% `deliver/3` and `do_announce_and_wait` with an orphaned by-class index entry
+%% that has no matching primary subs row: `claim_row/1` returns `not_found`.
+%% Covers the not_found branch in both paths (async: line 606; sync: line 507).
+stale_orphan_index_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            %% Async path: announce/2 → deliver/3 → claim_row not_found → ok
+            ?_test(begin
+                SubRef = make_ref(),
+                true = ets:insert(
+                    beamtalk_announcement_by_class,
+                    {{beamtalk_system_announcer, 'OrphanAsyncEvent', SubRef}}
+                ),
+                ok = beamtalk_announcements:announce('OrphanAsyncEvent', payload)
+            end),
+            %% Sync path: announceAndWait/2 → do_announce_and_wait → claim_row not_found → skip
+            ?_test(begin
+                SubRef2 = make_ref(),
+                true = ets:insert(
+                    beamtalk_announcement_by_class,
+                    {{beamtalk_system_announcer, 'OrphanSyncEvent', SubRef2}}
+                ),
+                ok = beamtalk_announcements:announceAndWait('OrphanSyncEvent', payload)
+            end)
+        ]
+    end}.
+
+%%====================================================================
 %% Helpers
 %%====================================================================
 

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_announcements_tests.erl
@@ -1528,6 +1528,7 @@ stale_dead_subscriber_test_() ->
                 after 1000 ->
                     ok
                 end,
+                ?assert(not is_process_alive(DeadPid)),
                 _SubRef = insert_subscription_row('StaleDeadAsyncEvent', DeadPid, h, false),
                 ok = beamtalk_announcements:announce('StaleDeadAsyncEvent', payload)
             end),
@@ -1539,6 +1540,7 @@ stale_dead_subscriber_test_() ->
                 after 1000 ->
                     ok
                 end,
+                ?assert(not is_process_alive(DeadPid2)),
                 _SubRef2 = insert_subscription_row('StaleDeadSyncEvent', DeadPid2, h, false),
                 ok = beamtalk_announcements:announceAndWait('StaleDeadSyncEvent', payload)
             end)


### PR DESCRIPTION
## Summary

Adds 10 EUnit tests for `beamtalk_announcements` paths that are never reached by the existing 1625-line suite, targeting the module's 70.6% coverage gap.

**Guard-fail (non-reference / non-atom / non-map) clauses** — lines 317, 359, 373, 1591:
- `unsubscribe/1` with a non-reference arg
- `is_active/1` with a non-reference arg
- `system_unsubscribe/2` with non-atom / non-pid args
- `isActiveRef/1` with a non-subscription term

**`run_handler/2` alternative forms on the sync (`announceAndWait`) path** — lines 706–713:
- Arity-0 fun handler (`fun() -> ok`) calls `Handler()` with no arg
- Opaque / catch-all handler (any other term is a no-op success)

**Stale-subscription deliver edge cases** — lines 503–507, 603–606:
- Async path (`announce/2` → `deliver/3`): subscriber pid dead at delivery time
- Async path: `claim_row/1` returns `not_found` (orphaned by-class index row)
- Sync path (`announceAndWait/2` → `do_announce_and_wait`): subscriber pid dead
- Sync path: `claim_row/1` returns `not_found`

Stale rows are inserted directly into the public ETS tables (bypassing `subscribe/4`, so no monitor is armed and auto-prune cannot race with dispatch) — following the pattern of the existing `insert_subscription_row/4` helper already used by the remote-pid heir tests.

## Test plan

- [x] `rebar3 eunit --module=beamtalk_announcements_tests` — 49 tests, 0 failures
- [x] Pre-push hooks green (clippy, dialyzer, erlfmt, Rust build, stdlib build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2jcAHi1emDSAxWEhipzKz

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2jcAHi1emDSAxWEhipzKz)_