### PR TITLE
test: add setUp/tearDown to ReflectionBasicTest to stop leaked actors

### DIFF
--- a/stdlib/test/reflection_basic_test.bt
+++ b/stdlib/test/reflection_basic_test.bt
@@ -82,8 +82,7 @@ TestCase subclass: ReflectionBasicTest
   testSelfFieldAtPutThreadsStateDirect =>
     self assert: self.a mutateAndReadDirect equals: 99
 
-  testSelfFieldAtPutTwoFields =>
-    self assert: self.a mutateTwoFields equals: 30
+  testSelfFieldAtPutTwoFields => self assert: self.a mutateTwoFields equals: 30
 
   testAssignThenReflectiveRead =>
     self assert: self.a assignAndReadReflective equals: 77

--- a/stdlib/test/reflection_basic_test.bt
+++ b/stdlib/test/reflection_basic_test.bt
@@ -10,56 +10,62 @@
 // BT-1168: Variable (symbol) arguments to respondsTo:, fieldAt:, fieldAt:put:
 
 TestCase subclass: ReflectionBasicTest
+  field: c = nil
+  field: a = nil
+
+  setUp =>
+    self.c := Counter spawn
+    self.a := ReflectionSelfMutateActor spawn
+
+  tearDown =>
+    self.c isNil ifFalse: [self.c stop]
+    self.a isNil ifFalse: [self.a stop]
 
   testDynamicRespondsTo =>
     // BT-1168: variable holding a symbol should work with respondsTo:
-    c := Counter spawn
     sel := #increment
-    self assert: (c respondsTo: sel)
+    self assert: (self.c respondsTo: sel)
     unknownSel := #nonExistent
-    self deny: (c respondsTo: unknownSel)
+    self deny: (self.c respondsTo: unknownSel)
 
   testDynamicFieldAt =>
     // BT-1168: variable holding a field name should work with fieldAt:
-    c := Counter spawn
     fieldName := #value
-    self assert: (c fieldAt: fieldName) equals: 0
-    c increment
-    self assert: (c fieldAt: fieldName) equals: 1
+    self assert: (self.c fieldAt: fieldName) equals: 0
+    self.c increment
+    self assert: (self.c fieldAt: fieldName) equals: 1
 
   testDynamicFieldAtPut =>
     // BT-1168: variable holding a field name should work with fieldAt:put:
-    c := Counter spawn
     fieldName := #value
-    c fieldAt: fieldName put: 99
-    self assert: c getValue equals: 99
+    self.c fieldAt: fieldName put: 99
+    self assert: self.c getValue equals: 99
 
   testActorReflectionApi =>
-    c := Counter spawn
     // Test class reflection
-    self assert: c class equals: Counter
+    self assert: self.c class equals: Counter
     // Test respondsTo: with symbol literal
-    self assert: (c respondsTo: #increment)
+    self assert: (self.c respondsTo: #increment)
     // Test respondsTo: with non-existent method
-    self deny: (c respondsTo: #nonExistent)
+    self deny: (self.c respondsTo: #nonExistent)
     // Test fieldNames
-    self assert: c fieldNames equals: #(#value)
+    self assert: self.c fieldNames equals: #(#value)
     // Test fieldAt: - read field value
-    self assert: (c fieldAt: #value) equals: 0
+    self assert: (self.c fieldAt: #value) equals: 0
     // Increment to change state
-    self assert: c increment equals: 1
+    self assert: self.c increment equals: 1
     // Test fieldAt: after state change
-    self assert: (c fieldAt: #value) equals: 1
+    self assert: (self.c fieldAt: #value) equals: 1
     // Test fieldAt:put: - set field value
-    self assert: (c fieldAt: #value put: 42) equals: 42
+    self assert: (self.c fieldAt: #value put: 42) equals: 42
     // Verify field was set
-    self assert: c getValue equals: 42
+    self assert: self.c getValue equals: 42
     // Test perform: - dynamic dispatch (zero-arity method)
-    self assert: (c perform: #getValue) equals: 42
+    self assert: (self.c perform: #getValue) equals: 42
     // Test perform: with another method
-    self assert: (c perform: #increment) equals: 43
+    self assert: (self.c perform: #increment) equals: 43
     // Verify increment worked via getValue
-    self assert: c getValue equals: 43
+    self assert: self.c getValue equals: 43
     // BT-359: fieldAt: on primitive value types (integers) raises immutable_value
     // Note: user-defined Value subclass: objects support fieldAt: for reading (BT-924)
     self should: [42 fieldAt: #x] raise: #immutable_value
@@ -71,17 +77,13 @@ TestCase subclass: ReflectionBasicTest
 
   // BT-1324: self fieldAt:put: must thread state so subsequent reads see the update
   testSelfFieldAtPutThreadsState =>
-    a := ReflectionSelfMutateActor spawn
-    self assert: a mutateAndReadReflective equals: 42
+    self assert: self.a mutateAndReadReflective equals: 42
 
   testSelfFieldAtPutThreadsStateDirect =>
-    a := ReflectionSelfMutateActor spawn
-    self assert: a mutateAndReadDirect equals: 99
+    self assert: self.a mutateAndReadDirect equals: 99
 
   testSelfFieldAtPutTwoFields =>
-    a := ReflectionSelfMutateActor spawn
-    self assert: a mutateTwoFields equals: 30
+    self assert: self.a mutateTwoFields equals: 30
 
   testAssignThenReflectiveRead =>
-    a := ReflectionSelfMutateActor spawn
-    self assert: a assignAndReadReflective equals: 77
+    self assert: self.a assignAndReadReflective equals: 77


### PR DESCRIPTION
## Summary

All 8 test methods in `reflection_basic_test.bt` spawned actors (`Counter` or `ReflectionSelfMutateActor`) inline without ever stopping them, leaving orphan OTP gen_server processes running after each test method returned.

**Smell:** repeated `c := Counter spawn` / `a := ReflectionSelfMutateActor spawn` at the top of each method, no tearDown cleanup.

**Fix:** move the spawns into `setUp` (with matching `field:` declarations) and add a nil-guarded `tearDown` that stops both actors — identical pattern to `actor_monitor_test.bt` and `actor_message_chaining_test.bt`.

**What changes:**
- Add `field: c = nil` and `field: a = nil` declarations
- Add `setUp` that spawns a fresh `Counter` (`self.c`) and `ReflectionSelfMutateActor` (`self.a`) before each test
- Add `tearDown` that stops both actors after each test
- Remove 8 inline `spawn` lines from test methods; replace local `c`/`a` references with `self.c`/`self.a`

**Blast radius:** one file, behaviour unchanged, all 2683 BUnit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hm1yq6HTdmcSJ9RYqevau

---
_Generated by [Claude Code](https://claude.ai/code/session_017hm1yq6HTdmcSJ9RYqevau)_