### PR TITLE
Type checker: spawnWith: key checking via MapLiteral call-site inspection + typo suggestions (BT-2750)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1226,6 +1226,8 @@ impl TypeChecker {
                 Some(arguments),
                 Some(env),
             );
+            // ADR 0104 Phase 2 (BT-2750): `C spawnWith: #{...}` literal-map key check.
+            self.check_spawn_with_map_keys(class_name, &selector_name, arguments, hierarchy);
             return self.check_class_side_send(
                 class_name,
                 &selector_name,
@@ -1280,6 +1282,9 @@ impl TypeChecker {
                 Some(arguments),
                 Some(env),
             );
+            // ADR 0104 Phase 2 (BT-2750): type-driven `cls spawnWith: #{...}`
+            // (receiver typed `Meta{C}`) literal-map key check.
+            self.check_spawn_with_map_keys(meta_class, &selector_name, arguments, hierarchy);
             let class_side =
                 self.check_class_side_send(meta_class, &selector_name, span, hierarchy, &arg_types);
             // ADR 0083: when no class-side method on `C` defined the result, a

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
@@ -34,6 +34,7 @@ mod self_class;
 mod self_type;
 mod set_operators;
 mod singleton_match_exhaustiveness;
+mod spawn_with_keys;
 mod state_fields;
 mod super_and_binary;
 mod typed_class;

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/spawn_with_keys.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/spawn_with_keys.rs
@@ -38,6 +38,32 @@ fn counter_actor(state: Vec<StateDeclaration>) -> ClassDefinition {
     }
 }
 
+/// Build a non-Actor class `Widget` (Value kind, superclass `Object`) that
+/// nonetheless carries state slots — used to exercise the Actor-kind guard.
+fn widget_value(state: Vec<StateDeclaration>) -> ClassDefinition {
+    ClassDefinition {
+        name: ident("Widget"),
+        superclass: Some(ident("Object")),
+        superclass_package: None,
+        class_kind: ClassKind::Value,
+        is_abstract: false,
+        is_sealed: false,
+        is_typed: false,
+        is_internal: false,
+        supervisor_kind: None,
+        state,
+        methods: vec![],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        superclass_type_args: vec![],
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        backing_module: None,
+        span: span(),
+    }
+}
+
 /// `count :: Integer = 0`
 fn count_slot() -> StateDeclaration {
     StateDeclaration::with_type_and_default(
@@ -331,6 +357,30 @@ fn spawn_with_on_class_reference_infers_known_instance() {
     assert!(
         key_diags(&checker).is_empty(),
         "known key must not warn on the pin: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn non_actor_class_with_state_slots_is_not_key_checked() {
+    // `spawnWith:` is an Actor protocol (ADR 0104). A non-Actor class with
+    // `state:` slots that receives `spawnWith:` with a bogus key must NOT get a
+    // key-check warning — the send is already a terminal DNU, and stacking a
+    // key-check on top is noise. Guards `check_spawn_with_map_keys` via
+    // `is_actor_subclass`.
+    let class = widget_value(vec![count_slot()]);
+    let module = make_module(vec![msg_send(
+        class_ref("Widget"),
+        MessageSelector::Keyword(vec![KeywordPart::new("spawnWith:", span())]),
+        vec![map_lit(vec![(key("cuont"), int_val(0, 100))])],
+    )]);
+    let hierarchy = ClassHierarchy::build(&make_module_with_classes(vec![], vec![class]))
+        .0
+        .unwrap();
+    let checker = check(&module, &hierarchy);
+    assert!(
+        key_diags(&checker).is_empty(),
+        "a non-Actor class must not be spawnWith: key-checked: {:?}",
         checker.diagnostics()
     );
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/spawn_with_keys.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/spawn_with_keys.rs
@@ -1,0 +1,366 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! `spawnWith:` map-literal call-site key checking (ADR 0104 Phase 2, BT-2750).
+//!
+//! `C spawnWith: #{...}` checks the literal map's keys against `C`'s declared
+//! `state:` slots and warns (with a typo suggestion) on an unknown key. When a
+//! slot is typed, the literal value's inferred type is checked against it.
+//! A non-literal `spawnWith:` argument is never inspected.
+
+use super::common::*;
+use crate::ast::MapPair;
+
+// --- Fixtures ------------------------------------------------------------
+
+/// Build an Actor subclass `Counter` with the given typed state slots.
+fn counter_actor(state: Vec<StateDeclaration>) -> ClassDefinition {
+    ClassDefinition {
+        name: ident("Counter"),
+        superclass: Some(ident("Actor")),
+        superclass_package: None,
+        class_kind: ClassKind::Actor,
+        is_abstract: false,
+        is_sealed: false,
+        is_typed: false,
+        is_internal: false,
+        supervisor_kind: None,
+        state,
+        methods: vec![],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        superclass_type_args: vec![],
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        backing_module: None,
+        span: span(),
+    }
+}
+
+/// `count :: Integer = 0`
+fn count_slot() -> StateDeclaration {
+    StateDeclaration::with_type_and_default(
+        ident("count"),
+        TypeAnnotation::simple("Integer", span()),
+        int_lit(0),
+        span(),
+    )
+}
+
+/// `timeoutMs :: Integer | #infinity`
+fn timeout_union_slot() -> StateDeclaration {
+    StateDeclaration::with_type(
+        ident("timeoutMs"),
+        TypeAnnotation::Union {
+            types: vec![
+                TypeAnnotation::Simple(ident("Integer")),
+                TypeAnnotation::Singleton {
+                    name: "infinity".into(),
+                    span: span(),
+                },
+            ],
+            span: span(),
+        },
+        span(),
+    )
+}
+
+/// A symbol map key `#name` with the shared span.
+fn key(name: &str) -> Expression {
+    Expression::Literal(Literal::Symbol(name.into()), span())
+}
+
+/// An integer literal value with a *distinct* span so its inferred type is
+/// keyed uniquely in the type map (the shared `span()` collides).
+fn int_val(n: i64, lo: u32) -> Expression {
+    Expression::Literal(Literal::Integer(n), Span::new(lo, lo + 1))
+}
+
+/// A string literal value with a distinct span.
+fn str_val(s: &str, lo: u32) -> Expression {
+    Expression::Literal(Literal::String(s.into()), Span::new(lo, lo + 1))
+}
+
+/// Build `#{ k1 => v1, ... }`.
+fn map_lit(pairs: Vec<(Expression, Expression)>) -> Expression {
+    Expression::MapLiteral {
+        pairs: pairs
+            .into_iter()
+            .map(|(k, v)| MapPair::new(k, v, span()))
+            .collect(),
+        span: span(),
+    }
+}
+
+/// `Counter spawnWith: <map>`
+fn spawn_with(map: Expression) -> Expression {
+    msg_send(
+        class_ref("Counter"),
+        MessageSelector::Keyword(vec![KeywordPart::new("spawnWith:", span())]),
+        vec![map],
+    )
+}
+
+/// Diagnostics whose message mentions a `spawnWith:` state-key concern.
+fn key_diags(checker: &TypeChecker) -> Vec<Diagnostic> {
+    checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("state key"))
+        .cloned()
+        .collect()
+}
+
+fn check(module: &Module, hierarchy: &ClassHierarchy) -> TypeChecker {
+    let mut checker = TypeChecker::new();
+    checker.check_module(module, hierarchy);
+    checker
+}
+
+// --- Tests ---------------------------------------------------------------
+
+#[test]
+fn known_keys_produce_no_diagnostic() {
+    // Counter spawnWith: #{#count => 0} — `count` is a declared slot, value is
+    // an Integer matching the declared type.
+    let class = counter_actor(vec![count_slot()]);
+    let module = make_module(vec![spawn_with(map_lit(vec![(
+        key("count"),
+        int_val(0, 100),
+    )]))]);
+    let hierarchy = ClassHierarchy::build(&make_module_with_classes(vec![], vec![class]))
+        .0
+        .unwrap();
+    let checker = check(&module, &hierarchy);
+    assert!(
+        key_diags(&checker).is_empty(),
+        "known key should not warn: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn unknown_key_warns_with_typo_suggestion() {
+    // Counter spawnWith: #{#cuont => 0} — `cuont` is not a slot; nearest is `count`.
+    let class = counter_actor(vec![count_slot()]);
+    let module = make_module(vec![spawn_with(map_lit(vec![(
+        key("cuont"),
+        int_val(0, 100),
+    )]))]);
+    let hierarchy = ClassHierarchy::build(&make_module_with_classes(vec![], vec![class]))
+        .0
+        .unwrap();
+    let checker = check(&module, &hierarchy);
+    let diags = key_diags(&checker);
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected one unknown-key warning: {diags:?}"
+    );
+    assert_eq!(diags[0].severity, crate::source_analysis::Severity::Warning);
+    assert!(
+        diags[0].message.contains("cuont") && diags[0].message.contains("count"),
+        "message should name the unknown key and the suggested slot: {}",
+        diags[0].message
+    );
+    assert!(
+        diags[0].message.contains("did you mean"),
+        "message should include a typo suggestion: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn unknown_key_without_close_slot_warns_without_suggestion() {
+    // A key nowhere near any slot still warns, just without a "did you mean".
+    let class = counter_actor(vec![count_slot()]);
+    let module = make_module(vec![spawn_with(map_lit(vec![(
+        key("completelyUnrelated"),
+        int_val(0, 100),
+    )]))]);
+    let hierarchy = ClassHierarchy::build(&make_module_with_classes(vec![], vec![class]))
+        .0
+        .unwrap();
+    let checker = check(&module, &hierarchy);
+    let diags = key_diags(&checker);
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected one unknown-key warning: {diags:?}"
+    );
+    assert!(
+        diags[0].message.contains("completelyUnrelated"),
+        "message should name the unknown key: {}",
+        diags[0].message
+    );
+    assert!(
+        !diags[0].message.contains("did you mean"),
+        "no close slot → no suggestion: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn value_type_mismatch_simple_slot_warns() {
+    // count :: Integer, but the value is a String.
+    let class = counter_actor(vec![count_slot()]);
+    let module = make_module(vec![spawn_with(map_lit(vec![(
+        key("count"),
+        str_val("bad", 100),
+    )]))]);
+    let hierarchy = ClassHierarchy::build(&make_module_with_classes(vec![], vec![class]))
+        .0
+        .unwrap();
+    let checker = check(&module, &hierarchy);
+    let diags: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("type mismatch for state key"))
+        .collect();
+    assert_eq!(diags.len(), 1, "expected one value-type warning: {diags:?}");
+    assert!(
+        diags[0].message.contains("count") && diags[0].message.contains("String"),
+        "message should name the slot and the offending type: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn value_type_matches_union_slot_no_warning() {
+    // timeoutMs :: Integer | #infinity, value is an Integer — compatible.
+    let class = counter_actor(vec![timeout_union_slot()]);
+    let module = make_module(vec![spawn_with(map_lit(vec![(
+        key("timeoutMs"),
+        int_val(30, 100),
+    )]))]);
+    let hierarchy = ClassHierarchy::build(&make_module_with_classes(vec![], vec![class]))
+        .0
+        .unwrap();
+    let checker = check(&module, &hierarchy);
+    assert!(
+        key_diags(&checker).is_empty(),
+        "Integer is a member of `Integer | #infinity`: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn value_type_mismatch_union_slot_warns() {
+    // timeoutMs :: Integer | #infinity, value is a String — no member matches.
+    let class = counter_actor(vec![timeout_union_slot()]);
+    let module = make_module(vec![spawn_with(map_lit(vec![(
+        key("timeoutMs"),
+        str_val("soon", 100),
+    )]))]);
+    let hierarchy = ClassHierarchy::build(&make_module_with_classes(vec![], vec![class]))
+        .0
+        .unwrap();
+    let checker = check(&module, &hierarchy);
+    let diags: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("type mismatch for state key"))
+        .collect();
+    assert_eq!(
+        diags.len(),
+        1,
+        "String is not a member of `Integer | #infinity`: {diags:?}"
+    );
+    assert!(
+        diags[0].message.contains("timeoutMs"),
+        "message should name the union slot: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn non_literal_dictionary_argument_is_silent() {
+    // d := #{#cuont => 0}   (a Dictionary-typed variable, typo and all)
+    // Counter spawnWith: d  — argument is NOT a MapLiteral → no key inspection.
+    let class = counter_actor(vec![count_slot()]);
+    let module = make_module(vec![
+        assign("d", map_lit(vec![(key("cuont"), int_val(0, 100))])),
+        msg_send(
+            class_ref("Counter"),
+            MessageSelector::Keyword(vec![KeywordPart::new("spawnWith:", span())]),
+            vec![var("d")],
+        ),
+    ]);
+    let hierarchy = ClassHierarchy::build(&make_module_with_classes(vec![], vec![class]))
+        .0
+        .unwrap();
+    let checker = check(&module, &hierarchy);
+    assert!(
+        key_diags(&checker).is_empty(),
+        "a non-literal (Dictionary) argument must not be key-checked: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn spawn_with_on_class_reference_infers_known_instance() {
+    // Pin (ADR 0083): `Counter spawnWith: #{#count => 0}` returns Known{Counter},
+    // so a subsequent unknown unary send warns about `Counter`.
+    let class = counter_actor(vec![count_slot()]);
+    let module = make_module(vec![
+        assign(
+            "x",
+            spawn_with(map_lit(vec![(key("count"), int_val(0, 100))])),
+        ),
+        msg_send(
+            var("x"),
+            MessageSelector::Unary("nonExistentMethod".into()),
+            vec![],
+        ),
+    ]);
+    let hierarchy = ClassHierarchy::build(&make_module_with_classes(vec![], vec![class]))
+        .0
+        .unwrap();
+    let checker = check(&module, &hierarchy);
+    let dnu: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("nonExistentMethod") || d.message.contains("Counter"))
+        .collect();
+    assert!(
+        !dnu.is_empty(),
+        "spawnWith: should infer Known{{Counter}} so the unknown send resolves against Counter: {:?}",
+        checker.diagnostics()
+    );
+    assert!(
+        key_diags(&checker).is_empty(),
+        "known key must not warn on the pin: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn spawn_with_via_meta_typed_variable_checks_keys() {
+    // Type-driven Meta{Counter} path: `cls := Counter` binds cls to Meta{Counter};
+    // `cls spawnWith: #{#cuont => 0}` must still key-check via the Meta branch.
+    let class = counter_actor(vec![count_slot()]);
+    let module = make_module(vec![
+        assign("cls", class_ref("Counter")),
+        msg_send(
+            var("cls"),
+            MessageSelector::Keyword(vec![KeywordPart::new("spawnWith:", span())]),
+            vec![map_lit(vec![(key("cuont"), int_val(0, 100))])],
+        ),
+    ]);
+    let hierarchy = ClassHierarchy::build(&make_module_with_classes(vec![], vec![class]))
+        .0
+        .unwrap();
+    let checker = check(&module, &hierarchy);
+    let diags = key_diags(&checker);
+    assert_eq!(
+        diags.len(),
+        1,
+        "Meta{{Counter}}-typed receiver should key-check: {diags:?}"
+    );
+    assert!(
+        diags[0].message.contains("did you mean") && diags[0].message.contains("count"),
+        "Meta path should also suggest the nearest slot: {}",
+        diags[0].message
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -15,7 +15,7 @@
 
 use std::collections::HashMap;
 
-use crate::ast::{Expression, TypeAnnotation};
+use crate::ast::{Expression, Literal, TypeAnnotation};
 use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
 use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
 use crate::semantic_analysis::string_utils::edit_distance;
@@ -1516,6 +1516,196 @@ impl TypeChecker {
             | InferredType::Negation { .. }
             | InferredType::Intersection { .. } => {}
         }
+    }
+
+    /// Shared call-site boundary for `spawnWith:` map-literal inspection
+    /// (ADR 0104 Phase 2, BT-2750).
+    ///
+    /// Returns the `MapPair`s of a `C spawnWith: #{...}` send when the argument
+    /// is a *literal* map — the only point at which per-key inspection is
+    /// possible, because map-literal inference otherwise collapses `#{...}` to a
+    /// single joined `Dictionary(K, V)` and discards the individual literal
+    /// keys. Returns `None` for any non-`spawnWith:` selector or a non-literal
+    /// first argument (e.g. a `Dictionary`-typed variable), so callers never
+    /// inspect a non-literal map — the key check produces no false positives.
+    ///
+    /// This is the reusable walk boundary: ADR 0103's BT-2755 value-sendability
+    /// check iterates the *same* `(key, value)` pairs at the same call site and
+    /// hooks in here.
+    pub(super) fn spawn_with_map_pairs<'a>(
+        selector: &str,
+        arguments: &'a [Expression],
+    ) -> Option<&'a [crate::ast::MapPair]> {
+        if selector != "spawnWith:" {
+            return None;
+        }
+        match arguments.first() {
+            Some(Expression::MapLiteral { pairs, .. }) => Some(pairs),
+            _ => None,
+        }
+    }
+
+    /// Check a `C spawnWith: #{...}` call site's map keys against `C`'s declared
+    /// `state:` slots (ADR 0104 Phase 2, BT-2750).
+    ///
+    /// For each symbol key in the literal map:
+    ///   * a key matching a declared slot (including inherited slots) passes;
+    ///     when that slot carries a type annotation, the literal value's inferred
+    ///     type is checked against it (see [`Self::check_spawn_with_value`]).
+    ///   * an unknown key emits a **Warning** — the provably-failing tier per
+    ///     ADR 0100, since a class's `state:` slot set is closed and declared
+    ///     in-program — with a typo suggestion naming the nearest slot when one
+    ///     is close (edit distance).
+    ///
+    /// No-ops when the argument is not a literal map (via
+    /// [`Self::spawn_with_map_pairs`]) or when the class declares no state slots.
+    pub(super) fn check_spawn_with_map_keys(
+        &mut self,
+        class_name: &EcoString,
+        selector: &str,
+        arguments: &[Expression],
+        hierarchy: &ClassHierarchy,
+    ) {
+        let Some(pairs) = Self::spawn_with_map_pairs(selector, arguments) else {
+            return;
+        };
+        // Declared state slot names, including inherited slots. An empty set
+        // means the class declares no state (e.g. a builtin, or one whose slots
+        // are not in the hierarchy) — bail rather than flag every key.
+        let slots = hierarchy.all_state(class_name);
+        if slots.is_empty() {
+            return;
+        }
+        for pair in pairs {
+            // Keys are symbol literals (`#count`); a non-symbol key is already a
+            // parse error (BT-1240) — skip it here.
+            let Expression::Literal(Literal::Symbol(key_name), key_span) = &pair.key else {
+                continue;
+            };
+            if slots.iter().any(|s| s.as_str() == key_name.as_str()) {
+                // Known slot — value-check against the declared type when typed.
+                if let Some(declared_ty) = hierarchy.state_field_type(class_name, key_name) {
+                    self.check_spawn_with_value(
+                        class_name,
+                        key_name,
+                        &declared_ty,
+                        &pair.value,
+                        hierarchy,
+                    );
+                }
+                continue;
+            }
+            // Unknown key → Warning + typo suggestion.
+            let message = match Self::closest_state_slot(key_name, &slots) {
+                Some(suggestion) => {
+                    format!("unknown state key `{key_name}` — did you mean `{suggestion}`?")
+                }
+                None => format!("unknown state key `{key_name}` for `{class_name}`"),
+            };
+            self.diagnostics.push(
+                Diagnostic::warning(message, *key_span)
+                    .with_category(DiagnosticCategory::Type)
+                    .with_hint(format!(
+                        "`spawnWith:` keys must be declared `state:` slots of `{class_name}`"
+                    )),
+            );
+        }
+    }
+
+    /// Check a `spawnWith:` literal value against a declared slot type
+    /// (ADR 0104 Phase 2, BT-2750).
+    ///
+    /// The value's inferred type is read back from the type map (populated when
+    /// the argument map literal was inferred), so the value expression is not
+    /// re-inferred and its own diagnostics are not double-emitted. Union slot
+    /// types (e.g. `Integer | #infinity`) are handled by [`Self::is_assignable_to`],
+    /// which already splits the declared union string and checks membership.
+    fn check_spawn_with_value(
+        &mut self,
+        class_name: &EcoString,
+        slot_name: &EcoString,
+        declared_ty: &EcoString,
+        value_expr: &Expression,
+        hierarchy: &ClassHierarchy,
+    ) {
+        let Some(value_ty) = self.type_map.get(value_expr.span()).cloned() else {
+            return; // Dynamic / unknown value type — skip conservatively.
+        };
+        let declared_display = InferredType::class_name_for_diagnostic(declared_ty.as_str());
+        match &value_ty {
+            InferredType::Known {
+                class_name: value_type,
+                ..
+            } => {
+                if !Self::is_assignable_to(value_type, declared_ty, hierarchy) {
+                    let value_display =
+                        InferredType::class_name_for_diagnostic(value_type.as_str());
+                    self.diagnostics.push(
+                        Diagnostic::warning(
+                            format!(
+                                "type mismatch for state key `{slot_name}` on `{class_name}`: declared {declared_display}, got {value_display}"
+                            ),
+                            value_expr.span(),
+                        )
+                        .with_category(DiagnosticCategory::Type)
+                        .with_hint(format!(
+                            "Expected {declared_display} for `{slot_name}`, got {value_display}"
+                        )),
+                    );
+                }
+            }
+            InferredType::Union { members, .. } => {
+                let Some((compat, total, incompatible)) =
+                    Self::classify_union_members(members, |m| {
+                        Self::is_assignable_to(m, declared_ty, hierarchy)
+                    })
+                else {
+                    return; // Contains Dynamic — skip.
+                };
+                if compat == total {
+                    return;
+                }
+                let union_display = value_ty
+                    .display_for_diagnostic()
+                    .unwrap_or_else(|| EcoString::from("Dynamic"));
+                let list = incompatible
+                    .iter()
+                    .map(|m| InferredType::class_name_for_diagnostic(m.as_str()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                self.diagnostics.push(
+                    Diagnostic::warning(
+                        format!(
+                            "type mismatch for state key `{slot_name}` on `{class_name}`: declared {declared_display}, got {union_display}"
+                        ),
+                        value_expr.span(),
+                    )
+                    .with_category(DiagnosticCategory::Type)
+                    .with_hint(format!(
+                        "Some members of {union_display} are not compatible with {declared_display}: {list}"
+                    )),
+                );
+            }
+            // Dynamic / Never / Meta / Negation / Intersection value — skip.
+            _ => {}
+        }
+    }
+
+    /// Find the declared state slot closest (by edit distance) to `target`, for
+    /// a "did you mean" typo suggestion. Mirrors [`Self::find_similar_selector`]'s
+    /// thresholds so suggestions stay conservative.
+    fn closest_state_slot(target: &str, slots: &[EcoString]) -> Option<EcoString> {
+        let mut best: Option<(EcoString, usize)> = None;
+        for slot in slots {
+            let dist = edit_distance(target, slot.as_str());
+            if dist <= 3
+                && dist < target.len() / 2 + 1
+                && best.as_ref().is_none_or(|(_, d)| dist < *d)
+            {
+                best = Some((slot.clone(), dist));
+            }
+        }
+        best.map(|(slot, _)| slot)
     }
 
     /// Check state default values match declared types at class definition time.

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1569,6 +1569,13 @@ impl TypeChecker {
         let Some(pairs) = Self::spawn_with_map_pairs(selector, arguments) else {
             return;
         };
+        // `spawnWith:` is an Actor protocol (ADR 0104). A non-Actor class with
+        // `state:` slots that receives a `spawnWith:` send is already a terminal
+        // DNU — key-checking on top of that is noise. Guard on the class kind so
+        // the diagnostic only fires where `spawnWith:` is a real constructor.
+        if !hierarchy.is_actor_subclass(class_name) {
+            return;
+        }
         // Declared state slot names, including inherited slots. An empty set
         // means the class declares no state (e.g. a builtin, or one whose slots
         // are not in the hierarchy) — bail rather than flag every key.
@@ -1698,7 +1705,11 @@ impl TypeChecker {
         let mut best: Option<(EcoString, usize)> = None;
         for slot in slots {
             let dist = edit_distance(target, slot.as_str());
-            if dist <= 3
+            // `dist > 0` documents the invariant that exact matches are already
+            // filtered by the caller (`continue`d before this is called) — and
+            // keeps the function correct if ever reused without that pre-filter.
+            if dist > 0
+                && dist <= 3
                 && dist < target.len() / 2 + 1
                 && best.as_ref().is_none_or(|(_, d)| dist < *d)
             {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1573,6 +1573,13 @@ impl TypeChecker {
         // `state:` slots that receives a `spawnWith:` send is already a terminal
         // DNU — key-checking on top of that is noise. Guard on the class kind so
         // the diagnostic only fires where `spawnWith:` is a real constructor.
+        //
+        // Scoping note: `is_actor_subclass` returns `false` when any link in the
+        // superclass chain is absent from the hierarchy, so key-checking is
+        // silently skipped for a partially-unresolved chain — a false negative,
+        // never a false positive. This is consistent with `all_state` /
+        // `state_field_type` / `superclass_chain`, which all break at the same
+        // unknown ancestor.
         if !hierarchy.is_actor_subclass(class_name) {
             return;
         }
@@ -1604,9 +1611,9 @@ impl TypeChecker {
             }
             // Unknown key → Warning + typo suggestion.
             let message = match Self::closest_state_slot(key_name, &slots) {
-                Some(suggestion) => {
-                    format!("unknown state key `{key_name}` — did you mean `{suggestion}`?")
-                }
+                Some(suggestion) => format!(
+                    "unknown state key `{key_name}` for `{class_name}` — did you mean `{suggestion}`?"
+                ),
                 None => format!("unknown state key `{key_name}` for `{class_name}`"),
             };
             self.diagnostics.push(

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1687,6 +1687,15 @@ impl TypeChecker {
                     .map(|m| InferredType::class_name_for_diagnostic(m.as_str()))
                     .collect::<Vec<_>>()
                     .join(", ");
+                // Mirror `check_field_assignment_type`: when no member is
+                // compatible, say so plainly rather than "some members".
+                let hint = if compat == 0 {
+                    format!("No member of {union_display} is compatible with {declared_display}")
+                } else {
+                    format!(
+                        "Some members of {union_display} are not compatible with {declared_display}: {list}"
+                    )
+                };
                 self.diagnostics.push(
                     Diagnostic::warning(
                         format!(
@@ -1695,9 +1704,7 @@ impl TypeChecker {
                         value_expr.span(),
                     )
                     .with_category(DiagnosticCategory::Type)
-                    .with_hint(format!(
-                        "Some members of {union_display} are not compatible with {declared_display}: {list}"
-                    )),
+                    .with_hint(hint),
                 );
             }
             // Dynamic / Never / Meta / Negation / Intersection value — skip.


### PR DESCRIPTION
## Summary

ADR 0104 Phase 2 ([Epic BT-2747](https://linear.app/beamtalk/issue/BT-2747)). Checks `spawnWith:` map keys against a class's declared `state:` slots and warns (with a typo suggestion) on an unknown key — plus slot-value type-checking.

- **Call-site `MapLiteral` inspection:** map-literal inference collapses `#{...}` to a joined `Dictionary(K,V)`, discarding keys. New helper `spawn_with_map_pairs(selector, arguments)` returns the literal pairs only for a `spawnWith:` send with a literal-map argument (so non-literal `Dictionary` args are never inspected — no false positives). Wired into both class-side dispatch branches of `infer_message_send_with_receiver_ty` (`Counter spawnWith:` and a class-typed variable).
- **Unknown-key Warning:** each symbol key not in the class's declared slot set (via `ClassHierarchy::all_state`, which distinguishes an unknown field from a declared-but-untyped one) emits a `Warning` — the provably-failing tier per ADR 0100. Message: `unknown state key \`cuont\` — did you mean \`count\`?` when a near slot exists (reuses `edit_distance` / `find_similar_selector` thresholds), else `unknown state key \`X\` for \`C\``.
- **Slot-value checking:** each value's inferred type (read back from `type_map`, no re-inference) is checked with `is_assignable_to`, covering simple **and** union-typed slots (`Integer | #infinity`).
- **No false positives:** classes with no Beamtalk `state:` declarations (state in the gen_server, e.g. stdlib `Subprocess`) are never flagged.
- **Reuse boundary for ADR 0103 BT-2755:** its value-sendability check iterates the same pairs via `spawn_with_map_pairs`.
- `spawn`/`spawnWith:` on `Meta{C}` still infer `Known{C}` (ADR 0083) — pinned.

## Test plan

- `cargo test -p beamtalk-core` — 4421 passed, 0 failed (9 new `spawn_with_keys` tests)
- `cargo clippy -p beamtalk-core --tests` — clean
- `just test-stdlib` — 223/223

Closes BT-2750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Prdqcp7hZd8ocum8ZfU2mk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Prdqcp7hZd8ocum8ZfU2mk)_