### PR TITLE
Codegen: compile-time error for field mutation in a block that can't thread state (BT-2792)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
@@ -1663,6 +1663,31 @@ fn test_each_with_index_wrong_arity_block_falls_through() {
 }
 
 #[test]
+fn test_each_with_index_wrong_arity_field_mutating_block_is_compile_error() {
+    // BT-2792: the compound case the 7 sibling "falls through" tests above and
+    // below deliberately avoid (they use pure bodies so they can assert on the
+    // dispatch/lists:foldl shape of successful codegen). When a block that
+    // falls through eachWithIndex:'s arity guard *also* mutates self.<field>,
+    // it reaches generate_block's generic fallback and must now be rejected at
+    // compile time — not silently produce Core Erlang erlc rejects.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    items eachWithIndex: [:x | self.total := self.total + x]\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _) = crate::source_analysis::parse(tokens);
+    let result = crate::codegen::core_erlang::generate_module(
+        &module,
+        crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(crate::codegen::core_erlang::CodeGenError::FieldAssignmentInStoredClosure { .. })
+        ),
+        "A field-mutating block that falls through eachWithIndex:'s arity guard must be a \
+         compile-time error (BT-2792), not silently accepted. Got: {result:?}"
+    );
+}
+
+#[test]
 fn test_each_with_index_value_type_desugars_without_reprojection() {
     // In a Value-type method the desugar fires (a mutating local still needs
     // threading) but the actor nil-with-state re-projection must NOT appear —

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
@@ -1680,7 +1680,9 @@ fn test_each_with_index_wrong_arity_field_mutating_block_is_compile_error() {
     assert!(
         matches!(
             result,
-            Err(crate::codegen::core_erlang::CodeGenError::FieldAssignmentInStoredClosure { .. })
+            Err(
+                crate::codegen::core_erlang::CodeGenError::FieldAssignmentInUnsupportedBlock { .. }
+            )
         ),
         "A field-mutating block that falls through eachWithIndex:'s arity guard must be a \
          compile-time error (BT-2792), not silently accepted. Got: {result:?}"

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
@@ -1647,8 +1647,10 @@ fn test_each_with_index_pure_block_falls_through() {
 fn test_each_with_index_wrong_arity_block_falls_through() {
     // A 1-arg block (wrong arity for eachWithIndex:) must not desugar; the
     // Collection.bt method will raise the correct runtime error (covers the
-    // arity guard in try_generate_each_with_index).
-    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    items eachWithIndex: [:x | self.total := self.total + x]\n";
+    // arity guard in try_generate_each_with_index). Body is a pure expression
+    // (not a `self.field :=` mutation) — see BT-2792, which made a mutating
+    // block that falls through to normal dispatch a compile-time error.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    items eachWithIndex: [:x | x + 1]\n";
     let code = codegen(src);
     assert!(
         code.contains("'send'(_items1, 'eachWithIndex:', ["),
@@ -1744,8 +1746,10 @@ fn test_each_with_index_degenerate_param_names_falls_through() {
     // `[:x :x | …]` — elem and index sharing a name — must not desugar; the
     // guard in try_generate_each_with_index leaves it to the normal dispatch
     // path's own diagnostics rather than building a fold with a shadowed
-    // accumulator parameter.
-    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    items eachWithIndex: [:x :x | self.total := self.total + x]\n";
+    // accumulator parameter. Body is a pure expression, not a `self.field :=`
+    // mutation — see BT-2792 (a mutating block that falls through to normal
+    // dispatch is now a compile-time error, tested separately).
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    items eachWithIndex: [:x :x | x + 1]\n";
     let code = codegen(src);
     assert!(
         code.contains("'send'(_items1, 'eachWithIndex:', ["),
@@ -1763,12 +1767,11 @@ fn test_each_with_index_non_literal_callable_falls_through() {
     // synthetic AST builders need the actual parameter names and body, so the
     // call dispatches to Collection.bt as an ordinary callable send.
     //
-    // NB: this does NOT mean the field mutation inside `blk` is threaded back
-    // to actor state correctly. It isn't — storing a self-mutating block in a
-    // local and invoking it later is a *pre-existing, general* codegen bug
-    // (unrelated to eachWithIndex:/do:separatedBy:) that produces Core Erlang
-    // `erlc` rejects with "unbound variable" in `dispatch/4`. See BT-2792.
-    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    blk := [:item :i | self.total := self.total + item]\n    items eachWithIndex: blk\n";
+    // Body is a pure expression, not a `self.field :=` mutation: storing a
+    // self-mutating block in a local and invoking it later is now a
+    // compile-time error (BT-2792, tested separately), so it can no longer be
+    // exercised via `codegen()`'s `expect`-success helper here.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    blk := [:item :i | item + i]\n    items eachWithIndex: blk\n";
     let code = codegen(src);
     assert!(
         code.contains("'send'(_items1, 'eachWithIndex:', [Blk]"),
@@ -1783,9 +1786,9 @@ fn test_each_with_index_non_literal_callable_falls_through() {
 #[test]
 fn test_do_separated_by_non_literal_callable_falls_through() {
     // Same non-literal guard as above, but for the `do:separatedBy:` element
-    // block argument. See BT-2792 for the pre-existing state-threading bug
-    // this scenario's field mutation would hit if actually compiled.
-    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    blk := [:x | self.total := self.total + x]\n    items do: blk separatedBy: [nil]\n";
+    // block argument. Body is a pure expression — see BT-2792, which made a
+    // stored self-mutating block invoked this way a compile-time error.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    blk := [:x | x + 1]\n    items do: blk separatedBy: [nil]\n";
     let code = codegen(src);
     // Bracket deliberately left open (no trailing `]`) here, unlike the
     // eachWithIndex: assertion above: do:separatedBy: passes two arguments
@@ -1805,11 +1808,9 @@ fn test_do_separated_by_non_literal_separator_falls_through() {
     // Symmetric with test_do_separated_by_non_literal_callable_falls_through,
     // but the *separator* block (not the element block) is the non-literal
     // variable. Both callable positions must be literal blocks for the
-    // desugar to fire.
-    //
-    // NB: `sep` mutates `self.total`, so the mutation is also subject to the
-    // BT-2792 state-threading bug when this falls through to normal dispatch.
-    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    sep := [self.total := self.total + 1]\n    items do: [:x | x printString] separatedBy: sep\n";
+    // desugar to fire. Body is a pure expression — see BT-2792, which made a
+    // stored self-mutating block invoked this way a compile-time error.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    sep := [nil]\n    items do: [:x | x printString] separatedBy: sep\n";
     let code = codegen(src);
     assert!(
         code.contains("'send'(_items1, 'do:separatedBy:', ["),
@@ -1848,8 +1849,10 @@ fn test_do_separated_by_value_type_desugars_without_reprojection() {
 fn test_each_with_index_zero_arity_block_falls_through() {
     // A 0-arg block is wrong arity too (the guard is `!= 2`, not `== 1`), so it
     // must fall through the same as the 1-arg case covered by
-    // test_each_with_index_wrong_arity_block_falls_through.
-    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    items eachWithIndex: [self.total := self.total + 1]\n";
+    // test_each_with_index_wrong_arity_block_falls_through. Body is a pure
+    // expression — see BT-2792, which made a mutating block that falls
+    // through to normal dispatch a compile-time error.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    items eachWithIndex: [1]\n";
     let code = codegen(src);
     assert!(
         code.contains("'send'(_items1, 'eachWithIndex:', ["),
@@ -1865,8 +1868,10 @@ fn test_each_with_index_zero_arity_block_falls_through() {
 fn test_do_separated_by_separator_with_param_falls_through() {
     // do:separatedBy:'s separator block must be 0-arg (`[…]`); a separator with
     // a parameter (`[:y | …]`) is wrong arity and must fall through, covering
-    // the `!separator_block.parameters.is_empty()` guard.
-    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    items do: [:x | x printString] separatedBy: [:y | self.total := self.total + 1]\n";
+    // the `!separator_block.parameters.is_empty()` guard. Body is a pure
+    // expression — see BT-2792, which made a mutating block that falls
+    // through to normal dispatch a compile-time error.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: items =>\n    items do: [:x | x printString] separatedBy: [:y | y + 1]\n";
     let code = codegen(src);
     assert!(
         code.contains("'send'(_items1, 'do:separatedBy:', ["),

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -723,6 +723,29 @@ impl CoreErlangGenerator {
             return self.generate_block_stateful(block, &captured_mutations);
         }
 
+        // BT-2792: A block reaching this generic fallback that also writes a
+        // `self.<field>` cannot correctly thread state. `self.field := ...`
+        // inside the block's own `fun` body still bumps the *shared*
+        // `state_threading` counter (next_state_var), but the resulting
+        // `let StateN = ... in ...` binding is scoped only inside that `fun` —
+        // it never reaches the enclosing method. The enclosing method then
+        // believes `StateN` is live and references it out of scope, which
+        // erlc rejects with "unbound variable". Every construct that *can*
+        // thread field mutations correctly (ifTrue:/ifFalse:/whileTrue:/do:/
+        // collect:/select:/reject:/inject:into:/timesRepeat:/to:do:, and a
+        // literal block passed directly to a self-send) is inlined or routed
+        // through `generate_block_stateful` before reaching this fallback —
+        // see BT-851's `tier2_method_info` scan and the `with_branch_context`
+        // callers in control_flow/. A block that still reaches here is opaque
+        // to the compiler (stored in a local var, returned, passed to a
+        // user-defined method and invoked later, etc.) and general call-site
+        // state threading for that shape isn't implemented yet. `Tier 2`
+        // (above) only ever promotes on *captured local* mutations, so it was
+        // never actually a fix for this — reinstate the `validate_stored_closure`
+        // diagnostic (its production call sites were removed under the belief
+        // Tier 2 made it obsolete) instead of silently emitting broken Core Erlang.
+        Self::validate_stored_closure(block, format!("offset {}", block.span.start()))?;
+
         // Pure block: plain fun (no mutations to thread via Tier 2)
         self.push_scope();
         // BT-1475: Track block nesting so self-cast sends route through the mailbox

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -675,7 +675,16 @@ impl CoreErlangGenerator {
     /// use identical logic and cannot drift independently.
     pub(super) fn captured_mutations_for_block(block: &Block) -> Vec<String> {
         use crate::codegen::core_erlang::block_analysis::analyze_block;
-        let analysis = analyze_block(block);
+        Self::captured_mutations_from_analysis(&analyze_block(block))
+    }
+
+    /// Same check as [`Self::captured_mutations_for_block`], but from an already-computed
+    /// analysis — lets callers that need more than one fact off a single `analyze_block`
+    /// pass (e.g. [`Self::generate_block`], which also checks `field_writes`) avoid
+    /// re-walking the block's AST.
+    fn captured_mutations_from_analysis(
+        analysis: &crate::codegen::core_erlang::block_analysis::BlockMutationAnalysis,
+    ) -> Vec<String> {
         analysis
             .local_writes
             .intersection(&analysis.captured_reads)
@@ -716,35 +725,24 @@ impl CoreErlangGenerator {
     }
 
     pub(super) fn generate_block(&mut self, block: &Block) -> Result<Document<'static>> {
-        let captured_mutations = Self::captured_mutations_for_block(block);
+        use crate::codegen::core_erlang::block_analysis::analyze_block;
+        let analysis = analyze_block(block);
+        let captured_mutations = Self::captured_mutations_from_analysis(&analysis);
 
         // BT-852: Blocks with captured local mutations use Tier 2 stateful calling convention.
         if !captured_mutations.is_empty() {
             return self.generate_block_stateful(block, &captured_mutations);
         }
 
-        // BT-2792: A block reaching this generic fallback that also writes a
-        // `self.<field>` cannot correctly thread state. `self.field := ...`
-        // inside the block's own `fun` body still bumps the *shared*
-        // `state_threading` counter (next_state_var), but the resulting
-        // `let StateN = ... in ...` binding is scoped only inside that `fun` —
-        // it never reaches the enclosing method. The enclosing method then
-        // believes `StateN` is live and references it out of scope, which
-        // erlc rejects with "unbound variable". Every construct that *can*
-        // thread field mutations correctly (ifTrue:/ifFalse:/whileTrue:/do:/
-        // collect:/select:/reject:/inject:into:/timesRepeat:/to:do:, and a
-        // literal block passed directly to a self-send) is inlined or routed
-        // through `generate_block_stateful` before reaching this fallback —
-        // see BT-851's `tier2_method_info` scan and the `with_branch_context`
-        // callers in control_flow/. A block that still reaches here is opaque
-        // to the compiler (stored in a local var, returned, passed to a
-        // user-defined method and invoked later, etc.) and general call-site
-        // state threading for that shape isn't implemented yet. `Tier 2`
-        // (above) only ever promotes on *captured local* mutations, so it was
-        // never actually a fix for this — reinstate the `validate_stored_closure`
-        // diagnostic (its production call sites were removed under the belief
-        // Tier 2 made it obsolete) instead of silently emitting broken Core Erlang.
-        Self::validate_stored_closure(block, format!("offset {}", block.span.start()))?;
+        // BT-2792: `self.field :=` inside a block that reaches this generic
+        // fallback can't correctly thread state — see `validate_stored_closure`
+        // for why, and BT-2797 for the follow-up that will lift this once
+        // stored/opaque blocks get proper Tier 2 support.
+        let location = self.span_to_line(block.span).map_or_else(
+            || format!("offset {}", block.span.start()),
+            |line| format!("line {line}"),
+        );
+        Self::validate_stored_closure(&analysis, location)?;
 
         // Pure block: plain fun (no mutations to thread via Tier 2)
         self.push_scope();

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -727,25 +727,42 @@ impl CoreErlangGenerator {
     pub(super) fn generate_block(&mut self, block: &Block) -> Result<Document<'static>> {
         use crate::codegen::core_erlang::block_analysis::analyze_block;
         let analysis = analyze_block(block);
+
+        // BT-2792: `self.field :=` inside a block that reaches this generic
+        // fallback can't correctly thread state — see `validate_stored_closure`
+        // for why, and BT-2797 for the follow-up that will lift this once
+        // stored/opaque blocks get proper Tier 2 support. Checked *before* the
+        // captured-local-mutation promotion below: a block with both a field
+        // write and a captured-local mutation (e.g. `[:x | outerCount :=
+        // outerCount + x. self.total := self.total + outerCount]`) would
+        // otherwise be routed to Tier 2 for the local mutation alone, which
+        // fixes nothing — `generate_block_value_call` and friends still call
+        // the resulting 2-arity stateful fun with only its declared params
+        // (no `StateAcc` argument), producing a `badarity` crash at runtime
+        // instead of the erlc-time failure this check exists to catch.
+        // Location is a lazy thunk: format!/span_to_line only run on the
+        // (rare) error path, not on every block that reaches this line.
+        //
+        // Guarded on field_writes specifically (not a bare call to
+        // validate_stored_closure) so a block with *only* captured-local
+        // mutations — the legitimate Tier 2 case handled below — doesn't
+        // spuriously trip validate_stored_closure's separate local-mutation
+        // branch, which only applies to blocks that never reach Tier 2 at all.
+        if !analysis.field_writes.is_empty() {
+            Self::validate_stored_closure(&analysis, || {
+                self.span_to_line(block.span).map_or_else(
+                    || format!("offset {}", block.span.start()),
+                    |line| format!("line {line}"),
+                )
+            })?;
+        }
+
         let captured_mutations = Self::captured_mutations_from_analysis(&analysis);
 
         // BT-852: Blocks with captured local mutations use Tier 2 stateful calling convention.
         if !captured_mutations.is_empty() {
             return self.generate_block_stateful(block, &captured_mutations);
         }
-
-        // BT-2792: `self.field :=` inside a block that reaches this generic
-        // fallback can't correctly thread state — see `validate_stored_closure`
-        // for why, and BT-2797 for the follow-up that will lift this once
-        // stored/opaque blocks get proper Tier 2 support. Location is a lazy
-        // thunk: format! only runs on the (rare) error path, not on every
-        // pure block that reaches this line.
-        Self::validate_stored_closure(&analysis, || {
-            self.span_to_line(block.span).map_or_else(
-                || format!("offset {}", block.span.start()),
-                |line| format!("line {line}"),
-            )
-        })?;
 
         // Pure block: plain fun (no mutations to thread via Tier 2)
         self.push_scope();

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -737,12 +737,15 @@ impl CoreErlangGenerator {
         // BT-2792: `self.field :=` inside a block that reaches this generic
         // fallback can't correctly thread state — see `validate_stored_closure`
         // for why, and BT-2797 for the follow-up that will lift this once
-        // stored/opaque blocks get proper Tier 2 support.
-        let location = self.span_to_line(block.span).map_or_else(
-            || format!("offset {}", block.span.start()),
-            |line| format!("line {line}"),
-        );
-        Self::validate_stored_closure(&analysis, location)?;
+        // stored/opaque blocks get proper Tier 2 support. Location is a lazy
+        // thunk: format! only runs on the (rare) error path, not on every
+        // pure block that reaches this line.
+        Self::validate_stored_closure(&analysis, || {
+            self.span_to_line(block.span).map_or_else(
+                || format!("offset {}", block.span.start()),
+                |line| format!("line {line}"),
+            )
+        })?;
 
         // Pure block: plain fun (no mutations to thread via Tier 2)
         self.push_scope();

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -3200,6 +3200,14 @@ impl CoreErlangGenerator {
     /// field assignments, and (separately) captured-local mutations. Returns an error for
     /// either; the local-mutation error is phrased as a warning in its message.
     ///
+    /// **Precondition for production callers:** only call this when
+    /// `analysis.field_writes` is non-empty. A valid Tier 2 block (captured-local
+    /// mutations, no field writes) passed here would incorrectly hit the
+    /// local-mutation branch and produce a spurious `LocalMutationInStoredClosure`
+    /// — that branch exists for this function's own unit tests, which construct
+    /// analyses field-write-empty on purpose to test it, not for callers on a path
+    /// where a genuine Tier 2 block could reach this function.
+    ///
     /// BT-852 claimed production call sites could be removed because blocks with
     /// mutations are supported via the Tier 2 stateful block protocol (ADR 0041).
     /// BT-2792 found that's only true for *captured local* mutations

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -3192,10 +3192,16 @@ impl CoreErlangGenerator {
     /// Returns an error for both field assignments and local mutations; the local-mutation
     /// error is phrased as a warning in its message.
     ///
-    /// BT-852: This function is retained for unit tests. Production call sites have been
-    /// removed since stored closures with mutations are now supported via the Tier 2
-    /// stateful block protocol (ADR 0041).
-    #[allow(dead_code)]
+    /// BT-852 claimed production call sites could be removed because stored closures
+    /// with mutations are supported via the Tier 2 stateful block protocol (ADR 0041).
+    /// BT-2792 found that's only true for *captured local* mutations
+    /// (`captured_mutations_for_block` in `expressions.rs`, which promotes to
+    /// `generate_block_stateful`) — Tier 2 promotion never triggers on `self.field :=`
+    /// writes. A block with field writes that reaches the generic "pure fun" fallback
+    /// in `generate_block` silently emits Core Erlang `erlc` rejects with "unbound
+    /// variable" (the block's own `fun` bumps the shared state-version counter, but
+    /// that binding is scoped inside the `fun` and never reaches the caller). Called
+    /// from `generate_block` to turn that into a clear compile-time diagnostic instead.
     fn validate_stored_closure(block: &Block, span_str: String) -> Result<()> {
         use crate::codegen::core_erlang::block_analysis::analyze_block;
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -189,9 +189,9 @@ pub enum CodeGenError {
     #[error(
         "Cannot assign to field '{field}' inside this block at {location}.\n\n\
              Field assignments only thread state back to the actor when the block is used \
-             directly with a control-flow construct (ifTrue:/whileTrue:/do:/collect:/...) or \
-             sent directly to self — not when it's stored in a variable, passed to a \
-             user-defined method, or otherwise invoked indirectly.\n\n\
+             directly with a control-flow construct (ifTrue:/whileTrue:/do:/collect:/...), \
+             sent directly to self, or immediately invoked (`[...] value`) — not when it's \
+             stored in a variable, passed to a user-defined method, or returned as a value.\n\n\
              Fix: Use the block directly at the call site, or extract the mutation into a method:\n\
              \x20 // Instead of:\n\
              \x20 myBlock := [:item | self.{field} := self.{field} + item].\n\
@@ -3216,9 +3216,15 @@ impl CoreErlangGenerator {
     /// about. BT-2797 tracks lifting the field-write restriction for stored/opaque
     /// blocks by generalizing Tier 2 the same way; once that lands this function's
     /// field-write branch should shrink to whatever shapes remain genuinely unsupported.
+    ///
+    /// `location` is a lazy thunk rather than a pre-formatted `String`: this is
+    /// called on every block that reaches `generate_block`'s fallback, and the
+    /// overwhelming majority return `Ok(())` here, so formatting the location
+    /// eagerly would allocate on every pure block instead of only on the (rare)
+    /// error path.
     fn validate_stored_closure(
         analysis: &block_analysis::BlockMutationAnalysis,
-        span_str: String,
+        location: impl FnOnce() -> String,
     ) -> Result<()> {
         // ERROR: Field assignments that can't thread state back are not allowed.
         // Sort before picking one so the reported field is deterministic across
@@ -3238,7 +3244,7 @@ impl CoreErlangGenerator {
             return Err(CodeGenError::FieldAssignmentInStoredClosure {
                 field: field.clone(),
                 field_capitalized,
-                location: span_str,
+                location: location(),
             });
         }
 
@@ -3258,7 +3264,7 @@ impl CoreErlangGenerator {
         } {
             return Err(CodeGenError::LocalMutationInStoredClosure {
                 variable: variable.clone(),
-                location: span_str,
+                location: location(),
             });
         }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -184,11 +184,15 @@ pub enum CodeGenError {
     #[error("formatting error: {0}")]
     Format(#[from] fmt::Error),
 
-    /// Field assignment in a stored closure.
+    /// Field assignment in a block that can't thread state back — whether the block is
+    /// assigned to a variable, passed as an argument, or returned (BT-2792).
     #[error(
-        "Cannot assign to field '{field}' inside a stored closure at {location}.\n\n\
-             Field assignments require immediate execution context for state threading.\n\n\
-             Fix: Use control flow directly, or extract to a method:\n\
+        "Cannot assign to field '{field}' inside this block at {location}.\n\n\
+             Field assignments only thread state back to the actor when the block is used \
+             directly with a control-flow construct (ifTrue:/whileTrue:/do:/collect:/...) or \
+             sent directly to self — not when it's stored in a variable, passed to a \
+             user-defined method, or otherwise invoked indirectly.\n\n\
+             Fix: Use the block directly at the call site, or extract the mutation into a method:\n\
              \x20 // Instead of:\n\
              \x20 myBlock := [:item | self.{field} := self.{field} + item].\n\
              \x20 items do: myBlock.\n\
@@ -3188,32 +3192,41 @@ impl CoreErlangGenerator {
             .collect()
     }
 
-    /// Validates that a stored closure (block assigned to variable) doesn't contain mutations.
-    /// Returns an error for both field assignments and local mutations; the local-mutation
-    /// error is phrased as a warning in its message.
+    /// Validates a block's mutation analysis for shapes that can't correctly thread state:
+    /// field assignments, and (separately) captured-local mutations. Returns an error for
+    /// either; the local-mutation error is phrased as a warning in its message.
     ///
-    /// BT-852 claimed production call sites could be removed because stored closures
-    /// with mutations are supported via the Tier 2 stateful block protocol (ADR 0041).
+    /// BT-852 claimed production call sites could be removed because blocks with
+    /// mutations are supported via the Tier 2 stateful block protocol (ADR 0041).
     /// BT-2792 found that's only true for *captured local* mutations
     /// (`captured_mutations_for_block` in `expressions.rs`, which promotes to
     /// `generate_block_stateful`) — Tier 2 promotion never triggers on `self.field :=`
     /// writes. A block with field writes that reaches the generic "pure fun" fallback
     /// in `generate_block` silently emits Core Erlang `erlc` rejects with "unbound
     /// variable" (the block's own `fun` bumps the shared state-version counter, but
-    /// that binding is scoped inside the `fun` and never reaches the caller). Called
-    /// from `generate_block` to turn that into a clear compile-time diagnostic instead.
-    fn validate_stored_closure(block: &Block, span_str: String) -> Result<()> {
-        use crate::codegen::core_erlang::block_analysis::analyze_block;
-
-        let analysis = analyze_block(block);
-
-        // ERROR: Field assignments in stored closures are not allowed
+    /// that binding is scoped inside the `fun` and never reaches the caller).
+    ///
+    /// Called from `generate_block` (with an already-computed analysis, so callers
+    /// that need more than this check don't re-walk the block's AST) to turn that into
+    /// a clear compile-time diagnostic instead. From that call site the local-mutation
+    /// branch below is unreachable in practice — `generate_block` already routes
+    /// captured-local mutations to Tier 2 before reaching this call — but it's kept
+    /// live (and directly unit-tested) since this function checks a block's mutation
+    /// shape in general, not just the field-write case `generate_block` currently cares
+    /// about. BT-2797 tracks lifting the field-write restriction for stored/opaque
+    /// blocks by generalizing Tier 2 the same way; once that lands this function's
+    /// field-write branch should shrink to whatever shapes remain genuinely unsupported.
+    fn validate_stored_closure(
+        analysis: &block_analysis::BlockMutationAnalysis,
+        span_str: String,
+    ) -> Result<()> {
+        // ERROR: Field assignments that can't thread state back are not allowed.
+        // Sort before picking one so the reported field is deterministic across
+        // builds/runs when a block writes more than one field.
         if !analysis.field_writes.is_empty() {
-            let field = analysis
-                .field_writes
-                .iter()
-                .next()
-                .expect("field_writes is non-empty");
+            let mut fields: Vec<&String> = analysis.field_writes.iter().collect();
+            fields.sort_unstable();
+            let field = fields[0];
             let field_capitalized = {
                 let mut chars = field.chars();
                 chars
@@ -3235,11 +3248,14 @@ impl CoreErlangGenerator {
         // BT-665: Only flag mutations of captured variables, not new local definitions.
         // A "captured mutation" is a write to a variable that was read before being
         // locally defined (i.e., it captures from outer scope).
-        if let Some(variable) = analysis
-            .local_writes
-            .intersection(&analysis.captured_reads)
-            .next()
-        {
+        if let Some(variable) = {
+            let mut vars: Vec<&String> = analysis
+                .local_writes
+                .intersection(&analysis.captured_reads)
+                .collect();
+            vars.sort_unstable();
+            vars.into_iter().next()
+        } {
             return Err(CodeGenError::LocalMutationInStoredClosure {
                 variable: variable.clone(),
                 location: span_str,

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -190,8 +190,9 @@ pub enum CodeGenError {
         "Cannot assign to field '{field}' inside this block at {location}.\n\n\
              Field assignments only thread state back to the actor when the block is used \
              directly with a control-flow construct (ifTrue:/whileTrue:/do:/collect:/...), \
-             sent directly to self, or immediately invoked (`[...] value`) — not when it's \
-             stored in a variable, passed to a user-defined method, or returned as a value.\n\n\
+             sent directly to self, or immediately invoked (`[...] value`, `[...] value: arg`, \
+             `[...] value:value:`, etc.) — not when it's stored in a variable, passed to a \
+             user-defined method, or returned as a value.\n\n\
              Fix: Use the block directly at the call site, or extract the mutation into a method:\n\
              \x20 // Instead of:\n\
              \x20 myBlock := [:item | self.{field} := self.{field} + item].\n\
@@ -2695,8 +2696,11 @@ impl CoreErlangGenerator {
                 Ok(doc)
             }
             Expression::Assignment { target, value, .. } => {
-                // BT-852: Stored blocks with mutations are now supported via Tier 2.
-                // generate_block() handles stateful emission; no validation needed here.
+                // BT-2792: Tier 2 only ever supported captured-local mutations, not
+                // field writes — a stored block with `self.field :=` is rejected by
+                // generate_block()'s validate_stored_closure call, not silently
+                // accepted. No validation needed *here* only because that check
+                // already lives inside generate_block() itself.
 
                 // Check if this is a field assignment (self.field := value)
                 if let Expression::FieldAccess {

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -204,7 +204,7 @@ pub enum CodeGenError {
              \x20 addTo{field_capitalized}: item => self.{field} := self.{field} + item.\n\
              \x20 items do: [:item | self addTo{field_capitalized}: item]."
     )]
-    FieldAssignmentInStoredClosure {
+    FieldAssignmentInUnsupportedBlock {
         /// The field being assigned.
         field: String,
         /// The capitalized field name for method suggestion.
@@ -3241,7 +3241,7 @@ impl CoreErlangGenerator {
                     .unwrap_or_default()
                     + chars.as_str()
             };
-            return Err(CodeGenError::FieldAssignmentInStoredClosure {
+            return Err(CodeGenError::FieldAssignmentInUnsupportedBlock {
                 field: field.clone(),
                 field_capitalized,
                 location: location(),

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -3208,20 +3208,25 @@ impl CoreErlangGenerator {
     ///
     /// Called from `generate_block` (with an already-computed analysis, so callers
     /// that need more than this check don't re-walk the block's AST) to turn that into
-    /// a clear compile-time diagnostic instead. From that call site the local-mutation
-    /// branch below is unreachable in practice — `generate_block` already routes
-    /// captured-local mutations to Tier 2 before reaching this call — but it's kept
-    /// live (and directly unit-tested) since this function checks a block's mutation
-    /// shape in general, not just the field-write case `generate_block` currently cares
-    /// about. BT-2797 tracks lifting the field-write restriction for stored/opaque
-    /// blocks by generalizing Tier 2 the same way; once that lands this function's
-    /// field-write branch should shrink to whatever shapes remain genuinely unsupported.
+    /// a clear compile-time diagnostic instead. `generate_block` only calls this when
+    /// `field_writes` is non-empty (checked *before* the Tier 2 captured-local-mutation
+    /// promotion, so a block with both a field write and a local mutation errors here
+    /// instead of silently reaching Tier 2 for the local mutation alone), so the field
+    /// branch below always fires from that call site and the local-mutation branch is
+    /// unreachable from it — it's kept live (and directly unit-tested) since this
+    /// function checks a block's mutation shape in general, not just the field-write
+    /// case `generate_block` currently cares about. BT-2797 tracks lifting the
+    /// field-write restriction for stored/opaque blocks by generalizing Tier 2 the same
+    /// way; once that lands this function's field-write branch should shrink to
+    /// whatever shapes remain genuinely unsupported.
     ///
-    /// `location` is a lazy thunk rather than a pre-formatted `String`: this is
-    /// called on every block that reaches `generate_block`'s fallback, and the
-    /// overwhelming majority return `Ok(())` here, so formatting the location
-    /// eagerly would allocate on every pure block instead of only on the (rare)
-    /// error path.
+    /// `location` is a lazy thunk rather than a pre-formatted `String`, so formatting
+    /// only happens when an error is actually produced. From `generate_block`'s call
+    /// site this always errors (it's only called when `field_writes` is non-empty), but
+    /// `generate_block` still runs `analyze_block` and checks `field_writes` on every
+    /// block it compiles — the thunk keeps this function itself free of `span_to_line`/
+    /// `format!` cost for callers (present or future) that reach it on a path where an
+    /// `Ok(())` result is actually possible, e.g. this function's own unit tests.
     fn validate_stored_closure(
         analysis: &block_analysis::BlockMutationAnalysis,
         location: impl FnOnce() -> String,

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -1126,13 +1126,18 @@ fn test_block_with_mixed_local_and_field_mutation_is_compile_error() {
     // params (no State argument) — `badarity`. The field check must fire
     // before the Tier 2 promotion, not after.
     //
-    // `outerCount` is used inside the block before its `outerCount := 0`
-    // definition in the enclosing method body — deliberately: block_analysis
-    // only classifies a variable as a *captured* mutation (vs. a fresh local
-    // definition local to the block) when it's read before being locally
-    // defined within the block itself. Defining `outerCount` in the block
-    // first would make it a new local, not a captured one, and the mixed
-    // local+field shape this test targets wouldn't reproduce.
+    // `outerCount := outerCount + x` is deliberately the block's first use of
+    // `outerCount`: block_analysis classifies a name as a *captured* mutation
+    // only when it's read before being locally defined *within the block*,
+    // and `outerCount + x` on the assignment's right-hand side reads the
+    // name before this statement (the block's only mention of it) defines
+    // it. Writing the block as `outerCount := 0. outerCount := outerCount +
+    // x` instead would make `outerCount` a fresh block-local, not a captured
+    // one, and the mixed local+field shape this test targets wouldn't
+    // reproduce. The outer method's own `outerCount := 0` — appearing after
+    // `blk`'s definition in program order — only needs to exist so the
+    // source parses as a variable Beamtalk program; it has no bearing on the
+    // capture classification itself.
     let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: item =>\n    blk := [:x | outerCount := outerCount + x. self.total := self.total + outerCount]\n    outerCount := 0\n    blk value: item\n";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _) = crate::source_analysis::parse(tokens);

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -1125,6 +1125,14 @@ fn test_block_with_mixed_local_and_field_mutation_is_compile_error() {
     // but generate_block_value_call and friends call it with only its declared
     // params (no State argument) — `badarity`. The field check must fire
     // before the Tier 2 promotion, not after.
+    //
+    // `outerCount` is used inside the block before its `outerCount := 0`
+    // definition in the enclosing method body — deliberately: block_analysis
+    // only classifies a variable as a *captured* mutation (vs. a fresh local
+    // definition local to the block) when it's read before being locally
+    // defined within the block itself. Defining `outerCount` in the block
+    // first would make it a new local, not a captured one, and the mixed
+    // local+field shape this test targets wouldn't reproduce.
     let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: item =>\n    blk := [:x | outerCount := outerCount + x. self.total := self.total + outerCount]\n    outerCount := 0\n    blk value: item\n";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _) = crate::source_analysis::parse(tokens);

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -345,7 +345,7 @@ fn test_validate_stored_closure_with_field_assignment() {
     let result = CoreErlangGenerator::validate_stored_closure(&analysis, || "test".to_string());
     assert!(result.is_err(), "Field assignment should produce error");
 
-    if let Err(CodeGenError::FieldAssignmentInStoredClosure {
+    if let Err(CodeGenError::FieldAssignmentInUnsupportedBlock {
         field,
         field_capitalized,
         ..
@@ -354,14 +354,21 @@ fn test_validate_stored_closure_with_field_assignment() {
         assert_eq!(field, "value");
         assert_eq!(field_capitalized, "Value");
     } else {
-        panic!("Expected FieldAssignmentInStoredClosure error");
+        panic!("Expected FieldAssignmentInUnsupportedBlock error");
     }
 }
 
 #[test]
 fn test_validate_stored_closure_field_takes_precedence() {
     // Block with both field and local assignment
-    // Field error should be reported first
+    // Field error should be reported first.
+    //
+    // This exercises validate_stored_closure's own contract directly. Through
+    // the production generate_block path this precedence is never actually
+    // observed: a block with both captured-local mutations and field writes
+    // is routed to generate_block_stateful (Tier 2) by the earlier
+    // captured_mutations check, so validate_stored_closure only ever sees the
+    // local-mutation branch when field_writes is already empty.
     let block = Block {
         parameters: vec![],
         body: vec![
@@ -399,7 +406,7 @@ fn test_validate_stored_closure_field_takes_precedence() {
     assert!(
         matches!(
             result,
-            Err(CodeGenError::FieldAssignmentInStoredClosure { .. })
+            Err(CodeGenError::FieldAssignmentInUnsupportedBlock { .. })
         ),
         "Field error should take precedence over local mutation"
     );
@@ -476,7 +483,7 @@ fn test_codegen_rejects_stored_closure_with_field_assignment() {
     assert!(
         matches!(
             result,
-            Err(CodeGenError::FieldAssignmentInStoredClosure { .. })
+            Err(CodeGenError::FieldAssignmentInUnsupportedBlock { .. })
         ),
         "Field assignment in a stored closure must be a compile-time error, not silently \
          accepted (BT-2792). Got: {result:?}"
@@ -1052,7 +1059,7 @@ fn test_actor_conditional_assign_rhs_emit_actor_threaded_assign_rhs() {
 fn test_immediately_invoked_literal_block_with_field_mutation_compiles() {
     // BT-2792: `[self.total := self.total + n] value` — a literal block that is
     // immediately invoked (the block is the *receiver* of `value`, not stored or
-    // passed) — must NOT hit the FieldAssignmentInStoredClosure rejection. The
+    // passed) — must NOT hit the FieldAssignmentInUnsupportedBlock rejection. The
     // compiler inlines this case correctly (state threads through StateAcc, same
     // as ifTrue:/do:), unlike a block bound to a variable and invoked later.
     let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: n =>\n    [self.total := self.total + n] value\n";
@@ -1082,9 +1089,40 @@ fn test_block_returned_from_method_with_field_mutation_is_compile_error() {
     assert!(
         matches!(
             result,
-            Err(CodeGenError::FieldAssignmentInStoredClosure { .. })
+            Err(CodeGenError::FieldAssignmentInUnsupportedBlock { .. })
         ),
         "A field-mutating block returned as a value must be a compile-time error \
          (BT-2792), not silently accepted. Got: {result:?}"
+    );
+}
+
+#[test]
+fn test_block_with_mixed_local_and_field_mutation_is_compile_error() {
+    // BT-2792 (PR review follow-up): a block with BOTH a captured-local
+    // mutation and a field write — e.g. `[:x | outerCount := outerCount + x.
+    // self.total := self.total + outerCount]` stored in a var and invoked
+    // later — used to bypass the field-write check entirely: captured_mutations
+    // is non-empty (from `outerCount`), so generate_block routed straight to
+    // Tier 2 for the local mutation, never reaching validate_stored_closure.
+    // That produced Core Erlang that *compiles* (passes erlc) but crashes at
+    // runtime: the resulting block is a 2-arity stateful fun (params + State),
+    // but generate_block_value_call and friends call it with only its declared
+    // params (no State argument) — `badarity`. The field check must fire
+    // before the Tier 2 promotion, not after.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: item =>\n    blk := [:x | outerCount := outerCount + x. self.total := self.total + outerCount]\n    outerCount := 0\n    blk value: item\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _) = crate::source_analysis::parse(tokens);
+    let result = crate::codegen::core_erlang::generate_module(
+        &module,
+        crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::FieldAssignmentInUnsupportedBlock { .. })
+        ),
+        "A block with both a local and a field mutation, reaching the opaque \
+         call-site fallback, must be a compile-time error — not code that \
+         compiles but crashes with badarity at runtime. Got: {result:?}"
     );
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -365,10 +365,11 @@ fn test_validate_stored_closure_field_takes_precedence() {
     //
     // This exercises validate_stored_closure's own contract directly. Through
     // the production generate_block path this precedence is never actually
-    // observed: a block with both captured-local mutations and field writes
-    // is routed to generate_block_stateful (Tier 2) by the earlier
-    // captured_mutations check, so validate_stored_closure only ever sees the
-    // local-mutation branch when field_writes is already empty.
+    // observed: generate_block only calls validate_stored_closure when
+    // field_writes is non-empty, and the field branch always returns early,
+    // so validate_stored_closure only ever sees the local-mutation branch
+    // when field_writes is already empty (which can only happen via direct
+    // unit-test calls, not through generate_block).
     let block = Block {
         parameters: vec![],
         body: vec![

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -359,7 +359,7 @@ fn test_validate_stored_closure_with_field_assignment() {
 }
 
 #[test]
-fn test_validate_stored_closure_field_takes_precedence() {
+fn test_validate_stored_closure_field_takes_precedence_contract() {
     // Block with both field and local assignment
     // Field error should be reported first.
     //

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -1072,6 +1072,21 @@ fn test_immediately_invoked_literal_block_with_field_mutation_compiles() {
 }
 
 #[test]
+fn test_immediately_invoked_literal_block_value_keyword_with_field_mutation_compiles() {
+    // BT-2792 (PR review follow-up): same as the unary `value` case above, but
+    // for the keyword form `[...] value: arg`. This goes through a separate
+    // code path (`try_generate_block_value_keyword`'s BT-1481 check in
+    // intrinsics.rs) that must also inline field mutations rather than falling
+    // through to generate_block's rejection.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: n =>\n    [:x | self.total := self.total + x] value: n\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'maps':'put'('total'"),
+        "Immediately-invoked block (value: form) with a field mutation must thread state via maps:put. Got:\n{code}"
+    );
+}
+
+#[test]
 fn test_block_returned_from_method_with_field_mutation_is_compile_error() {
     // BT-2792: `^[self.total := self.total + 1]` — a block *returned as a value*
     // (never invoked in this method) is not caught by any of the semantic-analysis

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -201,7 +201,8 @@ fn test_validate_stored_closure_empty_block() {
         span: Span::new(0, 2),
     };
 
-    let result = CoreErlangGenerator::validate_stored_closure(&block, "test".to_string());
+    let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
     assert!(result.is_ok(), "Empty block should be valid");
 }
 
@@ -232,7 +233,8 @@ fn test_validate_stored_closure_with_captured_mutation() {
         span: Span::new(0, 20),
     };
 
-    let result = CoreErlangGenerator::validate_stored_closure(&block, "test".to_string());
+    let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
     assert!(
         result.is_err(),
         "Captured variable mutation should produce error"
@@ -263,7 +265,8 @@ fn test_validate_stored_closure_with_new_local_definition() {
         span: Span::new(0, 11),
     };
 
-    let result = CoreErlangGenerator::validate_stored_closure(&block, "test".to_string());
+    let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
     assert!(
         result.is_ok(),
         "New local definition should be allowed in stored closure"
@@ -309,7 +312,8 @@ fn test_validate_stored_closure_with_new_local_used_later() {
         span: Span::new(0, 29),
     };
 
-    let result = CoreErlangGenerator::validate_stored_closure(&block, "test".to_string());
+    let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
     assert!(
         result.is_ok(),
         "Block with new local definition used later should be allowed"
@@ -337,7 +341,8 @@ fn test_validate_stored_closure_with_field_assignment() {
         span: Span::new(0, 17),
     };
 
-    let result = CoreErlangGenerator::validate_stored_closure(&block, "test".to_string());
+    let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
     assert!(result.is_err(), "Field assignment should produce error");
 
     if let Err(CodeGenError::FieldAssignmentInStoredClosure {
@@ -386,7 +391,8 @@ fn test_validate_stored_closure_field_takes_precedence() {
         span: Span::new(0, 29),
     };
 
-    let result = CoreErlangGenerator::validate_stored_closure(&block, "test".to_string());
+    let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
     assert!(result.is_err());
 
     // Should be field error (checked first), not local
@@ -1039,5 +1045,46 @@ fn test_actor_conditional_assign_rhs_emit_actor_threaded_assign_rhs() {
     assert!(
         code.contains("case "),
         "Conditional must compile to an inline case expression. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_immediately_invoked_literal_block_with_field_mutation_compiles() {
+    // BT-2792: `[self.total := self.total + n] value` — a literal block that is
+    // immediately invoked (the block is the *receiver* of `value`, not stored or
+    // passed) — must NOT hit the FieldAssignmentInStoredClosure rejection. The
+    // compiler inlines this case correctly (state threads through StateAcc, same
+    // as ifTrue:/do:), unlike a block bound to a variable and invoked later.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: n =>\n    [self.total := self.total + n] value\n";
+    let code = codegen(src);
+    assert!(
+        code.contains("'maps':'put'('total'"),
+        "Immediately-invoked block with a field mutation must thread state via maps:put. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_block_returned_from_method_with_field_mutation_is_compile_error() {
+    // BT-2792: `^[self.total := self.total + 1]` — a block *returned as a value*
+    // (never invoked in this method) is not caught by any of the semantic-analysis
+    // passes that guard field mutations in blocks (they only flag blocks that are
+    // stored to a variable or passed as a literal argument to an unsafe message
+    // send — see block_analyzer.rs's BlockContext::Stored check and
+    // class_validators.rs's BT-1793 check). It still reaches generate_block's
+    // generic fallback and must be rejected there.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  makeBlock =>\n    ^[self.total := self.total + 1]\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _) = crate::source_analysis::parse(tokens);
+    let result = crate::codegen::core_erlang::generate_module(
+        &module,
+        crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::FieldAssignmentInStoredClosure { .. })
+        ),
+        "A field-mutating block returned as a value must be a compile-time error \
+         (BT-2792), not silently accepted. Got: {result:?}"
     );
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -202,7 +202,7 @@ fn test_validate_stored_closure_empty_block() {
     };
 
     let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
-    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, || "test".to_string());
     assert!(result.is_ok(), "Empty block should be valid");
 }
 
@@ -234,7 +234,7 @@ fn test_validate_stored_closure_with_captured_mutation() {
     };
 
     let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
-    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, || "test".to_string());
     assert!(
         result.is_err(),
         "Captured variable mutation should produce error"
@@ -266,7 +266,7 @@ fn test_validate_stored_closure_with_new_local_definition() {
     };
 
     let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
-    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, || "test".to_string());
     assert!(
         result.is_ok(),
         "New local definition should be allowed in stored closure"
@@ -313,7 +313,7 @@ fn test_validate_stored_closure_with_new_local_used_later() {
     };
 
     let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
-    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, || "test".to_string());
     assert!(
         result.is_ok(),
         "Block with new local definition used later should be allowed"
@@ -342,7 +342,7 @@ fn test_validate_stored_closure_with_field_assignment() {
     };
 
     let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
-    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, || "test".to_string());
     assert!(result.is_err(), "Field assignment should produce error");
 
     if let Err(CodeGenError::FieldAssignmentInStoredClosure {
@@ -392,7 +392,7 @@ fn test_validate_stored_closure_field_takes_precedence() {
     };
 
     let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(&block);
-    let result = CoreErlangGenerator::validate_stored_closure(&analysis, "test".to_string());
+    let result = CoreErlangGenerator::validate_stored_closure(&analysis, || "test".to_string());
     assert!(result.is_err());
 
     // Should be field error (checked first), not local

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -400,9 +400,16 @@ fn test_validate_stored_closure_field_takes_precedence() {
 }
 
 #[test]
-fn test_codegen_allows_stored_closure_with_field_assignment() {
-    // Integration test: verify the full codegen pipeline allows field assignments
-    // in stored closures and successfully generates code for: test := [ myBlock := [self.value := 1]. myBlock ]
+fn test_codegen_rejects_stored_closure_with_field_assignment() {
+    // BT-2792: Integration test covering the full codegen pipeline for
+    // test := [ myBlock := [self.value := 1]. myBlock ]
+    //
+    // This used to be asserted as allowed (BT-852, "supported via Tier 2 stateful
+    // block protocol"), but Tier 2 promotion only ever triggers on *captured local*
+    // mutations, never on `self.field :=` writes — so this actually produced Core
+    // Erlang that `erlc` rejects with "unbound variable" (the inner block's `fun`
+    // bumps the shared state-version counter, but that binding is scoped inside the
+    // `fun` and never reaches the caller). Must now be a clear compile-time error.
     let module = Module {
         classes: vec![],
         method_definitions: Vec::new(),
@@ -459,11 +466,14 @@ fn test_codegen_allows_stored_closure_with_field_assignment() {
         file_trailing_comments: Vec::new(),
     };
 
-    // BT-852: Stored closures with field assignments are now allowed via Tier 2 protocol.
     let result = generate(&module);
     assert!(
-        result.is_ok(),
-        "Field assignment in stored closure should now be allowed via Tier 2 protocol. Got: {result:?}"
+        matches!(
+            result,
+            Err(CodeGenError::FieldAssignmentInStoredClosure { .. })
+        ),
+        "Field assignment in a stored closure must be a compile-time error, not silently \
+         accepted (BT-2792). Got: {result:?}"
     );
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -1136,7 +1136,7 @@ fn test_block_with_mixed_local_and_field_mutation_is_compile_error() {
     // one, and the mixed local+field shape this test targets wouldn't
     // reproduce. The outer method's own `outerCount := 0` — appearing after
     // `blk`'s definition in program order — only needs to exist so the
-    // source parses as a variable Beamtalk program; it has no bearing on the
+    // source parses as a valid Beamtalk program; it has no bearing on the
     // capture classification itself.
     let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: item =>\n    blk := [:x | outerCount := outerCount + x. self.total := self.total + outerCount]\n    outerCount := 0\n    blk value: item\n";
     let tokens = crate::source_analysis::lex_with_eof(src);


### PR DESCRIPTION
## Summary

A block whose body writes `self.<field> :=` and reaches `generate_block`'s generic "pure fun" fallback — stored in a local var, returned as a value, passed to a user-defined method and invoked later, etc. — silently produced Core Erlang `erlc` rejects with `unbound variable`. Root cause: the field assignment still bumps the shared `state_threading` version counter, but the resulting `let StateN = ... in ...` binding is scoped inside the block's own `fun` and never reaches the caller.

Tier 2 stateful-block promotion (`captured_mutations_for_block`) only ever triggers on *captured local-variable* mutations — it never checks field writes — so this was never actually fixed by the Tier 2 protocol, despite [BT-852](https://linear.app/beamtalk/issue/BT-852) believing it was and removing the production call site that used to catch this.

This PR reinstates that check (`validate_stored_closure` / `CodeGenError::FieldAssignmentInStoredClosure`) as a production call site in `generate_block`, turning the silent `erlc` crash into a clear compile-time diagnostic with concrete fix suggestions.

## Key changes

- **`generate_block`** (`expressions.rs`) — computes `analyze_block(block)` once and calls `validate_stored_closure` with it before falling through to the pure-fun path, instead of silently emitting broken Core Erlang.
- **`validate_stored_closure`** (`mod.rs`) — reinstated as a live call site; sorts `field_writes`/`local_writes` before picking a name to report (deterministic diagnostics); doc comment cross-references the BT-2797 follow-up.
- **`FieldAssignmentInStoredClosure`** message generalized — no longer assumes the block was bound to a variable (it fires for any block reaching the fallback); location now resolves to a line number via `span_to_line` when available, falling back to a byte offset.
- **Tests** — reworked the integration test that used to assert this case as allowed (it never validated against `erlc`); updated 7 `list_ops` fallthrough tests whose fixtures incidentally used field-mutating bodies unrelated to what they actually cover; added regression tests for: a field-mutating block falling through `eachWithIndex:`'s arity guard, an immediately-invoked literal block (correctly unaffected — it's inlined), and a block returned as a value (a real gap none of the compiler's semantic-analysis passes catch today).

## Verification

- Confirmed live via the CLI against the issue's own repro — now a clear, correctly-spanned diagnostic instead of an `erlc` crash.
- Confirmed the fix is not redundant with existing semantic-analysis guards: traced three independent pre-existing checks (`block_analyzer.rs`'s "Stored" context check, `class_validators.rs`'s BT-1793 check, per-selector arity checks) and found a genuine gap — a block *returned as a value* — that only this codegen-level check catches; added as a regression test.
- 4570 `beamtalk-core` Rust unit tests, clippy, Rust/Erlang fmt, dialyzer (0 warnings), stdlib build (103 modules), 223 stdlib tests all pass.

Follow-up: [BT-2797](https://linear.app/beamtalk/issue/BT-2797/codegen-thread-selffield-mutations-through-storedopaque-blocks-tier-2) tracks generalizing Tier 2 state threading so this pattern — a genuinely common Smalltalk idiom (stored callback blocks that mutate the receiver) — works instead of being rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7etfDiPFnHipA4WbSqeHA)_