### PR TITLE
Reload-triggered re-check orchestration (BT-2778)

### DIFF
--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -618,6 +618,13 @@ fn diagnostics_ok_response(diagnostics: &[DiagInfo]) -> Term {
                 (atom("message"), binary(&d.message)),
                 (atom("severity"), binary(&d.severity)),
                 (
+                    atom("category"),
+                    match &d.category {
+                        Some(c) => binary(c),
+                        None => atom("undefined"),
+                    },
+                ),
+                (
                     atom("start"),
                     Term::from(eetf::FixInteger::from(
                         i32::try_from(d.start).unwrap_or(i32::MAX),
@@ -787,12 +794,25 @@ fn compile_method_diagnostic_response(
 struct DiagInfo {
     /// Human-readable diagnostic message.
     message: String,
-    /// Severity level (`"error"` or `"warning"`).
+    /// Severity level (`"error"`, `"warning"`, `"lint"`, or `"hint"`).
     severity: String,
+    /// Diagnostic category (`"Dnu"`, `"Type"`, ...), when the checker tagged
+    /// one — `None` for parse errors and other untagged diagnostics
+    /// (ADR 0105 Phase 1, BT-2778: the re-check orchestration filters
+    /// findings by category).
+    category: Option<String>,
     /// Byte offset where the diagnosed span begins.
     start: u32,
     /// Byte offset where the diagnosed span ends.
     end: u32,
+}
+
+/// Render a `Diagnostic`'s category as the same `PascalCase` label
+/// `beamtalk lint` / `beamtalk-mcp` use (`category_name`), or `None` when
+/// the diagnostic carries no category.
+fn diag_category(d: &beamtalk_core::source_analysis::Diagnostic) -> Option<String> {
+    d.category
+        .map(|c| beamtalk_core::source_analysis::category_name(c).to_string())
 }
 
 /// Separate diagnostics into errors and warnings, returning structured info.
@@ -805,6 +825,7 @@ fn partition_diagnostics(
         .map(|d| DiagInfo {
             message: d.message.to_string(),
             severity: "error".to_string(),
+            category: diag_category(d),
             start: d.span.start(),
             end: d.span.end(),
         })
@@ -824,6 +845,7 @@ fn partition_diagnostics(
                 beamtalk_core::source_analysis::Severity::Hint => "hint".to_string(),
                 _ => "warning".to_string(),
             },
+            category: diag_category(d),
             start: d.span.start(),
             end: d.span.end(),
         })
@@ -1297,6 +1319,7 @@ fn handle_compile(request: &Map) -> Term {
                         "Standalone method targets unknown class `{target_class}` in this module"
                     ),
                     severity: "warning".to_string(),
+                    category: None,
                     start: method_def.span.start(),
                     end: method_def.span.end(),
                 });
@@ -1632,6 +1655,13 @@ fn handle_compile_method(request: &Map) -> Term {
 ///     semantic analysis here would emit false positives. Those checks run on
 ///     Compile (`compile_method`, which has class context); live squiggles
 ///     cover syntax.
+///
+/// The optional `class_hierarchy` field (ADR 0105 Phase 1, BT-2778) carries
+/// pre-loaded class metadata — the same channel `compile_expression` /
+/// `compile_method` already accept — so a re-check can inject a reloaded
+/// class's *new* signature and see the resulting diagnostics located and
+/// severity-tagged (`"expression"` mode only; `"method"` mode stays
+/// class-context-free per the paragraph above).
 fn handle_diagnostics(request: &Map) -> Term {
     let Some(source) = map_get(request, "source").and_then(term_to_string) else {
         return error_response(&["Missing or invalid 'source' field".to_string()]);
@@ -1644,10 +1674,12 @@ fn handle_diagnostics(request: &Map) -> Term {
         parse_diagnostics
     } else {
         let (module, parse_diagnostics) = beamtalk_core::source_analysis::parse(tokens);
-        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_with_known_vars(
+        let pre_class_hierarchy = extract_class_hierarchy(request);
+        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_with_known_vars_and_classes(
             &module,
             parse_diagnostics,
             &[],
+            pre_class_hierarchy,
         )
     };
 
@@ -1667,6 +1699,7 @@ fn diag_info(d: &beamtalk_core::source_analysis::Diagnostic) -> DiagInfo {
             beamtalk_core::source_analysis::Severity::Lint => "lint".to_string(),
             beamtalk_core::source_analysis::Severity::Hint => "hint".to_string(),
         },
+        category: diag_category(d),
         start: d.span.start(),
         end: d.span.end(),
     }
@@ -2453,6 +2486,92 @@ mod tests {
             map_get(m, "status"),
             Some(&atom("ok")),
             "compile_expression with class_hierarchy should succeed: {response:?}"
+        );
+    }
+
+    /// ADR 0105 Phase 1 (BT-2778): `diagnostics` accepts `class_hierarchy`
+    /// (like `compile_expression`/`compile_method` already did) and returns
+    /// severity- and category-tagged diagnostics, so a re-check can tell a
+    /// removed-selector `Dnu` from a `Type` mismatch without location alone.
+    #[test]
+    fn diagnostics_accepts_class_hierarchy_and_reports_category() {
+        use eetf::{FixInteger, List};
+
+        let method_info = Map::from([(
+            atom("getCount"),
+            Term::from(Map::from([
+                (atom("arity"), Term::from(FixInteger::from(0))),
+                (atom("param_types"), Term::from(List::from(vec![]))),
+                // The reload changed Counter>>getCount's return type to
+                // String — the caller's `+ 1` is now stale.
+                (atom("return_type"), atom("String")),
+            ])),
+        )]);
+        let counter_meta = Map::from([
+            (atom("superclass"), atom("Object")),
+            (atom("method_info"), Term::from(method_info)),
+        ]);
+        let class_hierarchy_term =
+            Term::from(Map::from([(atom("Counter"), Term::from(counter_meta))]));
+
+        let request = Map::from([
+            (atom("command"), atom("diagnostics")),
+            (
+                atom("source"),
+                binary(
+                    "Object subclass: Dashboard\n  refresh: c :: Counter -> Integer => (c getCount) + 1\n",
+                ),
+            ),
+            (atom("class_hierarchy"), class_hierarchy_term),
+        ]);
+
+        let response = handle_diagnostics(&request);
+        let Term::Map(ref m) = response else {
+            panic!("Expected map response");
+        };
+        assert_eq!(map_get(m, "status"), Some(&atom("ok")));
+        let Some(Term::List(diagnostics)) = map_get(m, "diagnostics") else {
+            panic!("Expected diagnostics list: {response:?}");
+        };
+        assert!(
+            !diagnostics.elements.is_empty(),
+            "expected at least one diagnostic for the now-stale `+ 1`: {response:?}"
+        );
+        // Every diagnostic carries a `category` key (an atom `undefined` or a
+        // binary label) — BT-2778's re-check orchestration filters on it.
+        for diag in &diagnostics.elements {
+            let Term::Map(dm) = diag else {
+                panic!("Expected diagnostic map, got {diag:?}");
+            };
+            assert!(
+                map_get(dm, "category").is_some(),
+                "diagnostic missing category key: {diag:?}"
+            );
+        }
+    }
+
+    /// Without `class_hierarchy`, `diagnostics` behaves exactly as before
+    /// (Counter is unknown, so no diagnostic is produced for the `+ 1` — the
+    /// checker treats an undeclared receiver type as unresolved-class, not
+    /// as `Counter`).
+    #[test]
+    fn diagnostics_without_class_hierarchy_is_unaffected() {
+        let request = Map::from([
+            (atom("command"), atom("diagnostics")),
+            (atom("source"), binary("1 + 1.")),
+        ]);
+
+        let response = handle_diagnostics(&request);
+        let Term::Map(ref m) = response else {
+            panic!("Expected map response");
+        };
+        assert_eq!(map_get(m, "status"), Some(&atom("ok")));
+        let Some(Term::List(diagnostics)) = map_get(m, "diagnostics") else {
+            panic!("Expected diagnostics list: {response:?}");
+        };
+        assert!(
+            diagnostics.elements.is_empty(),
+            "expected no diagnostics for a plain valid expression: {response:?}"
         );
     }
 

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler.erl
@@ -18,6 +18,7 @@ All functions delegate to `beamtalk_compiler_server' (port backend).
 - `compile/2' — Compile a file/class definition (`:load')
 - `diagnostics/1' — Get parse/semantic diagnostics only (default "expression" mode)
 - `diagnostics/2' — Get parse/semantic diagnostics under a named parse mode
+- `diagnostics/3' — Get parse/semantic diagnostics with options (e.g. opt-in class-hierarchy awareness)
 - `version/0' — Get compiler version
 - `compile_core_erlang/1' — Core Erlang → BEAM bytecode (in-memory)
 """.
@@ -29,6 +30,7 @@ All functions delegate to `beamtalk_compiler_server' (port backend).
     compile_method/3,
     diagnostics/1,
     diagnostics/2,
+    diagnostics/3,
     version/0,
     compile_core_erlang/1,
     resolve_completion_type/1,
@@ -137,6 +139,17 @@ diagnostics(Source) ->
 
 -doc """
 Get diagnostics for source code under a parse `Mode` (no code generation).
+Equivalent to `diagnostics/3` with `#{}` — see its doc for the `Mode` values
+and for the opt-in `class_hierarchy` option.
+""".
+-spec diagnostics(binary(), binary()) ->
+    {ok, [map()]} | {error, [binary()]}.
+diagnostics(Source, Mode) ->
+    beamtalk_compiler_server:diagnostics(Source, Mode).
+
+-doc """
+Get diagnostics for source code under a parse `Mode`, with options (no code
+generation).
 
 `Mode' selects the grammar the buffer is analysed under (BT-2569):
 
@@ -147,11 +160,17 @@ Get diagnostics for source code under a parse `Mode` (no code generation).
     longer trips a false `expected expression' error. Parse-only: a method has
     no class context here, so semantic checks (which would false-positive on
     field/`self' references) are deferred to Compile.
+
+`Options`: `class_hierarchy => boolean()` (ADR 0105 Phase 1, BT-2778,
+default `false`) — thread the ambient class cache into the check, so a
+receiver resolving to an already-loaded class is checked against its
+*current* interface. See `beamtalk_compiler_server:diagnostics/3` for why
+this is opt-in rather than the `diagnostics/2` default.
 """.
--spec diagnostics(binary(), binary()) ->
+-spec diagnostics(binary(), binary(), map()) ->
     {ok, [map()]} | {error, [binary()]}.
-diagnostics(Source, Mode) ->
-    beamtalk_compiler_server:diagnostics(Source, Mode).
+diagnostics(Source, Mode, Options) ->
+    beamtalk_compiler_server:diagnostics(Source, Mode, Options).
 
 -doc "Get compiler version.".
 -spec version() -> {ok, binary()} | {error, term()}.

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler.erl
@@ -130,7 +130,10 @@ compile_method(ClassSource, MethodSource, Options) ->
 -doc """
 Get diagnostics for source code (no code generation).
 
-Returns `{ok, [#{message, severity, start, end}]}' or `{error, Diagnostics}'.
+Returns `{ok, [#{message, severity, category, start, end}]}' or `{error,
+Diagnostics}'. `category' (ADR 0105 Phase 1, BT-2778) is a binary label
+(`<<"Dnu">>', `<<"Type">>', ...) when the checker tagged one, or the atom
+`undefined' otherwise.
 """.
 -spec diagnostics(binary()) ->
     {ok, [map()]} | {error, [binary()]}.
@@ -139,8 +142,9 @@ diagnostics(Source) ->
 
 -doc """
 Get diagnostics for source code under a parse `Mode` (no code generation).
-Equivalent to `diagnostics/3` with `#{}` — see its doc for the `Mode` values
-and for the opt-in `class_hierarchy` option.
+Equivalent to `diagnostics/3` with `#{}` — see its doc for the `Mode` values,
+the response shape (`diagnostics/1`'s doc), and the opt-in `class_hierarchy`
+option.
 """.
 -spec diagnostics(binary(), binary()) ->
     {ok, [map()]} | {error, [binary()]}.

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -29,6 +29,7 @@ to avoid temp files on disk (BT-48).
     compile_method/3,
     diagnostics/1,
     diagnostics/2,
+    diagnostics/3,
     version/0,
     compile_core_erlang/1,
     register_class/2,
@@ -158,11 +159,36 @@ compile_method(ClassSource, MethodSource, Options) ->
 diagnostics(Source) ->
     diagnostics(Source, <<"expression">>).
 
--doc "Get diagnostics for source code under a parse `Mode' (no code generation).".
+-doc """
+Get diagnostics for source code under a parse `Mode' (no code generation).
+Equivalent to `diagnostics/3' with `#{}' — no ambient class-hierarchy
+awareness (see `diagnostics/3').
+""".
 -spec diagnostics(binary(), binary()) ->
     {ok, [map()]} | {error, [binary()]}.
 diagnostics(Source, Mode) ->
-    gen_server:call(?MODULE, {diagnostics, Source, Mode}, 30000).
+    diagnostics(Source, Mode, #{}).
+
+-doc """
+Get diagnostics for source code under a parse `Mode', with options.
+
+Options:
+  class_hierarchy => boolean() — when `true' (ADR 0105 Phase 1, BT-2778),
+  threads the ambient class cache (the same `register_class' accumulation
+  `compile_expression'/`compile_method' already get, ADR 0050 Phase 4) into
+  the request, so a receiver resolving to an already-loaded class is checked
+  against that class's *current* interface. Defaults to `false' —
+  deliberately opt-in, not the default for `diagnostics/1,2', because this
+  command also backs the LiveView cockpit's keystroke-driven editor
+  diagnostics (BT-2556, `beamtalk_repl_ops_dev:diagnostics_for/2'), and
+  changing what fires on every keystroke for every existing caller is a
+  bigger behavioural change than this option's one new caller (BT-2778's
+  re-check orchestration) needs.
+""".
+-spec diagnostics(binary(), binary(), map()) ->
+    {ok, [map()]} | {error, [binary()]}.
+diagnostics(Source, Mode, Options) ->
+    gen_server:call(?MODULE, {diagnostics, Source, Mode, Options}, 30000).
 
 -doc "Get compiler version.".
 -spec version() -> {ok, binary()} | {error, term()}.
@@ -529,8 +555,17 @@ handle_call({resolve_completion_type, Expression}, _From, State) ->
         State#state.port, Expression, State#state.classes
     ),
     {reply, Result, State};
-handle_call({diagnostics, Source, Mode}, _From, State) ->
-    Result = do_diagnostics(State#state.port, Source, Mode),
+handle_call({diagnostics, Source, Mode, Options}, _From, State) ->
+    %% ADR 0105 Phase 1 (BT-2778): only thread the ambient class cache when
+    %% explicitly requested (see diagnostics/3's moduledoc) — the default
+    %% stays class-context-free so the keystroke-driven cockpit editor path
+    %% (BT-2556) is unaffected by this option's addition.
+    Classes =
+        case maps:get(class_hierarchy, Options, false) of
+            true -> State#state.classes;
+            false -> #{}
+        end,
+    Result = do_diagnostics(State#state.port, Source, Mode, Classes),
     {reply, Result, State};
 handle_call({find_senders_in_source, Source, Selector}, _From, State) ->
     Result = beamtalk_compiler_port:find_senders_in_source(
@@ -868,9 +903,11 @@ do_compile_method(Port, ClassSource, MethodSource, Options) ->
 
 %% Send a diagnostics request via the port. `Mode' selects the parse grammar
 %% (BT-2569): `<<"expression">>' (default, top-level script) or `<<"method">>'
-%% (bare method body — the System Browser method editor).
-do_diagnostics(Port, Source, Mode) ->
-    Request = #{command => diagnostics, source => Source, mode => Mode},
+%% (bare method body — the System Browser method editor). `Classes' is the
+%% ambient class cache (ADR 0105 Phase 1, BT-2778) — ignored by the port in
+%% `"method"' mode, which stays class-context-free by design.
+do_diagnostics(Port, Source, Mode, Classes) ->
+    Request = #{command => diagnostics, source => Source, mode => Mode, class_hierarchy => Classes},
     case send_port_request(Port, Request, 30000) of
         {ok, Response} ->
             handle_diagnostics_response(Response);

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
@@ -168,6 +168,11 @@ reload's own success/reply on this.
 -spec trigger(binary(), binary(), instance | class, classification()) -> result().
 trigger(ClassNameBin, SelectorBin, Side, Classification) ->
     try
+        %% `Side` is accepted (matching the signature store's capture/4 key)
+        %% but not threaded into do_trigger/3: beamtalk_xref:senders_of/1 is
+        %% selector-keyed only, with no instance/class-side component, so it
+        %% cannot narrow the dependent lookup. Kept in scope here purely for
+        %% the ?LOG_WARNING context below on a caught failure.
         do_trigger(ClassNameBin, SelectorBin, Classification)
     catch
         Class:Reason:Stack ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
@@ -1,0 +1,398 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_recheck).
+
+%%% **DDD Context:** Workspace Context
+
+-moduledoc """
+Reload-triggered re-check orchestration (ADR 0105 Phase 1, BT-2778).
+
+On every live definition change whose signature-generation diff
+(`beamtalk_workspace_signature_store:capture/4`, BT-2777) is *not* `no_op`,
+finds the change's known dependents and re-checks them, producing findings at
+ADR 0100 severities. Generalises the Phase 0 spike
+(`docs/internal/adr-0105-phase0-spike-findings.md`) to production.
+
+## Mechanism (ADR 0105 §Mechanism steps 2-3)
+
+1. **Dependent lookup.** `beamtalk_xref:senders_of/1` is selector-keyed —
+   sites carry a caller (`owner`/`method`/`line`) and a receiver *kind*
+   (self/super/ffi/other), but never a receiver *class* (ADR 0087). So a
+   `size` sender on an unrelated `List` comes back alongside the real
+   `Counter` dependent; xref cannot separate them.
+2. **The receiver-type filter is not a pre-filter — it is what re-checking
+   itself does.** Each candidate caller's *whole class* is re-checked through
+   the compiler with the changed class's *current* (already-live,
+   post-install) signature. A site whose receiver resolves to a different
+   type simply re-checks clean against that signature, because the checker
+   only applies `Counter>>getCount`'s new interface to sends whose receiver
+   it infers as `Counter`. This is why the **caller cap is load-bearing**:
+   every candidate is paid for with a compile before its relevance is known
+   (ADR 0105 Alternatives — the xref receiver-type-key extension is the
+   follow-up if this proves hot).
+3. **Re-check unit is the caller's whole class**, read from the *live image*
+   (`beamtalk_workspace_meta:get_class_source/1`), never disk — a flagged
+   caller may itself carry unflushed edits (ADR 0082). One
+   `beamtalk_compiler:diagnostics/3` port round-trip per distinct caller
+   class (multiple sites in the same class collapse into one request — the
+   compiler port rejects multi-class sources, so "batched" means "not one
+   round-trip per call site", per the Phase 0 spike finding).
+
+## Finding attribution (no severity escalation, ADR 0100)
+
+The ambient class hierarchy the compiler port already accumulates
+(`beamtalk_compiler_server`'s `register_class` cache, ADR 0050 Phase 4) is
+current by the time this module runs — the reload's `register_class/0` /
+`code:load_binary` already installed the new generation. So a
+`diagnostics/3` call (with `class_hierarchy => true`) against a candidate's
+live source sees the *new* signature for free; no explicit per-class
+override is constructed here. `class_hierarchy` is opt-in on `diagnostics/3`
+rather than the `diagnostics/2` default specifically so this module's new
+behaviour does not also change the keystroke-driven cockpit editor's
+diagnostics (BT-2556, `beamtalk_repl_ops_dev:diagnostics_for/2`), which
+stays on the unchanged class-context-free default.
+
+Returned diagnostics are filtered to the ones attributable to *this* reload,
+not just any pre-existing issue the candidate happens to have:
+
+- **`removal`** — a `Dnu`-category diagnostic naming the removed selector
+  (`'Selector'`, matching the exact quoting `type_checker/validation.rs`
+  emits) is kept. This is always `Hint` under ADR 0100 Rule 1 for a
+  closed-complete receiver; `Open`/`Dynamic` receivers never produce the
+  diagnostic in the first place — the checker is already silent for
+  `perform:`/DNU-overriding cases, so no extra suppression is needed here.
+- **`signature_change`** — any `Dnu`- or `Type`-category diagnostic is kept,
+  whatever severity the ordinary type checker gave it (no escalation, per
+  ADR 0105 §Severity). Unlike `removal`, this does **not** also require the
+  message to name the changed selector: a signature change is discovered
+  through whatever selector the caller applies to the now-different return
+  value (`getCount -> String` breaks the caller's `+`, not `getCount`
+  itself — confirmed empirically: the checker classifies "`String` does not
+  understand `'+'`" as `Dnu`, not `Type`, since it is itself an unresolved-
+  selector diagnostic on the *new* return type).
+- Anything else (unrelated pre-existing diagnostics in the same class, and
+  any `error`-severity diagnostic — a reload finding is never build-failing)
+  is dropped.
+
+**Documented precision limit:** this filters by *category* (+ selector name
+for removals only), not by matching the diagnostic's span against the exact
+xref call site. A caller class with an unrelated *pre-existing* `Dnu`/`Type`
+diagnostic could be misattributed to a `signature_change` reload. The
+`removal` path's selector-name match narrows this — a caller with an
+unrelated pre-existing `Dnu` on the *same selector name but a different
+receiver* (`someString reset` when `Counter>>reset` is what was removed) is
+still misattributed, since the match is on the message substring, not the
+receiver's identity — it is narrower than `signature_change`'s filter, not
+immune to the same class of false positive. Precise span-to-site (and
+receiver-identity) matching is a documented refinement, not built here —
+consistent with the ADR's other accepted-gap tradeoffs (one level of
+fan-out only, the proxy-routed-call miss).
+
+## Scope
+
+Produces and returns findings; does not publish them to any surface (LSP /
+REPL notification / workspace UI) or persist them across reloads — that is
+BT-2779 ("Publish reload-induced diagnostics on all surfaces + clearing-by-
+replacement semantics"), explicitly out of scope here. `trigger/4` is
+synchronous and best-effort: any internal failure degrades to an empty
+result rather than raising, since a re-check failure must never affect the
+reload that triggered it (ADR 0105: "advisory, never blocking").
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([trigger/4]).
+
+-ifdef(TEST).
+-export([group_by_owner/1, apply_cap/2, relevant_diagnostic/4, cap_note/1]).
+-endif.
+
+-export_type([finding/0, result/0]).
+
+-type classification() :: signature_change | removal.
+
+-type site_ref() :: #{method := binary(), line := pos_integer()}.
+
+%% The finding shape before `to_finding/6` attaches its classification-specific
+%% `note` — kept as its own type so `base_finding/6`'s spec is exact (it never
+%% sets `note`; only its two callers in `to_finding/6` do).
+-type finding_without_note() :: #{
+    owner := binary(),
+    changed_class := binary(),
+    selector := binary(),
+    classification := classification(),
+    severity := binary(),
+    category := binary() | undefined,
+    message := binary(),
+    sites := [site_ref()],
+    start := non_neg_integer(),
+    'end' := non_neg_integer()
+}.
+
+-type finding() :: #{
+    owner := binary(),
+    changed_class := binary(),
+    selector := binary(),
+    classification := classification(),
+    severity := binary(),
+    category := binary() | undefined,
+    message := binary(),
+    note := binary() | undefined,
+    sites := [site_ref()],
+    start := non_neg_integer(),
+    'end' := non_neg_integer()
+}.
+
+-type result() :: #{
+    findings := [finding()],
+    checked := non_neg_integer(),
+    total_candidates := non_neg_integer(),
+    not_checked := non_neg_integer(),
+    cap_note := binary() | undefined
+}.
+
+%%====================================================================
+%% API
+%%====================================================================
+
+-doc """
+Run the re-check orchestration for a reload of `{ClassNameBin, SelectorBin,
+Side}` classified as `Classification` (the non-`no_op` outcome of
+`beamtalk_workspace_signature_store:capture/4`).
+
+Never raises: any internal failure is logged and degrades to an empty
+`result()` (zero findings, zero candidates) — the caller should not gate the
+reload's own success/reply on this.
+""".
+-spec trigger(binary(), binary(), instance | class, classification()) -> result().
+trigger(ClassNameBin, SelectorBin, Side, Classification) ->
+    try
+        do_trigger(ClassNameBin, SelectorBin, Classification)
+    catch
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                "Re-check orchestration failed (reload unaffected)",
+                #{
+                    error_class => Class,
+                    reason => Reason,
+                    stack => Stack,
+                    class => ClassNameBin,
+                    selector => SelectorBin,
+                    side => Side,
+                    classification => Classification,
+                    domain => [beamtalk, runtime]
+                }
+            ),
+            empty_result()
+    end.
+
+%%====================================================================
+%% Internal
+%%====================================================================
+
+-spec empty_result() -> result().
+empty_result() ->
+    #{findings => [], checked => 0, total_candidates => 0, not_checked => 0, cap_note => undefined}.
+
+-spec do_trigger(binary(), binary(), classification()) -> result().
+do_trigger(ClassNameBin, SelectorBin, Classification) ->
+    %% `binary_to_existing_atom/2`, not `binary_to_atom/2`: by the time a
+    %% reload reaches this trigger the selector was just compiled into a live
+    %% class, so its atom already exists — using the existing-only conversion
+    %% fails fast (caught by trigger/4) instead of ever minting a fresh atom
+    %% from what is, transitively, patch-source-derived text (atom-table
+    %% exhaustion is a standing concern for `binary_to_atom` on
+    %% externally-influenced input).
+    Selector = binary_to_existing_atom(SelectorBin, utf8),
+    Sites = beamtalk_xref:senders_of(Selector),
+    OwnerGroups = group_by_owner(Sites),
+    Cap = recheck_caller_cap(),
+    {Kept, NotChecked} = apply_cap(OwnerGroups, Cap),
+    Outcomes = [
+        recheck_owner(Owner, OwnerSites, ClassNameBin, SelectorBin, Classification)
+     || {Owner, OwnerSites} <- Kept
+    ],
+    Findings = lists:flatmap(fun({_Status, OwnerFindings}) -> OwnerFindings end, Outcomes),
+    %% `checked` counts candidates a diagnostics round-trip actually completed
+    %% for — not every *kept* candidate: one with no recorded live source (a
+    %% stdlib/dependency class) or a compiler-port failure never ran a check,
+    %% so it must not inflate the "N callers checked" figure the ADR 0105 demo
+    %% reports ("2 callers re-checked, 1 stale").
+    CheckedCount = length([ok || {ok, _} <- Outcomes]),
+    #{
+        findings => Findings,
+        checked => CheckedCount,
+        total_candidates => length(OwnerGroups),
+        not_checked => NotChecked,
+        cap_note => cap_note(NotChecked)
+    }.
+
+-doc "Read the per-reload caller cap (ADR 0105 §Mechanism step 2).".
+-spec recheck_caller_cap() -> pos_integer().
+recheck_caller_cap() ->
+    application:get_env(beamtalk_workspace, recheck_caller_cap, 20).
+
+-doc """
+Group xref sites by caller class, deduping so multiple sends of the changed
+selector within the same class collapse into one re-check candidate
+(`{Owner, [Site, ...]}`, sorted by `Owner` for deterministic ordering — see
+`apply_cap/2`'s doc for what that ordering means for which candidates get
+dropped when the cap bites).
+""".
+-spec group_by_owner([map()]) -> [{atom(), [map()]}].
+group_by_owner(Sites) ->
+    %% `maps:groups_from_list/2` is a single O(n) pass (vs. an O(owners *
+    %% sites) re-scan of `Sites` per owner) — matters once a common selector
+    %% (`size`, `at:`) has thousands of sites. `lists:keysort/2` on the atom
+    %% keys restores the deterministic order the rest of this module (and its
+    %% tests) depend on; `maps:groups_from_list/2` does not guarantee one.
+    Grouped = maps:groups_from_list(fun(S) -> maps:get(owner, S) end, Sites),
+    lists:keysort(1, maps:to_list(Grouped)).
+
+-doc """
+Keep at most `Cap` candidates; return `{Kept, NotCheckedCount}` — the
+"N more not checked" note is `NotCheckedCount` rendered by `cap_note/1`.
+
+`Candidates` arrives sorted by owner class name (`group_by_owner/1`), so the
+kept set is always the alphabetically-first `Cap` owners — deterministic
+across runs (not random, not order-of-discovery-dependent), but also not
+relevance-ranked: an over-cap reload always drops the same
+alphabetically-last owners, every time, regardless of which caller is
+actually most likely to matter. Load-bearing only as an interim guard (ADR
+0105 Alternatives) — the real fix for a hot common selector is the xref
+receiver-type-key extension.
+""".
+-spec apply_cap([T], pos_integer()) -> {[T], non_neg_integer()}.
+apply_cap(Candidates, Cap) ->
+    Total = length(Candidates),
+    if
+        Total =< Cap -> {Candidates, 0};
+        true -> {lists:sublist(Candidates, Cap), Total - Cap}
+    end.
+
+-spec cap_note(non_neg_integer()) -> binary() | undefined.
+cap_note(0) ->
+    undefined;
+cap_note(N) ->
+    iolist_to_binary(io_lib:format("~p more not checked", [N])).
+
+-doc """
+Re-check one candidate caller class: read its live source (never disk — a
+flagged caller may itself carry unflushed edits, ADR 0082), run diagnostics
+through the compiler port, and keep only the diagnostics attributable to
+this reload (`relevant_diagnostic/4`).
+
+Returns `{Status, Findings}` — `Status` is `ok` only when a diagnostics
+round-trip actually completed for this candidate, so `do_trigger/3` can count
+`checked` accurately: a candidate with no live source recorded (never
+installed through `beamtalk_repl_loader`, e.g. a stdlib/dependency class) is
+`skipped` with a logged warning rather than falling back to disk, and a
+compiler-port failure for this one candidate is `failed` — both degrade to
+"no findings for this caller" rather than failing the whole reload's
+orchestration, but neither counts as a completed check.
+""".
+-spec recheck_owner(atom(), [map()], binary(), binary(), classification()) ->
+    {ok | skipped | failed, [finding()]}.
+recheck_owner(Owner, OwnerSites, ClassNameBin, SelectorBin, Classification) ->
+    OwnerBin = atom_to_binary(Owner, utf8),
+    case beamtalk_workspace_meta:get_class_source(OwnerBin) of
+        undefined ->
+            ?LOG_WARNING(
+                "Re-check skipped: no live source recorded for candidate caller",
+                #{owner => OwnerBin, domain => [beamtalk, runtime]}
+            ),
+            {skipped, []};
+        Source ->
+            SourceBin = unicode:characters_to_binary(Source),
+            %% `class_hierarchy => true` opts into the ambient class cache
+            %% (beamtalk_compiler_server:diagnostics/3) — this re-check is
+            %% the one caller that needs it; the keystroke-driven cockpit
+            %% editor path (BT-2556) stays on the class-context-free default.
+            case
+                beamtalk_compiler:diagnostics(SourceBin, <<"expression">>, #{
+                    class_hierarchy => true
+                })
+            of
+                {ok, Diagnostics} ->
+                    SiteRefs = [site_ref(S) || S <- OwnerSites],
+                    Findings = [
+                        to_finding(OwnerBin, ClassNameBin, SelectorBin, Classification, SiteRefs, D)
+                     || D <- Diagnostics,
+                        relevant_diagnostic(D, ClassNameBin, SelectorBin, Classification)
+                    ],
+                    {ok, Findings};
+                {error, Reason} ->
+                    ?LOG_WARNING(
+                        "Re-check compile failed for candidate caller (no findings reported)",
+                        #{owner => OwnerBin, reason => Reason, domain => [beamtalk, runtime]}
+                    ),
+                    {failed, []}
+            end
+    end.
+
+-spec site_ref(map()) -> site_ref().
+site_ref(Site) ->
+    #{
+        method => atom_to_binary(maps:get(method, Site), utf8),
+        line => maps:get(line, Site)
+    }.
+
+-doc """
+Is `Diagnostic` attributable to this reload? See the moduledoc's "Finding
+attribution" section for the exact rule and its documented precision limit.
+`error`-severity is always dropped — a reload finding is advisory, never
+build-failing (ADR 0105 §Severity).
+""".
+-spec relevant_diagnostic(map(), binary(), binary(), classification()) -> boolean().
+relevant_diagnostic(#{severity := <<"error">>}, _ClassNameBin, _SelectorBin, _Classification) ->
+    false;
+relevant_diagnostic(
+    #{category := <<"Dnu">>, message := Message}, _ClassNameBin, SelectorBin, removal
+) ->
+    binary:match(Message, quoted_selector(SelectorBin)) =/= nomatch;
+relevant_diagnostic(#{category := Category}, _ClassNameBin, _SelectorBin, signature_change) when
+    Category =:= <<"Dnu">>; Category =:= <<"Type">>
+->
+    true;
+relevant_diagnostic(_Diagnostic, _ClassNameBin, _SelectorBin, _Classification) ->
+    false.
+
+-spec quoted_selector(binary()) -> binary().
+quoted_selector(SelectorBin) ->
+    <<"'", SelectorBin/binary, "'">>.
+
+-spec to_finding(binary(), binary(), binary(), classification(), [site_ref()], map()) -> finding().
+to_finding(OwnerBin, ClassNameBin, SelectorBin, removal, SiteRefs, Diagnostic) ->
+    (base_finding(OwnerBin, ClassNameBin, SelectorBin, removal, SiteRefs, Diagnostic))#{
+        note => <<"removed by the reload of ", ClassNameBin/binary>>
+    };
+to_finding(OwnerBin, ClassNameBin, SelectorBin, signature_change, SiteRefs, Diagnostic) ->
+    (base_finding(OwnerBin, ClassNameBin, SelectorBin, signature_change, SiteRefs, Diagnostic))#{
+        note => undefined
+    }.
+
+-spec base_finding(binary(), binary(), binary(), classification(), [site_ref()], map()) ->
+    finding_without_note().
+base_finding(
+    OwnerBin,
+    ClassNameBin,
+    SelectorBin,
+    Classification,
+    SiteRefs,
+    #{
+        message := Message, severity := Severity, start := Start, 'end' := End
+    } = Diagnostic
+) ->
+    #{
+        owner => OwnerBin,
+        changed_class => ClassNameBin,
+        selector => SelectorBin,
+        classification => Classification,
+        severity => Severity,
+        category => maps:get(category, Diagnostic, undefined),
+        message => Message,
+        sites => SiteRefs,
+        start => Start,
+        'end' => End
+    }.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -875,6 +875,12 @@ remove_method(ClassNameBin, Selector, Side) ->
                     NewSourceBin = splice_out_span(ClassSourceBin, Span),
                     case reload_class_without_method(ClassNameBin, NewSourceBin) of
                         {ok, _} = Ok ->
+                            %% ADR 0105 Phase 1 (BT-2778): the removal is
+                            %% live — re-check known dependents (mirrors the
+                            %% install success path in load_recompiled_method/8).
+                            maybe_trigger_recheck(
+                                ClassNameBin, SelectorBin, Side, RemovalCapture
+                            ),
                             Ok;
                         {error, _} = Error ->
                             rollback_signature_generation(
@@ -890,15 +896,15 @@ remove_method(ClassNameBin, Selector, Side) ->
 %% Record a method removal into the signature-generation store (ADR 0105 Phase
 %% 1, BT-2777). Best-effort and self-swallowing, mirroring
 %% capture_signature_generation/1 — a store failure must never block the
-%% removal itself. Returns the same {captured, Prev} | not_captured outcome so
+%% removal itself. Returns the same capture_outcome() so
 %% the caller can roll back on a subsequent recompile failure.
 -spec capture_signature_removal(binary(), binary(), instance | class) -> capture_outcome().
 capture_signature_removal(ClassNameBin, SelectorBin, Side) ->
     try
-        {Prev, _Classification} = beamtalk_workspace_signature_store:capture(
+        {Prev, Classification} = beamtalk_workspace_signature_store:capture(
             ClassNameBin, SelectorBin, Side, removed
         ),
-        {captured, Prev}
+        {captured, Prev, Classification}
     catch
         Class:Reason:Stack ->
             ?LOG_WARNING(
@@ -1038,6 +1044,24 @@ load_recompiled_method(
             %% reconciliation. Ephemeral patches are not autoflushed because
             %% only durable+flushable entries are written by `flush/0'.
             maybe_autoflush(maps:get(intent, MethodInfo, durable)),
+            %% (5) ADR 0105 Phase 1 (BT-2778): re-check known dependents of a
+            %% signature_change/removal now that the new generation is live.
+            %% Best-effort, never affects this reply — see the function doc.
+            %%
+            %% Ordering invariant this relies on: beamtalk_recheck's re-check
+            %% needs the compiler port's ambient class cache
+            %% (beamtalk_compiler_server's `classes` map) to already reflect
+            %% THIS class's new signature. activate_module/2 above is
+            %% synchronous — it runs the freshly-loaded module's
+            %% register_class/0, which (via beamtalk_object_class:start/2,
+            %% ADR 0050 Phase 4) casts the new metadata to
+            %% beamtalk_compiler_server *before* activate_module returns here
+            %% — so by the time maybe_trigger_recheck's diagnostics/3 call
+            %% reaches that same gen_server, the cast is already enqueued
+            %% ahead of it. This holds because activate_module blocks on
+            %% class registration; it would break if that registration ever
+            %% became async relative to this call site.
+            maybe_trigger_recheck(ClassNameBin, SelectorBin, Side, CaptureOutcome),
             Result = <<ClassNameBin/binary, ">>", SelectorBin/binary>>,
             {ok, Result, <<>>, AllWarnings, State};
         {error, LoadReason} ->
@@ -1532,12 +1556,16 @@ do_emit_change_entry(MethodInfo) ->
     ok.
 
 %% The outcome of a best-effort signature-store capture (ADR 0105 Phase 1,
-%% BT-2777): `{captured, Prev}` when the store call succeeded (`Prev` is
-%% whatever it reported as the pre-capture generation — feed this straight
-%% back to rollback_signature_generation/4 on a subsequent install failure),
-%% or `not_captured` when the capture itself failed (nothing to roll back).
+%% BT-2777): `{captured, Prev, Classification}` when the store call succeeded
+%% (`Prev` is whatever it reported as the pre-capture generation — feed this
+%% straight back to rollback_signature_generation/4 on a subsequent install
+%% failure; `Classification` is `beamtalk_signature_diff:classification/0`,
+%% consumed by BT-2778's re-check trigger below), or `not_captured` when the
+%% capture itself failed (nothing to roll back, nothing to re-check).
 -type capture_outcome() ::
-    {captured, beamtalk_workspace_signature_store:maybe_signature()} | not_captured.
+    {captured, beamtalk_workspace_signature_store:maybe_signature(),
+        beamtalk_signature_diff:classification()}
+    | not_captured.
 
 %% Capture the freshly-compiled signature into the signature-generation store
 %% (ADR 0105 Phase 1, BT-2777). Called from load_recompiled_method/8 *before*
@@ -1574,10 +1602,10 @@ do_capture_signature_generation(MethodInfo) ->
         return_type => maps:get(return_type, MethodInfo, <<"Dynamic">>),
         param_types => maps:get(param_types, MethodInfo, [])
     },
-    {Prev, _Classification} = beamtalk_workspace_signature_store:capture(
+    {Prev, Classification} = beamtalk_workspace_signature_store:capture(
         ClassNameBin, SelectorBin, Side, NewSignature
     ),
-    {captured, Prev}.
+    {captured, Prev, Classification}.
 
 %% Undo a capture_signature_generation/1 (or capture_signature_removal/3) call
 %% whose install/removal subsequently failed (ADR 0105 Phase 1, BT-2777).
@@ -1587,7 +1615,7 @@ do_capture_signature_generation(MethodInfo) ->
 -spec rollback_signature_generation(binary(), binary(), instance | class, capture_outcome()) -> ok.
 rollback_signature_generation(_ClassNameBin, _SelectorBin, _Side, not_captured) ->
     ok;
-rollback_signature_generation(ClassNameBin, SelectorBin, Side, {captured, Prev}) ->
+rollback_signature_generation(ClassNameBin, SelectorBin, Side, {captured, Prev, _Classification}) ->
     try
         _ = beamtalk_workspace_signature_store:rollback(ClassNameBin, SelectorBin, Side, Prev),
         ok
@@ -1606,6 +1634,54 @@ rollback_signature_generation(ClassNameBin, SelectorBin, Side, {captured, Prev})
             ),
             ok
     end.
+
+%% Fire the re-check orchestration (ADR 0105 Phase 1, BT-2778) for a
+%% successfully-installed patch/removal whose signature-store capture
+%% classified the change as `signature_change` or `removal` — `no_op` (and
+%% `not_captured`, when the store itself failed) skip the re-check, since
+%% there is nothing to diff dependents against. Synchronous and best-effort:
+%% `beamtalk_recheck:trigger/4` never raises, but the count is still logged
+%% here for workspace-session visibility (surfacing findings to any surface
+%% is BT-2779's job, out of scope here).
+%%
+%% Accepted tradeoff (flagged on BT-2777's review, recorded on BT-2778):
+%% `Classification` is only as correct as the signature-generation store's
+%% chain. Two concurrent sessions patching the same `{Class, Selector, Side}`
+%% key can race `capture/4`/`rollback/4` such that a losing session's
+%% rollback overwrites the store with a generation that is no longer the
+%% actually-live one (`beamtalk_workspace_signature_store:rollback/4` does an
+%% unconditional put, not a conditional "restore only if I'm still current"
+%% write) — the *next* capture then diffs against the wrong baseline and this
+%% function can fire on a false `signature_change`/`no_op`. Not fixed here:
+%% the store is BT-2777's merged surface, and a full fix (per-key conditional
+%% rollback) is out of this issue's scope. Advisory-only mitigates the
+%% blast radius (a wrong finding is noise, not a build/runtime failure).
+-spec maybe_trigger_recheck(binary(), binary(), instance | class, capture_outcome()) -> ok.
+maybe_trigger_recheck(_ClassNameBin, _SelectorBin, _Side, not_captured) ->
+    ok;
+maybe_trigger_recheck(_ClassNameBin, _SelectorBin, _Side, {captured, _Prev, no_op}) ->
+    ok;
+maybe_trigger_recheck(ClassNameBin, SelectorBin, Side, {captured, _Prev, Classification}) ->
+    #{findings := Findings, checked := Checked, not_checked := NotChecked} =
+        beamtalk_recheck:trigger(ClassNameBin, SelectorBin, Side, Classification),
+    case Findings of
+        [] ->
+            ok;
+        _ ->
+            ?LOG_INFO(
+                "Reload re-check produced findings",
+                #{
+                    class => ClassNameBin,
+                    selector => SelectorBin,
+                    classification => Classification,
+                    callers_checked => Checked,
+                    callers_not_checked => NotChecked,
+                    finding_count => length(Findings),
+                    domain => [beamtalk, runtime]
+                }
+            )
+    end,
+    ok.
 
 -spec patch_side(boolean()) -> instance | class.
 patch_side(true) -> class;

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -877,7 +877,16 @@ remove_method(ClassNameBin, Selector, Side) ->
                         {ok, _} = Ok ->
                             %% ADR 0105 Phase 1 (BT-2778): the removal is
                             %% live — re-check known dependents (mirrors the
-                            %% install success path in load_recompiled_method/8).
+                            %% install success path in load_recompiled_method/8,
+                            %% including that function's ordering-invariant
+                            %% comment: reload_class_without_method above ran
+                            %% through reload_compile_and_load's synchronous
+                            %% activate_module/3 call before returning here, so
+                            %% the compiler port's ambient class cache already
+                            %% reflects this removal by the time
+                            %% maybe_trigger_recheck's diagnostics/3 call reaches
+                            %% it — same invariant, same fragility if that
+                            %% registration path ever becomes async).
                             maybe_trigger_recheck(
                                 ClassNameBin, SelectorBin, Side, RemovalCapture
                             ),
@@ -1046,7 +1055,13 @@ load_recompiled_method(
             maybe_autoflush(maps:get(intent, MethodInfo, durable)),
             %% (5) ADR 0105 Phase 1 (BT-2778): re-check known dependents of a
             %% signature_change/removal now that the new generation is live.
-            %% Best-effort, never affects this reply — see the function doc.
+            %% Best-effort, never affects this reply's *content* — see the
+            %% function doc — but it IS synchronous here, so it does delay
+            %% this reply by the re-check's wall time (bounded by the caller
+            %% cap; ~18.5ms/candidate warm per the Phase 0 spike, so normally
+            %% sub-second even at the default cap of 20). Moving this off the
+            %% install's critical path is BT-2779's concern once findings
+            %% have somewhere to go (publish/clearing across surfaces).
             %%
             %% Ordering invariant this relies on: beamtalk_recheck's re-check
             %% needs the compiler port's ambient class cache

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace.app.src
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace.app.src
@@ -9,6 +9,9 @@
         {repl_port, 9000},
         % 1 hour in milliseconds
         {idle_timeout, 3600000},
-        {workspace_cleanup_enabled, true}
+        {workspace_cleanup_enabled, true},
+        % ADR 0105 Phase 1 (BT-2778): max distinct caller classes re-checked
+        % per reload before the rest are reported as "N more not checked".
+        {recheck_caller_cap, 20}
     ]}
 ]}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
@@ -1,0 +1,570 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_recheck_tests).
+
+-moduledoc """
+Tests for beamtalk_recheck (ADR 0105 Phase 1, BT-2778).
+
+Two tiers:
+
+  * Pure unit tests for the deterministic helpers (`group_by_owner/1`,
+    `apply_cap/2`, `relevant_diagnostic/4`, `cap_note/1`) — no port, no xref,
+    no workspace processes.
+  * Integration tests exercising `trigger/4` end-to-end against the real
+    compiler port + a real `beamtalk_xref` + `beamtalk_workspace_meta`,
+    mirroring the ADR 0105 Phase 0 spike
+    (`docs/internal/adr-0105-phase0-spike-findings.md`) and
+    `beamtalk_repl_loader_tests.erl`'s integration-fixture pattern. The
+    walking-skeleton case: `ReCheckCounter>>size` changes `Integer -> String`;
+    `ReCheckDashboard>>refresh:` (a real dependent, `(c size) + 1`) goes
+    stale; `ReCheckListView>>render:` sends the same selector `size` but on a
+    `List` receiver — selector-keyed xref returns both candidates, and only
+    the receiver-type filter (which happens naturally at re-check, not as a
+    pre-filter — see the moduledoc of beamtalk_recheck) tells them apart.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Pure helpers — group_by_owner/1, apply_cap/2, cap_note/1
+%%====================================================================
+
+group_by_owner_dedupes_and_sorts_test() ->
+    Sites = [
+        #{owner => 'Zeta', method => m1, line => 1},
+        #{owner => 'Alpha', method => m2, line => 2},
+        #{owner => 'Zeta', method => m3, line => 3}
+    ],
+    Grouped = beamtalk_recheck:group_by_owner(Sites),
+    ?assertEqual(['Alpha', 'Zeta'], [Owner || {Owner, _} <- Grouped]),
+    {'Zeta', ZetaSites} = lists:keyfind('Zeta', 1, Grouped),
+    ?assertEqual(2, length(ZetaSites)).
+
+group_by_owner_empty_test() ->
+    ?assertEqual([], beamtalk_recheck:group_by_owner([])).
+
+apply_cap_under_limit_test() ->
+    ?assertEqual({[a, b], 0}, beamtalk_recheck:apply_cap([a, b], 5)).
+
+apply_cap_at_limit_test() ->
+    ?assertEqual({[a, b], 0}, beamtalk_recheck:apply_cap([a, b], 2)).
+
+apply_cap_over_limit_test() ->
+    ?assertEqual({[a, b], 3}, beamtalk_recheck:apply_cap([a, b, c, d, e], 2)).
+
+cap_note_zero_is_undefined_test() ->
+    ?assertEqual(undefined, beamtalk_recheck:cap_note(0)).
+
+cap_note_nonzero_test() ->
+    ?assertEqual(<<"3 more not checked">>, beamtalk_recheck:cap_note(3)).
+
+%%====================================================================
+%% Pure helper — relevant_diagnostic/4 (attribution filter)
+%%====================================================================
+
+relevant_diagnostic_removal_matches_quoted_selector_test() ->
+    Diag = #{
+        category => <<"Dnu">>,
+        message => <<"'ReCheckCounter' does not understand 'reset'">>,
+        severity => <<"hint">>,
+        start => 0,
+        'end' => 1
+    },
+    ?assert(beamtalk_recheck:relevant_diagnostic(Diag, <<"ReCheckCounter">>, <<"reset">>, removal)).
+
+relevant_diagnostic_removal_ignores_other_selector_test() ->
+    Diag = #{
+        category => <<"Dnu">>,
+        message => <<"'ReCheckCounter' does not understand 'unrelatedSelector'">>,
+        severity => <<"hint">>,
+        start => 0,
+        'end' => 1
+    },
+    ?assertNot(
+        beamtalk_recheck:relevant_diagnostic(Diag, <<"ReCheckCounter">>, <<"reset">>, removal)
+    ).
+
+relevant_diagnostic_signature_change_keeps_type_category_test() ->
+    Diag = #{
+        category => <<"Type">>,
+        message => <<"no member of 'String' understands '+'">>,
+        severity => <<"warning">>,
+        start => 0,
+        'end' => 1
+    },
+    ?assert(
+        beamtalk_recheck:relevant_diagnostic(
+            Diag, <<"ReCheckCounter">>, <<"size">>, signature_change
+        )
+    ).
+
+%% A signature_change also surfaces as a Dnu-category diagnostic in practice
+%% — e.g. `getCount -> String` breaks a caller's `+`, and the checker reports
+%% that as "`String` does not understand `'+'`" (Dnu), not a `Type` mismatch.
+%% Unlike `removal`, this deliberately does NOT require the message to name
+%% the changed selector (`size`) — see the moduledoc's documented precision
+%% limit.
+relevant_diagnostic_signature_change_keeps_dnu_category_test() ->
+    Diag = #{
+        category => <<"Dnu">>,
+        message => <<"String does not understand '+'">>,
+        severity => <<"hint">>,
+        start => 0,
+        'end' => 1
+    },
+    ?assert(
+        beamtalk_recheck:relevant_diagnostic(
+            Diag, <<"ReCheckCounter">>, <<"size">>, signature_change
+        )
+    ).
+
+relevant_diagnostic_signature_change_ignores_unused_category_test() ->
+    Diag = #{
+        category => <<"Unused">>,
+        message => <<"variable 'x' is never used">>,
+        severity => <<"lint">>,
+        start => 0,
+        'end' => 1
+    },
+    ?assertNot(
+        beamtalk_recheck:relevant_diagnostic(
+            Diag, <<"ReCheckCounter">>, <<"size">>, signature_change
+        )
+    ).
+
+relevant_diagnostic_never_keeps_error_severity_test() ->
+    Diag = #{
+        category => <<"Dnu">>,
+        message => <<"'ReCheckCounter' does not understand 'reset'">>,
+        severity => <<"error">>,
+        start => 0,
+        'end' => 1
+    },
+    ?assertNot(
+        beamtalk_recheck:relevant_diagnostic(Diag, <<"ReCheckCounter">>, <<"reset">>, removal)
+    ).
+
+relevant_diagnostic_ignores_undefined_category_test() ->
+    Diag = #{
+        category => undefined,
+        message => <<"some parse-level note">>,
+        severity => <<"warning">>,
+        start => 0,
+        'end' => 1
+    },
+    ?assertNot(
+        beamtalk_recheck:relevant_diagnostic(
+            Diag, <<"ReCheckCounter">>, <<"size">>, signature_change
+        )
+    ).
+
+%%====================================================================
+%% Integration fixture: real compiler port + xref + workspace_meta
+%%====================================================================
+
+recheck_setup() ->
+    application:ensure_all_started(compiler),
+    case application:ensure_all_started(beamtalk_compiler) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    application:ensure_all_started(beamtalk_runtime),
+    case whereis(beamtalk_workspace_meta) of
+        undefined -> ok;
+        MetaPid -> gen_server:stop(MetaPid)
+    end,
+    %% `repl => false` (run mode) is load-bearing for test isolation, not
+    %% just tidiness: in REPL mode (the default) `beamtalk_workspace_meta`
+    %% persists `class_sources` to
+    %% `~/.beamtalk/workspaces/<workspace_id>/metadata.json` and *reloads* it
+    %% on the next `init/1` — so a "fresh" restart under the same
+    %% `workspace_id` would resurrect a previous test's `set_class_source/2`
+    %% calls instead of starting empty (discovered via a genuinely-flaky
+    %% no-live-source test here). Run mode skips disk entirely.
+    {ok, _} = beamtalk_workspace_meta:start_link(#{
+        workspace_id => <<"recheck_test_ws">>,
+        project_path => undefined,
+        created_at => erlang:system_time(second),
+        repl => false
+    }),
+    clear_xref(),
+    beamtalk_compiler_server:clear_classes(),
+    ok.
+
+recheck_teardown(_) ->
+    case whereis(beamtalk_workspace_meta) of
+        undefined -> ok;
+        MetaPid -> gen_server:stop(MetaPid)
+    end,
+    clear_xref(),
+    _ = application:stop(beamtalk_compiler),
+    ok.
+
+clear_xref() ->
+    case whereis(beamtalk_xref) of
+        undefined ->
+            ok;
+        _Pid ->
+            try
+                sys:replace_state(beamtalk_xref, fun(S) ->
+                    ets:delete_all_objects(beamtalk_xref_methods),
+                    ets:delete_all_objects(beamtalk_xref_senders),
+                    ets:delete_all_objects(beamtalk_xref_references),
+                    ets:delete_all_objects(xref_class_gen),
+                    S
+                end)
+            catch
+                _:_ -> ok
+            end,
+            ok
+    end.
+
+%% xref payload: `ReCheckDashboard>>refresh:` sends `size` to a
+%% `ReCheckCounter`-typed parameter — the real dependent.
+dashboard_xref() ->
+    [
+        #{
+            class_side => false,
+            selector => 'refresh:',
+            line => 2,
+            sends => [#{selector => size, line => 2, recv_kind => other}],
+            references => [#{class => 'ReCheckCounter', line => 2}],
+            source_status => indexed,
+            provenance => class_body
+        }
+    ].
+
+%% xref payload: `ReCheckListView>>render:` also sends `size`, but to a
+%% `List`-typed parameter — an unrelated same-selector site.
+listview_xref() ->
+    [
+        #{
+            class_side => false,
+            selector => 'render:',
+            line => 2,
+            sends => [#{selector => size, line => 2, recv_kind => other}],
+            references => [],
+            source_status => indexed,
+            provenance => class_body
+        }
+    ].
+
+%% xref payload: `ReCheckDashboard>>cleanup:` sends the removed selector
+%% `reset` to a `ReCheckCounter`-typed parameter.
+dashboard_reset_xref() ->
+    [
+        #{
+            class_side => false,
+            selector => 'cleanup:',
+            line => 2,
+            sends => [#{selector => reset, line => 2, recv_kind => other}],
+            references => [#{class => 'ReCheckCounter', line => 2}],
+            source_status => indexed,
+            provenance => class_body
+        }
+    ].
+
+dashboard_source() ->
+    <<
+        "Object subclass: ReCheckDashboard\n"
+        "  refresh: c :: ReCheckCounter -> Integer => (c size) + 1\n"
+    >>.
+
+listview_source() ->
+    <<
+        "Object subclass: ReCheckListView\n"
+        "  render: xs :: List -> Integer => (xs size) + 1\n"
+    >>.
+
+dashboard_reset_source() ->
+    <<
+        "Object subclass: ReCheckDashboard\n"
+        "  cleanup: c :: ReCheckCounter => c reset\n"
+    >>.
+
+%% `class_hierarchy` entry for `ReCheckCounter`, the channel that carries the
+%% changed class's *current* signature to the checker (ADR 0105 §Mechanism
+%% step 1 — populated in production by beamtalk_compiler_server's
+%% register_class cache, ADR 0050 Phase 4).
+counter_hierarchy(MethodInfo) ->
+    #{superclass => 'Object', method_info => MethodInfo}.
+
+signature_change_finding_and_receiver_filter_test_() ->
+    {timeout, 30,
+        {setup, fun recheck_setup/0, fun recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    %% ReCheckCounter>>size now returns String (was Integer) —
+                    %% the ambient class cache already reflects the just-installed
+                    %% new generation, exactly as it would post-reload in production.
+                    beamtalk_compiler_server:register_class(
+                        'ReCheckCounter',
+                        counter_hierarchy(#{
+                            size => #{arity => 0, param_types => [], return_type => 'String'}
+                        })
+                    ),
+                    ok = beamtalk_xref:register_class('ReCheckDashboard', dashboard_xref()),
+                    ok = beamtalk_xref:register_class('ReCheckListView', listview_xref()),
+                    ok = beamtalk_workspace_meta:set_class_source(
+                        <<"ReCheckDashboard">>, dashboard_source()
+                    ),
+                    ok = beamtalk_workspace_meta:set_class_source(
+                        <<"ReCheckListView">>, listview_source()
+                    ),
+
+                    Result = beamtalk_recheck:trigger(
+                        <<"ReCheckCounter">>, <<"size">>, instance, signature_change
+                    ),
+                    #{findings := Findings, checked := Checked, not_checked := NotChecked} = Result,
+
+                    %% Both candidates were re-checked (xref is selector-keyed and
+                    %% cannot tell them apart on its own) ...
+                    ?assertEqual(2, Checked),
+                    ?assertEqual(0, NotChecked),
+
+                    %% ... but only the real dependent produced a finding — the
+                    %% unrelated ListView site re-checks clean because `xs` is
+                    %% statically `List`, not `ReCheckCounter`.
+                    ?assertEqual(1, length(Findings)),
+                    [Finding] = Findings,
+                    ?assertEqual(<<"ReCheckDashboard">>, maps:get(owner, Finding)),
+                    ?assertEqual(signature_change, maps:get(classification, Finding)),
+                    %% The checker reports "String does not understand '+'"
+                    %% as a Dnu-category diagnostic (an unresolved selector on
+                    %% the new return type), not a Type mismatch — see
+                    %% beamtalk_recheck's moduledoc.
+                    ?assertEqual(<<"Dnu">>, maps:get(category, Finding)),
+                    ?assert(lists:member(maps:get(severity, Finding), [<<"warning">>, <<"hint">>]))
+                end)
+            ]
+        end}}.
+
+removed_selector_hint_test_() ->
+    {timeout, 30,
+        {setup, fun recheck_setup/0, fun recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    %% ReCheckCounter no longer has `reset` at all — the ambient
+                    %% class cache reflects the post-removal generation.
+                    beamtalk_compiler_server:register_class(
+                        'ReCheckCounter', counter_hierarchy(#{})
+                    ),
+                    ok = beamtalk_xref:register_class('ReCheckDashboard', dashboard_reset_xref()),
+                    ok = beamtalk_workspace_meta:set_class_source(
+                        <<"ReCheckDashboard">>, dashboard_reset_source()
+                    ),
+
+                    Result = beamtalk_recheck:trigger(
+                        <<"ReCheckCounter">>, <<"reset">>, instance, removal
+                    ),
+                    #{findings := Findings, checked := Checked} = Result,
+
+                    ?assertEqual(1, Checked),
+                    ?assertEqual(1, length(Findings)),
+                    [Finding] = Findings,
+                    ?assertEqual(<<"ReCheckDashboard">>, maps:get(owner, Finding)),
+                    ?assertEqual(removal, maps:get(classification, Finding)),
+                    ?assertEqual(<<"Dnu">>, maps:get(category, Finding)),
+                    %% ADR 0100 Rule 1: an unresolved selector on a single
+                    %% closed-complete receiver is a Hint, never escalated.
+                    ?assertEqual(<<"hint">>, maps:get(severity, Finding)),
+                    ?assertEqual(
+                        <<"removed by the reload of ReCheckCounter">>, maps:get(note, Finding)
+                    )
+                end)
+            ]
+        end}}.
+
+caller_cap_note_test_() ->
+    {timeout, 30,
+        {setup, fun recheck_setup/0, fun recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    PrevCap = application:get_env(beamtalk_workspace, recheck_caller_cap, 20),
+                    application:set_env(beamtalk_workspace, recheck_caller_cap, 1),
+                    try
+                        beamtalk_compiler_server:register_class(
+                            'ReCheckCounter',
+                            counter_hierarchy(#{
+                                size => #{arity => 0, param_types => [], return_type => 'String'}
+                            })
+                        ),
+                        ok = beamtalk_xref:register_class('ReCheckDashboard', dashboard_xref()),
+                        ok = beamtalk_xref:register_class('ReCheckListView', listview_xref()),
+                        ok = beamtalk_workspace_meta:set_class_source(
+                            <<"ReCheckDashboard">>, dashboard_source()
+                        ),
+                        ok = beamtalk_workspace_meta:set_class_source(
+                            <<"ReCheckListView">>, listview_source()
+                        ),
+
+                        Result = beamtalk_recheck:trigger(
+                            <<"ReCheckCounter">>, <<"size">>, instance, signature_change
+                        ),
+                        #{
+                            checked := Checked,
+                            total_candidates := Total,
+                            not_checked := NotChecked,
+                            cap_note := CapNote
+                        } = Result,
+
+                        ?assertEqual(1, Checked),
+                        ?assertEqual(2, Total),
+                        ?assertEqual(1, NotChecked),
+                        ?assertEqual(<<"1 more not checked">>, CapNote)
+                    after
+                        application:set_env(beamtalk_workspace, recheck_caller_cap, PrevCap)
+                    end
+                end)
+            ]
+        end}}.
+
+%% xref payload: `ReCheckDashboard` sends `size` from TWO different methods —
+%% multiple sites in one caller class must collapse into one re-check
+%% candidate, not two (Mechanism step 3: "batched", one port round-trip per
+%% distinct caller class, not per call site).
+dashboard_two_sites_xref() ->
+    [
+        #{
+            class_side => false,
+            selector => 'refresh:',
+            line => 2,
+            sends => [#{selector => size, line => 2, recv_kind => other}],
+            references => [#{class => 'ReCheckCounter', line => 2}],
+            source_status => indexed,
+            provenance => class_body
+        },
+        #{
+            class_side => false,
+            selector => 'refreshTwice:',
+            line => 3,
+            sends => [#{selector => size, line => 3, recv_kind => other}],
+            references => [#{class => 'ReCheckCounter', line => 3}],
+            source_status => indexed,
+            provenance => class_body
+        }
+    ].
+
+dashboard_two_sites_source() ->
+    <<
+        "Object subclass: ReCheckDashboard\n"
+        "  refresh: c :: ReCheckCounter -> Integer => (c size) + 1\n"
+        "  refreshTwice: c :: ReCheckCounter -> Integer => (c size) + (c size)\n"
+    >>.
+
+multi_site_same_owner_collapses_to_one_check_test_() ->
+    {timeout, 30,
+        {setup, fun recheck_setup/0, fun recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    beamtalk_compiler_server:register_class(
+                        'ReCheckCounter',
+                        counter_hierarchy(#{
+                            size => #{arity => 0, param_types => [], return_type => 'String'}
+                        })
+                    ),
+                    ok = beamtalk_xref:register_class(
+                        'ReCheckDashboard', dashboard_two_sites_xref()
+                    ),
+                    ok = beamtalk_workspace_meta:set_class_source(
+                        <<"ReCheckDashboard">>, dashboard_two_sites_source()
+                    ),
+
+                    Result = beamtalk_recheck:trigger(
+                        <<"ReCheckCounter">>, <<"size">>, instance, signature_change
+                    ),
+                    #{
+                        findings := Findings,
+                        checked := Checked,
+                        total_candidates := Total
+                    } = Result,
+
+                    %% ONE candidate (ReCheckDashboard), not two, even though
+                    %% it has two distinct call sites of the changed selector.
+                    ?assertEqual(1, Total),
+                    ?assertEqual(1, Checked),
+                    %% Both stale sends surface as separate diagnostics from
+                    %% the single re-check, and both are attributed to the
+                    %% one owner with all of its known trigger sites listed.
+                    ?assert(length(Findings) >= 1),
+                    [FirstFinding | _] = Findings,
+                    ?assertEqual(<<"ReCheckDashboard">>, maps:get(owner, FirstFinding)),
+                    SiteMethods = [
+                        maps:get(method, S)
+                     || F <- Findings, S <- maps:get(sites, F)
+                    ],
+                    ?assertEqual(
+                        [<<"refresh:">>, <<"refreshTwice:">>],
+                        lists:usort(SiteMethods)
+                    )
+                end)
+            ]
+        end}}.
+
+no_live_source_is_skipped_not_checked_test_() ->
+    {timeout, 30,
+        {setup, fun recheck_setup/0, fun recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    beamtalk_compiler_server:register_class(
+                        'ReCheckCounter',
+                        counter_hierarchy(#{
+                            size => #{arity => 0, param_types => [], return_type => 'String'}
+                        })
+                    ),
+                    %% xref knows about a sender, but no `set_class_source/2`
+                    %% was ever recorded for it (e.g. a stdlib/dependency
+                    %% class, never installed through beamtalk_repl_loader).
+                    ok = beamtalk_xref:register_class('ReCheckDashboard', dashboard_xref()),
+
+                    Result = beamtalk_recheck:trigger(
+                        <<"ReCheckCounter">>, <<"size">>, instance, signature_change
+                    ),
+                    #{
+                        findings := Findings,
+                        checked := Checked,
+                        total_candidates := Total,
+                        not_checked := NotChecked
+                    } = Result,
+
+                    %% The candidate was a total candidate and NOT cap-dropped
+                    %% (not_checked counts only cap overflow) — it was simply
+                    %% never successfully checked, so `checked` must not count
+                    %% it either.
+                    ?assertEqual(1, Total),
+                    ?assertEqual(0, Checked),
+                    ?assertEqual(0, NotChecked),
+                    ?assertEqual([], Findings)
+                end)
+            ]
+        end}}.
+
+%% `trigger/4`'s headline safety guarantee (see its moduledoc: "Never
+%% raises") — a selector atom that was never compiled into any live class
+%% (so `binary_to_existing_atom/2` inside `do_trigger/3` raises `badarg`)
+%% must degrade to an empty result, not crash the caller (the install path
+%% in beamtalk_repl_loader that calls this must never fail the reload
+%% because the advisory re-check blew up).
+trigger_never_raises_on_unknown_selector_test_() ->
+    {timeout, 30,
+        {setup, fun recheck_setup/0, fun recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    NeverCompiledSelector = <<"reCheckNeverCompiledSelectorXyz">>,
+                    Result = beamtalk_recheck:trigger(
+                        <<"ReCheckCounter">>, NeverCompiledSelector, instance, signature_change
+                    ),
+                    ?assertEqual(
+                        #{
+                            findings => [],
+                            checked => 0,
+                            total_candidates => 0,
+                            not_checked => 0,
+                            cap_note => undefined
+                        },
+                        Result
+                    )
+                end)
+            ]
+        end}}.


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2778

Phase 1 of [ADR 0105](https://github.com/jamesc/beamtalk/blob/main/docs/ADR/0105-live-image-recheck-on-reload.md) (Live Image Re-Checking on Hot Reload), building on BT-2777's signature-generation store (merged as #2885) and the BT-2776 Phase 0 spike findings (`docs/internal/adr-0105-phase0-spike-findings.md`).

On a reload with a non-no-op signature diff, this finds the change's known dependents via `beamtalk_xref:senders_of/1`, re-checks each distinct caller class's live source through the compiler port, and produces findings at ADR 0100 severities — with no severity escalation, one level of fan-out only, and a numeric caller cap.

### Key changes

- **New `beamtalk_recheck.erl`** orchestrator: xref lookup → per-class dedup (`group_by_owner/1`, O(n) via `maps:groups_from_list/2`) → numeric caller cap with an "N more not checked" note → live-source re-check → a category+selector filter (`relevant_diagnostic/4`) that attributes reload-relevant diagnostics without escalating their severity.
- **Compiler port (Rust + Erlang)**: extends the `diagnostics` command to optionally accept `class_hierarchy` (plus a new `category` field on every diagnostic), exposed as an **opt-in** `beamtalk_compiler:diagnostics/3` (`class_hierarchy => true`) rather than changing the existing `diagnostics/2` default — that command also backs the LiveView cockpit's keystroke-driven editor diagnostics (BT-2556), so the default stays unchanged.
- **Wired into `beamtalk_repl_loader.erl`**: `load_recompiled_method/8` and `remove_method/3` fire the trigger after a successful install/removal, threading the signature-store's `signature_change`/`removal` classification through. Synchronous and best-effort — never affects the reload's own reply.
- **Receiver-type filtering** (ADR 0105 Mechanism step 2) is not a distinct filter pass — it's an emergent property of re-checking with the compiler's normal type inference, confirmed empirically by the `receiver-filter excludes an unrelated same-selector site` integration test.

### Design notes / deviations from the ADR's literal text

- "Batched into one compiler-port request per reload" is implemented as one round-trip *per distinct caller class* (multi-site collapse), not one request for the whole reload — the compiler port rejects multi-class sources (Phase 0 spike finding).
- Findings are produced and returned, not published/persisted to any surface — that's BT-2779's explicit scope.
- The concurrent-session rollback race flagged on BT-2777's review is accepted as a documented tradeoff here (see code comment on `beamtalk_repl_loader:maybe_trigger_recheck/4` and the BT-2778 Linear comment) — the fix (per-key conditional rollback in `beamtalk_workspace_signature_store`) is out of scope.
- Two known precision limits are documented in code (not fixed, consistent with the ADR's own accepted-gap pattern): a `signature_change` finding is attributed by diagnostic category rather than exact span-to-site matching; a synchronous-fan-out latency tail is tracked via a comment on BT-2781.

### Testing

- [x] `just build && just clippy && just fmt-check`
- [x] `just test-stdlib` (223/223), `just test-bunit` (2682/2684, 0 failed), `just test-runtime` (6774 tests, 0 failures)
- [x] `cargo test -p beamtalk-compiler-port` (49/49) — includes 2 new tests for the `diagnostics` command's `class_hierarchy` opt-in
- [x] New `beamtalk_recheck_tests.erl` (20 tests): pure helper coverage + real integration tests against the actual compiler port + xref, covering a signature-change finding on a real caller, a removed-selector Hint, the receiver-filter excluding an unrelated same-selector site, and the caller-cap note
- [x] `rebar3 dialyzer` clean
- Reviewed via `/review-code`'s full 3-pass process (diff, system, adversarial with an independent model) — findings addressed inline; see the BT-2778 Linear comment for the full list of design decisions and tradeoffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j5UBhVKaBHzM89fmSYXxy

---
_Generated by [Claude Code](https://claude.ai/code/session_019j5UBhVKaBHzM89fmSYXxy)_