### PR TITLE
Type checker: unify singleton_eq/is_nil narrowing onto intersect/difference (BT-2740)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1518,7 +1518,6 @@ impl TypeChecker {
                         union_ty,
                         &eq.info.singleton,
                         eq.info.negated,
-                        hierarchy,
                         span,
                     );
                 }
@@ -2324,17 +2323,27 @@ impl TypeChecker {
         let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
 
         let matched = InferredType::known(eq.singleton.clone());
-        let remainder = Self::union_without(&current_ty, &eq.singleton);
+        let provenance = super::TypeProvenance::Inferred(Span::default());
+        // ADR 0102 §2: the equality branches are the set-theoretic intersection
+        // and difference of the variable's current type with the tested
+        // singleton. `intersect(T, #foo)` is the "test holds" type (the values of
+        // `T` that could be `#foo`); `difference(T, #foo)` is the complementary
+        // type with `#foo` removed. An impossible test (`x :: Integer; x = #foo`)
+        // yields `intersect = Never` for the unreachable branch — the diagnostic
+        // for that case is emitted separately by
+        // `check_impossible_singleton_comparison`.
+        let holds = InferredType::intersect(&current_ty, &matched, provenance);
+        let removed = InferredType::difference(&current_ty, &matched, provenance);
         if eq.negated {
             // `x /= #foo`: the true branch removes the singleton; the false
             // branch is the singleton.
-            info.true_type = remainder;
-            info.false_type = Some(matched);
+            info.true_type = removed;
+            info.false_type = Some(holds);
         } else {
             // `x = #foo`: the true branch is the singleton; the false branch
             // removes it.
-            info.true_type = matched;
-            info.false_type = Some(remainder);
+            info.true_type = holds;
+            info.false_type = Some(removed);
         }
         info
     }
@@ -2356,11 +2365,10 @@ impl TypeChecker {
         current_ty: &InferredType,
         singleton: &EcoString,
         negated: bool,
-        hierarchy: &ClassHierarchy,
         test_span: Span,
     ) {
         if matches!(current_ty, InferredType::Dynamic(_) | InferredType::Never)
-            || Self::type_admits_singleton(current_ty, singleton, hierarchy)
+            || Self::type_admits_singleton(current_ty, singleton)
         {
             return;
         }
@@ -2376,75 +2384,21 @@ impl TypeChecker {
         );
     }
 
-    /// Removes every union member equal to the singleton named `removed` from
-    /// `ty` (BT-2617). The singleton counterpart of [`non_nil_type`].
+    /// BT-2624 / ADR 0102 §2: whether the singleton `singleton` (`#foo`) could
+    /// be a runtime value of `ty` — defined as `intersect(ty, #foo) != Never`.
     ///
-    /// - A union collapses to its single remaining member, or to `Never` when
-    ///   the singleton was its only member (the complementary branch is then
-    ///   unreachable).
-    /// - A non-union type that *is* the singleton yields `Never`; any other
-    ///   non-union type (including `Dynamic`) is returned unchanged, since
-    ///   there is no union to subtract from.
-    fn union_without(ty: &InferredType, removed: &EcoString) -> InferredType {
-        match ty {
-            InferredType::Union {
-                members,
-                provenance,
-            } => {
-                debug_assert!(
-                    members
-                        .iter()
-                        .all(|m| !matches!(m, InferredType::Union { .. })),
-                    "union members are kept flat by `union_of`, so a single subtraction pass suffices"
-                );
-                let kept: Vec<InferredType> = members
-                    .iter()
-                    .filter(|m| m.as_known().is_none_or(|n| n != removed))
-                    .cloned()
-                    .collect();
-                match kept.len() {
-                    0 => InferredType::Never,
-                    1 => kept.into_iter().next().unwrap(),
-                    _ => InferredType::Union {
-                        members: kept,
-                        provenance: *provenance,
-                    },
-                }
-            }
-            InferredType::Known { class_name, .. } if class_name == removed => InferredType::Never,
-            _ => ty.clone(),
-        }
-    }
-
-    /// BT-2624: Whether the singleton `singleton` (`#foo`) could be a runtime
-    /// value of `ty`. A member admits the singleton when it *is* that singleton,
-    /// or when it is a supertype of every singleton — `Symbol` or one of its
-    /// ancestors (`Object`, `ProtoObject`). Other concrete members (`Integer`, a
-    /// *different* singleton, …) do not admit it. `Dynamic` admits anything, so
-    /// callers stay conservative when the type is unknown.
-    fn type_admits_singleton(
-        ty: &InferredType,
-        singleton: &EcoString,
-        hierarchy: &ClassHierarchy,
-    ) -> bool {
-        match ty {
-            InferredType::Dynamic(_) => true,
-            InferredType::Union { members, .. } => members
-                .iter()
-                .any(|m| Self::type_admits_singleton(m, singleton, hierarchy)),
-            InferredType::Known { class_name, .. } => {
-                class_name == singleton
-                    || class_name == "Symbol"
-                    || hierarchy
-                        .superclass_chain("Symbol")
-                        .iter()
-                        .any(|c| c == class_name)
-            }
-            // `Meta`, `Never`, etc. do not admit a singleton: a class object or
-            // a divergent value can never equal a symbol literal, so a
-            // `metaVar = #foo` test is correctly flagged "can never be true".
-            _ => false,
-        }
+    /// Intersection already models singleton membership (`Symbol ∩ #foo = #foo`,
+    /// `Object ∩ #foo = #foo`, `Integer ∩ #foo = Never`, and it distributes over
+    /// unions), so this is the single source of truth for "the test could hold".
+    /// `Dynamic` intersects to the singleton (non-`Never`), so callers stay
+    /// conservative when the type is unknown.
+    fn type_admits_singleton(ty: &InferredType, singleton: &EcoString) -> bool {
+        let matched = InferredType::known(singleton.clone());
+        let provenance = super::TypeProvenance::Inferred(Span::default());
+        !matches!(
+            InferredType::intersect(ty, &matched, provenance),
+            InferredType::Never
+        )
     }
 
     /// BT-2045: Infer argument types for `on:do:` with exception class propagation.
@@ -3298,43 +3252,34 @@ impl TypeChecker {
     }
 
     /// Remove `UndefinedObject` (nil) from a union type or convert a known type
-    /// to itself if it is non-nil.
+    /// to itself if it is non-nil — the `isNil ifFalse:` branch type.
     ///
-    /// BT-2016: Also matches `"Nil"` as a defensive measure — `resolve_type_keyword`
-    /// should canonicalize to `"UndefinedObject"`, but downstream callers may
-    /// encounter `"Nil"` from BEAM metadata or return-type strings.
+    /// ADR 0102 §2: for a union receiver this routes through the set-theoretic
+    /// `difference` operator with `P = UndefinedObject` (nil's type). `"Nil"` is
+    /// subtracted alongside the canonical `UndefinedObject` as a defensive alias
+    /// (BT-2016) — `resolve_type_keyword` should canonicalize to
+    /// `"UndefinedObject"`, but downstream callers may encounter `"Nil"` from
+    /// BEAM metadata or return-type strings.
+    ///
+    /// Two behaviours are preserved from the pre-operator implementation:
+    /// - **Nil-only-union → `Dynamic` softening.** A union whose members are all
+    ///   nil would collapse to `Never` under `difference`; instead it softens to
+    ///   `Dynamic(Unknown)` so an unreachable `ifNotNil:` body still compiles.
+    /// - **Non-union pass-through.** A non-union type is returned unchanged (we
+    ///   cannot make a non-union "more non-nil"), rather than subtracting nil —
+    ///   which would turn a bare `UndefinedObject` receiver into `Never`.
     pub(super) fn non_nil_type(ty: &InferredType) -> InferredType {
         match ty {
-            InferredType::Union {
-                members,
-                provenance,
-            } => {
-                // Fast path: if no member is UndefinedObject/Nil, return unchanged.
-                let has_nil = members.iter().any(|m| {
-                    m.as_known().is_some_and(|n| {
-                        WellKnownClass::from_str(n).is_some_and(WellKnownClass::is_nil_class)
-                    })
-                });
-                if !has_nil {
-                    return ty.clone();
-                }
-                let non_nil: Vec<InferredType> = members
-                    .iter()
-                    .filter(|m| {
-                        m.as_known().is_none_or(|name| {
-                            !WellKnownClass::from_str(name)
-                                .is_some_and(WellKnownClass::is_nil_class)
-                        })
-                    })
-                    .cloned()
-                    .collect();
-                match non_nil.len() {
-                    0 => InferredType::Dynamic(DynamicReason::Unknown),
-                    1 => non_nil.into_iter().next().unwrap(),
-                    _ => InferredType::Union {
-                        members: non_nil,
-                        provenance: *provenance,
-                    },
+            InferredType::Union { .. } => {
+                let provenance = super::TypeProvenance::Inferred(Span::default());
+                // `P = UndefinedObject | Nil` (both nil spellings, BT-2016).
+                let nil = InferredType::simple_union(&["nil", "Nil"]);
+                let stripped = InferredType::difference(ty, &nil, provenance);
+                // Nil-only union collapses to `Never`; soften to `Dynamic`.
+                if matches!(stripped, InferredType::Never) {
+                    InferredType::Dynamic(DynamicReason::Unknown)
+                } else {
+                    stripped
                 }
             }
             // If the variable is not a union, narrowing away nil for a non-union

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
@@ -574,8 +574,8 @@ fn test_refine_singleton_eq_all_removed_is_never() {
 #[test]
 fn test_refine_singleton_eq_dynamic_variable_keeps_false_dynamic() {
     // An unbound variable resolves to Dynamic; `x = #foo` narrows the true
-    // branch to #foo and leaves the false branch Dynamic — there is no union to
-    // subtract from (exercises the `_ => ty.clone()` arm of `union_without`).
+    // branch to #foo and leaves the false branch Dynamic — `difference(Dynamic,
+    // #foo) = Dynamic` (Dynamic is opaque to subtraction, ADR 0102 §1).
     let hierarchy = ClassHierarchy::with_builtins();
     let env = TypeEnv::new(); // `x` is absent → Dynamic
     let expr = msg_send(
@@ -609,6 +609,56 @@ fn test_refine_singleton_symbol_left_inequality_swaps_branches() {
     let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
     assert_eq!(refined.true_type, InferredType::known("Integer"));
     assert_eq!(refined.false_type, Some(InferredType::known("#infinity")));
+}
+
+/// BT-2740 / ADR 0102 §2 (pinned corner 1): an impossible singleton test
+/// (`x :: Integer; x = #foo`) now narrows the *true* branch to `Never` via
+/// `intersect(Integer, #foo) = Never`. Previously `union_without` returned the
+/// singleton (`#foo`) unconditionally for the true branch even though it is
+/// unreachable. The "can never be true" diagnostic still fires elsewhere
+/// (`check_impossible_singleton_comparison`); only the branch type changed.
+#[test]
+fn test_refine_singleton_eq_impossible_true_branch_is_never() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("x", InferredType::known("Integer"));
+    let expr = msg_send(
+        var("x"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("foo")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    // True branch is unreachable — the value can never be `#foo`.
+    assert_eq!(refined.true_type, InferredType::Never);
+    // False branch keeps the full `Integer` type (nothing removable).
+    assert_eq!(refined.false_type, Some(InferredType::known("Integer")));
+}
+
+/// BT-2740 / ADR 0102 §2 (new capability): the false branch of `x = #foo` on a
+/// bare `Symbol` receiver narrows to the negation `Symbol \ #foo` (every symbol
+/// except `#foo`) and renders as `Symbol \ #foo` in hover.
+#[test]
+fn test_refine_singleton_eq_symbol_false_branch_is_negation() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut env = TypeEnv::new();
+    env.set_local("s", InferredType::known("Symbol"));
+    let expr = msg_send(
+        var("s"),
+        MessageSelector::Binary("=".into()),
+        vec![symbol_lit("foo")],
+    );
+    let info = TypeChecker::detect_narrowing(&expr).unwrap();
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    // True branch narrows to the singleton itself.
+    assert_eq!(refined.true_type, InferredType::known("#foo"));
+    // False branch is the complement `Symbol \ #foo`.
+    let false_ty = refined.false_type.expect("false branch present");
+    assert!(
+        matches!(false_ty, InferredType::Negation { .. }),
+        "expected a Negation, got: {false_ty:?}"
+    );
+    assert_eq!(false_ty.display_for_diagnostic().unwrap(), "Symbol \\ #foo");
 }
 
 /// BT-2624 (item 1) / BT-2631: testing a variable against a singleton it can


### PR DESCRIPTION
Implements [BT-2740](https://linear.app/beamtalk/issue/BT-2740) — Phase 2 group 1 of epic [BT-2738](https://linear.app/beamtalk/issue/BT-2738), ADR 0102 §2. Builds on BT-2739 (#2844).

## What

- `refine_singleton_narrowing`: `true_type = intersect(current, matched)`, `false_type = difference(current, matched)` (swapped when negated).
- Deleted `union_without`; `type_admits_singleton` redefined as `intersect(T, s) != Never`.
- `non_nil_type`'s union path routes through `difference` with `P = UndefinedObject | Nil`.
- New capability: the false branch of `x = #foo` on a bare `Symbol` receiver now narrows to `Negation{Symbol, #foo}` (hover renders `Symbol \ #foo`).

## Pinned corners

- **Corner 1:** `x :: Integer; x = #foo` — true branch is now `Never` (was `#foo`); `check_impossible_singleton_comparison` still fires, only the unreachable branch's type changes. New pin.
- **Corner 2 (preserved):** `is_nil`'s nil-only-union → `Dynamic` softening kept — `non_nil_type` re-softens the all-nil `Never` result back to `Dynamic`; `non_nil_type_all_nil_becomes_dynamic` stays green.

## Notes for reviewers

`type_admits_singleton` is slightly narrower than the old hierarchy walk for `Symbol` supertypes other than `Object` (non-nominal operator design, per the acceptance criterion) — no test exercises those receivers. Flagged for a possible follow-up.

## Verification

`cargo build/test/clippy -p beamtalk-core` all green (4337 tests); existing narrowing/union tests unchanged apart from corner 1's new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcZLbDP6grbDwzxkzZjVuk)_