### PR TITLE
setup-cloud: tolerate retired base-image PPA label change in apt-get update

### DIFF
--- a/scripts/setup-cloud.sh
+++ b/scripts/setup-cloud.sh
@@ -224,7 +224,7 @@ else
       info "Installing Erlang runtime deps (${_OTP_DEPS# })..."
       require_sudo
       # shellcheck disable=SC2086
-      if $SUDO apt-get update -qq && $SUDO apt-get install -y -qq --no-install-recommends ${_OTP_DEPS}; then
+      if $SUDO apt-get update -qq --allow-releaseinfo-change && $SUDO apt-get install -y -qq --no-install-recommends ${_OTP_DEPS}; then
         ok "Erlang runtime deps installed"
       else
         warn "Could not install Erlang runtime deps (${_OTP_DEPS# }) — erl may fail to start"
@@ -380,7 +380,7 @@ case "$OS_ID" in
     done
     if [ -n "$PKGS" ]; then
       require_sudo
-      $SUDO apt-get update -qq
+      $SUDO apt-get update -qq --allow-releaseinfo-change
       # shellcheck disable=SC2086
       $SUDO apt-get install -y -qq --no-install-recommends $PKGS
       ok "System packages installed"
@@ -424,7 +424,7 @@ else
   $SUDO chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     | $SUDO tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-  $SUDO apt-get update -qq
+  $SUDO apt-get update -qq --allow-releaseinfo-change
   $SUDO apt-get install -y -qq gh
   ok "GitHub CLI installed"
 fi


### PR DESCRIPTION
Fresh cloud environments fail setup with exit 100 at "Installing system
packages": the base image ships the retired ondrej/php PPA, whose maintainer
changed the repo Label to "Use https://packages.sury.org/php/ instead". apt
treats that as an error and `apt-get update` exits non-zero, aborting the
`set -euo pipefail` setup at the unguarded call (line 383).

Beamtalk uses no PHP — this PPA is pure base-image cruft. Add
`--allow-releaseinfo-change` to all three `apt-get update` calls so apt accepts
the harmless metadata change (and any similar future base-image PPA change)
instead of hard-failing. The flag only affects release-metadata changes, not
package signatures/integrity.

Verified: `apt-get update -qq --allow-releaseinfo-change` exits 0 on the
affected image; shellcheck clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EMvhKr85vSabHBZLv6staz