### PR TITLE
docs: daily refresh 2026-07-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@
 
 ### Internal
 
+- **Per-selector signature-generation store** — new `beamtalk_workspace_signature_store` gen_server and `beamtalk_signature_diff` module for tracking method signature generations across repeated hot-patches (ADR 0105 Phase 1). The compiler port now reports declared return/param types in compile responses; `beamtalk_repl_loader` captures pre-patch signatures and supports rollback on failed installs. No user-visible surface yet — infrastructure for live-image re-checking on hot reload (BT-2777, #2885).
 - Runtime dead-code + idiom consolidation: retire orphaned `beamtalk_behaviour_bt`, five zero-caller `beamtalk_runtime_api` delegators, and `beamtalk_repl_state:set_loaded_modules/2`; consolidate `reraise` (22 sites → `beamtalk_exception_handler`), `try_dispatch` (4 sites → `beamtalk_object_ops`), and ~120 stdlib error-construction sites onto shared helpers. Net −549 lines (#2879).
 - Collapse `beamtalk_error:new/2` + `with_selector/2` chains to `new/3` across 12 runtime modules — 36 call sites, no behavior change (#2814).
 - Consolidate zero-param dispatch BIFs to use `leaf::atom` pattern (BT-2498).


### PR DESCRIPTION
## Summary

Daily documentation refresh — 4 commits on `main` in the last 24 hours reviewed, 1 CHANGELOG entry added.

## Commits reviewed

| Commit | Description | Doc change |
|--------|-------------|------------|
| `0f67c62` | Per-selector signature-generation store + capture plumbing (BT-2777) | **CHANGELOG "Internal"** — new infrastructure entry for ADR 0105 Phase 1 |
| `8b0d018` | test(codegen): add Rust unit tests for BT-2703 eachWithIndex:/do:separatedBy: desugar | Skipped — test-only |
| `8860d38` | docs: daily refresh 2026-07-09 | Skipped — previous day's doc refresh |
| `6e8ac0c` | refactor: use for_each_expr_seq in single-method query files | Skipped — internal refactor, no behavior change |

## Commits skipped (internal / excluded)

| Commit | Reason |
|--------|--------|
| `8b0d018` | Purely test code (codegen unit tests under `tests.rs`) |
| `8860d38` | Docs-only commit (previous day's refresh) |
| `6e8ac0c` | Internal refactor — replaces hand-rolled triple-walk with existing `for_each_expr_seq` helper across 5 query files; no behavior change |

## Needs human judgment

None — all commits were classifiable from their diffs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZevxQGe3kJxwSRP3MPhye

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZevxQGe3kJxwSRP3MPhye)_