### PR TITLE
docs: branch reserved-name hint on binding kind (BT-2718)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/validators/reserved_name_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/reserved_name_validators.rs
@@ -108,6 +108,24 @@ fn check_declared_name(id: &Identifier, kind: &str, diagnostics: &mut Vec<Diagno
 /// Emits a diagnostic if `name` is in the reserved namespace, anchored at `span`.
 fn check_raw_name(name: &str, span: Span, kind: &str, diagnostics: &mut Vec<Diagnostic>) {
     if is_reserved_internal_name(name) {
+        // The hazard depends on where the name appears. Fields and class
+        // variables land as keys in the actor/object state map; parameters,
+        // block parameters, and locals become codegen-generated variables.
+        // Emit only the paragraph relevant to this declaration kind.
+        let hint = match kind {
+            "field" | "class variable" => {
+                "Rename it. A field or class variable beginning with `__` (double \
+                 underscore) becomes a reserved state-map key: `__local__`-prefixed keys \
+                 are silently stripped from persisted state on every dispatch commit, and \
+                 a `__methods__` or `__class_mod__` collision would overwrite the \
+                 runtime's dispatch metadata and corrupt method lookup."
+            }
+            _ => {
+                "Rename it. A parameter, block parameter, or local beginning with `__` \
+                 (double underscore) collides with the names the compiler generates for \
+                 control-flow temporaries."
+            }
+        };
         diagnostics.push(
             Diagnostic::error(
                 format!(
@@ -116,17 +134,7 @@ fn check_raw_name(name: &str, span: Span, kind: &str, diagnostics: &mut Vec<Diag
                 ),
                 span,
             )
-            .with_hint(
-                "Rename it. Identifiers beginning with `__` (double underscore) are \
-                 reserved for the compiler. A field or class variable with this prefix \
-                 becomes a reserved state-map key: `__local__`-prefixed keys are silently \
-                 stripped from persisted state on every dispatch commit, and a \
-                 `__methods__` or `__class_mod__` collision would overwrite the runtime's \
-                 dispatch metadata and corrupt method lookup. A parameter, block \
-                 parameter, or local with this prefix collides with the compiler's \
-                 control-flow temporary names."
-                    .to_string(),
-            ),
+            .with_hint(hint.to_string()),
         );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up polish to the BT-2718 reserved-`__`-name validator, addressing the "unified hint describes both hazards regardless of binding kind" nit from #2837's review.

The hint printed both hazard paragraphs — the state-map path *and* the control-flow path — on every collision, so a flagged `parameter` still showed the state-map wording (and a flagged `field` still showed the control-flow wording). Both were accurate but only one is ever relevant.

## Changes

- `reserved_name_validators.rs`: select a single hint paragraph based on `kind`:
  - **field / class variable** → state-map wording (`__local__` stripped from persisted state; `__methods__`/`__class_mod__` overwrite dispatch metadata).
  - **parameter / block parameter / local** → control-flow-temporary wording.

The error-message body is unchanged (still names the declaration kind and identifier, and mentions both internal uses).

## Testing

- Documentation-only change to the diagnostic hint (no logic change).
- `cargo test -p beamtalk-core reserved_name_validators`: 7 pass.
- `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9VeUFbKoJuCyS7mgWqAWa)_