### PR TITLE
Fan-out benchmarks + xref receiver-type-key decision (ADR 0105 Phase 2) (BT-2781)

### DIFF
--- a/docs/ADR/0105-live-image-recheck-on-reload.md
+++ b/docs/ADR/0105-live-image-recheck-on-reload.md
@@ -19,7 +19,7 @@ Proposed (2026-07-05)
 | 3 | [BT-2782](https://linear.app/beamtalk/issue/BT-2782) | Pre-save advisory + `:recheck image` command | S | BT-2778 |
 | 4 | [BT-2783](https://linear.app/beamtalk/issue/BT-2783) | E2E killer-demo test + docs + status flip | S | BT-2779, BT-2780, BT-2782 |
 
-Deferred / recorded follow-ups: xref receiver-type-key extension (BT-2781 decides), transitive re-check refinement, proxy meta-dependent tracking, single-method check API. Enabling ADRs (all landed): 0087 (xref), 0082 (edit/save), 0100 (severity), 0022 (compiler port), 0104 (actor/`spawnWith:` checking).
+Deferred / recorded follow-ups: xref receiver-type-key extension (decided by BT-2781, filed as [BT-2798](https://linear.app/beamtalk/issue/BT-2798)), transitive re-check refinement, proxy meta-dependent tracking, single-method check API. Enabling ADRs (all landed): 0087 (xref), 0082 (edit/save), 0100 (severity), 0022 (compiler port), 0104 (actor/`spawnWith:` checking).
 
 **Status:** Planned
 
@@ -272,6 +272,20 @@ Would make dependent lookup precise instead of selector-wide (Mechanism step
 generation lifecycle for a cost that only matters if common-selector fan-out
 proves hot in practice. Recorded as the follow-up, with the per-reload caller
 cap as the interim guard.
+
+**Phase 2 benchmark decision (BT-2781, full data in
+`docs/development/benchmarks.md` "Reload re-check fan-out"):** today's real
+stdlib fan-out does not yet justify the extension — the worst measured
+selector (`delegate`) has 23 distinct caller classes, barely over the
+default cap of 20, and every other selector is comfortably under it. But a
+controlled fan-out benchmark against the real `beamtalk_recheck:trigger/4`
+orchestration confirmed the interim cap's known limitation is severe once
+fan-out does grow past it: at 10x the cap, the alphabetic (non-relevance-
+ranked) cap silently drops **90% of genuine stale-caller findings**. Per-
+check cost is flat regardless of fan-out size, so the extension would be
+both a latency and a completeness win once that threshold is crossed.
+**Decision: not implemented now, filed as a proactive (non-blocking)
+follow-up — [BT-2798](https://linear.app/beamtalk/issue/BT-2798).**
 
 ### Static-only (no runtime trigger)
 Let the LSP re-check open files on edit, ignore the live image. Rejected: the

--- a/docs/development/benchmarks.md
+++ b/docs/development/benchmarks.md
@@ -91,6 +91,186 @@ re-introduces the per-call cost the index was meant to remove.
   and logs an `xref_miss` warning. They should be baked into `register_class/0`
   like the rest; tracked as a Phase 2 completeness gap.
 
+## Reload re-check fan-out — xref receiver-type-key decision (ADR 0105 Phase 2, BT-2781)
+
+ADR 0105's re-check orchestration (BT-2778) looks up a changed selector's
+callers via `beamtalk_xref:senders_of/1`, which is selector-keyed with no
+receiver-class component (ADR 0087's schema). The receiver-type filter that
+separates real dependents from same-selector-different-receiver false
+positives is not a pre-filter — it is an emergent property of re-checking
+each candidate through the compiler (`beamtalk_recheck`'s moduledoc). For a
+common selector this means paying a compile per candidate just to discover
+it isn't a real dependent, which is why the per-reload numeric caller cap
+(`recheck_caller_cap`, default 20) exists. This benchmark measures that
+fan-out to decide whether ADR 0087 needs a receiver-type key (ADR 0105
+Alternatives) to make the lookup precise instead of selector-wide.
+
+### Harness
+
+`runtime/perf/bench_recheck_fanout.escript`. Run from the `runtime/`
+directory after `just build`:
+
+```bash
+escript perf/bench_recheck_fanout.escript
+```
+
+Two parts:
+
+- **Part A (large-image survey)** — boots the full loaded stdlib workspace
+  (mirrors `bench_senders_xref.escript`) and ranks every indexed sent
+  selector by its distinct-caller-class count (the unit `beamtalk_recheck`
+  actually caps and re-checks — `group_by_owner/1` collapses multiple sites
+  in one caller class to a single candidate).
+- **Part B (controlled fan-out)** — drives the real
+  `beamtalk_recheck:trigger/4` orchestration (real compiler port, real xref,
+  real `beamtalk_workspace_meta`) over synthetic candidate sets of 5 / 20 /
+  50 / 200, with a fixed 10% real-dependent / 90% false-positive split
+  (modelling a heavily overloaded common selector), at both the default cap
+  (20) and uncapped. Real and false-positive candidates are interleaved by
+  index so alphabetic sort order — what `apply_cap/2` actually keeps under a
+  cap — doesn't systematically favour or penalise either group.
+
+### Workspace
+
+The loaded standard library: **103 classes** (grown from 81 at BT-2299's
+measurement), **1928 indexed send sites**, **416 distinct sent selectors**.
+
+### Results
+
+**Part A — today's real fan-out.** 325 of 416 selectors (78%) have exactly
+one distinct caller class. Ranked by **distinct caller-class count** (not
+raw site count — a selector sent many times by few classes is cheaper to
+re-check than one sent once each by many classes, since `beamtalk_recheck`
+caps and re-checks one candidate *per caller class*, not per site):
+
+| selector | sites | distinct caller classes |
+|---|---|---|
+| `delegate` | 193 | 23 |
+| `ifTrue:ifFalse:` | 114 | 17 |
+| `asString` | 35 | 17 |
+| `error:` | 39 | 13 |
+| `++` | 34 | 13 |
+
+The script also computes this exhaustively rather than by eyeballing the
+top-10 (an earlier draft ranked the "top 10" table by site count while
+claiming distinct-owner order — caught in review, since the two orderings
+disagree): **exactly 1 of 416 selectors** (`delegate`) has a distinct-owner
+count exceeding the default cap of 20, and only by 3.
+
+**Part B — controlled fan-out, default cap (20):**
+
+| candidates | checked | dropped | real findings | wall-clock | ms/checked |
+|---|---|---|---|---|---|
+| 5 | 5 | 0 | 1 of 1 | ~240 ms | ~48 ms |
+| 20 | 20 | 0 | 2 of 2 | ~730 ms | ~37 ms |
+| 50 | 20 | 30 | 2 of 5 | ~750 ms | ~38 ms |
+| 200 | 20 | 180 | 2 of 20 | ~760 ms | ~38 ms |
+
+**Part B — uncapped (full candidate set checked):**
+
+| candidates | checked | real findings | wall-clock | ms/checked |
+|---|---|---|---|---|
+| 5 | 5 | 1 | ~240 ms | ~47 ms |
+| 20 | 20 | 2 | ~790 ms | ~39 ms |
+| 50 | 50 | 5 | ~1980 ms | ~40 ms |
+| 200 | 200 | 20 | ~7580 ms | ~38 ms |
+
+### Interpretation
+
+- **Per-check cost is flat, ~33-48 ms/candidate**, regardless of fan-out size
+  — consistent with the Phase 0 spike's ~18.5 ms warm / ~58 ms cold figures
+  (these synthetic candidates are fresh classes, so nearer the cold end).
+  There is no quadratic or superlinear blowup as candidate count grows; cost
+  scales linearly with candidates checked. **Caveat:** every synthetic
+  candidate is a trivial one-method class, so this is a cost *floor* — real
+  caller classes (multi-method, larger source) will compile slower per
+  candidate. The floor is enough to establish "no superlinear blowup," but
+  not to bound absolute worst-case per-check latency in a large real
+  codebase.
+- **The cap does bound worst-case latency as designed** for this class-size
+  floor: wall-clock plateaus at ~700-760 ms once fan-out reaches/exceeds the
+  cap, regardless of whether the true candidate pool is 20 or 200. In the
+  *healthy* (non-degraded) case this stays comfortably interactive; with
+  larger real caller classes the plateau would sit higher (see caveat
+  above), but the *shape* — bounded regardless of true fan-out size — holds.
+- **The cap silently drops most real findings once fan-out exceeds it by a
+  wide margin.** At 50 candidates (2.5x the cap), only 2 of 5 real findings
+  (40%) survive; at 200 candidates (10x the cap), only 2 of 20 (10%) survive
+  — a **90% loss of genuine stale-caller findings**, because
+  `apply_cap/2` keeps the alphabetically-first N candidates without any
+  relevance ranking (its own documented limitation). This directly
+  undercuts the ADR's headline promise ("only genuinely-affected callers
+  surface") once a selector's real fan-out grows well past the cap.
+  **Caveat:** the fixture interleaves real/false candidates uniformly by
+  index, so this ~proportional loss is an *expected-value* reading; real
+  class-name distributions could cluster real dependents earlier or later
+  in alphabetic order, giving anywhere from ~0% to 100% loss for the same
+  candidate-pool shape — the fixture demonstrates the failure mode exists
+  and is severe on average, not a worst-case bound.
+- **This is not purely a future risk — it is already happening today, at
+  low grade.** `delegate` (23 distinct owners) already exceeds the cap of 20
+  in the live stdlib image, so a reload of a class implementing `delegate`
+  already silently drops re-checks for up to 3 alphabetically-last callers
+  today. It has not been a *visible* problem because `delegate` is an
+  internal proxy-forwarding selector (ADR 0104 territory), not one typical
+  user code sends directly — but the mechanism is live now, not hypothetical.
+- **Today's real stdlib fan-out (Part A) does not yet justify the xref
+  receiver-type-key extension** as an urgent fix: only one real selector
+  exceeds the cap, and only by 3. But the *shape* of the risk is confirmed
+  and quantified by Part B: as the image grows (more classes implementing a
+  common protocol selector like `size`/`at:`), the cap's failure mode is not
+  a graceful latency degradation — it is a silent, severe drop in finding
+  completeness.
+- **Synchronous tail-latency (flagged on BT-2778's issue thread) — not
+  simulated here.** A wedged/degraded compiler port was not reproduced
+  (would require mocking the port's timeout path); the theoretical worst
+  case remains `Cap × 30s` (the `beamtalk_compiler_server` call timeout)
+  under a fully serialized, wedged port, per the BT-2778 comment. The
+  *healthy*-case numbers above (cap=20 always finishes in under 1s) confirm
+  this is a tail-only risk, not a typical-case one.
+- **Methodology notes:** single-run timings, no explicit warmup — the N=5
+  round (first to run) is consistently the slowest per-check (~45-48 ms vs
+  ~33-38 ms for later rounds), most plausibly cold-start compiler-port /
+  ambient-class-hierarchy effects rather than a true N=5 cost difference.
+  Repeated full runs (3x) show the qualitative conclusions (flat per-check
+  cost, cap-bounded latency, severe finding-loss past 2.5x the cap) hold
+  consistently; the specific ms figures above should be read as
+  representative, not as tight bounds. The compiler-server's ambient class
+  cache is never cleared between the 8 rounds in one script run, so later
+  rounds run against a larger accumulated hierarchy — a possible confound
+  for absolute (not relative) timings that a from-scratch-per-round harness
+  would eliminate.
+
+### Decision (ADR 0105 Phase 2, BT-2781)
+
+**The xref receiver-type-key extension is not implemented now, but is
+warranted as a proactive (non-urgent) follow-up.** Rationale:
+
+1. Current real-world fan-out (Part A) is within the existing cap for
+   415 of 416 measured stdlib selectors; the one exception (`delegate`, an
+   internal proxy-forwarding selector) exceeds it by only 3 — a small,
+   already-occurring, low-visibility gap, not an urgent correctness or
+   latency problem.
+2. The controlled benchmark (Part B) proves the interim design's known
+   limitation (cap keeps an arbitrary, non-relevance-ranked subset) is not
+   theoretical: it causes a **quantified 90% loss of real findings** once a
+   selector's fan-out reaches 10x the cap — a plausible future state as the
+   image grows and common protocol selectors (`size`, `at:`, `do:`) accrue
+   more implementors and senders.
+3. The receiver-type key would fix *both* problems the cap only partially
+   addresses today — it shrinks the candidate set to true dependents before
+   the cap is even applied, so it is a completeness win (no more silently
+   dropped real findings) as well as a latency win (fewer wasted compiles).
+4. Given ADR 0105's own phased approach and that this changes ADR 0087's
+   shipped schema/generation lifecycle (non-trivial migration, per ADR 0105
+   Alternatives), the recommendation is to track this as a follow-up rather
+   than block current phases — see BT-2798 for scope.
+
+No regression: `bench_senders_xref.escript` (ADR 0087 Phase 3, BT-2299)
+re-run alongside this benchmark, unaffected (~1400x speedup vs source-scan,
+consistent with prior measurement; workspace grew from 81 to 103 classes in
+the interim, expected).
+
 ## Self-hosting cost: pure-BT enumeration vs native primitives (BT-2692 / BT-2708)
 
 A spike for the de-primitivization direction: how much slower is a pure-BT

--- a/runtime/perf/bench_recheck_fanout.escript
+++ b/runtime/perf/bench_recheck_fanout.escript
@@ -292,7 +292,7 @@ register_candidate(NameStr, Selector, ReceiverClass) ->
     XrefEntry = [
         #{
             class_side => false,
-            selector => go,
+            selector => 'go:',
             line => 2,
             sends => [#{selector => Selector, line => 2, recv_kind => other}],
             references => [#{class => ReceiverClass, line => 2}],

--- a/runtime/perf/bench_recheck_fanout.escript
+++ b/runtime/perf/bench_recheck_fanout.escript
@@ -44,7 +44,7 @@ main(_) ->
     {ok, _} = application:ensure_all_started(beamtalk_runtime),
     timer:sleep(500),
     %% Force-load the compiled stdlib modules so their on_load hooks register
-    %% the full 81-class workspace (mirrors bench_senders_xref.escript).
+    %% the full loaded stdlib workspace (mirrors bench_senders_xref.escript).
     lists:foreach(
         fun(Beam) ->
             Mod = list_to_atom(filename:basename(Beam, ".beam")),
@@ -166,17 +166,22 @@ part_b_controlled_fanout() ->
     ok.
 
 restart_workspace_meta() ->
+    %% beamtalk_workspace_meta is supervised (permanent, beamtalk_workspace_sup).
+    %% Stopping it races the supervisor's automatic restart, so if it's already
+    %% running just reuse it -- per-round selector names are already unique,
+    %% so there's no cross-round contamination risk from skipping a fresh start.
     case whereis(beamtalk_workspace_meta) of
-        undefined -> ok;
-        Pid -> gen_server:stop(Pid)
-    end,
-    {ok, _} = beamtalk_workspace_meta:start_link(#{
-        workspace_id => <<"bench_recheck_fanout_ws">>,
-        project_path => undefined,
-        created_at => erlang:system_time(second),
-        repl => false
-    }),
-    ok.
+        undefined ->
+            {ok, _} = beamtalk_workspace_meta:start_link(#{
+                workspace_id => <<"bench_recheck_fanout_ws">>,
+                project_path => undefined,
+                created_at => erlang:system_time(second),
+                repl => false
+            }),
+            ok;
+        _Pid ->
+            ok
+    end.
 
 %% One round: register N synthetic candidate classes for a fresh,
 %% round-scoped selector (so rounds never interfere with each other or with

--- a/runtime/perf/bench_recheck_fanout.escript
+++ b/runtime/perf/bench_recheck_fanout.escript
@@ -1,0 +1,309 @@
+#!/usr/bin/env escript
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Benchmark: reload-triggered re-check fan-out (ADR 0105 Phase 2, BT-2781).
+%%
+%% Measures the candidate-set size and wall-clock cost of
+%% `beamtalk_recheck:trigger/4` (BT-2778) for common vs rare selectors, to
+%% decide whether ADR 0087's xref schema needs a receiver-type key (ADR 0105
+%% Alternatives) or whether the existing selector-keyed lookup + at-recheck
+%% receiver filter + numeric caller cap is sufficient. Follows the
+%% before/after methodology of `bench_senders_xref.escript` (ADR 0087 Phase
+%% 3, BT-2299).
+%%
+%% Two parts:
+%%
+%%   Part A ("large image") — survey the REAL fan-out of every sent selector
+%%   in the full loaded stdlib workspace (100+ classes, 1000+ methods, same
+%%   workspace `bench_senders_xref.escript` loads): which selectors are
+%%   common (many senders) vs rare (one sender), and how many *distinct
+%%   caller classes* (the unit `beamtalk_recheck` caps and re-checks) each
+%%   implies today.
+%%
+%%   Part B ("controlled fan-out") — drive the REAL `beamtalk_recheck:trigger/4`
+%%   orchestration (real compiler port, real xref, real workspace_meta) over
+%%   synthetic candidate sets of increasing size (5/20/50/200), with a fixed
+%%   10% real-dependent / 90% false-positive split (modelling a heavily
+%%   overloaded common selector, e.g. `size`/`at:`). Measures wall-clock at
+%%   the default caller cap (20) and uncapped, so the cost of the current
+%%   "pay for a compile to find out a candidate isn't a real dependent"
+%%   design (moduledoc, beamtalk_recheck) is directly visible.
+%%
+%% Run from the `runtime/` directory after `just build`:
+%%
+%%   escript perf/bench_recheck_fanout.escript
+
+-mode(compile).
+
+main(_) ->
+    code:add_pathsa(filelib:wildcard("_build/default/lib/*/ebin")),
+    code:add_pathsa(filelib:wildcard("apps/*/ebin")),
+    {ok, _} = application:ensure_all_started(compiler),
+    {ok, _} = application:ensure_all_started(beamtalk_compiler),
+    {ok, _} = application:ensure_all_started(beamtalk_runtime),
+    timer:sleep(500),
+    %% Force-load the compiled stdlib modules so their on_load hooks register
+    %% the full 81-class workspace (mirrors bench_senders_xref.escript).
+    lists:foreach(
+        fun(Beam) ->
+            Mod = list_to_atom(filename:basename(Beam, ".beam")),
+            code:ensure_loaded(Mod)
+        end,
+        filelib:wildcard("apps/beamtalk_stdlib/ebin/bt@stdlib@*.beam")
+    ),
+    timer:sleep(1500),
+
+    part_a_large_image_survey(),
+    part_b_controlled_fanout(),
+    ok.
+
+%%====================================================================
+%% Part A: real stdlib fan-out survey (large-image scenario)
+%%====================================================================
+
+part_a_large_image_survey() ->
+    io:format("~n=== Part A: large-image fan-out survey (loaded stdlib) ===~n", []),
+    Classes = beamtalk_class_registry:live_class_entries(),
+    io:format("Workspace: ~p loaded classes~n", [length(Classes)]),
+
+    #{indexed := SendRows} = beamtalk_xref:all_sends_bt(),
+    io:format("Indexed send sites: ~p~n", [length(SendRows)]),
+
+    %% Group every indexed send by its sent selector into its DISTINCT owner
+    %% set (`usort` here, not just accumulated with duplicates) — this is the
+    %% figure that matters: `beamtalk_recheck` caps and re-checks one
+    %% candidate per caller *class*, regardless of how many sites in that
+    %% class send the selector (`group_by_owner/1`'s dedup). Ranking by raw
+    %% site count instead would put a selector with a few classes sending it
+    %% many times each ahead of one sent once each by many classes — exactly
+    %% backwards for "how many re-check candidates does this selector cost."
+    BySelector = lists:foldl(
+        fun(#{sent := Sel, owner := Owner}, Acc) ->
+            maps:update_with(Sel, fun(Owners) -> [Owner | Owners] end, [Owner], Acc)
+        end,
+        #{},
+        SendRows
+    ),
+    DistinctOwnerCounts = maps:map(fun(_Sel, Owners) -> length(lists:usort(Owners)) end, BySelector),
+    Ranked = lists:sort(
+        fun({_, CA}, {_, CB}) -> CA >= CB end,
+        maps:to_list(DistinctOwnerCounts)
+    ),
+
+    io:format("~nTop 10 most-common selectors (by distinct caller-class count):~n", []),
+    io:format("~-24s ~-12s ~-18s~n", ["selector", "sites", "distinct owners"]),
+    lists:foreach(
+        fun({Sel, OwnerCount}) ->
+            Sites = length(beamtalk_xref:senders_of(Sel)),
+            io:format("~-24s ~-12w ~-18w~n", [atom_to_list(Sel), Sites, OwnerCount])
+        end,
+        lists:sublist(Ranked, 10)
+    ),
+
+    DefaultCap = 20,
+    OverCap = [X || {_Sel, OwnerCount} = X <- Ranked, OwnerCount > DefaultCap],
+    io:format(
+        "~nSelectors whose distinct-owner count exceeds the default cap (~w): ~w of ~w total~n",
+        [DefaultCap, length(OverCap), length(Ranked)]
+    ),
+    lists:foreach(
+        fun({Sel, OwnerCount}) ->
+            io:format("  ~w: ~w distinct owners (~w over cap)~n", [
+                Sel, OwnerCount, OwnerCount - DefaultCap
+            ])
+        end,
+        OverCap
+    ),
+
+    RareOnes = [X || {_Sel, OwnerCount} = X <- Ranked, OwnerCount =:= 1],
+    io:format("~nSelectors with exactly 1 distinct caller class (rare): ~w of ~w total~n", [
+        length(RareOnes), length(Ranked)
+    ]),
+    case RareOnes of
+        [{RareSel, _} | _] ->
+            io:format("  example rare selector: ~w (1 site)~n", [RareSel]);
+        [] ->
+            ok
+    end,
+    ok.
+
+%%====================================================================
+%% Part B: controlled fan-out via the real beamtalk_recheck orchestration
+%%====================================================================
+
+part_b_controlled_fanout() ->
+    io:format("~n=== Part B: controlled fan-out (real beamtalk_recheck:trigger/4) ===~n", []),
+    restart_workspace_meta(),
+
+    DefaultCap = 20,
+    Fanouts = [5, 20, 50, 200],
+
+    io:format(
+        "~nDefault cap (~w) -- this is what a real reload pays today:~n", [DefaultCap]
+    ),
+    io:format("~-8s ~-10s ~-10s ~-12s ~-12s ~-14s ~-12s~n", [
+        "fanout", "checked", "dropped", "findings", "wall_ms", "ms/checked", "cap_note"
+    ]),
+    lists:foreach(
+        fun(N) -> run_round(N, DefaultCap) end,
+        Fanouts
+    ),
+
+    io:format(
+        "~nUncapped -- full cost of checking every candidate (what a receiver-type-keyed~n", []
+    ),
+    io:format(
+        "xref lookup would let the cap skip entirely, since only ~~10% are real dependents):~n", []
+    ),
+    io:format("~-8s ~-10s ~-10s ~-12s ~-12s ~-14s ~-12s~n", [
+        "fanout", "checked", "dropped", "findings", "wall_ms", "ms/checked", "cap_note"
+    ]),
+    lists:foreach(
+        fun(N) -> run_round(N, N) end,
+        Fanouts
+    ),
+    ok.
+
+restart_workspace_meta() ->
+    case whereis(beamtalk_workspace_meta) of
+        undefined -> ok;
+        Pid -> gen_server:stop(Pid)
+    end,
+    {ok, _} = beamtalk_workspace_meta:start_link(#{
+        workspace_id => <<"bench_recheck_fanout_ws">>,
+        project_path => undefined,
+        created_at => erlang:system_time(second),
+        repl => false
+    }),
+    ok.
+
+%% One round: register N synthetic candidate classes for a fresh,
+%% round-scoped selector (so rounds never interfere with each other or with
+%% the real stdlib senders from Part A), run the real recheck trigger under
+%% `Cap`, and print the result row.
+-spec run_round(pos_integer(), pos_integer()) -> ok.
+run_round(N, Cap) ->
+    PrevCap = application:get_env(beamtalk_workspace, recheck_caller_cap, 20),
+    application:set_env(beamtalk_workspace, recheck_caller_cap, Cap),
+    try
+        Tag = integer_to_list(N) ++ "_cap" ++ integer_to_list(Cap),
+        Selector = list_to_atom("benchFanoutSel" ++ Tag),
+        SelectorBin = atom_to_binary(Selector, utf8),
+        ChangedClass = list_to_atom("BenchChanged" ++ Tag),
+        ChangedClassBin = atom_to_binary(ChangedClass, utf8),
+        UnrelatedClass = list_to_atom("BenchUnrelated" ++ Tag),
+
+        %% ~10% real dependents (typed at the changed class), the rest false
+        %% positives (typed at an unrelated class that happens to implement
+        %% the same selector name unchanged) — models a heavily-overloaded
+        %% common selector where only a small fraction of same-selector sites
+        %% are real dependents of the reloaded class.
+
+        %% ChangedClass>>Selector: was Integer, now String (the reload).
+        beamtalk_compiler_server:register_class(ChangedClass, #{
+            superclass => 'Object',
+            method_info => #{Selector => #{arity => 0, param_types => [], return_type => 'String'}}
+        }),
+        %% UnrelatedClass>>Selector: unchanged Integer — re-checks clean.
+        beamtalk_compiler_server:register_class(UnrelatedClass, #{
+            superclass => 'Object',
+            method_info => #{Selector => #{arity => 0, param_types => [], return_type => 'Integer'}}
+        }),
+
+        %% Candidates are named `BenchCand<Tag>_<PaddedIndex>` uniformly (not
+        %% `BenchReal.../BenchFalse...`) and every 10th one is wired to the
+        %% real dependent (ChangedClass), the rest to the false-positive
+        %% (UnrelatedClass) — interleaved so alphabetic sort order (what
+        %% `apply_cap/2` keeps under a cap, per its documented "always drops
+        %% the same alphabetically-last owners" limitation) does not
+        %% systematically favour or penalise real dependents. A naming
+        %% scheme where all real names sorted after all false names would
+        %% silently make every capped round's `findings` artificially low —
+        %% not a property of the cap, just of the fixture.
+        PadWidth = length(integer_to_list(N)),
+        lists:foreach(
+            fun(I) ->
+                Receiver =
+                    case I rem 10 =:= 1 of
+                        true -> ChangedClass;
+                        false -> UnrelatedClass
+                    end,
+                register_candidate(
+                    "BenchCand" ++ Tag ++ "_" ++ pad_index(I, PadWidth),
+                    Selector,
+                    Receiver
+                )
+            end,
+            lists:seq(1, N)
+        ),
+
+        {WallUs, Result} = timer:tc(fun() ->
+            beamtalk_recheck:trigger(ChangedClassBin, SelectorBin, instance, signature_change)
+        end),
+        #{
+            findings := Findings,
+            checked := Checked,
+            not_checked := NotChecked,
+            cap_note := CapNote
+        } = Result,
+        WallMs = WallUs / 1000,
+        MsPerChecked =
+            case Checked of
+                0 -> 0.0;
+                _ -> WallMs / Checked
+            end,
+        io:format("~8p ~10p ~10p ~12p ~12.2f ~14.2f ~12s~n", [
+            N,
+            Checked,
+            NotChecked,
+            length(Findings),
+            WallMs,
+            MsPerChecked,
+            format_cap_note(CapNote)
+        ])
+    after
+        application:set_env(beamtalk_workspace, recheck_caller_cap, PrevCap)
+    end.
+
+-spec format_cap_note(binary() | undefined) -> string().
+format_cap_note(undefined) -> "-";
+format_cap_note(Bin) when is_binary(Bin) -> binary_to_list(Bin).
+
+%% Zero-pad `I` to `Width` digits so lexicographic (atom-name) sort order
+%% matches numeric order — see run_round/2's doc for why this matters.
+-spec pad_index(pos_integer(), pos_integer()) -> string().
+pad_index(I, Width) ->
+    Digits = integer_to_list(I),
+    Padding = lists:duplicate(max(0, Width - length(Digits)), $0),
+    Padding ++ Digits.
+
+-spec register_candidate(string(), atom(), atom()) -> ok.
+register_candidate(NameStr, Selector, ReceiverClass) ->
+    Name = list_to_atom(NameStr),
+    NameBin = list_to_binary(NameStr),
+    ReceiverBin = atom_to_binary(ReceiverClass, utf8),
+    SelectorBin = atom_to_binary(Selector, utf8),
+    XrefEntry = [
+        #{
+            class_side => false,
+            selector => go,
+            line => 2,
+            sends => [#{selector => Selector, line => 2, recv_kind => other}],
+            references => [#{class => ReceiverClass, line => 2}],
+            source_status => indexed,
+            provenance => class_body
+        }
+    ],
+    Source = <<
+        "Object subclass: ",
+        NameBin/binary,
+        "\n  go: c :: ",
+        ReceiverBin/binary,
+        " -> Integer => (c ",
+        SelectorBin/binary,
+        ") + 1\n"
+    >>,
+    ok = beamtalk_xref:register_class(Name, XrefEntry),
+    ok = beamtalk_workspace_meta:set_class_source(NameBin, Source),
+    ok.


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2781

Part of ADR 0105 (Epic BT-2775), Phase 2 — measure the reload re-check fan-out (BT-2778) for common vs rare selectors and decide whether ADR 0087's xref schema needs a receiver-type key.

- Adds `runtime/perf/bench_recheck_fanout.escript`: a two-part benchmark following the BT-2299 (`bench_senders_xref.escript`) methodology.
  - **Part A** — surveys real fan-out across the full loaded stdlib workspace (103 classes, 1928 indexed send sites, 416 distinct selectors), ranked exhaustively by distinct-caller-class count (the unit `beamtalk_recheck` actually caps/re-checks).
  - **Part B** — drives the real `beamtalk_recheck:trigger/4` orchestration (real compiler port, real xref, real workspace_meta) over synthetic candidate sets of 5/20/50/200 with a 10% real-dependent / 90% false-positive split, at the default cap (20) and uncapped.
- Records the decision in `docs/development/benchmarks.md` (full write-up with results/interpretation) and `docs/ADR/0105-live-image-recheck-on-reload.md` (Alternatives section note).
- Files a proactive, non-blocking follow-up issue for the xref receiver-type-key extension: [BT-2798](https://linear.app/beamtalk/issue/BT-2798) (child of BT-2775).

## Decision

Today's real stdlib fan-out doesn't justify implementing the extension now — exactly 1 of 416 selectors (`delegate`, an internal proxy-forwarding selector) exceeds the default cap of 20, and only by 3. But the controlled benchmark shows the interim caller-cap's known limitation (alphabetic, non-relevance-ranked drop) is severe once fan-out does grow past the cap: up to **90% loss of real findings** at 10x the cap. Per-check cost is flat (~33-48ms/candidate) regardless of fan-out size. Filed BT-2798 to track the extension as forward-looking work, not blocking any remaining ADR 0105 phase.

## Test plan

- [x] `just build`
- [x] `just clippy`
- [x] `just fmt-check`
- [x] `just test-stdlib` — 223/223 passed
- [x] `just test-bunit` — 2682/2684 passed, 0 failed
- [x] `just test-runtime` — 6776 tests, 0 failures
- [x] `escript perf/bench_recheck_fanout.escript` — runs clean, results recorded
- [x] `escript perf/bench_senders_xref.escript` — re-run alongside, no regression (~1400x speedup vs source-scan, consistent with BT-2299's prior measurement)
- [x] Adversarial review pass (`/review-code`) — caught and fixed a real ranking bug in Part A's selector table; added methodology caveats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j5UBhVKaBHzM89fmSYXxy

---
_Generated by [Claude Code](https://claude.ai/code/session_019j5UBhVKaBHzM89fmSYXxy)_