### PR TITLE
Type checker: nominal mismatch warning on protocol-typed params despite structural conformance (BT-2784)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/protocol.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/protocol.rs
@@ -440,6 +440,16 @@ fn make_json_generate_module(arg_name: &str, arg_type: &str, receiver_span: Span
 /// an unreached check. The companion negative test
 /// (`test_meta_receiver_class_method_protocol_param_non_conforming_warns`)
 /// proves the same path fires a warning when the argument does not conform.
+///
+/// BT-2784: also asserts there is no *nominal* "expects Printable, got
+/// Dictionary" mismatch. Before the fix, `check_argument_types`'s nominal
+/// class-hierarchy walk (`is_type_compatible`) had no protocol awareness: once
+/// `register_protocol_classes` (BT-1933) added `Printable` as a synthetic
+/// class entry, the "unknown type → compatible" escape hatch it relied on no
+/// longer applied, and Dictionary's ordinary superclass chain doesn't contain
+/// `Printable` — so a spurious nominal-mismatch diagnostic fired *alongside*
+/// the (correct) silent structural pass below. This is the false positive
+/// from PR #2862's "Pre-existing note".
 #[test]
 fn test_protocol_typed_param_no_false_positive_with_protocol_classes() {
     let (hierarchy, registry) = setup_json_class_side_fixture("Printable");
@@ -478,6 +488,23 @@ fn test_protocol_typed_param_no_false_positive_with_protocol_classes() {
         conformance_warnings.is_empty(),
         "Dictionary conforms to Printable (has asString) — no warning expected, got: {:?}",
         conformance_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+
+    // BT-2784: there should also be NO nominal "expects ..., got ..." mismatch
+    // — `check_argument_types`'s nominal walk must defer to the structural
+    // conformance check above for protocol-typed class-side params.
+    let nominal_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("expects") && d.message.contains("got"))
+        .collect();
+    assert!(
+        nominal_warnings.is_empty(),
+        "Dictionary structurally conforms to Printable — no nominal mismatch expected, got: {:?}",
+        nominal_warnings
             .iter()
             .map(|d| &d.message)
             .collect::<Vec<_>>()
@@ -526,6 +553,63 @@ fn test_meta_receiver_class_method_protocol_param_non_conforming_warns() {
             && conformance_warnings[0].message.contains("Serializable"),
         "Warning should mention Integer and Serializable, got: {}",
         conformance_warnings[0].message
+    );
+
+    // BT-2784: exactly one diagnostic total should mention Serializable — the
+    // structural "does not conform" warning above. A duplicate nominal
+    // "expects Serializable, got Integer" mismatch must NOT also fire.
+    let serializable_mentions: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("Serializable"))
+        .collect();
+    assert_eq!(
+        serializable_mentions.len(),
+        1,
+        "expected exactly one Serializable-related diagnostic (structural), not a duplicate nominal mismatch, got: {:?}",
+        serializable_mentions
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// BT-2784: skipping the nominal walk for protocol-typed class-side params
+/// must NOT swallow ordinary nominal mismatches on *non-protocol* class-side
+/// params. `JsonEncoder generate:` here declares its param as the real class
+/// `Integer` (not a protocol) — passing a `String` must still produce the
+/// nominal "expects Integer, got String" warning, proving the BT-2784 fix
+/// (`hierarchy.is_protocol_class(..)` guard) is scoped to protocol-typed
+/// params only.
+#[test]
+fn test_class_side_non_protocol_param_nominal_mismatch_still_warns() {
+    let (hierarchy, registry) = setup_json_class_side_fixture("Integer");
+
+    let receiver_span = Span::new(10, 14);
+    let module = make_json_generate_module("s", "String", receiver_span);
+
+    let mut checker = TypeChecker::new();
+    checker.check_module_with_protocols(&module, &hierarchy, &registry);
+
+    let nominal_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("expects") && d.message.contains("got"))
+        .collect();
+    assert_eq!(
+        nominal_warnings.len(),
+        1,
+        "String does not nominally match Integer — expected exactly 1 nominal mismatch, got: {:?}",
+        nominal_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        nominal_warnings[0].message.contains("Integer")
+            && nominal_warnings[0].message.contains("String"),
+        "Warning should mention Integer and String, got: {}",
+        nominal_warnings[0].message
     );
 }
 
@@ -1016,6 +1100,14 @@ fn make_widget_arg_module(selector: &str) -> Module {
 
 /// Positive: `Widget` has a class-side `serialize`, so the class object
 /// `Widget` conforms to `Serializable` — no warning for `zzyzx store: Widget`.
+///
+/// BT-2784: also asserts no nominal "expects Serializable, got Widget class"
+/// mismatch — the same nominal-walk false positive that affected the
+/// `Dictionary`/`Printable` class-side-param case also applies to
+/// `Meta`-typed (class-object) arguments, since `check_argument_types`'s
+/// `InferredType::Meta` arm shares the same protocol-unaware nominal
+/// comparison. The BT-2784 fix's `continue` guard runs before the
+/// `match arg_ty` split, so it covers this arm too.
 #[test]
 fn test_class_object_arg_conforms_via_class_side_method() {
     let (mut hierarchy, registry) = setup_intersection_param_fixture();
@@ -1034,6 +1126,20 @@ fn test_class_object_arg_conforms_via_class_side_method() {
         conformance_warnings.is_empty(),
         "Widget's class side has `serialize` — the class object conforms to Serializable, got: {:?}",
         conformance_warnings
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+
+    let nominal_warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("expects") && d.message.contains("got"))
+        .collect();
+    assert!(
+        nominal_warnings.is_empty(),
+        "Widget class object conforms to Serializable — no nominal mismatch expected, got: {:?}",
+        nominal_warnings
             .iter()
             .map(|d| &d.message)
             .collect::<Vec<_>>()

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1010,6 +1010,22 @@ impl TypeChecker {
             let Some(expected_ty) = expected else {
                 continue;
             };
+            // BT-2784: a protocol-typed parameter is registered as a synthetic
+            // sealed-abstract class entry by `register_protocol_classes`
+            // (BT-1933), so `hierarchy.has_class` sees it and the nominal
+            // walk below no longer takes the "unknown type → compatible"
+            // escape hatch. Nominal subtyping doesn't apply to protocols —
+            // conformance is structural — so defer entirely to
+            // `check_protocol_conformance_in_module` /
+            // `check_protocol_argument_conformance` (which run later in
+            // `check_module_with_protocols` and consult the protocol
+            // registry) rather than flagging a false "expects P, got C"
+            // mismatch here for an argument that structurally conforms.
+            // Applies to both class-side and instance-side params — the
+            // nominal walk has no protocol awareness on either path.
+            if hierarchy.is_protocol_class(super::type_resolver::base_name_of_string(expected_ty)) {
+                continue;
+            }
             let is_class_ref_arg = arg_exprs
                 .and_then(|exprs| exprs.get(i))
                 .is_some_and(|e| matches!(e, Expression::ClassReference { .. }));


### PR DESCRIPTION
## Summary

Fixes a false-positive type warning: when protocol definitions are registered as synthetic classes in the hierarchy (`register_protocol_classes`, BT-1933 — used by the LSP/language-service path), `check_argument_types`'s *nominal* class-hierarchy walk had no protocol awareness. Once a protocol like `Printable` is registered as a synthetic class entry, `hierarchy.has_class("Printable")` becomes `true`, so the "unknown type → compatible" escape hatch the nominal walk relied on stops applying — and a structurally-conforming argument (e.g. `Dictionary` passed where `:: Printable` is expected) gets a spurious `"expects Printable, got Dictionary"` diagnostic *alongside* the correct, silent structural conformance pass.

This is the "Pre-existing note" gap flagged in #2862 (BT-2761) while implementing Meta-typed (class-side) protocol conformance.

Linear issue: https://linear.app/beamtalk/issue/BT-2784

## Changes

- `crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs`: `check_argument_types` now skips the nominal comparison entirely for any parameter whose declared type is a registered protocol class (`hierarchy.is_protocol_class(base_name)`), deferring to the existing structural conformance pass (`check_protocol_conformance_in_module` / `check_protocol_argument_conformance`). The guard runs before the argument-shape match, so it covers `Known`, `Meta` (class-object), and `Union` argument shapes uniformly, and both class-side and instance-side parameters.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/tests/protocol.rs`:
  - Pinned the exact false-positive repro from #2862 (`Dictionary` argument to a class-side `Printable` param) as a regression test.
  - Added a negative test proving a genuinely non-conforming protocol argument still warns exactly once (no duplicate nominal diagnostic alongside the structural one).
  - Added a negative test proving ordinary (non-protocol) class-side nominal mismatches are still caught — confirming the new guard is scoped to protocol-typed params only.
  - Strengthened the existing class-object (`Meta`) argument conformance test with the same nominal-mismatch assertion, since the same false positive applied to that argument shape too.

## Acceptance criteria

- [x] `check_argument_types` recognises protocol-typed params and defers to structural conformance instead of nominal class comparison
- [x] False-positive repro from PR #2862's report pinned as a regression test
- [x] Genuinely non-conforming args still warn (negative test)
- [x] `just build-stdlib` stays clean (103 modules, zero diagnostics)

## Test plan

- [x] `cargo test -p beamtalk-core --lib semantic_analysis::type_checker::tests::protocol` — 23 passed
- [x] `cargo test -p beamtalk-core --lib` — 4568 passed, 0 failed
- [x] `just build-stdlib` — 103 modules, zero diagnostics
- [x] `just test` — Rust + stdlib + BUnit + runtime tests all green
- [x] `just build && just clippy && just fmt-check` — all clean
- [x] Verified the new regression tests fail without the fix (via a temporary `git stash`) and pass with it


---
_Generated by [Claude Code](https://claude.ai/code/session_01JGzBfxTuGtSr9gBQQsxTBf)_