### PR TITLE
docs: ADR 0102 — set-theoretic type operators for uniform narrowing

### DIFF
--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -1,4 +1,4 @@
-# ADR 0102: Set-Theoretic Type Operators (Intersection and Negation) for Uniform Narrowing
+# ADR 0102: Set-Theoretic Type Operators (Intersection and Negation) for Narrowing and Atom Exhaustiveness
 
 ## Status
 Proposed (2026-07-05)
@@ -22,6 +22,10 @@ types by hand** — but only for the narrow cases each idiom needs:
   how to subtract a single `#name` singleton from a *flat* union. It is the
   engine behind the `x = #foo` false-branch (`Integer | #infinity` minus
   `#infinity` ⇒ `Integer`).
+- `non_nil_type` (`inference.rs:3306`) is a **second, independent set-difference**
+  — remove `UndefinedObject` from a union — whose own doc comment calls
+  `union_without` its "singleton counterpart". Two hand-rolled differences that
+  don't share code.
 - `type_admits_singleton` (`inference.rs:2425`) is a **membership / subtyping
   test** hand-written for the singleton-vs-`Symbol` case.
 - `InferredType::union_of` (`types.rs:442`) is the **union** operator, with
@@ -60,10 +64,11 @@ with structure.
 - **BEAM-native.** Singletons *are* Erlang atoms; the algebra must stay
   faithful to runtime atom semantics.
 - **Controlled regressions.** The seven existing narrowing rules (across six
-  detector files) split into: those refactored with *identical* results
-  (`singleton_eq`), those changed *deliberately* with updated tests
-  (`class_eq`/`is_kind_of` true branch), and those left untouched (`is_result`).
-  See §2 — this is not a uniform "refactor everything onto one core".
+  detector files, `narrowing/rules/mod.rs:49-57`) split into: those refactored
+  with near-identical results (`singleton_eq`, `is_nil`), those changed
+  *deliberately* with updated tests (`class_eq`/`is_kind_of` true branch), and
+  those left untouched (`is_result`, `responds_to`). See §2 — this is not a
+  uniform "refactor everything onto one core".
 
 ## Decision
 
@@ -86,31 +91,43 @@ The two operators are introduced primarily as **normalising functions** —
 variants (`Known` / `Union` / `Never`) wherever the result is representable.
 This is deliberate: `refine_singleton_narrowing` today already returns the bare
 `matched` singleton, never a wrapped intersection, so most narrowing never needs
-new storage. Subtyping remains **set inclusion**, consistent with how singletons
-already relate to `Symbol` (`A <: B` iff `difference(A, B) == Never`).
+new storage. Subtyping remains **set inclusion** as the *mental model*, but the
+equation `A <: B` iff `difference(A, B) == Never` holds only on the **atom
+fragment** this ADR defines (singletons, `Symbol`, unions of them) — it is the
+north-star invariant (contract #1), not a claim about these partial operators.
+Nominal subtyping (`Integer <: Number`) remains the hierarchy walk, and
+`difference(Dynamic, P) = Dynamic` deliberately says nothing about gradual
+subtyping.
 
-Only **irreducible** results need new stored variants, and there are exactly two:
+Only **irreducible** results need new stored variants — and in Phase 1 there is
+exactly **one**:
 
 ```rust
 enum InferredType {
     Known { class_name, type_args, provenance },
     Union { members, provenance },        // t1 | t2 | ...
-    // NEW — only when the result cannot collapse to the above:
-    Intersection { members, provenance },  // irreducible conjunction, e.g.
-                                           // class ∩ protocol (unifies ADR 0068's `&`)
+    // NEW (Phase 1) — only when the result cannot collapse to the above:
     Negation { base, excluded, provenance }, // co-finite complement, e.g. Symbol \ #foo
+    // NEW (Phase 2, with `&` syntax) — see below:
+    Intersection { members, provenance },  // irreducible conjunction: class ∩ protocol
     Meta { class_name, provenance },
     Dynamic(DynamicReason),                // unchanged: gradual hole
     Never,                                  // bottom / none()
 }
 ```
 
-`Intersection` is the representation for ADR 0068's `&` protocol composition
-(`Collection(Object) & Comparable`, 0068 §Protocol Composition) generalised to
-any type — a single stored form for both, rather than two mechanisms. (0068
-specifies `&` at the syntax level; `TypeAnnotation` does not yet carry an
-intersection variant, so this ADR adds it — see Implementation.) See §3 for the
-syntax reconciliation.
+**The stored `Intersection` variant is deferred to Phase 2**, by the same
+precedent that defers nominal-class difference: under single inheritance,
+class ∩ class always *reduces* (to the subclass, or to `Never` for unrelated
+sealed classes), so `intersect()` in Phase 1 is a pure function over existing
+variants. The only *irreducible* intersection is **class ∩ protocol**, and its
+only producers are ADR 0068's `&` protocol composition — which 0068 *specifies*
+(§Protocol Composition, `Collection(Object) & Comparable`) but which is **not
+yet implemented** (`TypeAnnotation` has no intersection variant) — and a future
+`responds_to`-narrowing refinement this ADR does not touch (§2). Storing
+`Intersection` before either producer exists would tax every exhaustive match
+for a variant nothing constructs. It lands in Phase 2 alongside the `&` surface
+syntax; see §3 for the reconciliation.
 
 Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
 `union_of` — the `Dynamic` handling is deliberately different, see below):
@@ -133,7 +150,28 @@ Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
   implementing "like `union_of`" here would silently stop narrowing the common
   case of unannotated (`Dynamic`) receivers. Regression test required.
 - `Meta` and `Dynamic` are opaque to `Negation`: `difference` leaves them
-  unchanged rather than fabricating a complement.
+  unchanged rather than fabricating a complement. Symmetrically,
+  `difference(T, Dynamic) = T` — we cannot prove the unknown removed anything.
+- **Union on the right-hand side folds member-wise**:
+  `difference(T, A | B) = difference(difference(T, A), B)` and
+  `intersect(T, A | B) = union_of(intersect(T, A), intersect(T, B))`. The fold
+  is required by both §4's residual computation
+  (`difference(scrutinee, covered)`) and this ADR's own syntax example
+  `Symbol \ (#reserved | #internal)`.
+- **Generics (`type_args`) compare exactly, or not at all.** A member is
+  subtracted / matched only under *exact equality including type args*; the same
+  class name with different (or unknown) args is conservatively left alone —
+  `difference(List(Integer) | List(Symbol), List(Integer))` removes exactly one
+  member, and `difference(List(Integer) | List(Symbol), List)` is a no-op.
+  Today's `union_without` compares by class *name only* (`as_known()`,
+  `inference.rs:2400`) — safe solely because singletons carry no args; a general
+  `difference` inheriting name-only comparison would wrongly subtract both
+  `List` members. Property tests required.
+- **`union_of` learns the new variant and its absorption law**:
+  `(Symbol \ #foo) | #foo` ⇒ `Symbol`. `union_of` (`types.rs:442`) matches
+  exactly the current five variants with no wildcard, so this is an algebra
+  decision, not a match-arm chore — and `Negation` equality needs a canonical
+  ordering of `excluded` so order-independent union dedup keeps working.
 
 ### 2. Narrowing expressed as intersect / difference — where it applies
 
@@ -144,18 +182,33 @@ type `T` is:
 - **false branch:** `difference(T, P)`
 
 **This is an honest generalisation of `singleton_eq`, not a free port of all
-seven narrowing rules.** The rules divide into three groups, and the ADR must
-not pretend otherwise:
+seven narrowing rules** (`narrowing/rules/mod.rs` lists seven: `is_nil`, two
+`is_result` rules, `responds_to`, `is_kind_of`, `class_eq`, `singleton_eq`).
+They divide into three groups, and the ADR must not pretend otherwise:
 
-1. **Already this shape — `singleton_eq`.** `refine_singleton_narrowing`
-   (`inference.rs:2316`) hand-picks `matched` for one branch and `union_without`
-   for the other; it becomes literally:
+1. **Already (nearly) this shape — `singleton_eq`, `is_nil`.**
+   `refine_singleton_narrowing` (`inference.rs:2316`) hand-picks `matched` for
+   one branch and `union_without` for the other; it becomes literally:
    ```rust
    info.true_type  = intersect(&current_ty, &matched);
    info.false_type = Some(difference(&current_ty, &matched));  // swapped if negated
    ```
-   `type_admits_singleton` becomes `intersect(T, #foo) != Never`. **Pure win, no
-   behaviour change.**
+   `type_admits_singleton` becomes `intersect(T, #foo) != Never`. One
+   deliberate corner changes: today the true branch is `matched`
+   *unconditionally* (`inference.rs:2326`), so `x :: Integer; x = #foo` types
+   the true branch `#foo`; under `intersect` it becomes `Never`. The
+   impossible-comparison diagnostic **already fires** for exactly this case
+   (`check_impossible_singleton_comparison`), so only the (unreachable)
+   branch's *type* changes — pin with a new test.
+   `is_nil` is the same shape with `P = UndefinedObject` — its difference
+   engine, `non_nil_type` (`inference.rs:3306`), is the second hand-rolled
+   subtraction this ADR unifies. One documented divergence: `non_nil_type`
+   turns a nil-*only* union into `Dynamic`, not `Never` (test
+   `non_nil_type_all_nil_becomes_dynamic`), a deliberate open-world softening.
+   The port **keeps** that behaviour (`difference` special-cases the
+   all-members-removed result for `is_nil` narrowing, or `is_nil` keeps its
+   wrapper) — porting it blindly "for uniformity" would be a silent behaviour
+   change.
 
 2. **Ported, but a genuine behaviour change — `class_eq`, `is_kind_of`.** Today
    these set `true_type = P` *unconditionally* and `false_type = None`
@@ -170,25 +223,34 @@ not pretend otherwise:
    negation semantics: membership, display, hover), tracked separately — not
    assumed done by this ADR.
 
-3. **Cannot be intersect/difference at all — `is_result` (`isOk`/`isError`).**
+3. **Not expressible as intersect/difference — `is_result`, `responds_to`.**
    `refine_result_narrowing` keeps the full, unchanged `Result(T, E)` on *both*
-   branches: it narrows a runtime tag that has no `InferredType` representation.
-   `difference(Result, Result)` would wrongly yield `Never`. This idiom stays a
-   bespoke rule; the algebra does not touch it.
+   branches: it narrows a runtime tag that has no `InferredType` representation
+   (`difference(Result, Result)` would wrongly yield `Never`). `responds_to`
+   narrows to *protocol conformance*, which today has its own representation
+   path; it is untouched by this ADR, but is the designated **first consumer of
+   the stored `Intersection` variant** in Phase 2 (`T & Protocol` is exactly
+   what a `respondsTo:` true branch means) — noted so the Phase 2 design has a
+   real producer, not just syntax.
 
-So the deliverable is: unify group 1 immediately, route group 2 through
-`intersect` for the true branch (with the false branch gated on nominal-difference
-design), and leave group 3 alone. The detectors in `narrowing/rules/` all stay —
-they still recognise AST *shape* and produce `P`.
+So the deliverable is: unify group 1 immediately (with the two documented
+corners), route group 2 through `intersect` for the true branch (false branch
+gated on nominal-difference design), and leave group 3 alone. The detectors in
+`narrowing/rules/` all stay — they still recognise AST *shape* and produce `P`.
 
 ### 3. Surface syntax — reuse `&`, add a difference operator
 
-**Intersection already has a spelling.** ADR 0068 §Protocol Composition ships
-`&` in type annotations (`sort: items :: Collection(Object) & Comparable`), which
-is semantically an intersection. This ADR therefore does **not** invent a second
-intersection keyword — it *generalises `&`* from protocol-only conjunction to any
-two types. Only **difference/complement** is new surface syntax, written `\`
-("T without U"):
+**Intersection already has a spelling — on paper.** ADR 0068 §Protocol
+Composition *specifies* `&` in type annotations
+(`sort: items :: Collection(Object) & Comparable`) — semantically an
+intersection — but it is **not yet implemented** (no `TypeAnnotation` variant,
+no `&` handling in type position). This ADR therefore does **not** invent a
+second intersection keyword — implementing 0068's `&` and generalising it
+beyond protocol conjunction is Phase 2 work here, where class ∩ class reduces
+via the hierarchy (subclass, or `Never` for unrelated sealed classes — so
+`Integer & String` *is* defined: it is `Never`) and class ∩ protocol is the
+irreducible stored case. Only **difference/complement** is new surface syntax,
+written `\` ("T without U"):
 
 ```beamtalk
 // "any symbol except the reserved ones"
@@ -218,12 +280,19 @@ mixed `&`/`\` at the same tier require parentheses. Using operator symbols (not
 *identifier* in type position is an implicit method-local type parameter — a
 type param spelled `and` would otherwise silently shadow the operator.
 
-`\` is **already a binary-operator character** in the lexer (`lexer.rs:436`,
-alongside `&`, `%`, `~`), and Beamtalk does *not* use `\\` for modulo, so no new
-token is introduced — like `|` and `&`, `\` simply gains a type-level meaning
-inside annotation context. (Inside a value expression `\` remains an ordinary
-binary selector; the two readings are disambiguated by grammar context, exactly
-as `|`/`&` already are.)
+**Lexing is not symmetric with `|`, and the ADR must not pretend it is.** `|`
+works in type position because it is a **dedicated token**
+(`TokenKind::Pipe`, `token.rs:122`), deliberately split from `BinarySelector`.
+`\` and `&` currently lex as ordinary `BinarySelector`s (`lexer.rs:436`), and
+both are *live expression operators* — `&`/`|` are boolean ops and `\\`
+(double backslash) is the Smalltalk **modulo** selector (see
+`is_pure_binary_op`, `lint_validators.rs`). So the annotation parser must
+either special-case `BinarySelector("\\")` / `BinarySelector("&")` in type
+position, or promote them to dedicated tokens (which touches expression
+lexing). Additionally, because the lexer greedily consumes selector characters,
+the near-certain typo `Symbol \\ #foo` lexes as the *modulo* selector — Phase 2
+must ship a targeted parse error for `\\` in type position ("did you mean
+`\`?").
 
 ### 4. Exhaustiveness
 
@@ -272,6 +341,13 @@ actually returns `#west`). Therefore:
 - Because it is additive and non-`Error`, it does **not** regress the "no meaning
   changes" migration claim: previously-clean code that is now *inferred* as a
   singleton-union scrutinee gets an advisory warning, not a new build failure.
+- **Known discoverability cliff:** the warning silently vanishes when inference
+  widens the scrutinee (one `Dynamic`-returning arm, a reassignment) — the user
+  cannot distinguish "exhaustive" from "checker gave up". An opt-in assertion
+  (a marker on `match:` requesting exhaustiveness, analogous to TypeScript's
+  `satisfies never` idiom, which would then diagnose "cannot verify: scrutinee
+  is Dynamic") is the natural follow-up; deliberately **out of scope** here and
+  left to a future issue so this ADR stays advisory-only.
 
 ### REPL session
 
@@ -280,9 +356,13 @@ bt> x := someUnionReturning   "x :: Integer | #infinity"
 bt> (x = #infinity) ifTrue: [x] ifFalse: [x + 1]
                                           ^^^^^
    in the false branch, x :: Integer  (#infinity removed) → x + 1 type-checks
-bt> :type (Symbol \ #foo)
-   Symbol \ #foo   "co-finite: every atom except #foo"
 ```
+
+Co-finite types surface through **LSP hover** (already in scope — hover
+rendering is listed under affected components), which displays
+`Symbol \ #foo` for a variable so narrowed. No new REPL command is added —
+a `:type`-style command would be its own surface-parity decision
+(`docs/development/surface-parity.md`) and is out of scope here.
 
 ### Error example
 
@@ -373,7 +453,20 @@ d = #west
 Every new narrowing shape stays a new file plus bespoke true/false logic, and
 false-branch complements remain impossible beyond the singleton case (ADR 0068's
 noted gap persists). Rejected: the idiom list grows unboundedly and duplicates
-set logic the codebase already contains three times.
+set logic the codebase already contains four times (`union_of`, `union_without`,
+`non_nil_type`, `type_admits_singleton`).
+
+### Functions only — no stored `Negation` either
+The true minimum between status quo and Alternative A: ship `intersect` /
+`difference` as normalising functions, and when a difference is co-finite
+(irreducible), fall back to today's behaviour (`false_type = None` — no
+narrowing). Zero new `InferredType` variants, zero new match arms. Rejected
+because the fallback silently discards exactly the new expressiveness: the
+`Symbol`-typed false branch of `x = #foo` stays un-narrowed, hover cannot
+display "everything except `#foo`", and Phase 2's `\` syntax and residual-based
+exhaustiveness both *need* a representable co-finite result. Priced honestly:
+this saves one variant's worth of match arms, at the cost of the feature's
+point.
 
 ### Internal algebra only
 Add `Intersection`/`Negation` internally, refactor `union_without` /
@@ -404,10 +497,17 @@ needs full arrow/intersection-function typing. Documented as the destination in
   of `intersect(T, s) == Never` rather than a special case.
 
 ### Negative
-- `InferredType` grows **two** variants (`Intersection`, `Negation`); every
-  exhaustive `match` on it (equality, display, provenance, hover) must handle
-  them — though `intersect`/`difference` are normalising functions, so most
-  results stay in existing variants (see §1).
+- `InferredType` grows one variant in Phase 1 (`Negation`) and a second in
+  Phase 2 (`Intersection`); every exhaustive `match` on it (equality, display,
+  provenance, hover, **and `union_of` itself** — which has no wildcard arm and
+  needs the `(Symbol \ #foo) | #foo ⇒ Symbol` absorption law) must handle them —
+  though `intersect`/`difference` are normalising functions, so most results
+  stay in existing variants (see §1).
+- **Live `Never` branches are new.** Group 2 true branches (and group 1's
+  impossible-comparison corner) will type reachable code regions as `Never` for
+  the first time. The policy for message sends on a `Never`-typed receiver
+  (silent-as-unreachable, per ADR 0100's conservatism, vs. an unreachable-code
+  hint) must be decided in Phase 1 — currently unstated.
 - **`TypeAnnotation` (`ast/expression.rs`) also grows variants** for `&`/`\`
   (the AST enum is already ad-hoc — `FalseOr`, `ClassOf`, `SelfType`); every
   exhaustive match over it and `type_resolver.rs` must be updated. This cost was
@@ -418,7 +518,10 @@ needs full arrow/intersection-function typing. Documented as the destination in
 - Normalisation (dedup, absorption, `Dynamic` asymmetry, `&`/`\`/`|`
   interaction) is fiddly and needs property tests. Termination must be argued
   (finite atom/class basis; no recursive blow-up).
-- Surface `\` adds parser surface and a new precedence tier.
+- Surface `\`/`&` are harder to parse than `|` was: `|` is a dedicated token
+  while `\`/`&` lex as live `BinarySelector`s (`\\` is modulo), requiring
+  type-position special-casing or token promotion, plus the `\\`-typo parse
+  error (see §3).
 
 ### Neutral
 - No runtime, codegen, or hot-reload change — edit/compile-time only.
@@ -430,19 +533,25 @@ needs full arrow/intersection-function typing. Documented as the destination in
 
 ## Implementation
 
-**Phase 1 — internal operators + `singleton_eq` unification (Alternative A core) — ~M:**
-1. Add `intersect` / `difference` normalising functions and the `Intersection` /
-   `Negation` variants to `InferredType` (`types.rs`). Encode the `Dynamic`
-   asymmetry (§1) explicitly with a regression test; do **not** mirror
-   `union_of`'s Dynamic-absorbs rule.
-2. Update all exhaustive matches: `PartialEq`, `display_for_diagnostic`,
-   provenance accessors, `as_known`, hover rendering.
-3. Rewrite `refine_singleton_narrowing` (group 1), delete `union_without`,
-   redefine `type_admits_singleton` as `intersect(T, s) != Never`. **No
-   behaviour change — pin with existing narrowing/union tests.**
+**Phase 1 — internal operators + group-1 unification (Alternative A core) — ~M:**
+1. Add `intersect` / `difference` normalising functions and the **`Negation`
+   variant only** to `InferredType` (`types.rs`) — the stored `Intersection`
+   is Phase 2 (§1). Encode the `Dynamic` asymmetry, the RHS-union fold, the
+   exact-`type_args` rule, and the `union_of` absorption law (§1), each with a
+   regression/property test; do **not** mirror `union_of`'s Dynamic-absorbs rule.
+2. Update all exhaustive matches: `PartialEq` (canonical `excluded` ordering),
+   `display_for_diagnostic`, provenance accessors, `as_known`, hover rendering,
+   **`union_of`**.
+3. Rewrite `refine_singleton_narrowing` and `is_nil`'s branch computation
+   (group 1), delete `union_without`, redefine `type_admits_singleton` as
+   `intersect(T, s) != Never`. Behaviour pinned by existing narrowing/union
+   tests **plus two new pins** for the documented corners: the impossible
+   singleton test's true branch becoming `Never`, and `is_nil`'s
+   nil-only-union → `Dynamic` softening being preserved.
 4. Route `class_eq` / `is_kind_of` true branch through `intersect(T, P)` (group
-   2, true branch only), wiring the impossible-comparison hint. Leave their
-   false branch and `is_result` (group 3) untouched.
+   2, true branch only), wiring the impossible-comparison hint, **and decide the
+   `Never`-receiver send policy** (silent-as-unreachable vs. hint). Leave their
+   false branch, `is_result`, and `responds_to` (group 3) untouched.
 
 **Phase 1b — nominal-class difference (prerequisite for the class false-branch) — ~M (new semantics, design-heavy):**
 5. Define `difference` over the class hierarchy (membership, display, hover for
@@ -450,10 +559,13 @@ needs full arrow/intersection-function typing. Documented as the destination in
    *false* branch. Sequenced separately because it is new semantics, not a port.
 
 **Phase 2 — surface syntax + advisory exhaustiveness — ~M (parser + validator):**
-6. Generalise ADR 0068's `&` to any-type intersection and add `\` (difference)
-   to the annotation grammar — **new `TypeAnnotation` variants**
+6. Implement ADR 0068's `&` (spec-only today) generalised to any-type
+   intersection, add the stored `Intersection` variant (§1), and add `\`
+   (difference) to the annotation grammar — **new `TypeAnnotation` variants**
    (`ast/expression.rs`) plus every exhaustive match and `type_resolver.rs`.
-   Add the precedence tier (§3).
+   Handle the token asymmetry (§3): special-case `BinarySelector("&")`/`("\\")`
+   in type position or promote to dedicated tokens; ship the `\\`-typo parse
+   error. Add the precedence tier (§3).
 7. Add a **type-based, advisory** singleton-union exhaustiveness check to
    `match:`: compute `difference(scrutinee, covered)`; if non-`Never`, emit a
    `Warning`/`Lint` (never `Error`) gated by ADR 0100 completeness. Distinct from
@@ -466,9 +578,11 @@ codegen, runtime, REPL output values.
 
 ## Migration Path
 
-Backward compatible. `singleton_eq` narrowing (Phase 1 group 1) produces
-identical *results*, now via the shared algebra (pinned by existing narrowing/
-union tests). `class_eq`/`is_kind_of` true-branch narrowing (group 2) is a
+Backward compatible. `singleton_eq`/`is_nil` narrowing (Phase 1 group 1)
+produces identical *results* except two documented corners — the impossible
+singleton test's (already-diagnosed, unreachable) true branch becomes `Never`,
+and `is_nil`'s nil-only-union → `Dynamic` softening is deliberately preserved —
+both pinned by new tests alongside the existing narrowing/union suites. `class_eq`/`is_kind_of` true-branch narrowing (group 2) is a
 *deliberate* refinement — it can newly report an impossible comparison where the
 old code silently kept `P`; this is the intended improvement, routed through the
 existing hint machinery, and any affected test is updated in the same change.

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -125,6 +125,9 @@ enum InferredType {
     Known { class_name, type_args, provenance },
     Union { members, provenance },        // t1 | t2 | ...
     // NEW (Phase 1) — only when the result cannot collapse to the above:
+    // `excluded` is an InferredType (a singleton or a normalised union of
+    // singletons), NOT a raw atom name — `Symbol \ (#a | #b)` must be
+    // representable. See the union-excluded and flattening rules below.
     Negation { base, excluded, provenance }, // co-finite complement, e.g. Symbol \ #foo
     // NEW (Phase 2, with `&` syntax) — see below:
     Intersection { members, provenance },  // irreducible conjunction: class ∩ protocol
@@ -152,11 +155,25 @@ Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
 
 - `intersect(T, T)` ⇒ `T`; `intersect(T, Never)` ⇒ `Never`;
   `intersect(T, Object)` ⇒ `T`.
+- **LHS-union distribution** (load-bearing for the `singleton_eq` port — §2
+  group 1's "no behaviour change" claim depends on it):
+  `intersect(Union[T1 .. Tn], P) = union_of(intersect(T1, P) .. intersect(Tn, P))`
+  — so `intersect(Integer | #infinity, #infinity)` normalises to the bare
+  `#infinity`, matching today's `matched` lookup, never a stored wrapper.
+- Boundary rules: `difference(Never, P) = Never`; `difference(T, Never) = T`.
 - `difference(Union[..], #foo)` drops the member — this is exactly today's
   `union_without`, which is deleted in favour of the general function.
 - `difference(Symbol, #foo)` ⇒ `Negation{ base: Symbol, excluded: #foo }` —
   "any Symbol except `#foo`", the **co-finite atom set** Beamtalk cannot express
-  today. Nominal-class difference beyond atoms (`difference(Object, Number)`) is
+  today. `excluded` is an `InferredType`:
+  `difference(Symbol, #a | #b)` ⇒ `Negation{ Symbol, #a | #b }` (union of
+  singletons, kept in `union_of` normal form).
+- **Same-base flattening** — nested negation must not escape normal form:
+  `difference(Negation{ Symbol, E }, #bar)` ⇒
+  `Negation{ Symbol, union_of(E, #bar) }`. Termination follows: `excluded`
+  only grows within the finite set of singletons appearing in the program, so
+  no chain of `difference` calls recurses or grows unboundedly.
+  Nominal-class difference beyond atoms (`difference(Object, Number)`) is
   *not* defined by this ADR — see §2 and Consequences.
 - **`Dynamic` is asymmetric and must be stated explicitly**:
   `intersect(Dynamic, P) = P` (a positive test refines an unknown value to `P`),
@@ -292,8 +309,14 @@ per ADR 0068):
 | `\` | difference | middle (left-assoc, same tier as `&`) |
 | _(atomic type / `(...)`)_ | grouping | highest |
 
-`Integer \| Symbol \ #foo` therefore parses as `Integer \| (Symbol \ #foo)`;
-mixed `&`/`\` at the same tier require parentheses. Using operator symbols (not
+`Integer \| Symbol \ #foo` therefore parses as `Integer \| (Symbol \ #foo)`.
+Within one operator the tier is left-associative (`A \ B \ C` = `(A \ B) \ C`).
+**Mixing `&` and `\` without explicit grouping is a deliberate parse error** —
+not left-associative resolution: `A & B \ C` is rejected with "parenthesise to
+disambiguate". This is a grammar rule (the "incompatible infix operators"
+pattern, as OCaml and Rust use for ambiguous operator mixes), chosen because
+`(A & B) \ C` and `A & (B \ C)` differ and neither reading is obviously
+dominant. Using operator symbols (not
 `and`/`not` identifiers) also sidesteps ADR 0068's rule that an unrecognised
 *identifier* in type position is an implicit method-local type parameter — a
 type param spelled `and` would otherwise silently shadow the operator.
@@ -610,7 +633,8 @@ a scrutinee is now *inferred* as a singleton union. No existing `.bt` source
 changes meaning.
 
 ## References
-- Related issues: BT-XXX (to be filed via `/plan-adr`); builds on BT-2617,
+- Related issues: Epic BT-2738 (implementation — see Implementation Tracking
+  above for BT-2739…BT-2746); builds on BT-2617,
   BT-2624, BT-2631 (singleton narrowing / impossible-comparison diagnostics) and
   BT-1299 (`match:` exhaustiveness for sealed constructor patterns — extended
   here to singleton-union scrutinees)

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -153,8 +153,15 @@ syntax; see §3 for the reconciliation.
 Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
 `union_of` — the `Dynamic` handling is deliberately different, see below):
 
+- **Rule priority: the `Dynamic` rules are checked first**; the general rules
+  below apply only to non-`Dynamic` operands. This matters concretely for
+  `intersect(Dynamic, Object)`: the Dynamic rule gives `Object` (a positive
+  `x class = Object` test *refines* an unannotated variable), while the
+  general identity rule would wrongly give `Dynamic` (no narrowing). An
+  implementation that checks `intersect(T, Object) = T` first gets the wrong
+  answer silently.
 - `intersect(T, T)` ⇒ `T`; `intersect(T, Never)` ⇒ `Never`;
-  `intersect(T, Object)` ⇒ `T`.
+  `intersect(T, Object)` ⇒ `T` (non-`Dynamic` `T` — see priority above).
 - **LHS-union distribution** (load-bearing for the `singleton_eq` port — §2
   group 1's "no behaviour change" claim depends on it):
   `intersect(Union[T1 .. Tn], P) = union_of(intersect(T1, P) .. intersect(Tn, P))`
@@ -173,6 +180,16 @@ Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
   `Negation{ Symbol, union_of(E, #bar) }`. Termination follows: `excluded`
   only grows within the finite set of singletons appearing in the program, so
   no chain of `difference` calls recurses or grows unboundedly.
+- **Intersect through a complement** — required the moment narrowing *chains*
+  (the false branch of `x = #foo` leaves `x :: Symbol \ #foo`; a later
+  `x = #bar` in the same method computes
+  `intersect(Negation{Symbol, #foo}, #bar)`). The general law:
+  `intersect(Negation{B, E}, P) = difference(intersect(B, P), E)` —
+  set-theoretically `(B \ E) ∩ P = (B ∩ P) \ E` — which reduces via the rules
+  already given. For a singleton `s`: `s ∉ E` ⇒ `intersect(B, s)` (so
+  `#bar`), `s ∈ E` ⇒ `Never`. Without this rule a `Negation` LHS hits an
+  unhandled arm and every conservative fallback (panic, `Dynamic`, keep the
+  `Negation`) is a wrong narrowing outcome.
   Nominal-class difference beyond atoms (`difference(Object, Number)`) is
   *not* defined by this ADR — see §2 and Consequences.
 - **`Dynamic` is asymmetric and must be stated explicitly**:
@@ -202,11 +219,21 @@ Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
   `inference.rs:2400`) — safe solely because singletons carry no args; a general
   `difference` inheriting name-only comparison would wrongly subtract both
   `List` members. Property tests required.
-- **`union_of` learns the new variant and its absorption law**:
-  `(Symbol \ #foo) | #foo` ⇒ `Symbol`. `union_of` (`types.rs:442`) matches
-  exactly the current five variants with no wildcard, so this is an algebra
-  decision, not a match-arm chore — and `Negation` equality needs a canonical
-  ordering of `excluded` so order-independent union dedup keeps working.
+- **`union_of` learns the new variant and its full absorption-law set**
+  (`union_of` at `types.rs:442` matches exactly the current five variants with
+  no wildcard, so this is an algebra decision, not a match-arm chore):
+  - **Full restoration** — `(Symbol \ #foo) | #foo` ⇒ `Symbol`.
+  - **Partial absorption** — adding back *one* of several exclusions removes
+    it from `excluded`: `(Symbol \ (#foo | #bar)) | #foo` ⇒ `Symbol \ #bar`;
+    an emptied `excluded` yields the bare base.
+  - **Complement union (same base)** —
+    `Negation{B, E1} | Negation{B, E2}` ⇒ `Negation{B, intersect(E1, E2)}`
+    (set-theoretically `(B \ E1) ∪ (B \ E2) = B \ (E1 ∩ E2)`: "any Symbol
+    except {#a,#b}" or "any Symbol except {#b,#c}" = "any Symbol except #b").
+  - `Negation` equality needs a canonical ordering of `excluded` so
+    order-independent union dedup keeps working. Without the two laws above,
+    logically-equal `Negation` members inside a `Union` escape `PartialEq`
+    dedup and unions grow across repeated narrowing/widening passes.
 
 ### 2. Narrowing expressed as intersect / difference — where it applies
 

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -214,8 +214,12 @@ Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
   Nominal-class difference beyond atoms (`difference(Object, Number)`) is
   *not* defined by this ADR — see §2 and Consequences.
 - **`Dynamic` is asymmetric and must be stated explicitly**:
-  `intersect(Dynamic, P) = P` (a positive test refines an unknown value to `P`),
-  but `difference(Dynamic, P) = Dynamic` (we cannot subtract from the unknown).
+  `intersect(Dynamic, P) = P` **and symmetrically `intersect(P, Dynamic) = P`**
+  (a positive test refines an unknown value to `P`; `Dynamic` on *either* side
+  acts as the identity for intersect — a match that handles only
+  `(Dynamic, _)` and falls through on `(Known, Dynamic)` silently loses
+  narrowing), but `difference(Dynamic, P) = Dynamic` (we cannot subtract from
+  the unknown).
   This mirrors today's behaviour — `is_nil` sets the true branch to
   `UndefinedObject` regardless of receiver type, while `non_nil_type`
   (`inference.rs:3306`) leaves `Dynamic` unchanged on the false branch. It is the
@@ -243,10 +247,12 @@ Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
 - **`union_of` learns the new variant and its full absorption-law set**
   (`union_of` at `types.rs:442` matches exactly the current five variants with
   no wildcard, so this is an algebra decision, not a match-arm chore):
-  - **Full restoration** — `(Symbol \ #foo) | #foo` ⇒ `Symbol`.
-  - **Partial absorption** — adding back *one* of several exclusions removes
-    it from `excluded`: `(Symbol \ (#foo | #bar)) | #foo` ⇒ `Symbol \ #bar`;
-    an emptied `excluded` yields the bare base.
+  - **Partial absorption** — adding back an exclusion removes it from
+    `excluded`: `(Symbol \ (#foo | #bar)) | #foo` ⇒ `Symbol \ #bar`; an
+    emptied `excluded` yields the bare base.
+  - **Full restoration** — `(Symbol \ #foo) | #foo` ⇒ `Symbol` — is the
+    *degenerate case* of partial absorption (`excluded` empties), **not a
+    separate code path**: one rule implements both.
   - **Complement union (same base)** —
     `Negation{B, E1} | Negation{B, E2}` ⇒ `Negation{B, intersect(E1, E2)}`
     (set-theoretically `(B \ E1) ∪ (B \ E2) = B \ (E1 ∩ E2)`: "any Symbol
@@ -291,10 +297,16 @@ They divide into three groups, and the ADR must not pretend otherwise:
    subtraction this ADR unifies. One documented divergence: `non_nil_type`
    turns a nil-*only* union into `Dynamic`, not `Never` (test
    `non_nil_type_all_nil_becomes_dynamic`), a deliberate open-world softening.
-   The port **keeps** that behaviour (`difference` special-cases the
-   all-members-removed result for `is_nil` narrowing, or `is_nil` keeps its
-   wrapper) — porting it blindly "for uniformity" would be a silent behaviour
-   change.
+   The port **keeps** that behaviour, and the mechanism is **committed** (not
+   an implementation choice): `difference` itself stays **pure** —
+   `difference(Union[Nil], UndefinedObject)` is `Never`, because §4's
+   exhaustiveness residual *requires* all-members-removed to mean `Never` —
+   and the **`is_nil` narrowing call-site maps `Never` → `Dynamic`** as its
+   own open-world policy. Softening is a narrowing decision, not algebra; a
+   `difference`-internal special case would corrupt residuals, and a private
+   `is_nil` wrapper would keep a second hand-rolled subtraction alive,
+   defeating the unification. Porting blindly "for uniformity" would be a
+   silent behaviour change.
 
 2. **Ported, but a genuine behaviour change — `class_eq`, `is_kind_of`.** Today
    these set `true_type = P` *unconditionally* and `false_type = None`
@@ -597,9 +609,13 @@ needs full arrow/intersection-function typing. Documented as the destination in
   stay in existing variants (see §1).
 - **Live `Never` branches are new.** Group 2 true branches (and group 1's
   impossible-comparison corner) will type reachable code regions as `Never` for
-  the first time. The policy for message sends on a `Never`-typed receiver
-  (silent-as-unreachable, per ADR 0100's conservatism, vs. an unreachable-code
-  hint) must be decided in Phase 1 — currently unstated.
+  the first time. **Provisional default, committed here: sends on a
+  `Never`-typed receiver are silent** (silent-as-unreachable, per ADR 0100's
+  conservatism — the branch is already flagged by the impossible-comparison
+  hint at its source, so a second diagnostic per send inside it would be
+  noise). BT-2741 implements this default and may propose an
+  unreachable-code hint *as a revision* if implementation experience argues
+  for it — but ships the default, not an open question.
 - **`TypeAnnotation` (`ast/expression.rs`) also grows variants** for `&`/`\`
   (the AST enum is already ad-hoc — `FalseOr`, `ClassOf`, `SelfType`); every
   exhaustive match over it and `type_resolver.rs` must be updated. This cost was

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -68,11 +68,12 @@ with structure.
 ## Decision
 
 Adopt the two missing **set-theoretic operators as first-class members of
-`InferredType`** — intersection and negation/difference — and rebuild narrowing
-on top of them as a **uniform algebra** rather than per-idiom branch logic.
-Expose negation in surface type-annotation syntax, and use the algebra to drive
-**exhaustiveness checking** for `case`/multi-branch dispatch over singleton
-unions.
+`InferredType`** — intersection and negation/difference — and express narrowing
+through a shared `intersect`/`difference` core **where it applies** (unifying
+`singleton_eq` and giving `class`/`isKindOf:` a principled true branch; §2 is
+explicit that this is *not* a uniform rewrite of all seven rules). Expose
+difference in surface type-annotation syntax, and use the algebra to drive
+advisory **exhaustiveness checking** for `match:` over singleton unions.
 
 This is the middle of three possible commitments (see *Alternatives*): more
 than an internal-only refactor, less than a full CDuce-style semantic-subtyping
@@ -217,6 +218,13 @@ mixed `&`/`\` at the same tier require parentheses. Using operator symbols (not
 *identifier* in type position is an implicit method-local type parameter — a
 type param spelled `and` would otherwise silently shadow the operator.
 
+`\` is **already a binary-operator character** in the lexer (`lexer.rs:436`,
+alongside `&`, `%`, `~`), and Beamtalk does *not* use `\\` for modulo, so no new
+token is introduced — like `|` and `&`, `\` simply gains a type-level meaning
+inside annotation context. (Inside a value expression `\` remains an ordinary
+binary selector; the two readings are disambiguated by grammar context, exactly
+as `|`/`&` already are.)
+
 ### 4. Exhaustiveness
 
 Beamtalk has no Erlang-style multi-clause method heads — a selector maps to one
@@ -293,7 +301,7 @@ d = #west
 |---|---|---|
 | **Elixir (1.17+)** — gradual set-theoretic types (Castagna, Duboc, Valim) | Types *are* sets of values; closed under `or` / `and` / `not`. Atoms are singleton types (`:ok` is both value and type); `boolean() = true or false`; `nil`, `true`, `false` are atoms. `atom() and not (:foo or :bar)` expresses co-finite atom sets. `dynamic()` is a *range* of types kept "at the root", enabling gradual typing that still tracks structure. | **Adopt:** the three-operator algebra and singleton-as-set model — it is exactly what our `#foo`/`Symbol`/`union_without` code approximates. **Adapt:** we reuse ADR 0068's `&` for intersection and add `\` for difference as surface syntax (not Elixir's `and`/`not` keywords), with internal `intersect`/`difference` operators, without adopting the full semantic-subtyping decision procedure. **Leave (for now):** replacing `Dynamic(reason)` with a structural `dynamic()`; BDD emptiness checking. |
 | **CDuce / semantic subtyping** (the theory underneath Elixir) | Subtyping = set inclusion decided via emptiness of a Boolean combination of type constructors, implemented with BDDs. | The north-star. Rejected as the *implementation* today (XL, nominal-core mismatch); adopted as the *mental model* for our operators so a future upgrade is a deepening, not a rewrite. |
-| **TypeScript** | Discriminated unions + control-flow narrowing; literal (singleton) types; `Exclude<T, U>` at the *type-operator* level but **no first-class negation type** in values. | We go slightly further than TS values by making negation a real `InferredType`, which is what makes uniform false-branch narrowing and exhaustiveness fall out. |
+| **TypeScript** | Discriminated unions + control-flow narrowing; literal (singleton) types; `Exclude<T, U>` at the *type-operator* level but **no first-class negation type** in values. | We go slightly further than TS values by making negation a real `InferredType`, which is what makes *atom* false-branch narrowing and exhaustiveness fall out (nominal-class false-branch difference is deferred — §2). |
 | **Gleam** (BEAM, Rust-implemented, our closest typed-BEAM peer) | Sound nominal HM; **no** union/intersection/negation, exhaustiveness via nominal custom types. | Confirms exhaustiveness is table-stakes on BEAM, but Gleam gets it from closed nominal sum types; we get it from the atom-union algebra, which fits Beamtalk's open, atom-rich style better. |
 | **Dialyzer** (success typing) | Post-compilation, optimistic; has union/negation internally but no IDE-time narrowing. | Reaffirms why we compute this at edit time, not after codegen (`type-system-design.md`). |
 | **Smalltalk (Pharo/Squeak)** | No static types; `#foo` is just a Symbol, no singleton *type*. | No prior art to preserve — this is purely additive tooling that does not touch message-passing semantics. |
@@ -371,8 +379,10 @@ set logic the codebase already contains three times.
 Add `Intersection`/`Negation` internally, refactor `union_without` /
 `type_admits_singleton` / branch computation onto them, but expose no syntax and
 add no exhaustiveness. Rejected *as the terminal state* (adopted as phase 1):
-the operators are the expensive part; withholding the syntax + exhaustiveness
-that ride on them for free wastes the investment.
+the operators are the hard part, and the incremental cost of the surface syntax
+and exhaustiveness on top is small (chiefly `TypeAnnotation` variants and a
+residual check — see Implementation), so stopping short leaves most of the user
+value unrealised.
 
 ### Full semantic subtyping engine
 Replace nominal comparison with BDD-based emptiness checking and a structural
@@ -420,7 +430,7 @@ needs full arrow/intersection-function typing. Documented as the destination in
 
 ## Implementation
 
-**Phase 1 — internal operators + `singleton_eq` unification (Alternative A core):**
+**Phase 1 — internal operators + `singleton_eq` unification (Alternative A core) — ~M:**
 1. Add `intersect` / `difference` normalising functions and the `Intersection` /
    `Negation` variants to `InferredType` (`types.rs`). Encode the `Dynamic`
    asymmetry (§1) explicitly with a regression test; do **not** mirror
@@ -434,12 +444,12 @@ needs full arrow/intersection-function typing. Documented as the destination in
    2, true branch only), wiring the impossible-comparison hint. Leave their
    false branch and `is_result` (group 3) untouched.
 
-**Phase 1b — nominal-class difference (prerequisite for the class false-branch):**
+**Phase 1b — nominal-class difference (prerequisite for the class false-branch) — ~M (new semantics, design-heavy):**
 5. Define `difference` over the class hierarchy (membership, display, hover for
    `Negation` of a nominal base). Only then close the `class_eq`/`is_kind_of`
    *false* branch. Sequenced separately because it is new semantics, not a port.
 
-**Phase 2 — surface syntax + advisory exhaustiveness:**
+**Phase 2 — surface syntax + advisory exhaustiveness — ~M (parser + validator):**
 6. Generalise ADR 0068's `&` to any-type intersection and add `\` (difference)
    to the annotation grammar — **new `TypeAnnotation` variants**
    (`ast/expression.rs`) plus every exhaustive match and `type_resolver.rs`.

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -190,6 +190,17 @@ Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
   `#bar`), `s ∈ E` ⇒ `Never`. Without this rule a `Negation` LHS hits an
   unhandled arm and every conservative fallback (panic, `Dynamic`, keep the
   `Negation`) is a wrong narrowing outcome.
+- **Nominal base case** (required by the complement rule above *and* by
+  LHS-union distribution — `intersect(Integer | #infinity, #infinity)` only
+  reduces because `intersect(Integer, #infinity) = Never`):
+  `intersect(A, B) = B` when `B <: A` in the nominal hierarchy (e.g.
+  `intersect(Symbol, #foo) = #foo`), symmetrically `= A` when `A <: B`; and
+  `intersect(A, B) = Never` when `A` and `B` are hierarchy-unrelated (under
+  single inheritance an instance's class would have to sit below both, which
+  forces a chain relation — so unrelated classes are disjoint; e.g.
+  `intersect(Integer, #foo) = Never`). This follows from set inclusion;
+  stating it prevents implementations from silently falling through to a
+  conservative default on the most common call of all.
   Nominal-class difference beyond atoms (`difference(Object, Number)`) is
   *not* defined by this ADR — see §2 and Consequences.
 - **`Dynamic` is asymmetric and must be stated explicitly**:
@@ -231,9 +242,12 @@ Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
     (set-theoretically `(B \ E1) ∪ (B \ E2) = B \ (E1 ∩ E2)`: "any Symbol
     except {#a,#b}" or "any Symbol except {#b,#c}" = "any Symbol except #b").
   - `Negation` equality needs a canonical ordering of `excluded` so
-    order-independent union dedup keeps working. Without the two laws above,
-    logically-equal `Negation` members inside a `Union` escape `PartialEq`
-    dedup and unions grow across repeated narrowing/widening passes.
+    order-independent union dedup keeps working — **specified: members sorted
+    ascending by `class_name`**, so the form is deterministic across
+    serialisation round-trips and independent implementations. Without the
+    two laws above, logically-equal `Negation` members inside a `Union`
+    escape `PartialEq` dedup and unions grow across repeated
+    narrowing/widening passes.
 
 ### 2. Narrowing expressed as intersect / difference — where it applies
 

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -1,7 +1,25 @@
 # ADR 0102: Set-Theoretic Type Operators (Intersection and Negation) for Narrowing and Atom Exhaustiveness
 
 ## Status
-Proposed (2026-07-05)
+Accepted (2026-07-06)
+
+## Implementation Tracking
+
+**Epic:** [BT-2738](https://linear.app/beamtalk/issue/BT-2738)
+**Issues:**
+
+| Phase | Issue | Title | Size | Blocked by |
+|---|---|---|---|---|
+| 1 | [BT-2739](https://linear.app/beamtalk/issue/BT-2739) | intersect/difference operators + `Negation` variant | M | – |
+| 2 | [BT-2740](https://linear.app/beamtalk/issue/BT-2740) | Unify `singleton_eq`/`is_nil` narrowing; delete `union_without` | M | BT-2739 |
+| 2 | [BT-2741](https://linear.app/beamtalk/issue/BT-2741) | `class_eq`/`is_kind_of` true branch + `Never`-receiver policy | S | BT-2739 |
+| 1b | [BT-2744](https://linear.app/beamtalk/issue/BT-2744) | Nominal-class difference + class false branch (needs-spec) | M | BT-2741 |
+| 4 | [BT-2742](https://linear.app/beamtalk/issue/BT-2742) | `\` difference annotation syntax | M | BT-2739 |
+| 4 | [BT-2743](https://linear.app/beamtalk/issue/BT-2743) | `&` intersection syntax + stored `Intersection` variant | M | BT-2739 |
+| 5 | [BT-2745](https://linear.app/beamtalk/issue/BT-2745) | Advisory singleton-union `match:` exhaustiveness | M | BT-2740 |
+| 6 | [BT-2746](https://linear.app/beamtalk/issue/BT-2746) | E2E + docs + status flip | S | BT-2742, BT-2743, BT-2745 |
+
+**Status:** Planned
 
 ## Context
 

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -1,0 +1,340 @@
+# ADR 0102: Set-Theoretic Type Operators (Intersection and Negation) for Uniform Narrowing
+
+## Status
+Proposed (2026-07-05)
+
+## Context
+
+### Problem statement
+
+Beamtalk's type checker narrows types by pattern-matching a **fixed, growing
+list of AST idioms**. Each recognised shape (`isNil`, `class = Foo`,
+`isKindOf:`, `respondsTo:`, `x = #foo`, `isOk`/`isError`) is a separate
+detector file under `type_checker/narrowing/rules/`, and the true/false branch
+types are computed by bespoke, per-idiom logic. Adding a new form of narrowing
+means adding a new file and a new entry in the `RULES` table
+(`narrowing/rules/mod.rs`).
+
+Underneath these idioms, the checker is already performing **set operations on
+types by hand** — but only for the narrow cases each idiom needs:
+
+- `union_without` (`inference.rs:2388`) is a **set-difference** that only knows
+  how to subtract a single `#name` singleton from a *flat* union. It is the
+  engine behind the `x = #foo` false-branch (`Integer | #infinity` minus
+  `#infinity` ⇒ `Integer`).
+- `type_admits_singleton` (`inference.rs:2425`) is a **membership / subtyping
+  test** hand-written for the singleton-vs-`Symbol` case.
+- `InferredType::union_of` (`types.rs:442`) is the **union** operator, with
+  flattening and deduplication.
+
+There is no general algebra tying these together. The true branch of a test is
+computed one way, the false branch another, and each idiom re-derives both.
+ADR 0068 explicitly flagged the missing piece:
+
+> False-branch complement types (`ifFalse:` knowing "x is NOT Integer" —
+> requires difference types)
+
+as a known limitation. We have difference — but only for singletons removed
+from a flat union.
+
+### Current state
+
+Singletons are represented as `InferredType::Known { class_name: "#foo", .. }`
+— the `#` prefix *is* the singleton marker — and treated as subtypes of
+`Symbol` (the "singleton-as-Symbol convention", `type_resolver.rs:73`,
+`inference.rs:2035`). Unions are a first-class `InferredType::Union` variant.
+There is **no** intersection type and **no** negation type. `InferredType` is
+otherwise nominal: `Known`, `Union`, `Meta`, `Dynamic(reason)`, `Never`.
+
+`Dynamic(reason)` is a *checking hole* — it means "skip checking", not a type
+with structure.
+
+### Constraints
+
+- **Nominal core.** Beamtalk leans nominal — classes, the metaclass tower
+  (ADR 0036), structural protocols bolted on (ADR 0068 Stage 2). Any algebra
+  must embed nominal class types as basic elements, not replace them.
+- **Gradual-typing goal.** Types serve the developer; annotations are optional
+  (`docs/internal/type-system-design.md`). Nothing here may make untyped code
+  produce errors.
+- **BEAM-native.** Singletons *are* Erlang atoms; the algebra must stay
+  faithful to runtime atom semantics.
+- **No regressions.** The seven existing idioms and their tests must keep
+  passing; this is a refactor of their *foundation*, plus new expressiveness on
+  top.
+
+## Decision
+
+Adopt the two missing **set-theoretic operators as first-class members of
+`InferredType`** — intersection and negation/difference — and rebuild narrowing
+on top of them as a **uniform algebra** rather than per-idiom branch logic.
+Expose negation in surface type-annotation syntax, and use the algebra to drive
+**exhaustiveness checking** for `case`/multi-branch dispatch over singleton
+unions.
+
+This is the middle of three possible commitments (see *Alternatives*): more
+than an internal-only refactor, less than a full CDuce-style semantic-subtyping
+engine.
+
+### 1. Type representation
+
+Extend `InferredType` with two operators. Subtyping remains **set inclusion**,
+consistent with how singletons already relate to `Symbol`.
+
+```rust
+enum InferredType {
+    Known { class_name, type_args, provenance },
+    Union { members, provenance },        // t1 or t2 or ...
+    Intersection { members, provenance },  // NEW: t1 and t2 and ...
+    Negation { base, excluded, provenance }, // NEW: base and not excluded
+    Meta { class_name, provenance },
+    Dynamic(DynamicReason),                // unchanged: gradual hole
+    Never,                                  // bottom / none()
+}
+```
+
+Normalisation rules (mirroring `union_of`'s flatten/dedup discipline):
+
+- `T and T` ⇒ `T`; `T and Never` ⇒ `Never`; `T and Object` ⇒ `T`.
+- `Symbol and not #foo` is the canonical singleton complement — "any Symbol
+  except `#foo`" — the **co-finite atom set** Beamtalk cannot express today.
+- Difference is derived: `A \ B ≡ A and not B`. `union_without` becomes the
+  special case `Union[..] and not #name` and is deleted.
+
+### 2. Narrowing becomes two operations
+
+Every narrowing idiom collapses to the same two-line core. Given a test that a
+value has pattern-type `P` and a current type `T`:
+
+- **true branch:** `T and P` (intersection)
+- **false branch:** `T and not P` (negation/difference)
+
+`singleton_eq`'s `refine_singleton_narrowing` (`inference.rs:2316`) — which today
+hand-picks `matched` for one branch and `union_without` for the other — becomes:
+
+```rust
+info.true_type  = intersect(&current_ty, &matched);
+info.false_type = Some(difference(&current_ty, &matched));
+// (swapped when the test is negated)
+```
+
+The idiom detectors in `narrowing/rules/` stay — they still recognise AST
+*shape* and produce the pattern-type `P` — but they no longer each re-implement
+branch computation. `type_admits_singleton` becomes `intersect(T, #foo) !=
+Never`.
+
+### 3. Surface syntax
+
+Negation becomes writable in type annotations (`::`), composing with the
+existing `|` union syntax:
+
+```beamtalk
+// "any symbol except the reserved ones"
+tag :: Symbol and not (#reserved | #internal)
+
+// residual after handling the known cases
+handleRest: dir :: (#north | #south | #east | #west) and not #north => ...
+```
+
+`and` / `not` are parsed only inside a type-annotation context, so they do not
+collide with any binary message selector (`<` stays a message, per ADR 0068's
+rationale for parenthesis generics).
+
+### 4. Exhaustiveness
+
+Because difference is now total, a multi-branch dispatch over a singleton union
+can compute its **residual type**. When the residual is `Never`, the dispatch is
+exhaustive; when it is non-`Never`, the checker warns with the uncovered
+members.
+
+```beamtalk
+compass :: #north | #south | #east | #west := readHeading
+
+result := compass caseOf: {
+  [#north] -> "up".
+  [#south] -> "down".
+  [#east]  -> "right"
+}
+// ⚠️ non-exhaustive: `#west` is not handled
+//    (residual type: `#west`)
+```
+
+### REPL session
+
+```
+bt> x := someUnionReturning   "x :: Integer | #infinity"
+bt> (x = #infinity) ifTrue: [x] ifFalse: [x + 1]
+                                          ^^^^^
+   in the false branch, x :: Integer  (#infinity removed) → x + 1 type-checks
+bt> :type (Symbol and not #foo)
+   Symbol and not #foo   "co-finite: every atom except #foo"
+```
+
+### Error example
+
+```beamtalk
+d :: #north | #south := heading
+d = #west
+// ⚠️ comparison can never be true: `#west` is not a value of `#north | #south`
+//    (this diagnostic already exists via check_impossible_singleton_comparison;
+//     it is now a direct consequence of `intersect(T, #west) == Never`, not a
+//     special-cased check)
+```
+
+## Prior Art
+
+| Language / system | Approach | What we take / leave |
+|---|---|---|
+| **Elixir (1.17+)** — gradual set-theoretic types (Castagna, Duboc, Valim) | Types *are* sets of values; closed under `or` / `and` / `not`. Atoms are singleton types (`:ok` is both value and type); `boolean() = true or false`; `nil`, `true`, `false` are atoms. `atom() and not (:foo or :bar)` expresses co-finite atom sets. `dynamic()` is a *range* of types kept "at the root", enabling gradual typing that still tracks structure. | **Adopt:** the three-operator algebra and singleton-as-set model — it is exactly what our `#foo`/`Symbol`/`union_without` code approximates. **Adapt:** we add `and`/`not` as surface syntax and internal operators without adopting the full semantic-subtyping decision procedure. **Leave (for now):** replacing `Dynamic(reason)` with a structural `dynamic()`; BDD emptiness checking. |
+| **CDuce / semantic subtyping** (the theory underneath Elixir) | Subtyping = set inclusion decided via emptiness of a Boolean combination of type constructors, implemented with BDDs. | The north-star. Rejected as the *implementation* today (XL, nominal-core mismatch); adopted as the *mental model* for our operators so a future upgrade is a deepening, not a rewrite. |
+| **TypeScript** | Discriminated unions + control-flow narrowing; literal (singleton) types; `Exclude<T, U>` at the *type-operator* level but **no first-class negation type** in values. | We go slightly further than TS values by making negation a real `InferredType`, which is what makes uniform false-branch narrowing and exhaustiveness fall out. |
+| **Gleam** (BEAM, Rust-implemented, our closest typed-BEAM peer) | Sound nominal HM; **no** union/intersection/negation, exhaustiveness via nominal custom types. | Confirms exhaustiveness is table-stakes on BEAM, but Gleam gets it from closed nominal sum types; we get it from the atom-union algebra, which fits Beamtalk's open, atom-rich style better. |
+| **Dialyzer** (success typing) | Post-compilation, optimistic; has union/negation internally but no IDE-time narrowing. | Reaffirms why we compute this at edit time, not after codegen (`type-system-design.md`). |
+| **Smalltalk (Pharo/Squeak)** | No static types; `#foo` is just a Symbol, no singleton *type*. | No prior art to preserve — this is purely additive tooling that does not touch message-passing semantics. |
+
+## User Impact
+
+- **Newcomer (from Python/JS/TS):** `Symbol and not #foo` reads naturally to
+  anyone who has met TypeScript's `Exclude`/discriminated unions. The main new
+  payoff they *feel* is the non-exhaustive-`caseOf:` warning catching a missed
+  atom — a bug class that is otherwise a runtime `does_not_understand`.
+- **Smalltalk developer:** Zero change to message-passing or runtime semantics.
+  `#foo` is still a Symbol at runtime; this is edit-time tooling only. Purists
+  who never annotate see no new obligations (gradual guarantee preserved).
+- **Erlang/BEAM developer:** The algebra mirrors how they already think about
+  atoms (`ok | error | timeout`, "any atom but these"). Exhaustiveness over
+  atom unions matches the safety they'd want from `case`.
+- **Operator:** No runtime, codegen, or hot-reload impact — purely a
+  compile/edit-time analysis. Generated BEAM is unchanged.
+- **Tooling developer:** *Simpler*, not harder. One narrowing core (intersect /
+  difference) instead of N per-idiom branch computations; hover can render
+  `Symbol and not #foo`; new idioms need only produce a pattern-type `P`.
+
+## Steelman Analysis
+
+### Chosen: Internal operators + surface syntax + exhaustiveness
+- 🧑‍💻 **Newcomer:** "The `caseOf:` warning literally tells me which atom I
+  forgot — that's the feature I didn't know I wanted."
+- 🎩 **Smalltalk purist:** "It's opt-in annotation sugar; my un-annotated code
+  is untouched and messages still dispatch dynamically."
+- ⚙️ **BEAM veteran:** "Co-finite atom sets (`Symbol and not …`) are how I model
+  Erlang tagged returns; finally expressible."
+- 🏭 **Operator:** "Compile-time only, generated code identical — nothing new to
+  observe or debug in prod."
+- 🎨 **Language designer:** "Two operators subsume seven idioms' branch logic
+  *and* give exhaustiveness for free. Maximum expressiveness-per-concept."
+
+### Rejected A: Internal algebra only (no surface syntax, no exhaustiveness)
+- 🎨 **Language designer:** "Cleanest possible diff — refactor the hand-rolled
+  set ops onto one core, ship nothing user-facing, zero syntax risk."
+- ⚙️ **BEAM veteran:** "Lowest chance of destabilising the type checker."
+- **Why not chosen:** leaves the two most valuable user outcomes — writable
+  complements and exhaustiveness — on the table, when they are *cheap once the
+  operators exist*. Kept as the recommended **first implementation phase**.
+
+### Rejected B: Full semantic subtyping (CDuce engine, structural `dynamic()`)
+- 🎨 **Language designer:** "Provably sound, one decision procedure for
+  everything, matches Elixir exactly."
+- 🧑‍💻 **Newcomer:** "The type system would 'just know' every relationship."
+- **Why not chosen:** XL effort; a BDD emptiness engine and a structural
+  `dynamic()` are a rewrite of the nominal core (`Known` + hierarchy walk) for
+  benefit Beamtalk cannot yet spend. Documented as the **north-star** the
+  operator design deliberately keeps compatible.
+
+### Tension points
+- Designers split between A (minimal, safe) and B (complete, sound); the chosen
+  option is the pragmatic midpoint and sequences A as phase 1 → chosen as
+  phase 2.
+- Purists want *nothing* new; newcomers/BEAM devs want the expressiveness. The
+  gradual guarantee (untyped code unaffected) resolves this: the new power is
+  entirely opt-in.
+
+## Alternatives Considered
+
+### Status quo — keep adding per-idiom rules
+Every new narrowing shape stays a new file plus bespoke true/false logic, and
+false-branch complements remain impossible beyond the singleton case (ADR 0068's
+noted gap persists). Rejected: the idiom list grows unboundedly and duplicates
+set logic the codebase already contains three times.
+
+### Internal algebra only
+Add `Intersection`/`Negation` internally, refactor `union_without` /
+`type_admits_singleton` / branch computation onto them, but expose no syntax and
+add no exhaustiveness. Rejected *as the terminal state* (adopted as phase 1):
+the operators are the expensive part; withholding the syntax + exhaustiveness
+that ride on them for free wastes the investment.
+
+### Full semantic subtyping engine
+Replace nominal comparison with BDD-based emptiness checking and a structural
+`dynamic()`. Rejected as premature (see Steelman B); revisit if/when Beamtalk
+needs full arrow/intersection-function typing.
+
+## Consequences
+
+### Positive
+- One narrowing core (`intersect` for true, `difference` for false) replaces
+  per-idiom branch logic; `union_without` and `type_admits_singleton` collapse
+  into it.
+- False-branch complements work for **all** types, closing ADR 0068's gap.
+- Co-finite atom sets (`Symbol and not #foo`) become expressible.
+- Exhaustiveness checking over singleton unions — a real bug-catcher — falls out
+  of total difference.
+- The `check_impossible_singleton_comparison` diagnostic becomes a consequence
+  of `intersect(T, s) == Never` rather than a special case.
+
+### Negative
+- `InferredType` grows two variants; every exhaustive `match` on it (equality,
+  display, provenance, codegen-facing conversions) must handle them.
+- Normalisation (dedup, absorption, `and`/`or` interaction) is fiddly to get
+  right and needs thorough property tests.
+- Surface `and`/`not` adds parser surface in the annotation grammar.
+
+### Neutral
+- No runtime, codegen, or hot-reload change — edit/compile-time only.
+- `Dynamic(reason)` is untouched; this ADR does **not** make it structural
+  (that is the deferred phase-B/north-star work).
+
+## Implementation
+
+**Phase 1 — internal operators (the *Alternative A* core):**
+1. Add `Intersection` / `Negation` to `InferredType` (`types.rs`) with
+   normalisation helpers `intersect` / `difference`, mirroring `union_of`.
+2. Update all exhaustive matches: `PartialEq`, `display_for_diagnostic`,
+   provenance accessors, `as_known`, hover rendering.
+3. Rewrite `refine_singleton_narrowing`, delete `union_without`, redefine
+   `type_admits_singleton` as `intersect(T, s) != Never`.
+4. Keep the seven idiom detectors; strip their bespoke branch logic to emit a
+   pattern-type `P` consumed by the shared core.
+
+**Phase 2 — surface + exhaustiveness (this ADR's added scope):**
+5. Parse `and` / `not` inside type annotations (`source_analysis/parser`,
+   `TypeAnnotation`), resolve in `type_resolver.rs`.
+6. Compute residual types for `caseOf:` / multi-branch singleton dispatch and
+   emit non-exhaustiveness diagnostics.
+
+**Affected components:** type checker (`semantic_analysis/type_checker/*`),
+annotation parser + `TypeAnnotation` AST, hover/diagnostic rendering
+(`queries/hover_provider.rs`). **Not** affected: codegen, runtime, REPL output
+values.
+
+## Migration Path
+
+Backward compatible. Existing annotations, inference, and the seven narrowing
+idioms behave identically — their branch types are now produced by the shared
+algebra but the *results* are unchanged (covered by the existing narrowing and
+union tests). `and`/`not` annotation syntax and exhaustiveness warnings are
+purely additive; no existing `.bt` source changes meaning.
+
+## References
+- Related issues: BT-XXX (to be filed via `/plan-adr`); builds on BT-2617,
+  BT-2624, BT-2631 (singleton narrowing / impossible-comparison diagnostics)
+- Related ADRs: ADR 0068 (Parametric Types and Protocols — unions, narrowing,
+  and the noted difference-types gap), ADR 0025 (Gradual Typing and Protocols),
+  ADR 0053 (`::` annotation syntax), ADR 0036 (Metaclass tower)
+- Documentation: `docs/internal/type-system-design.md` (Union Types and
+  Narrowing); `crates/beamtalk-core/src/semantic_analysis/type_checker/`
+  (`types.rs` `union_of`, `inference.rs` `union_without` /
+  `type_admits_singleton` / `refine_singleton_narrowing`, `narrowing/rules/`)
+- External: [Gradual set-theoretic types — Elixir](https://hexdocs.pm/elixir/main/gradual-set-theoretic-types.html);
+  "The Design Principles of the Elixir Type System" (Castagna, Duboc, Valim);
+  [Strong arrows — elixir-lang.org](https://elixir-lang.org/blog/2023/09/20/strong-arrows-gradual-typing/)

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -59,9 +59,11 @@ with structure.
   produce errors.
 - **BEAM-native.** Singletons *are* Erlang atoms; the algebra must stay
   faithful to runtime atom semantics.
-- **No regressions.** The seven existing idioms and their tests must keep
-  passing; this is a refactor of their *foundation*, plus new expressiveness on
-  top.
+- **Controlled regressions.** The seven existing narrowing rules (across six
+  detector files) split into: those refactored with *identical* results
+  (`singleton_eq`), those changed *deliberately* with updated tests
+  (`class_eq`/`is_kind_of` true branch), and those left untouched (`is_result`).
+  See §2 — this is not a uniform "refactor everything onto one core".
 
 ## Decision
 
@@ -76,69 +78,144 @@ This is the middle of three possible commitments (see *Alternatives*): more
 than an internal-only refactor, less than a full CDuce-style semantic-subtyping
 engine.
 
-### 1. Type representation
+### 1. Operators, mostly as normalising functions
 
-Extend `InferredType` with two operators. Subtyping remains **set inclusion**,
-consistent with how singletons already relate to `Symbol`.
+The two operators are introduced primarily as **normalising functions** —
+`intersect(A, B)` and `difference(A, B)` — that return *existing* `InferredType`
+variants (`Known` / `Union` / `Never`) wherever the result is representable.
+This is deliberate: `refine_singleton_narrowing` today already returns the bare
+`matched` singleton, never a wrapped intersection, so most narrowing never needs
+new storage. Subtyping remains **set inclusion**, consistent with how singletons
+already relate to `Symbol` (`A <: B` iff `difference(A, B) == Never`).
+
+Only **irreducible** results need new stored variants, and there are exactly two:
 
 ```rust
 enum InferredType {
     Known { class_name, type_args, provenance },
-    Union { members, provenance },        // t1 or t2 or ...
-    Intersection { members, provenance },  // NEW: t1 and t2 and ...
-    Negation { base, excluded, provenance }, // NEW: base and not excluded
+    Union { members, provenance },        // t1 | t2 | ...
+    // NEW — only when the result cannot collapse to the above:
+    Intersection { members, provenance },  // irreducible conjunction, e.g.
+                                           // class ∩ protocol (unifies ADR 0068's `&`)
+    Negation { base, excluded, provenance }, // co-finite complement, e.g. Symbol \ #foo
     Meta { class_name, provenance },
     Dynamic(DynamicReason),                // unchanged: gradual hole
     Never,                                  // bottom / none()
 }
 ```
 
-Normalisation rules (mirroring `union_of`'s flatten/dedup discipline):
+`Intersection` is the representation for ADR 0068's `&` protocol composition
+(`Collection(Object) & Comparable`, 0068 §Protocol Composition) generalised to
+any type — a single stored form for both, rather than two mechanisms. (0068
+specifies `&` at the syntax level; `TypeAnnotation` does not yet carry an
+intersection variant, so this ADR adds it — see Implementation.) See §3 for the
+syntax reconciliation.
 
-- `T and T` ⇒ `T`; `T and Never` ⇒ `Never`; `T and Object` ⇒ `T`.
-- `Symbol and not #foo` is the canonical singleton complement — "any Symbol
-  except `#foo`" — the **co-finite atom set** Beamtalk cannot express today.
-- Difference is derived: `A \ B ≡ A and not B`. `union_without` becomes the
-  special case `Union[..] and not #name` and is deleted.
+Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
+`union_of` — the `Dynamic` handling is deliberately different, see below):
 
-### 2. Narrowing becomes two operations
+- `intersect(T, T)` ⇒ `T`; `intersect(T, Never)` ⇒ `Never`;
+  `intersect(T, Object)` ⇒ `T`.
+- `difference(Union[..], #foo)` drops the member — this is exactly today's
+  `union_without`, which is deleted in favour of the general function.
+- `difference(Symbol, #foo)` ⇒ `Negation{ base: Symbol, excluded: #foo }` —
+  "any Symbol except `#foo`", the **co-finite atom set** Beamtalk cannot express
+  today. Nominal-class difference beyond atoms (`difference(Object, Number)`) is
+  *not* defined by this ADR — see §2 and Consequences.
+- **`Dynamic` is asymmetric and must be stated explicitly**:
+  `intersect(Dynamic, P) = P` (a positive test refines an unknown value to `P`),
+  but `difference(Dynamic, P) = Dynamic` (we cannot subtract from the unknown).
+  This mirrors today's behaviour — `is_nil` sets the true branch to
+  `UndefinedObject` regardless of receiver type, while `non_nil_type`
+  (`inference.rs:3306`) leaves `Dynamic` unchanged on the false branch. It is the
+  **opposite** of `union_of`, where any `Dynamic` member absorbs the whole union;
+  implementing "like `union_of`" here would silently stop narrowing the common
+  case of unannotated (`Dynamic`) receivers. Regression test required.
+- `Meta` and `Dynamic` are opaque to `Negation`: `difference` leaves them
+  unchanged rather than fabricating a complement.
 
-Every narrowing idiom collapses to the same two-line core. Given a test that a
-value has pattern-type `P` and a current type `T`:
+### 2. Narrowing expressed as intersect / difference — where it applies
 
-- **true branch:** `T and P` (intersection)
-- **false branch:** `T and not P` (negation/difference)
+The target shape for a test that a value has pattern-type `P` against current
+type `T` is:
 
-`singleton_eq`'s `refine_singleton_narrowing` (`inference.rs:2316`) — which today
-hand-picks `matched` for one branch and `union_without` for the other — becomes:
+- **true branch:** `intersect(T, P)`
+- **false branch:** `difference(T, P)`
 
-```rust
-info.true_type  = intersect(&current_ty, &matched);
-info.false_type = Some(difference(&current_ty, &matched));
-// (swapped when the test is negated)
-```
+**This is an honest generalisation of `singleton_eq`, not a free port of all
+seven narrowing rules.** The rules divide into three groups, and the ADR must
+not pretend otherwise:
 
-The idiom detectors in `narrowing/rules/` stay — they still recognise AST
-*shape* and produce the pattern-type `P` — but they no longer each re-implement
-branch computation. `type_admits_singleton` becomes `intersect(T, #foo) !=
-Never`.
+1. **Already this shape — `singleton_eq`.** `refine_singleton_narrowing`
+   (`inference.rs:2316`) hand-picks `matched` for one branch and `union_without`
+   for the other; it becomes literally:
+   ```rust
+   info.true_type  = intersect(&current_ty, &matched);
+   info.false_type = Some(difference(&current_ty, &matched));  // swapped if negated
+   ```
+   `type_admits_singleton` becomes `intersect(T, #foo) != Never`. **Pure win, no
+   behaviour change.**
 
-### 3. Surface syntax
+2. **Ported, but a genuine behaviour change — `class_eq`, `is_kind_of`.** Today
+   these set `true_type = P` *unconditionally* and `false_type = None`
+   (`class_eq.rs`: `true_type: Known(name), false_type: None`). Moving the true
+   branch to `intersect(T, P)` is *new* logic: `x class = Bar` where `T` and
+   `Bar` are unrelated sealed classes would now yield `Never` and should route
+   through the same impossible-comparison hint the singleton path already has
+   (`check_impossible_singleton_comparison`, `inference.rs:2354`). Computing the
+   *false* branch requires **nominal-class difference** (`difference(T, Bar)`
+   over the class hierarchy), which §1 explicitly does *not* define. So closing
+   the class/`isKindOf:` false-branch gap is its own design step (nominal
+   negation semantics: membership, display, hover), tracked separately — not
+   assumed done by this ADR.
 
-Negation becomes writable in type annotations (`::`), composing with the
-existing `|` union syntax:
+3. **Cannot be intersect/difference at all — `is_result` (`isOk`/`isError`).**
+   `refine_result_narrowing` keeps the full, unchanged `Result(T, E)` on *both*
+   branches: it narrows a runtime tag that has no `InferredType` representation.
+   `difference(Result, Result)` would wrongly yield `Never`. This idiom stays a
+   bespoke rule; the algebra does not touch it.
+
+So the deliverable is: unify group 1 immediately, route group 2 through
+`intersect` for the true branch (with the false branch gated on nominal-difference
+design), and leave group 3 alone. The detectors in `narrowing/rules/` all stay —
+they still recognise AST *shape* and produce `P`.
+
+### 3. Surface syntax — reuse `&`, add a difference operator
+
+**Intersection already has a spelling.** ADR 0068 §Protocol Composition ships
+`&` in type annotations (`sort: items :: Collection(Object) & Comparable`), which
+is semantically an intersection. This ADR therefore does **not** invent a second
+intersection keyword — it *generalises `&`* from protocol-only conjunction to any
+two types. Only **difference/complement** is new surface syntax, written `\`
+("T without U"):
 
 ```beamtalk
 // "any symbol except the reserved ones"
-tag :: Symbol and not (#reserved | #internal)
+tag :: Symbol \ (#reserved | #internal)
 
 // residual after handling the known cases
-handleRest: dir :: (#north | #south | #east | #west) and not #north => ...
+handleRest: dir :: (#north | #south | #east | #west) \ #north => ...
+
+// intersection is the existing 0068 operator, now general
+thing :: Printable & Comparable
 ```
 
-`and` / `not` are parsed only inside a type-annotation context, so they do not
-collide with any binary message selector (`<` stays a message, per ADR 0068's
-rationale for parenthesis generics).
+Precedence, lowest-binding to highest (all parsed only inside a type-annotation
+context, so none collides with a binary message selector — `<` stays a message,
+per ADR 0068):
+
+| Operator | Meaning | Binding |
+|---|---|---|
+| `\|` | union | lowest |
+| `&` | intersection | middle |
+| `\` | difference | middle (left-assoc, same tier as `&`) |
+| _(atomic type / `(...)`)_ | grouping | highest |
+
+`Integer \| Symbol \ #foo` therefore parses as `Integer \| (Symbol \ #foo)`;
+mixed `&`/`\` at the same tier require parentheses. Using operator symbols (not
+`and`/`not` identifiers) also sidesteps ADR 0068's rule that an unrecognised
+*identifier* in type position is an implicit method-local type parameter — a
+type param spelled `and` would otherwise silently shadow the operator.
 
 ### 4. Exhaustiveness
 
@@ -148,7 +225,7 @@ message. `match:` **already performs exhaustiveness checking** (BT-1299) for
 sealed types with constructor patterns. This ADR *extends that same check to
 singleton-union scrutinees*, with the set-theoretic residual as its engine:
 because difference is now total, a `match:` over a singleton union can compute
-its **residual type** (`scrutinee_type and not (covered patterns)`). When the
+its **residual type** (`difference(scrutinee_type, covered patterns)`). When the
 residual is `Never` the `match:` is exhaustive; when it is non-`Never` the
 checker warns with the uncovered members.
 
@@ -164,13 +241,29 @@ result := compass match: [
 //    — either add a `#west ->` arm or a `_ ->` wildcard
 ```
 
-**Severity follows the open-world policy (ADR 0100).** A singleton-union
-annotation is a *closed* set, so this diagnostic is only emitted when the
-scrutinee's type is a known-closed singleton union — never when it is `Dynamic`,
-an open `Symbol`, or otherwise incompletely known. The same rule already governs
-`check_impossible_singleton_comparison`; ADR 0100 is the governing policy for
-*how severe* (Error / Warning / Lint) both diagnostics are, graded by the
-completeness of the checker's knowledge.
+**This is a type-based check, distinct from existing BT-1299 — and deliberately
+weaker.** Today's `match:` exhaustiveness is **pattern-based**: it keys on the
+constructor patterns in the arms and emits a hard `Diagnostic::error()`,
+*precisely because* Beamtalk "is dynamically typed — there is no resolved
+scrutinee type available at compile time." This ADR proposes trusting the
+*inferred* scrutinee type instead, which is strictly less conservative:
+inference can be wrong, and — under gradual typing — annotations are **not
+runtime-enforced**, so a "provably exhaustive" static claim cannot promise the
+`match:` won't crash at runtime (e.g. an FFI call typed `#north | #south` that
+actually returns `#west`). Therefore:
+
+- The singleton-union residual check is a **`Warning`/`Lint`, never a
+  build-breaking `Error`** — it is advisory, not a soundness guarantee. The
+  existing pattern-based BT-1299 error on sealed *constructor* patterns is
+  unchanged.
+- **Severity is governed by ADR 0100** (Open-World Diagnostic Policy), graded by
+  how complete the checker's knowledge is: emitted only when the scrutinee's
+  type is a *known-closed* singleton union — silent under `Dynamic`, an open
+  `Symbol`, `perform:`, or a possible `doesNotUnderstand:` receiver. The same
+  rule already governs `check_impossible_singleton_comparison`.
+- Because it is additive and non-`Error`, it does **not** regress the "no meaning
+  changes" migration claim: previously-clean code that is now *inferred* as a
+  singleton-union scrutinee gets an advisory warning, not a new build failure.
 
 ### REPL session
 
@@ -179,8 +272,8 @@ bt> x := someUnionReturning   "x :: Integer | #infinity"
 bt> (x = #infinity) ifTrue: [x] ifFalse: [x + 1]
                                           ^^^^^
    in the false branch, x :: Integer  (#infinity removed) → x + 1 type-checks
-bt> :type (Symbol and not #foo)
-   Symbol and not #foo   "co-finite: every atom except #foo"
+bt> :type (Symbol \ #foo)
+   Symbol \ #foo   "co-finite: every atom except #foo"
 ```
 
 ### Error example
@@ -198,7 +291,7 @@ d = #west
 
 | Language / system | Approach | What we take / leave |
 |---|---|---|
-| **Elixir (1.17+)** — gradual set-theoretic types (Castagna, Duboc, Valim) | Types *are* sets of values; closed under `or` / `and` / `not`. Atoms are singleton types (`:ok` is both value and type); `boolean() = true or false`; `nil`, `true`, `false` are atoms. `atom() and not (:foo or :bar)` expresses co-finite atom sets. `dynamic()` is a *range* of types kept "at the root", enabling gradual typing that still tracks structure. | **Adopt:** the three-operator algebra and singleton-as-set model — it is exactly what our `#foo`/`Symbol`/`union_without` code approximates. **Adapt:** we add `and`/`not` as surface syntax and internal operators without adopting the full semantic-subtyping decision procedure. **Leave (for now):** replacing `Dynamic(reason)` with a structural `dynamic()`; BDD emptiness checking. |
+| **Elixir (1.17+)** — gradual set-theoretic types (Castagna, Duboc, Valim) | Types *are* sets of values; closed under `or` / `and` / `not`. Atoms are singleton types (`:ok` is both value and type); `boolean() = true or false`; `nil`, `true`, `false` are atoms. `atom() and not (:foo or :bar)` expresses co-finite atom sets. `dynamic()` is a *range* of types kept "at the root", enabling gradual typing that still tracks structure. | **Adopt:** the three-operator algebra and singleton-as-set model — it is exactly what our `#foo`/`Symbol`/`union_without` code approximates. **Adapt:** we reuse ADR 0068's `&` for intersection and add `\` for difference as surface syntax (not Elixir's `and`/`not` keywords), with internal `intersect`/`difference` operators, without adopting the full semantic-subtyping decision procedure. **Leave (for now):** replacing `Dynamic(reason)` with a structural `dynamic()`; BDD emptiness checking. |
 | **CDuce / semantic subtyping** (the theory underneath Elixir) | Subtyping = set inclusion decided via emptiness of a Boolean combination of type constructors, implemented with BDDs. | The north-star. Rejected as the *implementation* today (XL, nominal-core mismatch); adopted as the *mental model* for our operators so a future upgrade is a deepening, not a rewrite. |
 | **TypeScript** | Discriminated unions + control-flow narrowing; literal (singleton) types; `Exclude<T, U>` at the *type-operator* level but **no first-class negation type** in values. | We go slightly further than TS values by making negation a real `InferredType`, which is what makes uniform false-branch narrowing and exhaustiveness fall out. |
 | **Gleam** (BEAM, Rust-implemented, our closest typed-BEAM peer) | Sound nominal HM; **no** union/intersection/negation, exhaustiveness via nominal custom types. | Confirms exhaustiveness is table-stakes on BEAM, but Gleam gets it from closed nominal sum types; we get it from the atom-union algebra, which fits Beamtalk's open, atom-rich style better. |
@@ -207,7 +300,7 @@ d = #west
 
 ## User Impact
 
-- **Newcomer (from Python/JS/TS):** `Symbol and not #foo` reads naturally to
+- **Newcomer (from Python/JS/TS):** `Symbol \ #foo` reads naturally to
   anyone who has met TypeScript's `Exclude`/discriminated unions. The main new
   payoff they *feel* is the non-exhaustive-`match:` warning catching a missed
   atom — a bug class that is otherwise a runtime error.
@@ -221,7 +314,7 @@ d = #west
   compile/edit-time analysis. Generated BEAM is unchanged.
 - **Tooling developer:** *Simpler*, not harder. One narrowing core (intersect /
   difference) instead of N per-idiom branch computations; hover can render
-  `Symbol and not #foo`; new idioms need only produce a pattern-type `P`.
+  `Symbol \ #foo`; new idioms need only produce a pattern-type `P`.
 
 ## Steelman Analysis
 
@@ -230,12 +323,14 @@ d = #west
   forgot — that's the feature I didn't know I wanted."
 - 🎩 **Smalltalk purist:** "It's opt-in annotation sugar; my un-annotated code
   is untouched and messages still dispatch dynamically."
-- ⚙️ **BEAM veteran:** "Co-finite atom sets (`Symbol and not …`) are how I model
+- ⚙️ **BEAM veteran:** "Co-finite atom sets (`Symbol \ …`) are how I model
   Erlang tagged returns; finally expressible."
 - 🏭 **Operator:** "Compile-time only, generated code identical — nothing new to
   observe or debug in prod."
-- 🎨 **Language designer:** "Two operators subsume seven idioms' branch logic
-  *and* give exhaustiveness for free. Maximum expressiveness-per-concept."
+- 🎨 **Language designer:** "Two normalising operators unify `singleton_eq`,
+  give `class`/`isKindOf:` a principled true branch, express co-finite atom
+  sets, and enable advisory `match:` exhaustiveness — one small algebra, several
+  payoffs."
 
 ### Rejected A: Internal algebra only (no surface syntax, no exhaustiveness)
 - 🎨 **Language designer:** "Cleanest possible diff — refactor the hand-rolled
@@ -288,59 +383,89 @@ needs full arrow/intersection-function typing. Documented as the destination in
 ## Consequences
 
 ### Positive
-- One narrowing core (`intersect` for true, `difference` for false) replaces
-  per-idiom branch logic; `union_without` and `type_admits_singleton` collapse
-  into it.
-- False-branch complements work for **all** types, closing ADR 0068's gap.
-- Co-finite atom sets (`Symbol and not #foo`) become expressible.
-- Exhaustiveness checking over singleton unions — a real bug-catcher — falls out
-  of total difference.
+- Shared `intersect` / `difference` primitives replace `singleton_eq`'s
+  hand-rolled branch logic (`union_without`, `type_admits_singleton`) with one
+  normalising core, and give `class_eq`/`is_kind_of` a principled true branch.
+- **Atom** complements become expressible — co-finite sets `Symbol \ #foo`,
+  closing ADR 0068's difference-types gap *for the singleton case*.
+- Advisory exhaustiveness over singleton-union `match:` scrutinees — a real
+  bug-catcher — falls out of atom difference.
 - The `check_impossible_singleton_comparison` diagnostic becomes a consequence
   of `intersect(T, s) == Never` rather than a special case.
 
 ### Negative
-- `InferredType` grows two variants; every exhaustive `match` on it (equality,
-  display, provenance, codegen-facing conversions) must handle them.
-- Normalisation (dedup, absorption, `and`/`or` interaction) is fiddly to get
-  right and needs thorough property tests.
-- Surface `and`/`not` adds parser surface in the annotation grammar.
+- `InferredType` grows **two** variants (`Intersection`, `Negation`); every
+  exhaustive `match` on it (equality, display, provenance, hover) must handle
+  them — though `intersect`/`difference` are normalising functions, so most
+  results stay in existing variants (see §1).
+- **`TypeAnnotation` (`ast/expression.rs`) also grows variants** for `&`/`\`
+  (the AST enum is already ad-hoc — `FalseOr`, `ClassOf`, `SelfType`); every
+  exhaustive match over it and `type_resolver.rs` must be updated. This cost was
+  easy to miss and is real.
+- **Nominal-class difference is left undefined** (`difference(Object, Number)`).
+  Closing the `class_eq`/`is_kind_of` *false* branch (§2 group 2) needs its
+  membership/display/hover semantics designed — deferred, not delivered here.
+- Normalisation (dedup, absorption, `Dynamic` asymmetry, `&`/`\`/`|`
+  interaction) is fiddly and needs property tests. Termination must be argued
+  (finite atom/class basis; no recursive blow-up).
+- Surface `\` adds parser surface and a new precedence tier.
 
 ### Neutral
 - No runtime, codegen, or hot-reload change — edit/compile-time only.
-- `Dynamic(reason)` is untouched; this ADR does **not** make it structural
-  (that is the deferred phase-B/north-star work).
+- The new exhaustiveness diagnostic is advisory (`Warning`/`Lint`), *not* a
+  soundness guarantee — gradual annotations aren't runtime-enforced (§4).
+- `Dynamic(reason)` is untouched and stays a checking hole; this ADR does **not**
+  make it structural (that is the deferred north-star work), but keeps it
+  isolable behind the operators per the north-star compatibility contract.
 
 ## Implementation
 
-**Phase 1 — internal operators (the *Alternative A* core):**
-1. Add `Intersection` / `Negation` to `InferredType` (`types.rs`) with
-   normalisation helpers `intersect` / `difference`, mirroring `union_of`.
+**Phase 1 — internal operators + `singleton_eq` unification (Alternative A core):**
+1. Add `intersect` / `difference` normalising functions and the `Intersection` /
+   `Negation` variants to `InferredType` (`types.rs`). Encode the `Dynamic`
+   asymmetry (§1) explicitly with a regression test; do **not** mirror
+   `union_of`'s Dynamic-absorbs rule.
 2. Update all exhaustive matches: `PartialEq`, `display_for_diagnostic`,
    provenance accessors, `as_known`, hover rendering.
-3. Rewrite `refine_singleton_narrowing`, delete `union_without`, redefine
-   `type_admits_singleton` as `intersect(T, s) != Never`.
-4. Keep the seven idiom detectors; strip their bespoke branch logic to emit a
-   pattern-type `P` consumed by the shared core.
+3. Rewrite `refine_singleton_narrowing` (group 1), delete `union_without`,
+   redefine `type_admits_singleton` as `intersect(T, s) != Never`. **No
+   behaviour change — pin with existing narrowing/union tests.**
+4. Route `class_eq` / `is_kind_of` true branch through `intersect(T, P)` (group
+   2, true branch only), wiring the impossible-comparison hint. Leave their
+   false branch and `is_result` (group 3) untouched.
 
-**Phase 2 — surface + exhaustiveness (this ADR's added scope):**
-5. Parse `and` / `not` inside type annotations (`source_analysis/parser`,
-   `TypeAnnotation`), resolve in `type_resolver.rs`.
-6. Extend `match:` exhaustiveness (BT-1299) to singleton-union scrutinees:
-   compute the residual type (`scrutinee and not covered`) and emit a
-   non-exhaustiveness diagnostic when it is not `Never`.
+**Phase 1b — nominal-class difference (prerequisite for the class false-branch):**
+5. Define `difference` over the class hierarchy (membership, display, hover for
+   `Negation` of a nominal base). Only then close the `class_eq`/`is_kind_of`
+   *false* branch. Sequenced separately because it is new semantics, not a port.
+
+**Phase 2 — surface syntax + advisory exhaustiveness:**
+6. Generalise ADR 0068's `&` to any-type intersection and add `\` (difference)
+   to the annotation grammar — **new `TypeAnnotation` variants**
+   (`ast/expression.rs`) plus every exhaustive match and `type_resolver.rs`.
+   Add the precedence tier (§3).
+7. Add a **type-based, advisory** singleton-union exhaustiveness check to
+   `match:`: compute `difference(scrutinee, covered)`; if non-`Never`, emit a
+   `Warning`/`Lint` (never `Error`) gated by ADR 0100 completeness. Distinct from
+   BT-1299's pattern-based error, which is unchanged.
 
 **Affected components:** type checker (`semantic_analysis/type_checker/*`),
-annotation parser + `TypeAnnotation` AST, hover/diagnostic rendering
-(`queries/hover_provider.rs`). **Not** affected: codegen, runtime, REPL output
-values.
+annotation parser + `TypeAnnotation` AST, `match:` exhaustiveness validator,
+hover/diagnostic rendering (`queries/hover_provider.rs`). **Not** affected:
+codegen, runtime, REPL output values.
 
 ## Migration Path
 
-Backward compatible. Existing annotations, inference, and the seven narrowing
-idioms behave identically — their branch types are now produced by the shared
-algebra but the *results* are unchanged (covered by the existing narrowing and
-union tests). `and`/`not` annotation syntax and exhaustiveness warnings are
-purely additive; no existing `.bt` source changes meaning.
+Backward compatible. `singleton_eq` narrowing (Phase 1 group 1) produces
+identical *results*, now via the shared algebra (pinned by existing narrowing/
+union tests). `class_eq`/`is_kind_of` true-branch narrowing (group 2) is a
+*deliberate* refinement — it can newly report an impossible comparison where the
+old code silently kept `P`; this is the intended improvement, routed through the
+existing hint machinery, and any affected test is updated in the same change.
+`&`/`\` syntax and the exhaustiveness diagnostic are additive; the latter is
+advisory (`Warning`/`Lint`), so no previously-clean build newly fails — even when
+a scrutinee is now *inferred* as a singleton union. No existing `.bt` source
+changes meaning.
 
 ## References
 - Related issues: BT-XXX (to be filed via `/plan-adr`); builds on BT-2617,

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -190,6 +190,16 @@ Normalisation rules (`intersect` / `difference`; **not** a blind mirror of
   `#bar`), `s ∈ E` ⇒ `Never`. Without this rule a `Negation` LHS hits an
   unhandled arm and every conservative fallback (panic, `Dynamic`, keep the
   `Negation`) is a wrong narrowing outcome.
+- **Negation on the RHS (symmetric complement)**:
+  `intersect(A, Negation{B, E}) = difference(intersect(A, B), E)` —
+  set-theoretically `A ∩ (B \ E) = (A ∩ B) \ E`. Dormant in Phase 1 (narrowing
+  pattern types are always `Known`/`Union`) but **fires in Phase 2**, when the
+  `\` surface syntax puts a `Negation` in pattern position — a `match` on the
+  first operand's variant would otherwise miss `(Known, Negation)` and fall
+  through, with the same wrong-outcome consequences as the LHS case.
+  Implementations may instead canonicalise (swap the `Negation` to the LHS and
+  apply the single rule — intersection is commutative), provided they do so
+  explicitly rather than by fall-through.
 - **Nominal base case** (required by the complement rule above *and* by
   LHS-union distribution — `intersect(Integer | #infinity, #infinity)` only
   reduces because `intersect(Integer, #infinity) = Never`):

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -142,22 +142,35 @@ rationale for parenthesis generics).
 
 ### 4. Exhaustiveness
 
-Because difference is now total, a multi-branch dispatch over a singleton union
-can compute its **residual type**. When the residual is `Never`, the dispatch is
-exhaustive; when it is non-`Never`, the checker warns with the uncovered
-members.
+Beamtalk has no Erlang-style multi-clause method heads — a selector maps to one
+method body, and case analysis happens *inside* it via the `match:` keyword
+message. `match:` **already performs exhaustiveness checking** (BT-1299) for
+sealed types with constructor patterns. This ADR *extends that same check to
+singleton-union scrutinees*, with the set-theoretic residual as its engine:
+because difference is now total, a `match:` over a singleton union can compute
+its **residual type** (`scrutinee_type and not (covered patterns)`). When the
+residual is `Never` the `match:` is exhaustive; when it is non-`Never` the
+checker warns with the uncovered members.
 
 ```beamtalk
 compass :: #north | #south | #east | #west := readHeading
 
-result := compass caseOf: {
-  [#north] -> "up".
-  [#south] -> "down".
-  [#east]  -> "right"
-}
-// ⚠️ non-exhaustive: `#west` is not handled
-//    (residual type: `#west`)
+result := compass match: [
+  #north -> "up";
+  #south -> "down";
+  #east  -> "right"
+]
+// ⚠️ non-exhaustive: `#west` is not handled  (residual type: `#west`)
+//    — either add a `#west ->` arm or a `_ ->` wildcard
 ```
+
+**Severity follows the open-world policy (ADR 0100).** A singleton-union
+annotation is a *closed* set, so this diagnostic is only emitted when the
+scrutinee's type is a known-closed singleton union — never when it is `Dynamic`,
+an open `Symbol`, or otherwise incompletely known. The same rule already governs
+`check_impossible_singleton_comparison`; ADR 0100 is the governing policy for
+*how severe* (Error / Warning / Lint) both diagnostics are, graded by the
+completeness of the checker's knowledge.
 
 ### REPL session
 
@@ -196,8 +209,8 @@ d = #west
 
 - **Newcomer (from Python/JS/TS):** `Symbol and not #foo` reads naturally to
   anyone who has met TypeScript's `Exclude`/discriminated unions. The main new
-  payoff they *feel* is the non-exhaustive-`caseOf:` warning catching a missed
-  atom — a bug class that is otherwise a runtime `does_not_understand`.
+  payoff they *feel* is the non-exhaustive-`match:` warning catching a missed
+  atom — a bug class that is otherwise a runtime error.
 - **Smalltalk developer:** Zero change to message-passing or runtime semantics.
   `#foo` is still a Symbol at runtime; this is edit-time tooling only. Purists
   who never annotate see no new obligations (gradual guarantee preserved).
@@ -213,7 +226,7 @@ d = #west
 ## Steelman Analysis
 
 ### Chosen: Internal operators + surface syntax + exhaustiveness
-- 🧑‍💻 **Newcomer:** "The `caseOf:` warning literally tells me which atom I
+- 🧑‍💻 **Newcomer:** "The `match:` warning literally tells me which atom I
   forgot — that's the feature I didn't know I wanted."
 - 🎩 **Smalltalk purist:** "It's opt-in annotation sugar; my un-annotated code
   is untouched and messages still dispatch dynamically."
@@ -312,8 +325,9 @@ needs full arrow/intersection-function typing. Documented as the destination in
 **Phase 2 — surface + exhaustiveness (this ADR's added scope):**
 5. Parse `and` / `not` inside type annotations (`source_analysis/parser`,
    `TypeAnnotation`), resolve in `type_resolver.rs`.
-6. Compute residual types for `caseOf:` / multi-branch singleton dispatch and
-   emit non-exhaustiveness diagnostics.
+6. Extend `match:` exhaustiveness (BT-1299) to singleton-union scrutinees:
+   compute the residual type (`scrutinee and not covered`) and emit a
+   non-exhaustiveness diagnostic when it is not `Never`.
 
 **Affected components:** type checker (`semantic_analysis/type_checker/*`),
 annotation parser + `TypeAnnotation` AST, hover/diagnostic rendering
@@ -330,10 +344,16 @@ purely additive; no existing `.bt` source changes meaning.
 
 ## References
 - Related issues: BT-XXX (to be filed via `/plan-adr`); builds on BT-2617,
-  BT-2624, BT-2631 (singleton narrowing / impossible-comparison diagnostics)
+  BT-2624, BT-2631 (singleton narrowing / impossible-comparison diagnostics) and
+  BT-1299 (`match:` exhaustiveness for sealed constructor patterns — extended
+  here to singleton-union scrutinees)
 - Related ADRs: ADR 0068 (Parametric Types and Protocols — unions, narrowing,
-  and the noted difference-types gap), ADR 0025 (Gradual Typing and Protocols),
-  ADR 0053 (`::` annotation syntax), ADR 0036 (Metaclass tower)
+  and the noted difference-types gap), ADR 0100 (Open-World Diagnostic Policy —
+  governs the severity of the exhaustiveness and impossible-comparison
+  diagnostics this ADR relies on), ADR 0025 (Gradual Typing and Protocols),
+  ADR 0053 (`::` annotation syntax), ADR 0036 (Metaclass tower), ADR 0083
+  (Metaclass-Aware Type Inference — the `Meta` variant these operators must
+  carry through)
 - Documentation: `docs/internal/set-theoretic-types-north-star.md` (the full
   vision + compatibility contract this ADR upholds);
   `docs/internal/type-system-design.md` (Union Types and

--- a/docs/ADR/0102-set-theoretic-type-operators.md
+++ b/docs/ADR/0102-set-theoretic-type-operators.md
@@ -238,8 +238,10 @@ d = #west
 - 🧑‍💻 **Newcomer:** "The type system would 'just know' every relationship."
 - **Why not chosen:** XL effort; a BDD emptiness engine and a structural
   `dynamic()` are a rewrite of the nominal core (`Known` + hierarchy walk) for
-  benefit Beamtalk cannot yet spend. Documented as the **north-star** the
-  operator design deliberately keeps compatible.
+  benefit Beamtalk cannot yet spend. Documented in full as the **north star**
+  this ADR is deliberately kept compatible with —
+  [`docs/internal/set-theoretic-types-north-star.md`](../internal/set-theoretic-types-north-star.md),
+  including the compatibility contract these operators must uphold.
 
 ### Tension points
 - Designers split between A (minimal, safe) and B (complete, sound); the chosen
@@ -267,7 +269,8 @@ that ride on them for free wastes the investment.
 ### Full semantic subtyping engine
 Replace nominal comparison with BDD-based emptiness checking and a structural
 `dynamic()`. Rejected as premature (see Steelman B); revisit if/when Beamtalk
-needs full arrow/intersection-function typing.
+needs full arrow/intersection-function typing. Documented as the destination in
+[`docs/internal/set-theoretic-types-north-star.md`](../internal/set-theoretic-types-north-star.md).
 
 ## Consequences
 
@@ -331,7 +334,9 @@ purely additive; no existing `.bt` source changes meaning.
 - Related ADRs: ADR 0068 (Parametric Types and Protocols — unions, narrowing,
   and the noted difference-types gap), ADR 0025 (Gradual Typing and Protocols),
   ADR 0053 (`::` annotation syntax), ADR 0036 (Metaclass tower)
-- Documentation: `docs/internal/type-system-design.md` (Union Types and
+- Documentation: `docs/internal/set-theoretic-types-north-star.md` (the full
+  vision + compatibility contract this ADR upholds);
+  `docs/internal/type-system-design.md` (Union Types and
   Narrowing); `crates/beamtalk-core/src/semantic_analysis/type_checker/`
   (`types.rs` `union_of`, `inference.rs` `union_without` /
   `type_admits_singleton` / `refine_singleton_narrowing`, `narrowing/rules/`)

--- a/docs/ADR/0103-sendability-typing-from-class-kinds.md
+++ b/docs/ADR/0103-sendability-typing-from-class-kinds.md
@@ -53,64 +53,105 @@ warn when a value's tier is too weak for the boundary it crosses.
 
 ```text
 Sendable       — Value kinds, primitives (Integer, String, …), Symbol,
-                 unions/collections of Sendable
-SendableRef    — Actor kinds (Pid-backed): reference semantics survive the
-                 send; validity tied to process lifetime
-HandleScoped   — Object kinds wrapping runtime-backed state (declared, see
-                 below): valid within a scope (node-global or process-bound)
-Unknown        — Dynamic, or Object kinds with no declaration (silent, per
-                 ADR 0100)
+                 unions/collections of Sendable; also opaque tokens with no
+                 owner (e.g. Reference — a raw make_ref() is hazard-free)
+SendableRef    — Pid-backed references: Actor kinds and the builtin `Pid`
+                 itself; reference semantics survive the send, validity tied
+                 to the process lifetime
+HandleScoped   — Object kinds wrapping runtime-backed state whose validity
+                 has a scope (see below)
+Unknown        — Dynamic, untyped FFI results (ADR 0075's
+                 Dynamic(DynamicSpec)), or Object kinds with no
+                 classification (silent, per ADR 0100)
 ```
 
 `Value` composes structurally: a `Value` whose field types are all `Sendable`
 is `Sendable`; a `Value` carrying a `HandleScoped` field inherits
 `HandleScoped` (the copy embeds the handle).
 
+Honest scoping note: **no diagnostic rule consumes `SendableRef` in v1** — it
+exists to classify `Pid`/Actor references correctly (they are neither plain
+data nor scoped handles) and to render truthfully in hover. If no rule ever
+reads it, collapsing to a three-tier lattice is a simplification the
+implementation is free to make; the tier is kept in the design because `Pid`'s
+behaviour genuinely differs from both neighbours.
+
+**Builtins are classified directly, not via annotation.** The flagship hazard
+classes already exist in the stdlib as `sealed typed Object subclass:` with no
+kind distinction — and one of them breaks a naive kind→tier rule: `Pid` is
+Object-kind but *behaves* as `SendableRef` (a live cross-node-valid process
+reference). Tier assignments for builtins ship as a table in the checker, not
+as source annotations:
+
+| Builtin | Tier | Why |
+|---|---|---|
+| `Pid` | `SendableRef` | live process reference; valid across nodes |
+| `Port` | `HandleScoped(#process)` | port dies with / is bound to its owner |
+| `Reference` | `Sendable` | opaque comparison token, no owner, no hazard |
+| `Subscription` | `HandleScoped(#node)` | wraps a node-local ETS row |
+| `FileHandle` | `HandleScoped(#process)` *(approximation)* | documented as "must not escape" its `open:do:` block — its true scope is *dynamic extent*, tighter than any process; `#process` is the conservative expressible bound (see Consequences) |
+
+This table **is the Phase 0 deliverable** — it makes the canonical hazards
+(`Port` in an actor message) warn on day one with zero user annotations.
+
 ### Declaring handle scope (the one new annotation)
 
-`Object subclass:` classes that wrap runtime state may declare their scope;
-undeclared Object kinds stay `Unknown` (silent):
+User-defined `Object subclass:` classes that wrap runtime state may declare
+their scope; undeclared Object kinds stay `Unknown` (silent):
 
 ```beamtalk
 // node-global handle: fine to send within the node, not across nodes
-sealed typed Object subclass: Subscription
+sealed typed Object subclass: MetricsTable
   handleScope: #node
-
-// process-bound handle (e.g. wraps a port): only meaningful in the owner
-sealed typed Object subclass: SocketHandle
-  handleScope: #process
 ```
+
+The scope is symbol-valued and the set is deliberately **open** — `#node` and
+`#process` ship first; a `#dynamicExtent` value (the `FileHandle` case) is a
+plausible later addition rather than a redesign. Construction of such classes
+follows the existing FFI-wrapping pattern (ADR 0101 `native:` / delegate, as
+`Ets` and `Subscription` do today).
 
 ### Checked boundaries
 
 1. **Actor message arguments and `spawnWith:` maps** — warn when a
-   `HandleScoped(#process)` value is passed; info-level note for
-   `#node`-scoped values only when the receiver is known to be remote
-   (named-actor registration on another node, ADR 0079).
+   `HandleScoped(#process)` value is passed. `#node`-scoped values are
+   **silent in v1**: warning usefully requires static knowledge that the
+   receiver is remote, and no such knowledge exists — ADR 0079 is explicitly
+   *local* (per-node) registration; cluster-wide registration is a deferred
+   future ADR. When that ADR lands, `#node`-scoped sends to known-remote
+   receivers gain an info-level note. Recorded as blocked, not designed here.
 2. **Blocks sent to actors** (including `Timer every:do:`, `!` casts) — warn
-   when the block's *captured environment* (already computed for closure
-   conversion) includes a `HandleScoped(#process)` value.
+   when the block captures a `HandleScoped(#process)` value. **This is new
+   analysis, not reuse**: the compiler has no closure-conversion pass (Core
+   Erlang funs capture natively), and the two existing capture datasets are
+   both name-only and invisible to the type checker —
+   `BlockMutationAnalysis.captured_reads` is computed at codegen time, and
+   the semantic-analysis `Analyser::collect_captures_and_mutations`
+   (`CapturedVar{name, defined_at}`) runs in Phase 3, *after* type checking.
+   The check therefore lives in a Phase 3 validator that joins
+   `CapturedVar`s with the type checker's `type_map` — budgeted as real work
+   in Implementation, with a tier-derivation function shared between it and
+   the Phase 2 message-argument checks.
 3. **Announcement payloads** — same rule as message arguments.
 
 ### Error example
 
 ```beamtalk
-sock := SocketHandle open: 8080
-worker ! [sock readLine]
-// ⚠️ block captures `sock` (SocketHandle, handleScope: #process) and is sent
-//    to another process — the handle is only valid in the owning process.
-//    Consider passing data, or an Actor that owns the socket.
+port := (Erlang erlang) openPort: cmd     // :: Port — builtin tier table
+worker ! [port send: data]
+// ⚠️ block captures `port` (Port — process-bound handle) and is sent to
+//    another process — a port is only usable by its owning process.
+//    Consider passing data, or an Actor that owns the port.
 ```
 
 ### REPL session
 
 ```
-bt> p := Point x: 1 y: 2        // Value — Sendable
-bt> counter ! (p)                // fine, no diagnostic
-bt> sub := announcer when: Tick do: [:e | e]
-bt> remoteWorker register: sub   // remote receiver + #node handle
-   ℹ️ `sub` (Subscription, handleScope: #node) sent to a remote node — the
-      handle will not be valid there
+bt> p := Point x: 1 y: 2         // Value — Sendable
+bt> counter add: p               // fine, no diagnostic
+bt> worker consume: port
+   ⚠️ `port` (Port — process-bound handle) passed in an actor message; it is
+      only usable by its owning process
 ```
 
 ## Prior Art
@@ -152,8 +193,11 @@ bt> remoteWorker register: sub   // remote receiver + #node handle
 ### Tension point
 Whether `#node`-scoped sends to *possibly*-remote receivers warn or stay
 silent: veterans want silence (distribution is deliberate), newcomers want the
-note. Resolved by grading on *knowledge*: warn only when remoteness is
-statically known (ADR 0079 registration), otherwise silent.
+note. Resolved by grading on *knowledge* — and today the checker has **none**:
+there is no static source of receiver remoteness (ADR 0079 is local-only
+registration; cluster registration is a future ADR). So `#node` findings are
+silent in v1, becoming info-level only when a cluster-registration ADR gives
+the checker something to grade on.
 
 ## Alternatives Considered
 
@@ -174,38 +218,71 @@ under-shoots.
 
 ### Positive
 - The first BEAM language where "will this value survive the send?" is a
-  typed, hover-visible property — at near-zero annotation cost.
-- Block-capture checking reuses closure-conversion data; no new analysis pass.
+  typed, hover-visible property — with the canonical hazards (`Port`) covered
+  by the builtin tier table at **zero** annotation cost.
 
 ### Negative
-- `handleScope:` is a new class-side keyword (parser + ClassHierarchy +
-  codegen metadata).
+- **This wires class-kind data into the type checker for the first time.**
+  `ClassHierarchy::resolve_class_kind` exists and is reachable, but nothing in
+  `inference.rs`/`validation.rs` consumes kind today (only downstream Phase 5
+  validators do) — this is net-new checker logic, not a refactor.
+- **Block-capture checking is genuinely new analysis** (see Checked
+  boundaries #2): a Phase 3 validator joining name-only `CapturedVar` data
+  with the type checker's `type_map`, plus a tier-derivation function shared
+  with the Phase 2 message-argument checks. Two phases, one shared core —
+  the split must be kept explicit or the tiers will drift.
+- `handleScope:` is a new class-side keyword — and ADR 0067's precedent says
+  such keywords are not cheap (its comparable keyword change took 11 tracked
+  issues across parser, ClassHierarchy, codegen metadata, and docs).
+- **Perverse incentive:** declaring `handleScope:` is what turns silence into
+  (advisory) findings, so authors of handle-wrapping classes are mildly
+  incentivised *not* to declare. Mitigation: a companion lint nudging
+  FFI-wrapping `Object` classes with no classification toward declaring, and
+  the builtin table covering the stdlib regardless.
+- The two-value scope enum is a knowing approximation: `FileHandle`'s true
+  scope is *dynamic extent* (must not escape `open:do:`), tighter than
+  `#process`. The open symbol set leaves room; the approximation is accepted
+  for v1.
 - Tier derivation for generic collections needs care
-  (`List(SocketHandle)` is `HandleScoped`); interacts with ADR 0102's
-  `type_args` rules.
+  (`List(Port)` is `HandleScoped`); interacts with ADR 0102's `type_args`
+  rules.
 - False silence is guaranteed under `Dynamic` — must be documented as
   advisory, not a guarantee.
 
 ### Neutral
 - No runtime or codegen behaviour change; metadata only.
+- Remote-node grading of `#node`-scoped sends is **blocked on a future
+  cluster-registration ADR** (ADR 0079 is local-only); nothing in v1 claims
+  remoteness knowledge.
 
 ## Implementation
 
-1. **Phase 0 (napkin):** derive tiers from class kinds only (no
-   `handleScope:`), warn on the single clearest case — `#process`-scoped
-   stdlib types (ports) passed in actor messages. Validates the plumbing.
-2. **Phase 1:** `handleScope:` keyword (parser, `ClassDefinition`,
-   `ClassHierarchy`, `__beamtalk_meta`), tier derivation incl. `Value`
-   composition, message-argument + `spawnWith:` checks. ~M.
-3. **Phase 2:** block-capture checking; Announcement payloads; remote-receiver
-   grading via ADR 0079 registration data. ~M.
+1. **Phase 0 (napkin, ~S):** builtin tier table (`Pid`, `Port`, `Reference`,
+   `Subscription`, `FileHandle`) + the message-argument check for
+   `HandleScoped(#process)`, wired into the type checker (first consumer of
+   class-kind data there). Proves the value with zero new syntax — `Port` in
+   an actor message warns.
+2. **Phase 1 (~M):** `handleScope:` keyword (parser, `ClassDefinition`,
+   `ClassHierarchy`, `__beamtalk_meta` — budget per the ADR 0067 precedent),
+   tier derivation incl. `Value` composition and `type_args`, `spawnWith:`
+   checks, hover rendering, stdlib inventory audit (Ets, Announcer, …).
+3. **Phase 2 (~M):** block-capture checking (Phase 3 validator + `type_map`
+   join + shared tier-derivation core); Announcement payloads; the
+   undeclared-handle-class companion lint.
+4. **Deferred (blocked):** remote-receiver grading of `#node` scopes — needs
+   the future cluster-registration ADR first.
 
-**Affected:** parser/AST, class hierarchy, type checker, hover; **not**
-codegen output semantics or runtime dispatch.
+**Affected:** parser/AST, class hierarchy, type checker (first kind-aware
+logic), a Phase 3 validator, hover; **not** codegen output semantics or
+runtime dispatch.
 
 ## References
 - Seed: `docs/internal/positioning.md` (Seed 1)
-- Related ADRs: ADR 0067 (class kinds), ADR 0042 (value types), ADR 0100
-  (advisory severity), ADR 0079 (named/remote actors), ADR 0102 (type
-  operators, `type_args` rules), ADR 0093 (Announcements)
+- Related ADRs: ADR 0067 (class kinds — incl. the keyword-cost precedent),
+  ADR 0042 (value types), ADR 0100 (advisory severity), ADR 0079 (named actor
+  registration — **local-only**; cluster registration deferred), ADR 0075
+  (FFI type definitions — untyped FFI results are `Dynamic(DynamicSpec)`,
+  hence tier `Unknown`), ADR 0101 (`native:` FFI-wrapping construction
+  pattern), ADR 0102 (type operators, `type_args` rules), ADR 0093
+  (Announcements)
 - Prior art: Pony reference capabilities; Rust `Send`/`Sync`

--- a/docs/ADR/0103-sendability-typing-from-class-kinds.md
+++ b/docs/ADR/0103-sendability-typing-from-class-kinds.md
@@ -69,12 +69,15 @@ Unknown        — Dynamic, untyped FFI results (ADR 0075's
 is `Sendable`; a `Value` carrying a `HandleScoped` field inherits
 `HandleScoped` (the copy embeds the handle).
 
-Honest scoping note: **no diagnostic rule consumes `SendableRef` in v1** — it
-exists to classify `Pid`/Actor references correctly (they are neither plain
-data nor scoped handles) and to render truthfully in hover. If no rule ever
-reads it, collapsing to a three-tier lattice is a simplification the
-implementation is free to make; the tier is kept in the design because `Pid`'s
-behaviour genuinely differs from both neighbours.
+Honest scoping note: **no diagnostic rule consumes `SendableRef` in v1**, and
+rather than leave the tier's fate as an implementation choice (which would let
+hover behaviour diverge between implementations), its v1 contract is fixed:
+**hover displays `SendableRef` for `Pid`- and Actor-typed values** — a
+testable requirement, shipped with the Phase 0 builtin tier table. That is the
+tier's *only* v1 consumer; the first diagnostic rule that gates on it (if any)
+arrives with the deferred remote-grading work. It earns a stored tier (rather
+than collapsing to three) because `Pid`'s behaviour genuinely differs from
+both neighbours and hover must say so truthfully.
 
 **Builtins are classified directly, not via annotation.** The flagship hazard
 classes already exist in the stdlib as `sealed typed Object subclass:` with no
@@ -138,11 +141,15 @@ follows the existing FFI-wrapping pattern (ADR 0101 `native:` / delegate, as
 
 ```beamtalk
 port := (Erlang erlang) openPort: cmd     // :: Port — builtin tier table
-worker ! [port send: data]
+worker schedule: [port readLine]
 // ⚠️ block captures `port` (Port — process-bound handle) and is sent to
 //    another process — a port is only usable by its owning process.
 //    Consider passing data, or an Actor that owns the port.
 ```
+
+(The block crosses the boundary as an ordinary message argument; the same
+check applies when the send is a postfix cast — `worker schedule: [...]!`.
+There is no infix `!` send in Beamtalk — see ADR 0104 §2.)
 
 ### REPL session
 

--- a/docs/ADR/0103-sendability-typing-from-class-kinds.md
+++ b/docs/ADR/0103-sendability-typing-from-class-kinds.md
@@ -65,9 +65,13 @@ Unknown        — Dynamic, untyped FFI results (ADR 0075's
                  classification (silent, per ADR 0100)
 ```
 
-`Value` composes structurally: a `Value` whose field types are all `Sendable`
-is `Sendable`; a `Value` carrying a `HandleScoped` field inherits
-`HandleScoped` (the copy embeds the handle).
+`Value` composes structurally, taking the **weakest** field tier: a `Value`
+whose field types are all `Sendable` is `Sendable`; a `Value` carrying a
+`SendableRef` field (and no `HandleScoped` field) inherits `SendableRef` (the
+copy embeds a Pid — reference semantics travel with it, and hover must say
+so); a `Value` carrying a `HandleScoped` field inherits `HandleScoped` (the
+copy embeds the handle). Ordering: `Sendable < SendableRef < HandleScoped`,
+with `Unknown` fields making the composite `Unknown`.
 
 Honest scoping note: **no diagnostic rule consumes `SendableRef` in v1**, and
 rather than leave the tier's fate as an implementation choice (which would let

--- a/docs/ADR/0103-sendability-typing-from-class-kinds.md
+++ b/docs/ADR/0103-sendability-typing-from-class-kinds.md
@@ -1,0 +1,211 @@
+# ADR 0103: Sendability Typing from Class Kinds
+
+## Status
+Proposed (2026-07-05)
+
+## Context
+
+### Problem statement
+
+Values cross process boundaries constantly in Beamtalk — actor message
+arguments and returns, `spawnWith:` initial state, Announcement payloads, and
+blocks handed to actors (e.g. `Timer every: 1000 do: [...]`). On the BEAM,
+a send *copies* the term. Whether that copy means what the sender thinks it
+means depends on what kind of value it is — and Beamtalk's three class kinds
+(ADR 0067) already name exactly the distinction that matters:
+
+| Kind | Runtime shape | What a send does | Hazard |
+|---|---|---|---|
+| `Value` | plain Erlang map, immutable | perfect copy — semantically free | none |
+| `Actor` | Pid reference | copies the *reference*; identity preserved | dies with the process; remote-node OK |
+| `Object` | no Beamtalk-managed data, but instances may wrap runtime-backed handles (ETS refs, ports — e.g. `Subscription`'s `SubRef`) | copies the handle | handle validity is **scoped** — many are node-global, some process-bound (ports), none survive naïve use after the owner dies; distribution to a remote node can silently break them |
+
+Today the type checker knows a receiver's class but does nothing with the
+*kind*. Sending a port-wrapping Object to an actor on another node, or
+capturing one in a block passed to `Timer`, is silently fine at compile time
+and confusing at runtime.
+
+### Why Beamtalk specifically (positioning)
+
+Elixir and Gleam cannot express this *question*: all their data is immutable,
+and their identity idioms (bare Pids, ETS handles, refs) carry no type-level
+distinction at all. Pony answers it with six reference capabilities and a
+famously steep learning curve. Beamtalk's surface syntax **already encodes the
+answer** — users write `Value subclass:` / `Actor subclass:` /
+`Object subclass:` today. The checker just has to use it. See
+`docs/internal/positioning.md` (Seed 1).
+
+### Constraints
+
+- **Advisory only.** ADR 0100 governs: sendability findings are warnings/lints
+  graded by knowledge completeness, never compile blockers. Dynamic receivers
+  and arguments are silent.
+- **No new annotations required** for the common case — the class kind *is*
+  the annotation.
+- **No runtime cost.** This is edit/compile-time analysis; codegen unchanged.
+
+## Decision
+
+Derive a **sendability tier** for every inferred type from its class kind, and
+warn when a value's tier is too weak for the boundary it crosses.
+
+### Tiers
+
+```text
+Sendable       — Value kinds, primitives (Integer, String, …), Symbol,
+                 unions/collections of Sendable
+SendableRef    — Actor kinds (Pid-backed): reference semantics survive the
+                 send; validity tied to process lifetime
+HandleScoped   — Object kinds wrapping runtime-backed state (declared, see
+                 below): valid within a scope (node-global or process-bound)
+Unknown        — Dynamic, or Object kinds with no declaration (silent, per
+                 ADR 0100)
+```
+
+`Value` composes structurally: a `Value` whose field types are all `Sendable`
+is `Sendable`; a `Value` carrying a `HandleScoped` field inherits
+`HandleScoped` (the copy embeds the handle).
+
+### Declaring handle scope (the one new annotation)
+
+`Object subclass:` classes that wrap runtime state may declare their scope;
+undeclared Object kinds stay `Unknown` (silent):
+
+```beamtalk
+// node-global handle: fine to send within the node, not across nodes
+sealed typed Object subclass: Subscription
+  handleScope: #node
+
+// process-bound handle (e.g. wraps a port): only meaningful in the owner
+sealed typed Object subclass: SocketHandle
+  handleScope: #process
+```
+
+### Checked boundaries
+
+1. **Actor message arguments and `spawnWith:` maps** — warn when a
+   `HandleScoped(#process)` value is passed; info-level note for
+   `#node`-scoped values only when the receiver is known to be remote
+   (named-actor registration on another node, ADR 0079).
+2. **Blocks sent to actors** (including `Timer every:do:`, `!` casts) — warn
+   when the block's *captured environment* (already computed for closure
+   conversion) includes a `HandleScoped(#process)` value.
+3. **Announcement payloads** — same rule as message arguments.
+
+### Error example
+
+```beamtalk
+sock := SocketHandle open: 8080
+worker ! [sock readLine]
+// ⚠️ block captures `sock` (SocketHandle, handleScope: #process) and is sent
+//    to another process — the handle is only valid in the owning process.
+//    Consider passing data, or an Actor that owns the socket.
+```
+
+### REPL session
+
+```
+bt> p := Point x: 1 y: 2        // Value — Sendable
+bt> counter ! (p)                // fine, no diagnostic
+bt> sub := announcer when: Tick do: [:e | e]
+bt> remoteWorker register: sub   // remote receiver + #node handle
+   ℹ️ `sub` (Subscription, handleScope: #node) sent to a remote node — the
+      handle will not be valid there
+```
+
+## Prior Art
+
+| System | Approach | Take / leave |
+|---|---|---|
+| **Pony** | Six reference capabilities (`iso`, `val`, `ref`, …) checked soundly | The *goal* (deny bad sends) without the cost: Pony's capabilities annotate every type use; Beamtalk reads three class kinds users already declare. We accept advisory instead of sound. |
+| **Rust** | `Send`/`Sync` auto-traits, structural derivation | The composition model — sendability derived structurally through fields — is exactly our `Value` rule. |
+| **Erlang/Elixir** | None; copy silently, handles carry no distinction | The gap this fills. |
+| **Gleam** | All-immutable so data is trivially sendable; typed `Subject` covers references only | Confirms the reference tier is worth typing; Gleam has no handle tier at all. |
+
+## User Impact
+
+- **Newcomer:** never sees this until they wrap a port and send it — then gets
+  an explanation instead of a hang. `handleScope:` is discoverable via the
+  class-kind docs.
+- **Smalltalk developer:** no change to message semantics; one optional
+  declaration keyword on FFI-wrapping classes.
+- **Erlang/BEAM developer:** finally a compile-time answer to "is it safe to
+  send this?" — a question they answer today by reading implementation.
+- **Operator:** fewer "works on one node, breaks distributed" surprises;
+  zero runtime change.
+- **Tooling developer:** tiers derive from existing `ClassHierarchy` kind
+  data; hover can show a value's tier.
+
+## Steelman Analysis
+
+- 🧑‍💻 **Newcomer, for doing nothing:** "I don't distribute; this warning is
+  noise." — Countered: `#process`-scoped warnings fire only on real
+  cross-process sends, which bite single-node users too.
+- ⚙️ **BEAM veteran, for runtime checks instead:** "Just crash early on bad
+  handle use." — Countered: the crash happens far from the send; edit-time
+  attribution is the point. Runtime checks also cost every send.
+- 🎨 **Language designer, for full capabilities (Pony):** "Advisory tiers are
+  unsound; mutation through a copied alias still lurks." — Acknowledged:
+  Beamtalk chooses gradual/advisory across the board (ADR 0100); soundness is
+  explicitly not the product (see positioning.md, "What this rules out").
+
+### Tension point
+Whether `#node`-scoped sends to *possibly*-remote receivers warn or stay
+silent: veterans want silence (distribution is deliberate), newcomers want the
+note. Resolved by grading on *knowledge*: warn only when remoteness is
+statically known (ADR 0079 registration), otherwise silent.
+
+## Alternatives Considered
+
+### Do nothing
+Handles keep failing at a distance. Rejected: the class-kind information is
+already declared; not using it wastes Beamtalk's one structural advantage here.
+
+### Runtime send-guards
+Wrap `gen_server` sends with tier checks. Rejected: per-send cost, crashes
+instead of edit-time diagnostics, and cannot see block captures.
+
+### Full capability system (Pony-style)
+Sound but demands per-use annotations and a learning curve incompatible with
+gradual adoption. Rejected; recorded as the sound end-state this deliberately
+under-shoots.
+
+## Consequences
+
+### Positive
+- The first BEAM language where "will this value survive the send?" is a
+  typed, hover-visible property — at near-zero annotation cost.
+- Block-capture checking reuses closure-conversion data; no new analysis pass.
+
+### Negative
+- `handleScope:` is a new class-side keyword (parser + ClassHierarchy +
+  codegen metadata).
+- Tier derivation for generic collections needs care
+  (`List(SocketHandle)` is `HandleScoped`); interacts with ADR 0102's
+  `type_args` rules.
+- False silence is guaranteed under `Dynamic` — must be documented as
+  advisory, not a guarantee.
+
+### Neutral
+- No runtime or codegen behaviour change; metadata only.
+
+## Implementation
+
+1. **Phase 0 (napkin):** derive tiers from class kinds only (no
+   `handleScope:`), warn on the single clearest case — `#process`-scoped
+   stdlib types (ports) passed in actor messages. Validates the plumbing.
+2. **Phase 1:** `handleScope:` keyword (parser, `ClassDefinition`,
+   `ClassHierarchy`, `__beamtalk_meta`), tier derivation incl. `Value`
+   composition, message-argument + `spawnWith:` checks. ~M.
+3. **Phase 2:** block-capture checking; Announcement payloads; remote-receiver
+   grading via ADR 0079 registration data. ~M.
+
+**Affected:** parser/AST, class hierarchy, type checker, hover; **not**
+codegen output semantics or runtime dispatch.
+
+## References
+- Seed: `docs/internal/positioning.md` (Seed 1)
+- Related ADRs: ADR 0067 (class kinds), ADR 0042 (value types), ADR 0100
+  (advisory severity), ADR 0079 (named/remote actors), ADR 0102 (type
+  operators, `type_args` rules), ADR 0093 (Announcements)
+- Prior art: Pony reference capabilities; Rust `Send`/`Sync`

--- a/docs/ADR/0104-typed-actor-protocols.md
+++ b/docs/ADR/0104-typed-actor-protocols.md
@@ -1,0 +1,206 @@
+# ADR 0104: Typed Actor Protocols — the Class Interface Is the Protocol
+
+## Status
+Proposed (2026-07-05)
+
+## Context
+
+### Problem statement
+
+Nobody on the BEAM types the process boundary well. Erlang/Elixir `GenServer`
+funnels every message through `handle_call/3` — the compiler cannot relate a
+call site to the clause that handles it. Gleam gets typed messaging only by
+inventing `Subject(msg)`, a parallel, non-OTP-standard actor layer.
+
+Beamtalk's model — **actor = class, message = selector, sync send =
+`gen_server:call`** — means the actor's class interface *already is* its
+protocol type. `docs/internal/type-system-design.md` names this Option A
+("messages typed by actor's interface") and recommends it, but no ADR ratifies
+it or defines the async edges. Meanwhile the checker already infers through
+sync actor sends as ordinary method sends — by accident of representation
+rather than by decision.
+
+### What is undefined today
+
+1. **Cast (`!`).** `worker doThing!` uses `gen_server:cast` and returns `nil`
+   immediately (`beamtalk-language-features.md` §Explicit Async Cast). What is
+   its static type — and should a cast to a method whose return value matters
+   be flagged?
+2. **`spawn` / `spawnWith:`.** Class-side constructors returning an actor
+   reference; `spawnWith:` takes an initial-state map that should check
+   against declared `state:` slots.
+3. **Timeouts.** `db withTimeout: 30000` returns a `TimeoutProxy` that
+   forwards everything — the proxy should be *transparent* to typing (same
+   interface as the wrapped actor), and a timed-out call raises rather than
+   returning, so return types are unchanged.
+4. **Cross-process DNU.** An unknown selector raises `does_not_understand` in
+   the *callee* process. Open-world policy (ADR 0100) applies with the same
+   knowledge grading as local sends.
+
+### Constraints
+
+- **No parallel messaging layer.** The whole point (contra Gleam) is that
+  typing falls out of the class interface. No `Subject`, no channel types.
+- **Advisory** per ADR 0100.
+- **OTP-transparent:** typed actors remain plain `gen_server`s callable from
+  Erlang/Elixir.
+
+## Decision
+
+Ratify Option A and define the four edges. An `Actor subclass:`'s **public
+method set is its message protocol**; the checker types actor sends exactly as
+method sends, with these rules:
+
+### 1. Sync send — already works; now guaranteed
+
+```beamtalk
+counter :: Counter := Counter spawn
+counter increment      // :: Integer — the method's declared/inferred return
+```
+
+### 2. Cast (`!`) types as `Nil` — and warns on discarded meaning
+
+```beamtalk
+counter increment!          // :: Nil — fire-and-forget
+x := counter getCount!      // ⚠️ cast discards the reply: `getCount` returns
+                            //    Integer, but `!` always yields nil
+```
+
+The rule: `expr selector!` has type `Nil`. When the target method's return
+type is neither `Nil` nor `Self` (conventional for fluent/command methods) and
+the cast's value is *used* (assigned, returned, or an argument), warn — the
+reply is silently thrown away.
+
+### 3. Constructors check state
+
+```beamtalk
+Counter spawnWith: #{count => 0}     // :: Counter — keys checked against
+                                     //    declared `state:` slots and types
+Counter spawnWith: #{cuont => 0}     // ⚠️ unknown state key `cuont` —
+                                     //    did you mean `count`?
+```
+
+`spawn` / `spawnWith:` on `Meta{C}` return `Known{C}` (instance type), using
+ADR 0083's metaclass-aware inference.
+
+### 4. Proxies are transparent; DNU follows ADR 0100
+
+`withTimeout:` returns a value typed as the *wrapped actor's class* (the
+`TimeoutProxy` forwards everything; a timeout raises, so return types are
+unchanged). Unknown selectors on a statically-known actor class get the same
+knowledge-graded diagnostic as any send (ADR 0100) — the process boundary adds
+no new severity rule.
+
+### Error example
+
+```beamtalk
+logger := Logger spawn
+logger logg: "hi"
+// ⚠️ Logger does not understand `logg:` — did you mean `log:`?
+//    (same open-world grading as a local send; the process boundary is
+//     invisible to the diagnostic)
+```
+
+## Prior Art
+
+| System | Approach | Take / leave |
+|---|---|---|
+| **Gleam `gleam_otp`** | `Subject(msg)` — typed channel, parallel to OTP | Proves demand for typed actors on BEAM; rejects the parallel layer. Beamtalk's dispatch *is* the typed surface, and stays OTP-standard. |
+| **Erlang/Elixir GenServer** | Untyped `handle_call` funnel | The baseline being improved on; Beamtalk actors remain callable as plain gen_servers. |
+| **Akka Typed (Scala)** | `Behavior[Msg]` — protocol as message ADT | Same goal via sum types; Beamtalk gets it via selectors, which also gives per-message docs/completion for free. |
+| **Pony** | Behaviours (async methods) are typed and return nothing | Validates "casts type as no-reply"; Pony makes it structural (`be` methods), we make it call-site (`!`). |
+| **Session types (research)** | Type message *sequences*, not just signatures | Deliberately out of scope: per-message typing is the 80%; protocol-state typing is research-grade and fights liveness. |
+
+## User Impact
+
+- **Newcomer:** actor calls autocomplete and type-check like any method call —
+  the process boundary costs nothing cognitively. The `!`-discards-reply
+  warning catches the classic beginner bug.
+- **Smalltalk developer:** "messages all the way down" (principle 6) now
+  extends to typing; nothing new to learn.
+- **Erlang/BEAM developer:** `spawnWith:` key checking is the map-typo safety
+  `init/1` never had. Cross-node calls type the same as local (location
+  transparency preserved).
+- **Operator:** none — no runtime or wire change.
+- **Tooling developer:** REPL/LSP completion on actor references needs no
+  special case; `TimeoutProxy` transparency is one inference rule.
+
+## Steelman Analysis
+
+- 🎨 **Language designer, for session types:** "Signatures don't catch
+  calling `stop` before `start` — protocol *state* is the real actor bug." —
+  True and acknowledged: recorded as future work; requires typestate that
+  fights hot reload (a state machine checked against code that can change
+  mid-protocol).
+- ⚙️ **BEAM veteran, for doing nothing:** "gen_server has worked untyped for
+  30 years; dialyzer specs exist." — Countered: specs don't check call sites
+  against handlers; Beamtalk gets that for free from its own dispatch — the
+  cost of ratifying it is near zero.
+- 🧑‍💻 **Newcomer, against the cast warning:** "I cast to methods with
+  returns all the time — the reply is *optional*." — Accommodated: the warning
+  fires only when the cast's value is **used**; bare `counter increment!` with
+  a meaningful return is idiomatic and silent.
+
+### Tension point
+Whether `spawnWith:` unknown-key checking should be an error (it is a certain
+runtime problem) or stay advisory. ADR 0100's ladder says: closed knowledge
+(own class, declared slots) permits higher severity — proposed as `Warning`
+now, revisit with strict mode.
+
+## Alternatives Considered
+
+### Typed channels (`Subject`-style)
+A parallel typed messaging layer à la Gleam. Rejected: duplicates dispatch,
+breaks "messages all the way down", and abandons OTP-standard call semantics —
+the exact trade Beamtalk exists to avoid.
+
+### Protocol objects per actor
+Generate a separate protocol type from each actor class and require it in
+annotations (`:: CounterProtocol`). Rejected: the class name already serves;
+a second name per actor is ceremony without information.
+
+### Session/typestate protocols
+Type legal message *sequences*. Rejected for now (see steelman) — research
+grade, poor fit with hot reload; per-message typing delivers most value.
+
+## Consequences
+
+### Positive
+- Typed actors with **zero new syntax** for the sync path — ratification plus
+  four small rules, most reusing existing inference (ADR 0083 metaclass
+  inference, ordinary method checking).
+- The cast-discard warning eliminates a real, common silent bug.
+- Distinctive vs whole ecosystem: typed actor messaging that is also plain
+  OTP.
+
+### Negative
+- `spawnWith:` checking needs `state:` slot types in `ClassHierarchy` metadata
+  (they exist for codegen; must be surfaced to the checker).
+- `TimeoutProxy` transparency is a special-case inference rule (proxy class →
+  wrapped class); any future proxy needs the same treatment or a general
+  `forwards ::` mechanism (see north-star DNU section — this is its option 3).
+- Cast-usage analysis ("is the value used?") adds a small dataflow check.
+
+### Neutral
+- No wire, runtime, or codegen change; Erlang callers see identical
+  gen_servers.
+
+## Implementation
+
+1. **Phase 1 (~S):** ratify sync-send typing with tests (it works today —
+   pin it); `!` types as `Nil`.
+2. **Phase 2 (~M):** cast-discard warning (usage analysis); `spawnWith:`
+   key/type checking against `state:` slots.
+3. **Phase 3 (~S):** `TimeoutProxy` transparency rule; cross-process DNU
+   wording unified with ADR 0100 diagnostics.
+
+**Affected:** type checker (inference + validation), class-hierarchy metadata,
+diagnostics; **not** runtime, codegen, or the wire protocol.
+
+## References
+- Seed: `docs/internal/positioning.md` (Seed 2)
+- Design basis: `docs/internal/type-system-design.md` §Actor Message Passing
+  (Option A); `docs/beamtalk-principles.md` 6, 7
+- Related ADRs: ADR 0100 (severity), ADR 0083 (metaclass inference), ADR 0079
+  (named actors), ADR 0067 (`state:`), ADR 0102 (operators)
+- Prior art: Gleam `gleam_otp` `Subject`; Akka Typed; Pony behaviours

--- a/docs/ADR/0104-typed-actor-protocols.md
+++ b/docs/ADR/0104-typed-actor-protocols.md
@@ -230,10 +230,10 @@ grade, poor fit with hot reload; per-message typing delivers most value.
 ## Implementation
 
 1. **Phase 1 (~S):** ratify sync-send typing with tests (it works today —
-   pin it); `!` retypes as `Nil` **behind the migration audit** (below); fix
-   the `beamtalk-language-features.md` cast-syntax inconsistency (its §Explicit
-   Async Cast shows a prefix `c ! increment` example the grammar does not
-   accept — real usage and the parser are postfix `c increment!`).
+   pin it); `!` retypes as `Nil` **behind the migration audit** (below). (The
+   `beamtalk-language-features.md` cast-syntax fix — prefix `c ! increment` →
+   postfix `c increment!` — is **already landed** in the PR that carries this
+   ADR; no Phase 1 work remains for it.)
 2. **Phase 2 (~M):** `spawnWith:` key checking — AST-level `MapLiteral` pair
    inspection at the call site, unknown-key `Warning` (provably-failing tier),
    typo suggestions; slot-value checking where ADR 0102's algebra permits.

--- a/docs/ADR/0104-typed-actor-protocols.md
+++ b/docs/ADR/0104-typed-actor-protocols.md
@@ -70,7 +70,10 @@ x := counter getCount!      // ✗ already a PARSE ERROR today:
 The grammar already enforces more than a warning could: casts are legal
 **only as bare statements** (`cast_in_expression_error`, enforced in the
 parser and pinned by parser tests — `x := foo bar!` and `^foo bar!` are
-rejected outright). So no "discarded reply" dataflow analysis is needed or
+rejected outright). For avoidance of doubt: the postfix statement-cast is the
+**only** `!` form — there is no infix `actor ! expr` in Beamtalk (raw Erlang
+`!` is not exposed as surface syntax), so there is exactly one async-send
+construct for the type rule and for ADR 0103's sendability checks to cover. So no "discarded reply" dataflow analysis is needed or
 possible — the only remaining rule is the *type*: a cast statement's value is
 `Nil` (today it is `Dynamic`).
 

--- a/docs/ADR/0104-typed-actor-protocols.md
+++ b/docs/ADR/0104-typed-actor-protocols.md
@@ -58,18 +58,35 @@ counter :: Counter := Counter spawn
 counter increment      // :: Integer — the method's declared/inferred return
 ```
 
-### 2. Cast (`!`) types as `Nil` — and warns on discarded meaning
+### 2. Cast (`!`) types as `Nil` — the misuse case is already a parse error
 
 ```beamtalk
-counter increment!          // :: Nil — fire-and-forget
-x := counter getCount!      // ⚠️ cast discards the reply: `getCount` returns
-                            //    Integer, but `!` always yields nil
+counter increment!          // :: Nil — fire-and-forget, bare statement
+x := counter getCount!      // ✗ already a PARSE ERROR today:
+                            //   cast_in_expression_error — a cast cannot be
+                            //   assigned, returned, or passed as an argument
 ```
 
-The rule: `expr selector!` has type `Nil`. When the target method's return
-type is neither `Nil` nor `Self` (conventional for fluent/command methods) and
-the cast's value is *used* (assigned, returned, or an argument), warn — the
-reply is silently thrown away.
+The grammar already enforces more than a warning could: casts are legal
+**only as bare statements** (`cast_in_expression_error`, enforced in the
+parser and pinned by parser tests — `x := foo bar!` and `^foo bar!` are
+rejected outright). So no "discarded reply" dataflow analysis is needed or
+possible — the only remaining rule is the *type*: a cast statement's value is
+`Nil` (today it is `Dynamic`).
+
+**That retype is not free.** Typing casts as `Nil` activates a currently
+dormant check: `check_return_type` skips `Dynamic` bodies, so a method
+declared `-> SomeType` whose body *ends* in a bare cast produces no
+diagnostic today but would newly warn ("body returns Nil"). That is usually a
+genuine catch (the method doesn't return what it declares), but it is a
+new-diagnostic wave on existing code — see Migration Path.
+
+One deliberate non-feature: there is **no** "you cast to a method with a
+meaningful return" warning. Fire-and-forget casts to result-returning methods
+(`self tick!`, `counter increment!` where `increment` returns the new count)
+are idiomatic — intent is not statically detectable, and unannotated mutators
+infer concrete return types (there is no implicit-`Self` convention to key
+off), so any such warning would mostly fire on correct code.
 
 ### 3. Constructors check state
 
@@ -83,13 +100,19 @@ Counter spawnWith: #{cuont => 0}     // ⚠️ unknown state key `cuont` —
 `spawn` / `spawnWith:` on `Meta{C}` return `Known{C}` (instance type), using
 ADR 0083's metaclass-aware inference.
 
-### 4. Proxies are transparent; DNU follows ADR 0100
+### 4. Proxy return-type transparency; DNU follows ADR 0100
 
-`withTimeout:` returns a value typed as the *wrapped actor's class* (the
-`TimeoutProxy` forwards everything; a timeout raises, so return types are
-unchanged). Unknown selectors on a statically-known actor class get the same
-knowledge-graded diagnostic as any send (ADR 0100) — the process boundary adds
-no new severity rule.
+Getting the *severity* right costs nothing — `TimeoutProxy` overrides
+`doesNotUnderstand:` to forward, and ADR 0100 already makes unresolved
+selectors on DNU-overriding receivers silent, so there are no false
+diagnostics today. What is actually missing is **positive inference**:
+`withTimeout:` is hardcoded to return `TimeoutProxy`
+(`generated_builtins.rs`), so `slowDb query: sql` types as `Dynamic` instead
+of the wrapped class's real return type. The rule: `withTimeout:` on a
+receiver of type `C` returns a value *typed as `C`* (a timeout raises rather
+than returning, so method return types are unchanged). Unknown selectors on a
+statically-known actor class get the same knowledge-graded diagnostic as any
+send (ADR 0100) — the process boundary adds no new severity rule.
 
 ### Error example
 
@@ -136,16 +159,23 @@ logger logg: "hi"
   30 years; dialyzer specs exist." — Countered: specs don't check call sites
   against handlers; Beamtalk gets that for free from its own dispatch — the
   cost of ratifying it is near zero.
-- 🧑‍💻 **Newcomer, against the cast warning:** "I cast to methods with
-  returns all the time — the reply is *optional*." — Accommodated: the warning
-  fires only when the cast's value is **used**; bare `counter increment!` with
-  a meaningful return is idiomatic and silent.
+- 🧑‍💻 **Newcomer, for a discarded-reply warning:** "Warn me when I cast to
+  something that returns a value I probably wanted!" — Rejected after checking
+  the grammar: casts are *already* illegal in expression position (parse
+  error), so the reply can never be accidentally consumed; and fire-and-forget
+  casts to result-returning methods are idiomatic, so an intent-guessing
+  warning would mostly fire on correct code (see Decision §2).
 
 ### Tension point
 Whether `spawnWith:` unknown-key checking should be an error (it is a certain
-runtime problem) or stay advisory. ADR 0100's ladder says: closed knowledge
-(own class, declared slots) permits higher severity — proposed as `Warning`
-now, revisit with strict mode.
+runtime problem) or stay advisory — and how `Warning` squares with ADR 0100,
+whose Rule 1 caps a single closed-complete receiver's *unresolved selector*
+at `Hint`. The reconciliation: an unknown `spawnWith:` key is not an
+unresolved selector but a **provably failing** construction — the class's
+`state:` slots are a closed set declared in the same program, and a key
+outside it cannot succeed — which is the tier ADR 0100 *does* grade `Warning`.
+Proposed as `Warning` on that basis (not as a silent escalation); revisit with
+strict mode.
 
 ## Alternatives Considered
 
@@ -174,12 +204,21 @@ grade, poor fit with hot reload; per-message typing delivers most value.
   OTP.
 
 ### Negative
-- `spawnWith:` checking needs `state:` slot types in `ClassHierarchy` metadata
-  (they exist for codegen; must be surfaced to the checker).
+- `spawnWith:` checking is **not** blocked on metadata — `state:` slot types
+  are already checker-visible (`ClassHierarchy::state_field_type`, already
+  consumed in inference). The real work is at the **call site**: map-literal
+  inference currently collapses to one joined `Dictionary(K, V)`, discarding
+  the individual literal keys, so key checking needs AST-level `MapLiteral`
+  pair inspection plus typo-suggestion logic that doesn't exist anywhere yet.
+- Slot *value* checking against union-typed slots (e.g. `TimeoutProxy`'s own
+  `timeoutMs :: Integer | #infinity`) rides on ADR 0102's union algebra.
 - `TimeoutProxy` transparency is a special-case inference rule (proxy class →
-  wrapped class); any future proxy needs the same treatment or a general
-  `forwards ::` mechanism (see north-star DNU section — this is its option 3).
-- Cast-usage analysis ("is the value used?") adds a small dataflow check.
+  wrapped class, replacing today's hardcoded `TimeoutProxy` return); any
+  future proxy needs the same treatment or a general `forwards ::` mechanism
+  (the north-star DNU section's option 3).
+- The cast retype (`Dynamic` → `Nil`) activates the dormant
+  `check_return_type` path for bare-cast method tails — a new-diagnostic wave
+  (see Migration Path).
 
 ### Neutral
 - No wire, runtime, or codegen change; Erlang callers see identical
@@ -188,19 +227,39 @@ grade, poor fit with hot reload; per-message typing delivers most value.
 ## Implementation
 
 1. **Phase 1 (~S):** ratify sync-send typing with tests (it works today —
-   pin it); `!` types as `Nil`.
-2. **Phase 2 (~M):** cast-discard warning (usage analysis); `spawnWith:`
-   key/type checking against `state:` slots.
-3. **Phase 3 (~S):** `TimeoutProxy` transparency rule; cross-process DNU
-   wording unified with ADR 0100 diagnostics.
+   pin it); `!` retypes as `Nil` **behind the migration audit** (below); fix
+   the `beamtalk-language-features.md` cast-syntax inconsistency (its §Explicit
+   Async Cast shows a prefix `c ! increment` example the grammar does not
+   accept — real usage and the parser are postfix `c increment!`).
+2. **Phase 2 (~M):** `spawnWith:` key checking — AST-level `MapLiteral` pair
+   inspection at the call site, unknown-key `Warning` (provably-failing tier),
+   typo suggestions; slot-value checking where ADR 0102's algebra permits.
+3. **Phase 3 (~S):** `TimeoutProxy` return-type transparency rule (replace
+   the hardcoded `TimeoutProxy` return); cross-process DNU wording unified
+   with ADR 0100 diagnostics.
 
-**Affected:** type checker (inference + validation), class-hierarchy metadata,
-diagnostics; **not** runtime, codegen, or the wire protocol.
+**Affected:** type checker (inference + validation), diagnostics, one
+language-features doc fix; **not** runtime, codegen, or the wire protocol.
+
+## Migration Path
+
+The only behaviour change on existing code is the cast retype: methods with a
+declared return type whose body **ends in a bare cast** currently escape
+`check_return_type` (`Dynamic` bails out) and will newly warn that the body
+returns `Nil`. This is usually a genuine mismatch worth surfacing, but it is
+a new-diagnostic wave: before shipping Phase 1, audit the stdlib and test
+corpus for bare-cast method tails and fix or annotate them in the same
+change. Everything else (`spawnWith:` checking, proxy transparency) is
+purely additive and advisory.
 
 ## References
 - Seed: `docs/internal/positioning.md` (Seed 2)
 - Design basis: `docs/internal/type-system-design.md` §Actor Message Passing
-  (Option A); `docs/beamtalk-principles.md` 6, 7
-- Related ADRs: ADR 0100 (severity), ADR 0083 (metaclass inference), ADR 0079
-  (named actors), ADR 0067 (`state:`), ADR 0102 (operators)
+  (Option A); `docs/beamtalk-principles.md` 6, 7;
+  `docs/internal/set-theoretic-types-north-star.md` §Working around
+  `doesNotUnderstand:` (option 3 — `forwards ::` for typed proxies)
+- Related ADRs: ADR 0100 (severity — incl. the provably-failing tier the
+  `spawnWith:` Warning rests on), ADR 0083 (metaclass inference), ADR 0079
+  (named actors), ADR 0067 (`state:`), ADR 0102 (union algebra for
+  union-typed slots)
 - Prior art: Gleam `gleam_otp` `Subject`; Akka Typed; Pony behaviours

--- a/docs/ADR/0105-live-image-recheck-on-reload.md
+++ b/docs/ADR/0105-live-image-recheck-on-reload.md
@@ -22,14 +22,26 @@ construction. **Nobody can demo: change a running method's signature and watch
 the stale callers light up.** The infrastructure to do it is unusually cheap
 for Beamtalk, because the hard part already shipped:
 
-- **ADR 0087 (Implemented):** `beamtalk_xref` maintains a selector→call-sites
-  index in the runtime, kept correct across hot reload (purge + new-generation
-  install) and ClassBuilder lifecycle hooks. That *is* the dependency graph
-  incremental re-checking needs.
+- **ADR 0087 (Implemented):** `beamtalk_xref` maintains a **selector-keyed**
+  call-sites index in the runtime (`{Selector, Site}` bag; sites carry owner,
+  method, line, `recv_kind` — *not* a static receiver class), kept correct
+  across hot reload and ClassBuilder lifecycle hooks. That is *most of* the
+  dependency graph incremental re-checking needs — see Mechanism step 2 for
+  what it is not.
 - **Principle 12:** the compiler is the language service — the same
-  `beamtalk-core` that compiled the edit can re-check its dependents.
+  `beamtalk-core` that compiled the edit can re-check its dependents (via the
+  compiler port, ADR 0022 — a separate OS process, so round-trips must batch).
 - **ADR 0100:** the severity ladder for "how certain is the checker" already
-  exists; reload-induced findings slot straight into it.
+  exists; reload-induced findings slot into it (see Severity — including one
+  place where this ADR must *not* silently escalate).
+
+One honest caveat up front: **hot-patching currently *discards* type
+metadata.** `put_method/4` deliberately clears the patched selector's
+signature and return type (`beamtalk_object_class.erl` — "return types are
+cleared for hot-patched methods; the compiler treats them as dynamic",
+confirmed by ADR 0050), and `__beamtalk_meta/0` is stale after live patches by
+design. So the interface delta this ADR needs is **new plumbing captured at
+patch time**, not a read of existing state — see Mechanism step 1.
 
 ### What "stale" means
 
@@ -62,23 +74,51 @@ as live diagnostics on all surfaces (LSP, workspace UI, REPL notification).
 
 ### Mechanism
 
-1. **Signature diff.** When the workspace compiler (`beamtalk_repl_compiler` /
-   ClassBuilder path) installs a redefinition, compute the *interface delta*
-   against the previous generation: per selector — added / removed /
-   signature-changed (using the same method metadata codegen already emits in
-   `__beamtalk_meta`).
-2. **Dependent lookup.** For each removed or signature-changed selector, query
-   `beamtalk_xref` (ADR 0087) for its call sites: `(module, selector, arity) →
-   [caller methods]`.
-3. **Targeted re-check.** Re-run the type checker on exactly those caller
-   methods against the *new* interface. One level only — a caller whose own
-   interface is unchanged by the finding does not trigger further fan-out
-   (its diagnostic is enough; its callers' relationship to *it* didn't
-   change).
+1. **Signature diff — captured at patch time, not read back.** The compiler
+   already computes the new method's signature when it compiles the edit; the
+   *compile response* must carry it, and the workspace must record it per
+   selector **before** `put_method/4` installs the patch (which clears type
+   metadata — see Context caveat). The previous generation's signature is
+   whatever was recorded at the *last* patch (or the original
+   `__beamtalk_meta` for never-patched methods). Capturing at every patch is
+   what keeps diffs working across repeated edits to the same method —
+   read-back from class state cannot, because the pre-patch type is wiped on
+   install. This is **new plumbing** through the compile-request/response
+   protocol and a small new signature-generation store in the workspace.
+2. **Dependent lookup — selector query, then receiver filter.**
+   `beamtalk_xref` is keyed by **selector only** (ADR 0087's schema has no
+   receiver-class component; `recv_kind` is self/super/ffi/other). So the
+   lookup is: query sites for the changed selector, then **filter candidates
+   by inferred receiver type** during re-check — a site calling `size` on a
+   `List` is not a dependent of `Counter>>size`. For common selectors this
+   filter is what keeps fan-out bounded; a **numeric cap on re-checked callers
+   per reload** (with a "N more not checked" note) is part of the design, and
+   extending the xref schema with a receiver-type key is the recorded
+   follow-up if fan-out proves hot (see Alternatives).
+3. **Re-check at file granularity, batched.** The checker's entry points are
+   whole-`Module` (`check_module` / `infer_types`); there is no
+   single-method check today. The unit of re-check is therefore the caller's
+   **enclosing compilation unit**, batched into **one compiler-port request**
+   per reload (the port is a separate OS process, ADR 0022 — ~2ms overhead
+   plus compile time per request; per-caller round-trips would not meet the
+   latency constraint). Sources come from the **live image**, never disk:
+   ADR 0082 makes in-memory `method_source` authoritative until
+   `Workspace flush`, and a flagged caller may itself carry unflushed edits.
+   A single-method check API is a possible later optimisation, not a
+   prerequisite. One level of fan-out only — with an honest caveat: the
+   cutoff is exact for callers with *declared* signatures, but a caller whose
+   *inferred* return type silently shifts (it delegates to the changed
+   method, no annotation) can propagate breakage to *its* callers unchecked.
+   That gap is **accepted** in this ADR; comparing re-inferred signatures at
+   the cutoff is the recorded refinement.
 4. **Publish.** Findings appear as diagnostics attributed to the caller's
    source location, tagged as reload-induced, on every surface
-   (surface-parity applies). They clear automatically when either side is
-   edited to agree.
+   (surface-parity applies). Clearing: a finding clears when either side is
+   re-edited to agree, when the change is undone via
+   `Workspace changes revert:` (ADR 0082), or on workspace restart
+   (reload-induced findings are session state, never persisted). Site-level
+   `@expect` markers keep their ADR 0100 Rule 3 precedence — an expected DNU
+   stays silent even when reload-induced.
 
 ### The demo (REPL/workspace session)
 
@@ -103,18 +143,36 @@ stay silent.
 ### Error example (removal)
 
 ```
-⚠ reload check: Counter>>reset was removed; 1 caller remains
+ℹ reload check: Counter>>reset was removed; 1 caller remains
    AdminPanel>>onClick (admin.bt:9): `counter reset` will raise
    does_not_understand at runtime
+   (Hint severity per ADR 0100 Rule 1 — single closed receiver)
 ```
 
 ### Severity
 
-Per ADR 0100's ladder: signature-mismatch and removed-selector findings on
-statically-known receivers are `Warning`; anything reached through `Dynamic`,
-`perform:`, or DNU-overriding receivers is silent or `Lint`. Reload-induced
-findings never block the reload (it already happened) and never fail a build
-(they live in the workspace session, not the artifact).
+ADR 0100 governs — and it must not be silently escalated. Its Rule 1 caps an
+unresolved selector on a single closed-complete receiver at **`Hint`** (its
+steelman explicitly rejects `Warning` there to avoid converting quiet hints
+into warnings overnight). Accordingly:
+
+- **Removed-selector findings** on a single statically-known receiver are
+  `Hint` — same as any other unresolved selector under Rule 1. Reload adds
+  attribution ("removed by the reload of X"), not severity.
+- **Signature-mismatch findings** (`+ 1` on a now-`String` return) are type
+  mismatches, not unresolved selectors — they take whatever severity the
+  ordinary type checker gives that mismatch. Reload changes *when* they're
+  discovered, not *how severe* they are.
+- Anything reached through `Dynamic`, `perform:`, or DNU-overriding receivers
+  is silent, as always. Site-level `@expect` (Rule 3) wins over reload
+  attribution.
+- If experience shows reload-induced findings deserve more prominence than
+  their static equivalents, that is an explicit ADR 0100 Rule 3 carve-out to
+  propose *there* (with the argument that post-reload certainty differs from
+  static certainty) — not a default this ADR smuggles in.
+
+Reload-induced findings never block the reload (it already happened) and
+never fail a build (they live in the workspace session, not the artifact).
 
 ## Prior Art
 
@@ -169,6 +227,22 @@ one-level; measure; ADR 0087's benchmarking precedent (BT-2299) applies.
 Simple and complete; unbounded latency as images grow. Rejected as the
 default; may become an explicit command (`:recheck image`).
 
+### Per-caller (single-method) re-check
+The ideal granularity — but no single-method check API exists (the checker's
+entry points are whole-`Module`). Building one is real infrastructure.
+**Adopted middle ground instead:** re-check the affected caller's whole
+enclosing compilation unit, batched into one port request (Mechanism step 3).
+Per-file is coarser than per-method but bounded, and reuses `check_module`
+unchanged; the single-method API is a later optimisation if file-granularity
+latency disappoints.
+
+### Extend xref with a receiver-type key
+Would make dependent lookup precise instead of selector-wide (Mechanism step
+2's filter). Not chosen now — it changes ADR 0087's shipped schema and
+generation lifecycle for a cost that only matters if common-selector fan-out
+proves hot in practice. Recorded as the follow-up, with the per-reload caller
+cap as the interim guard.
+
 ### Static-only (no runtime trigger)
 Let the LSP re-check open files on edit, ignore the live image. Rejected: the
 whole point is the *image* — callers in files nobody has open are exactly the
@@ -183,11 +257,15 @@ anti-liveness, and off-positioning.
 ### Positive
 - The thirty-second demo no BEAM language can give: live signature change →
   stale callers flagged with locations, from the running image.
-- Reuses shipped infrastructure (xref, language-service compiler, severity
-  policy, LSP publishing) — the novel code is a diff + a trigger + a targeted
-  re-check loop.
-- Makes ADR 0104's actor typing durable under liveness (actor interface
-  changes re-check senders).
+- Builds on shipped infrastructure (xref, compiler port, severity policy, LSP
+  publishing) — but honestly: the **new** code is real, not glue. Signature
+  capture at patch time (because hot-patch *clears* type metadata),
+  receiver-type filtering over selector-keyed xref results, and batched
+  whole-file re-checks are all net-new plumbing (see Mechanism). What's
+  reused is the checker itself, the index, and the diagnostic channels.
+- Would make ADR 0104's actor typing durable under liveness (actor interface
+  changes re-check senders) — noting 0104 is itself Proposed, so this is a
+  benefit contingent on an unbuilt dependency.
 
 ### Negative
 - The workspace runtime must call back into the Rust compiler for re-checks —
@@ -207,16 +285,23 @@ anti-liveness, and off-positioning.
 
 ## Implementation
 
-1. **Phase 0 (napkin, ~S):** hard-code one case end-to-end — method signature
-   change via workspace save → xref lookup → re-check one caller → one LSP
-   diagnostic. Proves the runtime→compiler round-trip, which is the risky
-   part.
-2. **Phase 1 (~M):** interface-delta computation from `__beamtalk_meta`
-   generations; removed-selector and signature-change findings; surface-parity
-   plumbing (LSP + workspace UI + REPL notice).
+1. **Phase 0 (napkin, ~M — this is the risky part, not an ~S):** one case
+   end-to-end, proving the three assumptions the reviewers flagged: (a)
+   signature captured from the **compile response at patch time** (before
+   `put_method/4` clears type metadata) and retained across generations; (b)
+   selector-keyed xref lookup + receiver-type filter finds the right caller;
+   (c) a batched whole-file re-check through the compiler port returns a
+   diagnostic within interactive latency. One method, one caller, one LSP
+   diagnostic — reading the caller's **live** `method_source`, not disk.
+2. **Phase 1 (~M):** generalise: per-selector signature store with generation
+   handling (incl. repeated edits to the same method); removed-selector and
+   signature-change findings at ADR 0100 severities; caller cap + "N more not
+   checked" note; surface-parity plumbing (LSP + workspace UI + REPL notice);
+   clearing on re-edit / `Workspace changes revert:` / restart.
 3. **Phase 2 (~M):** shape changes (`state:`/`field:`) integrated with ADR
-   0104's `spawnWith:`/accessor checking; clearing logic; benchmarks per the
-   BT-2299 precedent.
+   0104's `spawnWith:`/accessor checking (once 0104 lands); benchmarks per
+   the BT-2299 precedent — including the common-selector fan-out case that
+   decides whether the xref receiver-key extension is needed.
 4. **Phase 3 (~S):** pre-save advisory in the editor (check before install);
    explicit `:recheck image` command (surface-parity entry required).
 

--- a/docs/ADR/0105-live-image-recheck-on-reload.md
+++ b/docs/ADR/0105-live-image-recheck-on-reload.md
@@ -113,12 +113,21 @@ as live diagnostics on all surfaces (LSP, workspace UI, REPL notification).
    the cutoff is the recorded refinement.
 4. **Publish.** Findings appear as diagnostics attributed to the caller's
    source location, tagged as reload-induced, on every surface
-   (surface-parity applies). Clearing: a finding clears when either side is
-   re-edited to agree, when the change is undone via
-   `Workspace changes revert:` (ADR 0082), or on workspace restart
-   (reload-induced findings are session state, never persisted). Site-level
-   `@expect` markers keep their ADR 0100 Rule 3 precedence — an expected DNU
-   stays silent even when reload-induced.
+   (surface-parity applies). **Clearing is replacement, not just agreement**:
+   every re-check of a caller **replaces all of that caller's reload-induced
+   findings with the new result — clean or different** — so findings can never
+   refer to a stale interface generation. This one rule covers the two
+   otherwise-missed paths: (a) *reload-fixes-reload* — reload B restores or
+   adapts the callee, the dependent re-check runs again (Mechanism steps 1–3
+   fire on every reload), and the caller's finding clears without anyone
+   editing the caller; (b) *supersession* — back-to-back reloads of the same
+   method re-check the caller against generation B and replace any
+   generation-A finding rather than accumulating contradictory diagnostics.
+   Findings also clear on `Workspace changes revert:` (ADR 0082) and on
+   workspace restart (session state, never persisted). The Phase 0 napkin
+   must validate the supersession case explicitly. Site-level `@expect`
+   markers keep their ADR 0100 Rule 3 precedence — an expected DNU stays
+   silent even when reload-induced.
 
 ### The demo (REPL/workspace session)
 
@@ -130,15 +139,16 @@ bt> counter getCount + 1          // => 1
 // ... in the editor: change `getCount -> Integer` to `getCount -> String`,
 //     save (method-level hot reload, ADR 0082) ...
 
-⚠ reload check: 2 callers of Counter>>getCount are now stale
+⚠ reload check: Counter>>getCount signature changed (Integer → String);
+   2 callers re-checked, 1 stale
    Dashboard>>refresh (dashboard.bt:14): `self counter getCount + 1`
      — `+ 1` expects a number, `getCount` now returns String
-   StatsView>>render (stats.bt:31): argument to `Transcript show:` — OK? no:
-     expects String — this caller is fine and is not reported
 ```
 
-Only genuinely-affected callers surface; agreeing callers re-check clean and
-stay silent.
+Only genuinely-affected callers surface. `StatsView>>render` was the second
+re-checked caller — it passes `getCount` to `Transcript show:`, which expects
+a `String`, so it re-checks *clean* against the new signature and is silently
+suppressed (the header's "2 re-checked, 1 stale" is the only trace of it).
 
 ### Error example (removal)
 
@@ -274,6 +284,15 @@ anti-liveness, and off-positioning.
   handling.
 - xref covers *compiled* call sites; workspace-defined bindings/snippets need
   their own dependent tracking (session bindings layer, ADR 0081).
+- **Proxy-routed calls are invisible to the dependent lookup.** A call through
+  a forwarding proxy (`counter withTimeout: 5000` then `getCount` — ADR 0104
+  §4) reaches `Counter` via the proxy's DNU forwarding, so xref records the
+  site under the proxy path, not `Counter>>getCount`; a signature change to
+  `Counter` can produce a false "no stale callers" for proxy-wrapped usage —
+  exactly the "files nobody has open" case this ADR exists for. Fix path:
+  either track proxies as meta-dependents of the wrapped class's interface in
+  xref, or (interim) accept and document the gap. The Phase 0 napkin must
+  probe the proxy case to establish the actual miss scope.
 - Interface deltas require previous-generation metadata retention — small but
   new state in the class registry.
 - Findings can be stale-about-staleness: a caller flagged after reload A may

--- a/docs/ADR/0105-live-image-recheck-on-reload.md
+++ b/docs/ADR/0105-live-image-recheck-on-reload.md
@@ -1,0 +1,235 @@
+# ADR 0105: Live Image Re-Checking on Hot Reload
+
+## Status
+Proposed (2026-07-05)
+
+## Context
+
+### Problem statement
+
+Beamtalk's premise is code that changes while it runs — method-level edit &
+save (ADR 0082), live patching as a message send (principle 11), hot reload as
+core (principle 2). But the type checker only sees code at compile time, one
+compilation unit at a time. When a method's signature changes *live*, every
+existing caller in the image is now potentially stale — and today nothing
+tells anyone until the stale call misbehaves at runtime.
+
+This is also the ecosystem's open problem, and Beamtalk's clearest
+opportunity (`docs/internal/positioning.md`, Seed 3): Gleam's FAQ concedes
+upgrades cannot be type-checked ("the usual Erlang amount of safety");
+Elixir's inference has no live image to re-check; Dialyzer is post-hoc by
+construction. **Nobody can demo: change a running method's signature and watch
+the stale callers light up.** The infrastructure to do it is unusually cheap
+for Beamtalk, because the hard part already shipped:
+
+- **ADR 0087 (Implemented):** `beamtalk_xref` maintains a selector→call-sites
+  index in the runtime, kept correct across hot reload (purge + new-generation
+  install) and ClassBuilder lifecycle hooks. That *is* the dependency graph
+  incremental re-checking needs.
+- **Principle 12:** the compiler is the language service — the same
+  `beamtalk-core` that compiled the edit can re-check its dependents.
+- **ADR 0100:** the severity ladder for "how certain is the checker" already
+  exists; reload-induced findings slot straight into it.
+
+### What "stale" means
+
+A live redefinition can invalidate callers three ways:
+
+1. **Signature change** — return type or parameter types changed:
+   `getValue -> Integer` becomes `getValue -> String`; caller does
+   `self getValue + 1`.
+2. **Removal** — the selector no longer exists on the class; callers are now
+   DNU-at-runtime.
+3. **Shape change** — `state:`/`field:` slots added, removed, or retyped;
+   `spawnWith:` sites and field accessors are affected (with ADR 0104's
+   checking).
+
+### Constraints
+
+- **Advisory, never blocking** (ADR 0100). A reload is an *action that already
+  happened* — diagnostics inform, they cannot veto. (Whether a future strict
+  mode may pre-veto a reload is explicitly out of scope.)
+- **Bounded latency.** Re-checking runs at workspace-interaction speed;
+  transitive re-checking must be cut off, not exhaustive.
+- **Open world.** Reflective sends (`perform:`) and DNU handlers are invisible
+  to xref; findings are graded accordingly.
+
+## Decision
+
+On every live definition change (method save, class rebuild, module reload),
+run an **incremental re-check of known dependents** and publish the findings
+as live diagnostics on all surfaces (LSP, workspace UI, REPL notification).
+
+### Mechanism
+
+1. **Signature diff.** When the workspace compiler (`beamtalk_repl_compiler` /
+   ClassBuilder path) installs a redefinition, compute the *interface delta*
+   against the previous generation: per selector — added / removed /
+   signature-changed (using the same method metadata codegen already emits in
+   `__beamtalk_meta`).
+2. **Dependent lookup.** For each removed or signature-changed selector, query
+   `beamtalk_xref` (ADR 0087) for its call sites: `(module, selector, arity) →
+   [caller methods]`.
+3. **Targeted re-check.** Re-run the type checker on exactly those caller
+   methods against the *new* interface. One level only — a caller whose own
+   interface is unchanged by the finding does not trigger further fan-out
+   (its diagnostic is enough; its callers' relationship to *it* didn't
+   change).
+4. **Publish.** Findings appear as diagnostics attributed to the caller's
+   source location, tagged as reload-induced, on every surface
+   (surface-parity applies). They clear automatically when either side is
+   edited to agree.
+
+### The demo (REPL/workspace session)
+
+```
+bt> :load counter.bt
+bt> counter := Counter spawn
+bt> counter getCount + 1          // => 1
+
+// ... in the editor: change `getCount -> Integer` to `getCount -> String`,
+//     save (method-level hot reload, ADR 0082) ...
+
+⚠ reload check: 2 callers of Counter>>getCount are now stale
+   Dashboard>>refresh (dashboard.bt:14): `self counter getCount + 1`
+     — `+ 1` expects a number, `getCount` now returns String
+   StatsView>>render (stats.bt:31): argument to `Transcript show:` — OK? no:
+     expects String — this caller is fine and is not reported
+```
+
+Only genuinely-affected callers surface; agreeing callers re-check clean and
+stay silent.
+
+### Error example (removal)
+
+```
+⚠ reload check: Counter>>reset was removed; 1 caller remains
+   AdminPanel>>onClick (admin.bt:9): `counter reset` will raise
+   does_not_understand at runtime
+```
+
+### Severity
+
+Per ADR 0100's ladder: signature-mismatch and removed-selector findings on
+statically-known receivers are `Warning`; anything reached through `Dynamic`,
+`perform:`, or DNU-overriding receivers is silent or `Lint`. Reload-induced
+findings never block the reload (it already happened) and never fail a build
+(they live in the workspace session, not the artifact).
+
+## Prior Art
+
+| System | Approach | Take / leave |
+|---|---|---|
+| **Erlang/OTP** | Hot reload with `code_change/3`; type-blind | The substrate; we add the missing feedback loop on top of unchanged mechanics. |
+| **Gleam** | FAQ: upgrades cannot be type-checked | The conceded gap this ADR fills. |
+| **TypeScript LSP / watch mode** | Incremental re-check on file change with a dependency graph | The playbook (principle 12) — but tsc re-checks *files against files*; Beamtalk re-checks *the running image against its own next generation*. |
+| **Smalltalk (Pharo)** | Live redefinition, no static re-check; browser marks broken senders only syntactically | The liveness model; we add typed feedback Pharo never had. |
+| **Rust/hot-patching research (e.g. Erlang's relups, dynamic software update literature)** | Update-safety proofs, typestate for upgrades | Sound update-checking is research-grade; deliberately out of scope — we inform, not verify. |
+
+## User Impact
+
+- **Newcomer:** hot reload stops being scary — the system says what the edit
+  broke, immediately, with locations. This is the feature that teaches why
+  liveness + types is the pitch.
+- **Smalltalk developer:** the Pharo "senders of" reflex becomes automatic —
+  every save effectively runs a typed senders-check.
+- **Erlang/BEAM developer:** the answer to "what does this deploy break?"
+  before the crash report, using the same reload they already do.
+- **Operator:** workspace-session feature; production reload paths unchanged.
+  (A future CI mode — "re-check against a running staging image" — is noted,
+  not designed.)
+- **Tooling developer:** diagnostics flow through existing LSP publishing;
+  new work is the reload→re-check trigger and the reload-induced tag.
+
+## Steelman Analysis
+
+- ⚙️ **BEAM veteran, for doing nothing:** "OTP release handling has managed
+  untyped upgrades for decades; discipline works." — Countered: at OTP shops,
+  that discipline is senior engineers reading diffs. The check automates
+  exactly that reading, and stays advisory.
+- 🎨 **Language designer, for sound update-checking:** "Inform-only lets a
+  stale caller run; verify the upgrade or don't ship types." — Acknowledged:
+  sound dynamic-software-update is research-grade and would reintroduce the
+  Gleam trade (safety by forbidding liveness). Against the positioning
+  ("types serve a live system, advisory"), inform-only is the consistent
+  choice.
+- 🧑‍💻 **Newcomer, for blocking reloads on errors:** "If it's wrong, stop
+  me!" — Partially accommodated: a *pre-save* check in the editor (LSP already
+  sees the edit before the reload) can warn before installing; the post-reload
+  image check remains non-blocking. The pre-save path is Phase 3.
+
+### Tension point
+One-level vs transitive re-checking. Transitive is more complete but unbounded
+in a big image; one-level is fast and catches the direct damage. Start
+one-level; measure; ADR 0087's benchmarking precedent (BT-2299) applies.
+
+## Alternatives Considered
+
+### Whole-image re-check on every reload
+Simple and complete; unbounded latency as images grow. Rejected as the
+default; may become an explicit command (`:recheck image`).
+
+### Static-only (no runtime trigger)
+Let the LSP re-check open files on edit, ignore the live image. Rejected: the
+whole point is the *image* — callers in files nobody has open are exactly the
+ones people forget.
+
+### Sound upgrade verification
+Prove reload safety before install. Rejected (see steelman): research-grade,
+anti-liveness, and off-positioning.
+
+## Consequences
+
+### Positive
+- The thirty-second demo no BEAM language can give: live signature change →
+  stale callers flagged with locations, from the running image.
+- Reuses shipped infrastructure (xref, language-service compiler, severity
+  policy, LSP publishing) — the novel code is a diff + a trigger + a targeted
+  re-check loop.
+- Makes ADR 0104's actor typing durable under liveness (actor interface
+  changes re-check senders).
+
+### Negative
+- The workspace runtime must call back into the Rust compiler for re-checks —
+  a new runtime→compiler interaction path with failure modes (compiler
+  unavailable, version skew between image and sources) that need explicit
+  handling.
+- xref covers *compiled* call sites; workspace-defined bindings/snippets need
+  their own dependent tracking (session bindings layer, ADR 0081).
+- Interface deltas require previous-generation metadata retention — small but
+  new state in the class registry.
+- Findings can be stale-about-staleness: a caller flagged after reload A may
+  be fixed by reload B; clearing logic must be reliable or trust erodes.
+
+### Neutral
+- Production/artifact builds unchanged; this is a workspace-session feature.
+- Adds no new severity levels — slots into ADR 0100.
+
+## Implementation
+
+1. **Phase 0 (napkin, ~S):** hard-code one case end-to-end — method signature
+   change via workspace save → xref lookup → re-check one caller → one LSP
+   diagnostic. Proves the runtime→compiler round-trip, which is the risky
+   part.
+2. **Phase 1 (~M):** interface-delta computation from `__beamtalk_meta`
+   generations; removed-selector and signature-change findings; surface-parity
+   plumbing (LSP + workspace UI + REPL notice).
+3. **Phase 2 (~M):** shape changes (`state:`/`field:`) integrated with ADR
+   0104's `spawnWith:`/accessor checking; clearing logic; benchmarks per the
+   BT-2299 precedent.
+4. **Phase 3 (~S):** pre-save advisory in the editor (check before install);
+   explicit `:recheck image` command (surface-parity entry required).
+
+**Affected:** workspace runtime (`beamtalk_workspace`, reload/ClassBuilder
+hooks), `beamtalk_xref` queries, language service (`beamtalk-core`), LSP/REPL
+surfaces. **Not:** codegen output, production reload mechanics, the artifact
+build.
+
+## References
+- Seed: `docs/internal/positioning.md` (Seed 3 — "the killer demo")
+- Enabling ADRs: ADR 0087 (xref index, Implemented — the dependency graph),
+  ADR 0082 (method-level edit/save — the trigger), ADR 0100 (severity),
+  ADR 0104 (actor interface checking), ADR 0081 (session bindings)
+- Principles: 2 (Hot Reload is Core), 11 (Live Patching is a Message Send),
+  12 (Compiler is the Language Service)
+- External: [Gleam FAQ on hot code reloading](https://gleam.run/frequently-asked-questions/)

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -128,7 +128,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0099](0099-cli-application-story.md) | CLI Application Story — Console, Arguments, Exit, and Packaging | Accepted | 2026-06-26 |
 | [0100](0100-open-world-diagnostic-policy.md) | Open-World Diagnostic Policy for Unresolved Selectors and Classes | Proposed | 2026-06-27 |
 | [0101](0101-unified-erlang-interop-native-objects.md) | Unified Erlang Interop — `native:` for Stateless Objects, Wrap-by-Default FFI, Clean `@primitive`/`@intrinsic`/`native:` Split | Accepted | 2026-06-28 |
-| [0102](0102-set-theoretic-type-operators.md) | Set-Theoretic Type Operators (Intersection and Negation) for Uniform Narrowing | Proposed | 2026-07-05 |
+| [0102](0102-set-theoretic-type-operators.md) | Set-Theoretic Type Operators (Intersection and Negation) for Narrowing and Atom Exhaustiveness | Proposed | 2026-07-05 |
 
 > ADR 0086 was originally numbered 0069 (a collision with *Actor Observability and Tracing*) and was renumbered on 2026-05-25.
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -128,6 +128,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0099](0099-cli-application-story.md) | CLI Application Story — Console, Arguments, Exit, and Packaging | Accepted | 2026-06-26 |
 | [0100](0100-open-world-diagnostic-policy.md) | Open-World Diagnostic Policy for Unresolved Selectors and Classes | Proposed | 2026-06-27 |
 | [0101](0101-unified-erlang-interop-native-objects.md) | Unified Erlang Interop — `native:` for Stateless Objects, Wrap-by-Default FFI, Clean `@primitive`/`@intrinsic`/`native:` Split | Accepted | 2026-06-28 |
+| [0102](0102-set-theoretic-type-operators.md) | Set-Theoretic Type Operators (Intersection and Negation) for Uniform Narrowing | Proposed | 2026-07-05 |
 
 > ADR 0086 was originally numbered 0069 (a collision with *Actor Observability and Tracing*) and was renumbered on 2026-05-25.
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -128,7 +128,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0099](0099-cli-application-story.md) | CLI Application Story — Console, Arguments, Exit, and Packaging | Accepted | 2026-06-26 |
 | [0100](0100-open-world-diagnostic-policy.md) | Open-World Diagnostic Policy for Unresolved Selectors and Classes | Proposed | 2026-06-27 |
 | [0101](0101-unified-erlang-interop-native-objects.md) | Unified Erlang Interop — `native:` for Stateless Objects, Wrap-by-Default FFI, Clean `@primitive`/`@intrinsic`/`native:` Split | Accepted | 2026-06-28 |
-| [0102](0102-set-theoretic-type-operators.md) | Set-Theoretic Type Operators (Intersection and Negation) for Narrowing and Atom Exhaustiveness | Proposed | 2026-07-05 |
+| [0102](0102-set-theoretic-type-operators.md) | Set-Theoretic Type Operators (Intersection and Negation) for Narrowing and Atom Exhaustiveness | Accepted | 2026-07-06 |
 | [0103](0103-sendability-typing-from-class-kinds.md) | Sendability Typing from Class Kinds | Proposed | 2026-07-05 |
 | [0104](0104-typed-actor-protocols.md) | Typed Actor Protocols — the Class Interface Is the Protocol | Proposed | 2026-07-05 |
 | [0105](0105-live-image-recheck-on-reload.md) | Live Image Re-Checking on Hot Reload | Proposed | 2026-07-05 |

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -129,6 +129,9 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0100](0100-open-world-diagnostic-policy.md) | Open-World Diagnostic Policy for Unresolved Selectors and Classes | Proposed | 2026-06-27 |
 | [0101](0101-unified-erlang-interop-native-objects.md) | Unified Erlang Interop — `native:` for Stateless Objects, Wrap-by-Default FFI, Clean `@primitive`/`@intrinsic`/`native:` Split | Accepted | 2026-06-28 |
 | [0102](0102-set-theoretic-type-operators.md) | Set-Theoretic Type Operators (Intersection and Negation) for Narrowing and Atom Exhaustiveness | Proposed | 2026-07-05 |
+| [0103](0103-sendability-typing-from-class-kinds.md) | Sendability Typing from Class Kinds | Proposed | 2026-07-05 |
+| [0104](0104-typed-actor-protocols.md) | Typed Actor Protocols — the Class Interface Is the Protocol | Proposed | 2026-07-05 |
+| [0105](0105-live-image-recheck-on-reload.md) | Live Image Re-Checking on Hot Reload | Proposed | 2026-07-05 |
 
 > ADR 0086 was originally numbered 0069 (a collision with *Actor Observability and Tracing*) and was renumbered on 2026-05-25.
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -1863,8 +1863,12 @@ For fire-and-forget scenarios, use the `!` (bang) operator, which uses `gen_serv
 
 ```beamtalk
 // Fire-and-forget — does not block, returns nil
-c ! increment
+c increment!
 ```
+
+The `!` is **postfix** — it terminates the send it applies to. A cast is only
+legal as a bare statement: using its (always-`nil`) value in an assignment,
+return, or argument is a parse error (`cast_in_expression_error`).
 
 Use `!` when you intentionally don't need the result and don't want to block.
 

--- a/docs/beamtalk-syntax-rationale.md
+++ b/docs/beamtalk-syntax-rationale.md
@@ -461,6 +461,32 @@ Rejected. Functional style fights the "actors are objects" mental model we want.
 
 Rejected. LFE already exists for BEAM. We're explicitly targeting the Smalltalk aesthetic.
 
+### Erlang-style Multi-Clause Method Heads
+
+Rejected. Erlang's multiple function heads do two jobs, and Beamtalk covers both
+without them:
+
+- **Message dispatch** — Erlang needs N `handle_call` clauses because OTP funnels
+  every message through one function. Smalltalk selector dispatch *is* that
+  mechanism: each message is its own method, individually browsable,
+  documentable, and hot-reloadable.
+- **Data-shape dispatch** — discriminating on argument structure is `match:`
+  inside the body (see `Server >> handleInfo:` in the stdlib for the canonical
+  `handle_info` translation), with `when:` guards and exhaustiveness checking
+  (BT-1299, extended to singleton unions by ADR 0102).
+
+Adding heads would fragment the method as Beamtalk's unit of everything
+(method-level edit/save per ADR 0082, per-method hot reload, browser model),
+smuggle Erlang's ordered-clause semantics into an unordered method dictionary,
+and create a third failure mode between `function_clause` and DNU — for zero
+runtime benefit (BEAM lowers heads and in-body `case` to the same
+pattern-matching trees). Gleam reached the same conclusion on the same VM.
+
+*Door left ajar:* if `msg match:` boilerplate ever becomes a demonstrated pain
+point, the acceptable design is pattern-parameter **sugar that desugars to one
+method with a `match:` body** — typing, guards, and exhaustiveness then inherit
+for free. To be earned with evidence, not built speculatively.
+
 ---
 
 ## References

--- a/docs/internal/positioning.md
+++ b/docs/internal/positioning.md
@@ -1,0 +1,133 @@
+# Beamtalk in the BEAM Ecosystem — Positioning
+
+**Status:** Working position. Complements [beamtalk-principles.md](../beamtalk-principles.md)
+(which states what Beamtalk *is*) by stating what Beamtalk is *relative to its
+peers*, with emphasis on the type system's role.
+**Related:** [set-theoretic-types-north-star.md](set-theoretic-types-north-star.md) ·
+[ADR 0100](../ADR/0100-open-world-diagnostic-policy.md) ·
+[ADR 0102](../ADR/0102-set-theoretic-type-operators.md)
+
+---
+
+## The map, typing edition
+
+Every BEAM language answers a different question:
+
+| Language | The question it answers | Types | Liveness |
+|---|---|---|---|
+| **Erlang** | "Can a system run forever?" | Dynamic + Dialyzer/eqWAlizer (post-hoc, ops-grade) | Hot reload as *ops mechanism* |
+| **Elixir** | "Can BEAM be mainstream?" | Set-theoretic **inference** rolling in (1.17+); annotation culture still forming | IEx + recompile; reload is not a dev UX |
+| **Gleam** | "Can BEAM have ML soundness?" | Sound HM, closed world | **None** — no reflection, no DNU, no live redefinition; soundness bought by giving liveness up |
+| **Alpaca, Caramel, Hamler, Purerl** | Same as Gleam, earlier | Sound-ish | None — and mostly dead |
+| **Beamtalk** | **"Can types serve a *live* system?"** | Gradual, annotation-first, advisory (ADR 0100), set-theoretic operators (ADR 0102) | The whole point |
+
+Two readings of that table drive the strategy:
+
+**1. The graveyard has a lesson.** Every stalled typed-BEAM language fought the
+VM's dynamism to get soundness. Gleam survived by being excellent *and* adding
+a JS target — but it still had to amputate hot reload, reflection, and
+open-world dispatch to keep its guarantees. The dynamism-shaped hole in the
+typed-BEAM space is not an accident; it is the hard part everyone routed
+around. Beamtalk's bet is to make that hole the product.
+
+**2. The unclaimed quadrant is liveness × types.** Dialyzer is post-hoc.
+Elixir's types live compiler-side. Gleam's types cannot coexist with a mutating
+image. Nobody has **types as live tooling in a system that changes while it
+runs** — advisory severities graded by open-world knowledge (ADR 0100),
+narrowing and exhaustiveness as editor feedback (ADR 0102), conformance
+re-derived against the *current* image. This is the TypeScript playbook
+(principle 12 states it explicitly) — but TypeScript never had a live image to
+point it at.
+
+**The one-sentence placement:**
+
+> Elixir types *existing* code; Gleam types *closed* code; **Beamtalk types
+> *running* code.**
+
+Beamtalk is not competing with Elixir for "mainstream BEAM" or with Gleam for
+"sound BEAM." It occupies the corner both structurally cannot: the live one.
+The type system's job description follows: advisory not gatekeeping,
+open-world honest, tooling-fuel first, reload-surviving.
+
+## Three type-system opportunities this opens (ADR seeds)
+
+These are differentiators available to Beamtalk *specifically because* of
+decisions already shipped. Each should graduate to its own ADR/Linear issue
+when timely.
+
+### Seed 1 — Sendability typing from class kinds
+
+The cheapest big win nobody on BEAM has. Beamtalk already declares the
+three-way split the BEAM cares about:
+
+- `Value` — immutable; copy-on-send is semantically free ⇒ **sendable**
+- `Actor` — a shareable *reference* (Pid) ⇒ **sendable as a handle**
+- stateful, identity-bearing `Object` — meaningful only within its process ⇒
+  **process-local**
+
+That is a capability system **already present in the syntax** (ADR 0067's
+class-kind split). Pony needed six reference capabilities and a famously steep
+learning curve to track this; Beamtalk can check "you're sending a
+process-local mutable object to an actor" at edit time using distinctions
+users already write down, at near-zero annotation cost. Gleam cannot offer
+this (all-immutable, the question dissolves); Elixir silently deep-copies and
+lets identity bugs happen.
+
+### Seed 2 — Typed actor protocols without a parallel messaging layer
+
+Gleam's typed actors required inventing `Subject(msg)` — a non-OTP-standard
+actor layer — because bare functions-over-messages have no interface to type.
+Beamtalk's "actor = class, message = selector" means **the actor's class
+interface already is its protocol type**: typed actor messaging falls out of
+ordinary method checking (Option A in
+[type-system-design.md](type-system-design.md)). Remaining design work is the
+async edges: what `cast` returns (principle 7's sync-by-default makes the sync
+path trivial) and what DNU means across a process boundary (see the DNU
+section of the north-star doc). Small ADR, distinctive capability.
+
+### Seed 3 — Types × hot reload: the killer demo
+
+The unsolved question in the whole ecosystem: what happens to "checked" when a
+module is redefined live? ADR 0100's knowledge-graded severity is the
+foundation; the missing piece is **incremental re-checking of the image on
+reload** — change a method's signature in a running system and the workspace
+immediately flags the now-stale callers as live diagnostics instead of letting
+them crash later. No BEAM language can demo that today, and it is the demo
+that makes "types for a live system" legible in thirty seconds.
+
+## The orthogonal axis: agent-native development
+
+Beamtalk treats **MCP as a first-class surface** with parity requirements
+alongside CLI/REPL/LSP ([surface-parity.md](../development/surface-parity.md)).
+None of the peer languages were designed with agent-driven development as a
+surface. Combined with liveness — an agent that can *query and mutate a
+running image* through a structured protocol — this is a positioning axis
+orthogonal to the type story, and it may age into the more important one:
+the live image is as good an environment for an AI pair as it is for a human.
+
+## What this positioning rules out
+
+Consistency cuts both ways. Claiming the live corner means *not* chasing:
+
+- **Soundness competitions with Gleam.** Beamtalk's types are advisory by
+  design (ADR 0100); a soundness pitch would be both false and off-brand.
+- **Elixir's ecosystem breadth.** Interop (principle 9, ADR 0101) is the
+  answer to "where are the libraries?" — not a parallel ecosystem.
+- **Types as a compilation gate.** Any future "strict mode" must remain
+  opt-in; the default posture is TypeScript-style tooling, not OCaml-style
+  gatekeeping.
+
+## References
+
+- [beamtalk-principles.md](../beamtalk-principles.md) — especially 1
+  (Interactive-First), 2 (Hot Reload is Core), 7 (Sync-by-Default Actors),
+  12 (Compiler is the Language Service)
+- [set-theoretic-types-north-star.md](set-theoretic-types-north-star.md) —
+  the type-system destination and the nominal/structural recommendation
+- [ADR 0100](../ADR/0100-open-world-diagnostic-policy.md) — the advisory,
+  knowledge-graded diagnostic posture
+- [ADR 0102](../ADR/0102-set-theoretic-type-operators.md) — atoms, unions,
+  narrowing, exhaustiveness
+- Elixir set-theoretic types: [docs](https://hexdocs.pm/elixir/main/gradual-set-theoretic-types.html);
+  Gleam: [gleam.run](https://gleam.run) (typed subjects in `gleam_otp`);
+  eqWAlizer: [github.com/WhatsApp/eqwalizer](https://github.com/WhatsApp/eqwalizer)

--- a/docs/internal/positioning.md
+++ b/docs/internal/positioning.md
@@ -63,10 +63,11 @@ open-world honest, tooling-fuel first, reload-surviving.
 ## Three type-system opportunities this opens (ADR seeds)
 
 These are differentiators available to Beamtalk *specifically because* of
-decisions already shipped. Each should graduate to its own ADR/Linear issue
-when timely.
+decisions already shipped. Each has been drafted as a Proposed ADR (0103–0105).
 
 ### Seed 1 — Sendability typing from class kinds
+
+*Drafted as [ADR 0103](../ADR/0103-sendability-typing-from-class-kinds.md).*
 
 The cheapest big win nobody on BEAM has. Beamtalk already declares the
 three-way split the BEAM cares about (ADR 0067, `beamtalk-language-features.md`
@@ -95,6 +96,8 @@ which are references, and which are handles — the checker just has to use it.
 
 ### Seed 2 — Typed actor protocols without a parallel messaging layer
 
+*Drafted as [ADR 0104](../ADR/0104-typed-actor-protocols.md).*
+
 Gleam's typed actors required inventing `Subject(msg)` — a non-OTP-standard
 actor layer — because bare functions-over-messages have no interface to type.
 Beamtalk's "actor = class, message = selector" means **the actor's class
@@ -106,6 +109,8 @@ path trivial) and what DNU means across a process boundary (see the DNU
 section of the north-star doc). Small ADR, distinctive capability.
 
 ### Seed 3 — Types × hot reload: the killer demo
+
+*Drafted as [ADR 0105](../ADR/0105-live-image-recheck-on-reload.md).*
 
 The unsolved question in the whole ecosystem: what happens to "checked" when a
 module is redefined live? ADR 0100's knowledge-graded severity is the

--- a/docs/internal/positioning.md
+++ b/docs/internal/positioning.md
@@ -15,29 +15,40 @@ Every BEAM language answers a different question:
 
 | Language | The question it answers | Types | Liveness |
 |---|---|---|---|
-| **Erlang** | "Can a system run forever?" | Dynamic + Dialyzer/eqWAlizer (post-hoc, ops-grade) | Hot reload as *ops mechanism* |
-| **Elixir** | "Can BEAM be mainstream?" | Set-theoretic **inference** rolling in (1.17+); annotation culture still forming | IEx + recompile; reload is not a dev UX |
-| **Gleam** | "Can BEAM have ML soundness?" | Sound HM, closed world | **None** — no reflection, no DNU, no live redefinition; soundness bought by giving liveness up |
-| **Alpaca, Caramel, Hamler, Purerl** | Same as Gleam, earlier | Sound-ish | None — and mostly dead |
+| **Erlang** | "Can a system run forever?" | Dynamic + Dialyzer (post-hoc success typing) + eqWAlizer (spec-driven, IDE-integrated via ELP) | Hot reload as *ops mechanism* |
+| **Elixir** | "Can BEAM be mainstream?" | **v1.20 (June 2026): gradually typed** — full set-theoretic *inference*, **zero annotations by design**; type signatures explicitly deferred pending research (v1.21+) | IEx recompile + Phoenix dev reload — module-level, state-discarding; no image |
+| **Gleam** | "Can BEAM have ML soundness?" | Sound HM, closed world | VM-level reload works but is **untyped** — Gleam's own FAQ: upgrades cannot be type-checked, so reloads drop to "the usual Erlang amount of safety" |
+| **Alpaca, Caramel, Hamler** | Same as Gleam, earlier | Sound-ish | None — and dormant |
 | **Beamtalk** | **"Can types serve a *live* system?"** | Gradual, annotation-first, advisory (ADR 0100), set-theoretic operators (ADR 0102) | The whole point |
+
+(Purerl — the PureScript Erlang backend — is deliberately *not* in the
+graveyard row: it remains maintained and in production use at id3as, as a
+niche "bring PureScript to BEAM" tool rather than a BEAM-native language.)
 
 Two readings of that table drive the strategy:
 
 **1. The graveyard has a lesson.** Every stalled typed-BEAM language fought the
 VM's dynamism to get soundness. Gleam survived by being excellent *and* adding
-a JS target — but it still had to amputate hot reload, reflection, and
-open-world dispatch to keep its guarantees. The dynamism-shaped hole in the
+a JS target — but its guarantees stop at the reload boundary: reflection and
+open-world dispatch are out, and while VM-level hot reload still works, Gleam's
+own FAQ concedes upgrades cannot be type-checked, so a reloaded system falls
+back to "the usual Erlang amount of safety." The dynamism-shaped hole in the
 typed-BEAM space is not an accident; it is the hard part everyone routed
 around. Beamtalk's bet is to make that hole the product.
 
 **2. The unclaimed quadrant is liveness × types.** Dialyzer is post-hoc.
-Elixir's types live compiler-side. Gleam's types cannot coexist with a mutating
-image. Nobody has **types as live tooling in a system that changes while it
-runs** — advisory severities graded by open-world knowledge (ADR 0100),
-narrowing and exhaustiveness as editor feedback (ADR 0102), conformance
-re-derived against the *current* image. This is the TypeScript playbook
-(principle 12 states it explicitly) — but TypeScript never had a live image to
-point it at.
+Elixir's types are inference-only by explicit design (v1.20's milestone was
+"type-check every program *without introducing annotations*"; signatures are
+deferred research). Gleam's types stop at the reload boundary. Nobody has
+**types as live tooling in a system that changes while it runs** — advisory
+severities graded by open-world knowledge (ADR 0100), narrowing and
+exhaustiveness as editor feedback (ADR 0102), conformance re-derived against
+the *current* image. This is the TypeScript playbook (principle 12 states it
+explicitly) — but TypeScript never had a live image to point it at. Note the
+annotation contrast is *sharper* post-Elixir-1.20, not weaker: Elixir bet on
+inference-without-annotations; Beamtalk bets on **annotations as
+developer-facing tooling fuel**. Both are gradual; they are different
+products.
 
 **The one-sentence placement:**
 
@@ -58,20 +69,29 @@ when timely.
 ### Seed 1 — Sendability typing from class kinds
 
 The cheapest big win nobody on BEAM has. Beamtalk already declares the
-three-way split the BEAM cares about:
+three-way split the BEAM cares about (ADR 0067, `beamtalk-language-features.md`
+§Three Class Kinds):
 
-- `Value` — immutable; copy-on-send is semantically free ⇒ **sendable**
-- `Actor` — a shareable *reference* (Pid) ⇒ **sendable as a handle**
-- stateful, identity-bearing `Object` — meaningful only within its process ⇒
-  **process-local**
+- `Value` — immutable plain map; `self.slot :=` is a compile error;
+  copy-on-send is semantically free ⇒ **freely sendable**
+- `Actor` — identity is a Pid; state lives in the process ⇒ **sendable as a
+  reference**, identity preserved across the send
+- `Object` — no Beamtalk-managed data, but instances may wrap *runtime-backed
+  state* (ETS handles, ports, refs — e.g. `Subscription`'s `SubRef`) ⇒
+  **sendability depends on the handle's scope**: many handles are node-global
+  but none survive distribution to a remote node
 
-That is a capability system **already present in the syntax** (ADR 0067's
-class-kind split). Pony needed six reference capabilities and a famously steep
-learning curve to track this; Beamtalk can check "you're sending a
-process-local mutable object to an actor" at edit time using distinctions
-users already write down, at near-zero annotation cost. Gleam cannot offer
-this (all-immutable, the question dissolves); Elixir silently deep-copies and
-lets identity bugs happen.
+That is a capability lattice **already present in the syntax** — users write
+`Value subclass:` / `Actor subclass:` / `Object subclass:` today. Pony needed
+six reference capabilities and a famously steep learning curve to track this;
+Beamtalk can check "this value's meaning doesn't survive the send you're
+making" at edit time using distinctions users already write down, at
+near-zero annotation cost. The peers can't express the *question*: in Elixir
+and Gleam all data is immutable, so there is nothing identity-bearing to
+mis-send — but that also means their idioms for identity (bare Pids, ETS
+handles, refs) carry **no type-level distinction at all**. Beamtalk is the
+only BEAM language whose surface syntax already knows which values are data,
+which are references, and which are handles — the checker just has to use it.
 
 ### Seed 2 — Typed actor protocols without a parallel messaging layer
 
@@ -92,8 +112,10 @@ module is redefined live? ADR 0100's knowledge-graded severity is the
 foundation; the missing piece is **incremental re-checking of the image on
 reload** — change a method's signature in a running system and the workspace
 immediately flags the now-stale callers as live diagnostics instead of letting
-them crash later. No BEAM language can demo that today, and it is the demo
-that makes "types for a live system" legible in thirty seconds.
+them crash later. No BEAM language can demo that today — Gleam's FAQ
+explicitly concedes the gap ("it is not possible to type check the upgrades
+themselves"), and Elixir's inference has no image to re-check — and it is the
+demo that makes "types for a live system" legible in thirty seconds.
 
 ## The orthogonal axis: agent-native development
 
@@ -128,6 +150,11 @@ Consistency cuts both ways. Claiming the live corner means *not* chasing:
   knowledge-graded diagnostic posture
 - [ADR 0102](../ADR/0102-set-theoretic-type-operators.md) — atoms, unions,
   narrowing, exhaustiveness
-- Elixir set-theoretic types: [docs](https://hexdocs.pm/elixir/main/gradual-set-theoretic-types.html);
-  Gleam: [gleam.run](https://gleam.run) (typed subjects in `gleam_otp`);
-  eqWAlizer: [github.com/WhatsApp/eqwalizer](https://github.com/WhatsApp/eqwalizer)
+- Elixir set-theoretic types: [docs](https://hexdocs.pm/elixir/main/gradual-set-theoretic-types.html) ·
+  [v1.20 release — "now a gradually typed language"](https://elixir-lang.org/blog/2026/06/03/elixir-v1-20-0-released/) ·
+  [type-inference milestone & 15-month roadmap](https://elixir-lang.org/blog/2026/01/09/type-inference-of-all-and-next-15/)
+- Gleam: [FAQ — hot code reloading works but upgrades cannot be type-checked](https://gleam.run/frequently-asked-questions/) ·
+  typed subjects in `gleam_otp`
+- eqWAlizer (IDE-integrated via ELP): [github.com/WhatsApp/eqwalizer](https://github.com/WhatsApp/eqwalizer)
+- Purerl (maintained, niche): [purerl.fun](https://purerl.fun/) ·
+  [purescript-backend-erl](https://github.com/id3as/purescript-backend-erl)

--- a/docs/internal/set-theoretic-types-north-star.md
+++ b/docs/internal/set-theoretic-types-north-star.md
@@ -61,14 +61,110 @@ pragmatic departure Beamtalk made for tooling. A structural Beamtalk would make
 message-sets (protocols) the type layer and demote classes to
 implementation-sharing — essentially **Strongtalk** (Bracha & Griswold, 1993,
 already cited in ADR 0068), a static structural type system for Smalltalk. The
-real blockers are not feasibility but (a) **`Self`/binary-method typing** —
-`Comparable` needs "compare me to *my own type*", which pure structural typing
-can only express with `Self`-types or F-bounded/row polymorphism — and (b)
-**`doesNotUnderstand:`**, which makes an overriding receiver respond to *every*
-message and therefore structurally satisfy *every* type, undercutting the check.
-This document does **not** propose going structural; it records the option
-because "adopt full set-theoretic types" and "how nominal is Beamtalk" are the
-same question viewed from two sides.
+two things usually called "blockers" — (a) **`Self`/binary-method typing** and
+(b) **`doesNotUnderstand:`** — are better described as *constraints with known,
+mainstream solutions*; the two subsections below work each one out. This
+document does **not** propose going structural; it records the option because
+"adopt full set-theoretic types" and "how nominal is Beamtalk" are the same
+question viewed from two sides.
+
+### `Self` types and binary methods
+
+The awkward case is a **binary method** whose argument should be "the same type
+as the receiver": `Comparable` wants `< other :: Self -> Boolean`, `Equatable`
+wants `= other :: Self -> Boolean`, and the numeric tower wants `+ other`. This
+is the classic *binary-method problem* (Bruce, Cardelli, Castagna, Leavens,
+Pierce, "On Binary Methods", 1995): binary methods and ordinary **width
+subtyping conflict**. If `ColorPoint <: Point` and `Point` has `= : Point ->
+Bool`, then a meaningful `ColorPoint` needs `= : ColorPoint -> Bool` — but the
+argument is *contravariant*, so `ColorPoint`'s method is **not** a subtype of
+`Point`'s. You cannot have both "`ColorPoint` is-a `Point`" and "`=` compares me
+to my own type." This is a theorem, not a Beamtalk gap.
+
+The mainstream fixes, in order of how well they fit Beamtalk:
+
+1. **`Self` type resolved at the call site — Beamtalk already has this.**
+   `TypeAnnotation::SelfType` (bare `Self`) resolves to `Dynamic(Unknown)` at
+   annotation time and to the *static receiver class* at each call site
+   (`type_resolver.rs:61`, `:152`). So `< other :: Self -> Boolean` on an
+   `Integer` receiver already means `Integer -> Boolean` there. This is Kim
+   Bruce's **matching** relation done pragmatically at the call site rather than
+   as a separate judgement — and it is the mechanism a structural Beamtalk uses
+   for binary methods.
+2. **F-bounded polymorphism for *use-site* generic code.** A method that is
+   generic over comparables carries the recursive bound: `sort: items ::
+   Collection(T) where T <: Comparable(T)` — "T is any type that compares against
+   itself." Structurally, "X conforms to `Comparable`" just *is* the
+   self-referential check "X responds to `< : X -> Boolean`". This is exactly
+   Swift `T: Comparable`, Scala `T <: Ordered[T]`, Rust `T: Ord`, Java
+   `<T extends Comparable<T>>`, Haskell `Ord a =>`. Nothing exotic.
+3. **Set-theoretic intersection arrows do better than F-bounds for the tower.**
+   The north-star engine can give `+` an intersection type
+   `(Integer -> Integer) & (Float -> Float)` and refine the argument per branch
+   via typecase — Castagna's set-theoretic treatment of covariance/contravariance
+   handles binary methods more precisely than F-bounds alone. So going
+   set-theoretic *helps* here rather than making it worse.
+
+The price is real but bounded: **`Self`-using protocols (`Comparable`,
+`Equatable`) do not get free width subtyping** — you interact with them through
+`Self`/F-bounded polymorphism, not by upcasting a `ColorPoint` to a `Point` that
+has a binary `=`. Every production structural/OO type system (Swift, Scala,
+Rust) accepts exactly this trade, so it is well-trodden, not experimental.
+
+### Working around `doesNotUnderstand:`
+
+`doesNotUnderstand:` (DNU) looks like it destroys structural typing — an
+overriding receiver responds to *every* message, so it would structurally
+satisfy *every* type. That conclusion comes entirely from a **wrong definition
+of conformance**, and dissolves once fixed. Removing DNU is not on the table (it
+is the metaprogramming that makes this a Smalltalk); the work is to type
+DNU-*overriding* objects honestly. Note first that *default* DNU (raise
+`does_not_understand`) is already type-friendly — such an object responds to
+exactly its declared methods. Only a DNU **override** is the wrinkle.
+
+1. **Conform on the *published* interface, not the runtime-possible one.**
+   Define "A conforms to B" as "A's statically published interface covers B", not
+   "A could respond at runtime." Then a `method_missing`-style object is **not** a
+   universal subtype — its static interface is what it declares/publishes, and the
+   messages its DNU handler also catches are simply *outside the typed contract*.
+   Beamtalk is already committed to this stance: **ADR 0100** treats an unresolved
+   send as *not* proof of a bug precisely because DNU/`perform:`/reflection exist,
+   and only speaks up under closed knowledge.
+2. **Model a DNU object as an open row, not "everything".** Structural theory
+   already has the encoding: OCaml's `< foo : T; .. >` row variable and
+   TypeScript's `[msg: string]: …` index signature both mean "responds to *at
+   least* these, and maybe more." The `..` **is** the typed presence of a DNU
+   handler — sound, because you may only *rely* on the listed messages; the rest
+   need a guard.
+3. **Let a DNU class publish a forwarded protocol → a typed proxy.** A remote/lazy
+   proxy declares "I dynamically handle everything `Account` handles" (hypothetical
+   `forwards :: Account`), and the checker types it structurally as `Account` —
+   fully checked. This is Objective-C's `methodSignatureForSelector:` lifted to
+   compile time.
+4. **Fall back to `dynamic()` when the surface is genuinely open.** Un-typeable
+   metaprogramming (a builder fabricating arbitrary accessors) is typed
+   `dynamic()` — Beamtalk's existing `proxy :: Dynamic` opt-out. Gradual typing
+   exists *for exactly this*, and (§2) `dynamic()` composes without spreading.
+   Beamtalk's current protocol design already ships the optimistic version of
+   this as conformance tier 3 ("DNU-overriding classes conform to every
+   protocol"); the structural refinement keeps it as the fallback and *adds*
+   options 1–3 for when a tighter interface is knowable.
+5. **Interact via `respondsTo:` narrowing — already in the language.**
+   `x respondsTo: #foo ifTrue: [x foo]` turns "might not understand" into a
+   *checked* branch, and it is already a narrowing rule
+   (`narrowing/rules/responds_to.rs`). Row polymorphism + `respondsTo:` narrowing
+   is the complete, sound way to talk to an open-row/dynamic object.
+
+The one genuine casualty is the **strong-arrow check** (§3): you cannot prove an
+arrow "provably errors out of domain" for a receiver that might override DNU to
+*handle* the out-of-domain input instead of erroring. So strong-arrow *soundness
+claims* must be gated on sealed / non-DNU receivers — a narrow, well-understood
+restriction, not a system-wide blocker.
+
+**Prior art for both:** Strongtalk kept DNU and used a dynamic type as the escape
+(options 4–5); Ruby's Sorbet types `method_missing` via `T.untyped`/shims; Swift,
+Scala, Rust, and Haskell all resolve binary methods with `Self`/F-bounded
+constraints exactly as above.
 
 ## What "full" adds beyond ADR 0102
 
@@ -223,9 +319,14 @@ invariants:
   subtyping, or do they stay a separate structural check?
 - Does the **metaclass tower** (`Meta`) embed cleanly as basic types, or does
   `C class` subtyping need bespoke inclusions?
-- What is Beamtalk's **gradual guarantee** statement precisely, and which
-  operations are "strong arrows" given DNU (`doesNotUnderstand:`) can make *any*
-  selector succeed at runtime?
+- What is Beamtalk's **gradual guarantee** statement precisely? (The
+  **`doesNotUnderstand:`** interaction — strong arrows gated on non-DNU
+  receivers, conformance on published interfaces — is worked out in *Working
+  around `doesNotUnderstand:`* above; what remains open is the formal guarantee
+  statement, not the strategy.)
+- Should `Self`-using protocols use call-site resolution (today's mechanism) or
+  explicit F-bounded quantification (`T <: Comparable(T)`) for *use-site* generic
+  code — or both? (See *`Self` types and binary methods*.)
 - Performance envelope of emptiness checking at REPL/LSP edit-time latency.
 
 ## References

--- a/docs/internal/set-theoretic-types-north-star.md
+++ b/docs/internal/set-theoretic-types-north-star.md
@@ -63,7 +63,8 @@ implementation-sharing — essentially **Strongtalk** (Bracha & Griswold, 1993,
 already cited in ADR 0068), a static structural type system for Smalltalk. The
 two things usually called "blockers" — (a) **`Self`/binary-method typing** and
 (b) **`doesNotUnderstand:`** — are better described as *constraints with known,
-mainstream solutions*; the two subsections below work each one out. This
+mainstream solutions*; the next two subsections work each one out, and a third
+sketches what would actually change if Beamtalk made the move. This
 document does **not** propose going structural; it records the option because
 "adopt full set-theoretic types" and "how nominal is Beamtalk" are the same
 question viewed from two sides.
@@ -165,6 +166,79 @@ restriction, not a system-wide blocker.
 (options 4–5); Ruby's Sorbet types `method_missing` via `T.untyped`/shims; Swift,
 Scala, Rust, and Haskell all resolve binary methods with `Self`/F-bounded
 constraints exactly as above.
+
+### What would change if Beamtalk went structural
+
+Perhaps surprisingly: **class definition *syntax* barely changes.** You would
+still write `Account subclass: SavingsAccount`, `field:`/`state:` declarations,
+and methods exactly as today. What changes is what a class name **means in type
+position**, and nearly all of that lives in the type checker.
+
+**The semantic pivot.** Today `deposit: (into :: Account)` means "an `Account`
+or a *declared* subclass" (`Known { class_name }` + `superclass_chain` walk).
+Structurally, the same annotation means "**anything exposing `Account`'s message
+interface**" — a class name in type position becomes shorthand for the *shape*
+its instances expose (TypeScript's reading of a class name). Crucially, that
+shape is the **method set only**: `field:`/`state:` declarations are private —
+stdlib-wide, fields are accessed via `self.field` internally and messages
+externally — so fields never enter the public type. Encapsulation is what makes
+class-as-shape well-defined here.
+
+**`subclass:` sheds its typing job — carefully stated.** Today `subclass:` does
+two jobs: implementation reuse *and* declaring a subtype. Structurally,
+subtyping is *derived from shape*, so the declaration stops being the source of
+truth. But this is **not** a licence to "inherit without conforming":
+Smalltalk-style inheritance only adds/overrides methods, so a subclass's method
+set is a superset of its superclass's, and inheritance still *produces*
+structural subtyping in the ordinary case. What decoupling actually changes:
+
+- the **converse** becomes possible — a class can be `Account`-shaped, and
+  usable as one, *without* inheriting from `Account`;
+- a **signature-incompatible override** (narrowing a parameter, changing a
+  return) now honestly breaks the subtype relation instead of being silently
+  blessed by the declaration — the binary-method situation (see *`Self` types
+  and binary methods*) surfacing as a checked fact rather than a soundness hole.
+
+**What concretely changes elsewhere:**
+
+| Aspect | Nominal (today) | Structural |
+|---|---|---|
+| Type identity | `Known { class_name }` — the name | a message-set; a class name abbreviates one |
+| Subtyping | declared `superclass_chain` walk | shape inclusion (methods ⊇, signatures compatible) |
+| Annotations | class / protocol names | names **plus anonymous inline shapes**, e.g. `:: < withdraw: Money; balance -> Money >` |
+| Fields | private, not part of the type | unchanged — only the message surface types |
+| Narrowing idiom | `isKindOf:` / `class =` central | **`respondsTo:`** becomes primary (already a rule); `class =` narrows to a shape |
+| Exhaustiveness | `sealed` nominal hierarchies (BT-1299) | shifts toward **atom/tagged unions** (ADR 0102's machinery); `sealed` survives as a nominal island |
+| Errors | "expected `Account`, got `String`" | shape diff: "`String` is missing `withdraw:`" |
+| Tooling | "find subtypes" = hierarchy walk | "find conformers" = method-set search; rename refactors lose declared links to follow |
+
+Three second-order points, double-checked against the codebase:
+
+1. **Beamtalk is already further along than "leaning".** Structural conformance
+   is *implemented*, not just specified: `protocol.rs`
+   (`check_protocol_conformance_in_module`, ADR 0068 Phase 2b) performs
+   shape-based checking at call sites today. "Going structural" is therefore
+   promoting an existing mechanism from protocols-only to class-names-in-type-
+   position — an extension of shipped code, not new theory.
+2. **`sealed` does not disappear.** The stdlib uses `sealed` pervasively
+   (`sealed typed Object subclass: Subscription`, sealed `Announcement`
+   subclasses, `Result`). Sealed hierarchies remain *nominal islands* —
+   closed-world sets where BT-1299-style exhaustiveness and identity semantics
+   stay exact. This lands on the hybrid every production system chose:
+   TypeScript (structural + brands), Scala (nominal + refinements), Pony
+   (nominal `trait` + structural `interface`).
+3. **Structure is the BEAM-native fit.** Erlang data *is* structural — maps,
+   tagged tuples, atoms carry no nominal identity. Class-as-shape composes
+   directly with §4 (structural products) and the unified interop story
+   (ADR 0101): an Erlang map that satisfies a shape *is* that type, no wrapper
+   blessing required.
+
+So the realistic "structural Beamtalk" is not a rewrite of class definitions —
+it is: keep classes and `sealed` for implementation and closed-world cases, let
+class names in type position denote shapes, lean on protocols and
+`respondsTo:` narrowing as the primary vocabulary, and let atoms/unions carry
+exhaustiveness. Which is, deliberately, the same destination the set-theoretic
+sections describe from the value-set side.
 
 ## What "full" adds beyond ADR 0102
 

--- a/docs/internal/set-theoretic-types-north-star.md
+++ b/docs/internal/set-theoretic-types-north-star.md
@@ -466,7 +466,10 @@ invariants:
 - **Theory:** Giuseppe Castagna, Guillaume Duboc, José Valim — "The Design
   Principles of the Elixir Type System"; Castagna et al. semantic subtyping /
   CDuce line of work.
-- **Beamtalk:** [ADR 0102](../ADR/0102-set-theoretic-type-operators.md) (the
+- **Beamtalk:** [positioning.md](positioning.md) (where this type-system
+  strategy places Beamtalk in the BEAM ecosystem, plus the sendability /
+  typed-actor / types-×-reload ADR seeds) ·
+  [ADR 0102](../ADR/0102-set-theoretic-type-operators.md) (the
   first step) · [ADR 0068](../ADR/0068-parametric-types-and-protocols.md)
   (unions, narrowing, the noted difference-types gap) ·
   [ADR 0025](../ADR/0025-gradual-typing-and-protocols.md) ·

--- a/docs/internal/set-theoretic-types-north-star.md
+++ b/docs/internal/set-theoretic-types-north-star.md
@@ -77,21 +77,33 @@ off precisely where added.
 
 ### 3. Strong arrows and intersection function types
 
-Function types become first-class and **intersections of arrows** model
-multi-clause / overloaded methods directly:
+Function types become first-class. **Note the Beamtalk-specific caveat:** unlike
+Erlang/Elixir, Beamtalk has **no multi-clause method heads** — a selector maps
+to exactly one method body (the Smalltalk model), and case analysis happens
+*inside* the body via `match:` (see §5 / BT-1299 exhaustiveness). So arrow
+intersections here do **not** model overloaded clauses; they type a *single*
+method whose **result type covaries with its argument type**:
 
 ```
-// a method that is integer->integer AND float->float
-increment :: (Integer -> Integer) and (Float -> Float)
+// one method body; its result type depends on the input type
+abs :: (Integer -> Integer) and (Float -> Float)
 ```
+
+The intersection is the *signature*; a `match:` (or guard) in the body is what
+actually discriminates. This matters most for BEAM interop and numeric-tower
+methods, and less than it does in Erlang precisely because Beamtalk lacks clause
+heads.
 
 A **strong arrow** is a function statically provable to error on inputs outside
 its domain — checked by *negating the domain and type-checking*: if the body
 returns `none()` on out-of-domain input, the arrow is strong. Strong arrows are
 what let `dynamic()` cross the static/dynamic boundary without runtime checks
-(§2), because the underlying BEAM semantics already fail on invalid input. This
-is Elixir's "strong arrows" result and is the natural typing for Beamtalk's
-message-dispatch-heavy, multi-method style.
+(§2), because the underlying BEAM semantics already fail on invalid input.
+
+**Open tension (see Open Questions):** Beamtalk's `doesNotUnderstand:` can make
+*any* selector succeed at runtime, so "provably errors out of domain" needs a
+careful definition — DNU-overriding receivers may have *no* out-of-domain
+inputs at all.
 
 ### 4. Full structural products
 
@@ -151,9 +163,10 @@ invariants:
 - **`Dynamic(reason)` → `dynamic(t)`:** the reason-carrying hole becomes a
   bounded range; sites that today branch on `Dynamic` to "skip checking" instead
   intersect with `dynamic()` and continue.
-- **Methods → arrows:** method signatures become arrow types; multi-method /
-  overloaded selectors become arrow intersections; the strong-arrow check
-  gates dynamic-boundary inference.
+- **Methods → arrows:** method signatures become arrow types. Beamtalk has no
+  clause heads, so intersection arrows type a *single* method whose result
+  covaries with its argument type (the in-body `match:`/guard does the
+  discrimination); the strong-arrow check gates dynamic-boundary inference.
 - **Decision procedure:** introduce BDD-based emptiness under the existing
   `intersect`/`difference`/`union_of` API (contract invariant #2), swap the
   nominal shortcut for it incrementally, behind the same call sites.

--- a/docs/internal/set-theoretic-types-north-star.md
+++ b/docs/internal/set-theoretic-types-north-star.md
@@ -1,0 +1,186 @@
+# Set-Theoretic Types — North Star
+
+**Status:** Vision / directional. Not a committed decision.
+**Relationship to ADRs:** [ADR 0102](../ADR/0102-set-theoretic-type-operators.md)
+takes the first pragmatic step toward this vision (intersection + negation as
+`InferredType` operators, uniform narrowing, atom exhaustiveness). This document
+describes the *full* destination that ADR 0102 was deliberately designed to stay
+compatible with — so that reaching it is a **deepening, not a rewrite**.
+
+**Audience:** compiler authors deciding how far to push the type system, and
+anyone tempted to add a type-checker feature that would foreclose this path.
+
+---
+
+## The vision in one paragraph
+
+A type **is a set of values**. Subtyping **is set inclusion**, decided
+*semantically* (by asking "is this combination of types empty?") rather than by
+walking a nominal class hierarchy. The type language is closed under **union**
+(`or`), **intersection** (`and`), and **negation** (`not`), plus a first-class
+gradual type **`dynamic()`** that lets typed and untyped Beamtalk interoperate
+without runtime checks and without `dynamic()` "spreading everywhere". This is
+the Castagna/Duboc/Valim design that Elixir (1.17+) adopted; Beamtalk's
+singleton-as-`Symbol` convention, `Union` type, and hand-rolled `union_without`
+are all partial, nominal approximations of it.
+
+## What "full" adds beyond ADR 0102
+
+ADR 0102 gives us the *operators* and normalisation for the atom/nominal cases
+we narrow over today. The north star is five further steps.
+
+### 1. Semantic subtyping via emptiness checking
+
+Today subtyping is `class_name` comparison plus a `superclass_chain` walk.
+Semantic subtyping replaces this with a single primitive: `A <: B` iff
+`A and not B` is empty (`none()` / `Never`). Everything — union members, atom
+complements, function domains — reduces to **one emptiness decision procedure**,
+classically implemented over BDDs (binary decision diagrams) of type
+constructors.
+
+```
+integer() and atom()   ==>  none()      "disjoint — emptiness holds"
+#foo <: Symbol          <=>  (#foo and not Symbol) == none()
+```
+
+The payoff: the growing pile of special-case predicates
+(`type_admits_singleton`, impossible-comparison checks, member-of-union tests)
+all become "is this empty?" — no new predicate per shape.
+
+### 2. Structural `dynamic()` replacing the `Dynamic` hole
+
+Beamtalk's `Dynamic(reason)` is a **checking hole**: "skip all checking." The
+north-star `dynamic()` is a **type with structure** — a *range* of types kept
+"at the root" of any composite (`{ok, dynamic()}` normalises to
+`dynamic({ok, term()})`). Intersecting with `dynamic()` makes any type gradual:
+only a subset needs to statically hold.
+
+The critical property is that `dynamic()` **does not spread**. When a value of
+`dynamic()` reaches a *strong* operation (one Erlang guarantees will error on
+bad input — see §3), the checker returns the operation's real codomain
+(optionally `dynamic() and codomain`) instead of smearing `dynamic()` across
+everything downstream. This is what makes gradual typing usable at scale: adding
+one annotation tightens results *locally* instead of being swallowed by dynamic.
+
+```
+// today: a hole — inference stops
+x :: Dynamic
+
+// north star: a bounded range — inference continues through strong ops
+x :: dynamic() and (Integer | Symbol)
+x + 1        // Integer  (not dynamic()) — `+` is a strong arrow
+```
+
+This is the single biggest upgrade for Beamtalk's stated *gradual-typing* goal
+(`type-system-design.md`): untyped code stays unannotated, yet annotations pay
+off precisely where added.
+
+### 3. Strong arrows and intersection function types
+
+Function types become first-class and **intersections of arrows** model
+multi-clause / overloaded methods directly:
+
+```
+// a method that is integer->integer AND float->float
+increment :: (Integer -> Integer) and (Float -> Float)
+```
+
+A **strong arrow** is a function statically provable to error on inputs outside
+its domain — checked by *negating the domain and type-checking*: if the body
+returns `none()` on out-of-domain input, the arrow is strong. Strong arrows are
+what let `dynamic()` cross the static/dynamic boundary without runtime checks
+(§2), because the underlying BEAM semantics already fail on invalid input. This
+is Elixir's "strong arrows" result and is the natural typing for Beamtalk's
+message-dispatch-heavy, multi-method style.
+
+### 4. Full structural products
+
+Tuples, maps, and records typed structurally, with the same operators applying
+inside them — `{ok, T} or {error, E}` for tagged returns, map field types,
+negation inside products. This subsumes the ad-hoc handling of Erlang tagged
+tuples (`{ok, V} | {error, R}`) that Beamtalk interop leans on today.
+
+### 5. Negation everywhere
+
+ADR 0102 introduces negation for atoms/nominal narrowing. The north star allows
+`not T` for *any* `T`, which is what makes exhaustiveness, dead-branch
+detection, and the strong-arrow check total rather than atom-only.
+
+## Why not now
+
+- **Cost.** A sound emptiness/BDD decision procedure plus normalisation is a
+  substantial, subtle engine (Elixir's took years and a PhD). It is disjoint
+  from Beamtalk's current nominal comparison.
+- **Nominal-core mismatch.** Beamtalk is deliberately nominal — classes, the
+  metaclass tower (ADR 0036), structural protocols layered on (ADR 0068 Stage 2).
+  Full semantic subtyping is structural; adopting it means embedding nominal
+  classes as *basic types* in the lattice with declared inclusions, and
+  reconciling the metaclass story.
+- **Unspent benefit.** Arrow/intersection-function typing and a structural
+  `dynamic()` buy the most when there is a large typed surface to check. Today
+  the payoff is narrowing and atom exhaustiveness — exactly ADR 0102's scope.
+
+## Compatibility contract
+
+For the north star to remain a *deepening* rather than a *rewrite*, work done
+under ADR 0102 (and any type-checker change before then) must preserve these
+invariants:
+
+1. **Subtyping is set inclusion.** Never introduce a subtyping rule that is not
+   expressible as "`A and not B` is empty." The singleton-as-`Symbol` convention
+   already obeys this; keep it that way.
+2. **Operators normalise, and normalisation is centralised.** `union_of` /
+   `intersect` / `difference` are the *only* places types are combined, so the
+   decision procedure can later be swapped underneath them.
+3. **Nominal types are basic elements.** `Known { class_name }` and `Meta` must
+   read as opaque *basic types* in the lattice — never assume the algebra needs
+   to look inside a class name beyond identity + declared inclusions.
+4. **`Dynamic` is isolable.** Keep `Dynamic(reason)` behind the same combinators
+   so it can be replaced by a structural `dynamic()` (a range kept at the root)
+   without touching call sites. Do **not** let `Dynamic` leak special-case
+   handling into unrelated match arms.
+5. **Provenance survives operators.** `TypeProvenance` must thread through
+   intersection/negation as it does through union, so error messages keep
+   working when the engine deepens.
+
+## Migration sketch (if/when we commit)
+
+- **Nominal → basic types:** each class becomes a basic type; the hierarchy
+  (`superclass_chain`) becomes a set of *declared inclusions* fed to the
+  emptiness checker (`#foo <: Symbol <: Object` are just declared subset facts).
+- **`Dynamic(reason)` → `dynamic(t)`:** the reason-carrying hole becomes a
+  bounded range; sites that today branch on `Dynamic` to "skip checking" instead
+  intersect with `dynamic()` and continue.
+- **Methods → arrows:** method signatures become arrow types; multi-method /
+  overloaded selectors become arrow intersections; the strong-arrow check
+  gates dynamic-boundary inference.
+- **Decision procedure:** introduce BDD-based emptiness under the existing
+  `intersect`/`difference`/`union_of` API (contract invariant #2), swap the
+  nominal shortcut for it incrementally, behind the same call sites.
+
+## Open questions
+
+- How do **structural protocols** (ADR 0068 Stage 2) relate to arrow
+  intersections — are protocol conformance obligations expressible as arrow
+  subtyping, or do they stay a separate structural check?
+- Does the **metaclass tower** (`Meta`) embed cleanly as basic types, or does
+  `C class` subtyping need bespoke inclusions?
+- What is Beamtalk's **gradual guarantee** statement precisely, and which
+  operations are "strong arrows" given DNU (`doesNotUnderstand:`) can make *any*
+  selector succeed at runtime?
+- Performance envelope of emptiness checking at REPL/LSP edit-time latency.
+
+## References
+
+- **Elixir gradual set-theoretic types:**
+  [docs](https://hexdocs.pm/elixir/main/gradual-set-theoretic-types.html) ·
+  [Strong arrows — elixir-lang.org](https://elixir-lang.org/blog/2023/09/20/strong-arrows-gradual-typing/)
+- **Theory:** Giuseppe Castagna, Guillaume Duboc, José Valim — "The Design
+  Principles of the Elixir Type System"; Castagna et al. semantic subtyping /
+  CDuce line of work.
+- **Beamtalk:** [ADR 0102](../ADR/0102-set-theoretic-type-operators.md) (the
+  first step) · [ADR 0068](../ADR/0068-parametric-types-and-protocols.md)
+  (unions, narrowing, the noted difference-types gap) ·
+  [ADR 0025](../ADR/0025-gradual-typing-and-protocols.md) ·
+  [ADR 0036](../ADR/0036-full-metaclass-tower.md) ·
+  [type-system-design.md](type-system-design.md)

--- a/docs/internal/set-theoretic-types-north-star.md
+++ b/docs/internal/set-theoretic-types-north-star.md
@@ -24,6 +24,52 @@ the Castagna/Duboc/Valim design that Elixir (1.17+) adopted; Beamtalk's
 singleton-as-`Symbol` convention, `Union` type, and hand-rolled `union_without`
 are all partial, nominal approximations of it.
 
+## Nominal vs structural — and why it matters here
+
+This whole document hinges on one distinction, so it is worth stating plainly.
+
+- **Nominal typing:** a type's identity is its *name*, and subtyping is
+  *declared*. `Counter` is `Counter` because it is named so; `SavingsAccount <:
+  Account` because the class declaration says `Account subclass: SavingsAccount`.
+  Two classes with identical shape are still different types.
+- **Structural typing:** a type's identity is its *shape* (its set of
+  messages/fields), and subtyping is "has at least the required members" —
+  no declaration needed. Anything responding to `asString -> String` inhabits
+  `< asString -> String >`, whatever its class.
+
+**Beamtalk today leans nominal.** The evidence is in the representation:
+`InferredType::Known` carries a **`class_name`**, and subtyping is a walk of the
+*declared* hierarchy (`superclass_chain`). The class tower, the metaclass tower
+(ADR 0036), and the singleton-as-`Symbol` convention are all name-and-declaration
+based. The one structural exception is **protocols** (ADR 0068 Stage 2):
+conformance to `Printable` is automatic and shape-based — a structural layer
+grafted onto a nominal core.
+
+**The tension:** set-theoretic types are **structural at heart** — a type *is* a
+set of values and subtyping *is* inclusion computed on structure. So the nominal
+core is the single biggest impedance mismatch on the road to the north star.
+Adopting the full engine means embedding each nominal class as a **basic element**
+in the lattice and feeding its hierarchy in as **declared inclusion facts**
+(`#foo ⊆ Symbol ⊆ Object`) — i.e. *manufacturing* structure out of names, rather
+than reading it off the values.
+
+**Aside — could Beamtalk be structural instead?** Yes, and it would fit the
+set-theoretic model *more* naturally. Message-passing OO is structural by
+construction (dispatch is on the message, not a declared interface), so
+Smalltalk's duck typing is already structural-in-spirit; the nominal core is the
+pragmatic departure Beamtalk made for tooling. A structural Beamtalk would make
+message-sets (protocols) the type layer and demote classes to
+implementation-sharing — essentially **Strongtalk** (Bracha & Griswold, 1993,
+already cited in ADR 0068), a static structural type system for Smalltalk. The
+real blockers are not feasibility but (a) **`Self`/binary-method typing** —
+`Comparable` needs "compare me to *my own type*", which pure structural typing
+can only express with `Self`-types or F-bounded/row polymorphism — and (b)
+**`doesNotUnderstand:`**, which makes an overriding receiver respond to *every*
+message and therefore structurally satisfy *every* type, undercutting the check.
+This document does **not** propose going structural; it records the option
+because "adopt full set-theoretic types" and "how nominal is Beamtalk" are the
+same question viewed from two sides.
+
 ## What "full" adds beyond ADR 0102
 
 ADR 0102 gives us the *operators* and normalisation for the atom/nominal cases
@@ -123,11 +169,10 @@ detection, and the strong-arrow check total rather than atom-only.
 - **Cost.** A sound emptiness/BDD decision procedure plus normalisation is a
   substantial, subtle engine (Elixir's took years and a PhD). It is disjoint
   from Beamtalk's current nominal comparison.
-- **Nominal-core mismatch.** Beamtalk is deliberately nominal — classes, the
-  metaclass tower (ADR 0036), structural protocols layered on (ADR 0068 Stage 2).
-  Full semantic subtyping is structural; adopting it means embedding nominal
-  classes as *basic types* in the lattice with declared inclusions, and
-  reconciling the metaclass story.
+- **Nominal-core mismatch.** The big one, detailed in *Nominal vs structural*
+  above: Beamtalk's names-and-hierarchy core must be embedded as basic types
+  with declared inclusions before a structural, set-theoretic engine can decide
+  subtyping, plus the metaclass story has to be reconciled.
 - **Unspent benefit.** Arrow/intersection-function typing and a structural
   `dynamic()` buy the most when there is a large typed surface to check. Today
   the payoff is narrowing and atom exhaustiveness — exactly ADR 0102's scope.

--- a/docs/internal/set-theoretic-types-north-star.md
+++ b/docs/internal/set-theoretic-types-north-star.md
@@ -240,6 +240,61 @@ class names in type position denote shapes, lean on protocols and
 exhaustiveness. Which is, deliberately, the same destination the set-theoretic
 sections describe from the value-set side.
 
+### Recommendation: hybrid, structural by increments
+
+Should Beamtalk *move* to structural typing? **No — not as a project-level
+pivot. Yes — as a direction the existing roadmap already walks.** The
+reasoning, so it doesn't get re-litigated from scratch:
+
+**Against a wholesale move:**
+
+1. **Tooling is the value proposition, and nominal is better at tooling's
+   bread-and-butter.** Crisp errors ("expected `Account`, got `String`" beats a
+   method-set diff), O(depth) subtyping at LSP latency, declared links for
+   rename/find-subtypes. A pivot trades away strengths in exactly the dimension
+   Beamtalk competes on ("types serve the developer",
+   `type-system-design.md`).
+2. **The nominal machinery is deep and recent** — metaclass tower (ADR 0036),
+   metaclass-aware inference (ADR 0083), sealed exhaustiveness (BT-1299), the
+   singleton convention. A pivot strands that investment and reopens settled
+   decisions.
+3. **DNU + ADR 0100 cap the payoff.** The open-world policy forces the checker
+   to stay conservative regardless of conformance model; the soundness win
+   structural typing promises in a closed language mostly evaporates in an
+   open one.
+4. **Most code is unannotated** (gradual typing), and where annotations
+   concentrate — public API parameters — **protocols already provide structural
+   typing today** (`check_protocol_conformance_in_module`, shipped). The
+   marginal gain of also making class names structural is small relative to
+   the semantic rupture.
+
+**For continuing the structural lean** — message dispatch is structurally
+honest, BEAM data is structural (ADR 0101), and the set-theoretic north star
+delivers structural *semantics* incrementally with each step paying for
+itself. "Move to structural" and "walk the north star" are the same road; a
+separate pivot would just be the riskier way to travel it.
+
+**Sequence:**
+
+1. **Now:** ADR 0102 (atoms, unions, narrowing, advisory exhaustiveness).
+2. **Cheap, next:** make protocols the *recommended* annotation vocabulary for
+   public API parameters (docs/guidelines, possibly a lint) — more structural
+   typing using only shipped machinery.
+3. **Evidence-driven, later:** anonymous inline shapes
+   (`:: < withdraw: Money >`) *if* users demonstrably hit "I don't want to
+   name a protocol for one call site." Not before.
+4. **Only with the north-star engine:** the real pivot — class-name-in-type-
+   position denotes shape — because it needs set-inclusion subtyping anyway,
+   and doing it earlier means doing it twice.
+5. **Never:** removing nominal classes or `sealed` (the closed-world islands
+   do real exhaustiveness work).
+
+**Revisit triggers:** protocol annotations becoming the dominant annotation
+form in real code; interop typing demanding map-shapes; or a commitment to the
+north-star engine. Any of these makes step 4 timely. Absent them, the hybrid
+is the resting point — the same one TypeScript, Scala, and Pony converged on
+from both directions.
+
 ## What "full" adds beyond ADR 0102
 
 ADR 0102 gives us the *operators* and normalisation for the atom/nominal cases


### PR DESCRIPTION
## Summary

Adds **ADR 0102** proposing that Beamtalk adopt set-theoretic type *operators* (intersection `&`, difference/negation `\`) so that type narrowing becomes a small uniform algebra instead of a growing list of per-idiom AST rules — plus a companion **north-star design doc** capturing the full semantic-subtyping destination the operators are kept compatible with.

Motivated by a question about how the type system handles singleton symbols: today the codebase already does set algebra *by hand* but only narrowly — `union_of` (union), `union_without` (difference, singleton-only), and `type_admits_singleton` (membership) — and ADR 0068 explicitly flagged "false-branch complement types … requires difference types" as an open gap. This ADR generalises those.

## Scope (as decided)

Internal operators **+** surface syntax **+** exhaustiveness — the pragmatic midpoint between an internal-only refactor and a full CDuce-style engine (the latter documented as the north star, not adopted).

## Files

- `docs/ADR/0102-set-theoretic-type-operators.md` — the decision (Proposed)
- `docs/internal/set-theoretic-types-north-star.md` — full semantic-subtyping vision + compatibility contract + migration sketch
- `docs/ADR/README.md` — index entry

## Review

Ran the project's 3-pass ADR review including an adversarial fresh-eyes pass. It caught real overclaims, all fixed in the diff:

- **Honest narrowing scope** — dropped the "every idiom collapses to two lines" claim; the seven rules split into `singleton_eq` (identical port), `class_eq`/`is_kind_of` (deliberate true-branch change; false branch needs nominal difference, **deferred**), and `is_result` (tag narrowing, not expressible — untouched).
- **`Dynamic` asymmetry stated** — `intersect(Dynamic,P)=P` but `difference(Dynamic,P)=Dynamic`; mirroring `union_of` here would silently regress `isNil` narrowing on unannotated receivers.
- **Syntax reconciled** — reuse ADR 0068's existing `&` for intersection, add only `\` for difference (not Elixir's `and`/`not`), with a precedence table.
- **Exhaustiveness is advisory** — type-based `Warning`/`Lint` distinct from BT-1299's pattern-based error, gated by ADR 0100's open-world severity policy, with the gradual-soundness caveat (annotations aren't runtime-enforced) called out.
- Counted the `TypeAnnotation` AST cost and flagged nominal-class difference as undefined/deferred.

Grounded in Elixir's gradual set-theoretic types (Castagna/Duboc/Valim) and verified against the actual narrowing code (`narrowing/rules/`, `inference.rs`, `types.rs`).

## Next step

`/plan-adr` to break this into implementation issues (phase 1 = internal operators + `singleton_eq`; phase 1b = nominal difference; phase 2 = syntax + exhaustiveness). Docs-only change — no code, runtime, or codegen impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013K1RiTWpJo7fZNp4J5VCq2)_