### PR TITLE
Type checker: hierarchy-aware nominal intersect + canonical negation ordering (BT-2739 rework)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2332,7 +2332,7 @@ impl TypeChecker {
         // yields `intersect = Never` for the unreachable branch — the diagnostic
         // for that case is emitted separately by
         // `check_impossible_singleton_comparison`.
-        let holds = InferredType::intersect(&current_ty, &matched, provenance);
+        let holds = InferredType::intersect(&current_ty, &matched, provenance, Some(hierarchy));
         let removed = InferredType::difference(&current_ty, &matched, provenance);
         if eq.negated {
             // `x /= #foo`: the true branch removes the singleton; the false
@@ -2395,8 +2395,13 @@ impl TypeChecker {
     fn type_admits_singleton(ty: &InferredType, singleton: &EcoString) -> bool {
         let matched = InferredType::known(singleton.clone());
         let provenance = super::TypeProvenance::Inferred(Span::default());
+        // The pattern is always a bare *singleton*, which is never an entry in
+        // the class hierarchy, so the nominal-class base case of `intersect` is
+        // unreachable here — `None` is provably equivalent to threading a real
+        // hierarchy (a singleton relates only to `Symbol`/itself, handled by the
+        // explicit symbol arms).
         !matches!(
-            InferredType::intersect(ty, &matched, provenance),
+            InferredType::intersect(ty, &matched, provenance, None),
             InferredType::Never
         )
     }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2400,6 +2400,11 @@ impl TypeChecker {
         // unreachable here — `None` is provably equivalent to threading a real
         // hierarchy (a singleton relates only to `Symbol`/itself, handled by the
         // explicit symbol arms).
+        debug_assert!(
+            singleton.starts_with('#'),
+            "type_admits_singleton: `singleton` must be a bare symbol (`#foo`), \
+             not a nominal class — the `None` hierarchy below relies on it"
+        );
         !matches!(
             InferredType::intersect(ty, &matched, provenance, None),
             InferredType::Never

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/set_operators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/set_operators.rs
@@ -7,12 +7,14 @@
 //! Covers ADR 0102 §1 exactly: dedup, the full absorption-law set (restoration,
 //! partial, same-base complement union), LHS/RHS distribution and fold,
 //! same-base flattening, exact-generics matching, symbol-singleton membership,
-//! intersect-through-a-complement, the Dynamic asymmetry / rule-priority
-//! regression, and termination on arbitrary inputs.
+//! the nominal-class base case (via the class hierarchy), canonical `excluded`
+//! ordering, intersect-through-a-complement, the Dynamic asymmetry / rule-priority
+//! regression, commutativity, and termination on arbitrary inputs.
 
 use super::super::*;
 use super::common::*;
 
+use crate::semantic_analysis::ClassHierarchy;
 use proptest::prelude::*;
 
 // ── Fixtures ────────────────────────────────────────────────────────────
@@ -52,23 +54,29 @@ fn negation(excluded: InferredType) -> InferredType {
     }
 }
 
+/// The built-in class hierarchy — carries `Integer <: Number`, `String`, etc.,
+/// so the nominal-class base case of `intersect` can be exercised.
+fn hierarchy() -> ClassHierarchy {
+    ClassHierarchy::with_builtins()
+}
+
 // ── intersect: base rules ───────────────────────────────────────────────
 
 #[test]
 fn intersect_same_type_is_identity() {
     let t = InferredType::known("Integer");
-    assert_eq!(InferredType::intersect(&t, &t, prov()), t);
+    assert_eq!(InferredType::intersect(&t, &t, prov(), None), t);
 }
 
 #[test]
 fn intersect_with_never_is_never() {
     let t = InferredType::known("Integer");
     assert_eq!(
-        InferredType::intersect(&t, &InferredType::Never, prov()),
+        InferredType::intersect(&t, &InferredType::Never, prov(), None),
         InferredType::Never
     );
     assert_eq!(
-        InferredType::intersect(&InferredType::Never, &t, prov()),
+        InferredType::intersect(&InferredType::Never, &t, prov(), None),
         InferredType::Never
     );
 }
@@ -76,8 +84,8 @@ fn intersect_with_never_is_never() {
 #[test]
 fn intersect_with_object_is_identity() {
     let t = InferredType::known("Integer");
-    assert_eq!(InferredType::intersect(&t, &object(), prov()), t);
-    assert_eq!(InferredType::intersect(&object(), &t, prov()), t);
+    assert_eq!(InferredType::intersect(&t, &object(), prov(), None), t);
+    assert_eq!(InferredType::intersect(&object(), &t, prov(), None), t);
 }
 
 #[test]
@@ -87,7 +95,8 @@ fn intersect_distinct_concrete_types_are_disjoint() {
         InferredType::intersect(
             &InferredType::known("Integer"),
             &singleton("#infinity"),
-            prov()
+            prov(),
+            None
         ),
         InferredType::Never
     );
@@ -98,7 +107,7 @@ fn intersect_lhs_union_distributes_to_bare_singleton() {
     // ADR 0102 §1: `intersect(Integer | #infinity, #infinity)` normalises to
     // the *bare* singleton `#infinity`, never a stored wrapper.
     let lhs = InferredType::union_of(&[InferredType::known("Integer"), singleton("#infinity")]);
-    let result = InferredType::intersect(&lhs, &singleton("#infinity"), prov());
+    let result = InferredType::intersect(&lhs, &singleton("#infinity"), prov(), None);
     assert_eq!(result, singleton("#infinity"));
     assert!(
         matches!(result, InferredType::Known { .. }),
@@ -111,9 +120,72 @@ fn intersect_rhs_union_folds() {
     // `intersect(T, A | B) = union_of(intersect(T,A), intersect(T,B))`.
     let t = InferredType::union_of(&[InferredType::known("Integer"), singleton("#a")]);
     let rhs = InferredType::union_of(&[singleton("#a"), singleton("#b")]);
-    let result = InferredType::intersect(&t, &rhs, prov());
+    let result = InferredType::intersect(&t, &rhs, prov(), None);
     // `#a` survives (present on both sides); `#b`/`Integer` are disjoint → gone.
     assert_eq!(result, singleton("#a"));
+}
+
+// ── intersect: nominal-class base case (GAP 1, ADR 0102 §1) ──────────────
+
+#[test]
+fn intersect_nominal_subclass_reduces_to_subclass() {
+    // `Number ∩ Integer = Integer` (B <: A ⇒ B), symmetrically A <: B ⇒ A.
+    // Requires a hierarchy — `Integer <: Number` in the builtins.
+    let h = hierarchy();
+    let number = InferredType::known("Number");
+    let integer = InferredType::known("Integer");
+    assert_eq!(
+        InferredType::intersect(&number, &integer, prov(), Some(&h)),
+        integer
+    );
+    assert_eq!(
+        InferredType::intersect(&integer, &number, prov(), Some(&h)),
+        integer
+    );
+}
+
+#[test]
+fn intersect_nominal_unrelated_is_never() {
+    // Hierarchy-unrelated classes are disjoint (single inheritance):
+    // `Integer ∩ String = Never`, `Integer ∩ #foo = Never`.
+    let h = hierarchy();
+    let integer = InferredType::known("Integer");
+    let string = InferredType::known("String");
+    assert_eq!(
+        InferredType::intersect(&integer, &string, prov(), Some(&h)),
+        InferredType::Never
+    );
+    assert_eq!(
+        InferredType::intersect(&integer, &singleton("#foo"), prov(), Some(&h)),
+        InferredType::Never
+    );
+}
+
+#[test]
+fn intersect_symbol_singleton_preserved_with_hierarchy() {
+    // The `Symbol ∩ #foo = #foo` behaviour survives the nominal path —
+    // singletons are not hierarchy entries, so the explicit symbol arms win.
+    let h = hierarchy();
+    assert_eq!(
+        InferredType::intersect(&symbol(), &singleton("#foo"), prov(), Some(&h)),
+        singleton("#foo")
+    );
+    assert_eq!(
+        InferredType::intersect(&singleton("#foo"), &symbol(), prov(), Some(&h)),
+        singleton("#foo")
+    );
+}
+
+#[test]
+fn intersect_without_hierarchy_keeps_distinct_classes_disjoint() {
+    // GAP 1: `None` preserves the old structural-only behaviour — even a real
+    // subclass relation is invisible without a hierarchy.
+    let number = InferredType::known("Number");
+    let integer = InferredType::known("Integer");
+    assert_eq!(
+        InferredType::intersect(&number, &integer, prov(), None),
+        InferredType::Never
+    );
 }
 
 // ── intersect: rule priority (Dynamic first) ────────────────────────────
@@ -123,11 +195,11 @@ fn intersect_dynamic_is_checked_before_object() {
     // Gap 1: the `Dynamic` arm must win over the generic `T ∩ Object = T`
     // identity — `intersect(Dynamic, Object)` refines to `Object`, not `Dynamic`.
     assert_eq!(
-        InferredType::intersect(&dynamic(), &object(), prov()),
+        InferredType::intersect(&dynamic(), &object(), prov(), None),
         object()
     );
     assert_eq!(
-        InferredType::intersect(&object(), &dynamic(), prov()),
+        InferredType::intersect(&object(), &dynamic(), prov(), None),
         object()
     );
 }
@@ -139,11 +211,11 @@ fn intersect_symbol_with_singleton_keeps_singleton() {
     // A symbol singleton is a subtype of `Symbol`, so the narrower singleton
     // is kept in both orders.
     assert_eq!(
-        InferredType::intersect(&symbol(), &singleton("#foo"), prov()),
+        InferredType::intersect(&symbol(), &singleton("#foo"), prov(), None),
         singleton("#foo")
     );
     assert_eq!(
-        InferredType::intersect(&singleton("#foo"), &symbol(), prov()),
+        InferredType::intersect(&singleton("#foo"), &symbol(), prov(), None),
         singleton("#foo")
     );
 }
@@ -152,7 +224,7 @@ fn intersect_symbol_with_singleton_keeps_singleton() {
 fn intersect_distinct_singletons_are_disjoint() {
     // Distinct singleton disjointness is preserved.
     assert_eq!(
-        InferredType::intersect(&singleton("#foo"), &singleton("#bar"), prov()),
+        InferredType::intersect(&singleton("#foo"), &singleton("#bar"), prov(), None),
         InferredType::Never
     );
 }
@@ -164,7 +236,7 @@ fn intersect_complement_keeps_unexcluded_singleton() {
     // `intersect(Symbol \ #foo, #bar) = #bar` (#bar is a symbol, not excluded).
     let neg = negation(singleton("#foo"));
     assert_eq!(
-        InferredType::intersect(&neg, &singleton("#bar"), prov()),
+        InferredType::intersect(&neg, &singleton("#bar"), prov(), None),
         singleton("#bar")
     );
 }
@@ -174,7 +246,7 @@ fn intersect_complement_excludes_matching_singleton() {
     // `intersect(Symbol \ #foo, #foo) = Never` (#foo is excluded).
     let neg = negation(singleton("#foo"));
     assert_eq!(
-        InferredType::intersect(&neg, &singleton("#foo"), prov()),
+        InferredType::intersect(&neg, &singleton("#foo"), prov(), None),
         InferredType::Never
     );
 }
@@ -184,7 +256,7 @@ fn intersect_complement_with_union() {
     // `intersect(Symbol \ #foo, #foo | #bar | #baz) = #bar | #baz`.
     let neg = negation(singleton("#foo"));
     let rhs = InferredType::union_of(&[singleton("#foo"), singleton("#bar"), singleton("#baz")]);
-    let result = InferredType::intersect(&neg, &rhs, prov());
+    let result = InferredType::intersect(&neg, &rhs, prov(), None);
     assert_eq!(
         result,
         InferredType::union_of(&[singleton("#bar"), singleton("#baz")])
@@ -196,7 +268,7 @@ fn intersect_complement_lhs_is_symmetric() {
     // `intersect(#bar, Symbol \ #foo) = #bar` — Negation on the RHS too.
     let neg = negation(singleton("#foo"));
     assert_eq!(
-        InferredType::intersect(&singleton("#bar"), &neg, prov()),
+        InferredType::intersect(&singleton("#bar"), &neg, prov(), None),
         singleton("#bar")
     );
 }
@@ -208,6 +280,7 @@ fn intersect_two_complements_same_base() {
         &negation(singleton("#a")),
         &negation(singleton("#b")),
         prov(),
+        None,
     );
     let expected = negation(InferredType::union_of(&[singleton("#a"), singleton("#b")]));
     assert_eq!(result, expected);
@@ -235,18 +308,28 @@ fn difference_by_never_is_identity() {
 #[test]
 fn dynamic_asymmetry_regression() {
     // ADR 0102 §1, explicitly NOT union_of's Dynamic-absorbs rule:
-    //   intersect(Dynamic, P) = P
+    //   intersect(Dynamic, P) = P     (both orders)
     //   difference(Dynamic, P) = Dynamic
     //   difference(T, Dynamic) = T
     let p = InferredType::known("Integer");
-    assert_eq!(InferredType::intersect(&dynamic(), &p, prov()), p);
-    assert_eq!(InferredType::intersect(&p, &dynamic(), prov()), p);
+    assert_eq!(InferredType::intersect(&dynamic(), &p, prov(), None), p);
+    assert_eq!(InferredType::intersect(&p, &dynamic(), prov(), None), p);
     assert_eq!(
         InferredType::difference(&dynamic(), &p, prov()),
         dynamic(),
         "Dynamic never narrows under difference"
     );
     assert_eq!(InferredType::difference(&p, &dynamic(), prov()), p);
+}
+
+#[test]
+fn intersect_dynamic_identity_both_sides_with_hierarchy() {
+    // GAP 4: `intersect(P, Dynamic) = P` AND `intersect(Dynamic, P) = P`, and
+    // the Dynamic arm still wins even when a hierarchy is present.
+    let h = hierarchy();
+    let p = InferredType::known("Integer");
+    assert_eq!(InferredType::intersect(&dynamic(), &p, prov(), Some(&h)), p);
+    assert_eq!(InferredType::intersect(&p, &dynamic(), prov(), Some(&h)), p);
 }
 
 // ── difference: union member drop + generics ────────────────────────────
@@ -340,6 +423,35 @@ fn difference_rhs_union_folds_left() {
     );
     let direct = InferredType::difference(&symbol(), &removed, prov());
     assert_eq!(direct, folded);
+}
+
+// ── canonical `excluded` ordering (GAP 2, ADR 0102 §1) ──────────────────
+
+#[test]
+fn negation_excluded_is_canonically_sorted_ascending() {
+    // GAP 2: however the exclusions are built up, the stored `excluded` union
+    // is sorted ascending by `class_name` — deterministic serialisation.
+    // Build in reverse order (#b then #a) and assert the stored order is #a,#b.
+    let neg = InferredType::difference(
+        &InferredType::difference(&symbol(), &singleton("#b"), prov()),
+        &singleton("#a"),
+        prov(),
+    );
+    let InferredType::Negation { excluded, .. } = &neg else {
+        panic!("expected a Negation, got {neg:?}");
+    };
+    let InferredType::Union { members, .. } = excluded.as_ref() else {
+        panic!("expected a union of exclusions, got {excluded:?}");
+    };
+    let names: Vec<String> = members
+        .iter()
+        .filter_map(|m| m.as_known().map(ToString::to_string))
+        .collect();
+    assert_eq!(
+        names,
+        vec!["#a".to_string(), "#b".to_string()],
+        "excluded members must be sorted ascending by class_name"
+    );
 }
 
 // ── union_of: absorption law ────────────────────────────────────────────
@@ -500,10 +612,10 @@ proptest! {
         b in concrete_leaf(),
         p in concrete_leaf(),
     ) {
-        let lhs = InferredType::intersect(&InferredType::union_of(&[a.clone(), b.clone()]), &p, prov());
+        let lhs = InferredType::intersect(&InferredType::union_of(&[a.clone(), b.clone()]), &p, prov(), None);
         let rhs = InferredType::union_of(&[
-            InferredType::intersect(&a, &p, prov()),
-            InferredType::intersect(&b, &p, prov()),
+            InferredType::intersect(&a, &p, prov(), None),
+            InferredType::intersect(&b, &p, prov(), None),
         ]);
         prop_assert_eq!(lhs, rhs);
     }
@@ -552,17 +664,32 @@ proptest! {
         }
     }
 
-    /// Termination / no-panic: both operators return on arbitrary inputs.
+    /// Termination / no-panic: both operators return on arbitrary inputs
+    /// (with and without a hierarchy).
     #[test]
     fn prop_operators_terminate(a in any_type(), b in any_type()) {
-        let _ = InferredType::intersect(&a, &b, prov());
+        let h = hierarchy();
+        let _ = InferredType::intersect(&a, &b, prov(), Some(&h));
+        let _ = InferredType::intersect(&a, &b, prov(), None);
         let _ = InferredType::difference(&a, &b, prov());
+    }
+
+    /// GAP 3: commutativity — `intersect(a, b) == intersect(b, a)` across the
+    /// Phase-1 type fragment (Known classes, singletons, Symbol, unions,
+    /// negations, Dynamic, Never, Object), with the nominal hierarchy engaged.
+    #[test]
+    fn prop_intersect_commutes(a in any_type(), b in any_type()) {
+        let h = hierarchy();
+        prop_assert_eq!(
+            InferredType::intersect(&a, &b, prov(), Some(&h)),
+            InferredType::intersect(&b, &a, prov(), Some(&h)),
+        );
     }
 
     /// Dynamic asymmetry holds for any concrete `P`.
     #[test]
     fn prop_dynamic_asymmetry(p in concrete_leaf()) {
-        prop_assert_eq!(InferredType::intersect(&dynamic(), &p, prov()), p.clone());
+        prop_assert_eq!(InferredType::intersect(&dynamic(), &p, prov(), None), p.clone());
         prop_assert_eq!(InferredType::difference(&dynamic(), &p, prov()), dynamic());
         prop_assert_eq!(InferredType::difference(&p, &dynamic(), prov()), p);
     }
@@ -573,7 +700,7 @@ proptest! {
     #[test]
     fn prop_intersect_complement(s in singleton_strat(), p in singleton_strat()) {
         let neg = negation(s.clone());
-        let result = InferredType::intersect(&neg, &p, prov());
+        let result = InferredType::intersect(&neg, &p, prov(), None);
         if p == s {
             prop_assert_eq!(result, InferredType::Never);
         } else {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
@@ -891,6 +891,10 @@ impl InferredType {
     /// the hierarchy, so this returns `false` for them (their membership is
     /// handled by the explicit `Symbol`-singleton arms in
     /// [`intersect`](Self::intersect)).
+    ///
+    /// The reflexive `sub == sup` short-circuit is unreachable from `intersect`
+    /// (its match arm guards on differing names) but kept so the predicate is
+    /// correct standalone for future callers.
     fn is_nominal_subtype(hierarchy: &ClassHierarchy, sub: &str, sup: &str) -> bool {
         sub == sup || hierarchy.superclass_chain(sub).iter().any(|c| c == sup)
     }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
@@ -5,6 +5,7 @@
 //!
 //! **DDD Context:** Semantic Analysis
 
+use crate::semantic_analysis::ClassHierarchy;
 use crate::source_analysis::Span;
 use ecow::EcoString;
 
@@ -599,6 +600,51 @@ impl InferredType {
         matches!(ty, Self::Known { class_name, .. } if class_name == "Symbol")
     }
 
+    /// Builds a canonical [`Negation`](Self::Negation) — the sole construction
+    /// path, so every `Negation` in the system carries a **canonically ordered**
+    /// `excluded` set (ADR 0102 §1: members sorted ascending by `class_name`).
+    ///
+    /// Order-independent `PartialEq` already treats `Symbol \ (#a | #b)` and
+    /// `Symbol \ (#b | #a)` as equal; canonical ordering additionally makes the
+    /// stored form *deterministic* across serialisation round-trips and
+    /// independent implementations, so `Union` dedup and diagnostic output are
+    /// stable.
+    fn make_negation(base: Self, excluded: Self, provenance: TypeProvenance) -> Self {
+        Self::Negation {
+            base: Box::new(base),
+            excluded: Box::new(Self::canonical_excluded(excluded)),
+            provenance,
+        }
+    }
+
+    /// Sorts a `Negation`'s `excluded` union members ascending by `class_name`
+    /// (ADR 0102 §1). A lone singleton (or any non-`Union`) is already canonical.
+    fn canonical_excluded(excluded: Self) -> Self {
+        match excluded {
+            Self::Union {
+                mut members,
+                provenance,
+            } => {
+                members.sort_by(|x, y| Self::excluded_sort_key(x).cmp(&Self::excluded_sort_key(y)));
+                Self::Union {
+                    members,
+                    provenance,
+                }
+            }
+            other => other,
+        }
+    }
+
+    /// Sort key for a canonical `excluded` member — the singleton's
+    /// `class_name` (e.g. `#foo`). Non-`Known` members fall back to their
+    /// display name so ordering is still total.
+    fn excluded_sort_key(member: &Self) -> EcoString {
+        match member {
+            Self::Known { class_name, .. } => class_name.clone(),
+            other => other.display_name().unwrap_or_default(),
+        }
+    }
+
     /// Flattens `excluded` (a singleton or a normalised union of singletons)
     /// into its constituent members.
     fn excluded_members(excluded: &Self) -> Vec<Self> {
@@ -670,7 +716,9 @@ impl InferredType {
             // intersection (`E1 ∩ E2 ∩ …`).
             let mut merged = neg_excludeds[0].clone();
             for e in &neg_excludeds[1..] {
-                merged = Self::intersect(&merged, e, provenance);
+                // Structural singleton merge only — no hierarchy needed (and
+                // none is threaded through `union_of`).
+                merged = Self::intersect(&merged, e, provenance, None);
             }
             // Add back any excluded singleton that also appears bare (absorption).
             let remaining: Vec<Self> = if matches!(merged, Self::Never) {
@@ -688,11 +736,11 @@ impl InferredType {
                 // `Symbol \ {} = Symbol`.
                 Self::known("Symbol")
             } else {
-                Self::Negation {
-                    base: Box::new(Self::known("Symbol")),
-                    excluded: Box::new(Self::union_of(&remaining)),
+                Self::make_negation(
+                    Self::known("Symbol"),
+                    Self::union_of(&remaining),
                     provenance,
-                }
+                )
             }
         };
 
@@ -710,10 +758,22 @@ impl InferredType {
     /// Normalising **intersection** `A ∩ B` (ADR 0102 §1).
     ///
     /// Symbol-singleton membership IS modelled — a singleton `#foo` is a subtype
-    /// of `Symbol`, so `Symbol ∩ #foo = #foo`. Only the *general* nominal class
-    /// hierarchy (e.g. `Number ∩ Integer`) is out of scope: two ordinary
-    /// distinct `Known` classes are treated as disjoint (`Integer ∩ #infinity =
-    /// Never`, `Integer ∩ String = Never`).
+    /// of `Symbol`, so `Symbol ∩ #foo = #foo`. The general **nominal-class base
+    /// case** is also modelled *when a [`ClassHierarchy`] is supplied*
+    /// (`hierarchy = Some(_)`): `intersect(A, B) = B` when `B <: A`
+    /// (e.g. `Number ∩ Integer = Integer`), `= A` when `A <: B`, and `= Never`
+    /// when `A` and `B` are hierarchy-unrelated (single inheritance ⇒ unrelated
+    /// classes are disjoint, so `Integer ∩ String = Never`). Only nominal
+    /// *difference* (`Object \ Number`) stays out of scope (see
+    /// [`difference`](Self::difference)).
+    ///
+    /// The `hierarchy` argument is **optional** so the internal structural
+    /// callers (`union_of`'s complement-merge in
+    /// [`absorb_negations`](Self::absorb_negations)) can pass `None` — they only
+    /// merge singletons, which never need the hierarchy. When `None`, two
+    /// distinct non-symbol `Known` classes fall through to `Never` (the previous
+    /// behaviour). Narrowing call sites pass `Some(hierarchy)` so class narrowing
+    /// reduces correctly.
     ///
     /// Rules:
     /// - **Dynamic first:** `intersect(Dynamic, P) = P` (Dynamic acts as the top
@@ -721,10 +781,14 @@ impl InferredType {
     ///   before identity/Object so `intersect(Dynamic, Object) = Object`.
     /// - `intersect(T, T) = T`; `intersect(T, Never) = Never`;
     ///   `intersect(T, Object) = T`.
-    /// - **Intersect through a complement:** `intersect(Negation{B, E}, P) =
-    ///   difference(intersect(B, P), E)` — a `Negation` never reaches the
-    ///   disjoint default (needed for chained narrowing).
+    /// - **Intersect through a complement (both orders):**
+    ///   `intersect(Negation{B, E}, P) = difference(intersect(B, P), E)` and
+    ///   symmetrically `intersect(P, Negation{B, E}) =
+    ///   difference(intersect(P, B), E)` — a `Negation` never reaches the
+    ///   disjoint default (needed for chained narrowing / Phase 2 `\` syntax).
     /// - **Symbol-singleton membership:** `intersect(Symbol, #foo) = #foo`.
+    /// - **Nominal-class base case** (`hierarchy = Some`): `B <: A ⇒ B`,
+    ///   `A <: B ⇒ A`, unrelated ⇒ `Never`.
     /// - **LHS-union distribution:** `intersect(T1 | … | Tn, P) =
     ///   (T1 ∩ P) | … | (Tn ∩ P)`, e.g. `intersect(Integer | #infinity,
     ///   #infinity)` normalises to the bare singleton `#infinity`.
@@ -734,7 +798,12 @@ impl InferredType {
     /// The result is re-normalised through [`union_of`](Self::union_of).
     // Consumed by the narrowing rules landing later in ADR 0102's epic (BT-2738).
     #[allow(dead_code)]
-    pub(crate) fn intersect(a: &Self, b: &Self, provenance: TypeProvenance) -> Self {
+    pub(crate) fn intersect(
+        a: &Self,
+        b: &Self,
+        provenance: TypeProvenance,
+        hierarchy: Option<&ClassHierarchy>,
+    ) -> Self {
         match (a, b) {
             // Dynamic FIRST (before identity/Object): `intersect(Dynamic, P) = P`
             // refines the unknown, so `intersect(Dynamic, Object) = Object`.
@@ -745,19 +814,25 @@ impl InferredType {
             // Object (top) is the identity: `T ∩ Object = T`.
             (_, other) if Self::is_object(other) => a.clone(),
             (other, _) if Self::is_object(other) => b.clone(),
-            // Intersect through a complement: `(B \ E) ∩ P = (B ∩ P) \ E`.
-            // A `Negation` must never fall through to the disjoint default.
-            (Self::Negation { base, excluded, .. }, _) => {
-                Self::difference(&Self::intersect(base, b, provenance), excluded, provenance)
-            }
-            (_, Self::Negation { base, excluded, .. }) => {
-                Self::difference(&Self::intersect(a, base, provenance), excluded, provenance)
-            }
+            // Intersect through a complement (both orders): `(B \ E) ∩ P =
+            // (B ∩ P) \ E`. A `Negation` must never fall through to the disjoint
+            // default (the `(Known, Negation)` case fires in Phase 2's `\`
+            // syntax; missing it silently loses narrowing).
+            (Self::Negation { base, excluded, .. }, _) => Self::difference(
+                &Self::intersect(base, b, provenance, hierarchy),
+                excluded,
+                provenance,
+            ),
+            (_, Self::Negation { base, excluded, .. }) => Self::difference(
+                &Self::intersect(a, base, provenance, hierarchy),
+                excluded,
+                provenance,
+            ),
             // LHS-union distribution.
             (Self::Union { members, .. }, _) => {
                 let parts: Vec<Self> = members
                     .iter()
-                    .map(|m| Self::intersect(m, b, provenance))
+                    .map(|m| Self::intersect(m, b, provenance, hierarchy))
                     .collect();
                 Self::union_of(&parts)
             }
@@ -765,12 +840,13 @@ impl InferredType {
             (_, Self::Union { members, .. }) => {
                 let parts: Vec<Self> = members
                     .iter()
-                    .map(|m| Self::intersect(a, m, provenance))
+                    .map(|m| Self::intersect(a, m, provenance, hierarchy))
                     .collect();
                 Self::union_of(&parts)
             }
             // Symbol-singleton membership: `#foo <: Symbol`, so the narrower
-            // singleton is kept in both orders.
+            // singleton is kept in both orders. Checked before the general
+            // nominal case because singletons are not entries in the hierarchy.
             (Self::Known { .. }, Self::Known { class_name: s, .. })
                 if Self::is_symbol_base(a) && Self::is_symbol_singleton(s) =>
             {
@@ -783,10 +859,40 @@ impl InferredType {
             }
             // `T ∩ T = T` (exact structural equality, generics included).
             _ if a == b => a.clone(),
+            // Nominal-class base case (ADR 0102 §1): with a hierarchy, two
+            // distinct-named `Known` classes relate via subtyping — the subclass
+            // wins (`Number ∩ Integer = Integer`), and hierarchy-unrelated
+            // classes are disjoint (`Integer ∩ String = Never`). Without a
+            // hierarchy, or when the names match but generics differ (invariant
+            // args ⇒ disjoint), fall through to `Never` — the previous
+            // structural-only behaviour.
+            (Self::Known { class_name: an, .. }, Self::Known { class_name: bn, .. }) => {
+                match hierarchy {
+                    Some(h) if an != bn => {
+                        if Self::is_nominal_subtype(h, bn, an) {
+                            b.clone()
+                        } else if Self::is_nominal_subtype(h, an, bn) {
+                            a.clone()
+                        } else {
+                            Self::Never
+                        }
+                    }
+                    _ => Self::Never,
+                }
+            }
             // Distinct concrete types with no structural relationship (including
             // distinct singletons, `#foo ∩ #bar`) are disjoint.
             _ => Self::Never,
         }
+    }
+
+    /// Returns `true` if `sub` is `sup` or a (transitive) subclass of `sup` in
+    /// the nominal class hierarchy. Symbol singletons (`#foo`) are not entries in
+    /// the hierarchy, so this returns `false` for them (their membership is
+    /// handled by the explicit `Symbol`-singleton arms in
+    /// [`intersect`](Self::intersect)).
+    fn is_nominal_subtype(hierarchy: &ClassHierarchy, sub: &str, sup: &str) -> bool {
+        sub == sup || hierarchy.superclass_chain(sub).iter().any(|c| c == sup)
     }
 
     /// Normalising **difference** `A \ B` (ADR 0102 §1).
@@ -842,11 +948,11 @@ impl InferredType {
                 },
                 Self::Known { class_name, .. },
             ) if Self::is_symbol_base(base) && Self::is_symbol_singleton(class_name) => {
-                Self::Negation {
-                    base: base.clone(),
-                    excluded: Box::new(Self::union_of(&[(**excluded).clone(), b.clone()])),
-                    provenance: *neg_prov,
-                }
+                Self::make_negation(
+                    (**base).clone(),
+                    Self::union_of(&[(**excluded).clone(), b.clone()]),
+                    *neg_prov,
+                )
             }
             // `Symbol \ #foo = Negation{Symbol, #foo}`.
             (
@@ -854,11 +960,9 @@ impl InferredType {
                 Self::Known {
                     class_name: sym, ..
                 },
-            ) if class_name == "Symbol" && Self::is_symbol_singleton(sym) => Self::Negation {
-                base: Box::new(a.clone()),
-                excluded: Box::new(b.clone()),
-                provenance,
-            },
+            ) if class_name == "Symbol" && Self::is_symbol_singleton(sym) => {
+                Self::make_negation(a.clone(), b.clone(), provenance)
+            }
             // `T \ T = Never` (exact structural equality, generics included).
             _ if a == b => Self::Never,
             // Nothing structurally removable — no-op (nominal-class differences


### PR DESCRIPTION
Follow-up rework for [BT-2739](https://linear.app/beamtalk/issue/BT-2739), closing gaps added by ADR 0102 review rounds 4–6 (which landed after the original #2844 merged). Epic [BT-2738](https://linear.app/beamtalk/issue/BT-2738).

## What

- **Nominal `intersect` base case (round 4):** `intersect` now takes `hierarchy: Option<&ClassHierarchy>`. When present, distinct `Known` classes reduce via the hierarchy — `intersect(Number, Integer) = Integer` (`B <: A ⇒ B`, symmetric), `Never` for unrelated classes (single inheritance). With `None` (structural callers like `absorb_negations`), behaviour is unchanged. The `Symbol ∩ #foo = #foo` singleton arms are preserved ahead of the nominal arm. `difference` is untouched and stays pure.
- **Canonical `excluded` ordering (round 4):** new sole constructor `make_negation` sorts `excluded` union members ascending by `class_name`; all construction sites route through it.
- **Commutativity + Dynamic-both-sides (rounds 5–6):** added property test `prop_intersect_commutes` over the type fragment with the real hierarchy, and `intersect_dynamic_identity_both_sides_with_hierarchy`. The symmetric-complement arm and single-path absorption were already present; tests added to lock them.

## Call sites updated

`inference.rs` (`refine_singleton_narrowing` passes the real hierarchy; `type_admits_singleton` passes `None` — the pattern is always a bare singleton, never a hierarchy entry).

## Verification

`cargo build/test/clippy -p beamtalk-core` green (set_operators 51 tests, type_checker 839); the only failures were the environmental `assert_compiles_through_erlc` mise-trust codegen tests, unrelated. CI re-runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcZLbDP6grbDwzxkzZjVuk)_