### PR TITLE
Remove vestigial collect_inherited_fields; cross-file actor state via super-init chain (BT-2768)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -476,7 +476,9 @@ impl CoreErlangGenerator {
                 span: Some(field.span),
             });
         }
-        // For now, assume receiver is 'self' and access from State/Self
+        // Field access resolves against self's State/Self map. A non-self receiver
+        // is not valid (Beamtalk enforces encapsulation) and is rejected with a
+        // diagnostic in the fall-through below.
         if let Expression::Identifier(recv_id) = receiver {
             if recv_id.name == "self" {
                 // BT-1326: In hybrid mode, read-only fields are pre-extracted before the letrec.

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/state.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/state.rs
@@ -5,12 +5,13 @@
 //!
 //! **DDD Context:** Compilation — Code Generation
 //!
-//! Generates state field initializers for actor `init/1` callbacks,
-//! including inherited fields from parent classes.
+//! Generates state field initializers for actor `init/1` callbacks. Inherited
+//! state from a stateful parent is supplied by the super-init chain (BT-1417,
+//! see `gen_server/callbacks.rs`), not by this module.
 
 use super::super::document::{Document, leaf, line};
 use super::super::{CoreErlangGenerator, Result};
-use crate::ast::{Expression, Identifier, Module};
+use crate::ast::{Expression, Module};
 use crate::docvec;
 
 impl CoreErlangGenerator {
@@ -51,14 +52,21 @@ impl CoreErlangGenerator {
         Ok(fields)
     }
 
-    /// Generates all state fields including inherited ones (for base classes).
+    /// Generates the state fields for a class whose parent is a base class
+    /// (`Actor` / `Object` / none) — i.e. a class with no stateful ancestor.
     ///
     /// Returns a list of `Document` fragments, each representing one field
     /// initializer line (with a leading `line()` for indentation).
     /// The caller wraps these in a `nest()` at the appropriate level.
     ///
-    /// This version includes fields from module-level assignments and recursively
-    /// collects inherited fields from parent classes when they're in the same module.
+    /// Inherited state from a *non-base* parent is NOT collected here. A subclass
+    /// of a stateful actor instead has its `init/1` call the parent's compiled
+    /// `init/1` and merge its own fields on top — the super-init chain (BT-1417,
+    /// see `gen_server/callbacks.rs`). That `has_parent_init` path resolves the
+    /// parent's compiled module and so handles cross-file, stdlib, and package
+    /// parents uniformly; this function is only reached with a base-class parent.
+    /// It also emits fields from module-level `x := literal` assignments for
+    /// script/workspace modules.
     pub(in crate::codegen::core_erlang) fn generate_initial_state_fields(
         &mut self,
         module: &Module,
@@ -89,20 +97,9 @@ impl CoreErlangGenerator {
         });
 
         if let Some(class) = current_class {
-            // Collect inherited fields from parent classes (recursively)
-            let inherited_fields = Self::collect_inherited_fields(class.superclass_name(), module)?;
-
-            // Emit inherited fields first
-            for (field_name, default_value) in inherited_fields {
-                let value_code = self.expression_doc(&default_value)?;
-                fields.push(docvec![
-                    line(),
-                    docvec![", ", leaf::atom(field_name.clone()), " => "],
-                    value_code,
-                ]);
-            }
-
-            // Then emit this class's own fields (can override parent defaults)
+            // Emit this class's own fields. Inherited state from a non-base parent
+            // is supplied at runtime by the super-init chain (BT-1417), not collected
+            // here — this branch is only reached when the parent is a base class.
             for state in &class.state {
                 let value_code = if let Some(ref default_value) = state.default_value {
                     self.expression_doc(default_value)?
@@ -135,58 +132,6 @@ impl CoreErlangGenerator {
                 }
             }
         }
-
-        Ok(fields)
-    }
-
-    /// Recursively collects all inherited state fields from parent classes.
-    ///
-    /// Returns a vector of `(field_name, default_value)` pairs in inheritance order
-    /// (most distant ancestor first). This ensures parent fields are initialized
-    /// before child fields, allowing children to override parent defaults.
-    ///
-    /// Only works when parent classes are defined in the same Module AST.
-    /// For cross-file inheritance (e.g., from standard library classes), the
-    /// parent's fields are not included - they must be provided via `InitArgs` or
-    /// handled by a future import mechanism.
-    fn collect_inherited_fields(
-        parent_name: &str,
-        module: &Module,
-    ) -> Result<Vec<(String, Expression)>> {
-        let mut fields = Vec::new();
-
-        // Base case: Actor, Object, and root classes (none) have no state fields
-        if parent_name == "Actor" || parent_name == "Object" || parent_name == "none" {
-            return Ok(fields);
-        }
-
-        // Find parent class in the same module
-        let parent_class = module
-            .classes
-            .iter()
-            .find(|c| c.name.name.eq_ignore_ascii_case(parent_name));
-
-        if let Some(parent) = parent_class {
-            // Recursively collect grandparent fields first
-            let grandparent_fields =
-                Self::collect_inherited_fields(parent.superclass_name(), module)?;
-            fields.extend(grandparent_fields);
-
-            // Add this parent's fields
-            for state in &parent.state {
-                let default_value = if let Some(ref val) = state.default_value {
-                    val.clone()
-                } else {
-                    // No default - use nil
-                    Expression::Identifier(Identifier {
-                        name: "nil".into(),
-                        span: state.span,
-                    })
-                };
-                fields.push((state.name.name.to_string(), default_value));
-            }
-        }
-        // If parent not found in module, it's a cross-file reference - skip for now
 
         Ok(fields)
     }

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -4470,6 +4470,12 @@ fn test_handle_continue_dispatches_initialize_chain() {
 /// from `Actor`), `init/1` must call the parent's `init/1` to accumulate
 /// inherited state, then merge the child's own fields on top, and propagate
 /// any `{error, Reason}` the parent returns.
+///
+/// BT-2768: This is also the cross-file inherited-state regression coverage.
+/// The parent (`Counter`) is compiled in a *separate* module — its AST is absent
+/// here — yet the child correctly pulls the parent's state via `bt@counter:init/1`.
+/// This is why the old AST-only `collect_inherited_fields` was removed: the
+/// super-init chain already handles cross-file / stdlib / package parents.
 #[test]
 fn test_init_parent_actor_subclass_calls_parent_init() {
     // LoggingCounter extends Counter (itself an Actor subclass).


### PR DESCRIPTION
## Summary

Resolves [BT-2768](https://linear.app/beamtalk/issue/BT-2768) (final child of the BT-2766 legacy-compiler-cleanup epic).

BT-2768 was filed on the premise that gen_server codegen **silently drops a cross-file parent's state fields** (the `collect_inherited_fields` "skip cross-file for now" comment in `state.rs`). **Investigation shows that gap does not exist.**

`has_parent_init` is true for *any* superclass that isn't `Actor`/`Object` — it does not require the parent to be in the same file. So every actor subclassing a stateful parent (cross-file, stdlib, package alike) takes the **runtime super-init chain** (BT-1417): the child's `init/1` calls the parent's compiled `init/1` (`call parent_module:'init'`, resolved via `compiled_module_name`) and merges its own fields on top. `collect_inherited_fields` is only reached when the parent is a base class (`Actor`/`Object`/none), where it returns empty — so it **never actually collected anything**.

This is already proven by the existing `test_init_parent_actor_subclass_calls_parent_init` (BT-1417): it compiles `LoggingCounter` alone, with parent `Counter`'s AST absent (cross-file), and asserts the child pulls the parent's state via `bt@counter:init/1`.

## Changes

- **Remove the vestigial `collect_inherited_fields`** and its always-empty inherited-field emission loop in `generate_initial_state_fields`. **Verified byte-identical** — `test-package-compiler` snapshots unchanged (393 passed), confirming it was truly dead (this is the check that caught a bad deletion in the sibling BT-2772 PR, so it was run deliberately).
- **Correct the misleading docs** ("skip cross-file for now / future import mechanism") in `state.rs` (function + module) to point at the super-init chain.
- **Fix the stale `expressions.rs` comment** ("For now, assume receiver is 'self'") — non-self field access is already correctly rejected with a diagnostic.
- **Tag** `test_init_parent_actor_subclass_calls_parent_init` as the cross-file inherited-state regression coverage (satisfies the issue's AC#2).

Left as-is (out of scope, noted in the issue): the single-variant `MethodKind` guards — vacuous forward-scaffolding, harmless.

## Verification

- `cargo test -p test-package-compiler` — **393 passed, 0 failed, snapshots unchanged**
- `cargo test -p beamtalk-core` — **4552 passed, 0 failed**
- `cargo clippy -p beamtalk-core --all-targets`, `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMvhKr85vSabHBZLv6staz)_