### PR TITLE
Type checker: withTimeout: return-type transparency + cross-process DNU wording (BT-2751)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1420,6 +1420,23 @@ impl TypeChecker {
             // Infer return type from method info
             if let Some(method) = hierarchy.find_method(&resolve_class, &selector_name) {
                 if let Some(ref ret_ty) = method.return_type {
+                    // BT-2751 (ADR 0104 Phase 3): `withTimeout:` return-type
+                    // transparency. The generated-builtins table records the
+                    // static return type `TimeoutProxy`, but the proxy is
+                    // transparent — it forwards every message to the wrapped
+                    // actor and a timed-out call *raises* rather than returning,
+                    // so method return types are unchanged. Typing the result as
+                    // the opaque `TimeoutProxy` would make every forwarded
+                    // selector (`slowDb query: sql`) `Dynamic`. Instead, a
+                    // `withTimeout:` send on a receiver of static type `C` is
+                    // typed as `C` (with its type args preserved), so forwarded
+                    // calls resolve the wrapped class's real return types. The
+                    // table can only hold a static string, so the transparency
+                    // rule is applied here.
+                    if selector_name == "withTimeout:" && ret_ty.as_str() == "TimeoutProxy" {
+                        return receiver_ty.clone();
+                    }
+
                     // `Self` resolves to the static receiver class (with type args)
                     if ret_ty.as_str() == "Self" {
                         if type_args.is_empty() {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1432,8 +1432,15 @@ impl TypeChecker {
                     // typed as `C` (with its type args preserved), so forwarded
                     // calls resolve the wrapped class's real return types. The
                     // table can only hold a static string, so the transparency
-                    // rule is applied here.
-                    if selector_name == "withTimeout:" && ret_ty.as_str() == "TimeoutProxy" {
+                    // rule is applied here. Restricted to Actor subclasses so the
+                    // rule's correctness is an explicit constraint, not an implicit
+                    // consequence of `TimeoutProxy` being inaccessible from user
+                    // code (a user `withTimeout: -> TimeoutProxy` on a non-Actor
+                    // class would otherwise be silently retyped).
+                    if selector_name == "withTimeout:"
+                        && ret_ty.as_str() == "TimeoutProxy"
+                        && hierarchy.is_actor_subclass(&resolve_class)
+                    {
                         return receiver_ty.clone();
                     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1432,11 +1432,13 @@ impl TypeChecker {
                     // typed as `C` (with its type args preserved), so forwarded
                     // calls resolve the wrapped class's real return types. The
                     // table can only hold a static string, so the transparency
-                    // rule is applied here. Restricted to Actor subclasses so the
-                    // rule's correctness is an explicit constraint, not an implicit
-                    // consequence of `TimeoutProxy` being inaccessible from user
-                    // code (a user `withTimeout: -> TimeoutProxy` on a non-Actor
-                    // class would otherwise be silently retyped).
+                    // rule is applied here. Restricted to `Actor` and its
+                    // subclasses (`is_actor_subclass` returns true for the base
+                    // `Actor` itself too) so the rule's correctness is an explicit
+                    // constraint, not an implicit consequence of `TimeoutProxy`
+                    // being inaccessible from user code (a user
+                    // `withTimeout: -> TimeoutProxy` on a non-Actor class would
+                    // otherwise be silently retyped).
                     if selector_name == "withTimeout:"
                         && ret_ty.as_str() == "TimeoutProxy"
                         && hierarchy.is_actor_subclass(&resolve_class)

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
@@ -40,3 +40,4 @@ mod super_and_binary;
 mod typed_class;
 mod union_types;
 mod unions_checking;
+mod with_timeout_transparency;

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/with_timeout_transparency.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/with_timeout_transparency.rs
@@ -68,6 +68,47 @@ fn add_slow_db_actor(hierarchy: &mut ClassHierarchy) {
     hierarchy.add_from_beam_meta(vec![info]);
 }
 
+/// Register a non-Actor `Object` subclass `FakeProxy` that declares its own
+/// `withTimeout: :: Integer -> TimeoutProxy` method — used to pin that the
+/// transparency rule is guarded on Actor-kind and does NOT fire here.
+fn add_fake_proxy_object(hierarchy: &mut ClassHierarchy) {
+    use crate::semantic_analysis::class_hierarchy::{ClassInfo, MethodInfo};
+
+    let info = ClassInfo {
+        name: eco_string("FakeProxy"),
+        superclass: Some(eco_string("Object")),
+        is_sealed: false,
+        is_abstract: false,
+        is_typed: false,
+        is_internal: false,
+        package: None,
+        is_value: false,
+        is_native: false,
+        state: vec![],
+        state_types: std::collections::HashMap::new(),
+        state_has_default: std::collections::HashMap::new(),
+        methods: vec![MethodInfo {
+            selector: eco_string("withTimeout:"),
+            arity: 1,
+            kind: MethodKind::Primary,
+            defined_in: eco_string("FakeProxy"),
+            is_sealed: false,
+            is_internal: false,
+            spawns_block: false,
+            return_type: Some(eco_string("TimeoutProxy")),
+            param_types: vec![Some(eco_string("Integer"))],
+            doc: None,
+        }],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        type_param_bounds: vec![],
+        superclass_type_args: vec![],
+    };
+
+    hierarchy.add_from_beam_meta(vec![info]);
+}
+
 /// Build `receiver withTimeout: <ms>`.
 fn with_timeout(receiver: Expression, ms: i64) -> Expression {
     msg_send(
@@ -135,6 +176,30 @@ fn forwarded_call_on_proxy_infers_wrapped_return_type() {
             .iter()
             .all(|d| d.category != Some(DiagnosticCategory::Dnu)),
         "a real forwarded method must not warn as an unknown selector"
+    );
+}
+
+/// Guard invariant: the transparency rule fires only for `Actor`-kind
+/// receivers. A non-Actor class with its own `withTimeout: -> TimeoutProxy`
+/// method must keep the declared `TimeoutProxy` return, NOT be retyped as the
+/// receiver — otherwise a user type wrapping `withTimeout:` would be silently
+/// mis-typed. Pins the `is_actor_subclass` guard at inference.rs.
+#[test]
+fn non_actor_with_timeout_is_not_retyped() {
+    let mut hierarchy = ClassHierarchy::with_builtins();
+    add_fake_proxy_object(&mut hierarchy);
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local("fp", InferredType::known("FakeProxy"));
+
+    let ty = checker.infer_expr(&with_timeout(var("fp"), 5000), &hierarchy, &mut env, false);
+
+    assert_eq!(
+        ty,
+        InferredType::known("TimeoutProxy"),
+        "a non-Actor class's own `withTimeout: -> TimeoutProxy` must keep its \
+         declared return, not be retyped as the receiver (guard is Actor-only)"
     );
 }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/with_timeout_transparency.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/with_timeout_transparency.rs
@@ -133,10 +133,17 @@ fn forwarded_call_on_proxy_infers_wrapped_return_type() {
         checker
             .take_diagnostics()
             .iter()
-            .all(|d| !d.message.contains("does not understand")),
+            .all(|d| d.category != Some(DiagnosticCategory::Dnu)),
         "a real forwarded method must not warn as an unknown selector"
     );
 }
+
+// Note: `withTimeout:` returns `receiver_ty.clone()`, so type args are
+// preserved by construction for any receiver that reaches the guard. A
+// *generic* receiver (`Queue(Integer)`) is not covered here: parametric
+// receivers route through the generic-substitution path and resolve to
+// `Dynamic` before reaching the transparency rule — a separate inference
+// path, out of scope for ADR 0104 (whose actor examples are non-generic).
 
 /// AC #2 (two-step form via a binding): `slowDb := db withTimeout: 30000`
 /// then `slowDb query: sql` infers `List` — the binding carries the

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/with_timeout_transparency.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/with_timeout_transparency.rs
@@ -1,0 +1,326 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! BT-2751: `withTimeout:` return-type transparency + cross-process DNU
+//! wording (ADR 0104 Phase 3).
+//!
+//! `db withTimeout: 30000` returns a `TimeoutProxy` at runtime, but the proxy
+//! is *transparent*: it forwards every message to the wrapped actor, and a
+//! timed-out call raises rather than returning. So statically the result is
+//! typed as the wrapped receiver's type `C`, not the opaque `TimeoutProxy`.
+//! Forwarded calls therefore resolve the wrapped class's real return types
+//! instead of collapsing to `Dynamic`.
+//!
+//! Three behaviours are pinned here:
+//!
+//! 1. `db withTimeout: 30000` (`db :: SlowDb`) infers `SlowDb` — not
+//!    `TimeoutProxy`, not `Dynamic`.
+//! 2. A forwarded call on the proxy (`(db withTimeout: 30000) query: sql`)
+//!    infers the wrapped method's declared return type (`List`).
+//! 3. An unknown selector on a statically-known actor class gets the *same*
+//!    knowledge-graded DNU diagnostic as a local send — the process boundary
+//!    adds no new severity rule (ADR 0100). Sync actor sends already type as
+//!    method sends (BT-2749), so no code change was needed; this pins it.
+//! 4. A value typed literally as `TimeoutProxy` (the proxy's own type)
+//!    silences unresolved selectors, because `TimeoutProxy` overrides
+//!    `doesNotUnderstand:args:` to forward (ADR 0100).
+
+use super::common::*;
+
+/// Register a `SlowDb` Actor subclass with a `query: :: String -> List`
+/// method, modelling a wrapped actor whose forwarded calls carry a real,
+/// non-`Dynamic` return type.
+fn add_slow_db_actor(hierarchy: &mut ClassHierarchy) {
+    use crate::semantic_analysis::class_hierarchy::{ClassInfo, MethodInfo};
+
+    let info = ClassInfo {
+        name: eco_string("SlowDb"),
+        superclass: Some(eco_string("Actor")),
+        is_sealed: false,
+        is_abstract: false,
+        is_typed: false,
+        is_internal: false,
+        package: None,
+        is_value: false,
+        is_native: false,
+        state: vec![],
+        state_types: std::collections::HashMap::new(),
+        state_has_default: std::collections::HashMap::new(),
+        methods: vec![MethodInfo {
+            selector: eco_string("query:"),
+            arity: 1,
+            kind: MethodKind::Primary,
+            defined_in: eco_string("SlowDb"),
+            is_sealed: false,
+            is_internal: false,
+            spawns_block: false,
+            return_type: Some(eco_string("List")),
+            param_types: vec![Some(eco_string("String"))],
+            doc: None,
+        }],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        type_param_bounds: vec![],
+        superclass_type_args: vec![],
+    };
+
+    hierarchy.add_from_beam_meta(vec![info]);
+}
+
+/// Build `receiver withTimeout: <ms>`.
+fn with_timeout(receiver: Expression, ms: i64) -> Expression {
+    msg_send(
+        receiver,
+        MessageSelector::Keyword(vec![KeywordPart::new("withTimeout:", span())]),
+        vec![int_lit(ms)],
+    )
+}
+
+/// AC #1: `db withTimeout: 30000` on a `SlowDb` receiver infers `SlowDb`
+/// (transparency) — not `TimeoutProxy`, not `Dynamic`.
+#[test]
+fn with_timeout_infers_receiver_type() {
+    let mut hierarchy = ClassHierarchy::with_builtins();
+    add_slow_db_actor(&mut hierarchy);
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local("db", InferredType::known("SlowDb"));
+
+    let ty = checker.infer_expr(&with_timeout(var("db"), 30000), &hierarchy, &mut env, false);
+
+    assert_eq!(
+        ty,
+        InferredType::known("SlowDb"),
+        "`db withTimeout: 30000` must infer the wrapped receiver type SlowDb, \
+         not the opaque TimeoutProxy"
+    );
+    assert!(
+        checker.take_diagnostics().is_empty(),
+        "a well-typed withTimeout: send must not emit diagnostics"
+    );
+}
+
+/// AC #2: a forwarded call on the proxy infers the wrapped method's return
+/// type. `(db withTimeout: 30000) query: sql` → `List`. Before transparency
+/// this collapsed to `Dynamic` (unknown selector on the opaque proxy).
+#[test]
+fn forwarded_call_on_proxy_infers_wrapped_return_type() {
+    let mut hierarchy = ClassHierarchy::with_builtins();
+    add_slow_db_actor(&mut hierarchy);
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local("db", InferredType::known("SlowDb"));
+    env.set_local("sql", InferredType::known("String"));
+
+    let query = msg_send(
+        with_timeout(var("db"), 30000),
+        MessageSelector::Keyword(vec![KeywordPart::new("query:", span())]),
+        vec![var("sql")],
+    );
+
+    let ty = checker.infer_expr(&query, &hierarchy, &mut env, false);
+
+    assert_eq!(
+        ty,
+        InferredType::known("List"),
+        "`(db withTimeout: 30000) query: sql` must infer query:'s declared \
+         return type List through the transparent proxy"
+    );
+    assert!(
+        checker
+            .take_diagnostics()
+            .iter()
+            .all(|d| !d.message.contains("does not understand")),
+        "a real forwarded method must not warn as an unknown selector"
+    );
+}
+
+/// AC #2 (two-step form via a binding): `slowDb := db withTimeout: 30000`
+/// then `slowDb query: sql` infers `List` — the binding carries the
+/// transparent type, so the forwarded call resolves the wrapped method.
+#[test]
+fn proxy_binding_forwards_wrapped_return_type() {
+    let mut hierarchy = ClassHierarchy::with_builtins();
+    add_slow_db_actor(&mut hierarchy);
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local("db", InferredType::known("SlowDb"));
+    env.set_local("sql", InferredType::known("String"));
+
+    // slowDb := db withTimeout: 30000
+    let slow_db_ty =
+        checker.infer_expr(&with_timeout(var("db"), 30000), &hierarchy, &mut env, false);
+    assert_eq!(slow_db_ty, InferredType::known("SlowDb"));
+    env.set_local("slowDb", slow_db_ty);
+
+    // slowDb query: sql
+    let query = msg_send(
+        var("slowDb"),
+        MessageSelector::Keyword(vec![KeywordPart::new("query:", span())]),
+        vec![var("sql")],
+    );
+    let ty = checker.infer_expr(&query, &hierarchy, &mut env, false);
+
+    assert_eq!(
+        ty,
+        InferredType::known("List"),
+        "a binding assigned from withTimeout: must forward the wrapped return type"
+    );
+}
+
+/// Build a `ClassInfo` named `name` under `superclass` with one `log:` method.
+fn logger_class(
+    name: &str,
+    superclass: &str,
+) -> crate::semantic_analysis::class_hierarchy::ClassInfo {
+    use crate::semantic_analysis::class_hierarchy::{ClassInfo, MethodInfo};
+    ClassInfo {
+        name: eco_string(name),
+        superclass: Some(eco_string(superclass)),
+        is_sealed: false,
+        is_abstract: false,
+        is_typed: false,
+        is_internal: false,
+        package: None,
+        is_value: false,
+        is_native: false,
+        state: vec![],
+        state_types: std::collections::HashMap::new(),
+        state_has_default: std::collections::HashMap::new(),
+        methods: vec![MethodInfo {
+            selector: eco_string("log:"),
+            arity: 1,
+            kind: MethodKind::Primary,
+            defined_in: eco_string(name),
+            is_sealed: false,
+            is_internal: false,
+            spawns_block: false,
+            return_type: Some(eco_string("Nil")),
+            param_types: vec![Some(eco_string("String"))],
+            doc: None,
+        }],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        type_param_bounds: vec![],
+        superclass_type_args: vec![],
+    }
+}
+
+/// Send the typo selector `logg:` (for `log:`) to local `recv`.
+fn logg_send(recv: &str) -> Expression {
+    msg_send(
+        var(recv),
+        MessageSelector::Keyword(vec![KeywordPart::new("logg:", span())]),
+        vec![str_lit("hi")],
+    )
+}
+
+/// Infer `logg_send(recv)` against `hierarchy` with `recv :: class_name` and
+/// return the emitted diagnostics.
+fn dnu_diags_for(hierarchy: &ClassHierarchy, recv: &str, class_name: &str) -> Vec<Diagnostic> {
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local(recv, InferredType::known(class_name));
+    checker.infer_expr(&logg_send(recv), hierarchy, &mut env, false);
+    checker.take_diagnostics()
+}
+
+/// AC #3: an unknown selector on a statically-known actor class gets the same
+/// knowledge-graded DNU diagnostic as a local (plain-object) send. The process
+/// boundary adds no new severity rule (ADR 0100); sync actor sends already
+/// route through the shared `check_instance_selector` path (BT-2749), so the
+/// wording is unified with no code change — this test pins it.
+#[test]
+fn cross_process_dnu_wording_matches_local_send() {
+    // Two classes with an identical `log:` method: one an Actor subclass
+    // (cross-process sends), one a plain Object (local sends).
+    let mut hierarchy = ClassHierarchy::with_builtins();
+    hierarchy.add_from_beam_meta(vec![
+        logger_class("ActorLogger", "Actor"),
+        logger_class("LocalLogger", "Object"),
+    ]);
+
+    let actor_diags = dnu_diags_for(&hierarchy, "actorLog", "ActorLogger");
+    let local_diags = dnu_diags_for(&hierarchy, "localLog", "LocalLogger");
+
+    let actor_dnu = actor_diags
+        .iter()
+        .find(|d| d.category == Some(DiagnosticCategory::Dnu))
+        .expect("actor send of unknown selector must emit a DNU diagnostic");
+    let local_dnu = local_diags
+        .iter()
+        .find(|d| d.category == Some(DiagnosticCategory::Dnu))
+        .expect("local send of unknown selector must emit a DNU diagnostic");
+
+    // Same severity grade (ADR 0100), same category, same did-you-mean hint —
+    // the only difference is the receiver class name in the message text.
+    assert_eq!(
+        actor_dnu.severity, local_dnu.severity,
+        "cross-process DNU must have the same severity grade as a local send"
+    );
+    assert_eq!(actor_dnu.category, local_dnu.category);
+    assert_eq!(
+        actor_dnu.hint, local_dnu.hint,
+        "cross-process DNU must carry the same did-you-mean hint"
+    );
+    assert_eq!(
+        actor_dnu.message.as_str(),
+        "ActorLogger does not understand 'logg:'",
+        "cross-process DNU wording must match the unified local-send format"
+    );
+    assert_eq!(
+        local_dnu.message.as_str(),
+        "LocalLogger does not understand 'logg:'"
+    );
+    assert_eq!(
+        actor_dnu.hint.as_deref(),
+        Some("Did you mean 'log:'?"),
+        "the did-you-mean hint must survive the process boundary"
+    );
+
+    // The wording is identical once the receiver class name is factored out.
+    assert_eq!(
+        actor_dnu.message.replace("ActorLogger", "<Recv>"),
+        local_dnu.message.replace("LocalLogger", "<Recv>"),
+        "cross-process and local DNU wording must be unified"
+    );
+}
+
+/// AC #4: a value typed literally as `TimeoutProxy` (the proxy's own type)
+/// must not spuriously warn on any selector — `TimeoutProxy` overrides
+/// `doesNotUnderstand:args:` to forward, and ADR 0100 silences unresolved
+/// selectors on DNU-overriding receivers. This guards against a regression
+/// where transparency would leak a raw-proxy value into DNU checking.
+#[test]
+fn timeout_proxy_forwarded_selectors_do_not_warn() {
+    let hierarchy = ClassHierarchy::with_builtins();
+    assert!(
+        hierarchy.has_instance_dnu_override("TimeoutProxy"),
+        "TimeoutProxy must override doesNotUnderstand:args: for forwarding"
+    );
+
+    let mut checker = TypeChecker::new();
+    let mut env = TypeEnv::new();
+    env.set_local("proxy", InferredType::known("TimeoutProxy"));
+
+    let send = msg_send(
+        var("proxy"),
+        MessageSelector::Keyword(vec![KeywordPart::new("anyForwardedSelector:", span())]),
+        vec![int_lit(1)],
+    );
+    checker.infer_expr(&send, &hierarchy, &mut env, false);
+
+    assert!(
+        checker
+            .take_diagnostics()
+            .iter()
+            .all(|d| d.category != Some(DiagnosticCategory::Dnu)),
+        "an arbitrary selector on a TimeoutProxy-typed value must not warn — \
+         the proxy forwards via doesNotUnderstand:args:"
+    );
+}


### PR DESCRIPTION
## Summary

ADR 0104 Phase 3 ([Epic BT-2747](https://linear.app/beamtalk/issue/BT-2747)). Makes `withTimeout:` transparent to typing and pins cross-process DNU wording.

- **Proxy return-type transparency:** `withTimeout:` was hardcoded to return `TimeoutProxy`, so `slowDb query: sql` collapsed to `Dynamic` on the opaque proxy. Now intercepted in `infer_message_send_with_receiver_ty` — a `withTimeout:` send on a receiver of static type `C` returns `C` (type args preserved), so forwarded calls resolve the wrapped class's real return types. The generated-builtins entry keeps recording the true static `TimeoutProxy` return (accurate for docs/tools, and it's auto-generated from `stdlib/src/Actor.bt`); inference overrides it at the send site, matching how other receiver-type-dependent builtins are handled.
- **Cross-process DNU wording:** no code change needed — sync actor sends already type as method sends (BT-2749) and route through the shared `check_instance_selector` → `emit_unknown_selector_warning` path, producing the same knowledge-graded (ADR 0100) diagnostic as a local send. Added a pin test asserting the actor-send and local-send messages, severity, category, and did-you-mean hint all match (only the receiver class name differs).
- **No false positives** on `TimeoutProxy`'s forwarded selectors (ADR 0100 silences unresolved selectors on DNU-overriding receivers) — regression-tested.

## Test plan

- `cargo test -p beamtalk-core` — 4450 passed, 0 failed (5 new `with_timeout_transparency` tests)
- `cargo clippy -p beamtalk-core --tests` — clean
- `just test-stdlib` — 223/223

Closes BT-2751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Prdqcp7hZd8ocum8ZfU2mk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Prdqcp7hZd8ocum8ZfU2mk)_