### PR TITLE
test: add Boolean#isBoolean/xor:, String#isNotEmpty/lines, and describe_ops/0 tests

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_watch_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_watch_tests.erl
@@ -71,6 +71,18 @@ handle_pid_stats_unknown_actor_returns_error_test() ->
     ?assert(maps:is_key(<<"error">>, Decoded)).
 
 %%====================================================================
+%% describe_ops/0
+%%====================================================================
+
+describe_ops_returns_pid_stats_descriptor_test() ->
+    Ops = beamtalk_repl_ops_watch:describe_ops(),
+    ?assert(is_map(Ops)),
+    ?assert(maps:is_key(<<"pid-stats">>, Ops)),
+    PidStats = maps:get(<<"pid-stats">>, Ops),
+    ?assert(maps:is_key(<<"params">>, PidStats)),
+    ?assert(maps:is_key(<<"notes">>, PidStats)).
+
+%%====================================================================
 %% handle_term/4 — live registered actor returns a stats map
 %%====================================================================
 

--- a/stdlib/test/boolean_methods_test.bt
+++ b/stdlib/test/boolean_methods_test.bt
@@ -1,0 +1,19 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for Boolean predicate and logical methods:
+// isBoolean (Boolean), xor: (Boolean)
+
+TestCase subclass: BooleanMethodsTest
+
+  testIsBooleanOnTrue => self assert: true isBoolean
+
+  testIsBooleanOnFalse => self assert: false isBoolean
+
+  testXorTrueTrue => self deny: (true xor: true)
+
+  testXorTrueFalse => self assert: (true xor: false)
+
+  testXorFalseTrue => self assert: (false xor: true)
+
+  testXorFalseFalse => self deny: (false xor: false)

--- a/stdlib/test/string_new_methods_test.bt
+++ b/stdlib/test/string_new_methods_test.bt
@@ -50,3 +50,13 @@ TestCase subclass: StringNewMethodsTest
     self assert: "hello" isAlpha
     self deny: "hello1" isAlpha
     self deny: "" isAlpha
+    // isNotEmpty
+    self assert: "hello" isNotEmpty
+    self assert: " " isNotEmpty
+    self deny: "" isNotEmpty
+
+  testLines =>
+    nl := $\n asString
+    self assert: ("hello" ++ nl ++ "world") lines equals: #("hello", "world")
+    self assert: "hello" lines equals: #("hello")
+    self assert: ("a" ++ nl ++ "b" ++ nl ++ "c") lines equals: #("a", "b", "c")


### PR DESCRIPTION
## Summary

- Add `BooleanMethodsTest` in `stdlib/test/boolean_methods_test.bt` covering `Boolean#isBoolean` (2 tests) and `Boolean#xor:` (4 tests) — both methods were implemented but had zero BUnit assertions
- Extend `StringNewMethodsTest` with `isNotEmpty` assertions in `testStringPredicates` and a new `testLines` method (3 assertions) — `String#isNotEmpty` and `String#lines` were unexercised by the test suite
- Add `describe_ops_returns_pid_stats_descriptor_test/0` to `beamtalk_repl_ops_watch_tests.erl` covering the `describe_ops/0` export, which was the one public function in that module with no EUnit coverage

Total: 14 new test assertions across 3 files (1 new BUnit file, 1 extended BUnit file, 1 extended EUnit file).

## Test plan

- [x] `just test-bunit` — 245 files, 2596 tests, 0 failures
- [x] `just test-stdlib` — 250 tests, 0 failures
- [x] `rebar3 eunit --app beamtalk_workspace` — 2243 tests, 0 failures
- [x] `just ci` (pre-push hooks: clippy, cargo fmt, dialyzer, erlfmt, beamtalk fmt) — all passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQH5y7ycjKSLNxWdzrQiXx)_