### PR TITLE
ADR 0104: integration tests + docs + status flip to Accepted (BT-2752)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/adr_0104_integration.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/adr_0104_integration.rs
@@ -1,0 +1,344 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! ADR 0104 (Typed Actor Protocols) end-to-end integration tests (BT-2752).
+//!
+//! Unlike the per-feature unit tests (`cast_and_sync_send`, `spawn_with_keys`,
+//! `with_timeout_transparency`), which build the AST by hand and call
+//! `infer_expr` directly, these drive the **full diagnostic pipeline from real
+//! Beamtalk source strings** via `parse_source` + `run_with_expect`. They
+//! exercise all four ADR-0104 typing edges the way a user's program would hit
+//! them, so a regression in lexing, parsing, hierarchy construction, or
+//! checking — not just inference — is caught.
+//!
+//! The four edges, each covered here from source:
+//!
+//! 1. **Sync send return type** — `c increment` on an Actor resolves the
+//!    method's declared return (`Integer`).
+//! 2. **Cast (`!`) → `Nil`** — a bare cast statement types as `Nil`.
+//! 3. **`spawnWith:` key checking** — an unknown literal-map key warns with a
+//!    typo suggestion.
+//! 4. **`withTimeout:` transparency + cross-process DNU** — a forwarded call on
+//!    the timeout proxy resolves the wrapped actor's real return type, and an
+//!    unknown selector on a known Actor warns with local-send wording.
+//!
+//! Where "the send types as `T`" cannot be asserted directly (the harness
+//! surfaces diagnostics, not inferred types), we prove it with a **return-type
+//! control**: a method declaring the *wrong* return type over the same body
+//! produces the `check_return_type` mismatch warning ("declares return type X,
+//! but body returns Y") — which only fires when the body is a concrete `Known`
+//! type, so its presence pins the inferred type. Every edge is source-driven;
+//! no edge falls back to the AST-builder style.
+
+use super::common::*;
+
+/// Collect diagnostics whose message reports a `check_return_type` mismatch.
+fn return_type_diags(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
+    diags
+        .iter()
+        .filter(|d| d.message.contains("declares return type"))
+        .collect()
+}
+
+// ── Edge 1: sync send resolves the method's declared return type ────────────
+
+/// End-to-end spawn form (`c := Counter spawn` then `c increment` /
+/// `c getValue`): the sync sends resolve real Actor methods, so the program is
+/// clean — no DNU, no return-type noise.
+#[test]
+fn sync_send_on_spawned_actor_is_clean() {
+    let source = "\
+Actor subclass: Counter
+  state: count = 0
+  increment -> Integer => self.count := self.count + 1
+  getValue -> Integer => self.count
+
+c := Counter spawn
+c increment
+c getValue
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    assert!(
+        diags
+            .iter()
+            .all(|d| d.category != Some(DiagnosticCategory::Dnu)),
+        "sync sends to real Actor methods must not warn as unknown selectors: {diags:?}"
+    );
+    assert!(
+        return_type_diags(&diags).is_empty(),
+        "no return-type diagnostics expected for a clean program: {diags:?}"
+    );
+}
+
+/// Positive: a method declaring `-> Integer` whose body is the sync send
+/// `c increment` (a `-> Integer` Actor method) type-checks clean — proving the
+/// send resolves to `Integer`, the declared return.
+#[test]
+fn sync_send_matching_declared_return_is_clean() {
+    let source = "\
+Actor subclass: Counter
+  state: count = 0
+  increment -> Integer => self.count := self.count + 1
+
+Object subclass: Client
+  useCounter: c :: Counter -> Integer => c increment
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    assert!(
+        return_type_diags(&diags).is_empty(),
+        "`c increment` types as Integer, matching the declared return: {diags:?}"
+    );
+}
+
+/// Return-type control: declaring the *wrong* return (`-> String`) over the
+/// same `c increment` body warns "declares return type String, but body
+/// returns Integer" — pinning the sync send's inferred type as `Integer`.
+#[test]
+fn sync_send_wrong_declared_return_warns_proving_integer() {
+    let source = "\
+Actor subclass: Counter
+  state: count = 0
+  increment -> Integer => self.count := self.count + 1
+
+Object subclass: Client
+  useCounter: c :: Counter -> String => c increment
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let mismatches = return_type_diags(&diags);
+    assert_eq!(
+        mismatches.len(),
+        1,
+        "expected exactly one return-type mismatch: {diags:?}"
+    );
+    assert!(
+        mismatches[0].message.contains("String") && mismatches[0].message.contains("Integer"),
+        "mismatch must name declared String and inferred Integer: {}",
+        mismatches[0].message
+    );
+    assert!(
+        mismatches[0].message.contains("body returns Integer"),
+        "the sync send must be inferred as Integer: {}",
+        mismatches[0].message
+    );
+}
+
+// ── Edge 2: a bare cast statement (`!`) types as `Nil` ──────────────────────
+
+/// Positive: a method declaring `-> Nil` whose body ends in a bare cast
+/// (`c increment!`) type-checks clean — the fire-and-forget cast evaluates to
+/// `Nil`, matching the declared return.
+#[test]
+fn bare_cast_matching_nil_return_is_clean() {
+    let source = "\
+Actor subclass: Counter
+  state: count = 0
+  increment -> Integer => self.count := self.count + 1
+
+Object subclass: Client
+  notify: c :: Counter -> Nil => c increment!
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    assert!(
+        return_type_diags(&diags).is_empty(),
+        "a bare cast body types as Nil, matching `-> Nil`: {diags:?}"
+    );
+}
+
+/// Return-type control (the ADR migration case): declaring a non-`Nil` return
+/// (`-> Integer`) over a body that *ends in a bare cast* newly warns "body
+/// returns Nil" — pinning the cast statement's type as `Nil` even though the
+/// cast target (`increment`) itself declares `-> Integer`.
+#[test]
+fn bare_cast_under_nonnil_return_warns_body_returns_nil() {
+    let source = "\
+Actor subclass: Counter
+  state: count = 0
+  increment -> Integer => self.count := self.count + 1
+
+Object subclass: Client
+  notify: c :: Counter -> Integer => c increment!
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let mismatches = return_type_diags(&diags);
+    assert_eq!(
+        mismatches.len(),
+        1,
+        "expected exactly one return-type mismatch for the bare-cast tail: {diags:?}"
+    );
+    assert!(
+        mismatches[0].message.contains("Integer") && mismatches[0].message.contains("Nil"),
+        "mismatch must name declared Integer and inferred Nil: {}",
+        mismatches[0].message
+    );
+    assert!(
+        mismatches[0].message.contains("body returns Nil"),
+        "the bare cast statement must be inferred as Nil: {}",
+        mismatches[0].message
+    );
+}
+
+// ── Edge 3: `spawnWith:` literal-map key checking ───────────────────────────
+
+/// An unknown `spawnWith:` map key warns (a Warning per ADR 0100's
+/// provably-failing tier) and names the nearest declared slot as a suggestion.
+#[test]
+fn spawn_with_unknown_key_warns_with_suggestion() {
+    let source = "\
+Actor subclass: Counter
+  state: count = 0
+
+Counter spawnWith: #{#cuont => 0}
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let key_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("state key"))
+        .collect();
+    assert_eq!(
+        key_diags.len(),
+        1,
+        "expected one unknown-key warning: {diags:?}"
+    );
+    assert_eq!(
+        key_diags[0].severity,
+        crate::source_analysis::Severity::Warning
+    );
+    assert!(
+        key_diags[0].message.contains("cuont")
+            && key_diags[0].message.contains("count")
+            && key_diags[0].message.contains("did you mean"),
+        "warning must name the unknown key `cuont`, suggest `count`, and read \
+         as a typo suggestion: {}",
+        key_diags[0].message
+    );
+}
+
+/// A known `spawnWith:` map key (matching a declared `state:` slot) produces no
+/// key warning — the constructor is well-formed.
+#[test]
+fn spawn_with_known_key_is_clean() {
+    let source = "\
+Actor subclass: Counter
+  state: count = 0
+
+Counter spawnWith: #{#count => 0}
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    assert!(
+        diags.iter().all(|d| !d.message.contains("state key")),
+        "a declared slot key must not warn: {diags:?}"
+    );
+}
+
+// ── Edge 4: `withTimeout:` transparency + cross-process DNU ──────────────────
+
+/// Positive: a forwarded call through the timeout proxy
+/// (`(db withTimeout: 30000) query: "..."`) resolves `query:`'s declared return
+/// (`List`), so a method declaring `-> List` over that body is clean. Before
+/// transparency the proxy collapsed the forwarded call to `Dynamic`.
+#[test]
+fn with_timeout_forwarded_call_resolves_wrapped_return() {
+    let source = "\
+Actor subclass: SlowDb
+  state: rows = nil
+  query: sql :: String -> List => #(1, 2, 3)
+
+Object subclass: Client
+  run: db :: SlowDb -> List => (db withTimeout: 30000) query: \"SELECT\"
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    assert!(
+        return_type_diags(&diags).is_empty(),
+        "the forwarded `query:` resolves List through the transparent proxy: {diags:?}"
+    );
+    assert!(
+        diags
+            .iter()
+            .all(|d| d.category != Some(DiagnosticCategory::Dnu)),
+        "a real forwarded method must not warn as an unknown selector: {diags:?}"
+    );
+}
+
+/// Return-type control for transparency: declaring the wrong return
+/// (`-> String`) over the forwarded `query:` body warns "body returns List" —
+/// pinning that `withTimeout:` is transparent (result typed `SlowDb`) and the
+/// forwarded call resolves `query:`'s real `List` return, not `Dynamic`.
+#[test]
+fn with_timeout_wrong_return_warns_proving_list() {
+    let source = "\
+Actor subclass: SlowDb
+  state: rows = nil
+  query: sql :: String -> List => #(1, 2, 3)
+
+Object subclass: Client
+  run: db :: SlowDb -> String => (db withTimeout: 30000) query: \"SELECT\"
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let mismatches = return_type_diags(&diags);
+    assert_eq!(
+        mismatches.len(),
+        1,
+        "expected one return-type mismatch for the forwarded call: {diags:?}"
+    );
+    assert!(
+        mismatches[0].message.contains("String") && mismatches[0].message.contains("List"),
+        "mismatch must name declared String and forwarded List: {}",
+        mismatches[0].message
+    );
+    assert!(
+        mismatches[0].message.contains("body returns List"),
+        "the forwarded proxy call must be inferred as List: {}",
+        mismatches[0].message
+    );
+}
+
+/// Cross-process DNU: an unknown selector on a statically-known Actor
+/// (`logger logg: "hi"`) warns with the *same wording as a local send* — the
+/// process boundary is invisible to the diagnostic (ADR 0100). Matches the
+/// ADR's error example, including the did-you-mean hint naming `log:`.
+#[test]
+fn cross_process_dnu_warns_like_local_send() {
+    let source = "\
+Actor subclass: Logger
+  state: sink = nil
+  log: msg => self.sink := msg
+
+Object subclass: Client
+  useLogger: logger :: Logger => logger logg: \"hi\"
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let dnu = diags
+        .iter()
+        .find(|d| d.category == Some(DiagnosticCategory::Dnu))
+        .expect("an unknown selector on a known Actor must emit a DNU diagnostic");
+    assert_eq!(
+        dnu.message.as_str(),
+        "Logger does not understand 'logg:'",
+        "cross-process DNU wording must match the unified local-send format"
+    );
+    assert_eq!(
+        dnu.hint.as_deref(),
+        Some("Did you mean 'log:'?"),
+        "the did-you-mean hint must survive the process boundary"
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
@@ -8,6 +8,7 @@
 
 mod common;
 
+mod adr_0104_integration;
 mod arg_return_checking;
 mod basic_inference;
 mod cast_and_sync_send;

--- a/docs/ADR/0104-typed-actor-protocols.md
+++ b/docs/ADR/0104-typed-actor-protocols.md
@@ -1,7 +1,8 @@
 # ADR 0104: Typed Actor Protocols — the Class Interface Is the Protocol
 
 ## Status
-Proposed (2026-07-05)
+Accepted (2026-07-07) — implemented via Epic BT-2747 (Phases 1–4,
+BT-2749…BT-2752).
 
 ## Implementation Tracking
 
@@ -17,7 +18,10 @@ Proposed (2026-07-05)
 
 Sibling epic **[BT-2748](https://linear.app/beamtalk/issue/BT-2748)** (ADR 0103): BT-2750 shares the `spawnWith:` `MapLiteral` call-site inspection with BT-2755 (`related-to`, either order).
 
-**Status:** Planned
+**Status:** Implemented — all four phases (BT-2749…BT-2752) landed: sync-send
+typing + cast→`Nil` (Phase 1), `spawnWith:` key checking (Phase 2),
+`withTimeout:` transparency + cross-process DNU wording (Phase 3), and
+integration tests + docs + this status flip (Phase 4).
 
 ## Context
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -1966,6 +1966,46 @@ infDb stop
 
 **Lifecycle:** The proxy is a separate actor process. Capture the reference and call `stop` when finished to avoid leaking processes.
 
+### Static Typing of Actor Protocols (ADR 0104)
+
+An `Actor subclass:`'s public method set *is* its message protocol — the checker types actor sends exactly as ordinary method sends, with no parallel channel type and no new syntax. Four typing rules apply (all advisory per [ADR 0100](ADR/0100-diagnostic-severity-open-world.md), and static-only — no runtime, codegen, or wire change):
+
+1. **A sync send types as the method's return.** `c increment` on a `Counter` whose `increment` declares (or infers) `-> Integer` types as `Integer`, and forwards its declared/inferred return to callers:
+
+   ```beamtalk
+   c := Counter spawn
+   c increment          // :: Integer — the method's declared/inferred return
+   ```
+
+2. **A bare cast (`!`) types as `Nil`.** The fire-and-forget `gen_server:cast` has no synchronous reply, so a cast *statement* evaluates to `Nil` regardless of the target method's return type. (Using a cast's value in an assignment, return, or argument is already a parse error — see **Explicit Async Cast** above). One consequence: a method declaring a non-`Nil` return whose body *ends* in a bare cast now warns "body returns Nil" — usually a genuine bug where a mutator returns nothing:
+
+   ```beamtalk
+   c increment!         // :: Nil — no reply is awaited
+
+   // ⚠️ Method 'bump' declares return type Integer, but body returns Nil
+   bump -> Integer => c increment!
+   ```
+
+3. **`spawnWith:` keys are checked against `state:` slots.** The keys of a literal init-state map are validated against the actor's declared `state:` slots; an unknown key is a Warning (a provably-failing construction, not merely an unresolved selector) with a typo suggestion naming the nearest slot. When a slot is typed, the literal value's type is checked against it too:
+
+   ```beamtalk
+   Counter spawnWith: #{#count => 0}     // :: Counter — key `count` is a declared slot
+   Counter spawnWith: #{#cuont => 0}     // ⚠️ unknown state key `cuont` — did you mean `count`?
+   ```
+
+   Only a *literal* map is inspected; a `spawnWith:` argument flowing in through a variable is not key-checked. The rule fires only for `Actor subclass:` receivers.
+
+4. **`withTimeout:` is transparent; cross-process DNU grades like a local send.** `withTimeout:` returns a value typed as the *wrapped* actor (not the opaque `TimeoutProxy`), so forwarded calls resolve the wrapped class's real return types. A timeout raises rather than returning, so method return types are unchanged. An unknown selector on a statically-known actor gets the same knowledge-graded [ADR 0100](ADR/0100-diagnostic-severity-open-world.md) diagnostic as a local send — the process boundary is invisible to the checker:
+
+   ```beamtalk
+   (db withTimeout: 30000) query: sql    // resolves query:'s real return, not Dynamic
+
+   logger := Logger spawn
+   logger logg: "hi"                     // ⚠️ Logger does not understand 'logg:' — did you mean 'log:'?
+   ```
+
+See [ADR 0104](ADR/0104-typed-actor-protocols.md) for the full rationale, prior art, and the metaclass-aware constructor inference (ADR 0083) that types `spawn` / `spawnWith:`.
+
 ### BEAM Mapping
 
 | Beamtalk | BEAM |


### PR DESCRIPTION
## Summary

Final issue of ADR 0104 ([Epic BT-2747](https://linear.app/beamtalk/issue/BT-2747)) — validation, docs, and closeout. Flips ADR 0104 from Proposed to **Accepted**.

- **Integration tests** (`tests/adr_0104_integration.rs`, 10 tests) — drive the full diagnostic pipeline from real Beamtalk source (`parse_source` + `run_with_expect`), covering all four ADR-0104 edges end-to-end. Since the harness surfaces diagnostics (not inferred types), the "types as T" edges are pinned with a return-type control (declaring the wrong return over the same body triggers the `check_return_type` mismatch, which only fires on a concrete `Known` body):
  - Sync send return type — `c := Counter spawn; c increment` (positive `-> Integer` clean + negative `-> String` warns).
  - Cast → `Nil` — `c increment!` clean under `-> Nil`, warns under `-> Integer` (the ADR migration case).
  - `spawnWith:` unknown key — `Counter spawnWith: #{#cuont => 0}` warns naming `cuont` + "did you mean `count`?".
  - `withTimeout:` transparency + cross-process DNU — `(db withTimeout: 30000) query: "…"` resolves `query:`'s real `List`; `logger logg: "hi"` warns `Logger does not understand 'logg:'` with a `Did you mean 'log:'?` hint.
- **Docs** — new "Static Typing of Actor Protocols (ADR 0104)" subsection in `docs/beamtalk-language-features.md` (the four rules with examples, cross-referencing ADR 0104 / ADR 0100). No surface-parity note needed — diagnostics flow through the shared compiler path, equivalent across surfaces by construction.
- **ADR 0104 status** — `Proposed (2026-07-05)` → `Accepted (2026-07-07) — implemented via Epic BT-2747 (Phases 1–4)`; tracking `**Status:** Planned` → `Implemented`.

## Test plan

- `cargo test -p beamtalk-core` — 4461 passed, 0 failed (+10 new; doctests ok)
- `cargo clippy -p beamtalk-core --tests` — clean
- `just test-stdlib` — 223/223

Closes BT-2752. Completes Epic BT-2747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Prdqcp7hZd8ocum8ZfU2mk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Prdqcp7hZd8ocum8ZfU2mk)_