### PR TITLE
test: pin generic-actor withTimeout: transparency; fix inaccurate note

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/adr_0104_integration.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/adr_0104_integration.rs
@@ -310,6 +310,70 @@ Object subclass: Client
     );
 }
 
+/// Transparency preserves the receiver's **type args** for a *generic* actor:
+/// `b :: Boxed(Integer)`, and `(b withTimeout: t) echo: n` (where `echo:` is
+/// `x :: E -> E`) resolves `E = Integer`. A method declaring `-> Integer` over
+/// that body is clean. (Unlike the hand-built unit hierarchy in
+/// `with_timeout_transparency.rs`, the full compile pipeline exercised here
+/// reproduces the generic actor's method inheritance, so the proxy result is a
+/// concrete `Integer`, not `Dynamic`.)
+#[test]
+fn generic_actor_through_proxy_preserves_type_arg() {
+    let source = "\
+Actor subclass: Boxed(E)
+  echo: x :: E -> E => x
+
+Object subclass: Client
+  run: n :: Integer -> Integer =>
+    b :: Boxed(Integer) := Boxed spawn
+    (b withTimeout: 5000) echo: n
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    assert!(
+        return_type_diags(&diags).is_empty(),
+        "the generic forwarded `echo:` resolves E=Integer through the proxy: {diags:?}"
+    );
+    assert!(
+        diags
+            .iter()
+            .all(|d| d.category != Some(DiagnosticCategory::Dnu)),
+        "a real forwarded method on a generic actor must not warn as unknown: {diags:?}"
+    );
+}
+
+/// Return-type control for the generic case: declaring `-> String` over the
+/// same generic forwarded `echo: n` (n :: Integer) body warns "body returns
+/// Integer" — proving the type arg survives the proxy (result is concrete
+/// `Integer`, not `Dynamic`, which would produce no warning at all).
+#[test]
+fn generic_actor_through_proxy_wrong_return_warns_proving_integer() {
+    let source = "\
+Actor subclass: Boxed(E)
+  echo: x :: E -> E => x
+
+Object subclass: Client
+  run: n :: Integer -> String =>
+    b :: Boxed(Integer) := Boxed spawn
+    (b withTimeout: 5000) echo: n
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let mismatches = return_type_diags(&diags);
+    assert_eq!(
+        mismatches.len(),
+        1,
+        "expected one return-type mismatch for the generic forwarded call: {diags:?}"
+    );
+    assert!(
+        mismatches[0].message.contains("body returns Integer"),
+        "the generic proxy call must be inferred as Integer (type arg preserved): {}",
+        mismatches[0].message
+    );
+}
+
 /// Cross-process DNU: an unknown selector on a statically-known Actor
 /// (`logger logg: "hi"`) warns with the *same wording as a local send* — the
 /// process boundary is invisible to the diagnostic (ADR 0100). Matches the

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/with_timeout_transparency.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/with_timeout_transparency.rs
@@ -206,11 +206,13 @@ fn non_actor_with_timeout_is_not_retyped() {
 }
 
 // Note: `withTimeout:` returns `receiver_ty.clone()`, so type args are
-// preserved by construction for any receiver that reaches the guard. A
-// *generic* receiver (`Queue(Integer)`) is not covered here: parametric
-// receivers route through the generic-substitution path and resolve to
-// `Dynamic` before reaching the transparency rule — a separate inference
-// path, out of scope for ADR 0104 (whose actor examples are non-generic).
+// preserved for any receiver that reaches the guard — including *generic*
+// actors. `(q withTimeout: t) m` on `q :: Queue(Integer)` resolves `m`'s
+// return with `E = Integer`; this is verified end-to-end from real source in
+// `adr_0104_integration.rs::generic_actor_through_proxy_*`. It is pinned there
+// rather than here because the hand-built `ClassHierarchy` in this unit file
+// does not reproduce a generic actor's builtin-method inheritance the way the
+// full compile pipeline does.
 
 /// AC #2 (two-step form via a binding): `slowDb := db withTimeout: 30000`
 /// then `slowDb query: sql` infers `List` — the binding carries the


### PR DESCRIPTION
## Summary

Follow-up correction to ADR 0104 (BT-2751 / BT-2752). A note added in BT-2751's test file claimed a **generic** actor receiver collapses to `Dynamic` before the `withTimeout:` transparency rule and was "out of scope for ADR 0104". **That is false about the real compiler.**

Verified empirically via `beamtalk build`: for `q :: RingBuf(Integer) := RingBuf spawn`, both a direct send `q peek` and a forwarded `(q withTimeout: 5000) peek` infer `Integer` — the transparency rule preserves the receiver's type args through the proxy for generic actors too. The earlier unit test that returned `Dynamic` was a hand-built-`ClassHierarchy` artifact (the minimal test hierarchy didn't reproduce the generic actor's builtin-method inheritance the way the full compile pipeline does).

## Changes

- **Correct the note** in `with_timeout_transparency.rs` — it now states type args *are* preserved for generic actors and points at the source-driven pins below.
- **Add two integration tests** in `adr_0104_integration.rs` (real source via `parse_source`, matching the file's existing return-type-control style): a generic actor `Boxed(E)` with `echo: x :: E -> E`, sent through `withTimeout:`, is
  - clean under `run: n :: Integer -> Integer` (positive), and
  - warns "body returns Integer" under `-> String` (control — a `Dynamic` body would produce no warning, so this proves the proxy result is a concrete `Integer`).

No production code change — this corrects a comment and adds coverage that the shipped behavior was already correct.

## Test plan

- `cargo test -p beamtalk-core adr_0104_integration` — 12 passed (2 new)
- `cargo test -p beamtalk-core with_timeout_transparency` — 6 passed
- `cargo clippy -p beamtalk-core --tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Prdqcp7hZd8ocum8ZfU2mk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Prdqcp7hZd8ocum8ZfU2mk)_