### PR TITLE
Tighten 3 placeholder assertions in repl_command_aliases.btscript

### DIFF
--- a/tests/repl-protocol/cases/repl_command_aliases.btscript
+++ b/tests/repl-protocol/cases/repl_command_aliases.btscript
@@ -25,7 +25,7 @@
 
 // Load counter fixture via :load (alias for Workspace load:)
 :load tests/repl-protocol/fixtures/counter.bt
-// => _
+// => Loaded: Counter
 
 // The Workspace load: direct form also works
 Workspace load: "tests/repl-protocol/fixtures/reload_counter.bt"
@@ -37,7 +37,7 @@ Workspace load: "tests/repl-protocol/fixtures/reload_counter.bt"
 
 // Load a test fixture
 :load tests/repl-protocol/fixtures/counter_test.bt
-// => _
+// => Loaded: CounterTest
 
 // :test CounterTest → Workspace test: CounterTest
 :test CounterTest
@@ -55,9 +55,9 @@ Workspace load: "tests/repl-protocol/fixtures/reload_counter.bt"
 :reload Counter
 // => Counter
 
-// :reload (no arg) → reload last loaded file
+// :reload (no arg) → reload last loaded file (counter_test.bt, last :load target)
 :reload
-// => _
+// => Reloaded: CounterTest
 
 // After reload, Counter still works
 c := Counter spawn


### PR DESCRIPTION
## Summary

- Replace three `// => _` wildcard assertions in `tests/repl-protocol/cases/repl_command_aliases.btscript` with their real deterministic expected values
- `:load counter.bt` → `Loaded: Counter`
- `:load counter_test.bt` → `Loaded: CounterTest`
- `:reload` (no-arg) → `Reloaded: CounterTest`
- The two `:test` wildcards (lines 44, 48) remain `// => _` — their output includes per-run timing and varies by total test-class count

## Why these three are safe to pin

The `Loaded: <class>` / `Reloaded: <class>` format is produced by `ReplClient::load_and_report_with_verb` in `crates/beamtalk-cli/tests/repl_protocol.rs`. The same format is already used as pinned assertions in:
- `repl_commands.btscript` (line 72): `:load tests/repl-protocol/fixtures/point.bt` → `Loaded: Point`
- `load_directory.btscript` (line 107): `:reload` → `Reloaded: Point`

The `:reload` (no-arg) target is `counter_test.bt` because it is the last `:load` issued within this test file (the harness tracks `last_loaded_path` per-file, and the two explicit `:load` calls in this file set it to `counter_test.bt` by the time `:reload` runs).

## Test plan

- [x] `just test-repl-protocol` — all 3 tests pass (105s run, 0 failures)
- [x] Pre-push hook: clippy, fmt, dialyzer, erlfmt — all green

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rut8S9Bf9ExVmHUVeDBf9o)_