### PR TITLE
feat: reject user names colliding with reserved `__` state-key namespace (BT-2718)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -546,6 +546,9 @@ fn analyse_full_with_natives(
     validators::check_actor_new_usage(module, &result.class_hierarchy, &mut result.diagnostics);
     validators::check_object_new_usage(module, &result.class_hierarchy, &mut result.diagnostics);
     validators::check_new_field_names(module, &result.class_hierarchy, &mut result.diagnostics);
+    // BT-2718: Reject user names that collide with the reserved internal `__`
+    // state-key namespace (`__local__…`, `__methods__`, `__class_mod__`).
+    validators::check_reserved_internal_names(module, &mut result.diagnostics);
     validators::check_class_variable_access(
         module,
         &result.class_hierarchy,

--- a/crates/beamtalk-core/src/semantic_analysis/validators/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/mod.rs
@@ -12,12 +12,14 @@
 //! - `supervision_validators` — OTP supervision policy checks
 //! - `match_validators` — pattern match exhaustiveness
 //! - `native_validators` — native actor validation
+//! - `reserved_name_validators` — reserved internal-namespace name checks
 
 mod class_validators;
 mod lint_validators;
 mod match_validators;
 mod native_validators;
 pub(crate) mod package_validators;
+mod reserved_name_validators;
 mod structural_validators;
 mod supervision_validators;
 mod visibility_validators;
@@ -41,6 +43,7 @@ pub(crate) use native_validators::{
     check_native_state_fields,
 };
 pub(crate) use package_validators::check_package_qualifiers;
+pub(crate) use reserved_name_validators::check_reserved_internal_names;
 pub(crate) use structural_validators::{
     check_ffi_arity, check_unresolved_classes, check_unresolved_ffi_modules,
     check_workspace_shadows,

--- a/crates/beamtalk-core/src/semantic_analysis/validators/reserved_name_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/reserved_name_validators.rs
@@ -1,0 +1,227 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reserved internal-namespace name validation (BT-2718).
+//!
+//! **DDD Context:** Semantic Analysis
+//!
+//! Beamtalk's codegen reserves a `__`-prefixed map-key namespace inside
+//! actor/object state: `__methods__` and `__class_mod__` (dispatch metadata),
+//! and `__local__<name>` control-flow threading temporaries (BT-2717). The
+//! runtime's `beamtalk_actor:strip_local_temps/1` deletes every
+//! `__local__`-prefixed key from committed state on each dispatch, and
+//! `changed_state_keys/2` excludes the same prefix from watch notifications.
+//!
+//! Nothing at the language level guards this namespace — the lexer admits
+//! leading-underscore identifiers. A user declaration whose name lands in it
+//! (e.g. `state: __local__balance :: Integer = 0`) would be stored under the
+//! bare atom `'__local__balance'` and then **silently stripped from persisted
+//! state on every commit** — silent data loss. This validator rejects such
+//! names at compile time so the collision is impossible by construction.
+
+use crate::ast::{Expression, Identifier, Module};
+use crate::ast_walker::walk_module;
+use crate::semantic_analysis::extract_pattern_bindings;
+use crate::source_analysis::{Diagnostic, Span};
+
+/// The reserved-namespace prefix. Codegen-internal state keys
+/// (`__local__<name>`, `__methods__`, `__class_mod__`) all begin with a double
+/// underscore; reserving the whole prefix — rather than an explicit blocklist —
+/// keeps future internal keys safe by construction.
+const RESERVED_PREFIX: &str = "__";
+
+/// Returns `true` if `name` falls in the compiler's reserved internal
+/// state-key namespace.
+///
+/// A single leading underscore (`_unused`) is the conventional "intentionally
+/// ignored" marker and stays allowed — only the double-underscore prefix is
+/// reserved.
+fn is_reserved_internal_name(name: &str) -> bool {
+    name.starts_with(RESERVED_PREFIX)
+}
+
+/// BT-2718: Reject user-chosen names that collide with the compiler's reserved
+/// internal state-key namespace (the `__` prefix).
+///
+/// Covers every site where a user names a binding that could be packed into
+/// actor/object state or a control-flow-threaded local: instance fields, class
+/// variables, method parameters, block parameters, and local `:=` assignment
+/// targets (including destructuring binds).
+pub(crate) fn check_reserved_internal_names(module: &Module, diagnostics: &mut Vec<Diagnostic>) {
+    for class in &module.classes {
+        // Instance fields (`state:` / `field:`).
+        for field in &class.state {
+            check_declared_name(&field.name, "field", diagnostics);
+        }
+        // Class variables (`classState:`).
+        for var in &class.class_variables {
+            check_declared_name(&var.name, "class variable", diagnostics);
+        }
+        // Method parameters (instance- and class-side).
+        for method in class.methods.iter().chain(class.class_methods.iter()) {
+            for param in &method.parameters {
+                check_declared_name(&param.name, "parameter", diagnostics);
+            }
+        }
+    }
+
+    // Standalone (Tonel-style) method parameters: `MyClass >> foo: __x => …`.
+    for standalone in &module.method_definitions {
+        for param in &standalone.method.parameters {
+            check_declared_name(&param.name, "parameter", diagnostics);
+        }
+    }
+
+    // Block parameters and local `:=` assignment targets, everywhere a body
+    // appears (module-level expressions, class methods, standalone methods).
+    walk_module(module, &mut |expr| match expr {
+        Expression::Block(block) => {
+            for param in &block.parameters {
+                check_raw_name(
+                    param.name.as_str(),
+                    param.span,
+                    "block parameter",
+                    diagnostics,
+                );
+            }
+        }
+        Expression::Assignment { target, .. } => {
+            if let Expression::Identifier(id) = target.as_ref() {
+                check_declared_name(id, "local variable", diagnostics);
+            }
+        }
+        Expression::DestructureAssignment { pattern, .. } => {
+            let (bindings, _) = extract_pattern_bindings(pattern);
+            for id in &bindings {
+                check_declared_name(id, "local variable", diagnostics);
+            }
+        }
+        _ => {}
+    });
+}
+
+/// Emits a diagnostic if `id`'s name is in the reserved namespace.
+fn check_declared_name(id: &Identifier, kind: &str, diagnostics: &mut Vec<Diagnostic>) {
+    check_raw_name(id.name.as_str(), id.span, kind, diagnostics);
+}
+
+/// Emits a diagnostic if `name` is in the reserved namespace, anchored at `span`.
+fn check_raw_name(name: &str, span: Span, kind: &str, diagnostics: &mut Vec<Diagnostic>) {
+    if is_reserved_internal_name(name) {
+        diagnostics.push(
+            Diagnostic::error(
+                format!(
+                    "{kind} `{name}` uses the reserved `__` prefix, which the compiler \
+                     uses internally for actor/object state keys"
+                ),
+                span,
+            )
+            .with_hint(
+                "Rename it. Identifiers beginning with `__` (double underscore) are \
+                 reserved for compiler-internal state keys such as `__local__…`, \
+                 `__methods__`, and `__class_mod__`; a colliding name would be silently \
+                 dropped from persisted state."
+                    .to_string(),
+            ),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_support::parse_bt;
+
+    fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+        let module = parse_bt(source);
+        let mut diagnostics = Vec::new();
+        check_reserved_internal_names(&module, &mut diagnostics);
+        diagnostics
+    }
+
+    #[test]
+    fn reserved_prefix_helper() {
+        assert!(is_reserved_internal_name("__local__balance"));
+        assert!(is_reserved_internal_name("__methods__"));
+        assert!(is_reserved_internal_name("__class_mod__"));
+        // Single underscore is the "ignore me" convention — allowed.
+        assert!(!is_reserved_internal_name("_unused"));
+        assert!(!is_reserved_internal_name("balance"));
+    }
+
+    #[test]
+    fn rejects_reserved_field_name() {
+        let diagnostics =
+            diagnostics_for("Actor subclass: Counter\n  state: __local__balance :: Integer = 0\n");
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "expected one diagnostic: {diagnostics:?}"
+        );
+        assert!(diagnostics[0].message.contains("__local__balance"));
+        assert!(diagnostics[0].message.contains("field"));
+    }
+
+    #[test]
+    fn rejects_reserved_class_variable_name() {
+        let diagnostics =
+            diagnostics_for("Object subclass: Config\n  classState: __methods__ = 0\n");
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "expected one diagnostic: {diagnostics:?}"
+        );
+        assert!(diagnostics[0].message.contains("__methods__"));
+        assert!(diagnostics[0].message.contains("class variable"));
+    }
+
+    #[test]
+    fn rejects_reserved_parameter_name() {
+        let diagnostics =
+            diagnostics_for("Object subclass: Widget\n  set: __class_mod__ => ^__class_mod__\n");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("parameter") && d.message.contains("__class_mod__")),
+            "expected a parameter diagnostic: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_reserved_local_variable_target() {
+        let diagnostics = diagnostics_for(
+            "Object subclass: Widget\n  run => \n    __local__tmp := 1\n    ^__local__tmp\n",
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("local variable") && d.message.contains("__local__tmp")),
+            "expected a local-variable diagnostic: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_reserved_block_parameter() {
+        let diagnostics = diagnostics_for(
+            "Object subclass: Widget\n  run => [:__methods__ | __methods__ + 1] value: 1\n",
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("block parameter") && d.message.contains("__methods__")),
+            "expected a block-parameter diagnostic: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn allows_single_underscore_and_ordinary_names() {
+        let diagnostics = diagnostics_for(
+            "Actor subclass: Counter\n  state: balance :: Integer = 0\n  \
+             add: _ignored => \n    total := balance\n    ^total\n",
+        );
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected diagnostics: {diagnostics:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Codegen reserves a `__`-prefixed map-key namespace in actor/object state — `__methods__`, `__class_mod__`, and `__local__<name>` control-flow threading temporaries (BT-2717). Nothing at the language level guarded it, so a user field/var/param/local whose name landed in that namespace (e.g. `state: __local__balance :: Integer = 0`) would be stored under the bare atom and then **silently stripped from persisted state on every commit** by `beamtalk_actor:strip_local_temps/1` — silent data loss, plus a missing watch-notification slot.

This adds a semantic-analysis validator that makes the collision impossible by construction.

## Changes

- **New validator** `semantic_analysis/validators/reserved_name_validators.rs` (`check_reserved_internal_names`): rejects any user-declared name beginning with `__` at every binding site:
  - instance fields (`state:` / `field:`)
  - class variables (`classState:`)
  - method parameters (instance-, class-side, and standalone Tonel-style)
  - block parameters
  - local `:=` assignment targets, including destructuring binds
- Wired into the analysis pipeline in `semantic_analysis/mod.rs` alongside the other field-name checks.
- Reserving the whole double-underscore prefix — rather than an explicit blocklist — keeps future internal keys safe by construction. A single leading underscore (`_unused`) stays allowed. Each hit emits a spanned `Diagnostic` naming the offending declaration with a helpful rename hint.

## Testing

- 7 new unit tests: field, class-var, param, block-param, and local-var collisions, plus the reserved-prefix helper and an allow-list (`_unused` / ordinary names) case.
- `cargo test -p beamtalk-core`: 4289 pass.
- `just test-stdlib`: 103 modules build, 223 tests pass — no regression (confirmed no existing `.bt`/`.btscript` in stdlib, examples, tests, or repl-protocol declares `__`-prefixed names).
- `cargo clippy` / `cargo fmt` clean.

Closes BT-2718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9VeUFbKoJuCyS7mgWqAWa)_