### PR TITLE
Parser/CLI: harden bypassed error-recovery panics (BT-2767)

### DIFF
--- a/crates/beamtalk-cli/src/commands/run.rs
+++ b/crates/beamtalk-cli/src/commands/run.rs
@@ -105,7 +105,19 @@ pub fn run(
                  Example: beamtalk run {class_name} run"
             ))
         }
-        _ => unreachable!(),
+        // BT-2767: unreachable today — the guards above are exhaustive over
+        // every (class_or_dot, selector) combination that argv parsing can
+        // produce: `(".", None)`, `(_, Some(_))`, and `(_ != ".", None)`
+        // cover the whole space. Rust's guard-based match can't prove that
+        // exhaustiveness statically, so a catch-all arm is required. Kept as
+        // a real user-facing error rather than `unreachable!()` so a future
+        // refactor of the guards above degrades to a diagnostic instead of a
+        // panic on user argv (CLAUDE.md: "Never panic/unwrap() on user input").
+        (class_name, selector) => Err(miette!(
+            "Invalid arguments to `beamtalk run`: class_or_dot={class_name:?}, selector={selector:?}\n\
+             Usage: beamtalk run <ClassName> <selector> [args...]\n\
+             Or:    beamtalk run ."
+        )),
     }
 }
 

--- a/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
@@ -1045,8 +1045,7 @@ impl Parser {
     fn parse_block(&mut self) -> Expression {
         let start = self
             .expect(&TokenKind::LeftBracket, "Expected '['")
-            .unwrap()
-            .span();
+            .map_or_else(|| self.current_token().span(), |t: Token| t.span());
 
         let mut parameters = Vec::new();
 
@@ -1420,8 +1419,7 @@ impl Parser {
     fn parse_tuple_pattern(&mut self) -> Pattern {
         let start = self
             .expect(&TokenKind::LeftBrace, "Expected '{'")
-            .unwrap()
-            .span();
+            .map_or_else(|| self.current_token().span(), |t: Token| t.span());
 
         let mut elements = Vec::new();
 
@@ -2491,8 +2489,7 @@ impl Parser {
     fn parse_parenthesized(&mut self) -> Expression {
         let start = self
             .expect(&TokenKind::LeftParen, "Expected '('")
-            .unwrap()
-            .span();
+            .map_or_else(|| self.current_token().span(), |t: Token| t.span());
 
         let inner = self.parse_expression();
 
@@ -2687,6 +2684,71 @@ mod tests {
             errors[0].message.contains("bare word 'foo'"),
             "message: {}",
             errors[0].message
+        );
+    }
+
+    // ========================================================================
+    // BT-2767: expect().unwrap() hardening — guard-bypass regression tests
+    // ========================================================================
+    //
+    // parse_block, parse_tuple_pattern, and parse_parenthesized each start by
+    // calling `expect()` for their opening delimiter and used to `.unwrap()`
+    // the result directly, which would panic on a user-input parse error.
+    // In normal operation this is unreachable: every call site dispatches on
+    // the exact TokenKind before calling in (see `parse_primary` for '[' and
+    // '(', `parse_pattern` for '{'), so `expect()` always succeeds today.
+    //
+    // These tests call the private parse_* methods directly on a token
+    // stream that does NOT start with the expected delimiter, bypassing the
+    // dispatch guard, to prove that a future dispatch bug (or a new,
+    // unguarded caller) degrades to a diagnostic instead of a panic.
+
+    fn parser_for(src: &str) -> Parser {
+        Parser::new(crate::source_analysis::lex_with_eof(src))
+    }
+
+    #[test]
+    fn parse_block_guard_bypass_does_not_panic() {
+        let mut parser = parser_for("42"); // no leading '['
+        let expr = parser.parse_block();
+        assert!(matches!(expr, Expression::Block(_)));
+        assert!(
+            parser
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("Expected '['")),
+            "expected a diagnostic instead of a panic, got: {:?}",
+            parser.diagnostics
+        );
+    }
+
+    #[test]
+    fn parse_tuple_pattern_guard_bypass_does_not_panic() {
+        let mut parser = parser_for("42"); // no leading '{'
+        let pattern = parser.parse_tuple_pattern();
+        assert!(matches!(pattern, Pattern::Tuple { .. }));
+        assert!(
+            parser
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("Expected '{'")),
+            "expected a diagnostic instead of a panic, got: {:?}",
+            parser.diagnostics
+        );
+    }
+
+    #[test]
+    fn parse_parenthesized_guard_bypass_does_not_panic() {
+        let mut parser = parser_for("42"); // no leading '('
+        let expr = parser.parse_parenthesized();
+        assert!(matches!(expr, Expression::Parenthesized { .. }));
+        assert!(
+            parser
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("Expected '('")),
+            "expected a diagnostic instead of a panic, got: {:?}",
+            parser.diagnostics
         );
     }
 }


### PR DESCRIPTION
## Summary

Removes the only "graceful recovery exists but was bypassed" panics in the compiler, per BT-2767 (part of the BT-2766 legacy-compiler-cleanup epic).

- **Parser** — `parse_block`, `parse_tuple_pattern`, and `parse_parenthesized` each opened with `self.expect(&kind, msg).unwrap().span()`, throwing away the parser's designed `Option` + diagnostic recovery and panicking on a bypassed guard. Now they use `map_or_else(|| self.current_token().span(), |t| t.span())`, mirroring the closing-delimiter handling already used in `parse_parenthesized`.
- **CLI** — `beamtalk run`'s argv dispatch ended in `_ => unreachable!()`, the one production panic reachable directly from user argv. Replaced with a real user-facing `miette!` error (with a comment explaining why the catch-all arm is required despite being unreachable today).

## Tests

Three guard-bypass regression tests call the private `parse_*` methods on a token stream that omits the opening delimiter, proving each degrades to a diagnostic instead of panicking.

## Verification

`cargo build`, `cargo clippy --all-targets -D warnings`, and `cargo fmt --check` on `beamtalk-core` + `beamtalk-cli` all green; the three new tests pass; pre-push CI (lint) passed.

Closes BT-2767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMvhKr85vSabHBZLv6staz)_