### PR TITLE
Retire superseded compiler code paths (deprecated Position byte-offset methods, token full_span() trivia stub) (BT-2769)

### DIFF
--- a/crates/beamtalk-core/src/language_service/value_objects.rs
+++ b/crates/beamtalk-core/src/language_service/value_objects.rs
@@ -90,20 +90,6 @@ impl Position {
         Some(Self::new(line, (offset_val - line_start) as u32))
     }
 
-    /// Converts a byte offset to a position given source text (legacy).
-    ///
-    /// Returns `None` if the offset is out of bounds.
-    ///
-    /// **Deprecated:** Use `from_byte_offset` for type safety.
-    #[must_use]
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "source files over 4GB are not supported"
-    )]
-    pub fn from_offset(source: &str, offset: usize) -> Option<Self> {
-        Self::from_byte_offset(source, ByteOffset::new(offset as u32))
-    }
-
     /// Converts a position to a byte offset given source text.
     ///
     /// Returns `None` if the position is out of bounds.
@@ -113,21 +99,6 @@ impl Position {
         reason = "source files over 4GB are not supported"
     )]
     pub fn to_byte_offset(self, source: &str) -> Option<ByteOffset> {
-        self.to_offset(source)
-            .map(|off| ByteOffset::new(off as u32))
-    }
-
-    /// Converts a position to a byte offset given source text (legacy).
-    ///
-    /// Returns `None` if the position is out of bounds.
-    ///
-    /// **Deprecated:** Use `to_byte_offset` for type safety.
-    #[must_use]
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "source files over 4GB are not supported"
-    )]
-    pub fn to_offset(self, source: &str) -> Option<usize> {
         let mut current_line = 0;
         let mut line_start = 0;
 
@@ -135,7 +106,7 @@ impl Position {
             if current_line == self.line {
                 let col = (i - line_start) as u32;
                 if col == self.column {
-                    return Some(i);
+                    return Some(ByteOffset::new(i as u32));
                 }
             }
             if ch == '\n' {
@@ -152,7 +123,7 @@ impl Position {
         if current_line == self.line {
             let col = (source.len() - line_start) as u32;
             if col == self.column {
-                return Some(source.len());
+                return Some(ByteOffset::new(source.len() as u32));
             }
         }
 
@@ -442,78 +413,165 @@ mod tests {
     use super::*;
 
     #[test]
-    fn position_from_offset() {
+    fn position_from_byte_offset() {
         let source = "hello\nworld\n!";
-        assert_eq!(Position::from_offset(source, 0), Some(Position::new(0, 0)));
-        assert_eq!(Position::from_offset(source, 5), Some(Position::new(0, 5)));
-        assert_eq!(Position::from_offset(source, 6), Some(Position::new(1, 0)));
-        assert_eq!(Position::from_offset(source, 11), Some(Position::new(1, 5)));
-        assert_eq!(Position::from_offset(source, 12), Some(Position::new(2, 0)));
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(0)),
+            Some(Position::new(0, 0))
+        );
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(5)),
+            Some(Position::new(0, 5))
+        );
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(6)),
+            Some(Position::new(1, 0))
+        );
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(11)),
+            Some(Position::new(1, 5))
+        );
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(12)),
+            Some(Position::new(2, 0))
+        );
     }
 
     #[test]
-    fn position_to_offset() {
+    fn position_to_byte_offset() {
         let source = "hello\nworld\n!";
-        assert_eq!(Position::new(0, 0).to_offset(source), Some(0));
-        assert_eq!(Position::new(0, 5).to_offset(source), Some(5));
-        assert_eq!(Position::new(1, 0).to_offset(source), Some(6));
-        assert_eq!(Position::new(1, 5).to_offset(source), Some(11));
-        assert_eq!(Position::new(2, 0).to_offset(source), Some(12));
+        assert_eq!(
+            Position::new(0, 0).to_byte_offset(source),
+            Some(ByteOffset::new(0))
+        );
+        assert_eq!(
+            Position::new(0, 5).to_byte_offset(source),
+            Some(ByteOffset::new(5))
+        );
+        assert_eq!(
+            Position::new(1, 0).to_byte_offset(source),
+            Some(ByteOffset::new(6))
+        );
+        assert_eq!(
+            Position::new(1, 5).to_byte_offset(source),
+            Some(ByteOffset::new(11))
+        );
+        assert_eq!(
+            Position::new(2, 0).to_byte_offset(source),
+            Some(ByteOffset::new(12))
+        );
     }
 
     // UTF-8 multi-byte character tests
     #[test]
-    fn position_from_offset_with_multibyte_utf8() {
+    fn position_from_byte_offset_with_multibyte_utf8() {
         // "héllo" has é as 2 bytes (0xC3 0xA9), total 6 bytes
         let source = "héllo";
-        assert_eq!(Position::from_offset(source, 0), Some(Position::new(0, 0))); // h
-        assert_eq!(Position::from_offset(source, 1), Some(Position::new(0, 1))); // start of é
-        assert_eq!(Position::from_offset(source, 3), Some(Position::new(0, 3))); // l (after 2-byte é)
-        assert_eq!(Position::from_offset(source, 6), Some(Position::new(0, 6))); // end of string
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(0)),
+            Some(Position::new(0, 0))
+        ); // h
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(1)),
+            Some(Position::new(0, 1))
+        ); // start of é
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(3)),
+            Some(Position::new(0, 3))
+        ); // l (after 2-byte é)
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(6)),
+            Some(Position::new(0, 6))
+        ); // end of string
     }
 
     #[test]
-    fn position_from_offset_with_emoji() {
+    fn position_from_byte_offset_with_emoji() {
         // "a🎉b" has 🎉 as 4 bytes, total 6 bytes
         let source = "a🎉b";
-        assert_eq!(Position::from_offset(source, 0), Some(Position::new(0, 0))); // a
-        assert_eq!(Position::from_offset(source, 1), Some(Position::new(0, 1))); // start of 🎉
-        assert_eq!(Position::from_offset(source, 5), Some(Position::new(0, 5))); // b (after 4-byte emoji)
-        assert_eq!(Position::from_offset(source, 6), Some(Position::new(0, 6))); // end
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(0)),
+            Some(Position::new(0, 0))
+        ); // a
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(1)),
+            Some(Position::new(0, 1))
+        ); // start of 🎉
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(5)),
+            Some(Position::new(0, 5))
+        ); // b (after 4-byte emoji)
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(6)),
+            Some(Position::new(0, 6))
+        ); // end
     }
 
     #[test]
-    fn position_from_offset_with_cjk() {
+    fn position_from_byte_offset_with_cjk() {
         // "日本" has 2 CJK chars, each 3 bytes, total 6 bytes
         let source = "日本";
-        assert_eq!(Position::from_offset(source, 0), Some(Position::new(0, 0))); // 日
-        assert_eq!(Position::from_offset(source, 3), Some(Position::new(0, 3))); // 本
-        assert_eq!(Position::from_offset(source, 6), Some(Position::new(0, 6))); // end
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(0)),
+            Some(Position::new(0, 0))
+        ); // 日
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(3)),
+            Some(Position::new(0, 3))
+        ); // 本
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(6)),
+            Some(Position::new(0, 6))
+        ); // end
     }
 
     #[test]
-    fn position_to_offset_with_multibyte_utf8() {
+    fn position_to_byte_offset_with_multibyte_utf8() {
         let source = "héllo";
-        assert_eq!(Position::new(0, 0).to_offset(source), Some(0)); // h
-        assert_eq!(Position::new(0, 1).to_offset(source), Some(1)); // start of é
-        assert_eq!(Position::new(0, 3).to_offset(source), Some(3)); // l
-        assert_eq!(Position::new(0, 6).to_offset(source), Some(6)); // end
+        assert_eq!(
+            Position::new(0, 0).to_byte_offset(source),
+            Some(ByteOffset::new(0))
+        ); // h
+        assert_eq!(
+            Position::new(0, 1).to_byte_offset(source),
+            Some(ByteOffset::new(1))
+        ); // start of é
+        assert_eq!(
+            Position::new(0, 3).to_byte_offset(source),
+            Some(ByteOffset::new(3))
+        ); // l
+        assert_eq!(
+            Position::new(0, 6).to_byte_offset(source),
+            Some(ByteOffset::new(6))
+        ); // end
     }
 
     #[test]
-    fn position_from_offset_multiline_with_utf8() {
+    fn position_from_byte_offset_multiline_with_utf8() {
         // Test multiline with UTF-8
         let source = "héllo\nwörld";
-        assert_eq!(Position::from_offset(source, 0), Some(Position::new(0, 0))); // h
-        assert_eq!(Position::from_offset(source, 7), Some(Position::new(1, 0))); // w (after "héllo\n" which is 7 bytes)
-        assert_eq!(Position::from_offset(source, 8), Some(Position::new(1, 1))); // start of ö
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(0)),
+            Some(Position::new(0, 0))
+        ); // h
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(7)),
+            Some(Position::new(1, 0))
+        ); // w (after "héllo\n" which is 7 bytes)
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(8)),
+            Some(Position::new(1, 1))
+        ); // start of ö
     }
 
     #[test]
     fn position_out_of_bounds() {
         let source = "hello";
-        assert_eq!(Position::from_offset(source, 100), None);
-        assert_eq!(Position::new(10, 0).to_offset(source), None);
-        assert_eq!(Position::new(0, 100).to_offset(source), None);
+        assert_eq!(
+            Position::from_byte_offset(source, ByteOffset::new(100)),
+            None
+        );
+        assert_eq!(Position::new(10, 0).to_byte_offset(source), None);
+        assert_eq!(Position::new(0, 100).to_byte_offset(source), None);
     }
 }

--- a/crates/beamtalk-core/src/queries/completion_provider.rs
+++ b/crates/beamtalk-core/src/queries/completion_provider.rs
@@ -132,13 +132,8 @@ pub fn compute_completions(
     native_types: Option<&NativeTypeRegistry>,
 ) -> Vec<Completion> {
     // Validate position is within bounds
-    let offset = match position.to_offset(source) {
-        Some(o) => {
-            // Source files won't exceed u32::MAX bytes
-            #[expect(clippy::cast_possible_truncation, reason = "source files < 4GB")]
-            let offset = o as u32;
-            offset
-        }
+    let offset = match position.to_byte_offset(source) {
+        Some(o) => o.get(),
         None => return Vec::new(),
     };
     let mut completions = Vec::new();

--- a/crates/beamtalk-core/src/queries/hover_provider.rs
+++ b/crates/beamtalk-core/src/queries/hover_provider.rs
@@ -1422,6 +1422,7 @@ fn class_reference_hover_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::language_service::ByteOffset;
     use crate::semantic_analysis::ClassHierarchy;
     use crate::source_analysis::{lex_with_eof, parse};
 
@@ -1431,6 +1432,13 @@ mod tests {
         let (module, _) = parse(tokens);
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
         compute_hover(&module, source, position, &hierarchy, None)
+    }
+
+    /// Converts a byte offset (as returned by `str::find`/`str::rfind`) to a
+    /// `Position`, for test convenience.
+    fn pos_at(source: &str, offset: usize) -> Position {
+        let offset = u32::try_from(offset).expect("test source under 4GB");
+        Position::from_byte_offset(source, ByteOffset::new(offset)).unwrap()
     }
 
     #[test]
@@ -1502,7 +1510,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let selector_offset = source.rfind("increment").unwrap();
-        let pos = Position::from_offset(source, selector_offset).unwrap();
+        let pos = pos_at(source, selector_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         assert!(hover.is_some(), "Should hover call-site selector");
         let hover = hover.unwrap();
@@ -1631,7 +1639,7 @@ mod tests {
         // "self" appears at offset 59 in the method body
         // Find the exact offset of "self" in the source
         let self_offset = source.find("self.count").unwrap();
-        let pos = Position::from_offset(source, self_offset).unwrap();
+        let pos = pos_at(source, self_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         assert!(hover.is_some(), "Should find hover for self");
         let hover = hover.unwrap();
@@ -1651,7 +1659,7 @@ mod tests {
 
         // Find "self" in the class method body
         let class_method_self = source.find("self new:").unwrap();
-        let pos = Position::from_offset(source, class_method_self).unwrap();
+        let pos = pos_at(source, class_method_self);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         assert!(
             hover.is_some(),
@@ -1675,7 +1683,7 @@ mod tests {
 
         // Find the position of the top-level "Counter" reference
         let counter_pos = source.rfind("Counter").unwrap();
-        let pos = Position::from_offset(source, counter_pos).unwrap();
+        let pos = pos_at(source, counter_pos);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         assert!(hover.is_some(), "Should find hover for Counter reference");
         let hover = hover.unwrap();
@@ -1704,7 +1712,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let offset = source.find("count ::").unwrap();
-        let pos = Position::from_offset(source, offset).unwrap();
+        let pos = pos_at(source, offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
 
         assert!(hover.is_some(), "Should hover state declaration name");
@@ -1742,7 +1750,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let offset = source.find("count =").unwrap();
-        let pos = Position::from_offset(source, offset).unwrap();
+        let pos = pos_at(source, offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
 
         assert!(
@@ -1826,7 +1834,7 @@ mod tests {
         // Position at the `x` inside the `ifFalse:` block, not the
         // declaration or the guard.
         let offset = source.rfind("[x]").unwrap() + 1;
-        let pos = Position::from_offset(source, offset).unwrap();
+        let pos = pos_at(source, offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         assert!(hover.is_some(), "Should hover on narrowed `x`");
         let hover = hover.unwrap();
@@ -1881,7 +1889,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let self_offset = source.find("self.count").unwrap();
-        let pos = Position::from_offset(source, self_offset).unwrap();
+        let pos = pos_at(source, self_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         assert!(
             hover.is_some(),
@@ -1903,7 +1911,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let self_offset = source.find("self new:").unwrap();
-        let pos = Position::from_offset(source, self_offset).unwrap();
+        let pos = pos_at(source, self_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         assert!(
             hover.is_some(),
@@ -1925,7 +1933,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let selector_offset = source.find("increment =>").unwrap();
-        let pos = Position::from_offset(source, selector_offset).unwrap();
+        let pos = pos_at(source, selector_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
 
         assert!(hover.is_some(), "Should hover method declaration selector");
@@ -1945,7 +1953,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let selector_offset = source.find("at:").unwrap();
-        let pos = Position::from_offset(source, selector_offset).unwrap();
+        let pos = pos_at(source, selector_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
 
         assert!(hover.is_some(), "Should hover keyword declaration selector");
@@ -1965,7 +1973,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let param_offset = source.find("aBlock ::").unwrap();
-        let pos = Position::from_offset(source, param_offset).unwrap();
+        let pos = pos_at(source, param_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
 
         assert!(hover.is_some(), "Should hover typed parameter name");
@@ -1985,7 +1993,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let param_type_offset = source.find("Block ->").unwrap();
-        let param_type_pos = Position::from_offset(source, param_type_offset).unwrap();
+        let param_type_pos = pos_at(source, param_type_offset);
         let param_type_hover = compute_hover(&module, source, param_type_pos, &hierarchy, None);
         assert!(param_type_hover.is_some(), "Should hover parameter type");
         let param_type_hover = param_type_hover.unwrap();
@@ -1998,7 +2006,7 @@ mod tests {
         );
 
         let return_type_offset = source.find("-> Boolean").unwrap() + 3;
-        let return_type_pos = Position::from_offset(source, return_type_offset).unwrap();
+        let return_type_pos = pos_at(source, return_type_offset);
         let return_type_hover = compute_hover(&module, source, return_type_pos, &hierarchy, None);
         assert!(return_type_hover.is_some(), "Should hover return type");
         let return_type_hover = return_type_hover.unwrap();
@@ -2019,7 +2027,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let selector_offset = source.find("increment ->").unwrap();
-        let pos = Position::from_offset(source, selector_offset).unwrap();
+        let pos = pos_at(source, selector_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
 
         assert!(hover.is_some(), "Should hover declaration selector");
@@ -2048,7 +2056,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let object_offset = source.find("Object").unwrap();
-        let pos = Position::from_offset(source, object_offset).unwrap();
+        let pos = pos_at(source, object_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
 
         assert!(hover.is_some(), "Should hover superclass identifier");
@@ -2068,7 +2076,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let class_offset = source.find("Counter").unwrap();
-        let pos = Position::from_offset(source, class_offset).unwrap();
+        let pos = pos_at(source, class_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
 
         assert!(hover.is_some(), "Should hover class declaration name");
@@ -2091,7 +2099,7 @@ mod tests {
         // Hovering over `size` in `"hello" size` should show `size -> Integer`
         // "hello" is 7 chars, space at 7, size starts at 8
         let source = r#""hello" size"#;
-        let pos = Position::from_offset(source, 8).unwrap(); // inside "size"
+        let pos = pos_at(source, 8); // inside "size"
         let hover = hover_at(source, pos);
         assert!(hover.is_some(), "Should hover on stdlib selector");
         let hover = hover.unwrap();
@@ -2107,7 +2115,7 @@ mod tests {
         // Hovering over `abs` in `"hello" size abs` should show `abs -> Integer`
         // "hello" size = 12 chars, space at 12, abs at 13-15
         let source = r#""hello" size abs"#;
-        let pos = Position::from_offset(source, 13).unwrap(); // inside "abs"
+        let pos = pos_at(source, 13); // inside "abs"
         let hover = hover_at(source, pos);
         assert!(hover.is_some(), "Should hover on chained selector");
         let hover = hover.unwrap();
@@ -2127,7 +2135,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let selector_offset = source.rfind("value").unwrap();
-        let pos = Position::from_offset(source, selector_offset).unwrap();
+        let pos = pos_at(source, selector_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         assert!(
             hover.is_some(),
@@ -2150,7 +2158,7 @@ mod tests {
         let hierarchy = ClassHierarchy::build(&module).0.unwrap();
 
         let selector_offset = source.rfind("value").unwrap();
-        let pos = Position::from_offset(source, selector_offset).unwrap();
+        let pos = pos_at(source, selector_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         assert!(
             hover.is_some(),
@@ -2323,7 +2331,7 @@ mod tests {
 
         // Hover over "helper" method selector
         let helper_offset = source.find("helper").unwrap();
-        let pos = Position::from_offset(source, helper_offset).unwrap();
+        let pos = pos_at(source, helper_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         assert!(hover.is_some(), "Should hover on internal method selector");
         let hover = hover.unwrap();
@@ -2368,7 +2376,7 @@ mod tests {
         // Source: "Erlang lists reverse: #(1, 2, 3)"
         //         0123456789012345678901234
         let reverse_offset = source.find("reverse").unwrap();
-        let pos = Position::from_offset(source, reverse_offset).unwrap();
+        let pos = pos_at(source, reverse_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, Some(&registry));
         let hover = hover.expect("should get hover for FFI selector");
         assert!(
@@ -2401,7 +2409,7 @@ mod tests {
 
         // Hover over "reverse:" — no registry provided
         let reverse_offset = source.find("reverse").unwrap();
-        let pos = Position::from_offset(source, reverse_offset).unwrap();
+        let pos = pos_at(source, reverse_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         let hover = hover.expect("should get hover even without registry");
         let doc = hover.documentation.as_deref().unwrap_or("");
@@ -2421,7 +2429,7 @@ mod tests {
 
         // Hover over the `x` in the method body (the return expression)
         let body_x_offset = source.rfind('x').unwrap();
-        let pos = Position::from_offset(source, body_x_offset).unwrap();
+        let pos = pos_at(source, body_x_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         let hover = hover.expect("should get hover for unannotated param reference");
         assert!(
@@ -2441,7 +2449,7 @@ mod tests {
 
         // Hover over the `x` in the method body
         let body_x_offset = source.rfind('x').unwrap();
-        let pos = Position::from_offset(source, body_x_offset).unwrap();
+        let pos = pos_at(source, body_x_offset);
         let hover = compute_hover(&module, source, pos, &hierarchy, None);
         let hover = hover.expect("should get hover for annotated param reference");
         assert!(

--- a/crates/beamtalk-core/src/queries/signature_help_provider.rs
+++ b/crates/beamtalk-core/src/queries/signature_help_provider.rs
@@ -50,11 +50,7 @@ pub fn compute_signature_help(
     hierarchy: &ClassHierarchy,
     native_types: Option<&NativeTypeRegistry>,
 ) -> Option<SignatureHelp> {
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "source files over 4GB are not supported"
-    )]
-    let offset = position.to_offset(source)? as u32;
+    let offset = position.to_byte_offset(source)?.get();
     let type_map = infer_types(module, hierarchy);
 
     // Search top-level expressions

--- a/crates/beamtalk-core/src/source_analysis/token.rs
+++ b/crates/beamtalk-core/src/source_analysis/token.rs
@@ -477,17 +477,6 @@ impl Token {
         self.span
     }
 
-    /// Returns the full span including leading and trailing trivia.
-    ///
-    /// This is useful for formatting operations that need to preserve
-    /// all source text.
-    #[must_use]
-    pub fn full_span(&self) -> Span {
-        // For now, just return the token span
-        // When trivia has spans, this will merge them
-        self.span
-    }
-
     /// Returns the trivia that precedes this token.
     #[must_use]
     pub fn leading_trivia(&self) -> &[Trivia] {
@@ -985,14 +974,6 @@ mod tests {
         let token = Token::new(TokenKind::Integer("42".into()), Span::new(0, 2));
         let kind = token.into_kind();
         assert!(matches!(kind, TokenKind::Integer(s) if s == "42"));
-    }
-
-    #[test]
-    fn token_full_span() {
-        let token = Token::new(TokenKind::Identifier("x".into()), Span::new(5, 6));
-        // Currently full_span equals span (trivia spans not yet tracked)
-        assert_eq!(token.full_span().start(), 5);
-        assert_eq!(token.full_span().end(), 6);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Retires two low-risk legacy remnants in the compiler where a newer path already exists.

Linear issue: https://linear.app/beamtalk/issue/BT-2769

## Changes

- **Deprecated `Position` byte-offset conversions removed.** `Position::from_offset` / `to_offset` (labelled "(legacy)" / "Deprecated: Use `from_byte_offset`…") are gone. The scanning logic previously living in `to_offset` is inlined directly into `to_byte_offset` (returning `ByteOffset` instead of `usize`), dropping a redundant cast layer. Remaining callers were migrated:
  - `queries/signature_help_provider.rs` and `queries/completion_provider.rs` now use `to_byte_offset(...).get()` (removing the `cast_possible_truncation` `#[expect]` shims).
  - `queries/hover_provider.rs` tests now go through a small `pos_at(source, offset)` helper built on `from_byte_offset`.
  - `value_objects.rs` unit tests updated to exercise `from_byte_offset` / `to_byte_offset` directly.
- **`Token::full_span()` trivia stub removed** (with its test). It only ever returned `self.span` with a "when trivia has spans, this will merge them" comment; trivia don't carry spans yet and the method had no non-test callers, so it was silently returning a narrow span. Removed until trivia-span support lands rather than leaving a misleading stub.

## Acceptance criteria

- [x] All callers of `Position::from_offset`/`to_offset` moved to `from_byte_offset`/`to_byte_offset`; deprecated methods removed
- [x] `full_span()` removed with its test (no silently-narrow stub left behind)
- [x] Build, clippy (`--all-targets -D warnings`), and fmt green; affected test suites (value_objects, token, hover/completion/signature-help providers) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMvhKr85vSabHBZLv6staz

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMvhKr85vSabHBZLv6staz)_