### PR TITLE
docs: make reserved-name diagnostic accurate for all binding kinds (BT-2718)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/validators/reserved_name_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/reserved_name_validators.rs
@@ -112,16 +112,19 @@ fn check_raw_name(name: &str, span: Span, kind: &str, diagnostics: &mut Vec<Diag
             Diagnostic::error(
                 format!(
                     "{kind} `{name}` uses the reserved `__` prefix, which the compiler \
-                     uses internally for actor/object state keys"
+                     uses internally for state keys and control-flow temporaries"
                 ),
                 span,
             )
             .with_hint(
                 "Rename it. Identifiers beginning with `__` (double underscore) are \
-                 reserved for compiler-internal state keys. A `__local__`-prefixed name \
-                 is silently stripped from persisted state on every dispatch commit; a \
-                 `__methods__` or `__class_mod__` collision would instead overwrite the \
-                 runtime's dispatch metadata and corrupt method lookup."
+                 reserved for the compiler. A field or class variable with this prefix \
+                 becomes a reserved state-map key: `__local__`-prefixed keys are silently \
+                 stripped from persisted state on every dispatch commit, and a \
+                 `__methods__` or `__class_mod__` collision would overwrite the runtime's \
+                 dispatch metadata and corrupt method lookup. A parameter, block \
+                 parameter, or local with this prefix collides with the compiler's \
+                 control-flow temporary names."
                     .to_string(),
             ),
         );


### PR DESCRIPTION
## Summary

Follow-up polish to the BT-2718 reserved-`__`-name validator (PRs #2834 / #2835), addressing the "hint scope vs. binding kind" nit raised in #2835's review.

The diagnostic message and hint framed the collision hazard purely as **state-map persistence**. That's accurate for instance fields and class variables (which land as atom keys in the actor/object state map), but the validator also fires on **method parameters, block parameters, and local `:=` targets** — where the real hazard is a collision with the compiler's **control-flow temporary names**, not state persistence.

## Changes

- `reserved_name_validators.rs`:
  - Generalize the error message from "…used internally for actor/object state keys" → "…used internally for state keys and control-flow temporaries".
  - Split the hint into the two real paths: the state-map path (fields / class variables → strip for `__local__`, overwrite dispatch metadata for `__methods__`/`__class_mod__`) and the codegen-naming path (params / block params / locals → collides with compiler control-flow temporaries).

## Testing

- Documentation-only change to the diagnostic strings (no logic change); the message still names the offending declaration kind and identifier.
- `cargo test -p beamtalk-core reserved_name_validators`: 7 pass.
- `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9VeUFbKoJuCyS7mgWqAWa)_