### PR TITLE
Parser + type checker: `&` intersection with stored Intersection variant (BT-2743)

### DIFF
--- a/crates/beamtalk-cli/src/commands/generate/native.rs
+++ b/crates/beamtalk-cli/src/commands/generate/native.rs
@@ -354,6 +354,13 @@ fn format_type_annotation(ty: &TypeAnnotation) -> String {
                 format_type_annotation(excluded)
             )
         }
+        TypeAnnotation::Intersection { left, right, .. } => {
+            format!(
+                "{} & {}",
+                format_type_annotation(left),
+                format_type_annotation(right)
+            )
+        }
         // For other variants, just produce a placeholder
         _ => "Object".to_string(),
     }

--- a/crates/beamtalk-cli/src/commands/generate/stubs.rs
+++ b/crates/beamtalk-cli/src/commands/generate/stubs.rs
@@ -332,6 +332,22 @@ fn format_type(ty: &beamtalk_core::semantic_analysis::type_checker::InferredType
                 format!("{} \\ {}", format_type(base), format_type(excluded))
             }
         }
+        // ADR 0102/BT-2743: render an intersection as `A & B & …`. A union
+        // member is only reachable via explicit grouping; parenthesise to
+        // preserve meaning, matching `InferredType::display_with_options`.
+        InferredType::Intersection { members, .. } => {
+            let parts: Vec<String> = members
+                .iter()
+                .map(|m| {
+                    if matches!(m, InferredType::Union { .. }) {
+                        format!("({})", format_type(m))
+                    } else {
+                        format_type(m)
+                    }
+                })
+                .collect();
+            parts.join(" & ")
+        }
     }
 }
 

--- a/crates/beamtalk-core/src/ast/expression.rs
+++ b/crates/beamtalk-core/src/ast/expression.rs
@@ -823,6 +823,28 @@ pub enum TypeAnnotation {
         /// Source location of the entire difference type.
         span: Span,
     },
+    /// An intersection type (e.g., `Collection(Object) & Comparable`) — ADR
+    /// 0068 §Protocol Composition, ADR 0102 §1/§3.
+    ///
+    /// Denotes the values that are members of *both* `left` and `right`. The
+    /// `&` operator binds tighter than `|` and shares a precedence tier with
+    /// `\` (left-associative), so `Integer | Collection(Object) & Comparable`
+    /// parses as `Integer | (Collection(Object) & Comparable)` (ADR 0102 §3).
+    /// Resolves through [`InferredType::intersect`] during type resolution —
+    /// class ∩ class reduces via the hierarchy (subclass, or `Never`), while
+    /// class ∩ protocol is the irreducible case stored as
+    /// [`InferredType::Intersection`].
+    ///
+    /// [`InferredType::intersect`]: crate::semantic_analysis::type_checker::types
+    /// [`InferredType::Intersection`]: crate::semantic_analysis::type_checker::types
+    Intersection {
+        /// The left-hand operand.
+        left: Box<TypeAnnotation>,
+        /// The right-hand operand.
+        right: Box<TypeAnnotation>,
+        /// Source location of the entire intersection type.
+        span: Span,
+    },
     /// The `Self` return type — resolves to the static receiver class at call sites.
     ///
     /// Only valid in return position. Placing `Self` in parameter position is an error.
@@ -870,6 +892,7 @@ impl TypeAnnotation {
             | Self::Generic { span, .. }
             | Self::FalseOr { span, .. }
             | Self::Difference { span, .. }
+            | Self::Intersection { span, .. }
             | Self::SelfType { span }
             | Self::SelfClass { span }
             | Self::ClassOf { span, .. } => *span,
@@ -926,6 +949,17 @@ impl TypeAnnotation {
         }
     }
 
+    /// Creates an intersection type annotation (`left & right`, ADR 0068
+    /// §Protocol Composition, ADR 0102 §1/§3).
+    #[must_use]
+    pub fn intersection(left: TypeAnnotation, right: TypeAnnotation, span: Span) -> Self {
+        Self::Intersection {
+            left: Box::new(left),
+            right: Box::new(right),
+            span,
+        }
+    }
+
     /// Returns a human-readable name for this type annotation.
     ///
     /// Used by the class hierarchy to store declared state field types
@@ -968,15 +1002,28 @@ impl TypeAnnotation {
                 eco_format!("{inner_name} | False")
             }
             Self::Difference { base, excluded, .. } => {
-                // `\` binds tighter than `|`, so a union operand (only reachable
-                // via explicit grouping) is parenthesised to preserve meaning.
+                // `\` binds tighter than `|` and shares a tier with `&`, so a
+                // union or intersection operand (only reachable via explicit
+                // grouping) is parenthesised to preserve meaning.
                 let paren = |ty: &TypeAnnotation| match ty {
-                    Self::Union { .. } | Self::FalseOr { .. } => {
+                    Self::Union { .. } | Self::FalseOr { .. } | Self::Intersection { .. } => {
                         eco_format!("({})", ty.type_name())
                     }
                     _ => ty.type_name(),
                 };
                 eco_format!("{} \\ {}", paren(base), paren(excluded))
+            }
+            Self::Intersection { left, right, .. } => {
+                // `&` binds tighter than `|` and shares a tier with `\`; a
+                // union or difference operand (only reachable via explicit
+                // grouping) is parenthesised to preserve meaning.
+                let paren = |ty: &TypeAnnotation| match ty {
+                    Self::Union { .. } | Self::FalseOr { .. } | Self::Difference { .. } => {
+                        eco_format!("({})", ty.type_name())
+                    }
+                    _ => ty.type_name(),
+                };
+                eco_format!("{} & {}", paren(left), paren(right))
             }
             Self::SelfType { .. } => "Self".into(),
             Self::SelfClass { .. } => "Self class".into(),

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/callbacks.rs
@@ -640,6 +640,13 @@ impl CoreErlangGenerator {
                     Self::type_annotation_display(excluded)
                 )
             }
+            TypeAnnotation::Intersection { left, right, .. } => {
+                format!(
+                    "{} & {}",
+                    Self::type_annotation_display(left),
+                    Self::type_annotation_display(right)
+                )
+            }
             TypeAnnotation::SelfType { .. } => "Self".to_string(),
             TypeAnnotation::SelfClass { .. } => "Self class".to_string(),
             TypeAnnotation::ClassOf { class_name, .. } => format!("{} class", class_name.name),

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -70,6 +70,10 @@ fn collect_type_annotation_class_names(annotation: &TypeAnnotation, out: &mut Ve
             collect_type_annotation_class_names(base, out);
             collect_type_annotation_class_names(excluded, out);
         }
+        TypeAnnotation::Intersection { left, right, .. } => {
+            collect_type_annotation_class_names(left, out);
+            collect_type_annotation_class_names(right, out);
+        }
         TypeAnnotation::ClassOf { class_name, .. } => out.push(class_name.name.to_string()),
         TypeAnnotation::Singleton { .. }
         | TypeAnnotation::SelfType { .. }

--- a/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
@@ -87,6 +87,12 @@ fn type_annotation_to_spec(annotation: &TypeAnnotation) -> Document<'static> {
         // excluded set only narrows `base`, so the base spec is a sound (if
         // wider) over-approximation for the generated `-spec`.
         TypeAnnotation::Difference { base, .. } => type_annotation_to_spec(base),
+        // Intersection (`left & right`, ADR 0102 §1/§3) has no Erlang spec
+        // form either (Erlang `-spec` has no intersection-type constructor).
+        // Any single member's spec is a sound (if wider) over-approximation —
+        // a value of the intersection type is, in particular, a value of
+        // `left` — so pick the left operand, mirroring `Difference` above.
+        TypeAnnotation::Intersection { left, .. } => type_annotation_to_spec(left),
         // Self / Self class / <Name> class resolve to a receiver class at call
         // sites; in specs, treat as any()
         TypeAnnotation::SelfType { .. }

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -1023,6 +1023,10 @@ impl SimpleLanguageService {
                 Self::find_identifier_in_type_annotation(base, offset_val)
                     .or_else(|| Self::find_identifier_in_type_annotation(excluded, offset_val))
             }
+            TypeAnnotation::Intersection { left, right, .. } => {
+                Self::find_identifier_in_type_annotation(left, offset_val)
+                    .or_else(|| Self::find_identifier_in_type_annotation(right, offset_val))
+            }
             TypeAnnotation::ClassOf { class_name, .. } => {
                 if offset_val >= class_name.span.start() && offset_val < class_name.span.end() {
                     Some((class_name.clone(), class_name.span))

--- a/crates/beamtalk-core/src/queries/completion_provider.rs
+++ b/crates/beamtalk-core/src/queries/completion_provider.rs
@@ -746,7 +746,10 @@ fn receiver_side_of_type(ty: &InferredType) -> Option<ReceiverSide> {
         | InferredType::Dynamic(_)
         | InferredType::Never
         // A `Negation` (`Symbol \ #foo`) has no single receiver side (ADR 0102).
-        | InferredType::Negation { .. } => None,
+        | InferredType::Negation { .. }
+        // Nor does an `Intersection` (`P1 & P2`, ADR 0102/BT-2743) — it has no
+        // single class name to dispatch instance/class-side completions from.
+        | InferredType::Intersection { .. } => None,
     }
 }
 

--- a/crates/beamtalk-core/src/queries/hover_provider.rs
+++ b/crates/beamtalk-core/src/queries/hover_provider.rs
@@ -450,6 +450,13 @@ fn type_annotation_label(type_annotation: &crate::ast::TypeAnnotation) -> String
                 type_annotation_label(excluded)
             )
         }
+        crate::ast::TypeAnnotation::Intersection { left, right, .. } => {
+            format!(
+                "{} & {}",
+                type_annotation_label(left),
+                type_annotation_label(right)
+            )
+        }
         crate::ast::TypeAnnotation::SelfType { .. } => "Self".to_string(),
         crate::ast::TypeAnnotation::SelfClass { .. } => "Self class".to_string(),
         crate::ast::TypeAnnotation::ClassOf { class_name, .. } => {

--- a/crates/beamtalk-core/src/queries/references_provider.rs
+++ b/crates/beamtalk-core/src/queries/references_provider.rs
@@ -283,6 +283,10 @@ fn collect_type_annotation_refs(
             collect_type_annotation_refs(base, name, file_path, results);
             collect_type_annotation_refs(excluded, name, file_path, results);
         }
+        TypeAnnotation::Intersection { left, right, .. } => {
+            collect_type_annotation_refs(left, name, file_path, results);
+            collect_type_annotation_refs(right, name, file_path, results);
+        }
         TypeAnnotation::ClassOf { class_name, .. } => {
             if class_name.name == name {
                 results.push(Location::new(file_path.clone(), class_name.span));

--- a/crates/beamtalk-core/src/queries/references_to_query.rs
+++ b/crates/beamtalk-core/src/queries/references_to_query.rs
@@ -361,6 +361,10 @@ fn collect_all_type_refs(annotation: &TypeAnnotation, source: &str, hits: &mut V
             collect_all_type_refs(base, source, hits);
             collect_all_type_refs(excluded, source, hits);
         }
+        TypeAnnotation::Intersection { left, right, .. } => {
+            collect_all_type_refs(left, source, hits);
+            collect_all_type_refs(right, source, hits);
+        }
         TypeAnnotation::ClassOf {
             class_name: class_id,
             ..
@@ -569,6 +573,10 @@ fn collect_type_lines(
         TypeAnnotation::Difference { base, excluded, .. } => {
             collect_type_lines(base, class_name, source, lines);
             collect_type_lines(excluded, class_name, source, lines);
+        }
+        TypeAnnotation::Intersection { left, right, .. } => {
+            collect_type_lines(left, class_name, source, lines);
+            collect_type_lines(right, class_name, source, lines);
         }
         TypeAnnotation::ClassOf {
             class_name: class_id,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -118,7 +118,11 @@ impl TypeChecker {
                     "self",
                     super::type_resolver::receiver_type_for_class(&class.name.name, hierarchy),
                 );
-                Self::set_param_types(&mut method_env, &method.parameters);
+                Self::set_param_types(
+                    &mut method_env,
+                    &method.parameters,
+                    self.protocol_registry.as_ref(),
+                );
                 let body_type =
                     self.infer_stmts(&method.body, hierarchy, &mut method_env, is_abstract);
                 self.check_return_type(method, &body_type, &class.name.name, hierarchy);
@@ -155,7 +159,11 @@ impl TypeChecker {
                     "self",
                     super::type_resolver::receiver_type_for_class(&class.name.name, hierarchy),
                 );
-                Self::set_param_types(&mut method_env, &method.parameters);
+                Self::set_param_types(
+                    &mut method_env,
+                    &method.parameters,
+                    self.protocol_registry.as_ref(),
+                );
                 let body_type =
                     self.infer_stmts(&method.body, hierarchy, &mut method_env, is_abstract);
                 self.check_return_type(method, &body_type, &class.name.name, hierarchy);
@@ -210,7 +218,11 @@ impl TypeChecker {
                 "self",
                 super::type_resolver::receiver_type_for_class(class_name, hierarchy),
             );
-            Self::set_param_types(&mut method_env, &standalone.method.parameters);
+            Self::set_param_types(
+                &mut method_env,
+                &standalone.method.parameters,
+                self.protocol_registry.as_ref(),
+            );
             let body_type = self.infer_stmts(
                 &standalone.method.body,
                 hierarchy,
@@ -254,21 +266,30 @@ impl TypeChecker {
     /// Sets parameter types in the type environment from annotations.
     ///
     /// All parameters are always registered. Typed parameters are resolved
-    /// via [`resolve_type_annotation`]; untyped parameters are registered as
-    /// `Dynamic`. Generic annotations (e.g., `:: Result(Integer, Error)`) are
-    /// resolved to `Known` with `type_args`. Type parameters of enclosing
-    /// generic classes (e.g., `T` in `Result(T, E)`) resolve to `Dynamic` when
-    /// no substitution context is available.
+    /// via [`super::type_resolver::resolve_type_annotation`]; untyped
+    /// parameters are registered as `Dynamic`. Generic annotations (e.g.,
+    /// `:: Result(Integer, Error)`) are resolved to `Known` with `type_args`.
+    /// Type parameters of enclosing generic classes (e.g., `T` in
+    /// `Result(T, E)`) resolve to `Dynamic` when no substitution context is
+    /// available.
     /// Registering untyped params is necessary to prevent the bare-identifier
     /// state-field fallback in `infer_expr` from mis-inferring an untyped param
     /// as `self.<field>` when the parameter name shadows a state field name.
+    ///
+    /// `protocol_registry` (ADR 0102 §1/§3, BT-2743) is passed straight
+    /// through to the resolver so a parameter typed `:: P1 & P2` resolves
+    /// class ∩ protocol correctly; pass `None` when no registry is available.
     pub(super) fn set_param_types(
         env: &mut TypeEnv,
         parameters: &[crate::ast::ParameterDefinition],
+        protocol_registry: Option<&crate::semantic_analysis::protocol_registry::ProtocolRegistry>,
     ) {
+        let subst = super::type_resolver::SubstitutionMap::new();
         for param in parameters {
             let ty = match &param.type_annotation {
-                Some(ann) => Self::resolve_type_annotation(ann),
+                Some(ann) => {
+                    super::type_resolver::resolve_type_annotation(ann, &subst, protocol_registry)
+                }
                 None => InferredType::Dynamic(DynamicReason::UnannotatedParam), // preserve parameter shadowing of state fields
             };
             env.set_local(param.name.name.clone(), ty);
@@ -279,14 +300,16 @@ impl TypeChecker {
     ///
     /// Thin wrapper around
     /// [`super::type_resolver::resolve_type_annotation`] that supplies an
-    /// empty substitution map. Call sites that need method-local /
-    /// class-level type-parameter substitution should call the resolver
-    /// function directly with a populated [`super::type_resolver::SubstitutionMap`].
+    /// empty substitution map and no protocol registry. Call sites that need
+    /// method-local / class-level type-parameter substitution, or correct
+    /// resolution of `&`-typed protocol intersections (ADR 0102 §1/§3,
+    /// BT-2743), should call the resolver function directly with a populated
+    /// [`super::type_resolver::SubstitutionMap`] / protocol registry.
     ///
     /// **References:** BT-2025 — centralised parametric type resolution.
     pub(super) fn resolve_type_annotation(ann: &TypeAnnotation) -> InferredType {
         let subst = super::type_resolver::SubstitutionMap::new();
-        super::type_resolver::resolve_type_annotation(ann, &subst)
+        super::type_resolver::resolve_type_annotation(ann, &subst, None)
     }
 
     /// Resolves type-position keywords to their class names.
@@ -495,7 +518,14 @@ impl TypeChecker {
                 // of the inferred type. Emit a warning if the RHS has a known
                 // (non-Dynamic) type that is incompatible with the annotation.
                 let ty = if let Some(ann) = type_annotation {
-                    let declared = Self::resolve_type_annotation(ann);
+                    // ADR 0102 §1/§3 (BT-2743): thread the protocol registry
+                    // through so a local `x :: P1 & P2` annotation resolves
+                    // class ∩ protocol correctly rather than falling to `Never`.
+                    let declared = super::type_resolver::resolve_type_annotation(
+                        ann,
+                        &super::type_resolver::SubstitutionMap::new(),
+                        self.protocol_registry.as_ref(),
+                    );
                     // Check for type mismatch: known RHS that doesn't match declared type.
                     // Dynamic RHS (the primary use case for annotations) is accepted silently.
                     // Never RHS (diverging expressions like `self error:`) is compatible
@@ -2332,7 +2362,10 @@ impl TypeChecker {
         // yields `intersect = Never` for the unreachable branch — the diagnostic
         // for that case is emitted separately by
         // `check_impossible_singleton_comparison`.
-        let holds = InferredType::intersect(&current_ty, &matched, provenance, Some(hierarchy));
+        // Out of scope for narrowing (ADR 0102 §2 group 3 / BT-2743): singleton
+        // narrowing never intersects with a protocol name, so `None` here.
+        let holds =
+            InferredType::intersect(&current_ty, &matched, provenance, Some(hierarchy), None);
         let removed = InferredType::difference(&current_ty, &matched, provenance);
         if eq.negated {
             // `x /= #foo`: the true branch removes the singleton; the false
@@ -2406,7 +2439,9 @@ impl TypeChecker {
              not a nominal class — the `None` hierarchy below relies on it"
         );
         !matches!(
-            InferredType::intersect(ty, &matched, provenance, None),
+            // Likewise no protocol registry needed — a bare singleton is
+            // never a protocol name.
+            InferredType::intersect(ty, &matched, provenance, None, None),
             InferredType::Never
         )
     }
@@ -4928,7 +4963,7 @@ mod tests {
     fn set_param_types_untyped() {
         let params = vec![ParameterDefinition::new(ident("x"))];
         let mut env = TypeEnv::new();
-        TypeChecker::set_param_types(&mut env, &params);
+        TypeChecker::set_param_types(&mut env, &params, None);
         assert_eq!(
             env.get_local("x"),
             Some(InferredType::Dynamic(DynamicReason::Unknown))
@@ -4942,7 +4977,7 @@ mod tests {
             type_annotation: Some(TypeAnnotation::Simple(ident("Integer"))),
         }];
         let mut env = TypeEnv::new();
-        TypeChecker::set_param_types(&mut env, &params);
+        TypeChecker::set_param_types(&mut env, &params, None);
         assert_eq!(env.get_local("x"), Some(InferredType::known("Integer")));
     }
 
@@ -4956,7 +4991,7 @@ mod tests {
             ParameterDefinition::new(ident("y")),
         ];
         let mut env = TypeEnv::new();
-        TypeChecker::set_param_types(&mut env, &params);
+        TypeChecker::set_param_types(&mut env, &params, None);
         assert_eq!(env.get_local("x"), Some(InferredType::known("String")));
         assert_eq!(
             env.get_local("y"),

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
@@ -86,20 +86,49 @@ impl TypeChecker {
                         if let Some(method) = method {
                             for (i, arg) in arguments.iter().enumerate() {
                                 if let Some(Some(expected_ty)) = method.param_types.get(i) {
-                                    if Self::is_protocol_type(
+                                    let Some(arg_type) = self.type_map.get(arg.span()) else {
+                                        continue;
+                                    };
+                                    let arg_type = arg_type.clone();
+                                    // ADR 0068 §Protocol Composition / ADR 0102
+                                    // §1/§3 (BT-2743): a parameter declared
+                                    // `:: P1 & P2` requires conformance to
+                                    // *every* protocol part. `type_name()`
+                                    // renders the annotation as `"P1 & P2"`;
+                                    // split it and check each protocol part
+                                    // independently instead of treating the
+                                    // whole compound string as one (unregistered)
+                                    // name.
+                                    if let Some(parts) =
+                                        Self::split_intersection_type_string(expected_ty)
+                                    {
+                                        for part in parts {
+                                            if Self::is_protocol_type(
+                                                part,
+                                                hierarchy,
+                                                protocol_registry,
+                                            ) {
+                                                self.check_protocol_argument_conformance(
+                                                    &arg_type,
+                                                    part,
+                                                    *span,
+                                                    hierarchy,
+                                                    protocol_registry,
+                                                );
+                                            }
+                                        }
+                                    } else if Self::is_protocol_type(
                                         expected_ty,
                                         hierarchy,
                                         protocol_registry,
                                     ) {
-                                        if let Some(arg_type) = self.type_map.get(arg.span()) {
-                                            self.check_protocol_argument_conformance(
-                                                &arg_type.clone(),
-                                                expected_ty,
-                                                *span,
-                                                hierarchy,
-                                                protocol_registry,
-                                            );
-                                        }
+                                        self.check_protocol_argument_conformance(
+                                            &arg_type,
+                                            expected_ty,
+                                            *span,
+                                            hierarchy,
+                                            protocol_registry,
+                                        );
                                     }
                                 }
                             }
@@ -333,6 +362,10 @@ impl TypeChecker {
                 self.check_bounds_in_type_annotation(base, hierarchy, protocol_registry);
                 self.check_bounds_in_type_annotation(excluded, hierarchy, protocol_registry);
             }
+            TypeAnnotation::Intersection { left, right, .. } => {
+                self.check_bounds_in_type_annotation(left, hierarchy, protocol_registry);
+                self.check_bounds_in_type_annotation(right, hierarchy, protocol_registry);
+            }
             // Simple, SelfType, Singleton — no nested generics to check
             _ => {}
         }
@@ -481,6 +514,23 @@ impl TypeChecker {
                     EcoString::from(format!("{base_str} \\ {excl_str}"))
                 }
             }
+            // Intersection renders as `A & B & …` (ADR 0102/BT-2743), matching
+            // `InferredType::display_*`. A union member is only reachable via
+            // explicit grouping; parenthesise to preserve meaning.
+            InferredType::Intersection { members, .. } => EcoString::from(
+                members
+                    .iter()
+                    .map(|m| {
+                        let rendered = Self::inferred_type_to_string(m);
+                        if matches!(m, InferredType::Union { .. }) {
+                            format!("({rendered})")
+                        } else {
+                            rendered.to_string()
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" & "),
+            ),
         }
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/generics_substitution.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/generics_substitution.rs
@@ -156,7 +156,7 @@ fn set_param_types_resolves_generic_annotation() {
     }];
 
     let mut env = TypeEnv::new();
-    TypeChecker::set_param_types(&mut env, &params);
+    TypeChecker::set_param_types(&mut env, &params, None);
 
     let r_type = env.get_local("r").expect("r should be in env");
     match r_type {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/protocol.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/protocol.rs
@@ -487,3 +487,296 @@ fn test_protocol_typed_param_non_conforming_still_warns() {
         conformance_warnings[0].message
     );
 }
+
+// --- `&` intersection parameter types require conformance to BOTH protocol
+// parts (ADR 0068 §Protocol Composition, ADR 0102 §1/§3, BT-2743) ---
+
+/// Builds a `Zzyzx >> process:` **instance** method whose parameter is
+/// annotated `Printable & Serializable` (as `type_name()` would render the
+/// parsed `TypeAnnotation::Intersection`), plus the two protocols it
+/// references. Returns `(hierarchy, registry)` with both protocols and
+/// their classes registered, and the `Zzyzx` instance-method table installed.
+///
+/// Deliberately an *instance*-side method: `check_protocol_conformance_in_expr`
+/// only looks up `hierarchy.find_method` (instance methods) for a `Known`
+/// receiver type — a `ClassReference` receiver (`Zzyzx foo:`) infers as
+/// `InferredType::Meta`, which that check does not (yet) handle, so a
+/// class-side fixture would never reach the conformance check at all.
+fn setup_intersection_param_fixture() -> (
+    ClassHierarchy,
+    crate::semantic_analysis::protocol_registry::ProtocolRegistry,
+) {
+    use crate::semantic_analysis::class_hierarchy::{ClassInfo, MethodInfo};
+    use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
+
+    let mut hierarchy = ClassHierarchy::with_builtins();
+
+    let proto_module = Module {
+        protocols: vec![
+            ProtocolDefinition {
+                name: Identifier::new("Printable", span()),
+                type_params: vec![],
+                extending: None,
+                method_signatures: vec![ProtocolMethodSignature {
+                    selector: MessageSelector::Unary("asString".into()),
+                    parameters: vec![],
+                    return_type: Some(TypeAnnotation::simple("String", span())),
+                    comments: CommentAttachment::default(),
+                    doc_comment: None,
+                    span: span(),
+                }],
+                class_method_signatures: vec![],
+                comments: CommentAttachment::default(),
+                doc_comment: None,
+                span: span(),
+            },
+            ProtocolDefinition {
+                name: Identifier::new("Serializable", span()),
+                type_params: vec![],
+                extending: None,
+                method_signatures: vec![ProtocolMethodSignature {
+                    selector: MessageSelector::Unary("serialize".into()),
+                    parameters: vec![],
+                    return_type: Some(TypeAnnotation::simple("String", span())),
+                    comments: CommentAttachment::default(),
+                    doc_comment: None,
+                    span: span(),
+                }],
+                class_method_signatures: vec![],
+                comments: CommentAttachment::default(),
+                doc_comment: None,
+                span: span(),
+            },
+        ],
+        ..Module::new(vec![], span())
+    };
+
+    let mut registry = ProtocolRegistry::new();
+    let diags = registry.register_module(&proto_module, &hierarchy);
+    assert!(diags.is_empty());
+    hierarchy.register_protocol_classes(&proto_module);
+
+    let zzyzx_info = ClassInfo {
+        name: "Zzyzx".into(),
+        superclass: Some("Object".into()),
+        is_sealed: false,
+        is_abstract: false,
+        is_typed: false,
+        is_internal: false,
+        package: None,
+        is_value: true,
+        is_native: false,
+        state: vec![],
+        state_types: std::collections::HashMap::new(),
+        state_has_default: std::collections::HashMap::new(),
+        methods: vec![MethodInfo {
+            selector: "process:".into(),
+            arity: 1,
+            kind: MethodKind::Primary,
+            defined_in: "Zzyzx".into(),
+            is_sealed: false,
+            is_internal: false,
+            spawns_block: false,
+            return_type: Some("String".into()),
+            // `type_name()` for `TypeAnnotation::Intersection` renders as
+            // `"Printable & Serializable"` — this is exactly what
+            // `class_info.rs` stores for a real `:: Printable & Serializable`
+            // parameter annotation.
+            param_types: vec![Some("Printable & Serializable".into())],
+            doc: None,
+        }],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        type_param_bounds: vec![],
+        superclass_type_args: vec![],
+    };
+    hierarchy.add_from_beam_meta(vec![zzyzx_info]);
+
+    (hierarchy, registry)
+}
+
+#[test]
+fn test_intersection_param_missing_one_protocol_warns() {
+    // `Integer` has `asString` (conforms to Printable) but no `serialize`
+    // (does not conform to Serializable) — `Printable & Serializable`
+    // requires BOTH, so exactly one "does not conform" warning (mentioning
+    // Serializable) is expected.
+    let (hierarchy, registry) = setup_intersection_param_fixture();
+
+    // BT-2743 regression note: every synthetic node built by the `common`
+    // helpers (`var`, `msg_send`, …) shares the single fixed `span()`
+    // (`Span::new(0, 1)`), and `check_protocol_conformance_in_expr` looks up
+    // the receiver/argument types by span in the checker's `TypeMap`. With a
+    // shared span, the receiver's and argument's type_map entries collide and
+    // clobber each other — so this test gives the receiver and argument
+    // *distinct* spans (unlike the pre-existing class-side fixtures, which
+    // only ever asserted "no warning" and so never observed the collision).
+    let zzyzx_ident = Identifier::new("zzyzx", Span::new(10, 14));
+    let n_ident = Identifier::new("n", Span::new(20, 21));
+    let test_method = make_keyword_method(
+        &["run:", "with:"],
+        vec![("zzyzx", Some("Zzyzx")), ("n", Some("Integer"))],
+        vec![msg_send(
+            Expression::Identifier(zzyzx_ident),
+            MessageSelector::Keyword(vec![KeywordPart::new("process:", span())]),
+            vec![Expression::Identifier(n_ident)],
+        )],
+    );
+    let test_class = ClassDefinition::new(
+        ident("TestRunner"),
+        ident("Object"),
+        vec![],
+        vec![test_method],
+        span(),
+    );
+    let module = make_module_with_classes(vec![], vec![test_class]);
+
+    let mut checker = TypeChecker::new();
+    checker.check_module_with_protocols(&module, &hierarchy, &registry);
+
+    let conformance_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not conform"))
+        .collect();
+    assert_eq!(
+        conformance_warnings.len(),
+        1,
+        "Integer conforms to Printable but not Serializable — expected exactly 1 warning, got: {:?}",
+        conformance_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        conformance_warnings[0].message.contains("Serializable"),
+        "Warning should mention the missing protocol Serializable, got: {}",
+        conformance_warnings[0].message
+    );
+    assert!(
+        !conformance_warnings[0].message.contains("Printable"),
+        "Integer conforms to Printable — it should not be named in the warning, got: {}",
+        conformance_warnings[0].message
+    );
+}
+
+#[test]
+fn test_intersection_param_conforms_to_both_no_warning() {
+    // A class implementing both `asString` and `serialize` conforms to
+    // `Printable & Serializable` — no warning expected.
+    use crate::semantic_analysis::class_hierarchy::{ClassInfo, MethodInfo};
+
+    let (mut hierarchy, registry) = setup_intersection_param_fixture();
+
+    let report_info = ClassInfo {
+        name: "Report".into(),
+        superclass: Some("Object".into()),
+        is_sealed: false,
+        is_abstract: false,
+        is_typed: false,
+        is_internal: false,
+        package: None,
+        is_value: true,
+        is_native: false,
+        state: vec![],
+        state_types: std::collections::HashMap::new(),
+        state_has_default: std::collections::HashMap::new(),
+        methods: vec![
+            MethodInfo {
+                selector: "asString".into(),
+                arity: 0,
+                kind: MethodKind::Primary,
+                defined_in: "Report".into(),
+                is_sealed: false,
+                is_internal: false,
+                spawns_block: false,
+                return_type: Some("String".into()),
+                param_types: vec![],
+                doc: None,
+            },
+            MethodInfo {
+                selector: "serialize".into(),
+                arity: 0,
+                kind: MethodKind::Primary,
+                defined_in: "Report".into(),
+                is_sealed: false,
+                is_internal: false,
+                spawns_block: false,
+                return_type: Some("String".into()),
+                param_types: vec![],
+                doc: None,
+            },
+        ],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        type_param_bounds: vec![],
+        superclass_type_args: vec![],
+    };
+    hierarchy.add_from_beam_meta(vec![report_info]);
+
+    // See the BT-2743 regression note in `test_intersection_param_missing_one_protocol_warns`
+    // — the receiver and argument need distinct spans so their `TypeMap`
+    // entries don't collide.
+    let zzyzx_ident = Identifier::new("zzyzx", Span::new(10, 14));
+    let r_ident = Identifier::new("r", Span::new(20, 21));
+    let test_method = make_keyword_method(
+        &["run:", "with:"],
+        vec![("zzyzx", Some("Zzyzx")), ("r", Some("Report"))],
+        vec![msg_send(
+            Expression::Identifier(zzyzx_ident),
+            MessageSelector::Keyword(vec![KeywordPart::new("process:", span())]),
+            vec![Expression::Identifier(r_ident)],
+        )],
+    );
+    let test_class = ClassDefinition::new(
+        ident("TestRunner"),
+        ident("Object"),
+        vec![],
+        vec![test_method],
+        span(),
+    );
+    let module = make_module_with_classes(vec![], vec![test_class]);
+
+    let mut checker = TypeChecker::new();
+    checker.check_module_with_protocols(&module, &hierarchy, &registry);
+
+    let conformance_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("does not conform"))
+        .collect();
+    assert!(
+        conformance_warnings.is_empty(),
+        "Report conforms to both Printable and Serializable — no warning expected, got: {:?}",
+        conformance_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_split_intersection_type_string() {
+    assert_eq!(
+        TypeChecker::split_intersection_type_string("Printable & Serializable"),
+        Some(vec!["Printable", "Serializable"])
+    );
+    // Chained `&` (left-associative AST, flat `type_name()` rendering).
+    assert_eq!(
+        TypeChecker::split_intersection_type_string("A & B & C"),
+        Some(vec!["A", "B", "C"])
+    );
+    // No top-level `&` — not an intersection annotation.
+    assert_eq!(
+        TypeChecker::split_intersection_type_string("Printable"),
+        None
+    );
+    // A `&` nested inside a generic type argument's own parens must not be
+    // mistaken for a top-level split point.
+    assert_eq!(
+        TypeChecker::split_intersection_type_string("Collection(A & B)"),
+        None
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/set_operators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/set_operators.rs
@@ -65,18 +65,18 @@ fn hierarchy() -> ClassHierarchy {
 #[test]
 fn intersect_same_type_is_identity() {
     let t = InferredType::known("Integer");
-    assert_eq!(InferredType::intersect(&t, &t, prov(), None), t);
+    assert_eq!(InferredType::intersect(&t, &t, prov(), None, None), t);
 }
 
 #[test]
 fn intersect_with_never_is_never() {
     let t = InferredType::known("Integer");
     assert_eq!(
-        InferredType::intersect(&t, &InferredType::Never, prov(), None),
+        InferredType::intersect(&t, &InferredType::Never, prov(), None, None),
         InferredType::Never
     );
     assert_eq!(
-        InferredType::intersect(&InferredType::Never, &t, prov(), None),
+        InferredType::intersect(&InferredType::Never, &t, prov(), None, None),
         InferredType::Never
     );
 }
@@ -84,8 +84,14 @@ fn intersect_with_never_is_never() {
 #[test]
 fn intersect_with_object_is_identity() {
     let t = InferredType::known("Integer");
-    assert_eq!(InferredType::intersect(&t, &object(), prov(), None), t);
-    assert_eq!(InferredType::intersect(&object(), &t, prov(), None), t);
+    assert_eq!(
+        InferredType::intersect(&t, &object(), prov(), None, None),
+        t
+    );
+    assert_eq!(
+        InferredType::intersect(&object(), &t, prov(), None, None),
+        t
+    );
 }
 
 #[test]
@@ -96,6 +102,7 @@ fn intersect_distinct_concrete_types_are_disjoint() {
             &InferredType::known("Integer"),
             &singleton("#infinity"),
             prov(),
+            None,
             None
         ),
         InferredType::Never
@@ -107,7 +114,7 @@ fn intersect_lhs_union_distributes_to_bare_singleton() {
     // ADR 0102 §1: `intersect(Integer | #infinity, #infinity)` normalises to
     // the *bare* singleton `#infinity`, never a stored wrapper.
     let lhs = InferredType::union_of(&[InferredType::known("Integer"), singleton("#infinity")]);
-    let result = InferredType::intersect(&lhs, &singleton("#infinity"), prov(), None);
+    let result = InferredType::intersect(&lhs, &singleton("#infinity"), prov(), None, None);
     assert_eq!(result, singleton("#infinity"));
     assert!(
         matches!(result, InferredType::Known { .. }),
@@ -120,7 +127,7 @@ fn intersect_rhs_union_folds() {
     // `intersect(T, A | B) = union_of(intersect(T,A), intersect(T,B))`.
     let t = InferredType::union_of(&[InferredType::known("Integer"), singleton("#a")]);
     let rhs = InferredType::union_of(&[singleton("#a"), singleton("#b")]);
-    let result = InferredType::intersect(&t, &rhs, prov(), None);
+    let result = InferredType::intersect(&t, &rhs, prov(), None, None);
     // `#a` survives (present on both sides); `#b`/`Integer` are disjoint → gone.
     assert_eq!(result, singleton("#a"));
 }
@@ -135,11 +142,11 @@ fn intersect_nominal_subclass_reduces_to_subclass() {
     let number = InferredType::known("Number");
     let integer = InferredType::known("Integer");
     assert_eq!(
-        InferredType::intersect(&number, &integer, prov(), Some(&h)),
+        InferredType::intersect(&number, &integer, prov(), Some(&h), None),
         integer
     );
     assert_eq!(
-        InferredType::intersect(&integer, &number, prov(), Some(&h)),
+        InferredType::intersect(&integer, &number, prov(), Some(&h), None),
         integer
     );
 }
@@ -152,11 +159,11 @@ fn intersect_nominal_unrelated_is_never() {
     let integer = InferredType::known("Integer");
     let string = InferredType::known("String");
     assert_eq!(
-        InferredType::intersect(&integer, &string, prov(), Some(&h)),
+        InferredType::intersect(&integer, &string, prov(), Some(&h), None),
         InferredType::Never
     );
     assert_eq!(
-        InferredType::intersect(&integer, &singleton("#foo"), prov(), Some(&h)),
+        InferredType::intersect(&integer, &singleton("#foo"), prov(), Some(&h), None),
         InferredType::Never
     );
 }
@@ -167,11 +174,11 @@ fn intersect_symbol_singleton_preserved_with_hierarchy() {
     // singletons are not hierarchy entries, so the explicit symbol arms win.
     let h = hierarchy();
     assert_eq!(
-        InferredType::intersect(&symbol(), &singleton("#foo"), prov(), Some(&h)),
+        InferredType::intersect(&symbol(), &singleton("#foo"), prov(), Some(&h), None),
         singleton("#foo")
     );
     assert_eq!(
-        InferredType::intersect(&singleton("#foo"), &symbol(), prov(), Some(&h)),
+        InferredType::intersect(&singleton("#foo"), &symbol(), prov(), Some(&h), None),
         singleton("#foo")
     );
 }
@@ -183,7 +190,7 @@ fn intersect_without_hierarchy_keeps_distinct_classes_disjoint() {
     let number = InferredType::known("Number");
     let integer = InferredType::known("Integer");
     assert_eq!(
-        InferredType::intersect(&number, &integer, prov(), None),
+        InferredType::intersect(&number, &integer, prov(), None, None),
         InferredType::Never
     );
 }
@@ -195,11 +202,11 @@ fn intersect_dynamic_is_checked_before_object() {
     // Gap 1: the `Dynamic` arm must win over the generic `T ∩ Object = T`
     // identity — `intersect(Dynamic, Object)` refines to `Object`, not `Dynamic`.
     assert_eq!(
-        InferredType::intersect(&dynamic(), &object(), prov(), None),
+        InferredType::intersect(&dynamic(), &object(), prov(), None, None),
         object()
     );
     assert_eq!(
-        InferredType::intersect(&object(), &dynamic(), prov(), None),
+        InferredType::intersect(&object(), &dynamic(), prov(), None, None),
         object()
     );
 }
@@ -211,11 +218,11 @@ fn intersect_symbol_with_singleton_keeps_singleton() {
     // A symbol singleton is a subtype of `Symbol`, so the narrower singleton
     // is kept in both orders.
     assert_eq!(
-        InferredType::intersect(&symbol(), &singleton("#foo"), prov(), None),
+        InferredType::intersect(&symbol(), &singleton("#foo"), prov(), None, None),
         singleton("#foo")
     );
     assert_eq!(
-        InferredType::intersect(&singleton("#foo"), &symbol(), prov(), None),
+        InferredType::intersect(&singleton("#foo"), &symbol(), prov(), None, None),
         singleton("#foo")
     );
 }
@@ -224,7 +231,7 @@ fn intersect_symbol_with_singleton_keeps_singleton() {
 fn intersect_distinct_singletons_are_disjoint() {
     // Distinct singleton disjointness is preserved.
     assert_eq!(
-        InferredType::intersect(&singleton("#foo"), &singleton("#bar"), prov(), None),
+        InferredType::intersect(&singleton("#foo"), &singleton("#bar"), prov(), None, None),
         InferredType::Never
     );
 }
@@ -236,7 +243,7 @@ fn intersect_complement_keeps_unexcluded_singleton() {
     // `intersect(Symbol \ #foo, #bar) = #bar` (#bar is a symbol, not excluded).
     let neg = negation(singleton("#foo"));
     assert_eq!(
-        InferredType::intersect(&neg, &singleton("#bar"), prov(), None),
+        InferredType::intersect(&neg, &singleton("#bar"), prov(), None, None),
         singleton("#bar")
     );
 }
@@ -246,7 +253,7 @@ fn intersect_complement_excludes_matching_singleton() {
     // `intersect(Symbol \ #foo, #foo) = Never` (#foo is excluded).
     let neg = negation(singleton("#foo"));
     assert_eq!(
-        InferredType::intersect(&neg, &singleton("#foo"), prov(), None),
+        InferredType::intersect(&neg, &singleton("#foo"), prov(), None, None),
         InferredType::Never
     );
 }
@@ -256,7 +263,7 @@ fn intersect_complement_with_union() {
     // `intersect(Symbol \ #foo, #foo | #bar | #baz) = #bar | #baz`.
     let neg = negation(singleton("#foo"));
     let rhs = InferredType::union_of(&[singleton("#foo"), singleton("#bar"), singleton("#baz")]);
-    let result = InferredType::intersect(&neg, &rhs, prov(), None);
+    let result = InferredType::intersect(&neg, &rhs, prov(), None, None);
     assert_eq!(
         result,
         InferredType::union_of(&[singleton("#bar"), singleton("#baz")])
@@ -268,7 +275,7 @@ fn intersect_complement_lhs_is_symmetric() {
     // `intersect(#bar, Symbol \ #foo) = #bar` — Negation on the RHS too.
     let neg = negation(singleton("#foo"));
     assert_eq!(
-        InferredType::intersect(&singleton("#bar"), &neg, prov(), None),
+        InferredType::intersect(&singleton("#bar"), &neg, prov(), None, None),
         singleton("#bar")
     );
 }
@@ -280,6 +287,7 @@ fn intersect_two_complements_same_base() {
         &negation(singleton("#a")),
         &negation(singleton("#b")),
         prov(),
+        None,
         None,
     );
     let expected = negation(InferredType::union_of(&[singleton("#a"), singleton("#b")]));
@@ -312,8 +320,14 @@ fn dynamic_asymmetry_regression() {
     //   difference(Dynamic, P) = Dynamic
     //   difference(T, Dynamic) = T
     let p = InferredType::known("Integer");
-    assert_eq!(InferredType::intersect(&dynamic(), &p, prov(), None), p);
-    assert_eq!(InferredType::intersect(&p, &dynamic(), prov(), None), p);
+    assert_eq!(
+        InferredType::intersect(&dynamic(), &p, prov(), None, None),
+        p
+    );
+    assert_eq!(
+        InferredType::intersect(&p, &dynamic(), prov(), None, None),
+        p
+    );
     assert_eq!(
         InferredType::difference(&dynamic(), &p, prov()),
         dynamic(),
@@ -328,8 +342,14 @@ fn intersect_dynamic_identity_both_sides_with_hierarchy() {
     // the Dynamic arm still wins even when a hierarchy is present.
     let h = hierarchy();
     let p = InferredType::known("Integer");
-    assert_eq!(InferredType::intersect(&dynamic(), &p, prov(), Some(&h)), p);
-    assert_eq!(InferredType::intersect(&p, &dynamic(), prov(), Some(&h)), p);
+    assert_eq!(
+        InferredType::intersect(&dynamic(), &p, prov(), Some(&h), None),
+        p
+    );
+    assert_eq!(
+        InferredType::intersect(&p, &dynamic(), prov(), Some(&h), None),
+        p
+    );
 }
 
 // ── difference: union member drop + generics ────────────────────────────
@@ -552,6 +572,274 @@ fn negation_is_not_known() {
     assert!(negation(singleton("#a")).as_known().is_none());
 }
 
+// ── Intersection (ADR 0102 §1/§3, BT-2743) ──────────────────────────────
+
+/// Builds a minimal `ProtocolRegistry` containing empty (no required method)
+/// protocols under the given names — enough for `has_protocol` checks.
+fn protocol_registry_with(
+    names: &[&str],
+) -> crate::semantic_analysis::protocol_registry::ProtocolRegistry {
+    use crate::ast::{CommentAttachment, Module, ProtocolDefinition};
+    use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
+
+    let h = hierarchy();
+    let proto_module = Module {
+        protocols: names
+            .iter()
+            .map(|name| ProtocolDefinition {
+                name: crate::ast::Identifier::new(*name, Span::default()),
+                type_params: vec![],
+                extending: None,
+                method_signatures: vec![],
+                class_method_signatures: vec![],
+                comments: CommentAttachment::default(),
+                doc_comment: None,
+                span: Span::default(),
+            })
+            .collect(),
+        ..Module::new(vec![], Span::default())
+    };
+    let mut registry = ProtocolRegistry::new();
+    let diags = registry.register_module(&proto_module, &h);
+    assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+    registry
+}
+
+#[test]
+fn intersect_class_and_protocol_produces_stored_intersection() {
+    // `Collection & Comparable` (class ∩ protocol) is the irreducible case —
+    // ADR 0068's flagship `&` example. Requires the protocol registry so
+    // `Comparable` is recognised as a protocol rather than an unrelated class.
+    let registry = protocol_registry_with(&["Comparable"]);
+    let result = InferredType::intersect(
+        &InferredType::known("Collection"),
+        &InferredType::known("Comparable"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    let InferredType::Intersection { members, .. } = result else {
+        panic!("expected Intersection, got {result:?}");
+    };
+    assert_eq!(members.len(), 2);
+    assert!(members.contains(&InferredType::known("Collection")));
+    assert!(members.contains(&InferredType::known("Comparable")));
+}
+
+#[test]
+fn intersect_protocol_and_protocol_produces_stored_intersection() {
+    // Protocol ∩ protocol is likewise irreducible.
+    let registry = protocol_registry_with(&["Printable", "Comparable"]);
+    let result = InferredType::intersect(
+        &InferredType::known("Printable"),
+        &InferredType::known("Comparable"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    assert!(matches!(result, InferredType::Intersection { .. }));
+}
+
+#[test]
+fn intersect_class_and_protocol_without_registry_falls_back_to_never() {
+    // Without a registry, `intersect` cannot distinguish a protocol name from
+    // an unrelated class — conservatively `Never` (documented `None` fallback).
+    let result = InferredType::intersect(
+        &InferredType::known("Collection"),
+        &InferredType::known("Comparable"),
+        prov(),
+        None,
+        None,
+    );
+    assert_eq!(result, InferredType::Never);
+}
+
+#[test]
+fn intersect_class_and_class_still_reduces_with_hierarchy_even_with_registry() {
+    // GAP 1 must not regress (BT-2743 task instruction): class ∩ class still
+    // reduces via the nominal hierarchy — `Number ∩ Integer = Integer` — even
+    // when a (empty, unrelated) protocol registry is also supplied.
+    let registry = protocol_registry_with(&["Comparable"]);
+    let h = hierarchy();
+    let number = InferredType::known("Number");
+    let integer = InferredType::known("Integer");
+    assert_eq!(
+        InferredType::intersect(&number, &integer, prov(), Some(&h), Some(&registry)),
+        integer
+    );
+}
+
+#[test]
+fn intersect_unrelated_classes_is_never_the_adr_headline_example() {
+    // ADR 0102 §1: "`Integer & String` *is* defined: it is `Never`" — holds
+    // even with a protocol registry present (neither name is a protocol).
+    let registry = protocol_registry_with(&["Comparable"]);
+    let result = InferredType::intersect(
+        &InferredType::known("Integer"),
+        &InferredType::known("String"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    assert_eq!(result, InferredType::Never);
+}
+
+#[test]
+fn intersect_equality_is_order_independent() {
+    let registry = protocol_registry_with(&["Printable", "Comparable"]);
+    let ab = InferredType::intersect(
+        &InferredType::known("Printable"),
+        &InferredType::known("Comparable"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    let ba = InferredType::intersect(
+        &InferredType::known("Comparable"),
+        &InferredType::known("Printable"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    assert_eq!(ab, ba);
+}
+
+#[test]
+fn intersect_flattens_three_way_chain() {
+    // `A & B & C` parses left-associatively as `(A & B) & C` (ADR 0102 §3),
+    // and resolving that through repeated pairwise `intersect` calls must
+    // flatten to a single 3-member `Intersection{A, B, C}` — never a nested
+    // `Intersection{Intersection{A,B}, C}` (which would break exhaustive
+    // matches / display / equality elsewhere expecting a flat `members`).
+    let registry = protocol_registry_with(&["A", "B", "C"]);
+    let ab = InferredType::intersect(
+        &InferredType::known("A"),
+        &InferredType::known("B"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    let abc = InferredType::intersect(
+        &ab,
+        &InferredType::known("C"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    let InferredType::Intersection { members, .. } = &abc else {
+        panic!("expected Intersection, got {abc:?}");
+    };
+    assert_eq!(
+        members.len(),
+        3,
+        "expected a flat 3-member Intersection, got {members:?}"
+    );
+    assert!(
+        !members
+            .iter()
+            .any(|m| matches!(m, InferredType::Intersection { .. })),
+        "Intersection must not nest another Intersection, got {members:?}"
+    );
+    assert!(members.contains(&InferredType::known("A")));
+    assert!(members.contains(&InferredType::known("B")));
+    assert!(members.contains(&InferredType::known("C")));
+}
+
+#[test]
+fn intersect_flattening_dedups_repeated_member() {
+    // `(A & B) & B` must flatten and dedup to the 2-member `{A, B}`, not a
+    // 3-member `{A, B, B}`.
+    let registry = protocol_registry_with(&["A", "B"]);
+    let ab = InferredType::intersect(
+        &InferredType::known("A"),
+        &InferredType::known("B"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    let result = InferredType::intersect(
+        &ab,
+        &InferredType::known("B"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    let InferredType::Intersection { members, .. } = &result else {
+        panic!("expected Intersection, got {result:?}");
+    };
+    assert_eq!(
+        members.len(),
+        2,
+        "expected dedup to 2 members, got {members:?}"
+    );
+}
+
+#[test]
+fn intersect_display_renders_ampersand() {
+    let registry = protocol_registry_with(&["Printable", "Comparable"]);
+    let result = InferredType::intersect(
+        &InferredType::known("Printable"),
+        &InferredType::known("Comparable"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    let rendered = result.display_for_diagnostic().unwrap();
+    assert!(
+        rendered == "Printable & Comparable" || rendered == "Comparable & Printable",
+        "unexpected render: {rendered}"
+    );
+}
+
+#[test]
+fn intersection_is_not_known() {
+    let registry = protocol_registry_with(&["Printable", "Comparable"]);
+    let result = InferredType::intersect(
+        &InferredType::known("Printable"),
+        &InferredType::known("Comparable"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    assert!(result.as_known().is_none());
+}
+
+#[test]
+fn intersection_provenance_accessor() {
+    let registry = protocol_registry_with(&["Printable", "Comparable"]);
+    let declared = TypeProvenance::Declared(Span::new(3, 9));
+    let result = InferredType::intersect(
+        &InferredType::known("Printable"),
+        &InferredType::known("Comparable"),
+        declared,
+        None,
+        Some(&registry),
+    );
+    assert_eq!(result.provenance(), Some(declared));
+}
+
+#[test]
+fn union_of_treats_intersection_as_opaque_member() {
+    // `union_of` dedups an `Intersection` by structural equality but applies
+    // no absorption law to it (unlike `Negation`) — ADR 0102 §1, BT-2743.
+    let registry = protocol_registry_with(&["Printable", "Comparable"]);
+    let inter = InferredType::intersect(
+        &InferredType::known("Printable"),
+        &InferredType::known("Comparable"),
+        prov(),
+        None,
+        Some(&registry),
+    );
+    // Dedup: unioning with itself yields the same Intersection, not a Union.
+    assert_eq!(
+        InferredType::union_of(&[inter.clone(), inter.clone()]),
+        inter
+    );
+    // Distinct from an unrelated member: produces a genuine Union.
+    let union = InferredType::union_of(&[inter.clone(), InferredType::known("Integer")]);
+    assert!(matches!(union, InferredType::Union { .. }));
+}
+
 // ── Property tests ──────────────────────────────────────────────────────
 
 /// Concrete, non-`Dynamic`/`Never` leaf types (safe for the algebraic laws).
@@ -612,10 +900,10 @@ proptest! {
         b in concrete_leaf(),
         p in concrete_leaf(),
     ) {
-        let lhs = InferredType::intersect(&InferredType::union_of(&[a.clone(), b.clone()]), &p, prov(), None);
+        let lhs = InferredType::intersect(&InferredType::union_of(&[a.clone(), b.clone()]), &p, prov(), None, None);
         let rhs = InferredType::union_of(&[
-            InferredType::intersect(&a, &p, prov(), None),
-            InferredType::intersect(&b, &p, prov(), None),
+            InferredType::intersect(&a, &p, prov(), None, None),
+            InferredType::intersect(&b, &p, prov(), None, None),
         ]);
         prop_assert_eq!(lhs, rhs);
     }
@@ -669,8 +957,8 @@ proptest! {
     #[test]
     fn prop_operators_terminate(a in any_type(), b in any_type()) {
         let h = hierarchy();
-        let _ = InferredType::intersect(&a, &b, prov(), Some(&h));
-        let _ = InferredType::intersect(&a, &b, prov(), None);
+        let _ = InferredType::intersect(&a, &b, prov(), Some(&h), None);
+        let _ = InferredType::intersect(&a, &b, prov(), None, None);
         let _ = InferredType::difference(&a, &b, prov());
     }
 
@@ -681,15 +969,15 @@ proptest! {
     fn prop_intersect_commutes(a in any_type(), b in any_type()) {
         let h = hierarchy();
         prop_assert_eq!(
-            InferredType::intersect(&a, &b, prov(), Some(&h)),
-            InferredType::intersect(&b, &a, prov(), Some(&h)),
+            InferredType::intersect(&a, &b, prov(), Some(&h), None),
+            InferredType::intersect(&b, &a, prov(), Some(&h), None),
         );
     }
 
     /// Dynamic asymmetry holds for any concrete `P`.
     #[test]
     fn prop_dynamic_asymmetry(p in concrete_leaf()) {
-        prop_assert_eq!(InferredType::intersect(&dynamic(), &p, prov(), None), p.clone());
+        prop_assert_eq!(InferredType::intersect(&dynamic(), &p, prov(), None, None), p.clone());
         prop_assert_eq!(InferredType::difference(&dynamic(), &p, prov()), dynamic());
         prop_assert_eq!(InferredType::difference(&p, &dynamic(), prov()), p);
     }
@@ -700,7 +988,7 @@ proptest! {
     #[test]
     fn prop_intersect_complement(s in singleton_strat(), p in singleton_strat()) {
         let neg = negation(s.clone());
-        let result = InferredType::intersect(&neg, &p, prov(), None);
+        let result = InferredType::intersect(&neg, &p, prov(), None, None);
         if p == s {
             prop_assert_eq!(result, InferredType::Never);
         } else {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/set_operators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/set_operators.rs
@@ -996,3 +996,40 @@ proptest! {
         }
     }
 }
+
+#[test]
+fn intersect_intersection_with_disjoint_class_reduces_to_never() {
+    // `Printable & Integer & String`: the flatten arms must re-check pairwise
+    // disjointness — `Integer ∩ String = Never` under single inheritance, so
+    // the chain reduces to `Never` rather than storing a three-member
+    // Intersection that violates its own invariant. Both operand orders.
+    let registry = protocol_registry_with(&["Printable"]);
+    let h = hierarchy();
+    let step1 = InferredType::intersect(
+        &InferredType::known("Printable"),
+        &InferredType::known("Integer"),
+        prov(),
+        Some(&h),
+        Some(&registry),
+    );
+    assert!(
+        matches!(step1, InferredType::Intersection { .. }),
+        "expected stored Intersection, got {step1:?}"
+    );
+    let left = InferredType::intersect(
+        &step1,
+        &InferredType::known("String"),
+        prov(),
+        Some(&h),
+        Some(&registry),
+    );
+    assert_eq!(left, InferredType::Never);
+    let right = InferredType::intersect(
+        &InferredType::known("String"),
+        &step1,
+        prov(),
+        Some(&h),
+        Some(&registry),
+    );
+    assert_eq!(right, InferredType::Never);
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -27,6 +27,7 @@ use ecow::{EcoString, eco_format};
 
 use crate::ast::TypeAnnotation;
 use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
+use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
 
 use super::well_known::WellKnownClass;
 use super::{DynamicReason, InferredType, TypeProvenance};
@@ -60,6 +61,16 @@ pub(in crate::semantic_analysis) type SubstitutionMap = HashMap<EcoString, Infer
 ///   machinery.
 /// * [`TypeAnnotation::Difference`] — `base \ excluded`, resolved through
 ///   [`InferredType::difference`] (ADR 0102 §1). Reducible cases normalise.
+/// * [`TypeAnnotation::Intersection`] — `left & right`, resolved through
+///   [`InferredType::intersect`] (ADR 0102 §1/§3, BT-2743) with `hierarchy =
+///   None` (this resolver does not consult the class hierarchy — see below)
+///   and the `protocol_registry` parameter passed through unchanged. Class ∩
+///   protocol resolves correctly whenever a registry is supplied (protocol
+///   names are recognised without needing the hierarchy — protocols and
+///   classes share one namespace). Class ∩ class only reduces via nominal
+///   subtyping when a *future* caller threads a hierarchy in; without one, two
+///   distinct, non-protocol class names conservatively fall to `Never` (same
+///   structural-only default `intersect` already uses elsewhere).
 /// * [`TypeAnnotation::SelfType`] — returns `Dynamic(Unknown)`. Bare `Self`
 ///   is resolved at the *call site* where the static receiver class is known;
 ///   the annotation-resolution pass does not have that context.
@@ -79,9 +90,17 @@ pub(in crate::semantic_analysis) type SubstitutionMap = HashMap<EcoString, Infer
 /// "does this class exist?" is a call-site decision that happens *after* the
 /// annotation resolves, not during. A future evolution may thread one in for
 /// type-alias resolution; no current caller needs it.
+///
+/// `protocol_registry` (ADR 0102 §1/§3, BT-2743) is threaded through purely
+/// for [`TypeAnnotation::Intersection`] resolution — every other variant
+/// ignores it. Pass `None` when no registry is available (the annotation
+/// still resolves; `&`-typed protocol intersections just won't recognise a
+/// protocol name and will conservatively fall to `Never`, matching
+/// [`InferredType::intersect`]'s documented `None` behaviour).
 pub(in crate::semantic_analysis) fn resolve_type_annotation(
     ann: &TypeAnnotation,
     subst: &SubstitutionMap,
+    protocol_registry: Option<&ProtocolRegistry>,
 ) -> InferredType {
     match ann {
         TypeAnnotation::Simple(type_id) => {
@@ -107,7 +126,7 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation(
         } => {
             let type_args: Vec<InferredType> = parameters
                 .iter()
-                .map(|p| resolve_type_annotation(p, subst))
+                .map(|p| resolve_type_annotation(p, subst, protocol_registry))
                 .collect();
             InferredType::Known {
                 class_name: base.name.clone(),
@@ -118,12 +137,12 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation(
         TypeAnnotation::Union { types, .. } => {
             let members: Vec<InferredType> = types
                 .iter()
-                .map(|t| resolve_type_annotation(t, subst))
+                .map(|t| resolve_type_annotation(t, subst, protocol_registry))
                 .collect();
             InferredType::union_of(&members)
         }
         TypeAnnotation::FalseOr { inner, .. } => {
-            let inner_ty = resolve_type_annotation(inner, subst);
+            let inner_ty = resolve_type_annotation(inner, subst, protocol_registry);
             InferredType::union_of(&[inner_ty, InferredType::known("False")])
         }
         TypeAnnotation::Difference { base, excluded, .. } => {
@@ -131,9 +150,25 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation(
             // `difference` set operation (BT-2739). Reducible cases normalise —
             // e.g. an excluded member that drops a union member, or `T \ T`
             // collapsing to `Never`.
-            let base_ty = resolve_type_annotation(base, subst);
-            let excluded_ty = resolve_type_annotation(excluded, subst);
+            let base_ty = resolve_type_annotation(base, subst, protocol_registry);
+            let excluded_ty = resolve_type_annotation(excluded, subst, protocol_registry);
             InferredType::difference(&base_ty, &excluded_ty, TypeProvenance::Declared(ann.span()))
+        }
+        TypeAnnotation::Intersection { left, right, .. } => {
+            // ADR 0102 §1/§3, BT-2743: `left & right` resolves through the
+            // shared `intersect` set operation. `hierarchy` is `None` (this
+            // resolver never consults it); `protocol_registry` is passed
+            // through so class ∩ protocol resolves to the stored
+            // `Intersection` instead of falling through to `Never`.
+            let left_ty = resolve_type_annotation(left, subst, protocol_registry);
+            let right_ty = resolve_type_annotation(right, subst, protocol_registry);
+            InferredType::intersect(
+                &left_ty,
+                &right_ty,
+                TypeProvenance::Declared(ann.span()),
+                None,
+                protocol_registry,
+            )
         }
         TypeAnnotation::ClassOf { class_name, .. } => {
             // ADR 0083: `<ClassName> class` is the metatype of the named class.
@@ -377,14 +412,14 @@ mod tests {
     #[test]
     fn simple_class_name_resolves_to_known() {
         let ann = TypeAnnotation::Simple(ident("Integer"));
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert_eq!(result, InferredType::known("Integer"));
     }
 
     #[test]
     fn simple_nil_keyword_resolves_to_undefined_object() {
         let ann = TypeAnnotation::Simple(ident("nil"));
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert_eq!(result, InferredType::known("UndefinedObject"));
     }
 
@@ -394,7 +429,7 @@ mod tests {
         // canonicalize to the same class as lowercase `nil` so narrowing under
         // `isNil` works regardless of which the user typed.
         let ann = TypeAnnotation::Simple(ident("Nil"));
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert_eq!(result, InferredType::known("UndefinedObject"));
     }
 
@@ -403,11 +438,11 @@ mod tests {
         let true_ann = TypeAnnotation::Simple(ident("true"));
         let false_ann = TypeAnnotation::Simple(ident("false"));
         assert_eq!(
-            resolve_type_annotation(&true_ann, &empty_subst()),
+            resolve_type_annotation(&true_ann, &empty_subst(), None),
             InferredType::known("True")
         );
         assert_eq!(
-            resolve_type_annotation(&false_ann, &empty_subst()),
+            resolve_type_annotation(&false_ann, &empty_subst(), None),
             InferredType::known("False")
         );
     }
@@ -415,7 +450,7 @@ mod tests {
     #[test]
     fn simple_never_keyword_resolves_to_never() {
         let ann = TypeAnnotation::Simple(ident("Never"));
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert_eq!(result, InferredType::Never);
     }
 
@@ -426,7 +461,7 @@ mod tests {
         let ann = TypeAnnotation::Simple(ident("T"));
         let mut subst = SubstitutionMap::new();
         subst.insert("T".into(), InferredType::known("Integer"));
-        let result = resolve_type_annotation(&ann, &subst);
+        let result = resolve_type_annotation(&ann, &subst, None);
         assert_eq!(result, InferredType::known("Integer"));
     }
 
@@ -436,7 +471,7 @@ mod tests {
         // downstream code (e.g. `is_generic_type_param`-aware call sites) can
         // decide whether to fall back to Dynamic.
         let ann = TypeAnnotation::Simple(ident("T"));
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert_eq!(result, InferredType::known("T"));
     }
 
@@ -452,7 +487,7 @@ mod tests {
             ],
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         match result {
             InferredType::Known {
                 class_name,
@@ -484,7 +519,7 @@ mod tests {
             parameters: vec![inner],
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         let InferredType::Known {
             class_name,
             type_args,
@@ -523,7 +558,7 @@ mod tests {
         let mut subst = SubstitutionMap::new();
         subst.insert("T".into(), InferredType::known("Integer"));
         subst.insert("E".into(), InferredType::known("String"));
-        let result = resolve_type_annotation(&ann, &subst);
+        let result = resolve_type_annotation(&ann, &subst, None);
         let InferredType::Known {
             class_name,
             type_args,
@@ -549,7 +584,7 @@ mod tests {
             ],
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         let InferredType::Union { members, .. } = result else {
             panic!("expected Union");
         };
@@ -575,7 +610,7 @@ mod tests {
             ],
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         let InferredType::Union { members, .. } = result else {
             panic!("expected Union");
         };
@@ -601,7 +636,7 @@ mod tests {
             inner: Box::new(TypeAnnotation::Simple(ident("Integer"))),
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         let InferredType::Union { members, .. } = result else {
             panic!("expected Union, got {result:?}");
         };
@@ -623,7 +658,7 @@ mod tests {
             },
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         let InferredType::Negation { base, excluded, .. } = result else {
             panic!("expected Negation, got {result:?}");
         };
@@ -639,7 +674,7 @@ mod tests {
             TypeAnnotation::Simple(ident("Integer")),
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert_eq!(result, InferredType::Never);
     }
 
@@ -658,8 +693,118 @@ mod tests {
             TypeAnnotation::Simple(ident("String")),
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert_eq!(result, InferredType::known("Integer"));
+    }
+
+    // ---- resolve_type_annotation: intersection ----
+
+    /// Builds a minimal `ProtocolRegistry` containing empty (no required
+    /// method) protocols under the given names — enough for `has_protocol`
+    /// checks without needing a full conformance fixture.
+    fn protocol_registry_with(names: &[&str]) -> ProtocolRegistry {
+        use crate::ast::{CommentAttachment, Module, ProtocolDefinition};
+
+        let hierarchy = builtin_hierarchy();
+        let proto_module = Module {
+            protocols: names
+                .iter()
+                .map(|name| ProtocolDefinition {
+                    name: ident(name),
+                    type_params: vec![],
+                    extending: None,
+                    method_signatures: vec![],
+                    class_method_signatures: vec![],
+                    comments: CommentAttachment::default(),
+                    doc_comment: None,
+                    span: span(),
+                })
+                .collect(),
+            ..Module::new(vec![], span())
+        };
+        let mut registry = ProtocolRegistry::new();
+        let diags = registry.register_module(&proto_module, &hierarchy);
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+        registry
+    }
+
+    #[test]
+    fn intersection_of_identical_types_collapses_to_known() {
+        // `Integer & Integer` = Integer (identity, reducible).
+        let ann = TypeAnnotation::intersection(
+            TypeAnnotation::Simple(ident("Integer")),
+            TypeAnnotation::Simple(ident("Integer")),
+            span(),
+        );
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        assert_eq!(result, InferredType::known("Integer"));
+    }
+
+    #[test]
+    fn intersection_unrelated_classes_is_never() {
+        // `Integer & String` = Never — ADR 0102 §1's example: unrelated
+        // classes are disjoint under single inheritance. No protocol registry
+        // needed since neither side is a protocol.
+        let ann = TypeAnnotation::intersection(
+            TypeAnnotation::Simple(ident("Integer")),
+            TypeAnnotation::Simple(ident("String")),
+            span(),
+        );
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        assert_eq!(result, InferredType::Never);
+    }
+
+    #[test]
+    fn intersection_class_and_protocol_produces_stored_intersection() {
+        // `Collection & Comparable` (class ∩ protocol) is the irreducible case
+        // ADR 0102 §1/§3 stores — the flagship `&` example from ADR 0068's
+        // Protocol Composition section. Requires the protocol registry to
+        // recognise `Comparable` as a protocol rather than an unrelated class.
+        let registry = protocol_registry_with(&["Comparable"]);
+        let ann = TypeAnnotation::intersection(
+            TypeAnnotation::Simple(ident("Collection")),
+            TypeAnnotation::Simple(ident("Comparable")),
+            span(),
+        );
+        let result = resolve_type_annotation(&ann, &empty_subst(), Some(&registry));
+        let InferredType::Intersection { members, .. } = result else {
+            panic!("expected Intersection, got {result:?}");
+        };
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&InferredType::known("Collection")));
+        assert!(members.contains(&InferredType::known("Comparable")));
+    }
+
+    #[test]
+    fn intersection_without_protocol_registry_falls_back_to_never() {
+        // Without a registry, `Collection & Comparable` cannot be distinguished
+        // from two unrelated classes and conservatively resolves to `Never` —
+        // a documented limitation (see `resolve_type_annotation`'s doc
+        // comment): callers that need class ∩ protocol reduction must
+        // thread a `ProtocolRegistry` through.
+        let ann = TypeAnnotation::intersection(
+            TypeAnnotation::Simple(ident("Collection")),
+            TypeAnnotation::Simple(ident("Comparable")),
+            span(),
+        );
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        assert_eq!(result, InferredType::Never);
+    }
+
+    #[test]
+    fn intersection_of_two_protocols_produces_stored_intersection() {
+        // Protocol ∩ protocol is likewise irreducible.
+        let registry = protocol_registry_with(&["Printable", "Comparable"]);
+        let ann = TypeAnnotation::intersection(
+            TypeAnnotation::Simple(ident("Printable")),
+            TypeAnnotation::Simple(ident("Comparable")),
+            span(),
+        );
+        let result = resolve_type_annotation(&ann, &empty_subst(), Some(&registry));
+        assert!(
+            matches!(result, InferredType::Intersection { .. }),
+            "expected Intersection, got {result:?}"
+        );
     }
 
     // ---- resolve_type_annotation: Self / Self class ----
@@ -667,7 +812,7 @@ mod tests {
     #[test]
     fn self_type_resolves_to_dynamic() {
         let ann = TypeAnnotation::SelfType { span: span() };
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert!(matches!(result, InferredType::Dynamic(_)));
     }
 
@@ -677,7 +822,7 @@ mod tests {
         // reserved `Self` subst key. Without it (the free-function default),
         // it still falls back to Dynamic so existing patterns keep working.
         let ann = TypeAnnotation::SelfClass { span: span() };
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert!(matches!(result, InferredType::Dynamic(_)));
     }
 
@@ -688,7 +833,7 @@ mod tests {
         let ann = TypeAnnotation::SelfClass { span: span() };
         let mut subst = SubstitutionMap::new();
         subst.insert("Self".into(), InferredType::known("Counter"));
-        let result = resolve_type_annotation(&ann, &subst);
+        let result = resolve_type_annotation(&ann, &subst, None);
         assert_eq!(result.as_meta().map(EcoString::as_str), Some("Counter"));
     }
 
@@ -701,7 +846,7 @@ mod tests {
             class_name: ident("Actor"),
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert_eq!(result.as_meta().map(EcoString::as_str), Some("Actor"));
     }
 
@@ -713,7 +858,7 @@ mod tests {
             name: "ok".into(),
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst());
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
         assert_eq!(result, InferredType::known("#ok"));
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
@@ -928,11 +928,28 @@ impl InferredType {
             // (those arms already matched), `Dynamic`/`Never`/`Object`
             // (matched even earlier), or a `Negation` (matched above too).
             (Self::Intersection { members, .. }, _) => {
+                // Re-check pairwise disjointness before appending: without
+                // this, `Printable & Integer & String` would flatten to
+                // `Intersection{Integer, Printable, String}` instead of
+                // reducing to `Never` (`Integer ∩ String = Never`), violating
+                // the stored-intersection invariant.
+                for m in members {
+                    let pair = Self::intersect(m, b, provenance, hierarchy, protocol_registry);
+                    if matches!(pair, Self::Never) {
+                        return Self::Never;
+                    }
+                }
                 let mut merged = members.clone();
                 merged.push(b.clone());
                 Self::normalize_intersection(merged, provenance)
             }
             (_, Self::Intersection { members, .. }) => {
+                for m in members {
+                    let pair = Self::intersect(a, m, provenance, hierarchy, protocol_registry);
+                    if matches!(pair, Self::Never) {
+                        return Self::Never;
+                    }
+                }
                 let mut merged = members.clone();
                 merged.push(a.clone());
                 Self::normalize_intersection(merged, provenance)

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/types.rs
@@ -6,6 +6,7 @@
 //! **DDD Context:** Semantic Analysis
 
 use crate::semantic_analysis::ClassHierarchy;
+use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
 use crate::source_analysis::Span;
 use ecow::EcoString;
 
@@ -189,6 +190,28 @@ pub enum InferredType {
         /// Where this negation came from.
         provenance: TypeProvenance,
     },
+    /// An irreducible intersection type `A ∩ B ∩ …` (ADR 0102 §1/§3).
+    ///
+    /// Produced by [`intersect`](InferredType::intersect) only for the one
+    /// case that cannot collapse to an existing variant: **class ∩
+    /// protocol** (e.g. `Collection(Object) & Comparable`, ADR 0068 §Protocol
+    /// Composition). Class ∩ class always reduces via the nominal hierarchy
+    /// (to the subclass, or `Never` for hierarchy-unrelated sealed classes),
+    /// so a stored `Intersection` never contains two classes related by
+    /// inheritance — every member is either a protocol, or a class that does
+    /// not (as far as the checker can prove) reduce against its co-members.
+    ///
+    /// **Normal form.** `members` has at least two entries, is **flattened**
+    /// (a nested `Intersection` is never a member — constructing one merges
+    /// the nested members into the parent), and is **deduplicated** by
+    /// structural equality. **Equality is order-independent** (mirrors
+    /// [`Union`](Self::Union)).
+    Intersection {
+        /// The intersected member types (≥2, flattened, deduplicated).
+        members: Vec<InferredType>,
+        /// Where this intersection came from.
+        provenance: TypeProvenance,
+    },
 }
 
 impl PartialEq for InferredType {
@@ -225,6 +248,9 @@ impl PartialEq for InferredType {
                     ..
                 },
             ) => base_a == base_b && excluded_a == excluded_b,
+            (Self::Intersection { members: a, .. }, Self::Intersection { members: b, .. }) => {
+                a.len() == b.len() && a.iter().all(|m| b.contains(m))
+            }
             (Self::Dynamic(_), Self::Dynamic(_)) | (Self::Never, Self::Never) => true,
             _ => false,
         }
@@ -332,7 +358,10 @@ impl InferredType {
             | Self::Never
             // A negation (`Symbol \ #foo`) is not a single known class — callers
             // must handle it structurally, not as a bare class name.
-            | Self::Negation { .. } => None,
+            | Self::Negation { .. }
+            // An intersection (`A & B`) is not a single known class either —
+            // callers must handle it structurally (ADR 0102 §1).
+            | Self::Intersection { .. } => None,
         }
     }
 
@@ -347,7 +376,8 @@ impl InferredType {
             Self::Known { provenance, .. }
             | Self::Union { provenance, .. }
             | Self::Meta { provenance, .. }
-            | Self::Negation { provenance, .. } => Some(*provenance),
+            | Self::Negation { provenance, .. }
+            | Self::Intersection { provenance, .. } => Some(*provenance),
             Self::Dynamic(_) | Self::Never => None,
         }
     }
@@ -499,6 +529,25 @@ impl InferredType {
                     EcoString::from(format!("{base_str} \\ {excluded_str}"))
                 }
             }
+            Self::Intersection { members, .. } => {
+                let mut result = EcoString::new();
+                for (i, m) in members.iter().enumerate() {
+                    if i > 0 {
+                        result.push_str(" & ");
+                    }
+                    // `&` binds tighter than `|`; a union member is only
+                    // reachable via explicit grouping, so parenthesise to
+                    // preserve meaning.
+                    if matches!(m, Self::Union { .. }) {
+                        result.push('(');
+                        result.push_str(&m.display_with_options(opts));
+                        result.push(')');
+                    } else {
+                        result.push_str(&m.display_with_options(opts));
+                    }
+                }
+                result
+            }
         }
     }
 
@@ -517,7 +566,12 @@ impl InferredType {
             match m {
                 Self::Known { provenance, .. }
                 | Self::Meta { provenance, .. }
-                | Self::Negation { provenance, .. } => {
+                | Self::Negation { provenance, .. }
+                // `Intersection` is opaque to `union_of` (ADR 0102 §1) — treated
+                // like any other opaque member: kept as-is and deduplicated by
+                // structural equality, with no absorption/flattening law of its
+                // own (unlike `Negation`, which `union_of` actively simplifies).
+                | Self::Intersection { provenance, .. } => {
                     if matches!(best_provenance, TypeProvenance::Inferred(_))
                         && !matches!(provenance, TypeProvenance::Inferred(_))
                     {
@@ -716,9 +770,9 @@ impl InferredType {
             // intersection (`E1 ∩ E2 ∩ …`).
             let mut merged = neg_excludeds[0].clone();
             for e in &neg_excludeds[1..] {
-                // Structural singleton merge only — no hierarchy needed (and
-                // none is threaded through `union_of`).
-                merged = Self::intersect(&merged, e, provenance, None);
+                // Structural singleton merge only — no hierarchy or protocol
+                // registry needed (and neither is threaded through `union_of`).
+                merged = Self::intersect(&merged, e, provenance, None, None);
             }
             // Add back any excluded singleton that also appears bare (absorption).
             let remaining: Vec<Self> = if matches!(merged, Self::Never) {
@@ -775,6 +829,14 @@ impl InferredType {
     /// behaviour). Narrowing call sites pass `Some(hierarchy)` so class narrowing
     /// reduces correctly.
     ///
+    /// The `protocol_registry` argument is likewise **optional**
+    /// (ADR 0102 §1/§3, BT-2743): supplying it lets `intersect` recognise a
+    /// protocol name and route class ∩ protocol / protocol ∩ protocol to the
+    /// stored [`Intersection`](Self::Intersection) instead of falling through
+    /// to the disjoint default. `None` preserves the pre-BT-2743 structural
+    /// behaviour (two distinct-named `Known` types with no proven relation
+    /// are `Never`).
+    ///
     /// Rules:
     /// - **Dynamic first:** `intersect(Dynamic, P) = P` (Dynamic acts as the top
     ///   type for intersection — *not* union's "Dynamic absorbs" rule). Checked
@@ -787,6 +849,15 @@ impl InferredType {
     ///   difference(intersect(P, B), E)` — a `Negation` never reaches the
     ///   disjoint default (needed for chained narrowing / Phase 2 `\` syntax).
     /// - **Symbol-singleton membership:** `intersect(Symbol, #foo) = #foo`.
+    /// - **Class ∩ protocol / protocol ∩ protocol** (`protocol_registry =
+    ///   Some`, ADR 0102 §1/§3): when the two distinct-named `Known` operands
+    ///   include at least one protocol name, the result is the normalised,
+    ///   irreducible [`Intersection`](Self::Intersection) — e.g.
+    ///   `Collection(Object) ∩ Comparable`. Checked before the nominal-class
+    ///   base case because a protocol is never an entry in the class
+    ///   hierarchy's subtype lattice, and protocols/classes share one
+    ///   namespace (collisions are compile errors), so `has_protocol(name)`
+    ///   alone identifies a protocol without consulting the hierarchy.
     /// - **Nominal-class base case** (`hierarchy = Some`): `B <: A ⇒ B`,
     ///   `A <: B ⇒ A`, unrelated ⇒ `Never`.
     /// - **LHS-union distribution:** `intersect(T1 | … | Tn, P) =
@@ -803,6 +874,7 @@ impl InferredType {
         b: &Self,
         provenance: TypeProvenance,
         hierarchy: Option<&ClassHierarchy>,
+        protocol_registry: Option<&ProtocolRegistry>,
     ) -> Self {
         match (a, b) {
             // Dynamic FIRST (before identity/Object): `intersect(Dynamic, P) = P`
@@ -819,12 +891,12 @@ impl InferredType {
             // default (the `(Known, Negation)` case fires in Phase 2's `\`
             // syntax; missing it silently loses narrowing).
             (Self::Negation { base, excluded, .. }, _) => Self::difference(
-                &Self::intersect(base, b, provenance, hierarchy),
+                &Self::intersect(base, b, provenance, hierarchy, protocol_registry),
                 excluded,
                 provenance,
             ),
             (_, Self::Negation { base, excluded, .. }) => Self::difference(
-                &Self::intersect(a, base, provenance, hierarchy),
+                &Self::intersect(a, base, provenance, hierarchy, protocol_registry),
                 excluded,
                 provenance,
             ),
@@ -832,7 +904,7 @@ impl InferredType {
             (Self::Union { members, .. }, _) => {
                 let parts: Vec<Self> = members
                     .iter()
-                    .map(|m| Self::intersect(m, b, provenance, hierarchy))
+                    .map(|m| Self::intersect(m, b, provenance, hierarchy, protocol_registry))
                     .collect();
                 Self::union_of(&parts)
             }
@@ -840,9 +912,30 @@ impl InferredType {
             (_, Self::Union { members, .. }) => {
                 let parts: Vec<Self> = members
                     .iter()
-                    .map(|m| Self::intersect(a, m, provenance, hierarchy))
+                    .map(|m| Self::intersect(a, m, provenance, hierarchy, protocol_registry))
                     .collect();
                 Self::union_of(&parts)
+            }
+            // Intersect through an existing stored Intersection (both
+            // orders) — flatten rather than falling through to the disjoint
+            // default (ADR 0102 §1/§3, BT-2743). Needed so a 3+-way `&`
+            // chain (`A & B & C`, parsed left-associatively as `(A & B) &
+            // C`) reduces through repeated pairwise `intersect` calls to a
+            // single flat, deduplicated `Intersection` instead of silently
+            // losing a member. Checked after the `Union` arms above so
+            // `intersect(Intersection{..}, T1 | T2)` still distributes over
+            // the union first — by this point neither operand is a `Union`
+            // (those arms already matched), `Dynamic`/`Never`/`Object`
+            // (matched even earlier), or a `Negation` (matched above too).
+            (Self::Intersection { members, .. }, _) => {
+                let mut merged = members.clone();
+                merged.push(b.clone());
+                Self::normalize_intersection(merged, provenance)
+            }
+            (_, Self::Intersection { members, .. }) => {
+                let mut merged = members.clone();
+                merged.push(a.clone());
+                Self::normalize_intersection(merged, provenance)
             }
             // Symbol-singleton membership: `#foo <: Symbol`, so the narrower
             // singleton is kept in both orders. Checked before the general
@@ -859,6 +952,17 @@ impl InferredType {
             }
             // `T ∩ T = T` (exact structural equality, generics included).
             _ if a == b => a.clone(),
+            // Class ∩ protocol / protocol ∩ protocol (ADR 0102 §1/§3, BT-2743):
+            // the irreducible intersection. Must be checked before the nominal
+            // arm below — a protocol name is never a hierarchy entry, so
+            // without this arm it would silently fall through to `Never`.
+            (Self::Known { class_name: an, .. }, Self::Known { class_name: bn, .. })
+                if an != bn
+                    && protocol_registry
+                        .is_some_and(|r| r.has_protocol(an) || r.has_protocol(bn)) =>
+            {
+                Self::normalize_intersection(vec![a.clone(), b.clone()], provenance)
+            }
             // Nominal-class base case (ADR 0102 §1): with a hierarchy, two
             // distinct-named `Known` classes relate via subtyping — the subclass
             // wins (`Number ∩ Integer = Integer`), and hierarchy-unrelated
@@ -883,6 +987,56 @@ impl InferredType {
             // Distinct concrete types with no structural relationship (including
             // distinct singletons, `#foo ∩ #bar`) are disjoint.
             _ => Self::Never,
+        }
+    }
+
+    /// Builds a normalised [`Intersection`](Self::Intersection) — the sole
+    /// construction path (ADR 0102 §1), analogous to
+    /// [`make_negation`](Self::make_negation).
+    ///
+    /// - **Flattens** nested `Intersection` members into the parent (an
+    ///   `Intersection` never contains another `Intersection`).
+    /// - **Deduplicates** by structural equality.
+    /// - **Degenerate case:** if flattening/dedup leaves a single member, it
+    ///   is returned bare rather than wrapped (mirrors `union_of`'s
+    ///   single-member collapse).
+    /// - Sorted by display name so independent constructions of the same
+    ///   logical intersection produce the same stored order (equality is
+    ///   already order-independent; this makes serialisation/output
+    ///   deterministic too, mirroring `Negation`'s canonical `excluded`
+    ///   ordering).
+    fn normalize_intersection(raw: Vec<Self>, provenance: TypeProvenance) -> Self {
+        let mut flat: Vec<Self> = Vec::with_capacity(raw.len());
+        for m in raw {
+            match m {
+                Self::Intersection { members, .. } => {
+                    for inner in members {
+                        if !flat.contains(&inner) {
+                            flat.push(inner);
+                        }
+                    }
+                }
+                other => {
+                    if !flat.contains(&other) {
+                        flat.push(other);
+                    }
+                }
+            }
+        }
+        flat.sort_by(|x, y| {
+            x.display_name()
+                .unwrap_or_default()
+                .cmp(&y.display_name().unwrap_or_default())
+        });
+        match flat.len() {
+            // Unreachable from `intersect`'s call site (which always passes two
+            // distinct members), kept for a total/defensive standalone helper.
+            0 => Self::Never,
+            1 => flat.into_iter().next().unwrap_or(Self::Never),
+            _ => Self::Intersection {
+                members: flat,
+                provenance,
+            },
         }
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1022,8 +1022,15 @@ impl TypeChecker {
                         .push(diag.with_category(DiagnosticCategory::Type));
                 }
                 // A `Negation` (`Symbol \ #foo`) is a narrowed `Symbol`; skip
-                // conservatively like `Dynamic`/`Never` (ADR 0102).
-                InferredType::Dynamic(_) | InferredType::Never | InferredType::Negation { .. } => {}
+                // conservatively like `Dynamic`/`Never` (ADR 0102). An
+                // `Intersection` (`P1 & P2`, ADR 0102/BT-2743) as the
+                // *argument's own* inferred type is likewise skipped — see
+                // `check_protocol_argument_conformance` for the flagship
+                // "parameter declared `P1 & P2`" conformance check.
+                InferredType::Dynamic(_)
+                | InferredType::Never
+                | InferredType::Negation { .. }
+                | InferredType::Intersection { .. } => {}
             }
         }
     }
@@ -1179,10 +1186,13 @@ impl TypeChecker {
             // `Meta` is unreachable in practice; skip checking (like `Dynamic`)
             // to stay safe should a future annotation resolve to a metatype.
             // A `Negation` (`Symbol \ #foo`) is a narrowed `Symbol`; skip like
-            // `Meta`/`Dynamic` (ADR 0102).
+            // `Meta`/`Dynamic` (ADR 0102). An `Intersection` (`P1 & P2`, ADR
+            // 0102/BT-2743) declared return type has no single `Known` body
+            // shape to compare against here; skip conservatively too.
             InferredType::Meta { .. }
             | InferredType::Dynamic(_)
-            | InferredType::Negation { .. } => {}
+            | InferredType::Negation { .. }
+            | InferredType::Intersection { .. } => {}
         }
     }
 
@@ -1498,8 +1508,13 @@ impl TypeChecker {
                 }
             }
             // A `Negation` (`Symbol \ #foo`) is a narrowed `Symbol`; skip
-            // conservatively like `Dynamic`/`Never` (ADR 0102).
-            InferredType::Dynamic(_) | InferredType::Never | InferredType::Negation { .. } => {}
+            // conservatively like `Dynamic`/`Never` (ADR 0102). Likewise an
+            // `Intersection` (`P1 & P2`, ADR 0102/BT-2743) as the value's own
+            // inferred type — skip conservatively.
+            InferredType::Dynamic(_)
+            | InferredType::Never
+            | InferredType::Negation { .. }
+            | InferredType::Intersection { .. } => {}
         }
     }
 
@@ -1925,8 +1940,17 @@ impl TypeChecker {
             // protocol is out of scope for Slice 1 — skip the metatype rather
             // than emit a false positive (same as `Never`, which diverges).
             // A `Negation` (`Symbol \ #foo`) is a narrowed `Symbol`; skip like
-            // `Meta`/`Never` (ADR 0102).
-            InferredType::Meta { .. } | InferredType::Never | InferredType::Negation { .. } => {}
+            // `Meta`/`Never` (ADR 0102). An `Intersection` (`P1 & P2`, ADR
+            // 0102/BT-2743) as the *argument's own* inferred type is a rarer,
+            // deeper case (the value's declared type is itself a stored
+            // intersection) — skip conservatively rather than guess which
+            // member to check; the flagship "parameter declared `P1 & P2`"
+            // case is handled by splitting `expected_protocol` in
+            // `check_protocol_conformance_in_expr`, not here.
+            InferredType::Meta { .. }
+            | InferredType::Never
+            | InferredType::Negation { .. }
+            | InferredType::Intersection { .. } => {}
         }
     }
 
@@ -1946,6 +1970,42 @@ impl TypeChecker {
         // or only present as a synthetic protocol class entry (added by register_protocol_classes)
         protocol_registry.has_protocol(base_name)
             && (!hierarchy.has_class(base_name) || hierarchy.is_protocol_class(base_name))
+    }
+
+    /// Splits a `type_name()`-rendered intersection string (`"P1 & P2 & …"`,
+    /// ADR 0068 §Protocol Composition / ADR 0102 §1/§3, BT-2743) into its
+    /// top-level `&`-joined parts.
+    ///
+    /// Respects parenthesis nesting so a generic type argument's own
+    /// annotation (which may itself contain `(`/`)`) is never mistaken for a
+    /// top-level split point. Returns `None` when the string has no
+    /// top-level `&` — i.e. it isn't an intersection annotation, and callers
+    /// should fall back to single-type handling (`is_protocol_type` /
+    /// `check_protocol_argument_conformance`).
+    ///
+    /// Used by [`check_protocol_conformance_in_expr`](super::protocol::TypeChecker::check_protocol_conformance_in_expr)
+    /// so a parameter declared `:: P1 & P2` is checked for conformance to
+    /// **both** protocol parts, per ADR 0068's protocol-composition use case.
+    pub(super) fn split_intersection_type_string(type_name: &str) -> Option<Vec<&str>> {
+        let mut depth: usize = 0;
+        let mut parts = Vec::new();
+        let mut start = 0usize;
+        for (i, byte) in type_name.bytes().enumerate() {
+            match byte {
+                b'(' => depth += 1,
+                b')' => depth = depth.saturating_sub(1),
+                b'&' if depth == 0 => {
+                    parts.push(type_name[start..i].trim());
+                    start = i + 1;
+                }
+                _ => {}
+            }
+        }
+        if parts.is_empty() {
+            return None;
+        }
+        parts.push(type_name[start..].trim());
+        Some(parts)
     }
 
     /// Check type parameter bounds for a generic type application (ADR 0068 Phase 2d).
@@ -2075,11 +2135,16 @@ impl TypeChecker {
                 // its class-side bound conformance is out of scope here — skip.
                 // Dynamic/Never values: can't verify bounds (skip silently).
                 // A `Negation` (`Symbol \ #foo`) is a narrowed `Symbol`; skip
-                // like `Meta`/`Dynamic`/`Never` (ADR 0102).
+                // like `Meta`/`Dynamic`/`Never` (ADR 0102). An `Intersection`
+                // (`P1 & P2`, ADR 0102/BT-2743) as a type argument is likewise
+                // skipped — a bound is a single protocol name, and checking
+                // it against one member of the intersection risks a false
+                // positive when a *different* member is the one that conforms.
                 InferredType::Meta { .. }
                 | InferredType::Dynamic(_)
                 | InferredType::Never
-                | InferredType::Negation { .. } => {}
+                | InferredType::Negation { .. }
+                | InferredType::Intersection { .. } => {}
             }
         }
     }

--- a/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
@@ -567,12 +567,14 @@ pub(crate) fn check_redundant_local_type_annotation(
             return;
         }
         // Widening annotations are load-bearing: keep them. A difference
-        // (`Symbol \ #foo`) narrows the RHS type, so it is load-bearing too.
+        // (`Symbol \ #foo`) or intersection (`P1 & P2`) narrows/composes the
+        // RHS type, so both are load-bearing too.
         if matches!(
             annotation,
             TypeAnnotation::Union { .. }
                 | TypeAnnotation::FalseOr { .. }
                 | TypeAnnotation::Difference { .. }
+                | TypeAnnotation::Intersection { .. }
         ) {
             return;
         }
@@ -595,6 +597,7 @@ pub(crate) fn check_redundant_local_type_annotation(
         let resolved = crate::semantic_analysis::type_checker::resolve_type_annotation(
             annotation,
             &empty_subst,
+            None,
         );
         let InferredType::Known {
             class_name: ann_class,

--- a/crates/beamtalk-core/src/semantic_analysis/validators/visibility_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/visibility_validators.rs
@@ -314,6 +314,10 @@ fn check_type_annotation_cross_package(
             check_type_annotation_cross_package(base, current_pkg, hierarchy, diagnostics);
             check_type_annotation_cross_package(excluded, current_pkg, hierarchy, diagnostics);
         }
+        TypeAnnotation::Intersection { left, right, .. } => {
+            check_type_annotation_cross_package(left, current_pkg, hierarchy, diagnostics);
+            check_type_annotation_cross_package(right, current_pkg, hierarchy, diagnostics);
+        }
         TypeAnnotation::ClassOf { class_name, .. } => {
             check_cross_package_ref(
                 &class_name.name,
@@ -389,6 +393,7 @@ fn check_leaked_visibility_class(
 ///
 /// An internal class from the *same* package appearing in the public signature
 /// of a public class is a leaked-visibility error.
+#[allow(clippy::too_many_lines)] // ADR 0102/BT-2743 added an `Intersection` recursion arm
 fn check_type_annotation_leaked(
     ty: &TypeAnnotation,
     class_name: &ecow::EcoString,
@@ -465,6 +470,24 @@ fn check_type_annotation_leaked(
             );
             check_type_annotation_leaked(
                 excluded,
+                class_name,
+                method_selector,
+                current_pkg,
+                hierarchy,
+                diagnostics,
+            );
+        }
+        TypeAnnotation::Intersection { left, right, .. } => {
+            check_type_annotation_leaked(
+                left,
+                class_name,
+                method_selector,
+                current_pkg,
+                hierarchy,
+                diagnostics,
+            );
+            check_type_annotation_leaked(
+                right,
                 class_name,
                 method_selector,
                 current_pkg,

--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -724,20 +724,22 @@ impl Parser {
     }
 
     /// Returns `true` if the token at `offset` continues a type annotation with
-    /// a binary type operator: union `|`, difference `\`, or the `\\` typo for
-    /// `\` (ADR 0102 §3, BT-2742).
+    /// a binary type operator: union `|`, difference `\`, intersection `&`, or
+    /// the `\\` typo for `\` (ADR 0102 §3, BT-2742, BT-2743).
     ///
     /// Used by the lookahead helpers to skip over a type-operator chain when
     /// deciding whether a `-> Type =>` / `:: Type` sequence is a method header.
-    /// The precedence distinction between `\` and `|` is irrelevant here — these
-    /// helpers only confirm the chain terminates at a `=>`/`)`; the parser
+    /// The precedence distinction between `\`, `&`, and `|` is irrelevant here —
+    /// these helpers only confirm the chain terminates at a `=>`/`)`; the parser
     /// enforces precedence in [`parse_difference_type`](Self::parse_difference_type).
     /// The `\\` typo is treated as a chain operator so the method is still
     /// recognised and the parser can emit the targeted "did you mean `\`?" error.
     pub(super) fn is_type_chain_operator(&self, offset: usize) -> bool {
         match self.peek_at(offset) {
             Some(TokenKind::Pipe) => true,
-            Some(TokenKind::BinarySelector(s)) => s.as_str() == "\\" || s.as_str() == "\\\\",
+            Some(TokenKind::BinarySelector(s)) => {
+                s.as_str() == "\\" || s.as_str() == "\\\\" || s.as_str() == "&"
+            }
             _ => false,
         }
     }
@@ -945,12 +947,14 @@ impl Parser {
         })
     }
 
-    /// Parses a type annotation, including union types (`Integer | String`)
-    /// and difference types (`Symbol \ #foo`).
+    /// Parses a type annotation, including union types (`Integer | String`),
+    /// difference types (`Symbol \ #foo`), and intersection types
+    /// (`Collection(Object) & Comparable`).
     ///
     /// Precedence (ADR 0102 §3): `|` (union) is the loosest tier; `\`
-    /// (difference) binds tighter, so `Integer | Symbol \ #foo` parses as
-    /// `Integer | (Symbol \ #foo)`. The `\` tier is handled by
+    /// (difference) and `&` (intersection) bind tighter and share a tier, so
+    /// `Integer | Symbol \ #foo` parses as `Integer | (Symbol \ #foo)`. The
+    /// `\`/`&` tier is handled by
     /// [`parse_difference_type`](Self::parse_difference_type).
     pub(super) fn parse_type_annotation(&mut self) -> TypeAnnotation {
         let first = self.parse_difference_type();
@@ -975,32 +979,65 @@ impl Parser {
         }
     }
 
-    /// Parses a difference type (`Type \ Type`), the precedence tier between
-    /// unions (`|`) and single type atoms (ADR 0102 §3).
+    /// Parses a difference/intersection type (`Type \ Type`, `Type & Type`),
+    /// the shared precedence tier between unions (`|`) and single type atoms
+    /// (ADR 0102 §3).
     ///
-    /// `\` binds tighter than `|` and is left-associative, so `A \ B \ C`
-    /// parses as `(A \ B) \ C`. This tier is shared with the intersection
-    /// operator `&` (BT-2743), which slots in here at the same precedence.
+    /// `\` and `&` bind tighter than `|` and are each left-associative, so
+    /// `A \ B \ C` parses as `(A \ B) \ C` and `A & B & C` parses as
+    /// `(A & B) & C`. Per ADR 0102 §3, **mixing `&` and `\` in the same chain
+    /// without explicit grouping is a deliberate parse error** — not a
+    /// left-associative resolution, since `(A & B) \ C` and `A & (B \ C)`
+    /// differ and neither reading is obviously dominant. Once the chain
+    /// commits to one operator (whichever appears first), encountering the
+    /// other emits a diagnostic; recovery keeps building the AST using the
+    /// originally-committed operator so a single mismatch doesn't cascade
+    /// into unrelated downstream errors.
     ///
-    /// The `\` operator lexes as `BinarySelector("\")` (a single backslash);
-    /// it is special-cased *only* in type-annotation position — in a value
-    /// expression `\` remains an ordinary binary selector, untouched. The
-    /// modulo selector `\\` (two backslashes, which the lexer greedily merges)
-    /// is almost certainly a typo for `\` here and gets a targeted diagnostic.
+    /// The `\`/`&` operators lex as ordinary `BinarySelector`s; they are
+    /// special-cased *only* in type-annotation position — in a value
+    /// expression they remain ordinary binary selectors, untouched. The
+    /// modulo selector `\\` (two backslashes, which the lexer greedily
+    /// merges) is almost certainly a typo for `\` here and gets a targeted
+    /// diagnostic.
     fn parse_difference_type(&mut self) -> TypeAnnotation {
         let mut ty = self.parse_single_type_annotation();
+        // Which operator this chain has committed to (`true` = `&`, `false` =
+        // `\`) — `None` until the first `&`/`\` is seen. Used to reject a
+        // same-tier operator switch without explicit grouping (ADR 0102 §3).
+        let mut chain_is_and: Option<bool> = None;
 
         loop {
             let TokenKind::BinarySelector(op) = self.current_kind() else {
                 break;
             };
             match op.as_str() {
-                // `\` — the difference operator.
-                "\\" => {
-                    self.advance(); // consume `\`
-                    let excluded = self.parse_single_type_annotation();
-                    let span = ty.span().merge(excluded.span());
-                    ty = TypeAnnotation::difference(ty, excluded, span);
+                // `\` — the difference operator, `&` — the intersection
+                // operator. Both share this precedence tier.
+                "\\" | "&" => {
+                    let is_and = op.as_str() == "&";
+                    match chain_is_and {
+                        None => chain_is_and = Some(is_and),
+                        Some(started) if started != is_and => {
+                            self.error(
+                                "Cannot mix `&` and `\\` in a type annotation without \
+                                 parentheses; parenthesise to disambiguate",
+                            );
+                            // Recovery: keep building the AST using the
+                            // originally-committed operator so this single
+                            // diagnostic doesn't cascade into a confusing
+                            // secondary error at the next token.
+                        }
+                        Some(_) => {}
+                    }
+                    self.advance(); // consume `\` or `&`
+                    let rhs = self.parse_single_type_annotation();
+                    let span = ty.span().merge(rhs.span());
+                    ty = if chain_is_and == Some(true) {
+                        TypeAnnotation::intersection(ty, rhs, span)
+                    } else {
+                        TypeAnnotation::difference(ty, rhs, span)
+                    };
                 }
                 // `\\` — the modulo selector, greedily lexed from `\\`. In type
                 // position this is a typo for the difference operator `\`.
@@ -1008,6 +1045,9 @@ impl Parser {
                     self.error(
                         "Unexpected `\\\\` in type annotation; did you mean `\\` (type difference)?",
                     );
+                    if chain_is_and.is_none() {
+                        chain_is_and = Some(false);
+                    }
                     self.advance(); // consume `\\` to recover
                     let excluded = self.parse_single_type_annotation();
                     let span = ty.span().merge(excluded.span());

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
@@ -1628,3 +1628,150 @@ fn value_position_backslash_is_unchanged() {
         "value-position `\\` must parse as before (unchanged), got: {diagnostics:?}"
     );
 }
+
+// ==========================================================================
+// Intersection type annotations (`&`) — ADR 0068 §Protocol Composition,
+// ADR 0102 §1/§3, BT-2743
+// ==========================================================================
+
+#[test]
+fn parse_intersection_return_type() {
+    // `Collection(Object) & Comparable` parses as
+    // Intersection { left: Generic(Collection, [Object]), right: Comparable }.
+    let module = parse_ok(
+        "Object subclass: Foo
+  narrow -> Collection(Object) & Comparable => self",
+    );
+    let ret_ty = module.classes[0].methods[0].return_type.as_ref().unwrap();
+    let TypeAnnotation::Intersection { left, right, .. } = ret_ty else {
+        panic!("expected Intersection, got {ret_ty:?}");
+    };
+    assert!(
+        matches!(left.as_ref(), TypeAnnotation::Generic { base, .. } if base.name == "Collection")
+    );
+    assert!(matches!(right.as_ref(), TypeAnnotation::Simple(id) if id.name == "Comparable"));
+}
+
+#[test]
+fn parse_intersection_state_field() {
+    // `field: tag :: Printable & Comparable = nil` in a typed class.
+    let module = parse_ok(
+        "typed Value subclass: Spec
+  field: tag :: Printable & Comparable = nil",
+    );
+    let ann = module.classes[0].state[0].type_annotation.as_ref().unwrap();
+    assert!(
+        matches!(ann, TypeAnnotation::Intersection { .. }),
+        "expected Intersection, got {ann:?}"
+    );
+}
+
+#[test]
+fn parse_intersection_binds_tighter_than_union() {
+    // ADR 0102 §3: `Integer | Printable & Comparable` parses as
+    // `Integer | (Printable & Comparable)` — `&` binds tighter than `|`.
+    let module = parse_ok(
+        "Object subclass: Foo
+  narrow -> Integer | Printable & Comparable => 1",
+    );
+    let ret_ty = module.classes[0].methods[0].return_type.as_ref().unwrap();
+    let TypeAnnotation::Union { types, .. } = ret_ty else {
+        panic!("expected Union, got {ret_ty:?}");
+    };
+    assert_eq!(types.len(), 2, "union has two members: {types:?}");
+    assert!(
+        matches!(&types[0], TypeAnnotation::Simple(id) if id.name == "Integer"),
+        "first member is Integer, got {:?}",
+        types[0]
+    );
+    let TypeAnnotation::Intersection { left, right, .. } = &types[1] else {
+        panic!("second member must be an Intersection, got {:?}", types[1]);
+    };
+    assert!(matches!(left.as_ref(), TypeAnnotation::Simple(id) if id.name == "Printable"));
+    assert!(matches!(right.as_ref(), TypeAnnotation::Simple(id) if id.name == "Comparable"));
+}
+
+#[test]
+fn parse_intersection_is_left_associative() {
+    // ADR 0102 §3: `A & B & C` parses as `(A & B) & C`.
+    let module = parse_ok(
+        "Object subclass: Foo
+  narrow -> A & B & C => self",
+    );
+    let ret_ty = module.classes[0].methods[0].return_type.as_ref().unwrap();
+    let TypeAnnotation::Intersection { left, right, .. } = ret_ty else {
+        panic!("expected outer Intersection, got {ret_ty:?}");
+    };
+    // Outer right is C; the outer left is the inner `A & B`.
+    assert!(matches!(right.as_ref(), TypeAnnotation::Simple(id) if id.name == "C"));
+    let TypeAnnotation::Intersection {
+        left: inner_left,
+        right: inner_right,
+        ..
+    } = left.as_ref()
+    else {
+        panic!("expected inner Intersection in left, got {left:?}");
+    };
+    assert!(matches!(inner_left.as_ref(), TypeAnnotation::Simple(id) if id.name == "A"));
+    assert!(matches!(inner_right.as_ref(), TypeAnnotation::Simple(id) if id.name == "B"));
+}
+
+#[test]
+fn parse_intersection_type_name_round_trips() {
+    let module = parse_ok(
+        "Object subclass: Foo
+  narrow -> Printable & Comparable => self",
+    );
+    let ret_ty = module.classes[0].methods[0].return_type.as_ref().unwrap();
+    assert_eq!(ret_ty.type_name().as_str(), "Printable & Comparable");
+}
+
+#[test]
+fn parse_mixed_intersection_and_difference_without_parens_is_error() {
+    // ADR 0102 §3: mixing `&` and `\` in the same chain without explicit
+    // grouping is a deliberate parse error — `(A & B) \ C` and `A & (B \ C)`
+    // differ and neither reading is obviously dominant.
+    let diagnostics = parse_err(
+        "Object subclass: Foo
+  narrow -> A & B \\ #c => self",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("Cannot mix") && d.message.contains('&')),
+        "expected a mixed-operator diagnostic, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn parse_mixed_difference_and_intersection_without_parens_is_error() {
+    // Same rule, opposite order: `A \ #b & C` also requires parens.
+    let diagnostics = parse_err(
+        "Object subclass: Foo
+  narrow -> A \\ #b & C => self",
+    );
+    assert!(
+        diagnostics.iter().any(|d| d.message.contains("Cannot mix")),
+        "expected a mixed-operator diagnostic, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn value_position_ampersand_is_unchanged() {
+    // The `&` intersection operator is special-cased *only* in type-annotation
+    // position (BT-2743), mirroring `\` (BT-2742). In a value expression `&`
+    // has no binding power (like `\`), so `x & x` parses exactly as it did
+    // before this change — an "expected expression" error, never a silent
+    // type-intersection. The method header `combine: x =>` is still detected,
+    // proving the type-chain lookahead did not leak into value position.
+    let diagnostics = parse_err(
+        "Object subclass: Foo
+  combine: x => x & x",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("expected expression")),
+        "value-position `&` must parse as before (unchanged), got: {diagnostics:?}"
+    );
+}

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -1726,6 +1726,13 @@ fn unparse_type_annotation(ty: &TypeAnnotation) -> Document<'static> {
                 unparse_type_annotation(excluded)
             ]
         }
+        TypeAnnotation::Intersection { left, right, .. } => {
+            docvec![
+                unparse_type_annotation(left),
+                " & ",
+                unparse_type_annotation(right)
+            ]
+        }
         TypeAnnotation::SelfType { .. } => Document::Str("Self"),
         TypeAnnotation::SelfClass { .. } => Document::Str("Self class"),
         TypeAnnotation::ClassOf { class_name, .. } => {
@@ -1897,6 +1904,35 @@ mod tests {
         assert!(
             formatted.contains("Symbol \\ #foo"),
             "difference type must survive round-trip, got: {formatted}"
+        );
+    }
+
+    // --- Intersection type annotation unparsing (ADR 0068 §Protocol
+    // Composition, ADR 0102 §1/§3, BT-2743) ---
+
+    #[test]
+    fn intersection_type_annotation_unparses() {
+        // `Printable & Comparable` unparses back to `Printable & Comparable`.
+        let ann = crate::ast::TypeAnnotation::intersection(
+            crate::ast::TypeAnnotation::simple("Printable", span()),
+            crate::ast::TypeAnnotation::simple("Comparable", span()),
+            span(),
+        );
+        assert_eq!(
+            unparse_type_annotation(&ann).to_pretty_string(),
+            "Printable & Comparable"
+        );
+    }
+
+    #[test]
+    fn intersection_return_type_round_trips_through_format_source() {
+        // Parse → unparse must preserve `Collection(Object) & Comparable` in a
+        // method return type.
+        let source = "Object subclass: Foo\n  narrow -> Collection(Object) & Comparable => self\n";
+        let formatted = format_source(source).expect("should format");
+        assert!(
+            formatted.contains("Collection(Object) & Comparable"),
+            "intersection type must survive round-trip, got: {formatted}"
         );
     }
 


### PR DESCRIPTION
Implements [BT-2743](https://linear.app/beamtalk/issue/BT-2743) — Phase 4 of epic [BT-2738](https://linear.app/beamtalk/issue/BT-2738): the `&` intersection annotation ADR 0068 specified but never implemented, generalised per ADR 0102 §1/§3. Follows BT-2742's (`\`, #2846) parser pattern exactly.

## What

- **`InferredType::Intersection { members, provenance }`** stored variant + all exhaustive matches (order-independent `PartialEq`, `A & B` display, hover, `union_of`, formatters).
- **`intersect()` extended** with an optional `protocol_registry` param: class ∩ protocol (and protocol ∩ protocol) produce a normalized flattened `Intersection`; class ∩ class keeps reducing via the hierarchy. Existing call sites pass `None` — no regression.
- **Parser:** `&` in type-annotation position only, same tier as `\` (tighter than `|`, left-assoc); `BinarySelector("&")` special-cased like `\`. Mixed `&`/`\` without parens rejected with the ADR's "parenthesise to disambiguate" diagnostic.
- **`type_resolver`** resolves via `intersect`; `set_param_types` and the assignment-annotation path thread the live protocol registry, so `Collection(Object) & Comparable` (the ADR 0068 flagship case) resolves to a stored `Intersection` for declared params/locals.
- **Protocol conformance:** `:: P1 & P2` requires conformance to both, with tests.
- **Latent bug fixed:** the previous `intersect` had no `Intersection` LHS/RHS arms, so a 3-way `A & B & C` chain would have collapsed to `Never`; added flattening + `normalize_intersection` + regression tests.

## Flagged for reviewers

- Grouping parens don't exist in type position yet, so the mixed `&`/`\` rejection currently has no escape hatch (gap noted for BT-2746).
- Pre-existing (untouched): `check_protocol_conformance_in_expr` never checks `Meta`-typed receivers, making one existing class-method conformance test vacuous — follow-up issue candidate.

## Verification

`cargo build/test/clippy -p beamtalk-core -p beamtalk-cli` all green (4386 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcZLbDP6grbDwzxkzZjVuk)_