### PR TITLE
Parser + type resolver: `\` difference operator in type annotations (BT-2742)

### DIFF
--- a/crates/beamtalk-cli/src/commands/generate/native.rs
+++ b/crates/beamtalk-cli/src/commands/generate/native.rs
@@ -347,6 +347,13 @@ fn format_type_annotation(ty: &TypeAnnotation) -> String {
             let params: Vec<String> = parameters.iter().map(format_type_annotation).collect();
             format!("{}({})", base.name, params.join(", "))
         }
+        TypeAnnotation::Difference { base, excluded, .. } => {
+            format!(
+                "{} \\ {}",
+                format_type_annotation(base),
+                format_type_annotation(excluded)
+            )
+        }
         // For other variants, just produce a placeholder
         _ => "Object".to_string(),
     }

--- a/crates/beamtalk-core/src/ast/expression.rs
+++ b/crates/beamtalk-core/src/ast/expression.rs
@@ -806,6 +806,23 @@ pub enum TypeAnnotation {
         /// Source location of the entire false-or type.
         span: Span,
     },
+    /// A difference/negation type (e.g., `Symbol \ #foo`) — ADR 0102 §1.
+    ///
+    /// Denotes the values of `base` that are *not* values of `excluded`.
+    /// The `\` operator binds tighter than `|` and shares a precedence tier
+    /// with `&` (left-associative), so `Integer | Symbol \ #foo` parses as
+    /// `Integer | (Symbol \ #foo)` (ADR 0102 §3). Resolves through
+    /// [`InferredType::difference`] during type resolution.
+    ///
+    /// [`InferredType::difference`]: crate::semantic_analysis::type_checker::types
+    Difference {
+        /// The base type being narrowed.
+        base: Box<TypeAnnotation>,
+        /// The type removed from `base`.
+        excluded: Box<TypeAnnotation>,
+        /// Source location of the entire difference type.
+        span: Span,
+    },
     /// The `Self` return type — resolves to the static receiver class at call sites.
     ///
     /// Only valid in return position. Placing `Self` in parameter position is an error.
@@ -852,6 +869,7 @@ impl TypeAnnotation {
             | Self::Singleton { span, .. }
             | Self::Generic { span, .. }
             | Self::FalseOr { span, .. }
+            | Self::Difference { span, .. }
             | Self::SelfType { span }
             | Self::SelfClass { span }
             | Self::ClassOf { span, .. } => *span,
@@ -898,6 +916,16 @@ impl TypeAnnotation {
         }
     }
 
+    /// Creates a difference type annotation (`base \ excluded`, ADR 0102 §1).
+    #[must_use]
+    pub fn difference(base: TypeAnnotation, excluded: TypeAnnotation, span: Span) -> Self {
+        Self::Difference {
+            base: Box::new(base),
+            excluded: Box::new(excluded),
+            span,
+        }
+    }
+
     /// Returns a human-readable name for this type annotation.
     ///
     /// Used by the class hierarchy to store declared state field types
@@ -938,6 +966,17 @@ impl TypeAnnotation {
                     _ => inner.type_name(),
                 };
                 eco_format!("{inner_name} | False")
+            }
+            Self::Difference { base, excluded, .. } => {
+                // `\` binds tighter than `|`, so a union operand (only reachable
+                // via explicit grouping) is parenthesised to preserve meaning.
+                let paren = |ty: &TypeAnnotation| match ty {
+                    Self::Union { .. } | Self::FalseOr { .. } => {
+                        eco_format!("({})", ty.type_name())
+                    }
+                    _ => ty.type_name(),
+                };
+                eco_format!("{} \\ {}", paren(base), paren(excluded))
             }
             Self::SelfType { .. } => "Self".into(),
             Self::SelfClass { .. } => "Self class".into(),

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -633,6 +633,13 @@ impl CoreErlangGenerator {
             TypeAnnotation::FalseOr { inner, .. } => {
                 format!("{} | False", Self::type_annotation_display(inner))
             }
+            TypeAnnotation::Difference { base, excluded, .. } => {
+                format!(
+                    "{} \\ {}",
+                    Self::type_annotation_display(base),
+                    Self::type_annotation_display(excluded)
+                )
+            }
             TypeAnnotation::SelfType { .. } => "Self".to_string(),
             TypeAnnotation::SelfClass { .. } => "Self class".to_string(),
             TypeAnnotation::ClassOf { class_name, .. } => format!("{} class", class_name.name),

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -66,6 +66,10 @@ fn collect_type_annotation_class_names(annotation: &TypeAnnotation, out: &mut Ve
         TypeAnnotation::FalseOr { inner, .. } => {
             collect_type_annotation_class_names(inner, out);
         }
+        TypeAnnotation::Difference { base, excluded, .. } => {
+            collect_type_annotation_class_names(base, out);
+            collect_type_annotation_class_names(excluded, out);
+        }
         TypeAnnotation::ClassOf { class_name, .. } => out.push(class_name.name.to_string()),
         TypeAnnotation::Singleton { .. }
         | TypeAnnotation::SelfType { .. }

--- a/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
@@ -83,6 +83,10 @@ fn type_annotation_to_spec(annotation: &TypeAnnotation) -> Document<'static> {
                 ", {'atom', 0, 'false'}]}"
             ]
         }
+        // Difference (`base \ excluded`) has no precise Erlang spec form; the
+        // excluded set only narrows `base`, so the base spec is a sound (if
+        // wider) over-approximation for the generated `-spec`.
+        TypeAnnotation::Difference { base, .. } => type_annotation_to_spec(base),
         // Self / Self class / <Name> class resolve to a receiver class at call
         // sites; in specs, treat as any()
         TypeAnnotation::SelfType { .. }

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -1019,6 +1019,10 @@ impl SimpleLanguageService {
             TypeAnnotation::FalseOr { inner, .. } => {
                 Self::find_identifier_in_type_annotation(inner, offset_val)
             }
+            TypeAnnotation::Difference { base, excluded, .. } => {
+                Self::find_identifier_in_type_annotation(base, offset_val)
+                    .or_else(|| Self::find_identifier_in_type_annotation(excluded, offset_val))
+            }
             TypeAnnotation::ClassOf { class_name, .. } => {
                 if offset_val >= class_name.span.start() && offset_val < class_name.span.end() {
                     Some((class_name.clone(), class_name.span))

--- a/crates/beamtalk-core/src/queries/hover_provider.rs
+++ b/crates/beamtalk-core/src/queries/hover_provider.rs
@@ -443,6 +443,13 @@ fn type_annotation_label(type_annotation: &crate::ast::TypeAnnotation) -> String
         crate::ast::TypeAnnotation::FalseOr { inner, .. } => {
             format!("{}?", type_annotation_label(inner))
         }
+        crate::ast::TypeAnnotation::Difference { base, excluded, .. } => {
+            format!(
+                "{} \\ {}",
+                type_annotation_label(base),
+                type_annotation_label(excluded)
+            )
+        }
         crate::ast::TypeAnnotation::SelfType { .. } => "Self".to_string(),
         crate::ast::TypeAnnotation::SelfClass { .. } => "Self class".to_string(),
         crate::ast::TypeAnnotation::ClassOf { class_name, .. } => {

--- a/crates/beamtalk-core/src/queries/references_provider.rs
+++ b/crates/beamtalk-core/src/queries/references_provider.rs
@@ -279,6 +279,10 @@ fn collect_type_annotation_refs(
         TypeAnnotation::FalseOr { inner, .. } => {
             collect_type_annotation_refs(inner, name, file_path, results);
         }
+        TypeAnnotation::Difference { base, excluded, .. } => {
+            collect_type_annotation_refs(base, name, file_path, results);
+            collect_type_annotation_refs(excluded, name, file_path, results);
+        }
         TypeAnnotation::ClassOf { class_name, .. } => {
             if class_name.name == name {
                 results.push(Location::new(file_path.clone(), class_name.span));

--- a/crates/beamtalk-core/src/queries/references_to_query.rs
+++ b/crates/beamtalk-core/src/queries/references_to_query.rs
@@ -357,6 +357,10 @@ fn collect_all_type_refs(annotation: &TypeAnnotation, source: &str, hits: &mut V
         TypeAnnotation::FalseOr { inner, .. } => {
             collect_all_type_refs(inner, source, hits);
         }
+        TypeAnnotation::Difference { base, excluded, .. } => {
+            collect_all_type_refs(base, source, hits);
+            collect_all_type_refs(excluded, source, hits);
+        }
         TypeAnnotation::ClassOf {
             class_name: class_id,
             ..
@@ -561,6 +565,10 @@ fn collect_type_lines(
         }
         TypeAnnotation::FalseOr { inner, .. } => {
             collect_type_lines(inner, class_name, source, lines);
+        }
+        TypeAnnotation::Difference { base, excluded, .. } => {
+            collect_type_lines(base, class_name, source, lines);
+            collect_type_lines(excluded, class_name, source, lines);
         }
         TypeAnnotation::ClassOf {
             class_name: class_id,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
@@ -329,6 +329,10 @@ impl TypeChecker {
             TypeAnnotation::FalseOr { inner, .. } => {
                 self.check_bounds_in_type_annotation(inner, hierarchy, protocol_registry);
             }
+            TypeAnnotation::Difference { base, excluded, .. } => {
+                self.check_bounds_in_type_annotation(base, hierarchy, protocol_registry);
+                self.check_bounds_in_type_annotation(excluded, hierarchy, protocol_registry);
+            }
             // Simple, SelfType, Singleton — no nested generics to check
             _ => {}
         }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -58,6 +58,8 @@ pub(in crate::semantic_analysis) type SubstitutionMap = HashMap<EcoString, Infer
 ///   [`InferredType::union_of`] which handles flattening and deduplication.
 /// * [`TypeAnnotation::FalseOr`] — `inner | False`, using the same union
 ///   machinery.
+/// * [`TypeAnnotation::Difference`] — `base \ excluded`, resolved through
+///   [`InferredType::difference`] (ADR 0102 §1). Reducible cases normalise.
 /// * [`TypeAnnotation::SelfType`] — returns `Dynamic(Unknown)`. Bare `Self`
 ///   is resolved at the *call site* where the static receiver class is known;
 ///   the annotation-resolution pass does not have that context.
@@ -123,6 +125,15 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation(
         TypeAnnotation::FalseOr { inner, .. } => {
             let inner_ty = resolve_type_annotation(inner, subst);
             InferredType::union_of(&[inner_ty, InferredType::known("False")])
+        }
+        TypeAnnotation::Difference { base, excluded, .. } => {
+            // ADR 0102 §1: `base \ excluded` resolves through the shared
+            // `difference` set operation (BT-2739). Reducible cases normalise —
+            // e.g. an excluded member that drops a union member, or `T \ T`
+            // collapsing to `Never`.
+            let base_ty = resolve_type_annotation(base, subst);
+            let excluded_ty = resolve_type_annotation(excluded, subst);
+            InferredType::difference(&base_ty, &excluded_ty, TypeProvenance::Declared(ann.span()))
         }
         TypeAnnotation::ClassOf { class_name, .. } => {
             // ADR 0083: `<ClassName> class` is the metatype of the named class.
@@ -597,6 +608,58 @@ mod tests {
         assert_eq!(members.len(), 2);
         assert!(members.contains(&InferredType::known("Integer")));
         assert!(members.contains(&InferredType::known("False")));
+    }
+
+    // ---- resolve_type_annotation: difference ----
+
+    #[test]
+    fn difference_symbol_minus_singleton_produces_negation() {
+        // `Symbol \ #foo` → Negation { base: Symbol, excluded: #foo }.
+        let ann = TypeAnnotation::difference(
+            TypeAnnotation::Simple(ident("Symbol")),
+            TypeAnnotation::Singleton {
+                name: "foo".into(),
+                span: span(),
+            },
+            span(),
+        );
+        let result = resolve_type_annotation(&ann, &empty_subst());
+        let InferredType::Negation { base, excluded, .. } = result else {
+            panic!("expected Negation, got {result:?}");
+        };
+        assert_eq!(*base, InferredType::known("Symbol"));
+        assert_eq!(*excluded, InferredType::known("#foo"));
+    }
+
+    #[test]
+    fn difference_of_identical_types_collapses_to_never() {
+        // `Integer \ Integer` = Never (reducible case, normalised by `difference`).
+        let ann = TypeAnnotation::difference(
+            TypeAnnotation::Simple(ident("Integer")),
+            TypeAnnotation::Simple(ident("Integer")),
+            span(),
+        );
+        let result = resolve_type_annotation(&ann, &empty_subst());
+        assert_eq!(result, InferredType::Never);
+    }
+
+    #[test]
+    fn difference_dropping_union_member_normalises() {
+        // `(Integer | String) \ String` drops the `String` member, leaving
+        // `Integer` (LHS-union distribution in `difference`).
+        let ann = TypeAnnotation::difference(
+            TypeAnnotation::Union {
+                types: vec![
+                    TypeAnnotation::Simple(ident("Integer")),
+                    TypeAnnotation::Simple(ident("String")),
+                ],
+                span: span(),
+            },
+            TypeAnnotation::Simple(ident("String")),
+            span(),
+        );
+        let result = resolve_type_annotation(&ann, &empty_subst());
+        assert_eq!(result, InferredType::known("Integer"));
     }
 
     // ---- resolve_type_annotation: Self / Self class ----

--- a/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
@@ -566,10 +566,13 @@ pub(crate) fn check_redundant_local_type_annotation(
         if !matches!(target.as_ref(), Expression::Identifier(_)) {
             return;
         }
-        // Widening annotations are load-bearing: keep them.
+        // Widening annotations are load-bearing: keep them. A difference
+        // (`Symbol \ #foo`) narrows the RHS type, so it is load-bearing too.
         if matches!(
             annotation,
-            TypeAnnotation::Union { .. } | TypeAnnotation::FalseOr { .. }
+            TypeAnnotation::Union { .. }
+                | TypeAnnotation::FalseOr { .. }
+                | TypeAnnotation::Difference { .. }
         ) {
             return;
         }

--- a/crates/beamtalk-core/src/semantic_analysis/validators/visibility_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/visibility_validators.rs
@@ -310,6 +310,10 @@ fn check_type_annotation_cross_package(
         TypeAnnotation::FalseOr { inner, .. } => {
             check_type_annotation_cross_package(inner, current_pkg, hierarchy, diagnostics);
         }
+        TypeAnnotation::Difference { base, excluded, .. } => {
+            check_type_annotation_cross_package(base, current_pkg, hierarchy, diagnostics);
+            check_type_annotation_cross_package(excluded, current_pkg, hierarchy, diagnostics);
+        }
         TypeAnnotation::ClassOf { class_name, .. } => {
             check_cross_package_ref(
                 &class_name.name,
@@ -443,6 +447,24 @@ fn check_type_annotation_leaked(
         TypeAnnotation::FalseOr { inner, .. } => {
             check_type_annotation_leaked(
                 inner,
+                class_name,
+                method_selector,
+                current_pkg,
+                hierarchy,
+                diagnostics,
+            );
+        }
+        TypeAnnotation::Difference { base, excluded, .. } => {
+            check_type_annotation_leaked(
+                base,
+                class_name,
+                method_selector,
+                current_pkg,
+                hierarchy,
+                diagnostics,
+            );
+            check_type_annotation_leaked(
+                excluded,
                 class_name,
                 method_selector,
                 current_pkg,

--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -519,7 +519,7 @@ impl Parser {
             }
         }
         // Skip union types: `| Type`
-        while matches!(self.peek_at(o), Some(TokenKind::Pipe)) {
+        while self.is_type_chain_operator(o) {
             o += 1;
             if !is_type_name_token(self.peek_at(o)) {
                 return DoubleColonSkip::Malformed(o);
@@ -563,7 +563,7 @@ impl Parser {
             o = self.skip_paren_type_params(o)?;
         }
         // Union in type param position: `Type | Type`
-        while matches!(self.peek_at(o), Some(TokenKind::Pipe)) {
+        while self.is_type_chain_operator(o) {
             o += 1;
             if !is_type_name_token(self.peek_at(o)) {
                 return None;
@@ -587,7 +587,7 @@ impl Parser {
                 o = self.skip_paren_type_params(o)?;
             }
             // Union
-            while matches!(self.peek_at(o), Some(TokenKind::Pipe)) {
+            while self.is_type_chain_operator(o) {
                 o += 1;
                 if !is_type_name_token(self.peek_at(o)) {
                     return None;
@@ -679,7 +679,7 @@ impl Parser {
             }
         }
         // Skip union types: `| Type`
-        while matches!(self.peek_at(o), Some(TokenKind::Pipe)) {
+        while self.is_type_chain_operator(o) {
             o += 1;
             if !is_type_name_token(self.peek_at(o)) {
                 return false;
@@ -720,6 +720,25 @@ impl Parser {
             o + 2
         } else {
             o + 1
+        }
+    }
+
+    /// Returns `true` if the token at `offset` continues a type annotation with
+    /// a binary type operator: union `|`, difference `\`, or the `\\` typo for
+    /// `\` (ADR 0102 §3, BT-2742).
+    ///
+    /// Used by the lookahead helpers to skip over a type-operator chain when
+    /// deciding whether a `-> Type =>` / `:: Type` sequence is a method header.
+    /// The precedence distinction between `\` and `|` is irrelevant here — these
+    /// helpers only confirm the chain terminates at a `=>`/`)`; the parser
+    /// enforces precedence in [`parse_difference_type`](Self::parse_difference_type).
+    /// The `\\` typo is treated as a chain operator so the method is still
+    /// recognised and the parser can emit the targeted "did you mean `\`?" error.
+    pub(super) fn is_type_chain_operator(&self, offset: usize) -> bool {
+        match self.peek_at(offset) {
+            Some(TokenKind::Pipe) => true,
+            Some(TokenKind::BinarySelector(s)) => s.as_str() == "\\" || s.as_str() == "\\\\",
+            _ => false,
         }
     }
 
@@ -926,9 +945,15 @@ impl Parser {
         })
     }
 
-    /// Parses a type annotation, including union types (`Integer | String`).
+    /// Parses a type annotation, including union types (`Integer | String`)
+    /// and difference types (`Symbol \ #foo`).
+    ///
+    /// Precedence (ADR 0102 §3): `|` (union) is the loosest tier; `\`
+    /// (difference) binds tighter, so `Integer | Symbol \ #foo` parses as
+    /// `Integer | (Symbol \ #foo)`. The `\` tier is handled by
+    /// [`parse_difference_type`](Self::parse_difference_type).
     pub(super) fn parse_type_annotation(&mut self) -> TypeAnnotation {
-        let first = self.parse_single_type_annotation();
+        let first = self.parse_difference_type();
 
         // Check for union type: `Type | Type | ...`
         if !matches!(self.current_kind(), TokenKind::Pipe) {
@@ -940,7 +965,7 @@ impl Parser {
 
         while matches!(self.current_kind(), TokenKind::Pipe) {
             self.advance(); // consume `|`
-            types.push(self.parse_single_type_annotation());
+            types.push(self.parse_difference_type());
         }
 
         let end_span = types.last().map_or(start_span, TypeAnnotation::span);
@@ -948,6 +973,51 @@ impl Parser {
             types,
             span: start_span.merge(end_span),
         }
+    }
+
+    /// Parses a difference type (`Type \ Type`), the precedence tier between
+    /// unions (`|`) and single type atoms (ADR 0102 §3).
+    ///
+    /// `\` binds tighter than `|` and is left-associative, so `A \ B \ C`
+    /// parses as `(A \ B) \ C`. This tier is shared with the intersection
+    /// operator `&` (BT-2743), which slots in here at the same precedence.
+    ///
+    /// The `\` operator lexes as `BinarySelector("\")` (a single backslash);
+    /// it is special-cased *only* in type-annotation position — in a value
+    /// expression `\` remains an ordinary binary selector, untouched. The
+    /// modulo selector `\\` (two backslashes, which the lexer greedily merges)
+    /// is almost certainly a typo for `\` here and gets a targeted diagnostic.
+    fn parse_difference_type(&mut self) -> TypeAnnotation {
+        let mut ty = self.parse_single_type_annotation();
+
+        loop {
+            let TokenKind::BinarySelector(op) = self.current_kind() else {
+                break;
+            };
+            match op.as_str() {
+                // `\` — the difference operator.
+                "\\" => {
+                    self.advance(); // consume `\`
+                    let excluded = self.parse_single_type_annotation();
+                    let span = ty.span().merge(excluded.span());
+                    ty = TypeAnnotation::difference(ty, excluded, span);
+                }
+                // `\\` — the modulo selector, greedily lexed from `\\`. In type
+                // position this is a typo for the difference operator `\`.
+                "\\\\" => {
+                    self.error(
+                        "Unexpected `\\\\` in type annotation; did you mean `\\` (type difference)?",
+                    );
+                    self.advance(); // consume `\\` to recover
+                    let excluded = self.parse_single_type_annotation();
+                    let span = ty.span().merge(excluded.span());
+                    ty = TypeAnnotation::difference(ty, excluded, span);
+                }
+                _ => break,
+            }
+        }
+
+        ty
     }
 
     /// Parses a single type annotation (no unions).

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -1448,7 +1448,7 @@ impl Parser {
                     }
                 }
                 // Skip union tail: `| Type | Type ...`
-                while matches!(self.peek_at(offset), Some(TokenKind::Pipe)) {
+                while self.is_type_chain_operator(offset) {
                     offset += 1;
                     if !matches!(self.peek_at(offset), Some(TokenKind::Identifier(_))) {
                         return false;
@@ -1510,7 +1510,7 @@ impl Parser {
                         }
                     }
                     // Skip union tail: `| Type | Type ...`
-                    while matches!(self.peek_at(offset), Some(TokenKind::Pipe)) {
+                    while self.is_type_chain_operator(offset) {
                         offset += 1;
                         if !matches!(self.peek_at(offset), Some(TokenKind::Identifier(_))) {
                             return false;

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
@@ -1496,3 +1496,135 @@ fn parse_class_metatype_as_later_union_member_in_generic_arg() {
         types[1]
     );
 }
+
+// ==========================================================================
+// Difference type annotations (`\`) — ADR 0102 §1/§3, BT-2742
+// ==========================================================================
+
+#[test]
+fn parse_difference_return_type() {
+    // `Symbol \ #foo` parses as Difference { base: Symbol, excluded: #foo }.
+    let module = parse_ok(
+        "Object subclass: Foo
+  narrow -> Symbol \\ #foo => #bar",
+    );
+    let ret_ty = module.classes[0].methods[0].return_type.as_ref().unwrap();
+    let TypeAnnotation::Difference { base, excluded, .. } = ret_ty else {
+        panic!("expected Difference, got {ret_ty:?}");
+    };
+    assert!(matches!(base.as_ref(), TypeAnnotation::Simple(id) if id.name == "Symbol"));
+    assert!(matches!(excluded.as_ref(), TypeAnnotation::Singleton { name, .. } if name == "foo"));
+}
+
+#[test]
+fn parse_difference_state_field() {
+    // `field: x :: Symbol \ #foo = nil` in a typed class.
+    let module = parse_ok(
+        "typed Value subclass: Spec
+  field: tag :: Symbol \\ #foo = #bar",
+    );
+    let ann = module.classes[0].state[0].type_annotation.as_ref().unwrap();
+    assert!(
+        matches!(ann, TypeAnnotation::Difference { .. }),
+        "expected Difference, got {ann:?}"
+    );
+}
+
+#[test]
+fn parse_difference_binds_tighter_than_union() {
+    // ADR 0102 §3: `Integer | Symbol \ #foo` parses as
+    // `Integer | (Symbol \ #foo)` — `\` binds tighter than `|`.
+    let module = parse_ok(
+        "Object subclass: Foo
+  narrow -> Integer | Symbol \\ #foo => 1",
+    );
+    let ret_ty = module.classes[0].methods[0].return_type.as_ref().unwrap();
+    let TypeAnnotation::Union { types, .. } = ret_ty else {
+        panic!("expected Union, got {ret_ty:?}");
+    };
+    assert_eq!(types.len(), 2, "union has two members: {types:?}");
+    assert!(
+        matches!(&types[0], TypeAnnotation::Simple(id) if id.name == "Integer"),
+        "first member is Integer, got {:?}",
+        types[0]
+    );
+    let TypeAnnotation::Difference { base, excluded, .. } = &types[1] else {
+        panic!("second member must be a Difference, got {:?}", types[1]);
+    };
+    assert!(matches!(base.as_ref(), TypeAnnotation::Simple(id) if id.name == "Symbol"));
+    assert!(matches!(excluded.as_ref(), TypeAnnotation::Singleton { name, .. } if name == "foo"));
+}
+
+#[test]
+fn parse_difference_is_left_associative() {
+    // ADR 0102 §3: `Symbol \ #a \ #b` parses as `(Symbol \ #a) \ #b`.
+    let module = parse_ok(
+        "Object subclass: Foo
+  narrow -> Symbol \\ #a \\ #b => #c",
+    );
+    let ret_ty = module.classes[0].methods[0].return_type.as_ref().unwrap();
+    let TypeAnnotation::Difference { base, excluded, .. } = ret_ty else {
+        panic!("expected outer Difference, got {ret_ty:?}");
+    };
+    // Outer excluded is #b; the outer base is the inner `Symbol \ #a`.
+    assert!(matches!(excluded.as_ref(), TypeAnnotation::Singleton { name, .. } if name == "b"));
+    let TypeAnnotation::Difference {
+        base: inner_base,
+        excluded: inner_excluded,
+        ..
+    } = base.as_ref()
+    else {
+        panic!("expected inner Difference in base, got {base:?}");
+    };
+    assert!(matches!(inner_base.as_ref(), TypeAnnotation::Simple(id) if id.name == "Symbol"));
+    assert!(
+        matches!(inner_excluded.as_ref(), TypeAnnotation::Singleton { name, .. } if name == "a")
+    );
+}
+
+#[test]
+fn parse_difference_type_name_round_trips() {
+    let module = parse_ok(
+        "Object subclass: Foo
+  narrow -> Symbol \\ #foo => #bar",
+    );
+    let ret_ty = module.classes[0].methods[0].return_type.as_ref().unwrap();
+    assert_eq!(ret_ty.type_name().as_str(), "Symbol \\ #foo");
+}
+
+#[test]
+fn parse_double_backslash_in_type_position_is_typo_error() {
+    // The lexer greedily merges `\\` into the modulo selector. In type position
+    // that is almost certainly a typo for the difference operator `\`, so we
+    // emit a targeted diagnostic pointing at `\`.
+    let diagnostics = parse_err(
+        "Object subclass: Foo
+  narrow -> Symbol \\\\ #foo => #bar",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("did you mean") && d.message.contains('\\')),
+        "expected a `did you mean \\` diagnostic, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn value_position_backslash_is_unchanged() {
+    // The `\` difference operator is special-cased *only* in type-annotation
+    // position (BT-2742). In a value expression `\` remains an ordinary binary
+    // selector with no binding power, so `x \ x` parses exactly as it did
+    // before this change — an "expected expression" error, never a silent
+    // type-difference. The method header `combine: x =>` is still detected,
+    // proving the type-chain lookahead did not leak into value position.
+    let diagnostics = parse_err(
+        "Object subclass: Foo
+  combine: x => x \\ x",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("expected expression")),
+        "value-position `\\` must parse as before (unchanged), got: {diagnostics:?}"
+    );
+}

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -1719,6 +1719,13 @@ fn unparse_type_annotation(ty: &TypeAnnotation) -> Document<'static> {
         TypeAnnotation::FalseOr { inner, .. } => {
             docvec![unparse_type_annotation(inner), " | False"]
         }
+        TypeAnnotation::Difference { base, excluded, .. } => {
+            docvec![
+                unparse_type_annotation(base),
+                " \\ ",
+                unparse_type_annotation(excluded)
+            ]
+        }
         TypeAnnotation::SelfType { .. } => Document::Str("Self"),
         TypeAnnotation::SelfClass { .. } => Document::Str("Self class"),
         TypeAnnotation::ClassOf { class_name, .. } => {
@@ -1864,6 +1871,33 @@ mod tests {
         let pass1 = format_source(source).expect("pass1 should succeed");
         let pass2 = format_source(&pass1).expect("pass2 should succeed");
         assert_eq!(pass1, pass2, "format_source must be idempotent");
+    }
+
+    // --- Difference type annotation unparsing (BT-2742) ---
+
+    #[test]
+    fn difference_type_annotation_unparses() {
+        // `Symbol \ #foo` unparses back to `Symbol \ #foo`.
+        let ann = crate::ast::TypeAnnotation::difference(
+            crate::ast::TypeAnnotation::simple("Symbol", span()),
+            crate::ast::TypeAnnotation::singleton("foo", span()),
+            span(),
+        );
+        assert_eq!(
+            unparse_type_annotation(&ann).to_pretty_string(),
+            "Symbol \\ #foo"
+        );
+    }
+
+    #[test]
+    fn difference_return_type_round_trips_through_format_source() {
+        // Parse → unparse must preserve `Symbol \ #foo` in a method return type.
+        let source = "Object subclass: Foo\n  narrow -> Symbol \\ #foo => #bar\n";
+        let formatted = format_source(source).expect("should format");
+        assert!(
+            formatted.contains("Symbol \\ #foo"),
+            "difference type must survive round-trip, got: {formatted}"
+        );
     }
 
     // --- Comment unparsing ---


### PR DESCRIPTION
Implements [BT-2742](https://linear.app/beamtalk/issue/BT-2742) — Phase 4 (surface syntax) of epic [BT-2738](https://linear.app/beamtalk/issue/BT-2738), ADR 0102 §3. Builds on BT-2739 (#2844).

## What

- New `TypeAnnotation` difference variant; all exhaustive matches over `TypeAnnotation` updated (AST, codegen, hover, references, protocol, language service, unparse, validators).
- Parser accepts `\` in **type-annotation position only**, at ADR §3 precedence: binds tighter than `|`, same tier as `&`, left-associative (`Integer | Symbol \ #foo` → `Integer | (Symbol \ #foo)`). `\` in value-expression position is unchanged.
- `\` lexes as `BinarySelector("\\")` and is special-cased in type position.
- Targeted parse error for `\\` (modulo selector) in type position ("did you mean `\`?").
- `type_resolver.rs` resolves the annotation via BT-2739's `difference` (so `Symbol \ #foo` → `Negation`, reducible cases normalise).
- Parser precedence tests, resolver tests, unparse round-trips (+132 lines of type-annotation parser tests).

## Out of scope

`&` intersection syntax and the stored `Intersection` variant — that's BT-2743.

## Verification

Rebased onto current `main` (ADR 0102 present). `cargo build/test/clippy -p beamtalk-core` all green (4349 tests, clippy `-D warnings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcZLbDP6grbDwzxkzZjVuk)_