### PR TITLE
test: tighten printString assertions in binary_test.bt

### DIFF
--- a/stdlib/test/binary_test.bt
+++ b/stdlib/test/binary_test.bt
@@ -435,8 +435,8 @@ TestCase subclass: BinaryTest
   testPrintStringValidUtf8 =>
     bin := Binary fromBytes: #(104, 105)
     result := bin printString
-    self assert: (result includesSubstring: "hi")
+    self assert: result equals: """hi"""
 
   testPrintStringOnString =>
     result := "hello" printString
-    self assert: (result includesSubstring: "hello")
+    self assert: result equals: """hello"""


### PR DESCRIPTION
## Summary

- Replace two `includesSubstring:` assertions with exact `equals:` assertions in `stdlib/test/binary_test.bt`

## What changed

`testPrintStringValidUtf8` and `testPrintStringOnString` used loose `includesSubstring:` checks where the actual return value is fully deterministic:

```diff
-    self assert: (result includesSubstring: "hi")
+    self assert: result equals: """hi"""

-    self assert: (result includesSubstring: "hello")
+    self assert: result equals: """hello"""
```

`printString` on a valid UTF-8 binary dispatches to String's `printString`, which wraps the content in double-quote characters. This is already pinned in `object_protocol_test.bt`:

```beamtalk
self assert: "hello" printString equals: """hello"""
```

The new assertions are strictly stronger — they catch any wrong value, not just values that don't contain the substring.

## Test plan

- [x] `just test-bunit test/binary_test.bt` — 82 tests, 80 passed, 0 failed
- [x] `just test-bunit` — 2666 tests, 2664 passed, 0 failed (the 2 non-passing are pre-existing `@expect type` skips, unchanged)

_Nightly test-quality routine — loose-assertion smell fix._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRy1nJEAg7yTkKFFGowjYs)_