### PR TITLE
docs: clarify reserved-name hint distinguishes the two failure modes (BT-2718)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/validators/reserved_name_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/reserved_name_validators.rs
@@ -118,9 +118,10 @@ fn check_raw_name(name: &str, span: Span, kind: &str, diagnostics: &mut Vec<Diag
             )
             .with_hint(
                 "Rename it. Identifiers beginning with `__` (double underscore) are \
-                 reserved for compiler-internal state keys such as `__local__…`, \
-                 `__methods__`, and `__class_mod__`; a colliding name would be silently \
-                 dropped from persisted state."
+                 reserved for compiler-internal state keys. A `__local__`-prefixed name \
+                 is silently stripped from persisted state on every dispatch commit; a \
+                 `__methods__` or `__class_mod__` collision would instead overwrite the \
+                 runtime's dispatch metadata and corrupt method lookup."
                     .to_string(),
             ),
         );


### PR DESCRIPTION
## Summary

Follow-up to #2834 (BT-2718), addressing the non-blocking review suggestion left on that PR after it had already merged.

The reserved-`__`-name diagnostic hint previously said a colliding name would be "silently dropped from persisted state." That's accurate only for `__local__`-prefixed names, which `beamtalk_actor:strip_local_temps/1` strips from the state map on every dispatch commit. For `__methods__` / `__class_mod__` the failure mode is the *opposite*: the user's value would **overwrite** the runtime's dispatch-metadata entry on actor creation, corrupting method lookup.

This splits the hint so it describes both paths accurately.

## Changes

- `reserved_name_validators.rs`: reword the `check_raw_name` hint to distinguish the strip path (`__local__…`) from the overwrite/corruption path (`__methods__`, `__class_mod__`).

## Testing

- Documentation-only change to a diagnostic hint string (no logic change).
- `cargo test -p beamtalk-core reserved_name_validators`: 7 pass.
- `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9VeUFbKoJuCyS7mgWqAWa)_