### PR TITLE
CI: retry Claude review on missing verdict; gate stays fail-closed (BT-2765)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -186,16 +186,16 @@ jobs:
       - name: Gate on verdict
         if: always()
         run: |
-          # BT-2765: this check is advisory (reviews post as comments/inline threads,
-          # not commits), so an infra failure here must not produce a hard BLOCK on an
-          # otherwise-green PR. After two attempts (see the review + retry steps above),
-          # a still-missing verdict means the agent died before writing one — most likely
-          # infra/API rate-limit, not "nothing to report" — so exit NEUTRAL (0) with a
-          # loud warning instead of failing the job. A genuine verdict (PASS or BLOCK)
-          # is gated exactly as before.
+          # BT-2765: the review agent occasionally dies before writing .claude-verdict
+          # (infra/API rate-limit). The retry step above absorbs one such failure; if
+          # the verdict is STILL missing after both attempts, the gate stays
+          # FAIL-CLOSED (deliberate decision, 2026-07-06): a missing verdict blocks,
+          # because passing silently would let an unreviewed PR through the gate.
+          # The error message distinguishes the infra case from a genuine BLOCK so a
+          # human can re-run the job rather than hunt for phantom findings.
           if [ ! -f .claude-verdict ]; then
-            echo "::warning::Review agent produced no verdict after retry — treating as SKIPPED (infra), not BLOCK"
-            exit 0
+            echo "::error::No verdict after review + retry — agent infra failure; re-run this job (gate is fail-closed)"
+            exit 1
           fi
           verdict=$(tr -d '[:space:]' < .claude-verdict)
           echo "Claude verdict: $verdict"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -110,7 +110,16 @@ jobs:
             echo '__BTPROMPTEOF__'
           } >> "$GITHUB_OUTPUT"
 
-      - uses: anthropics/claude-code-action@v1
+      # BT-2765: the review agent occasionally dies before writing .claude-verdict
+      # (observed pattern: transient infra/API failure, e.g. rate-limit/quota — the
+      # gate step used to treat *any* missing verdict as a hard BLOCK, which turned
+      # infra hiccups into false red X's on otherwise-green PRs). continue-on-error
+      # lets the job carry on to the retry step below instead of stopping here if
+      # this step itself exits non-zero.
+      - name: Run Claude review
+        id: review
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The reviewer never mutates the repo directly: it reads code, runs
@@ -121,6 +130,28 @@ jobs:
           # mcp__github_inline_comment__create_inline_comment is the action's own tool
           # for line-anchored comments; it must be listed explicitly because
           # --allowedTools REPLACES the action's default tool set rather than extending it.
+          claude_args: '--max-turns 50 --model ${{ steps.model.outputs.model }} --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"'
+          prompt: ${{ steps.load_prompt.outputs.prompt }}
+
+      # No verdict after the first attempt usually means the agent step died early
+      # (e.g. API rate-limit/quota) rather than that the review legitimately found
+      # nothing to say. Back off briefly before retrying so a transient rate-limit
+      # window has a chance to clear (PR-level concurrency above already serialises
+      # runs per-PR, so this is the only additional backoff needed).
+      - name: Wait before retry
+        if: always() && hashFiles('.claude-verdict') == ''
+        run: sleep 30
+
+      # Single retry of the exact same review step, only when the first attempt left
+      # no verdict file. If this also produces no verdict, the gate step below fails
+      # soft (neutral) instead of blocking — see "Gate on verdict".
+      - name: Retry Claude review (no verdict from first attempt)
+        id: review_retry
+        if: always() && hashFiles('.claude-verdict') == ''
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--max-turns 50 --model ${{ steps.model.outputs.model }} --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"'
           prompt: ${{ steps.load_prompt.outputs.prompt }}
 
@@ -155,9 +186,16 @@ jobs:
       - name: Gate on verdict
         if: always()
         run: |
+          # BT-2765: this check is advisory (reviews post as comments/inline threads,
+          # not commits), so an infra failure here must not produce a hard BLOCK on an
+          # otherwise-green PR. After two attempts (see the review + retry steps above),
+          # a still-missing verdict means the agent died before writing one — most likely
+          # infra/API rate-limit, not "nothing to report" — so exit NEUTRAL (0) with a
+          # loud warning instead of failing the job. A genuine verdict (PASS or BLOCK)
+          # is gated exactly as before.
           if [ ! -f .claude-verdict ]; then
-            echo "::error::No verdict file written — treating as BLOCK"
-            exit 1
+            echo "::warning::Review agent produced no verdict after retry — treating as SKIPPED (infra), not BLOCK"
+            exit 0
           fi
           verdict=$(tr -d '[:space:]' < .claude-verdict)
           echo "Claude verdict: $verdict"


### PR DESCRIPTION
Implements [BT-2765](https://linear.app/beamtalk/issue/BT-2765). The `Claude BeamTalk Review` check was failing ~30s in with `No verdict file written — treating as BLOCK` (the review agent dying early — likely API rate limiting — before writing `.claude-verdict`), producing false red X's on green PRs repeatedly on 2026-07-06.

## What

- The review step gets `continue-on-error: true` + an identical **retry invocation** gated on `hashFiles('.claude-verdict') == ''`, with a 30s backoff sleep between attempts. The retry only fires when the first attempt produced no verdict.
- **The gate remains fail-closed** (explicit decision by @jamesc, 2026-07-06): if no verdict exists after both attempts, the job still hard-fails — a silent pass would let an unreviewed PR through. The error message now distinguishes the infra case ("re-run this job") from a genuine BLOCK verdict.
- Genuine PASS/BLOCK verdicts are gated exactly as before. The existing per-PR concurrency group and the sticky "did not complete" PR comment are unchanged.

## Validation

YAML parses (python yaml.safe_load); `if:` expression style matches the file's existing conventions. Workflow behaviour can't be tested locally — the diff is minimal (+41/−3 then the fail-closed amendment) and commented step-by-step for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcZLbDP6grbDwzxkzZjVuk)_