### PR TITLE
test: replace placeholder assertions in extension_type_annotations.btscript

### DIFF
--- a/tests/repl-protocol/cases/extension_type_annotations.btscript
+++ b/tests/repl-protocol/cases/extension_type_annotations.btscript
@@ -22,10 +22,10 @@ Value subclass: Greeter
 // ===========================================================================
 
 Greeter >> shout :: -> String => self greet uppercase
-// => _
+// => Greeter>>shout
 
 g := Greeter new
-// => _
+// => Greeter(name: "World")
 
 g shout
 // => HELLO, WORLD
@@ -35,7 +35,7 @@ g shout
 // ===========================================================================
 
 Greeter >> greetWith: prefix :: String :: -> String => prefix ++ self.name
-// => _
+// => Greeter>>greetWith:
 
 g greetWith: "Hi, "
 // => Hi, World
@@ -45,7 +45,7 @@ g greetWith: "Hi, "
 // ===========================================================================
 
 Greeter >> reversed -> String => self greet reverse
-// => _
+// => Greeter>>reversed
 
 g reversed
 // => dlroW ,olleH


### PR DESCRIPTION
## Summary

Replaces four `// => _` wildcard assertions in `tests/repl-protocol/cases/extension_type_annotations.btscript` with their concrete, deterministic values:

- `Greeter >> shout :: -> String` definition now asserts `// => Greeter>>shout`
- `Greeter new` now asserts `// => Greeter(name: "World")`
- `Greeter >> greetWith: prefix :: String :: -> String` definition now asserts `// => Greeter>>greetWith:`
- `Greeter >> reversed -> String` definition now asserts `// => Greeter>>reversed`

All four values are fully deterministic: extension method definitions always return `ClassName>>selector`, and `Greeter new` always constructs the same value object with the default field. The wildcards were placeholders that accepted any output, making the test assertions weaker than they needed to be.

`e2e_language_tests` passes with the tightened assertions confirmed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfbhqmhqBt9dDfFiE94dxq)_