### PR TITLE
refactor(mcp): extract canonicalize_or_clone helper in server

### DIFF
--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -2292,7 +2292,7 @@ fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
             // summary. BT-2056: Unreadable package-only files produce a softer
             // warning since cross-file class extraction may be incomplete but
             // the targets themselves were still checked.
-            let canonical = std::fs::canonicalize(file).unwrap_or_else(|_| file.clone());
+            let canonical = canonicalize_or_clone(file);
             if target_set.contains(&canonical) {
                 unreadable_target_files.push(file.to_string_lossy().into_owned());
             } else {
@@ -2305,7 +2305,7 @@ fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
         let (module, parse_diags) = parse(tokens);
         all_class_infos.extend(ClassHierarchy::extract_class_infos(&module));
 
-        let canonical = std::fs::canonicalize(file).unwrap_or_else(|_| file.clone());
+        let canonical = canonicalize_or_clone(file);
         if target_set.contains(&canonical) {
             parsed_files.push((file_str, source, module, parse_diags));
         }
@@ -2398,6 +2398,13 @@ fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
         result["error"] = serde_json::json!(format!("Failed to read target file(s): {joined}"));
     }
     result
+}
+
+/// Canonicalize `path`, falling back to a plain clone when the path cannot be
+/// resolved (e.g. it does not yet exist or permissions are denied). Used as a
+/// normalized key for path-based deduplication in the two-pass lint pipeline.
+fn canonicalize_or_clone(path: &std::path::Path) -> std::path::PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// Resolve `path` to a list of `.bt` source files, or return a `LintResult`
@@ -2494,7 +2501,7 @@ fn run_lint_structured(path: &str) -> LintResult {
 
     for file in &extraction_files {
         let Ok(source) = std::fs::read_to_string(file) else {
-            let canonical = std::fs::canonicalize(file).unwrap_or_else(|_| file.clone());
+            let canonical = canonicalize_or_clone(file);
             if target_set.contains(&canonical) {
                 errors.push(LintDiagnostic {
                     file: file.to_string_lossy().into_owned(),
@@ -2526,7 +2533,7 @@ fn run_lint_structured(path: &str) -> LintResult {
 
         all_class_infos.extend(ClassHierarchy::extract_class_infos(&module));
 
-        let canonical = std::fs::canonicalize(file).unwrap_or_else(|_| file.clone());
+        let canonical = canonicalize_or_clone(file);
         if target_set.contains(&canonical) {
             parsed_targets.push((file.clone(), source, module, parse_diags));
         }


### PR DESCRIPTION
## Summary

`crates/beamtalk-mcp/src/server.rs` inlined the same fallback-canonicalize one-liner four times across two functions:

```rust
std::fs::canonicalize(file).unwrap_or_else(|_| file.clone())
```

This PR extracts it into a private named helper that mirrors the equivalent already present in `crates/beamtalk-cli/src/commands/lint.rs`:

```rust
/// Canonicalize `path`, falling back to a plain clone when the path cannot be
/// resolved (e.g. it does not yet exist or permissions are denied). Used as a
/// normalized key for path-based deduplication in the two-pass lint pipeline.
fn canonicalize_or_clone(path: &std::path::Path) -> std::path::PathBuf {
    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
}
```

## Change

- **`crates/beamtalk-mcp/src/server.rs`** — add `canonicalize_or_clone`, replace 4 inline occurrences in `compute_diagnostic_summary` (lines 2295, 2308) and `run_lint_structured` (lines 2497, 2529).

## Correctness

No behaviour change. `path.to_path_buf()` on `&Path` is semantically identical to `file.clone()` on `&PathBuf` — both copy the underlying `OsString` bytes into a fresh `PathBuf`. The MCP server deliberately uses `std::path::Path` (not `camino::Utf8Path`) so that files with non-UTF-8 names are preserved, which is why this is a separate function rather than sharing the CLI one.

All 91 MCP tests pass. Full CI (clippy, fmt, dialyzer) green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U66pt8wfVy14gC6R2bNMjH)_