### PR TITLE
test: add table-absent EUnit tests for beamtalk_class_metadata (+5.5% coverage)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_metadata_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_metadata_tests.erl
@@ -301,6 +301,27 @@ with_no_main_table(Fun) ->
         ets:insert(?FUN_TABLE, SavedFuns)
     end.
 
+%% Helper: delete the fun table, run Fun, restore state.
+%% Used by delete_class_method_funs_when_fun_table_absent_test below.
+%% Fun must not invoke new/0 (directly or via set_runtime_class_methods/2),
+%% as that would recreate ?FUN_TABLE and defeat the test.  Tests that need
+%% pre-deletion table setup (e.g. lookup_class_method_fun_when_fun_table_absent_test)
+%% must handle the two-phase setup-then-delete inline instead.
+with_no_fun_table(Fun) ->
+    beamtalk_class_metadata:new(),
+    SavedMeta = ets:tab2list(?TABLE),
+    SavedFuns = ets:tab2list(?FUN_TABLE),
+    ets:delete(?FUN_TABLE),
+    try
+        Fun()
+    after
+        beamtalk_class_metadata:new(),
+        ets:delete_all_objects(?TABLE),
+        ets:delete_all_objects(?FUN_TABLE),
+        ets:insert(?TABLE, SavedMeta),
+        ets:insert(?FUN_TABLE, SavedFuns)
+    end.
+
 %% match_subclasses/1 returns [] when the metadata table does not exist.
 match_subclasses_when_table_absent_test() ->
     with_no_main_table(fun() ->
@@ -352,16 +373,6 @@ lookup_class_method_fun_when_fun_table_absent_test() ->
 %% delete_class_method_funs/1 returns ok when the fun table does not exist.
 %% Exercises the ets:info(?FUN_TABLE) =:= undefined branch (line ~430).
 delete_class_method_funs_when_fun_table_absent_test() ->
-    beamtalk_class_metadata:new(),
-    SavedMeta = ets:tab2list(?TABLE),
-    SavedFuns = ets:tab2list(?FUN_TABLE),
-    ets:delete(?FUN_TABLE),
-    try
+    with_no_fun_table(fun() ->
         ?assertEqual(ok, beamtalk_class_metadata:delete_class_method_funs('AnyClass'))
-    after
-        beamtalk_class_metadata:new(),
-        ets:delete_all_objects(?TABLE),
-        ets:delete_all_objects(?FUN_TABLE),
-        ets:insert(?TABLE, SavedMeta),
-        ets:insert(?FUN_TABLE, SavedFuns)
-    end.
+    end).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_metadata_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_metadata_tests.erl
@@ -272,3 +272,96 @@ all_builtins_includes_core_classes_test() ->
     ?assert(lists:member('Object', Builtins)),
     ?assert(lists:member('Actor', Builtins)),
     ?assert(lists:member('Integer', Builtins)).
+
+%%====================================================================
+%% Table-absent paths (BT-2222 follow-up)
+%%
+%% Existing tests use with_clean_table/with_clean_tables which always
+%% call new/0 first, ensuring both tables exist before each assertion.
+%% These tests exercise the ets:info(Table) =:= undefined branches that
+%% are reached when the tables have not yet been initialised — real
+%% behaviour during early boot or tests that run before new/0 is called.
+%%====================================================================
+
+%% Helper: delete the main metadata table, run Fun, restore state.
+%% Used by the three tests below that exercise the "table absent" return
+%% values of match_subclasses/1, foldl/2, and lookup_methods/1.
+with_no_main_table(Fun) ->
+    beamtalk_class_metadata:new(),
+    SavedMeta = ets:tab2list(?TABLE),
+    SavedFuns = ets:tab2list(?FUN_TABLE),
+    ets:delete(?TABLE),
+    try
+        Fun()
+    after
+        beamtalk_class_metadata:new(),
+        ets:delete_all_objects(?TABLE),
+        ets:delete_all_objects(?FUN_TABLE),
+        ets:insert(?TABLE, SavedMeta),
+        ets:insert(?FUN_TABLE, SavedFuns)
+    end.
+
+%% match_subclasses/1 returns [] when the metadata table does not exist.
+match_subclasses_when_table_absent_test() ->
+    with_no_main_table(fun() ->
+        ?assertEqual([], beamtalk_class_metadata:match_subclasses('Object'))
+    end).
+
+%% foldl/2 returns the initial accumulator when the metadata table does not exist.
+foldl_when_table_absent_test() ->
+    with_no_main_table(fun() ->
+        Result = beamtalk_class_metadata:foldl(fun({_, _}, Acc) -> Acc end, sentinel),
+        ?assertEqual(sentinel, Result)
+    end).
+
+%% lookup_methods/1 returns not_found when the metadata table does not exist
+%% (exercises the undefined-table branch inside the internal row/1 function).
+lookup_methods_when_table_absent_test() ->
+    with_no_main_table(fun() ->
+        ?assertEqual(not_found, beamtalk_class_metadata:lookup_methods('AnyClass'))
+    end).
+
+%% lookup_class_method_fun/2 returns error when the fun table does not exist,
+%% even when the class's has_runtime_class_methods gate flag is true.
+%% Exercises the ets:info(?FUN_TABLE) =:= undefined branch (line ~409).
+lookup_class_method_fun_when_fun_table_absent_test() ->
+    beamtalk_class_metadata:new(),
+    SavedMeta = ets:tab2list(?TABLE),
+    SavedFuns = ets:tab2list(?FUN_TABLE),
+    ets:delete_all_objects(?TABLE),
+    ets:delete_all_objects(?FUN_TABLE),
+    try
+        %% Set up a class with the gate flag enabled while both tables exist.
+        ok = beamtalk_class_metadata:insert('GateClass', m, [], 'Object'),
+        Info = #{block => fun(_, V) -> V end, arity => 2},
+        ok = beamtalk_class_metadata:put_class_method_fun('GateClass', f, Info),
+        ok = beamtalk_class_metadata:set_runtime_class_methods('GateClass', [f]),
+        ?assert(beamtalk_class_metadata:has_runtime_class_methods('GateClass')),
+        %% Delete the fun table to simulate it being absent.
+        ets:delete(?FUN_TABLE),
+        %% Gate is open but fun table is gone: must return error.
+        ?assertEqual(error, beamtalk_class_metadata:lookup_class_method_fun('GateClass', f))
+    after
+        beamtalk_class_metadata:new(),
+        ets:delete_all_objects(?TABLE),
+        ets:delete_all_objects(?FUN_TABLE),
+        ets:insert(?TABLE, SavedMeta),
+        ets:insert(?FUN_TABLE, SavedFuns)
+    end.
+
+%% delete_class_method_funs/1 returns ok when the fun table does not exist.
+%% Exercises the ets:info(?FUN_TABLE) =:= undefined branch (line ~430).
+delete_class_method_funs_when_fun_table_absent_test() ->
+    beamtalk_class_metadata:new(),
+    SavedMeta = ets:tab2list(?TABLE),
+    SavedFuns = ets:tab2list(?FUN_TABLE),
+    ets:delete(?FUN_TABLE),
+    try
+        ?assertEqual(ok, beamtalk_class_metadata:delete_class_method_funs('AnyClass'))
+    after
+        beamtalk_class_metadata:new(),
+        ets:delete_all_objects(?TABLE),
+        ets:delete_all_objects(?FUN_TABLE),
+        ets:insert(?TABLE, SavedMeta),
+        ets:insert(?FUN_TABLE, SavedFuns)
+    end.


### PR DESCRIPTION
## Summary

Closes a real coverage gap in `beamtalk_class_metadata` (77.8% → 83.3%, +5.5pp, 70→75/90 executable lines) by testing the five `ets:info(Table) =:= undefined` branches reached when ETS tables have not yet been initialised.

Coverage data sourced from the `coverage-reports` artifact on the most recent successful CI run on `main` (run 28823998553, 2026-07-06).

## What was missing

All existing tests call `new/0` via `with_clean_table`/`with_clean_tables` before touching the tables, so the "table absent" return paths were never exercised. These are real behaviours during early boot (before `beamtalk_runtime_app:start/2` runs `new/0`) or in test suites that call the module before initialisation.

The remaining 15 uncovered lines are TOCTOU `error:badarg` catches (race between `ets:info` and the actual ETS op) — deterministically untriggerable.

## Changes

**`runtime/apps/beamtalk_runtime/test/beamtalk_class_metadata_tests.erl`** — 5 new EUnit tests + 1 helper:

| Test | Branch covered |
|------|----------------|
| `match_subclasses_when_table_absent_test` | `ets:info(?TABLE) =:= undefined → []` |
| `foldl_when_table_absent_test` | `ets:info(?TABLE) =:= undefined → Acc0` |
| `lookup_methods_when_table_absent_test` | `row/1` undefined-table → `not_found` |
| `lookup_class_method_fun_when_fun_table_absent_test` | gate=true, `?FUN_TABLE` absent → `error` |
| `delete_class_method_funs_when_fun_table_absent_test` | `?FUN_TABLE` absent → `ok` |

`with_no_main_table/1` helper follows the same save/restore pattern as the existing `with_clean_table`/`with_clean_tables` helpers.

## Test results

- `rebar3 eunit --module=beamtalk_class_metadata_tests`: **27 tests, 0 failures** (was 22)
- `just test`: all suites green (5220 + 1582 Erlang runtime tests, 2683 BUnit tests, 223 stdlib tests)
- erlfmt: clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwoVhD4JUwSDPz4K8ZLK8U)_