### PR TITLE
Parser: grouping parentheses in type-annotation position (BT-2760)

### DIFF
--- a/crates/beamtalk-core/src/ast/expression.rs
+++ b/crates/beamtalk-core/src/ast/expression.rs
@@ -1034,18 +1034,15 @@ impl TypeAnnotation {
                 // difference: `\` is left-associative, so `Symbol \ (#a \ #b)`
                 // must not print as `Symbol \ #a \ #b` (which re-parses as
                 // `(Symbol \ #a) \ #b`).
-                let base_name = match base.as_ref() {
-                    Self::Union { .. } | Self::FalseOr { .. } | Self::Intersection { .. } => {
-                        eco_format!("({})", base.type_name())
-                    }
-                    _ => base.type_name(),
+                let base_name = if base.needs_parens_in_difference(false) {
+                    eco_format!("({})", base.type_name())
+                } else {
+                    base.type_name()
                 };
-                let excluded_name = match excluded.as_ref() {
-                    Self::Union { .. }
-                    | Self::FalseOr { .. }
-                    | Self::Intersection { .. }
-                    | Self::Difference { .. } => eco_format!("({})", excluded.type_name()),
-                    _ => excluded.type_name(),
+                let excluded_name = if excluded.needs_parens_in_difference(true) {
+                    eco_format!("({})", excluded.type_name())
+                } else {
+                    excluded.type_name()
                 };
                 eco_format!("{base_name} \\ {excluded_name}")
             }
@@ -1057,24 +1054,56 @@ impl TypeAnnotation {
                 // intersection: `&` is left-associative, so `A & (B & C)`
                 // must not print as `A & B & C` (which re-parses as
                 // `(A & B) & C`).
-                let left_name = match left.as_ref() {
-                    Self::Union { .. } | Self::FalseOr { .. } | Self::Difference { .. } => {
-                        eco_format!("({})", left.type_name())
-                    }
-                    _ => left.type_name(),
+                let left_name = if left.needs_parens_in_intersection(false) {
+                    eco_format!("({})", left.type_name())
+                } else {
+                    left.type_name()
                 };
-                let right_name = match right.as_ref() {
-                    Self::Union { .. }
-                    | Self::FalseOr { .. }
-                    | Self::Difference { .. }
-                    | Self::Intersection { .. } => eco_format!("({})", right.type_name()),
-                    _ => right.type_name(),
+                let right_name = if right.needs_parens_in_intersection(true) {
+                    eco_format!("({})", right.type_name())
+                } else {
+                    right.type_name()
                 };
                 eco_format!("{left_name} & {right_name}")
             }
             Self::SelfType { .. } => "Self".into(),
             Self::SelfClass { .. } => "Self class".into(),
             Self::ClassOf { class_name, .. } => eco_format!("{} class", class_name.name),
+        }
+    }
+
+    /// `true` when `self`, used as an operand of `\`, must be parenthesised
+    /// for the printed form to re-parse to the same AST (BT-2760).
+    ///
+    /// `\` binds tighter than `|` and shares a tier with `&`, so a grouped
+    /// union or intersection operand keeps its parens. The *excluded* (right)
+    /// operand additionally needs parens when it is itself a difference:
+    /// `\` is left-associative, so `Symbol \ (#a \ #b)` must not print as
+    /// `Symbol \ #a \ #b`.
+    ///
+    /// Single source of truth for both [`type_name`](Self::type_name) and the
+    /// formatter's `unparse_type_annotation` — keep them in sync by calling
+    /// this, not by duplicating the match.
+    pub(crate) fn needs_parens_in_difference(&self, is_excluded: bool) -> bool {
+        match self {
+            Self::Union { .. } | Self::FalseOr { .. } | Self::Intersection { .. } => true,
+            Self::Difference { .. } => is_excluded,
+            _ => false,
+        }
+    }
+
+    /// `true` when `self`, used as an operand of `&`, must be parenthesised
+    /// for the printed form to re-parse to the same AST (BT-2760).
+    ///
+    /// Mirror image of [`needs_parens_in_difference`](Self::needs_parens_in_difference):
+    /// grouped union/difference operands keep parens, and the *right* operand
+    /// of the left-associative `&` keeps them when it is itself an
+    /// intersection (`A & (B & C)`).
+    pub(crate) fn needs_parens_in_intersection(&self, is_right: bool) -> bool {
+        match self {
+            Self::Union { .. } | Self::FalseOr { .. } | Self::Difference { .. } => true,
+            Self::Intersection { .. } => is_right,
+            _ => false,
         }
     }
 }

--- a/crates/beamtalk-core/src/ast/expression.rs
+++ b/crates/beamtalk-core/src/ast/expression.rs
@@ -899,6 +899,31 @@ impl TypeAnnotation {
         }
     }
 
+    /// Returns this annotation with its span widened to `span`, preserving
+    /// the variant and all its contents unchanged.
+    ///
+    /// Used to fold grouping parentheses in type-annotation position
+    /// (BT-2760, e.g. `(A & B) \ C`) into the inner annotation transparently:
+    /// the parsed shape is exactly what the parens contained, but the span
+    /// grows to cover the parens themselves so diagnostics/hover point at the
+    /// whole written group.
+    #[must_use]
+    pub fn with_span(mut self, span: Span) -> Self {
+        match &mut self {
+            Self::Simple(id) => id.span = span,
+            Self::Union { span: s, .. }
+            | Self::Singleton { span: s, .. }
+            | Self::Generic { span: s, .. }
+            | Self::FalseOr { span: s, .. }
+            | Self::Difference { span: s, .. }
+            | Self::Intersection { span: s, .. }
+            | Self::SelfType { span: s }
+            | Self::SelfClass { span: s }
+            | Self::ClassOf { span: s, .. } => *s = span,
+        }
+        self
+    }
+
     /// Creates a simple type annotation.
     #[must_use]
     pub fn simple(name: impl Into<EcoString>, span: Span) -> Self {
@@ -1004,26 +1029,48 @@ impl TypeAnnotation {
             Self::Difference { base, excluded, .. } => {
                 // `\` binds tighter than `|` and shares a tier with `&`, so a
                 // union or intersection operand (only reachable via explicit
-                // grouping) is parenthesised to preserve meaning.
-                let paren = |ty: &TypeAnnotation| match ty {
+                // grouping) is parenthesised to preserve meaning. The right
+                // operand additionally needs parens when it is itself a
+                // difference: `\` is left-associative, so `Symbol \ (#a \ #b)`
+                // must not print as `Symbol \ #a \ #b` (which re-parses as
+                // `(Symbol \ #a) \ #b`).
+                let base_name = match base.as_ref() {
                     Self::Union { .. } | Self::FalseOr { .. } | Self::Intersection { .. } => {
-                        eco_format!("({})", ty.type_name())
+                        eco_format!("({})", base.type_name())
                     }
-                    _ => ty.type_name(),
+                    _ => base.type_name(),
                 };
-                eco_format!("{} \\ {}", paren(base), paren(excluded))
+                let excluded_name = match excluded.as_ref() {
+                    Self::Union { .. }
+                    | Self::FalseOr { .. }
+                    | Self::Intersection { .. }
+                    | Self::Difference { .. } => eco_format!("({})", excluded.type_name()),
+                    _ => excluded.type_name(),
+                };
+                eco_format!("{base_name} \\ {excluded_name}")
             }
             Self::Intersection { left, right, .. } => {
                 // `&` binds tighter than `|` and shares a tier with `\`; a
                 // union or difference operand (only reachable via explicit
-                // grouping) is parenthesised to preserve meaning.
-                let paren = |ty: &TypeAnnotation| match ty {
+                // grouping) is parenthesised to preserve meaning. The right
+                // operand additionally needs parens when it is itself an
+                // intersection: `&` is left-associative, so `A & (B & C)`
+                // must not print as `A & B & C` (which re-parses as
+                // `(A & B) & C`).
+                let left_name = match left.as_ref() {
                     Self::Union { .. } | Self::FalseOr { .. } | Self::Difference { .. } => {
-                        eco_format!("({})", ty.type_name())
+                        eco_format!("({})", left.type_name())
                     }
-                    _ => ty.type_name(),
+                    _ => left.type_name(),
                 };
-                eco_format!("{} & {}", paren(left), paren(right))
+                let right_name = match right.as_ref() {
+                    Self::Union { .. }
+                    | Self::FalseOr { .. }
+                    | Self::Difference { .. }
+                    | Self::Intersection { .. } => eco_format!("({})", right.type_name()),
+                    _ => right.type_name(),
+                };
+                eco_format!("{left_name} & {right_name}")
             }
             Self::SelfType { .. } => "Self".into(),
             Self::SelfClass { .. } => "Self class".into(),

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -807,6 +807,33 @@ mod tests {
         );
     }
 
+    #[test]
+    fn grouped_mixed_intersection_then_difference_resolves_transparently() {
+        // `(Symbol & Symbol) \ #foo` — writable since grouping parens in
+        // type-annotation position (BT-2760). Grouping is transparent in the
+        // AST, so the resolver just sees Difference { base: Intersection },
+        // no new `InferredType`: the intersection reduces (identity) to
+        // `Symbol`, then the difference produces the usual `Negation`.
+        let ann = TypeAnnotation::difference(
+            TypeAnnotation::intersection(
+                TypeAnnotation::Simple(ident("Symbol")),
+                TypeAnnotation::Simple(ident("Symbol")),
+                span(),
+            ),
+            TypeAnnotation::Singleton {
+                name: "foo".into(),
+                span: span(),
+            },
+            span(),
+        );
+        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let InferredType::Negation { base, excluded, .. } = result else {
+            panic!("expected Negation, got {result:?}");
+        };
+        assert_eq!(*base, InferredType::known("Symbol"));
+        assert_eq!(*excluded, InferredType::known("#foo"));
+    }
+
     // ---- resolve_type_annotation: Self / Self class ----
 
     #[test]

--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -505,34 +505,67 @@ impl Parser {
             return DoubleColonSkip::NotPresent;
         }
         let mut o = offset + 1;
-        if !is_type_name_token(self.peek_at(o)) {
+        let Some(after) = self.skip_type_operand(o) else {
             return DoubleColonSkip::Malformed(o);
+        };
+        o = after;
+        // Skip the type-operator chain: `| Type`, `\ Type`, `& Type`
+        while self.is_type_chain_operator(o) {
+            o += 1;
+            let Some(after) = self.skip_type_operand(o) else {
+                return DoubleColonSkip::Malformed(o);
+            };
+            o = after;
         }
-        // Advance past the type name, consuming a trailing `class` metatype
-        // suffix on the same line (BT-1952 / BT-2034). This lets binary method
-        // headers like `+ other :: Actor class => ...` be recognized.
-        o = self.skip_type_name_with_metatype(o);
+        DoubleColonSkip::Valid(o)
+    }
+
+    /// Skips a single type operand in lookahead context: a type name (with
+    /// optional `class` metatype suffix and generic parameter list) or a
+    /// parenthesised type group `( ... )` (BT-2760).
+    ///
+    /// Returns the offset after the operand, or `None` if no type operand
+    /// starts at `offset`. A malformed generic parameter list after a valid
+    /// type name is tolerated (the offset stops at the `(`) so the parser can
+    /// emit the specific diagnostic — matching the pre-existing lookahead
+    /// behaviour.
+    fn skip_type_operand(&self, offset: usize) -> Option<usize> {
+        if matches!(self.peek_at(offset), Some(TokenKind::LeftParen)) {
+            return self.skip_grouped_type(offset);
+        }
+        if !is_type_name_token(self.peek_at(offset)) {
+            return None;
+        }
+        let mut o = self.skip_type_name_with_metatype(offset);
         // Skip generic type parameters: `Name(Type, Type, ...)`
         if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
             if let Some(after) = self.skip_paren_type_params(o) {
                 o = after;
             }
         }
-        // Skip union types: `| Type`
+        Some(o)
+    }
+
+    /// Skips a parenthesised type group `( Type (op Type)* )` in lookahead
+    /// context (BT-2760), keeping lookahead in lock-step with
+    /// `parse_single_type_annotation`'s grouping-paren branch.
+    ///
+    /// Starting at the `(` token, advances past the matching `)` and returns
+    /// the offset after it. Returns `None` if the contents are not a type
+    /// chain or the closing `)` is missing.
+    fn skip_grouped_type(&self, offset: usize) -> Option<usize> {
+        debug_assert!(matches!(self.peek_at(offset), Some(TokenKind::LeftParen)));
+        let mut o = offset + 1; // past `(`
+        o = self.skip_type_operand(o)?;
         while self.is_type_chain_operator(o) {
             o += 1;
-            if !is_type_name_token(self.peek_at(o)) {
-                return DoubleColonSkip::Malformed(o);
-            }
-            o = self.skip_type_name_with_metatype(o);
-            // Skip generic type parameters on union member
-            if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
-                if let Some(after) = self.skip_paren_type_params(o) {
-                    o = after;
-                }
-            }
+            o = self.skip_type_operand(o)?;
         }
-        DoubleColonSkip::Valid(o)
+        if matches!(self.peek_at(o), Some(TokenKind::RightParen)) {
+            Some(o + 1)
+        } else {
+            None
+        }
     }
 
     /// Skips a parenthesized type parameter list in lookahead context.
@@ -552,57 +585,40 @@ impl Parser {
             return Some(o + 1);
         }
         // First type param
-        if !is_type_name_token(self.peek_at(o)) {
-            return None;
-        }
-        o = self.skip_type_name_with_metatype(o);
-        // Skip optional bound: `:: Protocol`
-        o = self.skip_optional_type_param_bound(o);
-        // Nested generic: `Name(Type(...))`
-        if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
-            o = self.skip_paren_type_params(o)?;
-        }
-        // Union in type param position: `Type | Type`
-        while self.is_type_chain_operator(o) {
-            o += 1;
-            if !is_type_name_token(self.peek_at(o)) {
-                return None;
-            }
-            o = self.skip_type_name_with_metatype(o);
-            if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
-                o = self.skip_paren_type_params(o)?;
-            }
-        }
+        o = self.skip_type_param(o)?;
         // Additional type params: `, Type`
         while is_comma_opt(self.peek_at(o)) {
             o += 1;
-            if !is_type_name_token(self.peek_at(o)) {
-                return None;
-            }
-            o = self.skip_type_name_with_metatype(o);
-            // Skip optional bound: `:: Protocol`
-            o = self.skip_optional_type_param_bound(o);
-            // Nested generic
-            if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
-                o = self.skip_paren_type_params(o)?;
-            }
-            // Union
-            while self.is_type_chain_operator(o) {
-                o += 1;
-                if !is_type_name_token(self.peek_at(o)) {
-                    return None;
-                }
-                o = self.skip_type_name_with_metatype(o);
-                if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
-                    o = self.skip_paren_type_params(o)?;
-                }
-            }
+            o = self.skip_type_param(o)?;
         }
         if matches!(self.peek_at(o), Some(TokenKind::RightParen)) {
             Some(o + 1)
         } else {
             None
         }
+    }
+
+    /// Skips one type parameter/argument in lookahead context: a type
+    /// operand (name with optional metatype/generics, or a parenthesised
+    /// group — see [`skip_type_operand`](Self::skip_type_operand)), an
+    /// optional `:: Bound` (ADR 0068 Phase 2d), a nested generic parameter
+    /// list after the bound, and any trailing `|`/`\`/`&` operator chain.
+    ///
+    /// Returns the offset after the parameter, or `None` if malformed.
+    fn skip_type_param(&self, offset: usize) -> Option<usize> {
+        let mut o = self.skip_type_operand(offset)?;
+        // Skip optional bound: `:: Protocol`
+        o = self.skip_optional_type_param_bound(o);
+        // Nested generic after a bound: `T :: Printable(X)`
+        if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
+            o = self.skip_paren_type_params(o)?;
+        }
+        // Operator chain in type param position: `Type | Type`, `Type \ #a`
+        while self.is_type_chain_operator(o) {
+            o += 1;
+            o = self.skip_type_operand(o)?;
+        }
+        Some(o)
     }
 
     /// Skips an optional `:: Identifier` bound in lookahead context.
@@ -658,39 +674,27 @@ impl Parser {
         if !matches!(self.peek_at(offset), Some(TokenKind::Arrow)) {
             return false;
         }
-        // Skip -> Type (and possible | Type unions, generic params)
+        // Skip -> Type (and possible | Type unions, generic params, groups)
         let mut o = offset + 1;
         // Allow `-> =>` (missing type) for error recovery
         if matches!(self.peek_at(o), Some(TokenKind::FatArrow)) {
             return true;
         }
-        // Must have at least one type name
-        if !is_type_name_token(self.peek_at(o)) {
+        // Must have at least one type operand: a type name (BT-1952 /
+        // BT-2034: including a trailing `class` metatype token, so `-> Self
+        // class =>` and `-> Actor class | Nil =>` are recognized) or a
+        // parenthesised group (BT-2760: `-> (A & B) \ #c =>`).
+        let Some(after) = self.skip_type_operand(o) else {
             return false;
-        }
-        // BT-1952 / BT-2034: advance past the first type name, consuming a
-        // trailing `class` metatype token if present so that forms like
-        // `-> Self class =>` and `-> Actor class | Nil =>` are also recognized.
-        o = self.skip_type_name_with_metatype(o);
-        // Skip generic type parameters: `Type(T, E)`
-        if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
-            if let Some(after) = self.skip_paren_type_params(o) {
-                o = after;
-            }
-        }
-        // Skip union types: `| Type`
+        };
+        o = after;
+        // Skip the type-operator chain: `| Type`, `\ Type`, `& Type`
         while self.is_type_chain_operator(o) {
             o += 1;
-            if !is_type_name_token(self.peek_at(o)) {
+            let Some(after) = self.skip_type_operand(o) else {
                 return false;
-            }
-            o = self.skip_type_name_with_metatype(o);
-            // Skip generic params on union member
-            if matches!(self.peek_at(o), Some(TokenKind::LeftParen)) {
-                if let Some(after) = self.skip_paren_type_params(o) {
-                    o = after;
-                }
-            }
+            };
+            o = after;
         }
         matches!(self.peek_at(o), Some(TokenKind::FatArrow))
     }
@@ -957,6 +961,19 @@ impl Parser {
     /// `\`/`&` tier is handled by
     /// [`parse_difference_type`](Self::parse_difference_type).
     pub(super) fn parse_type_annotation(&mut self) -> TypeAnnotation {
+        // Unions are n-ary and associative, so a grouped union member —
+        // `(A | B) | C`, only reachable via grouping parens (BT-2760) — is
+        // spliced into the enclosing union rather than nested. This keeps
+        // the AST canonical: `(A | B) | C` and `A | B | C` are the same
+        // annotation, and unparsing (`type_name`) round-trips.
+        fn push_union_member(types: &mut Vec<TypeAnnotation>, ty: TypeAnnotation) {
+            if let TypeAnnotation::Union { types: inner, .. } = ty {
+                types.extend(inner);
+            } else {
+                types.push(ty);
+            }
+        }
+
         let first = self.parse_difference_type();
 
         // Check for union type: `Type | Type | ...`
@@ -965,11 +982,12 @@ impl Parser {
         }
 
         let start_span = first.span();
-        let mut types = vec![first];
+        let mut types = Vec::new();
+        push_union_member(&mut types, first);
 
         while matches!(self.current_kind(), TokenKind::Pipe) {
             self.advance(); // consume `|`
-            types.push(self.parse_difference_type());
+            push_union_member(&mut types, self.parse_difference_type());
         }
 
         let end_span = types.last().map_or(start_span, TypeAnnotation::span);
@@ -1068,7 +1086,43 @@ impl Parser {
     /// - Self type: `Self`
     /// - Self class metatype: `Self class`
     /// - Singleton types: `#foo` (a subtype of `Symbol`, ADR 0068)
+    /// - Grouping parentheses: `(Type)` (BT-2760, see below)
     pub(super) fn parse_single_type_annotation(&mut self) -> TypeAnnotation {
+        if matches!(self.current_kind(), TokenKind::LeftParen) {
+            // Grouping parentheses in type-annotation position (BT-2760,
+            // unblocking ADR 0102 §3's mixed `&`/`\` disambiguation). Parsed
+            // *transparently*: the parenthesised annotation is returned with
+            // its original shape — only the span widens to cover the parens
+            // — rather than wrapping it in a new AST node. This is enough
+            // because:
+            // - the resolver (`type_resolver.rs`) matches on the existing
+            //   variants and never needs to know grouping parens were there;
+            // - `TypeAnnotation::type_name()` (the unparser) already
+            //   re-derives parens where precedence demands them — the
+            //   `Difference`/`Intersection` arms parenthesise a nested
+            //   `Union`/`FalseOr`/opposite-operator operand — so a group that
+            //   changed the parse (e.g. `(A & B) \ C`) round-trips, while a
+            //   redundant group (e.g. `(Integer)`) collapses away, which is
+            //   fine since it doesn't change the AST shape.
+            // Recursing into `parse_type_annotation` (not
+            // `parse_single_type_annotation`/`parse_difference_type`) allows
+            // full unions and fresh `&`/`\` chains inside the group — the
+            // mixed-operator diagnostic's `chain_is_and` state is local to
+            // each `parse_difference_type` call, so a new chain started
+            // inside the parens is independent of the chain outside it.
+            let start = self.current_token().span();
+            self.advance(); // consume `(`
+            let inner = self.parse_type_annotation();
+            let end = if matches!(self.current_kind(), TokenKind::RightParen) {
+                let end = self.current_token().span();
+                self.advance(); // consume `)`
+                end
+            } else {
+                self.error("Expected ')' to close grouping parentheses in type annotation");
+                inner.span()
+            };
+            return inner.with_span(start.merge(end));
+        }
         if let TokenKind::Identifier(name) = self.current_kind() {
             let span = self.current_token().span();
             if name.as_str() == "Self" {

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/type_tests.rs
@@ -1775,3 +1775,334 @@ fn value_position_ampersand_is_unchanged() {
         "value-position `&` must parse as before (unchanged), got: {diagnostics:?}"
     );
 }
+
+// ==========================================================================
+// Grouping parentheses in type-annotation position — BT-2760, ADR 0102 §3
+// ==========================================================================
+
+/// Parses `ty` as the return type of a method and returns the annotation.
+fn parse_return_type(ty: &str) -> TypeAnnotation {
+    let module = parse_ok(&format!("Object subclass: Foo\n  narrow -> {ty} => self"));
+    module.classes[0].methods[0]
+        .return_type
+        .clone()
+        .expect("method must have a return type")
+}
+
+/// Asserts that unparsing (`type_name`) is a fixed point: parsing `ty`,
+/// printing it, and re-parsing the printed form yields the same printed
+/// form again. Combined with the shape assertions in the individual tests,
+/// this checks that `type_name` re-derives grouping parens exactly where
+/// precedence requires them.
+fn assert_type_name_round_trips(ty: &str) {
+    let parsed = parse_return_type(ty);
+    let printed = parsed.type_name();
+    let reparsed = parse_return_type(&printed);
+    assert_eq!(
+        reparsed.type_name(),
+        printed,
+        "type_name must be a fixed point for `{ty}`"
+    );
+}
+
+#[test]
+fn parse_grouped_simple_type_is_transparent() {
+    // `(Integer)` parses as plain `Integer` — no extra AST node, only the
+    // span widens to cover the parens.
+    let ret_ty = parse_return_type("(Integer)");
+    assert!(
+        matches!(&ret_ty, TypeAnnotation::Simple(id) if id.name == "Integer"),
+        "expected transparent Simple, got {ret_ty:?}"
+    );
+}
+
+#[test]
+fn parse_grouped_type_span_covers_parens() {
+    let source = "Object subclass: Foo\n  narrow -> (A & B) => self";
+    let module = parse_ok(source);
+    let ret_ty = module.classes[0].methods[0].return_type.as_ref().unwrap();
+    let span = ret_ty.span();
+    assert_eq!(
+        &source[span.start() as usize..span.end() as usize],
+        "(A & B)",
+        "group span must cover the parens"
+    );
+}
+
+#[test]
+fn parse_grouped_intersection_then_difference() {
+    // `(A & B) \ #c` — the previously unwritable mixed form (BT-2760):
+    // Difference { base: Intersection(A, B), excluded: #c }.
+    let ret_ty = parse_return_type("(A & B) \\ #c");
+    let TypeAnnotation::Difference { base, excluded, .. } = &ret_ty else {
+        panic!("expected Difference, got {ret_ty:?}");
+    };
+    let TypeAnnotation::Intersection { left, right, .. } = base.as_ref() else {
+        panic!("expected Intersection base, got {base:?}");
+    };
+    assert!(matches!(left.as_ref(), TypeAnnotation::Simple(id) if id.name == "A"));
+    assert!(matches!(right.as_ref(), TypeAnnotation::Simple(id) if id.name == "B"));
+    assert!(matches!(excluded.as_ref(), TypeAnnotation::Singleton { name, .. } if name == "c"));
+}
+
+#[test]
+fn parse_intersection_with_grouped_difference() {
+    // `A & (B \ #c)` — the other mixed reading, now writable explicitly:
+    // Intersection { left: A, right: Difference(B, #c) }.
+    let ret_ty = parse_return_type("A & (B \\ #c)");
+    let TypeAnnotation::Intersection { left, right, .. } = &ret_ty else {
+        panic!("expected Intersection, got {ret_ty:?}");
+    };
+    assert!(matches!(left.as_ref(), TypeAnnotation::Simple(id) if id.name == "A"));
+    let TypeAnnotation::Difference { base, excluded, .. } = right.as_ref() else {
+        panic!("expected Difference right, got {right:?}");
+    };
+    assert!(matches!(base.as_ref(), TypeAnnotation::Simple(id) if id.name == "B"));
+    assert!(matches!(excluded.as_ref(), TypeAnnotation::Singleton { name, .. } if name == "c"));
+}
+
+#[test]
+fn parse_difference_with_grouped_union_excluded() {
+    // `Symbol \ (#a | #b)` — ADR 0102 §3's own example form:
+    // Difference { base: Symbol, excluded: Union(#a, #b) }.
+    let ret_ty = parse_return_type("Symbol \\ (#a | #b)");
+    let TypeAnnotation::Difference { base, excluded, .. } = &ret_ty else {
+        panic!("expected Difference, got {ret_ty:?}");
+    };
+    assert!(matches!(base.as_ref(), TypeAnnotation::Simple(id) if id.name == "Symbol"));
+    let TypeAnnotation::Union { types, .. } = excluded.as_ref() else {
+        panic!("expected Union excluded, got {excluded:?}");
+    };
+    assert_eq!(types.len(), 2);
+    assert!(matches!(&types[0], TypeAnnotation::Singleton { name, .. } if name == "a"));
+    assert!(matches!(&types[1], TypeAnnotation::Singleton { name, .. } if name == "b"));
+}
+
+#[test]
+fn parse_union_with_grouped_difference_member() {
+    // `Integer | (Symbol \ #foo)` — the group is redundant (same parse as the
+    // bare form) but must still be accepted.
+    let ret_ty = parse_return_type("Integer | (Symbol \\ #foo)");
+    let TypeAnnotation::Union { types, .. } = &ret_ty else {
+        panic!("expected Union, got {ret_ty:?}");
+    };
+    assert_eq!(types.len(), 2);
+    assert!(matches!(&types[0], TypeAnnotation::Simple(id) if id.name == "Integer"));
+    assert!(
+        matches!(&types[1], TypeAnnotation::Difference { .. }),
+        "second member must be a Difference, got {:?}",
+        types[1]
+    );
+}
+
+#[test]
+fn parse_nested_groups() {
+    // Groups nest: `((A & B)) \ #c` parses identically to `(A & B) \ #c`.
+    let ret_ty = parse_return_type("((A & B)) \\ #c");
+    let TypeAnnotation::Difference { base, .. } = &ret_ty else {
+        panic!("expected Difference, got {ret_ty:?}");
+    };
+    assert!(
+        matches!(base.as_ref(), TypeAnnotation::Intersection { .. }),
+        "expected Intersection base, got {base:?}"
+    );
+}
+
+#[test]
+fn parse_grouped_union_member_splices_into_enclosing_union() {
+    // Unions are n-ary and associative, so `(A | B) | C` splices into a flat
+    // three-member union — keeping the AST canonical and `type_name`
+    // round-trippable.
+    let ret_ty = parse_return_type("(A | B) | C");
+    let TypeAnnotation::Union { types, .. } = &ret_ty else {
+        panic!("expected Union, got {ret_ty:?}");
+    };
+    assert_eq!(types.len(), 3, "union must be flat: {types:?}");
+    assert!(matches!(&types[0], TypeAnnotation::Simple(id) if id.name == "A"));
+    assert!(matches!(&types[1], TypeAnnotation::Simple(id) if id.name == "B"));
+    assert!(matches!(&types[2], TypeAnnotation::Simple(id) if id.name == "C"));
+}
+
+#[test]
+fn parse_grouped_right_nested_difference() {
+    // `Symbol \ (#a \ #b)` — right-nested same-operator group; distinct from
+    // the left-associative bare chain `Symbol \ #a \ #b`.
+    let ret_ty = parse_return_type("Symbol \\ (#a \\ #b)");
+    let TypeAnnotation::Difference { base, excluded, .. } = &ret_ty else {
+        panic!("expected Difference, got {ret_ty:?}");
+    };
+    assert!(matches!(base.as_ref(), TypeAnnotation::Simple(id) if id.name == "Symbol"));
+    assert!(
+        matches!(excluded.as_ref(), TypeAnnotation::Difference { .. }),
+        "expected right-nested Difference, got {excluded:?}"
+    );
+}
+
+#[test]
+fn parse_grouped_type_in_param_annotation() {
+    // Grouped type on a keyword-method parameter: the method-header
+    // lookahead (`skip_double_colon_type`) must recognise the group.
+    let module = parse_ok(
+        "Object subclass: Foo
+  narrow: x :: (A & B) \\ #c => x",
+    );
+    let method = &module.classes[0].methods[0];
+    let ann = method.parameters[0].type_annotation.as_ref().unwrap();
+    assert!(
+        matches!(ann, TypeAnnotation::Difference { .. }),
+        "expected Difference param annotation, got {ann:?}"
+    );
+}
+
+#[test]
+fn parse_grouped_type_in_state_annotation() {
+    let module = parse_ok(
+        "typed Value subclass: Spec
+  field: tag :: Symbol \\ (#a | #b) = nil",
+    );
+    let ann = module.classes[0].state[0].type_annotation.as_ref().unwrap();
+    assert!(
+        matches!(ann, TypeAnnotation::Difference { .. }),
+        "expected Difference field annotation, got {ann:?}"
+    );
+}
+
+#[test]
+fn parse_grouped_type_in_generic_argument() {
+    // A group inside a generic argument list: `List((A & B) \ #c)`.
+    let ret_ty = parse_return_type("List((A & B) \\ #c)");
+    let TypeAnnotation::Generic {
+        base, parameters, ..
+    } = &ret_ty
+    else {
+        panic!("expected Generic, got {ret_ty:?}");
+    };
+    assert_eq!(base.name, "List");
+    assert_eq!(parameters.len(), 1);
+    assert!(
+        matches!(&parameters[0], TypeAnnotation::Difference { .. }),
+        "expected Difference type argument, got {:?}",
+        parameters[0]
+    );
+}
+
+#[test]
+fn parse_unparenthesised_mixed_still_errors() {
+    // The bare mixed chain remains a deliberate parse error (ADR 0102 §3) —
+    // grouping parens are the escape hatch, not a precedence change.
+    let diagnostics = parse_err(
+        "Object subclass: Foo
+  narrow -> A & B \\ #c => self",
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("Cannot mix") && d.message.contains("parenthesise")),
+        "expected the mixed-operator diagnostic, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn parse_unclosed_group_errors() {
+    // A state declaration parses its `::` annotation unconditionally (no
+    // method-header lookahead), so the unclosed group reaches the annotation
+    // parser and gets the targeted diagnostic. (In a method header an
+    // unclosed group makes the lookahead reject the line as a header
+    // entirely, so it falls back to expression-parse errors instead.)
+    let diagnostics = parse_err(
+        "Object subclass: Foo
+  state: x :: (A | B = 1",
+    );
+    assert!(
+        diagnostics.iter().any(|d| d
+            .message
+            .contains("Expected ')' to close grouping parentheses")),
+        "expected an unclosed-group diagnostic, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn grouped_type_name_round_trips() {
+    // `type_name` re-derives parens exactly where precedence requires them,
+    // so printing and re-parsing is a fixed point.
+    assert_type_name_round_trips("(A & B) \\ #c");
+    assert_type_name_round_trips("A & (B \\ #c)");
+    assert_type_name_round_trips("Symbol \\ (#a | #b)");
+    assert_type_name_round_trips("Integer | (Symbol \\ #foo)");
+    assert_type_name_round_trips("Symbol \\ (#a \\ #b)");
+    assert_type_name_round_trips("A & (B & C)");
+    assert_type_name_round_trips("(A | B) | C");
+    assert_type_name_round_trips("(Integer)");
+    assert_type_name_round_trips("List((A & B) \\ #c)");
+}
+
+#[test]
+fn grouped_type_name_prints_required_parens_only() {
+    // Groups that changed the parse keep their parens; redundant groups
+    // collapse away.
+    assert_eq!(
+        parse_return_type("(A & B) \\ #c").type_name().as_str(),
+        "(A & B) \\ #c"
+    );
+    assert_eq!(
+        parse_return_type("Symbol \\ (#a | #b)")
+            .type_name()
+            .as_str(),
+        "Symbol \\ (#a | #b)"
+    );
+    assert_eq!(
+        parse_return_type("Symbol \\ (#a \\ #b)")
+            .type_name()
+            .as_str(),
+        "Symbol \\ (#a \\ #b)"
+    );
+    // Redundant grouping collapses: `(Integer)` prints as `Integer`, and a
+    // grouped tighter-binding member needs no parens under `|`.
+    assert_eq!(
+        parse_return_type("(Integer)").type_name().as_str(),
+        "Integer"
+    );
+    assert_eq!(
+        parse_return_type("Integer | (Symbol \\ #foo)")
+            .type_name()
+            .as_str(),
+        "Integer | Symbol \\ #foo"
+    );
+}
+
+#[test]
+fn value_expression_parens_unchanged_by_type_grouping() {
+    // Guard: `(...)` in a value expression still parses as a parenthesized
+    // expression — the type-position grouping (BT-2760) must not leak.
+    let module = parse_ok(
+        "Object subclass: Foo
+  combine: x => (x + 1) * 2",
+    );
+    let method = &module.classes[0].methods[0];
+    assert_eq!(method.selector.name(), "combine:");
+    assert_eq!(method.body.len(), 1);
+}
+
+#[test]
+fn parse_doc_examples_for_grouped_types() {
+    // The exact forms documented in docs/beamtalk-language-features.md
+    // (§Difference and Intersection Types) must parse.
+    parse_ok(
+        "Object subclass: Foo
+  run =>
+    tag :: Symbol \\ (#a | #b) := #c
+    tag",
+    );
+    parse_ok(
+        "Object subclass: Foo
+  withSentinel: ms :: Integer | (Symbol \\ #infinity) => ms",
+    );
+    parse_ok(
+        "Object subclass: Foo
+  narrow -> (A & B) \\ #c => self",
+    );
+    parse_ok(
+        "Object subclass: Foo
+  narrow -> A & (B \\ #c) => self",
+    );
+}

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -1721,50 +1721,21 @@ fn unparse_type_annotation(ty: &TypeAnnotation) -> Document<'static> {
         }
         TypeAnnotation::Difference { base, excluded, .. } => {
             // Re-derive grouping parens (BT-2760) where re-parsing would
-            // otherwise change the AST: a union/intersection operand (only
-            // reachable via explicit grouping) must stay grouped, and the
-            // right operand of the left-associative `\` must stay grouped
-            // when it is itself a difference (`Symbol \ (#a \ #b)`).
-            let base_parens = matches!(
-                base.as_ref(),
-                TypeAnnotation::Union { .. }
-                    | TypeAnnotation::FalseOr { .. }
-                    | TypeAnnotation::Intersection { .. }
-            );
-            let excluded_parens = matches!(
-                excluded.as_ref(),
-                TypeAnnotation::Union { .. }
-                    | TypeAnnotation::FalseOr { .. }
-                    | TypeAnnotation::Intersection { .. }
-                    | TypeAnnotation::Difference { .. }
-            );
+            // otherwise change the AST. The predicate is shared with
+            // `TypeAnnotation::type_name` — single source of truth.
             docvec![
-                unparse_grouped_type(base, base_parens),
+                unparse_grouped_type(base, base.needs_parens_in_difference(false)),
                 " \\ ",
-                unparse_grouped_type(excluded, excluded_parens)
+                unparse_grouped_type(excluded, excluded.needs_parens_in_difference(true))
             ]
         }
         TypeAnnotation::Intersection { left, right, .. } => {
-            // Mirror image of `Difference` above: `&` shares the tier with
-            // `\` and is left-associative, so grouped union/difference
-            // operands and a right-nested intersection keep their parens.
-            let left_parens = matches!(
-                left.as_ref(),
-                TypeAnnotation::Union { .. }
-                    | TypeAnnotation::FalseOr { .. }
-                    | TypeAnnotation::Difference { .. }
-            );
-            let right_parens = matches!(
-                right.as_ref(),
-                TypeAnnotation::Union { .. }
-                    | TypeAnnotation::FalseOr { .. }
-                    | TypeAnnotation::Difference { .. }
-                    | TypeAnnotation::Intersection { .. }
-            );
+            // Mirror image of `Difference` above; predicate shared with
+            // `TypeAnnotation::type_name`.
             docvec![
-                unparse_grouped_type(left, left_parens),
+                unparse_grouped_type(left, left.needs_parens_in_intersection(false)),
                 " & ",
-                unparse_grouped_type(right, right_parens)
+                unparse_grouped_type(right, right.needs_parens_in_intersection(true))
             ]
         }
         TypeAnnotation::SelfType { .. } => Document::Str("Self"),

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -1720,17 +1720,51 @@ fn unparse_type_annotation(ty: &TypeAnnotation) -> Document<'static> {
             docvec![unparse_type_annotation(inner), " | False"]
         }
         TypeAnnotation::Difference { base, excluded, .. } => {
+            // Re-derive grouping parens (BT-2760) where re-parsing would
+            // otherwise change the AST: a union/intersection operand (only
+            // reachable via explicit grouping) must stay grouped, and the
+            // right operand of the left-associative `\` must stay grouped
+            // when it is itself a difference (`Symbol \ (#a \ #b)`).
+            let base_parens = matches!(
+                base.as_ref(),
+                TypeAnnotation::Union { .. }
+                    | TypeAnnotation::FalseOr { .. }
+                    | TypeAnnotation::Intersection { .. }
+            );
+            let excluded_parens = matches!(
+                excluded.as_ref(),
+                TypeAnnotation::Union { .. }
+                    | TypeAnnotation::FalseOr { .. }
+                    | TypeAnnotation::Intersection { .. }
+                    | TypeAnnotation::Difference { .. }
+            );
             docvec![
-                unparse_type_annotation(base),
+                unparse_grouped_type(base, base_parens),
                 " \\ ",
-                unparse_type_annotation(excluded)
+                unparse_grouped_type(excluded, excluded_parens)
             ]
         }
         TypeAnnotation::Intersection { left, right, .. } => {
+            // Mirror image of `Difference` above: `&` shares the tier with
+            // `\` and is left-associative, so grouped union/difference
+            // operands and a right-nested intersection keep their parens.
+            let left_parens = matches!(
+                left.as_ref(),
+                TypeAnnotation::Union { .. }
+                    | TypeAnnotation::FalseOr { .. }
+                    | TypeAnnotation::Difference { .. }
+            );
+            let right_parens = matches!(
+                right.as_ref(),
+                TypeAnnotation::Union { .. }
+                    | TypeAnnotation::FalseOr { .. }
+                    | TypeAnnotation::Difference { .. }
+                    | TypeAnnotation::Intersection { .. }
+            );
             docvec![
-                unparse_type_annotation(left),
+                unparse_grouped_type(left, left_parens),
                 " & ",
-                unparse_type_annotation(right)
+                unparse_grouped_type(right, right_parens)
             ]
         }
         TypeAnnotation::SelfType { .. } => Document::Str("Self"),
@@ -1738,6 +1772,18 @@ fn unparse_type_annotation(ty: &TypeAnnotation) -> Document<'static> {
         TypeAnnotation::ClassOf { class_name, .. } => {
             docvec![leaf::ident(&class_name.name), " class"]
         }
+    }
+}
+
+/// Unparses a `\`/`&` operand, wrapping it in grouping parentheses
+/// (BT-2760) when `parens` is set — i.e. when re-parsing the bare operand
+/// would bind differently (see the `Difference`/`Intersection` arms of
+/// [`unparse_type_annotation`]).
+fn unparse_grouped_type(ty: &TypeAnnotation, parens: bool) -> Document<'static> {
+    if parens {
+        docvec!["(", unparse_type_annotation(ty), ")"]
+    } else {
+        unparse_type_annotation(ty)
     }
 }
 
@@ -1934,6 +1980,102 @@ mod tests {
             formatted.contains("Collection(Object) & Comparable"),
             "intersection type must survive round-trip, got: {formatted}"
         );
+    }
+
+    // --- Grouping parentheses in type annotations (BT-2760) ---
+
+    #[test]
+    fn grouped_difference_operands_unparse_with_parens() {
+        // `Difference { base: Intersection }` must re-derive the grouping
+        // parens — the bare form `A & B \ #c` is the mixed-operator parse
+        // error (ADR 0102 §3).
+        let ann = crate::ast::TypeAnnotation::difference(
+            crate::ast::TypeAnnotation::intersection(
+                crate::ast::TypeAnnotation::simple("A", span()),
+                crate::ast::TypeAnnotation::simple("B", span()),
+                span(),
+            ),
+            crate::ast::TypeAnnotation::singleton("c", span()),
+            span(),
+        );
+        assert_eq!(
+            unparse_type_annotation(&ann).to_pretty_string(),
+            "(A & B) \\ #c"
+        );
+    }
+
+    #[test]
+    fn grouped_union_excluded_unparses_with_parens() {
+        // `Symbol \ (#a | #b)` — a union excluded operand keeps its parens
+        // (`\` binds tighter than `|`).
+        let ann = crate::ast::TypeAnnotation::difference(
+            crate::ast::TypeAnnotation::simple("Symbol", span()),
+            crate::ast::TypeAnnotation::union(
+                vec![
+                    crate::ast::TypeAnnotation::singleton("a", span()),
+                    crate::ast::TypeAnnotation::singleton("b", span()),
+                ],
+                span(),
+            ),
+            span(),
+        );
+        assert_eq!(
+            unparse_type_annotation(&ann).to_pretty_string(),
+            "Symbol \\ (#a | #b)"
+        );
+    }
+
+    #[test]
+    fn right_nested_difference_unparses_with_parens() {
+        // `\` is left-associative, so a right-nested difference must keep
+        // its parens: `Symbol \ (#a \ #b)`, not `Symbol \ #a \ #b`.
+        let ann = crate::ast::TypeAnnotation::difference(
+            crate::ast::TypeAnnotation::simple("Symbol", span()),
+            crate::ast::TypeAnnotation::difference(
+                crate::ast::TypeAnnotation::singleton("a", span()),
+                crate::ast::TypeAnnotation::singleton("b", span()),
+                span(),
+            ),
+            span(),
+        );
+        assert_eq!(
+            unparse_type_annotation(&ann).to_pretty_string(),
+            "Symbol \\ (#a \\ #b)"
+        );
+    }
+
+    #[test]
+    fn grouped_mixed_types_round_trip_through_format_source() {
+        // Parse → unparse preserves the parenthesised mixed forms (BT-2760),
+        // and the formatter is idempotent on them.
+        for (source, expected) in [
+            (
+                "Object subclass: Foo\n  narrow -> (A & B) \\ #c => self\n",
+                "(A & B) \\ #c",
+            ),
+            (
+                "Object subclass: Foo\n  narrow -> A & (B \\ #c) => self\n",
+                "A & (B \\ #c)",
+            ),
+            (
+                "Object subclass: Foo\n  narrow -> Symbol \\ (#a | #b) => #c\n",
+                "Symbol \\ (#a | #b)",
+            ),
+            (
+                "Object subclass: Foo\n  narrow -> Integer | (Symbol \\ #foo) => 1\n",
+                // The group is redundant (`\` already binds tighter than
+                // `|`), so the formatter drops it.
+                "Integer | Symbol \\ #foo",
+            ),
+        ] {
+            let formatted = format_source(source).expect("should format");
+            assert!(
+                formatted.contains(expected),
+                "grouped type must survive round-trip: expected `{expected}` in: {formatted}"
+            );
+            let reformatted = format_source(&formatted).expect("should reformat");
+            assert_eq!(formatted, reformatted, "format must be idempotent");
+        }
     }
 
     // --- Comment unparsing ---

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -1617,9 +1617,27 @@ requires: value :: A & B & C => ...
 
 So `Integer | Symbol \ #foo` parses as `Integer | (Symbol \ #foo)` — `\` binds tighter than `|`. Within one operator, chains are left-associative: `Symbol \ #a \ #b` parses as `(Symbol \ #a) \ #b`, and `A & B & C` parses as `(A & B) & C`.
 
-**Known limitation: no grouping parentheses in type position (yet).** Unlike value expressions, `(...)` is not a grouping operator inside a type annotation — parentheses there are only used for generic type arguments (`Result(T, E)`). So there is currently no way to write, say, "any Symbol except one of a union of exclusions" with an explicit parenthesised group (`Symbol \ (#a | #b)` does **not** parse) — write it as a chain of subtractions instead, which the algebra normalises to the same result: `Symbol \ #a \ #b`.
+**Grouping parentheses.** `(...)` is a grouping operator inside a type annotation, just as in value expressions (in addition to its generic-argument use, `Result(T, E)`). A group wraps any annotation — unions, `&`/`\` chains, generics — and groups nest. Grouping is purely syntactic: the parenthesised annotation is the same annotation, so `(Integer)` means `Integer`, and `(A | B) | C` is the same flat three-member union as `A | B | C`.
 
-This same limitation is why **mixing `&` and `\` in the same chain without parentheses is a deliberate parse error**, not a left-associative fallback — `A & B \ C` is rejected with "Cannot mix `&` and `\` in a type annotation without parentheses; parenthesise to disambiguate", because `(A & B) \ C` and `A & (B \ C)` differ and neither reading is obviously the intended one. Since grouping parens don't exist in type position today, there is currently no way to write *either* explicitly — don't mix the two operators in one annotation; if you need both, split the narrowing into two steps (e.g. an intermediate local variable annotation).
+```beamtalk
+// subtract a whole union in one step — equivalent to the chain
+// `Symbol \ #a \ #b`, which the algebra normalises to the same result
+tag :: Symbol \ (#a | #b) := #c
+
+// a grouped difference as a union member (parens redundant here — `\`
+// already binds tighter than `|` — but allowed)
+withSentinel: ms :: Integer | (Symbol \ #infinity) => ...
+```
+
+Grouping is also how you mix `&` and `\` in one annotation: **mixing them in the same chain without parentheses is a deliberate parse error**, not a left-associative fallback — `A & B \ #c` is rejected with "Cannot mix `&` and `\` in a type annotation without parentheses; parenthesise to disambiguate", because `(A & B) \ #c` and `A & (B \ #c)` differ and neither reading is obviously the intended one. Parenthesise the reading you mean:
+
+```beamtalk
+// intersect first, then subtract
+narrow -> (A & B) \ #c => ...
+
+// subtract first, then intersect
+narrow -> A & (B \ #c) => ...
+```
 
 The lexer also greedily merges `\\` (two backslashes) into the Smalltalk modulo selector, so a doubled backslash in type position — the natural typo for `\` — gets a targeted diagnostic ("did you mean `\`?") instead of a confusing generic parse error.
 


### PR DESCRIPTION
Implements [BT-2760](https://linear.app/beamtalk/issue/BT-2760) — gives the mixed `&`/`\` diagnostic its escape hatch (follow-up from BT-2743/BT-2746, ADR 0102 §3).

## What

- **Transparent parse, no new AST node:** `parse_single_type_annotation` handles a leading `(` by recursing and returning the inner annotation with its span widened over the parens (new `TypeAnnotation::with_span`). `type_resolver.rs` needed zero changes — transparency pinned by test.
- `(A & B) \ #c`, `A & (B \ #c)`, `Symbol \ (#a | #b)`, `Integer | (Symbol \ #foo)` all parse; the bare mixed chain still errors with the existing "parenthesise to disambiguate" diagnostic (the chain state is per-call, so parenthesised sub-chains are independent).
- `(A | B) | C` splices into a flat n-ary `Union` (canonical, round-trippable).
- Method-header lookahead learned groups (shared `skip_type_operand`/`skip_grouped_type`) so grouped param/return/generic types are still recognised as headers.
- **Unparse re-derives parens** (both `type_name` and the formatter): opposite-tier operands, unions, and same-operator right operands (left-associativity: `Symbol \ (#a \ #b)` must not flatten). Redundant groups collapse. Also fixes a latent formatter bug where `Difference{base: Intersection}` printed as the unparseable `A & B \ #c`.
- Docs: the BT-2746 "no grouping parens yet" limitation note replaced; every doc example pinned by a dedicated parser test.
- Value-expression `(...)` untouched (guard test).

## Verification

`cargo build/test/clippy -p beamtalk-core` green (4435 tests, 23 new); `just build-stdlib` 103 modules, zero diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcZLbDP6grbDwzxkzZjVuk)_