### PR TITLE
Document expression-based dispatch + unprefixed module fallback as live (BT-2772)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/dispatch.rs
@@ -31,7 +31,11 @@ impl CoreErlangGenerator {
         &self,
         module: &Module,
     ) -> Result<Document<'static>> {
-        // Collect methods from expression-based definitions (legacy)
+        // Collect methods from expression-based script/workspace modules: top-level
+        // `name := [block]` assignments compiled as the module's methods. This is a
+        // LIVE compilation mode (the package/workspace compiler — exercised by the
+        // test-package-compiler snapshot cases), distinct from class definitions.
+        // Not dead code: removing it strips methods from every compiled script.
         let mut methods: Vec<(String, usize)> = module
             .expressions
             .iter()
@@ -101,7 +105,11 @@ impl CoreErlangGenerator {
         &self,
         module: &Module,
     ) -> Result<Document<'static>> {
-        // Collect methods from expression-based definitions (legacy)
+        // Collect methods from expression-based script/workspace modules: top-level
+        // `name := [block]` assignments compiled as the module's methods. This is a
+        // LIVE compilation mode (the package/workspace compiler — exercised by the
+        // test-package-compiler snapshot cases), distinct from class definitions.
+        // Not dead code: removing it strips methods from every compiled script.
         let mut methods: Vec<String> = module
             .expressions
             .iter()
@@ -233,8 +241,10 @@ impl CoreErlangGenerator {
 
     /// Generates the dispatch/4 function for message routing.
     ///
-    /// This function is complex because it handles both legacy expression-based modules
-    /// and class definitions, including the `doesNotUnderstand:args:` fallback per BT-29.
+    /// Handles both expression-based script/workspace modules (top-level
+    /// `name := [block]` assignments become methods — a live mode used by the
+    /// package/workspace compiler) and class definitions, including the
+    /// `doesNotUnderstand:args:` fallback per BT-29.
     pub(in crate::codegen::core_erlang) fn generate_dispatch(
         &mut self,
         module: &Module,
@@ -295,7 +305,9 @@ impl CoreErlangGenerator {
         Ok(Document::Vec(docs))
     }
 
-    /// Generates a dispatch case clause for a legacy expression-based method.
+    /// Generates a dispatch case clause for an expression-based method — a
+    /// top-level `name := [block]` binding in a script/workspace module. This is
+    /// a live compilation mode (not dead/legacy); see `generate_method_table`.
     ///
     /// Handles scope setup, NLR detection, body generation, and the Args
     /// destructuring case when the method has parameters.

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/state.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/state.rs
@@ -116,7 +116,10 @@ impl CoreErlangGenerator {
                 ]);
             }
         } else {
-            // Fallback: if no matching class found (legacy modules), emit all class fields
+            // Fallback: no class matched the module name. Reached by hand-constructed test
+            // fixtures that build a `Module` with an unprefixed/bare class name (e.g.
+            // "counter") instead of the `bt@…` scheme real compilation uses — see
+            // `util::module_matches_class`. Load-bearing for those tests, not dead code.
             for class in &module.classes {
                 for state in &class.state {
                     let value_code = if let Some(ref default_value) = state.default_value {

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -400,6 +400,8 @@ pub(super) fn user_package_prefix(module_name: &str) -> Option<String> {
 ///
 /// ADR 0016/0026: Module names may be prefixed with `bt@` (user code),
 /// `bt@stdlib@` (stdlib), `bt@{package}@` (package mode), or unprefixed (legacy/tests).
+/// The unprefixed arm is retained because hand-constructed test-fixture `Module`s use
+/// bare class names (e.g. "counter"); real compilation always emits a `bt@…` prefix.
 pub(super) fn module_matches_class(module_name: &str, class_name: &str) -> bool {
     let snake = to_module_name(class_name);
     module_name == snake

--- a/crates/beamtalk-core/src/semantic_analysis/facts.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/facts.rs
@@ -237,8 +237,9 @@ pub fn compute_semantic_facts(module: &Module) -> SemanticFacts {
 
     // Process module-level expressions
     for stmt in &module.expressions {
-        // Detect legacy expression-based method blocks (used by gen_server dispatch legacy path).
-        // These are top-level assignments of the form `methodName := [:param | body]`.
+        // Detect expression-based method blocks — top-level `methodName := [:param | body]`
+        // assignments in a script/workspace module, which the gen_server dispatch compiles
+        // as the module's methods (a live mode, not dead code; see gen_server/dispatch.rs).
         // The block body is treated as method-level (inside_block=false): a ^ directly in the
         // block is a normal early return, not an NLR — only ^ inside a *nested* block is NLR.
         if let Expression::Assignment { value, .. } = &stmt.expression {


### PR DESCRIPTION
## Summary

Resolves [BT-2772](https://linear.app/beamtalk/issue/BT-2772) (BT-2766 legacy-compiler-cleanup epic). The issue was "investigate two coexisting codegen paths; **delete if dead, document if a live producer remains.**"

**Finding: both paths have live producers, so this is documentation-only — no code removed.** An initial attempt to delete the expression-based dispatch path failed CI (see below), which is exactly what confirmed the producer.

### Path A — expression-based gen_server dispatch → LIVE, kept + documented

Top-level `name := [block]` assignments in a **script/workspace module** are compiled as that module's methods (dispatch clause, `method_table`, `has_method`). The **package/workspace script compiler** is the live producer — standalone `.bt` scripts like `numbers := [1]` or `blockWithOp := [:x :y | ...]` rely on it, and it's exercised by the `test-package-compiler` snapshot cases. Deleting it stripped methods from every compiled script (21 `test-package-compiler` snapshots changed). The misleading `(legacy)` comments in `dispatch.rs` / `facts.rs` are reworded to name the producer so it isn't mistaken for dead code again.

### Path B — unprefixed module-name fallback → LIVE, kept + documented

Hand-constructed test-fixture `Module`s use bare class names (e.g. `"counter"`) rather than the `bt@…` scheme real compilation emits. `util::module_matches_class` supports them (with a dedicated test). Documented at the fallback sites (`gen_server/state.rs`, `util::module_matches_class`).

## Changes

Comment/doc-only. No behaviour change, no codegen change.

## Verification

- `cargo test -p test-package-compiler` — **393 passed, 0 failed** (the suite that caught the bad deletion)
- `cargo test -p beamtalk-core`, `cargo clippy -p beamtalk-core --all-targets`, `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)