### PR TITLE
Fix flaky ClassMethodSupervisor supervision tests (BT-2729)

### DIFF
--- a/stdlib/test/supervision_class_method_test.bt
+++ b/stdlib/test/supervision_class_method_test.bt
@@ -9,6 +9,12 @@
 
 TestCase subclass: SupervisionClassMethodTest
 
+  // BT-2729: these tests share the globally-registered `ClassMethodSupervisor`
+  // singleton with SupervisorWhichTest. Run serially so a concurrent class
+  // cannot `stop` the shared supervisor (and its child) between this test's
+  // `which:` and the message it sends to the resolved child.
+  class serial -> Boolean => true
+
   // === childSpec encoding ===
   testChildSpecUsesClassMethodStartFn =>
     spec := (ClassMethodActor supervisionSpec withClassMethod: #create:value:) withArgs: #(#hello, 42)

--- a/stdlib/test/supervisor_which_test.bt
+++ b/stdlib/test/supervisor_which_test.bt
@@ -12,6 +12,12 @@
 
 TestCase subclass: SupervisorWhichTest
 
+  // BT-2729: these tests share the globally-registered `ClassMethodSupervisor`
+  // singleton with SupervisionClassMethodTest. Run serially so a concurrent
+  // class cannot `stop` the shared supervisor (and its child) between this
+  // test's `which:` and the message it sends to the resolved child.
+  class serial -> Boolean => true
+
   // === ok with child — class has a running child ===
   testWhichReturnsOkWithChild =>
     sup := (ClassMethodSupervisor supervise) unwrap


### PR DESCRIPTION
## Summary

Fixes the intermittent BUnit failure where supervision tests report
`Cannot send 'label' to unknown (actor process has terminated)`.

Linear: https://linear.app/beamtalk/issue/BT-2729

## Root cause

`SupervisorWhichTest` and `SupervisionClassMethodTest` both drive the
`ClassMethodSupervisor`, which registers as a **global singleton** keyed on
its class-name module (`supervisor:start_link({local, Module}, ...)`). BUnit
runs test classes concurrently by default, so the two classes share that one
registered supervisor. When one class calls `sup stop` — a synchronous
`gen_server:stop/1` that also terminates the supervised child — between the
other class's `which:` resolution and the message it sends to the resolved
child, the child is already gone. That is why the failure *moved between the
two suites* across runs and only ever surfaced under the full concurrent
suite, never in isolation.

## Fix

Mark both test classes `class serial -> Boolean => true`. The runner
partitions serial classes and runs them one at a time after all concurrent
classes complete, so the shared registered singleton is never touched by two
classes at once. `gen_server:stop/1` is synchronous, so within a serial class
each test's `stop` fully tears down (and unregisters) before the next test's
`supervise`. This matches the documented purpose of `serial` (tests that touch
registered process names / global state), already used by `tracing_test.bt`
and `timeout_proxy_test.bt`.

Polling `isAlive` before asserting — the issue's alternative suggestion —
would not close the race, since a concurrent class can still `stop` the shared
supervisor after the poll succeeds. No production change was required.

## Key changes

- `stdlib/test/supervisor_which_test.bt` — add `serial` override + rationale.
- `stdlib/test/supervision_class_method_test.bt` — add `serial` override + rationale.

## Verification

`just test-bunit` (full concurrent suite) passed **10/10 consecutive runs**
(2664 passed / 0 failed each), satisfying both acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLrufmmcQCFYaxZGFhe8H2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLrufmmcQCFYaxZGFhe8H2)_