### PR TITLE
ADR 0103 polish: @expect sendability e2e test + header clause ordering doc (BT-2774)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/sendability_checking.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/sendability_checking.rs
@@ -194,3 +194,55 @@ fn spawn_with_sendable_value_silent() {
         "sendable spawnWith: value must not warn: {diags:?}"
     );
 }
+
+// --- @expect sendability suppression (BT-2774) ---
+
+/// Parse `src`, build its hierarchy, run the full diagnostic pipeline
+/// (type check + `@expect` suppression via `apply_expect_directives`).
+fn check_source_with_expect(src: &str) -> Vec<Diagnostic> {
+    let module = parse_source(src);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    run_with_expect(&module, &hierarchy)
+}
+
+#[test]
+fn expect_sendability_suppresses_actor_message_warning() {
+    // A `Port` passed in an actor message is a sendability Warning (boundary #1,
+    // ADR 0103). `@expect sendability` on the preceding line must suppress it
+    // end-to-end — this is the only coverage of the
+    // `(Sendability, Sendability)` arm in `category_matches`; a rename of the
+    // `DiagnosticCategory` variant would otherwise silently break suppression.
+
+    // Without the directive: the warning fires.
+    let bare = "Actor subclass: Worker\n  \
+        use: p => p asString\n\n\
+        Object subclass: Main\n  \
+        run: port :: Port with: worker :: Worker =>\n    \
+        worker use: port\n";
+    let diags_without = check_source_with_expect(bare);
+    assert_eq!(
+        sendability_warnings(&diags_without).len(),
+        1,
+        "Port in an actor message must warn without @expect, got: {diags_without:?}"
+    );
+
+    // With `@expect sendability`: the warning is suppressed, and the directive
+    // is not reported stale (it matched a real diagnostic).
+    let suppressed = "Actor subclass: Worker\n  \
+        use: p => p asString\n\n\
+        Object subclass: Main\n  \
+        run: port :: Port with: worker :: Worker =>\n    \
+        @expect sendability\n    \
+        worker use: port\n";
+    let diags_with = check_source_with_expect(suppressed);
+    assert!(
+        sendability_warnings(&diags_with).is_empty(),
+        "@expect sendability must suppress the actor-message warning, got: {diags_with:?}"
+    );
+    assert!(
+        diags_with
+            .iter()
+            .all(|d| !d.message.contains("stale @expect")),
+        "@expect sendability should not be reported stale, got: {diags_with:?}"
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -834,21 +834,11 @@ impl TypeChecker {
             .all(|(e, a)| Self::type_args_compatible(e, a, hierarchy))
     }
 
-    /// ADR 0103 (Phase 0): warn when a process-bound handle
-    /// (`HandleScoped(#process)`) is passed as an argument in an actor message.
-    ///
-    /// Runs independently of whether the receiver's handler has typed
-    /// parameters — the hazard is about *what* is sent, not the declared
-    /// parameter type — so it is invoked before the method lookup in
-    /// [`check_argument_types`]. `#node`-scoped and `Unknown` arguments stay
-    /// silent in v1 (no static remoteness knowledge; advisory per ADR 0100).
-    ///
-    /// Class-side sends (`spawnWith:` maps, `new:`) are Phase 1 (BT-2755).
-    /// ADR 0103 (Phase 1): warn when a process-bound handle appears as a value
-    /// in a `spawnWith:` initial-state map — the map is copied into the new
-    /// actor process, so a `HandleScoped(#process)` value is only usable by its
-    /// original owner. Inspects the `MapLiteral` call-site pairs (shared model
-    /// with ADR 0104's `spawnWith:` key checking).
+    /// ADR 0103 (Phase 1): warn when a process-bound handle
+    /// (`HandleScoped(#process)`) appears as a value in a `spawnWith:`
+    /// initial-state map — the map is copied into the new actor process, so the
+    /// value is only usable by its original owner. Inspects the `MapLiteral`
+    /// call-site pairs (shared model with ADR 0104's `spawnWith:` key checking).
     pub(super) fn check_spawn_with_sendability(
         &mut self,
         selector: &str,
@@ -896,6 +886,19 @@ impl TypeChecker {
         }
     }
 
+    /// ADR 0103 (Phase 0): warn when a process-bound handle
+    /// (`HandleScoped(#process)`) is passed as an argument in an actor message
+    /// (boundary #1) or used as an Announcement payload (boundary #3) — both
+    /// copy the term across a process boundary. The wording differs; the tier
+    /// rule does not.
+    ///
+    /// Runs independently of whether the receiver's handler has typed
+    /// parameters — the hazard is about *what* is sent, not the declared
+    /// parameter type — so it is invoked before the method lookup in
+    /// [`check_argument_types`]. `#node`-scoped and `Unknown` arguments stay
+    /// silent in v1 (no static remoteness knowledge; advisory per ADR 0100).
+    /// Class-side `spawnWith:` maps are handled by
+    /// [`check_spawn_with_sendability`].
     #[allow(clippy::too_many_arguments)] // boundary context: selector + receiver flags + arg spans
     pub(super) fn check_arg_sendability(
         &mut self,

--- a/docs/ADR/0103-sendability-typing-from-class-kinds.md
+++ b/docs/ADR/0103-sendability-typing-from-class-kinds.md
@@ -157,6 +157,11 @@ plausible later addition rather than a redesign. Construction of such classes
 follows the existing FFI-wrapping pattern (ADR 0101 `native:` / delegate, as
 `Ets` and `Subscription` do today).
 
+Header clauses are parsed in a fixed order:
+`modifiers` → `Superclass subclass: Name(TypeParams)` → `native: module` →
+`handleScope: #scope`. `native:` must precede `handleScope:`; reversing them
+(`handleScope: #process native: pb`) silently drops the `native:` clause.
+
 ### Checked boundaries
 
 1. **Actor message arguments and `spawnWith:` maps** — warn when a

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -337,6 +337,12 @@ declaration is an advisory no-op). A companion lint nudges FFI-wrapping
 (`native:`) Object classes that carry instance behaviour but declare no scope.
 Suppress a sendability finding with `@expect sendability`.
 
+Header clauses are parsed in a fixed order — write them as:
+`modifiers` → `Superclass subclass: Name(TypeParams)` → `native: module` →
+`handleScope: #scope`. In particular `native:` must precede `handleScope:`;
+reversing them (`handleScope: #process native: pb`) silently drops the
+`native:` clause (it falls into the class body).
+
 ### Wrong Keyword Errors
 
 The compiler enforces keyword/class-kind rules with clear error messages:


### PR DESCRIPTION
Small follow-ups from the ADR 0103 sendability review (epic BT-2748).

1. **`@expect sendability` e2e test** — adds the only end-to-end coverage of the `(ExpectCategory::Sendability, DiagnosticCategory::Sendability)` arm in `category_matches`: a `Port` passed in an actor message is suppressed by `@expect sendability`, and fires without the directive. A rename of the `DiagnosticCategory` variant would otherwise silently break suppression.
2. **Header clause ordering docs** — documents the canonical class-header clause order (modifiers → `Superclass subclass: Name(TypeParams)` → `native: module` → `handleScope: #scope`) in `docs/beamtalk-language-features.md` and ADR 0103, noting that reversing `native:`/`handleScope:` silently drops `native:`.
3. **Doc-comment tidy** on the sendability arg checks.

`just test-rust`, clippy, and fmt green (via the pre-push CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP3kLDrHLrBUMY3xEd3gFP)_