### PR TITLE
Per-selector signature-generation store + capture plumbing (BT-2777)

### DIFF
--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -440,12 +440,56 @@ fn class_definition_ok_response(
     Term::from(Map::from(map))
 }
 
+/// Compute the declared signature (return type + parameter types) of a method
+/// definition for the ADR 0105 Phase 1 signature-generation store (BT-2777).
+///
+/// Uses `TypeAnnotation::type_name()` — the same canonical string rendering
+/// the class hierarchy already uses for declared state/method types — so the
+/// workspace-side store compares like-for-like against `__beamtalk_meta`
+/// seeded signatures. An absent annotation (param or return) is reported as
+/// the sentinel `"Dynamic"` rather than omitted, so the signature-diff always
+/// has two comparable values.
+///
+/// **Scope note (Phase 0 finding, `docs/internal/adr-0105-phase0-spike-findings.md`
+/// §1b):** only *declared* annotations are captured here, not re-inferred
+/// return types. Reading declared annotations is the cheaper interim the spike
+/// recommended; extending this to inferred (unannotated) return types is a
+/// follow-up once a cheap way to thread `TypeMap` through the port response
+/// exists.
+fn method_signature_terms(method: &beamtalk_core::ast::MethodDefinition) -> (String, Vec<String>) {
+    const DYNAMIC: &str = "Dynamic";
+    let return_type = method
+        .return_type
+        .as_ref()
+        .map_or_else(|| DYNAMIC.to_string(), |rt| rt.type_name().to_string());
+    let param_types = method
+        .parameters
+        .iter()
+        .map(|p| {
+            p.type_annotation
+                .as_ref()
+                .map_or_else(|| DYNAMIC.to_string(), |ta| ta.type_name().to_string())
+        })
+        .collect();
+    (return_type, param_types)
+}
+
+/// Build ETF term list from parameter type-name strings.
+fn build_param_type_terms(param_types: &[String]) -> Term {
+    Term::from(List::from(
+        param_types.iter().map(|t| binary(t)).collect::<Vec<_>>(),
+    ))
+}
+
 /// Build a response map for a successful standalone method definition in REPL.
+#[allow(clippy::too_many_arguments)]
 fn method_definition_ok_response(
     class_name: &str,
     selector: &str,
     is_class_method: bool,
     method_source: &str,
+    return_type: &str,
+    param_types: &[String],
     warnings: &[String],
 ) -> Term {
     Term::from(Map::from([
@@ -462,6 +506,12 @@ fn method_definition_ok_response(
             },
         ),
         (atom("method_source"), binary(method_source)),
+        // ADR 0105 Phase 1 (BT-2777): the compiled method's declared signature,
+        // carried so the workspace can capture it into the signature-generation
+        // store before the patch installs (the pre-patch signature is otherwise
+        // unrecoverable — see beamtalk_object_class.erl's put_method/4 clearing).
+        (atom("return_type"), binary(return_type)),
+        (atom("param_types"), build_param_type_terms(param_types)),
         (
             atom("warnings"),
             Term::from(List::from(build_warning_terms(warnings))),
@@ -524,6 +574,8 @@ fn compile_method_ok_response(
     is_class_method: bool,
     method_source: &str,
     merged_class_source: &str,
+    return_type: &str,
+    param_types: &[String],
     warnings: &[String],
 ) -> Term {
     Term::from(Map::from([
@@ -546,6 +598,10 @@ fn compile_method_ok_response(
         ),
         (atom("method_source"), binary(method_source)),
         (atom("merged_class_source"), binary(merged_class_source)),
+        // ADR 0105 Phase 1 (BT-2777): see method_definition_ok_response's doc
+        // comment for why this is carried (signature-generation store capture).
+        (atom("return_type"), binary(return_type)),
+        (atom("param_types"), build_param_type_terms(param_types)),
         (
             atom("warnings"),
             Term::from(List::from(build_warning_terms(warnings))),
@@ -882,11 +938,14 @@ fn handle_compile_expression(request: &Map) -> Term {
         // follow-up). `unparse_method` re-emits the parsed method, comments and
         // all, so the recorded source round-trips cleanly.
         let method_source = beamtalk_core::unparse::unparse_method(&method_def.method);
+        let (return_type, param_types) = method_signature_terms(&method_def.method);
         return method_definition_ok_response(
             &class_name,
             &selector,
             method_def.is_class_method,
             &method_source,
+            &return_type,
+            &param_types,
             &warnings,
         );
     }
@@ -1447,7 +1506,7 @@ fn handle_compile_method(request: &Map) -> Term {
     // diagnostics can be reported relative to the method snippet the user edits
     // (BT-2563 #2). Its span now indexes into `merged_class_source`, the same
     // coordinate system as every diagnostic span.
-    let patched_method_span = merged_module
+    let patched_method = merged_module
         .classes
         .iter()
         .find(|c| c.name.name == class_name)
@@ -1460,8 +1519,16 @@ fn handle_compile_method(request: &Map) -> Term {
             methods
                 .iter()
                 .find(|m| m.selector.name() == selector && m.kind == patched_kind)
-        })
-        .map(|m| m.span);
+        });
+    let patched_method_span = patched_method.map(|m| m.span);
+    // ADR 0105 Phase 1 (BT-2777): declared signature of the patched method, read
+    // from the re-parsed merged module so it reflects exactly what was installed
+    // (not the standalone pre-merge parse). Falls back to "Dynamic"/no params in
+    // the never-should-happen case the method isn't found post-merge.
+    let (patched_return_type, patched_param_types) = patched_method.map_or_else(
+        || ("Dynamic".to_string(), Vec::new()),
+        method_signature_terms,
+    );
 
     // 4. Full semantic analysis on the MERGED module — catches method errors in
     //    class context (undefined fields, type errors). Every diagnostic span
@@ -1539,6 +1606,8 @@ fn handle_compile_method(request: &Map) -> Term {
             is_class_method,
             &canonical_method_source,
             &merged_class_source,
+            &patched_return_type,
+            &patched_param_types,
             &warning_msgs,
         ),
         // Codegen spans are now relative to the re-parsed merged module, so the
@@ -2890,6 +2959,79 @@ Object subclass: Counter
         let module_name = map_get(m, "module_name").and_then(term_to_string);
         assert_eq!(module_name.as_deref(), Some("bt@my_thing"));
     }
+
+    /// ADR 0105 Phase 1 (BT-2777): the standalone `Class >> sel` method-definition
+    /// response (the REPL `>>` live-patch path) must carry the declared signature
+    /// alongside the existing `method_source`, so the workspace can capture it into
+    /// the signature-generation store before the patch installs.
+    #[test]
+    fn standalone_method_definition_carries_declared_signature() {
+        let request = Map::from([
+            (atom("command"), atom("compile_expression")),
+            (
+                atom("source"),
+                binary("Counter >> setValue: v :: Integer -> Object => self.value := v"),
+            ),
+            (atom("module"), binary("bt@repl_eval_1")),
+            (atom("known_vars"), Term::from(List::from(vec![]))),
+        ]);
+
+        let response = handle_compile_expression(&request);
+        let Term::Map(ref m) = response else {
+            panic!("Expected a map response, got: {response:?}");
+        };
+
+        assert_eq!(
+            map_get(m, "kind").and_then(term_to_atom).as_deref(),
+            Some("method_definition")
+        );
+        assert_eq!(
+            map_get(m, "return_type")
+                .and_then(term_to_string)
+                .as_deref(),
+            Some("Object")
+        );
+        let Some(Term::List(param_types)) = map_get(m, "param_types") else {
+            panic!("Expected param_types list, got: {m:?}");
+        };
+        let param_type_strs: Vec<String> = param_types
+            .elements
+            .iter()
+            .filter_map(term_to_string)
+            .collect();
+        assert_eq!(param_type_strs, vec!["Integer".to_string()]);
+    }
+
+    /// Unannotated standalone method definitions report the `"Dynamic"` sentinel
+    /// rather than omitting the fields.
+    #[test]
+    fn standalone_method_definition_reports_dynamic_when_unannotated() {
+        let request = Map::from([
+            (atom("command"), atom("compile_expression")),
+            (
+                atom("source"),
+                binary("Counter >> increment => self.value := self.value + 1"),
+            ),
+            (atom("module"), binary("bt@repl_eval_1")),
+            (atom("known_vars"), Term::from(List::from(vec![]))),
+        ]);
+
+        let response = handle_compile_expression(&request);
+        let Term::Map(ref m) = response else {
+            panic!("Expected a map response, got: {response:?}");
+        };
+
+        assert_eq!(
+            map_get(m, "return_type")
+                .and_then(term_to_string)
+                .as_deref(),
+            Some("Dynamic")
+        );
+        assert_eq!(
+            map_get(m, "param_types"),
+            Some(&Term::from(List::from(Vec::<Term>::new())))
+        );
+    }
 }
 
 // ============================================================================
@@ -2960,6 +3102,16 @@ mod property_tests {
         } else {
             None
         }
+    }
+
+    /// Extract a list-of-binary-valued field from a response Term (e.g. `param_types`).
+    fn response_field_str_list(term: &Term, key: &str) -> Option<Vec<String>> {
+        if let Term::Map(map) = term {
+            if let Some(Term::List(list)) = map_get(map, key) {
+                return Some(list.elements.iter().filter_map(term_to_string).collect());
+            }
+        }
+        None
     }
 
     const COMPILE_METHOD_CLASS: &str = "Actor subclass: EventStore\n  state: events = #{}\n\n  initialize -> Nil =>\n    self.events := #{}";
@@ -3080,6 +3232,59 @@ mod property_tests {
         assert!(
             !merged.contains(">>"),
             "merged class should be inline, not `>>` extensions:\n{merged}"
+        );
+    }
+
+    #[test]
+    fn compile_method_response_carries_declared_signature() {
+        // ADR 0105 Phase 1 (BT-2777): the compile_method response must carry the
+        // patched method's declared return/param types so the workspace can
+        // capture them into the signature-generation store before install.
+        let request = Term::from(Map::from([
+            (atom("command"), atom("compile_method")),
+            (atom("class_source"), binary(COMPILE_METHOD_CLASS)),
+            (
+                atom("method_source"),
+                binary("touch: n :: Integer -> Object =>\n  self"),
+            ),
+            (atom("is_class_method"), atom("false")),
+        ]));
+        let response = handle_request(&request);
+        assert_eq!(
+            response_status(&response).as_deref(),
+            Some("ok"),
+            "resp: {response:?}"
+        );
+        assert_eq!(
+            response_field_str(&response, "return_type").as_deref(),
+            Some("Object")
+        );
+        assert_eq!(
+            response_field_str_list(&response, "param_types").as_deref(),
+            Some(&["Integer".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn compile_method_response_reports_dynamic_for_unannotated_signature() {
+        // No return/param annotations on the patched method → both fields report
+        // the "Dynamic" sentinel (never omitted, so the diff always compares two
+        // values).
+        let request = Term::from(Map::from([
+            (atom("command"), atom("compile_method")),
+            (atom("class_source"), binary(COMPILE_METHOD_CLASS)),
+            (atom("method_source"), binary("touch: n =>\n  self")),
+            (atom("is_class_method"), atom("false")),
+        ]));
+        let response = handle_request(&request);
+        assert_eq!(response_status(&response).as_deref(), Some("ok"));
+        assert_eq!(
+            response_field_str(&response, "return_type").as_deref(),
+            Some("Dynamic")
+        );
+        assert_eq!(
+            response_field_str_list(&response, "param_types").as_deref(),
+            Some(&["Dynamic".to_string()][..])
         );
     }
 

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_port.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_port.erl
@@ -987,20 +987,31 @@ handle_response(
                 BaseInfo
         end,
     {ok, class_definition, ClassInfo};
-handle_response(#{
-    status := ok,
-    kind := method_definition,
-    class_name := ClassName,
-    selector := Selector,
-    is_class_method := IsClassMethod,
-    method_source := MethodSource,
-    warnings := Warnings
-}) ->
+handle_response(
+    #{
+        status := ok,
+        kind := method_definition,
+        class_name := ClassName,
+        selector := Selector,
+        is_class_method := IsClassMethod,
+        method_source := MethodSource,
+        warnings := Warnings
+    } = Response
+) ->
+    %% ADR 0105 Phase 1 (BT-2777): return_type/param_types carry the compiled
+    %% method's declared signature so the workspace can capture it into the
+    %% signature-generation store before the patch installs. Defaulted so an
+    %% older compiler-port binary (pre-BT-2777) that omits these keys still
+    %% decodes.
+    ReturnType = maps:get(return_type, Response, <<"Dynamic">>),
+    ParamTypes = maps:get(param_types, Response, []),
     {ok, method_definition, #{
         class_name => ClassName,
         selector => Selector,
         is_class_method => IsClassMethod,
         method_source => MethodSource,
+        return_type => ReturnType,
+        param_types => ParamTypes,
         warnings => Warnings
     }};
 %% BT-1612: Protocol definition response

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -941,18 +941,26 @@ handle_compile_response(Other) ->
 
 %% Decode the `compile_method` response: the compiled class module plus the
 %% recovered method metadata (canonical source, selector, side).
-handle_compile_method_response(#{
-    status := ok,
-    kind := method_definition,
-    core_erlang := CoreErlang,
-    module_name := ModuleName,
-    classes := Classes,
-    selector := Selector,
-    is_class_method := IsClassMethod,
-    method_source := MethodSource,
-    merged_class_source := MergedClassSource,
-    warnings := Warnings
-}) ->
+handle_compile_method_response(
+    #{
+        status := ok,
+        kind := method_definition,
+        core_erlang := CoreErlang,
+        module_name := ModuleName,
+        classes := Classes,
+        selector := Selector,
+        is_class_method := IsClassMethod,
+        method_source := MethodSource,
+        merged_class_source := MergedClassSource,
+        warnings := Warnings
+    } = Response
+) ->
+    %% ADR 0105 Phase 1 (BT-2777): return_type/param_types carry the patched
+    %% method's declared signature so the workspace can capture it into the
+    %% signature-generation store before install. Defaulted so an older
+    %% compiler-port binary (pre-BT-2777) that omits these keys still decodes.
+    ReturnType = maps:get(return_type, Response, <<"Dynamic">>),
+    ParamTypes = maps:get(param_types, Response, []),
     {ok, #{
         core_erlang => CoreErlang,
         module_name => ModuleName,
@@ -961,6 +969,8 @@ handle_compile_method_response(#{
         is_class_method => decode_bool(IsClassMethod),
         method_source => MethodSource,
         merged_class_source => MergedClassSource,
+        return_type => ReturnType,
+        param_types => ParamTypes,
         warnings => Warnings
     }};
 handle_compile_method_response(#{status := error, diagnostics := Diagnostics}) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
@@ -369,6 +369,11 @@ compile_method_reload(ClassSource, MethodSource, Options) ->
                                 is_class_method => maps:get(is_class_method, CR, false),
                                 method_source => maps:get(method_source, CR),
                                 merged_class_source => maps:get(merged_class_source, CR),
+                                %% ADR 0105 Phase 1 (BT-2777): declared signature,
+                                %% forwarded so the signature-generation store can
+                                %% capture it before the patch installs.
+                                return_type => maps:get(return_type, CR, <<"Dynamic">>),
+                                param_types => maps:get(param_types, CR, []),
                                 warnings => maps:get(warnings, CR, [])
                             }};
                         {error, Reason} ->
@@ -398,9 +403,20 @@ compile_expression_via_port(Expression, ModuleName, Bindings) ->
                     compile_class_definition_result(ClassInfo, ModuleName);
                 {ok, method_definition, MethodInfo} ->
                     Warnings = maps:get(warnings, MethodInfo, []),
+                    %% ADR 0105 Phase 1 (BT-2777): return_type/param_types ride
+                    %% along so the signature-generation store can capture the
+                    %% declared signature before the patch installs.
                     {ok, method_definition,
                         maps:with(
-                            [class_name, selector, is_class_method, method_source], MethodInfo
+                            [
+                                class_name,
+                                selector,
+                                is_class_method,
+                                method_source,
+                                return_type,
+                                param_types
+                            ],
+                            MethodInfo
                         ),
                         Warnings};
                 %% BT-1612: Protocol definition — compile Core Erlang to BEAM

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -799,6 +799,10 @@ install_method_with_source(
                 merged_class_source := MergedClassSource,
                 warnings := RecompileWarnings
             } = Result,
+            %% ADR 0105 Phase 1 (BT-2777): declared signature, carried through to
+            %% load_recompiled_method's capture-before-install hook.
+            ReturnType = maps:get(return_type, Result, <<"Dynamic">>),
+            ParamTypes = maps:get(param_types, Result, []),
             MethodInfo = #{
                 class_name => ClassNameBin,
                 selector => Selector,
@@ -806,7 +810,9 @@ install_method_with_source(
                 method_source => CanonicalSource,
                 intent => Intent,
                 author => Author,
-                author_kind => AuthorKind
+                author_kind => AuthorKind,
+                return_type => ReturnType,
+                param_types => ParamTypes
             },
             AllWarnings = Warnings ++ RecompileWarnings,
             load_recompiled_method(
@@ -855,11 +861,58 @@ remove_method(ClassNameBin, Selector, Side) ->
                 )
             of
                 {ok, Span, _Body} ->
+                    %% ADR 0105 Phase 1 (BT-2777): record the removal in the
+                    %% signature-generation store BEFORE the recompile-without-
+                    %% the-method installs (mirrors capture_signature_generation/1
+                    %% in load_recompiled_method/8 — this IS the install for a
+                    %% deletion, and must run beforehand so a first-ever capture
+                    %% still seeds the method's pre-removal signature from
+                    %% __beamtalk_meta/0 rather than the just-recompiled module,
+                    %% which no longer has this selector at all). Rolled back
+                    %% below if the recompile fails, so a failed removal never
+                    %% poisons the store with a removal that didn't happen.
+                    RemovalCapture = capture_signature_removal(ClassNameBin, SelectorBin, Side),
                     NewSourceBin = splice_out_span(ClassSourceBin, Span),
-                    reload_class_without_method(ClassNameBin, NewSourceBin);
+                    case reload_class_without_method(ClassNameBin, NewSourceBin) of
+                        {ok, _} = Ok ->
+                            Ok;
+                        {error, _} = Error ->
+                            rollback_signature_generation(
+                                ClassNameBin, SelectorBin, Side, RemovalCapture
+                            ),
+                            Error
+                    end;
                 {error, Reason, _Msg} ->
                     {error, {method_not_found, Reason}}
             end
+    end.
+
+%% Record a method removal into the signature-generation store (ADR 0105 Phase
+%% 1, BT-2777). Best-effort and self-swallowing, mirroring
+%% capture_signature_generation/1 — a store failure must never block the
+%% removal itself. Returns the same {captured, Prev} | not_captured outcome so
+%% the caller can roll back on a subsequent recompile failure.
+-spec capture_signature_removal(binary(), binary(), instance | class) -> capture_outcome().
+capture_signature_removal(ClassNameBin, SelectorBin, Side) ->
+    try
+        {Prev, _Classification} = beamtalk_workspace_signature_store:capture(
+            ClassNameBin, SelectorBin, Side, removed
+        ),
+        {captured, Prev}
+    catch
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                "Failed to capture method-removal signature generation (removal proceeding)",
+                #{
+                    error_class => Class,
+                    reason => Reason,
+                    stack => Stack,
+                    class => ClassNameBin,
+                    selector => SelectorBin,
+                    domain => [beamtalk, runtime]
+                }
+            ),
+            not_captured
     end.
 
 %% Recompile the (method-removed) class source and hot-reload it, preserving the
@@ -941,6 +994,18 @@ load_recompiled_method(
     State
 ) ->
     #{class_name := ClassNameBin, selector := SelectorBin} = MethodInfo,
+    Side = patch_side(maps:get(is_class_method, MethodInfo, false)),
+    %% ADR 0105 Phase 1 (BT-2777): capture the freshly-compiled signature into
+    %% the signature-generation store BEFORE the patch installs. Must run here
+    %% (not after code:load_binary below) — install reloads the class's
+    %% compiled module under its *existing* atom, so a first-ever capture made
+    %% after install would seed from the just-installed module's own
+    %% __beamtalk_meta/0 (comparing the new generation against itself) instead
+    %% of the true pre-patch original. Rolled back on the {error, LoadReason}
+    %% branch below, so a load failure never leaves the store holding a
+    %% generation that was never actually live. Best-effort: a store failure
+    %% must never block the install.
+    CaptureOutcome = capture_signature_generation(MethodInfo),
     %% Pass the class's on-disk source path (when known) so `code:which/1`
     %% reports a real path — keeping a patched project class classified as a
     %% project class, not "stdlib"/"dynamic" (BT-2553 follow-up).
@@ -976,6 +1041,10 @@ load_recompiled_method(
             Result = <<ClassNameBin/binary, ">>", SelectorBin/binary>>,
             {ok, Result, <<>>, AllWarnings, State};
         {error, LoadReason} ->
+            %% ADR 0105 Phase 1 (BT-2777): the install this capture described
+            %% never happened — undo it so the store still reflects the actually
+            %% live generation.
+            rollback_signature_generation(ClassNameBin, SelectorBin, Side, CaptureOutcome),
             ClassAtoms = class_name_atoms(Classes),
             case beamtalk_runtime_api:drain_pending_load_errors_by_names(ClassAtoms) of
                 [{_ClassName, StructuredError} | _] ->
@@ -1461,6 +1530,82 @@ do_emit_change_entry(MethodInfo) ->
     Entry = add_flushability(Base, ClassNameBin, SelectorBin, Side),
     _ = beamtalk_workspace_changelog:append(Entry),
     ok.
+
+%% The outcome of a best-effort signature-store capture (ADR 0105 Phase 1,
+%% BT-2777): `{captured, Prev}` when the store call succeeded (`Prev` is
+%% whatever it reported as the pre-capture generation — feed this straight
+%% back to rollback_signature_generation/4 on a subsequent install failure),
+%% or `not_captured` when the capture itself failed (nothing to roll back).
+-type capture_outcome() ::
+    {captured, beamtalk_workspace_signature_store:maybe_signature()} | not_captured.
+
+%% Capture the freshly-compiled signature into the signature-generation store
+%% (ADR 0105 Phase 1, BT-2777). Called from load_recompiled_method/8 *before*
+%% the patch installs — see the call site for why ordering matters. Best-effort
+%% and self-swallowing, mirroring emit_change_entry/1: the store is diagnostic
+%% plumbing for a later re-check (BT-2778), never a gate on the install itself.
+%% Returns the capture_outcome() so the caller can roll back on install failure.
+-spec capture_signature_generation(map()) -> capture_outcome().
+capture_signature_generation(MethodInfo) ->
+    try
+        do_capture_signature_generation(MethodInfo)
+    catch
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                "Failed to capture method signature generation (install proceeding)",
+                #{
+                    error_class => Class,
+                    reason => Reason,
+                    stack => Stack,
+                    method_info => maps:with([class_name, selector], MethodInfo),
+                    domain => [beamtalk, runtime]
+                }
+            ),
+            not_captured
+    end.
+
+-spec do_capture_signature_generation(map()) -> capture_outcome().
+do_capture_signature_generation(MethodInfo) ->
+    ClassNameBin = maps:get(class_name, MethodInfo),
+    SelectorBin = maps:get(selector, MethodInfo),
+    IsClassMethod = maps:get(is_class_method, MethodInfo, false),
+    Side = patch_side(IsClassMethod),
+    NewSignature = #{
+        return_type => maps:get(return_type, MethodInfo, <<"Dynamic">>),
+        param_types => maps:get(param_types, MethodInfo, [])
+    },
+    {Prev, _Classification} = beamtalk_workspace_signature_store:capture(
+        ClassNameBin, SelectorBin, Side, NewSignature
+    ),
+    {captured, Prev}.
+
+%% Undo a capture_signature_generation/1 (or capture_signature_removal/3) call
+%% whose install/removal subsequently failed (ADR 0105 Phase 1, BT-2777).
+%% `not_captured` is a no-op (the capture itself never wrote anything). Best-
+%% effort and self-swallowing — a rollback failure must never surface as the
+%% install/removal error the caller is already propagating.
+-spec rollback_signature_generation(binary(), binary(), instance | class, capture_outcome()) -> ok.
+rollback_signature_generation(_ClassNameBin, _SelectorBin, _Side, not_captured) ->
+    ok;
+rollback_signature_generation(ClassNameBin, SelectorBin, Side, {captured, Prev}) ->
+    try
+        _ = beamtalk_workspace_signature_store:rollback(ClassNameBin, SelectorBin, Side, Prev),
+        ok
+    catch
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                "Failed to roll back method signature generation (install/removal failure proceeding)",
+                #{
+                    error_class => Class,
+                    reason => Reason,
+                    stack => Stack,
+                    class => ClassNameBin,
+                    selector => SelectorBin,
+                    domain => [beamtalk, runtime]
+                }
+            ),
+            ok
+    end.
 
 -spec patch_side(boolean()) -> instance | class.
 patch_side(true) -> class;

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_signature_diff.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_signature_diff.erl
@@ -60,7 +60,7 @@ Classify the change from `Old` (generation N-1) to `New` (generation N).
   `New` being the same map) — `no_op`.
 - Anything else — `signature_change`.
 """.
--spec diff(maybe_signature(), maybe_signature() | removed) -> classification().
+-spec diff(maybe_signature(), maybe_signature()) -> classification().
 diff(_Old, removed) ->
     removal;
 diff(undefined, _New) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_signature_diff.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_signature_diff.erl
@@ -1,0 +1,71 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_signature_diff).
+
+%%% **DDD Context:** Workspace Context
+
+-moduledoc """
+Pure signature-diff classification (ADR 0105 Phase 1, BT-2777).
+
+Given a method's previous-generation signature and its newly-compiled
+signature, classifies the change as `signature_change` (return/param types
+differ), `removal` (the selector no longer exists), or `no_op` (nothing
+comparable changed, including "no previous generation to compare against").
+
+This module is deliberately side-effect-free — it does not know about the
+class registry, the compiler port, or the signature-generation store
+(`beamtalk_workspace_signature_store`). Callers pass in already-resolved
+signature values; `beamtalk_workspace_signature_store:capture/4` is the usual
+caller (it resolves the previous generation and then delegates here).
+
+Shape/`state:` diffs (added/removed/retyped fields) are explicitly out of
+scope — ADR 0105 Phase 2.
+""".
+
+-export([diff/2]).
+
+-export_type([signature/0, classification/0]).
+
+%% A method's declared signature: return type + positional parameter types,
+%% each rendered as the same type-name string the class hierarchy and
+%% `__beamtalk_meta/0` use (`TypeAnnotation:type_name/0` on the compiler
+%% side). An unannotated return/param is the `<<"Dynamic">>` sentinel, never
+%% omitted, so two signatures are always directly comparable.
+-type signature() :: #{return_type := binary(), param_types := [binary()]}.
+
+%% `removed` marks that the selector no longer exists on the class (BT-2777
+%% acceptance criteria's "removal" case — the method-delete path records this
+%% instead of a signature() map). `undefined` marks "no generation recorded
+%% yet" — the seed state before any patch, or an unresolvable original
+%% (nothing to compare against, so classification degrades to `no_op` rather
+%% than risk a false "signature changed").
+-type maybe_signature() :: signature() | removed | undefined.
+
+-type classification() :: signature_change | removal | no_op.
+
+-doc """
+Classify the change from `Old` (generation N-1) to `New` (generation N).
+
+- `New =:= removed` — the method was deleted. Always `removal`, regardless of
+  `Old` (even if `Old` was itself `removed` — a double-delete is still a
+  removal report, not a no-op; callers are not expected to invoke `diff/2`
+  twice for the same removal, but the classification stays honest either way).
+- `Old =:= undefined` — no previous generation to compare against (first-ever
+  capture for this selector, or the original signature could not be
+  resolved). Reporting `signature_change` here would be a guess with no
+  baseline, so this is `no_op` — advisory-never-blocking (ADR 0105) means we
+  do not manufacture a finding from nothing.
+- `Old =:= New` (structural equality, including `Old =:= removed` and
+  `New` being the same map) — `no_op`.
+- Anything else — `signature_change`.
+""".
+-spec diff(maybe_signature(), maybe_signature() | removed) -> classification().
+diff(_Old, removed) ->
+    removal;
+diff(undefined, _New) ->
+    no_op;
+diff(Old, New) when Old =:= New ->
+    no_op;
+diff(_Old, _New) ->
+    signature_change.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_signature_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_signature_store.erl
@@ -1,0 +1,264 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_workspace_signature_store).
+-behaviour(gen_server).
+
+%%% **DDD Context:** Workspace Context
+
+-moduledoc """
+Per-selector signature-generation store (ADR 0105 Phase 1, BT-2777).
+
+Hot-patching clears a method's type metadata on install (`put_method/4`
+deliberately wipes `method_signatures`/`method_return_types` per ADR 0050 —
+`beamtalk_object_class.erl`; the IDE-save/`compile:source:` recompile path
+overwrites it with the *new* generation, losing the *previous* one just as
+surely). Either way, once a patch installs, the pre-patch signature is gone
+from live class state. This store is the plumbing that survives the wipe: the
+install hook (`beamtalk_repl_loader:load_recompiled_method/8`) calls
+`capture/4` with the freshly-compiled signature *before* the patch installs,
+so the diff always compares the new generation against the one actually
+recorded at the previous patch — never against wiped/overwritten class state.
+
+## Generation handling
+
+`capture/4` is the whole contract: given the newly-compiled signature for
+`{Class, Selector, Side}`, it looks up whatever was recorded at the *last*
+patch (or seeds from the class's original, never-patched `__beamtalk_meta/0`
+when this is the first patch this session), classifies the change via
+`beamtalk_signature_diff:diff/2`, records the new signature as the entry for
+the next patch, and returns `{PreviousSignature, Classification}`. Repeated
+edits to the same method therefore chain correctly: generation N's "previous"
+is always exactly what generation N-1 installed, not generation 0.
+
+## Session-only, never persisted
+
+State lives in this gen_server's process dictionary-free `#state{}` map —
+plain in-memory, no ETS, no disk. It is supervised under
+`beamtalk_workspace_sup` alongside `beamtalk_workspace_meta`, so a workspace
+restart (a fresh BEAM node) starts a fresh, empty store — exactly the ADR's
+"session state, never persisted to the artifact" requirement. `clear/0` gives
+callers (e.g. `Workspace changes revert:`) an explicit reset without a full
+restart.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([start_link/0, capture/4, previous/3, rollback/4, clear/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+
+-ifdef(TEST).
+-export([seed_from_meta/3, meta_type_to_binary/1]).
+-endif.
+
+-export_type([side/0, signature/0, maybe_signature/0]).
+
+-type side() :: instance | class.
+-type signature() :: #{return_type := binary(), param_types := [binary()]}.
+-type maybe_signature() :: signature() | removed | undefined.
+-type key() :: {binary(), binary(), side()}.
+
+-record(state, {sigs = #{} :: #{key() => signature() | removed}}).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+-doc "Start the signature-generation store (one per workspace).".
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-doc """
+Capture the newly-compiled signature for `{ClassName, Selector, Side}`,
+diffing it against whatever was recorded at the previous patch (or the
+class's original `__beamtalk_meta/0` for a never-patched method).
+
+`NewSignature` is either a `signature()` map (a patch installing a method) or
+the atom `removed` (a method being deleted — `beamtalk_repl_loader:remove_method/3`).
+
+**Must be called *before* the install** (before `code:load_binary/3` for a
+patch, before the recompile-without-the-method for a removal) — never after.
+The install reloads the class's compiled module under its *existing* atom, so
+a call made after install would read the *new* code's `__beamtalk_meta/0` when
+seeding a first-ever capture, silently comparing the new generation against
+itself (`no_op` every time) instead of the true original. Calling before
+install means a load/reload failure would otherwise leave the store holding a
+generation that was never actually live — pair every `capture/4` call with a
+`rollback/4` call on that failure path (see `rollback/4`).
+
+Returns `{PreviousSignature, Classification}` — the caller (BT-2778's
+re-check orchestration) uses `Classification` to decide whether a re-check is
+warranted at all (`no_op` short-circuits it).
+""".
+-spec capture(binary(), binary(), side(), signature() | removed) ->
+    {maybe_signature(), beamtalk_signature_diff:classification()}.
+capture(ClassName, Selector, Side, NewSignature) when
+    is_binary(ClassName), is_binary(Selector), (Side =:= instance orelse Side =:= class)
+->
+    gen_server:call(?MODULE, {capture, ClassName, Selector, Side, NewSignature}).
+
+-doc """
+Read-only lookup of the signature that `capture/4` would currently treat as
+"previous" for `{ClassName, Selector, Side}` — from the store if this
+selector has been patched this session, else seeded from `__beamtalk_meta/0`.
+Does not mutate the store. Exposed for the re-check orchestration (BT-2778)
+and for tests.
+""".
+-spec previous(binary(), binary(), side()) -> maybe_signature().
+previous(ClassName, Selector, Side) when
+    is_binary(ClassName), is_binary(Selector), (Side =:= instance orelse Side =:= class)
+->
+    gen_server:call(?MODULE, {previous, ClassName, Selector, Side}).
+
+-doc """
+Undo a `capture/4` call whose install/removal turned out to fail, restoring
+`{ClassName, Selector, Side}` to `PreviousSignature` (the first element of the
+`{PreviousSignature, Classification}` pair that `capture/4` returned).
+
+`capture/4` must run *before* the install it describes (to seed correctly from
+still-live pre-patch class state — see its doc), which means its write can't
+simply be deferred until success is known. `rollback/4` is the other half:
+call it when the install/removal that followed `capture/4` failed, so a failed
+attempt never leaves the store holding a generation that was never actually
+live. `PreviousSignature` of `undefined` removes the key entirely — the
+correct state when the failed attempt was itself the first-ever capture for
+this selector (nothing should be there at all).
+""".
+-spec rollback(binary(), binary(), side(), maybe_signature()) -> ok.
+rollback(ClassName, Selector, Side, PreviousSignature) when
+    is_binary(ClassName), is_binary(Selector), (Side =:= instance orelse Side =:= class)
+->
+    gen_server:call(?MODULE, {rollback, ClassName, Selector, Side, PreviousSignature}).
+
+-doc """
+Clear every recorded generation (`Workspace changes revert:`, tests). The next
+`capture/4` for any selector re-seeds from `__beamtalk_meta/0` as if this were
+a fresh workspace.
+""".
+-spec clear() -> ok.
+clear() ->
+    gen_server:call(?MODULE, clear).
+
+%%====================================================================
+%% gen_server callbacks
+%%====================================================================
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_call({capture, ClassName, Selector, Side, NewSignature}, _From, State = #state{sigs = Sigs}) ->
+    Key = {ClassName, Selector, Side},
+    Prev =
+        case maps:find(Key, Sigs) of
+            {ok, V} -> V;
+            error -> seed_from_meta(ClassName, Selector, Side)
+        end,
+    Classification = beamtalk_signature_diff:diff(Prev, NewSignature),
+    NewSigs = Sigs#{Key => NewSignature},
+    {reply, {Prev, Classification}, State#state{sigs = NewSigs}};
+handle_call({previous, ClassName, Selector, Side}, _From, State = #state{sigs = Sigs}) ->
+    Key = {ClassName, Selector, Side},
+    Prev =
+        case maps:find(Key, Sigs) of
+            {ok, V} -> V;
+            error -> seed_from_meta(ClassName, Selector, Side)
+        end,
+    {reply, Prev, State};
+handle_call({rollback, ClassName, Selector, Side, undefined}, _From, State = #state{sigs = Sigs}) ->
+    Key = {ClassName, Selector, Side},
+    {reply, ok, State#state{sigs = maps:remove(Key, Sigs)}};
+handle_call(
+    {rollback, ClassName, Selector, Side, PreviousSignature}, _From, State = #state{sigs = Sigs}
+) ->
+    Key = {ClassName, Selector, Side},
+    {reply, ok, State#state{sigs = Sigs#{Key => PreviousSignature}}};
+handle_call(clear, _From, State) ->
+    {reply, ok, State#state{sigs = #{}}};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%====================================================================
+%% Internal functions
+%%====================================================================
+
+-doc """
+Seed the "original" (never-patched) signature from the class's compiled
+`__beamtalk_meta/0`, for the first `capture/4` this session against a
+selector. Best-effort: any resolution failure (class not registered, no
+`__beamtalk_meta/0` exported, selector not a known method) returns
+`undefined` — "no baseline to compare against" — rather than raising, since a
+brand-new method or a not-yet-loaded class are both ordinary, not errors.
+""".
+-spec seed_from_meta(binary(), binary(), side()) -> maybe_signature().
+seed_from_meta(ClassName, Selector, Side) ->
+    try
+        ClassAtom = binary_to_existing_atom(ClassName, utf8),
+        {ok, Module} = beamtalk_class_metadata:lookup_module(ClassAtom),
+        %% A qualified remote call auto-loads an as-yet-unloaded module (unlike
+        %% erlang:function_exported/3, which only inspects already-loaded code
+        %% and silently reports `false` for a module nobody has touched yet —
+        %% exactly the state a rarely-hit class can be in during a workspace
+        %% session). `undef` from a module with no `__beamtalk_meta/0` (or no
+        %% code at all) is caught below like any other resolution failure.
+        Meta = Module:'__beamtalk_meta'(),
+        InfoKey =
+            case Side of
+                instance -> method_info;
+                class -> class_method_info
+            end,
+        MethodInfoMap = maps:get(InfoKey, Meta, #{}),
+        SelectorAtom = binary_to_existing_atom(Selector, utf8),
+        case maps:find(SelectorAtom, MethodInfoMap) of
+            {ok, Entry} ->
+                #{
+                    return_type => meta_type_to_binary(maps:get(return_type, Entry, none)),
+                    param_types => [
+                        meta_type_to_binary(T)
+                     || T <- maps:get(param_types, Entry, [])
+                    ]
+                };
+            error ->
+                undefined
+        end
+    catch
+        _:_ ->
+            undefined
+    end.
+
+-doc """
+Render a `meta_type_repr()` (ADR 0068 — atom, `{type_param, Name, Index}`, or
+`{generic, Base, Params}`) as the same type-name string the compiler emits via
+`TypeAnnotation:type_name/0`, so a `__beamtalk_meta`-seeded signature compares
+equal to a freshly-compiled one when nothing actually changed.
+""".
+-spec meta_type_to_binary(term()) -> binary().
+meta_type_to_binary(none) ->
+    <<"Dynamic">>;
+meta_type_to_binary(Atom) when is_atom(Atom) ->
+    atom_to_binary(Atom, utf8);
+meta_type_to_binary({type_param, Name, _Index}) when is_atom(Name) ->
+    atom_to_binary(Name, utf8);
+meta_type_to_binary({generic, Base, Params}) when is_atom(Base), is_list(Params) ->
+    ParamBins = [meta_type_to_binary(P) || P <- Params],
+    iolist_to_binary([
+        atom_to_binary(Base, utf8), "(", lists:join(<<", ">>, ParamBins), ")"
+    ]);
+meta_type_to_binary(Other) ->
+    %% Defensive fallback for a shape this module doesn't recognise — never
+    %% crash the capture hook over a cosmetic rendering gap.
+    iolist_to_binary(io_lib:format("~p", [Other])).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_signature_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_signature_store.erl
@@ -203,7 +203,10 @@ Seed the "original" (never-patched) signature from the class's compiled
 selector. Best-effort: any resolution failure (class not registered, no
 `__beamtalk_meta/0` exported, selector not a known method) returns
 `undefined` — "no baseline to compare against" — rather than raising, since a
-brand-new method or a not-yet-loaded class are both ordinary, not errors.
+brand-new method or a not-yet-loaded class are both ordinary, not errors. The
+ordinary/expected failure modes (`badarg`, `{badmatch, not_found}`, `undef`)
+degrade silently; anything else is logged at `?LOG_WARNING` before degrading,
+since an unrecognised failure is more likely a real bug than routine absence.
 """.
 -spec seed_from_meta(binary(), binary(), side()) -> maybe_signature().
 seed_from_meta(ClassName, Selector, Side) ->
@@ -237,7 +240,33 @@ seed_from_meta(ClassName, Selector, Side) ->
                 undefined
         end
     catch
-        _:_ ->
+        %% Expected, ordinary resolution failures — silent, no log:
+        %%   badarg   — ClassName/Selector isn't an atom yet (brand-new this session).
+        %%   {badmatch, not_found} — class not registered in beamtalk_class_metadata.
+        %%   undef    — Module has no __beamtalk_meta/0 (or no code at all).
+        error:badarg ->
+            undefined;
+        error:{badmatch, not_found} ->
+            undefined;
+        error:undef ->
+            undefined;
+        %% Anything else is unexpected — still degrade to `undefined` (this
+        %% function must never crash the capture hook), but log it so a real
+        %% bug (e.g. a __beamtalk_meta/0 shape this module doesn't understand)
+        %% doesn't silently masquerade as "no baseline to compare against".
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                "Unexpected failure seeding signature from __beamtalk_meta/0",
+                #{
+                    error_class => Class,
+                    reason => Reason,
+                    stack => Stack,
+                    class => ClassName,
+                    selector => Selector,
+                    side => Side,
+                    domain => [beamtalk, runtime]
+                }
+            ),
             undefined
     end.
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_signature_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_signature_store.erl
@@ -147,6 +147,7 @@ clear() ->
 %%====================================================================
 
 init([]) ->
+    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
     {ok, #state{}}.
 
 handle_call({capture, ClassName, Selector, Side, NewSignature}, _From, State = #state{sigs = Sigs}) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_sup.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_sup.erl
@@ -22,12 +22,13 @@ Architecture (from ADR 0004, implemented in BT-262):
 beamtalk_workspace_sup
   ├─ beamtalk_workspace_meta      % Metadata (project path, created_at)
   ├─ beamtalk_workspace_changelog % Append-only ChangeLog (ADR 0082, BT-2282)
-  ├─ beamtalk_workspace_signature_store % Signature-generation store (ADR 0105, BT-2777)
   ├─ beamtalk_transcript_stream    % Transcript singleton (ADR 0010, Actor)
   ├─ beamtalk_actor_registry       % Workspace-wide actor registry
   ├─ beamtalk_workspace_bootstrap % Class var bootstrap (ADR 0019)
   │     (also initialises sealed Object singletons: BeamtalkInterface, WorkspaceInterface)
   ├─ beamtalk_actor_sup           % Supervises user actors
+  │   -- REPL mode only (repl=true) below this line --
+  ├─ beamtalk_workspace_signature_store % Signature-generation store (ADR 0105, BT-2777)
   ├─ beamtalk_session_sup         % Supervises session shell processes (before repl_server)
   ├─ beamtalk_repl_server         % TCP server (session-per-connection)
   └─ beamtalk_idle_monitor        % Tracks activity, self-terminates if idle
@@ -156,21 +157,6 @@ init(Config) ->
                 shutdown => 5000,
                 type => worker,
                 modules => [beamtalk_workspace_changelog]
-            },
-
-            %% Signature-generation store (ADR 0105 Phase 1, BT-2777).
-            %% Per-selector previous-generation method signatures, captured at
-            %% patch time so a diff survives the class-state metadata wipe.
-            %% Session-only (no disk persistence) — no config dependency, so it
-            %% can start anywhere after meta; placed alongside the ChangeLog
-            %% since both are install-hook targets of beamtalk_repl_loader.
-            #{
-                id => beamtalk_workspace_signature_store,
-                start => {beamtalk_workspace_signature_store, start_link, []},
-                restart => permanent,
-                shutdown => 5000,
-                type => worker,
-                modules => [beamtalk_workspace_signature_store]
             }
 
             %% Actor singleton — workspace singletons (ADR 0010 Phase 2, ADR 0019 Phase 4)
@@ -222,12 +208,29 @@ init(Config) ->
 -doc """
 Return child specs for REPL-mode children.
 When repl=false (run mode), these are omitted: no TCP listener, no idle monitor,
-no per-connection session supervisor.
+no per-connection session supervisor, no signature-generation store.
 """.
 repl_child_specs(false, _TcpPort, _WorkspaceId, _BindAddr, _AutoCleanup, _MaxIdleSeconds) ->
     [];
 repl_child_specs(true, TcpPort, WorkspaceId, BindAddr, AutoCleanup, MaxIdleSeconds) ->
     [
+        %% Signature-generation store (ADR 0105 Phase 1, BT-2777).
+        %% Per-selector previous-generation method signatures, captured at
+        %% patch time so a diff survives the class-state metadata wipe. Only
+        %% meaningful in REPL mode — run mode (repl=false) executes a
+        %% precompiled artifact with no live-edit path (no session, no way to
+        %% reach beamtalk_repl_loader:install_method/9), so there is nothing
+        %% for it to capture there. Started before session_sup/repl_server so
+        %% it's ready before any REPL connection could trigger an install.
+        #{
+            id => beamtalk_workspace_signature_store,
+            start => {beamtalk_workspace_signature_store, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [beamtalk_workspace_signature_store]
+        },
+
         %% Session supervisor (one child per REPL connection).
         %%
         %% MUST start before beamtalk_repl_server: the REPL server's init/1 binds

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_sup.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_sup.erl
@@ -22,6 +22,7 @@ Architecture (from ADR 0004, implemented in BT-262):
 beamtalk_workspace_sup
   ├─ beamtalk_workspace_meta      % Metadata (project path, created_at)
   ├─ beamtalk_workspace_changelog % Append-only ChangeLog (ADR 0082, BT-2282)
+  ├─ beamtalk_workspace_signature_store % Signature-generation store (ADR 0105, BT-2777)
   ├─ beamtalk_transcript_stream    % Transcript singleton (ADR 0010, Actor)
   ├─ beamtalk_actor_registry       % Workspace-wide actor registry
   ├─ beamtalk_workspace_bootstrap % Class var bootstrap (ADR 0019)
@@ -155,6 +156,21 @@ init(Config) ->
                 shutdown => 5000,
                 type => worker,
                 modules => [beamtalk_workspace_changelog]
+            },
+
+            %% Signature-generation store (ADR 0105 Phase 1, BT-2777).
+            %% Per-selector previous-generation method signatures, captured at
+            %% patch time so a diff survives the class-state metadata wipe.
+            %% Session-only (no disk persistence) — no config dependency, so it
+            %% can start anywhere after meta; placed alongside the ChangeLog
+            %% since both are install-hook targets of beamtalk_repl_loader.
+            #{
+                id => beamtalk_workspace_signature_store,
+                start => {beamtalk_workspace_signature_store, start_link, []},
+                restart => permanent,
+                shutdown => 5000,
+                type => worker,
+                modules => [beamtalk_workspace_signature_store]
             }
 
             %% Actor singleton — workspace singletons (ADR 0010 Phase 2, ADR 0019 Phase 4)

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_tests.erl
@@ -744,6 +744,15 @@ loader_setup() ->
         _ ->
             ok
     end,
+    %% ADR 0105 Phase 1 (BT-2777): a live signature-generation store lets
+    %% capture_signature_generation/1 actually record into the store instead
+    %% of taking only its best-effort catch path (`noproc`).
+    case whereis(beamtalk_workspace_signature_store) of
+        undefined ->
+            {ok, _} = beamtalk_workspace_signature_store:start_link();
+        _ ->
+            ok
+    end,
     Proj.
 
 loader_teardown(Proj) ->
@@ -757,6 +766,10 @@ loader_teardown(Proj) ->
     case whereis(beamtalk_workspace_meta) of
         undefined -> ok;
         MetaPid -> gen_server:stop(MetaPid)
+    end,
+    case whereis(beamtalk_workspace_signature_store) of
+        undefined -> ok;
+        SigStorePid -> gen_server:stop(SigStorePid)
     end,
     %% Stop the compiler app so later test modules in the shared EUnit node see
     %% the baseline "compiler not running" state (noproc error-path tests in
@@ -886,6 +899,96 @@ t_install_method_preserves_comments(_Proj) ->
     ),
     Src2 = stored_method_source('InstallDoc', bumped),
     ?assertEqual(Src1, Src2).
+
+%% ADR 0105 Phase 1 (BT-2777): a save through the real structured install path
+%% (compile_method -> load_recompiled_method -> capture_signature_generation)
+%% must land a correctly-typed signature in the store — not just the direct
+%% beamtalk_workspace_signature_store:capture/4 API tested in isolation in
+%% beamtalk_workspace_signature_store_tests.erl. This is the plumbing test: a
+%% dropped/misspelled key anywhere in the return_type/param_types forwarding
+%% chain (compiler port -> compiler_server -> repl_compiler -> repl_loader)
+%% would otherwise collapse silently to the "Dynamic"/[] degenerate signature.
+t_install_method_records_signature(_Proj) ->
+    Proj = live_project_dir(),
+    Path = write_bt_under(
+        Proj,
+        "src",
+        "SignatureCapture.bt",
+        <<"Actor subclass: SignatureCapture\n  state: v = 1\n\n  value -> Integer =>\n    self.v\n">>
+    ),
+    State0 = beamtalk_repl_state:new(undefined, 0),
+    {ok, _, State1} = beamtalk_repl_loader:handle_load(Path, State0),
+    ?assertMatch(
+        {ok, _, _, _, _},
+        beamtalk_repl_loader:install_method(
+            <<"SignatureCapture">>,
+            <<"describe:">>,
+            <<"describe: n :: Integer -> String =>\n  \"x\"">>,
+            durable,
+            <<"test">>,
+            human,
+            [],
+            State1
+        )
+    ),
+    Signature = beamtalk_workspace_signature_store:previous(
+        <<"SignatureCapture">>, <<"describe:">>, instance
+    ),
+    ?assertEqual(
+        #{return_type => <<"String">>, param_types => [<<"Integer">>]}, Signature
+    ).
+
+%% Two successive saves to the same method must chain: the second save's
+%% "previous" is the first save's signature, not undefined/generation 0 — the
+%% core ADR 0105 generation-handling guarantee, exercised end-to-end.
+t_install_method_chains_signature_generations(_Proj) ->
+    Proj = live_project_dir(),
+    Path = write_bt_under(
+        Proj,
+        "src",
+        "SignatureChain.bt",
+        <<"Actor subclass: SignatureChain\n  state: v = 1\n\n  value -> Integer =>\n    self.v\n">>
+    ),
+    State0 = beamtalk_repl_state:new(undefined, 0),
+    {ok, _, State1} = beamtalk_repl_loader:handle_load(Path, State0),
+    ?assertMatch(
+        {ok, _, _, _, _},
+        beamtalk_repl_loader:install_method(
+            <<"SignatureChain">>,
+            <<"getValue">>,
+            <<"getValue -> Integer =>\n  self.v">>,
+            durable,
+            <<"test">>,
+            human,
+            [],
+            State1
+        )
+    ),
+    Gen1 = beamtalk_workspace_signature_store:previous(
+        <<"SignatureChain">>, <<"getValue">>, instance
+    ),
+    ?assertEqual(#{return_type => <<"Integer">>, param_types => []}, Gen1),
+    ?assertMatch(
+        {ok, _, _, _, _},
+        beamtalk_repl_loader:install_method(
+            <<"SignatureChain">>,
+            <<"getValue">>,
+            <<"getValue -> String =>\n  \"x\"">>,
+            durable,
+            <<"test">>,
+            human,
+            [],
+            State1
+        )
+    ),
+    %% The store's "previous" now reflects generation 2 (the just-installed
+    %% String-returning body) — proving generation 1's Integer signature was
+    %% correctly recorded and chained through, not left as generation 0/undefined.
+    Gen2 = beamtalk_workspace_signature_store:previous(
+        <<"SignatureChain">>, <<"getValue">>, instance
+    ),
+    ?assertEqual(#{return_type => <<"String">>, param_types => []}, Gen2),
+    ?assertNotEqual(Gen1, Gen2).
 
 %% BT-2567: `browse-method-source`'s `disk_differs` re-reads the on-disk class
 %% file *live* each browse, so an out-of-band rewrite (an external editor, or
@@ -1129,6 +1232,14 @@ loader_integration_test_() ->
             end},
             {"new method flushes at class body indentation (BT-2583)", fun() ->
                 t_new_method_appends_indented(Proj)
+            end},
+            %% ADR 0105 Phase 1 (BT-2777): the signature-generation store, exercised
+            %% through the real install path (not just direct store API calls).
+            {"install_method records the declared signature in the store", fun() ->
+                t_install_method_records_signature(Proj)
+            end},
+            {"repeated install_method chains store generations", fun() ->
+                t_install_method_chains_signature_generations(Proj)
             end}
         ]
     end}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_signature_diff_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_signature_diff_tests.erl
@@ -1,0 +1,56 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_signature_diff_tests).
+
+-moduledoc "Unit tests for beamtalk_signature_diff (ADR 0105 Phase 1, BT-2777).".
+
+-include_lib("eunit/include/eunit.hrl").
+
+sig(ReturnType, ParamTypes) ->
+    #{return_type => ReturnType, param_types => ParamTypes}.
+
+%% Identical signatures classify as no_op — nothing worth a re-check finding.
+identical_signatures_is_no_op_test() ->
+    Sig = sig(<<"Integer">>, [<<"Integer">>]),
+    ?assertEqual(no_op, beamtalk_signature_diff:diff(Sig, Sig)).
+
+%% A changed return type is a signature_change.
+changed_return_type_is_signature_change_test() ->
+    Old = sig(<<"Integer">>, []),
+    New = sig(<<"String">>, []),
+    ?assertEqual(signature_change, beamtalk_signature_diff:diff(Old, New)).
+
+%% A changed parameter type is a signature_change, even with the same return type.
+changed_param_type_is_signature_change_test() ->
+    Old = sig(<<"Object">>, [<<"Integer">>]),
+    New = sig(<<"Object">>, [<<"String">>]),
+    ?assertEqual(signature_change, beamtalk_signature_diff:diff(Old, New)).
+
+%% Adding/removing a parameter (arity change) is a signature_change.
+changed_arity_is_signature_change_test() ->
+    Old = sig(<<"Object">>, [<<"Integer">>]),
+    New = sig(<<"Object">>, [<<"Integer">>, <<"String">>]),
+    ?assertEqual(signature_change, beamtalk_signature_diff:diff(Old, New)).
+
+%% New =:= removed is always classified as removal, regardless of Old.
+removed_selector_is_removal_test() ->
+    Old = sig(<<"Integer">>, []),
+    ?assertEqual(removal, beamtalk_signature_diff:diff(Old, removed)).
+
+%% Even a prior removal followed by another `removed` classifies as removal
+%% (diff/2 does not special-case "was already gone" — it just reports what New says).
+double_removal_is_still_removal_test() ->
+    ?assertEqual(removal, beamtalk_signature_diff:diff(removed, removed)).
+
+%% No previous generation (never patched, unresolvable original) is a no_op —
+%% there is nothing to compare against, so no finding is manufactured.
+no_previous_generation_is_no_op_test() ->
+    New = sig(<<"Integer">>, []),
+    ?assertEqual(no_op, beamtalk_signature_diff:diff(undefined, New)).
+
+%% A method reappearing after a removal (Old =:= removed, New a real signature)
+%% is a signature_change — the interface is different from what it was.
+readded_after_removal_is_signature_change_test() ->
+    New = sig(<<"Integer">>, []),
+    ?assertEqual(signature_change, beamtalk_signature_diff:diff(removed, New)).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_signature_store_fixture.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_signature_store_fixture.erl
@@ -1,0 +1,57 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_signature_store_fixture).
+
+-moduledoc """
+Static `__beamtalk_meta/0` fixture for `beamtalk_workspace_signature_store_tests`
+(ADR 0105 Phase 1, BT-2777).
+
+Hand-written to match the exact shape the Rust codegen emits for
+`method_info`/`class_method_info` entries (`meta_method_info_map` in
+`crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs`), so a
+test registering this module via `beamtalk_class_metadata:insert/4` exercises
+`beamtalk_workspace_signature_store:seed_from_meta/3` against a realistic
+never-patched original signature — the fallback case a compile-response
+capture never touches.
+""".
+
+-export(['__beamtalk_meta'/0]).
+
+'__beamtalk_meta'() ->
+    #{
+        class => 'FixtureClass',
+        superclass => 'Object',
+        method_info => #{
+            greet => #{
+                arity => 1,
+                param_types => ['String'],
+                return_type => 'Integer',
+                is_sealed => false,
+                visibility => public
+            },
+            untyped => #{
+                arity => 0,
+                param_types => [],
+                return_type => none,
+                is_sealed => false,
+                visibility => public
+            },
+            generic_result => #{
+                arity => 0,
+                param_types => [],
+                return_type => {generic, 'Result', ['Integer', 'String']},
+                is_sealed => false,
+                visibility => public
+            }
+        },
+        class_method_info => #{
+            'new' => #{
+                arity => 0,
+                param_types => [],
+                return_type => 'FixtureClass',
+                is_sealed => false,
+                visibility => public
+            }
+        }
+    }.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_signature_store_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_signature_store_tests.erl
@@ -1,0 +1,388 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_workspace_signature_store_tests).
+
+-moduledoc """
+Unit tests for beamtalk_workspace_signature_store (ADR 0105 Phase 1, BT-2777).
+
+Covers:
+- capture-before-install ordering (the store update itself, independent of any
+  install call — capture/4 is what the install hook calls before code:load_binary)
+- repeated-edit generation chaining (generation N's "previous" is exactly
+  what generation N-1 recorded, not generation 0 or wiped class state)
+- diff classification threaded through from beamtalk_signature_diff
+- removal + re-add
+- rollback/4 undoing a capture whose install/removal subsequently failed
+  (including that it only undoes the single capture it's paired with)
+- clear/0 resets the session
+- __beamtalk_meta/0 seeding for a never-patched selector (both the "no meta
+  exported" degrade and the real read path via beamtalk_signature_store_fixture)
+
+The end-to-end thread from a real install (`beamtalk_repl_loader:install_method/9`)
+through to a correctly-populated store entry is covered in
+`beamtalk_repl_loader_tests.erl`, not here — this module tests the store's own
+API contract in isolation.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TABLE, beamtalk_class_metadata).
+
+sig(ReturnType, ParamTypes) ->
+    #{return_type => ReturnType, param_types => ParamTypes}.
+
+%%====================================================================
+%% Fixtures
+%%====================================================================
+
+setup() ->
+    {ok, Pid} = beamtalk_workspace_signature_store:start_link(),
+    Pid.
+
+cleanup(Pid) ->
+    case is_process_alive(Pid) of
+        true ->
+            Ref = monitor(process, Pid),
+            unlink(Pid),
+            exit(Pid, shutdown),
+            receive
+                {'DOWN', Ref, process, Pid, _} -> ok
+            after 1000 -> ok
+            end;
+        false ->
+            ok
+    end.
+
+store_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun first_capture_has_no_previous_and_is_no_op/1,
+        fun repeated_capture_chains_generations/1,
+        fun identical_capture_is_no_op/1,
+        fun previous_does_not_mutate_store/1,
+        fun capture_removal_then_readd/1,
+        fun clear_resets_the_session/1,
+        fun different_selectors_are_independent/1,
+        fun different_sides_are_independent/1,
+        fun rollback_to_a_signature_restores_it_as_previous/1,
+        fun rollback_to_undefined_removes_the_key/1,
+        fun rollback_after_a_chain_only_undoes_the_last_capture/1
+    ]}.
+
+%%====================================================================
+%% Generation handling (core AC coverage)
+%%====================================================================
+
+%% Nothing recorded yet, and the class isn't registered — no baseline exists,
+%% so the classification is no_op (never a manufactured signature_change).
+first_capture_has_no_previous_and_is_no_op(_Pid) ->
+    New = sig(<<"Integer">>, []),
+    {Prev, Classification} =
+        beamtalk_workspace_signature_store:capture(<<"Unregistered">>, <<"foo">>, instance, New),
+    [
+        ?_assertEqual(undefined, Prev),
+        ?_assertEqual(no_op, Classification)
+    ].
+
+%% Three edits to the same selector: each capture's "previous" must be exactly
+%% the immediately-prior generation, not generation 0 and not wiped state.
+repeated_capture_chains_generations(_Pid) ->
+    Sig1 = sig(<<"Integer">>, []),
+    Sig2 = sig(<<"String">>, []),
+    Sig3 = sig(<<"Object">>, [<<"Integer">>]),
+    {Prev1, C1} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"getCount">>, instance, Sig1),
+    {Prev2, C2} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"getCount">>, instance, Sig2),
+    {Prev3, C3} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"getCount">>, instance, Sig3),
+    [
+        %% Generation 1: no baseline.
+        ?_assertEqual(undefined, Prev1),
+        ?_assertEqual(no_op, C1),
+        %% Generation 2: previous is generation 1 (Sig1), not undefined.
+        ?_assertEqual(Sig1, Prev2),
+        ?_assertEqual(signature_change, C2),
+        %% Generation 3: previous is generation 2 (Sig2) — NOT Sig1 (generation 1)
+        %% and not the wiped/absent class state. This is the chaining property
+        %% the ADR calls out explicitly.
+        ?_assertEqual(Sig2, Prev3),
+        ?_assertEqual(signature_change, C3)
+    ].
+
+%% Capturing the same signature twice in a row is a no_op — nothing to report.
+identical_capture_is_no_op(_Pid) ->
+    Sig = sig(<<"Integer">>, [<<"String">>]),
+    {_, _} = beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig),
+    {Prev, Classification} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig),
+    [
+        ?_assertEqual(Sig, Prev),
+        ?_assertEqual(no_op, Classification)
+    ].
+
+%% previous/3 is read-only: calling it repeatedly must not change what the
+%% next capture/4 sees as "previous".
+previous_does_not_mutate_store(_Pid) ->
+    Sig1 = sig(<<"Integer">>, []),
+    {_, _} = beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig1),
+    P1 = beamtalk_workspace_signature_store:previous(<<"Counter">>, <<"m">>, instance),
+    P2 = beamtalk_workspace_signature_store:previous(<<"Counter">>, <<"m">>, instance),
+    Sig2 = sig(<<"String">>, []),
+    {Prev3, _} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig2),
+    [
+        ?_assertEqual(Sig1, P1),
+        ?_assertEqual(Sig1, P2),
+        ?_assertEqual(Sig1, Prev3)
+    ].
+
+%% A removal records `removed`; a subsequent re-add diffs against `removed`
+%% (a signature_change — the interface is different from "gone").
+capture_removal_then_readd(_Pid) ->
+    Sig1 = sig(<<"Integer">>, []),
+    {_, _} = beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig1),
+    {PrevAtRemoval, RemovalClass} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, removed),
+    Sig2 = sig(<<"String">>, []),
+    {PrevAtReadd, ReaddClass} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig2),
+    [
+        ?_assertEqual(Sig1, PrevAtRemoval),
+        ?_assertEqual(removal, RemovalClass),
+        ?_assertEqual(removed, PrevAtReadd),
+        ?_assertEqual(signature_change, ReaddClass)
+    ].
+
+%% clear/0 drops every recorded generation — the next capture behaves as if
+%% this were a fresh workspace session.
+clear_resets_the_session(_Pid) ->
+    Sig1 = sig(<<"Integer">>, []),
+    {_, _} = beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig1),
+    ok = beamtalk_workspace_signature_store:clear(),
+    {Prev, Classification} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig1),
+    [
+        ?_assertEqual(undefined, Prev),
+        ?_assertEqual(no_op, Classification)
+    ].
+
+%% Two different selectors on the same class keep independent generation chains.
+different_selectors_are_independent(_Pid) ->
+    SigA = sig(<<"Integer">>, []),
+    SigB = sig(<<"String">>, []),
+    {_, _} = beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"a">>, instance, SigA),
+    {PrevB, ClassB} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"b">>, instance, SigB),
+    [
+        ?_assertEqual(undefined, PrevB),
+        ?_assertEqual(no_op, ClassB)
+    ].
+
+%% Instance-side and class-side methods with the same selector name on the
+%% same class are independent generation chains (Side is part of the key).
+different_sides_are_independent(_Pid) ->
+    InstanceSig = sig(<<"Integer">>, []),
+    ClassSig = sig(<<"Counter">>, []),
+    {_, _} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"new">>, instance, InstanceSig),
+    {PrevClassSide, ClassificationClassSide} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"new">>, class, ClassSig),
+    [
+        ?_assertEqual(undefined, PrevClassSide),
+        ?_assertEqual(no_op, ClassificationClassSide)
+    ].
+
+%%====================================================================
+%% rollback/4 (ADR 0105 Phase 1, BT-2777 — undo a failed install/removal)
+%%====================================================================
+
+%% Rolling back to a prior signature restores it as "previous" for the next
+%% capture — as if the failed capture had never happened.
+rollback_to_a_signature_restores_it_as_previous(_Pid) ->
+    Sig1 = sig(<<"Integer">>, []),
+    FailedSig = sig(<<"String">>, []),
+    {_, _} = beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig1),
+    %% Simulate: a second edit is captured, but its install then fails.
+    {PrevAtFailedCapture, _} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, FailedSig),
+    ok = beamtalk_workspace_signature_store:rollback(
+        <<"Counter">>, <<"m">>, instance, PrevAtFailedCapture
+    ),
+    %% The next real capture must see Sig1 as previous, not FailedSig.
+    Sig2 = sig(<<"Object">>, []),
+    {Prev, Classification} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig2),
+    [
+        ?_assertEqual(Sig1, PrevAtFailedCapture),
+        ?_assertEqual(Sig1, Prev),
+        ?_assertEqual(signature_change, Classification)
+    ].
+
+%% Rolling back with `undefined` (the failed capture was itself the first-ever
+%% capture for this selector) removes the key entirely — the next capture
+%% re-seeds from scratch rather than treating the failed attempt as "previous".
+rollback_to_undefined_removes_the_key(_Pid) ->
+    FailedSig = sig(<<"String">>, []),
+    {PrevAtFailedCapture, _} =
+        beamtalk_workspace_signature_store:capture(
+            <<"NeverPatched">>, <<"m">>, instance, FailedSig
+        ),
+    ok = beamtalk_workspace_signature_store:rollback(
+        <<"NeverPatched">>, <<"m">>, instance, PrevAtFailedCapture
+    ),
+    Sig1 = sig(<<"Object">>, []),
+    {Prev, Classification} =
+        beamtalk_workspace_signature_store:capture(<<"NeverPatched">>, <<"m">>, instance, Sig1),
+    [
+        ?_assertEqual(undefined, PrevAtFailedCapture),
+        %% Same outcome as a genuine first-ever capture — the failed attempt
+        %% left no trace.
+        ?_assertEqual(undefined, Prev),
+        ?_assertEqual(no_op, Classification)
+    ].
+
+%% A rollback only undoes the single capture it corresponds to — it must not
+%% reach further back into the generation chain than the one write it's
+%% paired with.
+rollback_after_a_chain_only_undoes_the_last_capture(_Pid) ->
+    Sig1 = sig(<<"Integer">>, []),
+    Sig2 = sig(<<"String">>, []),
+    FailedSig3 = sig(<<"Object">>, []),
+    {_, _} = beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig1),
+    {_, _} = beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig2),
+    {PrevAtFailedCapture, _} =
+        beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, FailedSig3),
+    ok = beamtalk_workspace_signature_store:rollback(
+        <<"Counter">>, <<"m">>, instance, PrevAtFailedCapture
+    ),
+    %% Rolled back to Sig2 (generation 2), not Sig1 (generation 1).
+    Sig4 = sig(<<"Nil">>, []),
+    {Prev, _} = beamtalk_workspace_signature_store:capture(<<"Counter">>, <<"m">>, instance, Sig4),
+    [
+        ?_assertEqual(Sig2, PrevAtFailedCapture),
+        ?_assertEqual(Sig2, Prev)
+    ].
+
+%%====================================================================
+%% __beamtalk_meta/0 seeding (the never-patched-method baseline)
+%%====================================================================
+
+%% Registered class + module, but the module exports no __beamtalk_meta/0
+%% (e.g. a plain Erlang module registered defensively) — seeding degrades to
+%% `undefined` rather than crashing the capture hook.
+seed_degrades_to_undefined_when_no_meta_exported_test() ->
+    beamtalk_class_metadata:new(),
+    ok = beamtalk_class_metadata:insert('NoMetaClass', lists, [foo], 'Object'),
+    try
+        {ok, Pid} = beamtalk_workspace_signature_store:start_link(),
+        try
+            New = sig(<<"Integer">>, []),
+            {Prev, Classification} =
+                beamtalk_workspace_signature_store:capture(
+                    <<"NoMetaClass">>, <<"foo">>, instance, New
+                ),
+            ?assertEqual(undefined, Prev),
+            ?assertEqual(no_op, Classification)
+        after
+            cleanup(Pid)
+        end
+    after
+        ets:delete(?TABLE, 'NoMetaClass')
+    end.
+
+%% A registered class whose module exports a realistic __beamtalk_meta/0 (via
+%% beamtalk_signature_store_fixture) seeds the ORIGINAL, never-patched
+%% signature — read once, on the first capture for that selector.
+seed_reads_original_signature_from_meta_test() ->
+    beamtalk_class_metadata:new(),
+    ok = beamtalk_class_metadata:insert(
+        'FixtureClass', beamtalk_signature_store_fixture, [greet], 'Object'
+    ),
+    try
+        {ok, Pid} = beamtalk_workspace_signature_store:start_link(),
+        try
+            New = sig(<<"String">>, [<<"String">>]),
+            {Prev, Classification} =
+                beamtalk_workspace_signature_store:capture(
+                    <<"FixtureClass">>, <<"greet">>, instance, New
+                ),
+            ?assertEqual(sig(<<"Integer">>, [<<"String">>]), Prev),
+            ?assertEqual(signature_change, Classification)
+        after
+            cleanup(Pid)
+        end
+    after
+        ets:delete(?TABLE, 'FixtureClass')
+    end.
+
+%% An unannotated (return_type = none) never-patched method seeds as the
+%% "Dynamic" sentinel, matching what the compiler side reports for an
+%% unannotated method — so a freshly-compiled Dynamic-returning method
+%% diffs as no_op against its own never-patched original, not a false positive.
+seed_reads_dynamic_for_unannotated_meta_entry_test() ->
+    beamtalk_class_metadata:new(),
+    ok = beamtalk_class_metadata:insert(
+        'FixtureClass', beamtalk_signature_store_fixture, [untyped], 'Object'
+    ),
+    try
+        {ok, Pid} = beamtalk_workspace_signature_store:start_link(),
+        try
+            New = sig(<<"Dynamic">>, []),
+            {Prev, Classification} =
+                beamtalk_workspace_signature_store:capture(
+                    <<"FixtureClass">>, <<"untyped">>, instance, New
+                ),
+            ?assertEqual(sig(<<"Dynamic">>, []), Prev),
+            ?assertEqual(no_op, Classification)
+        after
+            cleanup(Pid)
+        end
+    after
+        ets:delete(?TABLE, 'FixtureClass')
+    end.
+
+%% Class-side selectors seed from `class_method_info`, not `method_info`.
+seed_reads_class_side_from_class_method_info_test() ->
+    beamtalk_class_metadata:new(),
+    ok = beamtalk_class_metadata:insert(
+        'FixtureClass', beamtalk_signature_store_fixture, ['new'], 'Object'
+    ),
+    try
+        {ok, Pid} = beamtalk_workspace_signature_store:start_link(),
+        try
+            New = sig(<<"FixtureClass">>, []),
+            {Prev, Classification} =
+                beamtalk_workspace_signature_store:capture(
+                    <<"FixtureClass">>, <<"new">>, class, New
+                ),
+            ?assertEqual(sig(<<"FixtureClass">>, []), Prev),
+            ?assertEqual(no_op, Classification)
+        after
+            cleanup(Pid)
+        end
+    after
+        ets:delete(?TABLE, 'FixtureClass')
+    end.
+
+%%====================================================================
+%% meta_type_to_binary/1 (exported for TEST)
+%%====================================================================
+
+meta_type_to_binary_test_() ->
+    [
+        ?_assertEqual(<<"Dynamic">>, beamtalk_workspace_signature_store:meta_type_to_binary(none)),
+        ?_assertEqual(
+            <<"Integer">>, beamtalk_workspace_signature_store:meta_type_to_binary('Integer')
+        ),
+        ?_assertEqual(
+            <<"T">>,
+            beamtalk_workspace_signature_store:meta_type_to_binary({type_param, 'T', 0})
+        ),
+        ?_assertEqual(
+            <<"Result(Integer, String)">>,
+            beamtalk_workspace_signature_store:meta_type_to_binary(
+                {generic, 'Result', ['Integer', 'String']}
+            )
+        )
+    ].

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_sup_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_sup_tests.erl
@@ -49,14 +49,15 @@ supervisor_intensity_test() ->
 children_count_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(test_config()),
 
-    %% Should have 9 children: workspace_meta, workspace_changelog,
-    %% transcript_stream, actor_registry, workspace_bootstrap, repl_server,
-    %% idle_monitor, actor_sup, session_sup.
+    %% Should have 10 children: workspace_meta, workspace_changelog,
+    %% workspace_signature_store, transcript_stream, actor_registry,
+    %% workspace_bootstrap, repl_server, idle_monitor, actor_sup, session_sup.
     %% BeamtalkInterface and WorkspaceInterface are value singletons (no gen_server).
     %% BT-2531: the class_events / bindings_events / flush_events pub/sub
     %% gen_servers were retired — those push streams now ride the SystemAnnouncer
     %% bus (`beamtalk_announcements`, supervised under `beamtalk_runtime_sup`).
-    ?assertEqual(9, length(ChildSpecs)).
+    %% ADR 0105 Phase 1 (BT-2777): workspace_signature_store added.
+    ?assertEqual(10, length(ChildSpecs)).
 
 children_ids_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(test_config()),
@@ -67,6 +68,7 @@ children_ids_test() ->
     Ids = [maps:get(id, Spec) || Spec <- ChildSpecs],
     ?assert(lists:member(beamtalk_workspace_meta, Ids)),
     ?assert(lists:member(beamtalk_workspace_changelog, Ids)),
+    ?assert(lists:member(beamtalk_workspace_signature_store, Ids)),
     ?assert(lists:member(beamtalk_transcript_stream, Ids)),
     ?assertNot(lists:member('bt@stdlib@beamtalk_interface', Ids)),
     ?assertNot(lists:member('bt@stdlib@workspace_interface', Ids)),
@@ -288,6 +290,8 @@ all_children_alive_test() ->
         ExpectedIds = [
             beamtalk_workspace_meta,
             beamtalk_workspace_changelog,
+            %% ADR 0105 Phase 1 (BT-2777).
+            beamtalk_workspace_signature_store,
             beamtalk_transcript_stream,
             beamtalk_actor_registry,
             beamtalk_workspace_bootstrap,
@@ -499,12 +503,13 @@ run_mode_config() ->
 run_mode_children_count_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(run_mode_config()),
 
-    %% Run mode: 6 children (no repl_server, idle_monitor, session_sup).
-    %% workspace_meta, workspace_changelog, transcript_stream, actor_registry,
-    %% workspace_bootstrap, actor_sup.
+    %% Run mode: 7 children (no repl_server, idle_monitor, session_sup).
+    %% workspace_meta, workspace_changelog, workspace_signature_store,
+    %% transcript_stream, actor_registry, workspace_bootstrap, actor_sup.
     %% BT-2531: class_events / bindings_events / flush_events retired (those push
     %% streams now ride the SystemAnnouncer bus).
-    ?assertEqual(6, length(ChildSpecs)).
+    %% ADR 0105 Phase 1 (BT-2777): workspace_signature_store added.
+    ?assertEqual(7, length(ChildSpecs)).
 
 run_mode_no_repl_server_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(run_mode_config()),

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_sup_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_sup_tests.erl
@@ -503,13 +503,15 @@ run_mode_config() ->
 run_mode_children_count_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(run_mode_config()),
 
-    %% Run mode: 7 children (no repl_server, idle_monitor, session_sup).
-    %% workspace_meta, workspace_changelog, workspace_signature_store,
-    %% transcript_stream, actor_registry, workspace_bootstrap, actor_sup.
+    %% Run mode: 6 children (no repl_server, idle_monitor, session_sup,
+    %% workspace_signature_store — all REPL-only).
+    %% workspace_meta, workspace_changelog, transcript_stream, actor_registry,
+    %% workspace_bootstrap, actor_sup.
     %% BT-2531: class_events / bindings_events / flush_events retired (those push
     %% streams now ride the SystemAnnouncer bus).
-    %% ADR 0105 Phase 1 (BT-2777): workspace_signature_store added.
-    ?assertEqual(7, length(ChildSpecs)).
+    %% ADR 0105 Phase 1 (BT-2777): workspace_signature_store is REPL-only (run
+    %% mode has no live-edit path to feed it) — see run_mode_no_signature_store_test.
+    ?assertEqual(6, length(ChildSpecs)).
 
 run_mode_no_repl_server_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(run_mode_config()),
@@ -528,6 +530,17 @@ run_mode_no_session_sup_test() ->
 
     Ids = [maps:get(id, S) || S <- ChildSpecs],
     ?assertNot(lists:member(beamtalk_session_sup, Ids)).
+
+%% ADR 0105 Phase 1 (BT-2777): run mode executes a precompiled artifact with
+%% no live-edit path (no session, no way to reach
+%% beamtalk_repl_loader:install_method/9), so the signature-generation store
+%% — REPL-only, like session_sup/repl_server/idle_monitor above — must not
+%% start there.
+run_mode_no_signature_store_test() ->
+    {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(run_mode_config()),
+
+    Ids = [maps:get(id, S) || S <- ChildSpecs],
+    ?assertNot(lists:member(beamtalk_workspace_signature_store, Ids)).
 
 run_mode_required_children_present_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_workspace_sup:init(run_mode_config()),


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2777

Phase 1 of [ADR 0105](https://github.com/jamesc/beamtalk/blob/main/docs/ADR/0105-live-image-recheck-on-reload.md) (Live Image Re-Checking on Hot Reload), building on the Phase 0 spike (BT-2776) findings in `docs/internal/adr-0105-phase0-spike-findings.md`.

Hot-patching clears a method's type metadata on install, so interface diffs cannot be read back from class state after a patch — the previous-generation signature must be captured at patch time and retained across repeated edits to the same method. This PR builds the store + protocol plumbing that makes diffs work across *repeated* edits.

### Key changes

- **Compiler port (Rust)** now reports a patched method's declared signature (return type + param types, `"Dynamic"` sentinel when unannotated) in the `compile_expression`/`compile_method` responses, threaded through the Erlang `beamtalk_compiler_port` / `beamtalk_compiler_server` / `beamtalk_repl_compiler` layers.
- **New `beamtalk_workspace_signature_store`** gen_server: per-`(class, selector, side)` generation store, session-only (never persisted to the artifact — cleared on workspace restart). Seeds from a class's compiled `__beamtalk_meta/0` on the first capture for a never-patched method.
  - `capture/4` must run *before* the install it describes, so it sees live pre-patch class state rather than the just-reloaded module's own (new) meta.
  - `rollback/4` undoes a capture whose install/removal subsequently failed, so a failed patch never poisons the store with a generation that was never actually live.
- **New `beamtalk_signature_diff`** — pure module classifying a signature change as `signature_change` / `removal` / `no_op`.
- **Wired into `beamtalk_repl_loader`**: `load_recompiled_method/8` (the single production install chokepoint for both the REPL `>>` path and the IDE-save/MCP path — Phase 0 discovered both converge here) and `remove_method/3`. Both best-effort — a store failure never blocks the install/removal.

### Design notes / deviations from the ADR's literal text

- The ADR's mechanism text describes hooking `beamtalk_object_class:put_method/4`. The Phase 0 spike found `put_method/4` isn't actually used by either production live-edit path (both go through a full-class recompile + `code:load_binary`), so the capture hook lives in `beamtalk_repl_loader:load_recompiled_method/8` instead — the real, single install chokepoint. Hooking `put_method/4` directly would also violate the dependency direction (`beamtalk_runtime` does not depend on `beamtalk_workspace`).
- Phase 1 captures *declared* annotations only (via `TypeAnnotation::type_name()`), not re-inferred return types for unannotated methods — the cheaper interim the Phase 0 findings recommended. Extending to inferred return types is a documented follow-up.

## Test plan

- [x] `just build`, `just clippy`, `just fmt-check`, `just dialyzer` all clean
- [x] `just test` (Rust, stdlib, BUnit, Erlang runtime EUnit — thousands of tests, 0 failures caused by this change)
- [x] `just test-repl-protocol` (e2e) clean
- [x] New EUnit coverage: `beamtalk_signature_diff_tests`, `beamtalk_workspace_signature_store_tests` (generation chaining, rollback, `__beamtalk_meta` seeding), and two new end-to-end tests in `beamtalk_repl_loader_tests` that exercise the real install path (not just the store's direct API) to prove the return_type/param_types plumbing isn't silently dropped anywhere in the forwarding chain
- [x] New Rust unit tests in `beamtalk-compiler-port` for both the `compile_expression` (REPL `>>`) and `compile_method` (IDE-save) response paths, including the unannotated "Dynamic" sentinel case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j5UBhVKaBHzM89fmSYXxy


---
_Generated by [Claude Code](https://claude.ai/code/session_019j5UBhVKaBHzM89fmSYXxy)_