### PR TITLE
Set logger process domain in init/1 for beamtalk_workspace gen_servers

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_idle_monitor.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_idle_monitor.erl
@@ -79,6 +79,7 @@ mark_activity() ->
 %%% gen_server callbacks
 
 init(Config) ->
+    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
     Enabled = maps:get(enabled, Config, true),
     MaxIdleSeconds = maps:get(max_idle_seconds, Config, 3600 * 4),
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_actors.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_actors.erl
@@ -197,6 +197,7 @@ get_pids_for_module(RegistryPid, ModuleName) ->
 %%% gen_server callbacks
 
 init([]) ->
+    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
     {ok, #state{actors = #{}, monitors = #{}}}.
 
 handle_call({register, ActorPid, ClassName, ModuleName}, _From, State) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
@@ -118,6 +118,7 @@ get_nonce() ->
 %%% gen_server callbacks
 
 init(Config) ->
+    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
     Port = maps:get(port, Config),
     WorkspaceId = maps:get(workspace_id, Config, undefined),
     BindAddr = maps:get(bind_addr, Config, {127, 0, 0, 1}),

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
@@ -230,6 +230,7 @@ init(SessionId) when is_binary(SessionId) ->
     %% — default to empty origin metadata (→ `kind => unknown`).
     init({SessionId, #{}});
 init({SessionId, Meta}) when is_map(Meta) ->
+    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
     %% Create session-specific REPL state
     %% We use undefined for listen_socket and port since session doesn't own TCP connection
     %%

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_bootstrap.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_bootstrap.erl
@@ -53,6 +53,7 @@ start_link(ProjectPath) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [ProjectPath], []).
 
 init([ProjectPath]) ->
+    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
     %% Create the user-bindings ETS table here so that this long-lived process
     %% owns it. If created inside a short-lived eval worker instead, the table
     %% would be deleted when that worker exits (ETS tables are deleted on owner

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
@@ -339,6 +339,7 @@ set_setting(Key, Value) when is_atom(Key) ->
 %%% gen_server callbacks
 
 init(InitialMetadata) ->
+    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
     WorkspaceId = maps:get(workspace_id, InitialMetadata),
     ProjectPath = maps:get(project_path, InitialMetadata, undefined),
     %% BT-775: Auto-detect package name from beamtalk.toml at project_path


### PR DESCRIPTION
## Summary

Six gen_server modules in `beamtalk_workspace` emitted logs with per-call `domain => [beamtalk, runtime]` but were missing the process-level domain setup mandated by CLAUDE.md ("Set `domain` metadata in `init/1` via `logger:set_process_metadata(#{domain => [beamtalk, runtime]})`").

This PR adds `logger:set_process_metadata(#{domain => [beamtalk, runtime]})` as the first statement in each `init/1`, matching the pattern already used by `beamtalk_workspace_changelog`, `beamtalk_trace_store`, and `beamtalk_xref`.

**Affected modules:**
- `beamtalk_idle_monitor`
- `beamtalk_repl_actors`
- `beamtalk_repl_server`
- `beamtalk_repl_shell` (second init/1 clause — where the process actually starts)
- `beamtalk_workspace_bootstrap`
- `beamtalk_workspace_meta`

## Details

No logic change. Existing per-call `domain` fields in individual `?LOG_*` calls are left in place (belt-and-suspenders). The change is purely additive: process metadata is now set once at startup rather than only being present on log calls that remembered to include it.

Follow-up candidates (separate OTP apps, filed as issue scope):
- `beamtalk_object_class` (beamtalk_runtime)
- `beamtalk_compiler_server` (beamtalk_compiler)
- `beamtalk_subprocess` (beamtalk_stdlib)

---
_Generated by [Claude Code](https://claude.ai/code/session_016M8REjxPjM8fQUVH8Xkx3t)_