### PR TITLE
Codegen: fix three Tier 2 stored/opaque block bugs (BT-2807, BT-2808, BT-2809)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -13,9 +13,9 @@ use super::super::document::{Document, INDENT, join, leaf, line, nest};
 use super::super::selector_mangler::safe_class_method_fn_name;
 use super::super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result, block_analysis};
 use crate::ast::{
-    Block, ClassDefinition, ClassKind, Expression, Identifier, Literal, MapPair, MessageSelector,
-    MethodDefinition, MethodKind, Module, ParameterDefinition, StateDeclaration, TypeAnnotation,
-    TypeParamDecl, WellKnownSelector,
+    Block, CascadeMessage, ClassDefinition, ClassKind, Expression, Identifier, Literal, MapPair,
+    MessageSelector, MethodDefinition, MethodKind, Module, ParameterDefinition, StateDeclaration,
+    TypeAnnotation, TypeParamDecl, WellKnownSelector,
 };
 use crate::docvec;
 use crate::unparse::unparse_method_display_signature;
@@ -447,6 +447,60 @@ impl CoreErlangGenerator {
         }
     }
 
+    /// BT-2808: Normalizes a `Cascade` into its true underlying receiver and the
+    /// full ordered list of messages sent to it.
+    ///
+    /// The parser (`parse_cascade`) folds the cascade's *first* message into
+    /// `Cascade.receiver` as a whole `MessageSend` — e.g. for `blk value: x;
+    /// value: y`, `receiver` is `MessageSend(blk, value:, [x])` and `messages`
+    /// holds only the remaining `value: y`. Every safety/codegen decision needs
+    /// the TRUE receiver (`blk`) and ALL messages sent to it (both `value: x`
+    /// and `value: y`), so this mirrors the same normalization
+    /// `generate_cascade` (expressions.rs) already performs for ordinary
+    /// (non-Tier-2) cascade codegen.
+    fn normalize_cascade<'a>(
+        receiver: &'a Expression,
+        messages: &'a [CascadeMessage],
+    ) -> (&'a Expression, Vec<(&'a MessageSelector, &'a [Expression])>) {
+        if let Expression::MessageSend {
+            receiver: inner,
+            selector: first_selector,
+            arguments: first_arguments,
+            ..
+        } = receiver
+        {
+            let mut all: Vec<(&MessageSelector, &[Expression])> =
+                Vec::with_capacity(messages.len() + 1);
+            all.push((first_selector, first_arguments.as_slice()));
+            for msg in messages {
+                all.push((&msg.selector, msg.arguments.as_slice()));
+            }
+            (inner.as_ref(), all)
+        } else {
+            let all: Vec<(&MessageSelector, &[Expression])> = messages
+                .iter()
+                .map(|msg| (&msg.selector, msg.arguments.as_slice()))
+                .collect();
+            (receiver, all)
+        }
+    }
+
+    /// BT-2797/BT-2808: Returns true if `selector` is a `value`/`value:`/
+    /// `value:value:`/`value:value:value:` send — the "safe" family that lets a
+    /// Tier 2 block value be invoked without escaping to a call site that
+    /// doesn't know to thread state through it.
+    fn is_safe_value_family_selector(selector: &MessageSelector) -> bool {
+        matches!(
+            selector.well_known(),
+            Some(
+                WellKnownSelector::Value
+                    | WellKnownSelector::ValueColon
+                    | WellKnownSelector::ValueValue
+                    | WellKnownSelector::ValueValueValue
+            )
+        )
+    }
+
     /// BT-2797: Scans `expr` for references to `var_name`, returning
     /// `(has_unsafe_use, has_safe_use)`.
     ///
@@ -487,15 +541,7 @@ impl CoreErlangGenerator {
                 let is_safe_value_send = matches!(
                     receiver.as_ref(),
                     Expression::Identifier(id) if id.name == var_name
-                ) && matches!(
-                    selector.well_known(),
-                    Some(
-                        WellKnownSelector::Value
-                            | WellKnownSelector::ValueColon
-                            | WellKnownSelector::ValueValue
-                            | WellKnownSelector::ValueValueValue
-                    )
-                );
+                ) && Self::is_safe_value_family_selector(selector);
                 let (mut unsafe_, mut safe) = if is_safe_value_send {
                     (false, true)
                 } else {
@@ -532,9 +578,33 @@ impl CoreErlangGenerator {
             Expression::Cascade {
                 receiver, messages, ..
             } => {
-                let (mut unsafe_, mut safe) = Self::scan_var_uses(receiver, var_name);
-                for msg in messages {
-                    for arg in &msg.arguments {
+                // BT-2808: when the cascade's true underlying receiver (see
+                // `normalize_cascade`) *is* var_name itself (e.g. `blk value: x;
+                // value: y`), the generic recursive scan would hit the plain
+                // `Identifier` arm and unconditionally report it unsafe. Mirror the
+                // `MessageSend` arm's `is_safe_value_send` check instead: if EVERY
+                // message sent to that receiver (including the one folded into
+                // `receiver` by the parser) is itself a safe
+                // `value`/`value:`/`value:value:`/`value:value:value:` send, the
+                // whole cascade is as safe as a single safe value send would be.
+                let (underlying_receiver, all_messages) =
+                    Self::normalize_cascade(receiver, messages);
+                let receiver_is_var = matches!(
+                    underlying_receiver,
+                    Expression::Identifier(id) if id.name == var_name
+                );
+                let all_messages_safe_value_sends = receiver_is_var
+                    && !all_messages.is_empty()
+                    && all_messages
+                        .iter()
+                        .all(|(sel, _)| Self::is_safe_value_family_selector(sel));
+                let (mut unsafe_, mut safe) = if all_messages_safe_value_sends {
+                    (false, true)
+                } else {
+                    Self::scan_var_uses(underlying_receiver, var_name)
+                };
+                for (_, args) in &all_messages {
+                    for arg in *args {
                         let (u, s) = Self::scan_var_uses(arg, var_name);
                         unsafe_ |= u;
                         safe |= s;
@@ -3378,6 +3448,37 @@ impl CoreErlangGenerator {
                 }
             }
         }
+        // BT-2808: `blk value: x; value: y` — a cascade where every message
+        // (including the one the parser folds into `receiver` — see
+        // `normalize_cascade`) is itself a safe value-family send on a receiver
+        // that (by the same rules as the single-send case above) may hold a
+        // Tier 2 block. Each message needs the same tuple-unpacking treatment
+        // as a single Tier2ValueCall, sequenced through
+        // `generate_tier2_cascade_doc`.
+        if let Expression::Cascade {
+            receiver, messages, ..
+        } = expr
+        {
+            let (underlying_receiver, all_messages) = Self::normalize_cascade(receiver, messages);
+            let all_safe_value_sends = !all_messages.is_empty()
+                && all_messages
+                    .iter()
+                    .all(|(sel, _)| Self::is_safe_value_family_selector(sel));
+            if all_safe_value_sends {
+                if let Expression::Identifier(id) = underlying_receiver {
+                    if self.tier2_block_params.contains(id.name.as_str())
+                        || self.tier2_local_vars.contains(id.name.as_str())
+                    {
+                        return true;
+                    }
+                }
+                if self.context == super::super::CodeGenContext::Actor
+                    && Self::is_self_field_access(underlying_receiver)
+                {
+                    return true;
+                }
+            }
+        }
         false
     }
 
@@ -3439,7 +3540,95 @@ impl CoreErlangGenerator {
                 );
             }
         }
+        // BT-2808: `blk value: x; value: y` — proved safe by `is_tier2_value_call`'s
+        // Cascade branch. Unlike the single-send case, `expression_doc` has no
+        // generic Tier 2 cascade handling to fall through to, so this must be
+        // generated directly regardless of receiver kind.
+        if let Expression::Cascade {
+            receiver, messages, ..
+        } = expr
+        {
+            let (underlying_receiver, all_messages) = Self::normalize_cascade(receiver, messages);
+            return self.generate_tier2_cascade_doc(underlying_receiver, &all_messages);
+        }
         self.expression_doc(expr)
+    }
+
+    /// BT-2808: Generates a sequential Tier 2 tuple-unpacking cascade
+    /// (`blk value: x; value: y`), reached only for a `Cascade` expression that
+    /// `is_tier2_value_call` already proved is entirely safe `value`-family
+    /// sends on a receiver that may hold a Tier 2 block.
+    ///
+    /// The receiver is evaluated once per message rather than hoisted into a
+    /// single shared binding — harmless here since a `tier2_block_params`/
+    /// `tier2_local_vars`/`self.field` receiver is always a pure variable or
+    /// field read, never an expression with side effects. Each message is
+    /// generated with the *current* threaded state (via
+    /// `generate_block_value_call_stateful`/`generate_block_value_call_runtime_discriminated`,
+    /// both of which read `self.current_state_var()` internally), then its
+    /// returned `{Result, NewState}` tuple is unpacked and `NewState` becomes
+    /// the current state for the next message — mirroring the sequencing the
+    /// bare (non-cascade) `Tier2ValueCall`/`LocalAssignTier2` call sites already
+    /// use between statements.
+    ///
+    /// Matching ordinary (non-Tier-2) cascade semantics, the overall value is
+    /// the result of the LAST message. Returns a `{Result, NewState}` tuple
+    /// with that contract — callers unpack it exactly like a single
+    /// `Tier2ValueCall` (see `generate_tier2_value_call_doc`'s own callers).
+    fn generate_tier2_cascade_doc(
+        &mut self,
+        receiver: &Expression,
+        all_messages: &[(&MessageSelector, &[Expression])],
+    ) -> Result<Document<'static>> {
+        let use_runtime_discrimination =
+            self.context == CodeGenContext::Actor && Self::is_self_field_access(receiver);
+
+        let mut parts: Vec<Document<'static>> = Vec::with_capacity(all_messages.len() + 1);
+        let mut result_var: Option<String> = None;
+        let mut state_var: Option<String> = None;
+        for (selector, args) in all_messages {
+            let call_doc = if use_runtime_discrimination {
+                self.generate_block_value_call_runtime_discriminated(
+                    receiver,
+                    args,
+                    &selector.name(),
+                )?
+            } else {
+                self.generate_block_value_call_stateful(receiver, args)?
+            };
+            let tuple_var = self.fresh_temp_var("CascTuple");
+            let this_result = self.fresh_temp_var("CascResult");
+            let this_state = self.next_state_var();
+            parts.push(docvec![
+                "let ",
+                leaf::var(tuple_var.clone()),
+                " = ",
+                call_doc,
+                " in let ",
+                leaf::var(this_result.clone()),
+                " = call 'erlang':'element'(1, ",
+                leaf::var(tuple_var.clone()),
+                ") in let ",
+                leaf::var(this_state.clone()),
+                " = call 'erlang':'element'(2, ",
+                leaf::var(tuple_var),
+                ") in ",
+            ]);
+            result_var = Some(this_result);
+            state_var = Some(this_state);
+        }
+        // is_tier2_value_call requires a non-empty message list before ever
+        // routing here, so both are always populated by the loop above.
+        let result_var = result_var.expect("BT-2808: cascade must have at least one message");
+        let state_var = state_var.expect("BT-2808: cascade must have at least one message");
+        parts.push(docvec![
+            "{",
+            leaf::var(result_var),
+            ", ",
+            leaf::var(state_var),
+            "}"
+        ]);
+        Ok(Document::Vec(parts))
     }
 
     /// Checks if a control flow expression actually threads state through mutations.

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -1211,6 +1211,51 @@ fn test_bt2797_same_method_tier2_local_var_threads_state_correctly() {
 }
 
 #[test]
+fn test_bt2808_cascade_on_tier2_local_var_compiles_and_threads_state() {
+    // BT-2808: `blk value: item; value: item` — a cascade sending two safe
+    // `value:` sends to the SAME Tier 2 local var. Before the fix,
+    // `scan_var_uses`'s `Cascade` arm hit the generic `Identifier` arm on the
+    // receiver (since the receiver *is* `blk`) and unconditionally reported it
+    // unsafe, so `prescan_tier2_local_vars` never promoted `blk` and this hit
+    // the `FieldAssignmentInUnsupportedBlock` compile-time diagnostic even
+    // though the pattern is exactly as safe as a single `blk value: item`.
+    let src = "Actor subclass: Ctr\n  state: total = 0\n\n  run: item =>\n    blk := [:x | self.total := self.total + x]\n    blk value: item; value: item\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _) = crate::source_analysis::parse(tokens);
+    let code = crate::codegen::core_erlang::generate_module(
+        &module,
+        crate::codegen::core_erlang::CodegenOptions::new("test").with_workspace_mode(true),
+    )
+    .expect("cascade of safe value: sends on a Tier 2 local var must compile (BT-2808)");
+
+    // Both cascaded `value:` sends must apply the block with a threaded state
+    // argument, and each must unpack its own {Result, NewState} tuple — not
+    // just the first message (which would silently drop the second mutation).
+    let apply_count = regex::Regex::new(r"apply _Fun\w* \(_item\w*, \w*State\w*\)")
+        .unwrap()
+        .find_iter(&code)
+        .count();
+    assert_eq!(
+        apply_count, 2,
+        "both cascaded value: sends must apply the block with a threaded \
+         state argument. Got: {code}"
+    );
+    let element1_count = regex::Regex::new(r"call 'erlang':'element'\(1, _\w+\)")
+        .unwrap()
+        .find_iter(&code)
+        .count();
+    let element2_count = regex::Regex::new(r"call 'erlang':'element'\(2, _\w+\)")
+        .unwrap()
+        .find_iter(&code)
+        .count();
+    assert!(
+        element1_count >= 2 && element2_count >= 2,
+        "each cascaded value: send's {{Result, NewState}} tuple must be \
+         unpacked separately so both mutations thread through. Got: {code}"
+    );
+}
+
+#[test]
 fn test_bt2797_local_tier2_block_never_invoked_again_is_still_compile_error() {
     // BT-2797 regression guard: `blk := [block needing Tier 2]` where `blk` is
     // never referenced again in the rest of the method — here because the

--- a/crates/beamtalk-core/src/semantic_analysis/block_analyzer.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_analyzer.rs
@@ -115,11 +115,45 @@ impl Analyser {
                         ).with_hint("Inline the block at the call site, or extract the field assignment into a separate method"));
                     }
                 }
-                MutationKind::CapturedVariable { .. } | MutationKind::LocalVariable { .. } => {
+                MutationKind::CapturedVariable { name } => {
                     // BT-856 (ADR 0041 Phase 3): Captured variable mutations in Stored/Passed
-                    // blocks are now supported via the Tier 2 stateful block protocol (BT-852).
-                    // State is threaded through StateAcc maps so mutations propagate correctly.
-                    // No diagnostic needed — this is valid and working behaviour.
+                    // blocks are supported via the Tier 2 stateful block protocol (BT-852).
+                    // State is threaded through the *calling method's own* StateAcc map, so
+                    // mutations propagate correctly back to that same method — this is valid
+                    // and working behaviour, and needs no diagnostic in that case.
+                    //
+                    // BT-2809: that threading mechanism breaks down for a block stored into
+                    // an instance field (`self.field := [block]`), because the field may be
+                    // invoked from a *different* method than the one that assigned it (the
+                    // whole point of BT-2797). `generate_block_stateful`'s captured-var
+                    // codegen keys the mutation into `'__local__<var>'` on the *calling*
+                    // method's own State — a different method's State was never seeded with
+                    // that key, so the runtime fallback silently returns the value the
+                    // variable had at block-*definition* time forever, and the stray key
+                    // then leaks into the actor's persistent gen_server state once the call
+                    // site merges the returned state back in. Unlike a field mutation (BT-2797
+                    // made those cross-method-safe via runtime is_function/2 discrimination),
+                    // a captured local has no cross-method-visible home to thread through, so
+                    // this is flagged the same way a field-write-plus-captured-local mix
+                    // already is above (`has_captured_local_mutations`) — just for the
+                    // captured-local-only case that arm never reaches.
+                    if matches!(parent_context, Some(ExprContext::FieldAssignment)) {
+                        self.result.diagnostics.push(Diagnostic::error(
+                            format!(
+                                "cannot mutate captured variable '{name}' inside a closure stored in a field\n\
+                                 \n\
+                                 = help: a field-stored block may be invoked from a different method, \
+                                   which has no way to see this variable's mutation\n\
+                                 = help: use a field instead of a captured local variable: `self.{name} := ...`"
+                            ),
+                            mutation.span,
+                        ).with_hint("Store the mutated value in a field, or extract the block and the variable into the same method"));
+                    }
+                }
+                MutationKind::LocalVariable { .. } => {
+                    // A block-local variable (defined AND used only inside the block, not
+                    // captured from an outer scope) never escapes the block invocation —
+                    // no state threading is needed, so no diagnostic applies in any context.
                 }
             }
         }
@@ -397,6 +431,44 @@ mod tests {
                 .iter()
                 .any(|d| d.message.contains("cannot assign to field")),
             "Expected field-in-stored-block error, got: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn bt2809_captured_local_only_field_stored_block_produces_error() {
+        // BT-2809: a block stored in a field whose ONLY mutation is a captured
+        // local (no field write) must be flagged — it can be invoked from a
+        // different method whose State never seeded the captured variable's
+        // '__local__' key, silently returning the stale definition-time value.
+        let src = "Actor subclass: Ctr\n  state: total = 0\n  state: callback = nil\n\n  setup =>\n    count := 0\n    self.callback := [:n | count := count + n]\n\n  process: n =>\n    self.callback value: n\n";
+        let module = parse_module(src);
+        let result = analyse(&module);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("cannot mutate captured variable")),
+            "Expected captured-local-in-field-stored-block error, got: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn captured_local_only_stored_in_local_var_same_method_produces_no_error() {
+        // BT-856/BT-2809 sanity check: a block stored in a *local variable* (not
+        // a field) with only a captured-local mutation must remain undiagnosed —
+        // codegen's prescan_tier2_local_vars proves per-method safety for this
+        // shape (BT-2797), and it's the well-established BT-856 pattern.
+        let src = "Object subclass: Foo\n  bar =>\n    count := 0\n    blk := [:n | count := count + n]\n    blk value: 5";
+        let module = parse_module(src);
+        let result = analyse(&module);
+        assert!(
+            !result
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("cannot mutate captured variable")),
+            "Did not expect a captured-local error for a locally-stored block, got: {:?}",
             result.diagnostics
         );
     }

--- a/crates/beamtalk-core/src/semantic_analysis/block_analyzer.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_analyzer.rs
@@ -137,7 +137,18 @@ impl Analyser {
                     // this is flagged the same way a field-write-plus-captured-local mix
                     // already is above (`has_captured_local_mutations`) — just for the
                     // captured-local-only case that arm never reaches.
-                    if matches!(parent_context, Some(ExprContext::FieldAssignment)) {
+                    //
+                    // Only fire for the captured-local-ONLY case: when a field write
+                    // *also* exists in the same block, the Field arm above already emits
+                    // its own diagnostic for this exact mix (that's what its
+                    // `has_captured_local_mutations` check is for), so skip here to avoid
+                    // reporting two separate errors for one closure.
+                    let has_field_mutation = mutations
+                        .iter()
+                        .any(|m| matches!(m.kind, MutationKind::Field { .. }));
+                    if matches!(parent_context, Some(ExprContext::FieldAssignment))
+                        && !has_field_mutation
+                    {
                         self.result.diagnostics.push(Diagnostic::error(
                             format!(
                                 "cannot mutate captured variable '{name}' inside a closure stored in a field\n\
@@ -450,6 +461,32 @@ mod tests {
                 .iter()
                 .any(|d| d.message.contains("cannot mutate captured variable")),
             "Expected captured-local-in-field-stored-block error, got: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn bt2809_mixed_field_and_captured_local_in_field_stored_block_produces_one_error() {
+        // Code review follow-up: a field-stored block with BOTH a field write and
+        // a captured-local mutation must produce exactly ONE diagnostic (the
+        // Field arm's "cannot assign to field"), not two — the CapturedVariable
+        // arm's own diagnostic is for the captured-local-ONLY case; firing both
+        // for the same closure would be confusing, redundant double-reporting.
+        let src = "Actor subclass: Ctr\n  state: total = 0\n\n  setup =>\n    count := 0\n    self.callback := [:n | self.total := n. count := count + n]\n";
+        let module = parse_module(src);
+        let result = analyse(&module);
+        assert_eq!(
+            result.diagnostics.len(),
+            1,
+            "Expected exactly one diagnostic for a field-stored block with both a \
+             field write and a captured-local mutation, got: {:?}",
+            result.diagnostics
+        );
+        assert!(
+            result.diagnostics[0]
+                .message
+                .contains("cannot assign to field"),
+            "Expected the field-write diagnostic to be the one reported, got: {:?}",
             result.diagnostics
         );
     }

--- a/crates/beamtalk-core/src/semantic_analysis/block_facts.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_facts.rs
@@ -8,6 +8,7 @@
 //! This domain service analyzes blocks to detect which variables and fields are
 //! read/written, enabling proper state threading in tail-recursive loops.
 
+use crate::ast::well_known::WellKnownSelector;
 use crate::ast::{Block, Expression, MessageSelector};
 use std::collections::HashSet;
 
@@ -26,6 +27,12 @@ pub struct BlockMutationAnalysis {
     pub field_writes: HashSet<String>,
     /// BT-245: Whether the block contains self-sends (which may mutate actor state).
     pub has_self_sends: bool,
+    /// BT-2807: Whether the block contains a `self.field value(:...)` send — invoking
+    /// a block stored in a field. The stored block's body isn't visible here (it may
+    /// be assigned anywhere), so this is conservative: any such call is treated as a
+    /// potential mutation source, since the field may hold a Tier 2 (state-mutating)
+    /// block that would otherwise silently skip state threading.
+    pub has_field_value_call: bool,
 }
 
 impl BlockMutationAnalysis {
@@ -39,10 +46,11 @@ impl BlockMutationAnalysis {
         !self.local_writes.is_empty() || !self.field_writes.is_empty()
     }
 
-    /// BT-245: Returns true if the block has any state-affecting operations.
-    /// This includes field writes AND self-sends (which may mutate actor state).
+    /// BT-245/BT-2807: Returns true if the block has any state-affecting operations.
+    /// This includes field writes, self-sends, and `self.field value(:...)` calls
+    /// (which may all mutate actor state).
     pub fn has_state_effects(&self) -> bool {
-        !self.field_writes.is_empty() || self.has_self_sends
+        !self.field_writes.is_empty() || self.has_self_sends || self.has_field_value_call
     }
 
     /// Returns all variables that need threading (read AND written).
@@ -174,6 +182,12 @@ fn analyze_expression(
             if is_self_reference(receiver) {
                 analysis.has_self_sends = true;
             }
+            // BT-2807: Detect `self.field value(:...)` — invoking a block stored in a
+            // field. The field may hold a Tier 2 (state-mutating) block, so this is
+            // conservatively treated as a potential mutation source.
+            if is_self_field_value_send(receiver, selector) {
+                analysis.has_field_value_call = true;
+            }
             analyze_expression(receiver, analysis, ctx);
             // BT-1053: ifTrue:/ifFalse:/ifTrue:ifFalse: blocks are compiled inline
             // (not as closures), so their local_writes and some captured_reads affect
@@ -210,6 +224,9 @@ fn analyze_expression(
                         if nested.has_self_sends {
                             analysis.has_self_sends = true;
                         }
+                        if nested.has_field_value_call {
+                            analysis.has_field_value_call = true;
+                        }
                     } else {
                         analyze_expression(arg, analysis, ctx);
                     }
@@ -237,6 +254,12 @@ fn analyze_expression(
             analysis
                 .field_writes
                 .extend(nested_analysis.field_writes.iter().cloned());
+            // BT-2807: propagate `self.field value(:...)` calls the same way as
+            // field_writes — a nested block invoking a stored (possibly Tier 2) block
+            // is itself a potential mutation source visible to the outer analysis.
+            if nested_analysis.has_field_value_call {
+                analysis.has_field_value_call = true;
+            }
         }
 
         Expression::Return { value, .. } => {
@@ -382,6 +405,25 @@ fn collect_pattern_bindings(
 /// Returns true if the expression is a reference to `self`.
 fn is_self_reference(expr: &Expression) -> bool {
     matches!(expr, Expression::Identifier(id) if id.name == "self")
+}
+
+/// BT-2807: Returns true if `receiver`/`selector` form a `self.field value(:...)`
+/// send — a `value`/`value:`/`value:value:`/`value:value:value:` message sent
+/// directly to a field access on `self`. Used to detect a stored (possibly Tier 2)
+/// block being invoked, which `analyze_block` otherwise has no visibility into.
+fn is_self_field_value_send(receiver: &Expression, selector: &MessageSelector) -> bool {
+    matches!(
+        receiver,
+        Expression::FieldAccess { receiver: r, .. } if is_self_reference(r)
+    ) && matches!(
+        selector.well_known(),
+        Some(
+            WellKnownSelector::Value
+                | WellKnownSelector::ValueColon
+                | WellKnownSelector::ValueValue
+                | WellKnownSelector::ValueValueValue
+        )
+    )
 }
 
 /// Returns true if the selector is an inline conditional (`ifTrue:`, `ifFalse:`, or
@@ -569,6 +611,57 @@ mod tests {
         let analysis = analyze_block(&block);
         assert!(analysis.field_writes.contains("value"));
         assert!(!analysis.field_reads.contains("value"));
+    }
+
+    #[test]
+    fn test_analyze_self_field_value_call() {
+        // BT-2807: [self.onTick value: x] — invoking a block stored in a field must
+        // be flagged as a potential mutation source, even with no literal field write.
+        let block = Block::new(
+            vec![],
+            vec![bare(Expression::MessageSend {
+                receiver: Box::new(Expression::FieldAccess {
+                    receiver: Box::new(make_expr_id("self")),
+                    field: make_id("onTick"),
+                    span: Span::new(0, 14),
+                }),
+                selector: MessageSelector::Keyword(vec![crate::ast::KeywordPart::new(
+                    "value:",
+                    Span::new(15, 21),
+                )]),
+                arguments: vec![make_expr_id("x")],
+                is_cast: false,
+                span: Span::new(0, 23),
+            })],
+            Span::new(0, 25),
+        );
+        let analysis = analyze_block(&block);
+        assert!(
+            analysis.has_field_value_call,
+            "self.field value: should set has_field_value_call"
+        );
+        assert!(analysis.field_writes.is_empty());
+        assert!(
+            analysis.has_state_effects(),
+            "has_field_value_call should make has_state_effects true"
+        );
+    }
+
+    #[test]
+    fn test_analyze_self_field_read_is_not_value_call() {
+        // Sanity check: a plain field read (no `value` send) must NOT set
+        // has_field_value_call.
+        let block = Block::new(
+            vec![],
+            vec![bare(Expression::FieldAccess {
+                receiver: Box::new(make_expr_id("self")),
+                field: make_id("onTick"),
+                span: Span::new(0, 14),
+            })],
+            Span::new(0, 16),
+        );
+        let analysis = analyze_block(&block);
+        assert!(!analysis.has_field_value_call);
     }
 
     #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/block_facts.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_facts.rs
@@ -269,8 +269,33 @@ fn analyze_expression(
         Expression::Cascade {
             receiver, messages, ..
         } => {
+            // `analyze_expression(receiver, ..)` below already checks whether the
+            // cascade's FIRST message is a `self.field value(:...)` send: the
+            // parser folds it into `receiver` as a whole `MessageSend` (see
+            // `parse_cascade`), so `receiver` here IS that MessageSend, and the
+            // `MessageSend` arm's own `is_self_field_value_send` check covers it.
+            //
+            // Code review follow-up (BT-2807): the SECOND and later cascaded
+            // messages are sent to that same underlying receiver too — cascade
+            // semantics evaluate the receiver once and send every message to it —
+            // but `messages` here only stores their selector/arguments, not a
+            // re-wrapped MessageSend, so nothing before this fix ever checked
+            // whether one of THEM was a `self.field value(:...)` send. Extract the
+            // one true underlying receiver shared by every cascaded message (the
+            // inner receiver of the folded first-message MessageSend, or
+            // `receiver` itself if there was no message to fold) and check each
+            // later message's own selector against it directly.
             analyze_expression(receiver, analysis, ctx);
+            let cascade_receiver = match receiver.as_ref() {
+                Expression::MessageSend {
+                    receiver: inner, ..
+                } => inner.as_ref(),
+                other => other,
+            };
             for msg in messages {
+                if is_self_field_value_send(cascade_receiver, &msg.selector) {
+                    analysis.has_field_value_call = true;
+                }
                 for arg in &msg.arguments {
                     analyze_expression(arg, analysis, ctx);
                 }
@@ -662,6 +687,49 @@ mod tests {
         );
         let analysis = analyze_block(&block);
         assert!(!analysis.has_field_value_call);
+    }
+
+    #[test]
+    fn test_analyze_self_field_value_call_as_non_first_cascade_message() {
+        // Code review follow-up (BT-2807): [self.onTick displayString; value: x] —
+        // the parser folds the cascade's FIRST message ("displayString") into
+        // Cascade.receiver as a whole MessageSend, so the true underlying
+        // receiver ("self.onTick") is one level deeper than Cascade.receiver
+        // itself. A self.field value(:...) send appearing as the SECOND (or
+        // later) cascaded message must still be detected, not just a first-message
+        // self.field value(:...) send.
+        let block = Block::new(
+            vec![],
+            vec![bare(Expression::Cascade {
+                receiver: Box::new(Expression::MessageSend {
+                    receiver: Box::new(Expression::FieldAccess {
+                        receiver: Box::new(make_expr_id("self")),
+                        field: make_id("onTick"),
+                        span: Span::new(0, 14),
+                    }),
+                    selector: MessageSelector::Unary("displayString".into()),
+                    arguments: vec![],
+                    is_cast: false,
+                    span: Span::new(0, 28),
+                }),
+                messages: vec![crate::ast::CascadeMessage::new(
+                    MessageSelector::Keyword(vec![crate::ast::KeywordPart::new(
+                        "value:",
+                        Span::new(30, 36),
+                    )]),
+                    vec![make_expr_id("x")],
+                    Span::new(30, 38),
+                )],
+                span: Span::new(0, 38),
+            })],
+            Span::new(0, 40),
+        );
+        let analysis = analyze_block(&block);
+        assert!(
+            analysis.has_field_value_call,
+            "a self.field value(:...) send as the second cascade message must \
+             still set has_field_value_call"
+        );
     }
 
     #[test]

--- a/stdlib/test/fixtures/tier2_field_stored_block_test_actor.bt
+++ b/stdlib/test/fixtures/tier2_field_stored_block_test_actor.bt
@@ -21,10 +21,23 @@ Actor subclass: Tier2FieldStoredBlockTestActor
   // (setup) than the one calling it.
   tick: x => self.onTick value: x
 
+  // BT-2808: cascades two safe `value:` sends to the same field-stored block
+  // in one statement — the parser folds the first send into Cascade.receiver
+  // as a whole MessageSend (`self.onTick value: x`), leaving only the second
+  // `value: x` in Cascade.messages.
+  tickTwice: x => self.onTick value: x; value: x
+
   // BT-2797: end-to-end — assign in setup, invoke (twice) in tick:, confirm
   // the field mutation inside the block propagates back to actor state.
   testFieldStoredBlockAcrossMethods =>
     self setup
     self tick: 5
     self tick: 3
+    self.total
+
+  // BT-2808: end-to-end — a cascade of two value: sends to the same
+  // field-stored Tier 2 block must thread state through BOTH sends: 5 + 5 = 10.
+  testFieldStoredBlockCascadeInvocation =>
+    self setup
+    self tickTwice: 5
     self.total

--- a/stdlib/test/fixtures/tier2_subexpr_and_conditional_block_test_actor.bt
+++ b/stdlib/test/fixtures/tier2_subexpr_and_conditional_block_test_actor.bt
@@ -23,11 +23,11 @@
 //    would either drop the field mutation silently or crash with a badarity
 //    error.
 //
-// Note: a *bare* `self.field value:` call with no other field mutation in
-// the same branch does not currently trigger state-threading detection at
-// all (block_analysis only looks for literal `self.slot :=` assignments) —
-// that is a separate, pre-existing gap outside BT-2797's scope, not
-// exercised here.
+// BT-2807: a *bare* `self.field value:` call with no other field mutation in
+// the same branch now also triggers state-threading detection (block_analysis
+// treats any `self.field value(:...)` send as a potential mutation source, not
+// just a literal `self.slot :=` assignment) — see
+// testBareFieldStoredBlockValueAloneInsideConditional below.
 
 Actor subclass: Tier2SubexprAndConditionalBlockTestActor
   state: total = 0
@@ -52,6 +52,12 @@ Actor subclass: Tier2SubexprAndConditionalBlockTestActor
       ]
     self.total
 
+  // BT-2807: Tier 2 field-stored block invoked bare inside a conditional
+  // branch with NO other field mutation alongside it in that branch.
+  tickIfPositiveBareOnly: x =>
+    x > 0 ifTrue: [self.onTick value: x]
+    self.total
+
   testStoredPureBlockInArgumentPosition =>
     self setupDoubler
     self addDoubled: 5
@@ -61,4 +67,11 @@ Actor subclass: Tier2SubexprAndConditionalBlockTestActor
     self setupOnTick
     self tickIfPositive: 5
     self tickIfPositive: -3
+    self.total
+
+  // BT-2807: 5 is added (x > 0), -3 is not (x <= 0) — total ends at 5.
+  testBareFieldStoredBlockValueAloneInsideConditional =>
+    self setupOnTick
+    self tickIfPositiveBareOnly: 5
+    self tickIfPositiveBareOnly: -3
     self.total

--- a/stdlib/test/tier2_field_stored_block_test.bt
+++ b/stdlib/test/tier2_field_stored_block_test.bt
@@ -22,3 +22,9 @@ TestCase subclass: Tier2FieldStoredBlockTest
   testFieldStoredBlockInvokedFromDifferentMethod =>
     actor := Tier2FieldStoredBlockTestActor spawn
     self assert: actor testFieldStoredBlockAcrossMethods equals: 8
+
+  // BT-2808: `self.onTick value: x; value: x` — a cascade of two safe value:
+  // sends to the same field-stored Tier 2 block, both must thread state.
+  testFieldStoredBlockCascadeInvocation =>
+    actor := Tier2FieldStoredBlockTestActor spawn
+    self assert: actor testFieldStoredBlockCascadeInvocation equals: 10

--- a/stdlib/test/tier2_subexpr_and_conditional_block_test.bt
+++ b/stdlib/test/tier2_subexpr_and_conditional_block_test.bt
@@ -22,3 +22,9 @@ TestCase subclass: Tier2SubexprAndConditionalBlockTest
   testStoredMutatingBlockInvokedBareInsideConditional =>
     actor := Tier2SubexprAndConditionalBlockTestActor spawn
     self assert: actor testStoredMutatingBlockInvokedBareInsideConditional equals: 5
+
+  // BT-2807: a bare `self.field value:` with NO other field mutation in the
+  // same conditional branch must still trigger state threading.
+  testBareFieldStoredBlockValueAloneInsideConditional =>
+    actor := Tier2SubexprAndConditionalBlockTestActor spawn
+    self assert: actor testBareFieldStoredBlockValueAloneInsideConditional equals: 5


### PR DESCRIPTION
## Summary

Fixes three codegen bugs discovered during BT-2797's review (PR #2899), all in the "field-stored/opaque Tier 2 block" area — a block stored in an instance field or local variable, mutating actor state, invoked later via `value:`/`value:value:`/cascade.

- **BT-2807** — a bare `self.field value:` with no other field mutation in the same nested block (e.g. inside `ifTrue:`) didn't trigger state threading, so a genuinely Tier 2 stored block crashed with `badarity` or silently lost its mutation. `block_facts::analyze_block` now tracks a `has_field_value_call` fact and folds it into `has_state_effects()`.
- **BT-2808** — `blk value: x; value: y` cascades on a Tier 2 local var/param/field-stored block were rejected at compile time. The parser folds a cascade's first message into `Cascade.receiver` as a whole `MessageSend`, which the original safety scan didn't account for. Added `normalize_cascade` to decompose the true receiver + full message list, and `generate_tier2_cascade_doc` to thread state sequentially through each cascaded send.
- **BT-2809** — a field-stored block whose only mutation is a captured local (not a field write) compiled and ran without crashing, but silently corrupted actor state when invoked from a different method than the one that assigned it (stale definition-time value returned forever, stray `'__local__'` key leaking into persistent gen_server state). Now a clear compile-time diagnostic instead.

A 4th commit addresses two issues found in this PR's own code review:
- `block_facts.rs`'s cascade handling for BT-2807 only checked the cascade's *first* message for a `self.field value:` send, missing the identical pattern as a later cascaded message.
- BT-2809's diagnostic double-fired (two separate errors) for a block with both a field write and a captured-local mutation; now emits just the one.

Also filed **BT-2810** as a follow-up: a systematic test matrix for the field-stored/opaque Tier 2 block axis, since coverage there was reactive (one hand-written regression test per bug found in review) rather than systematic like the existing `mutation_matrix_test.bt` (BT-1480).

## Test plan

- [x] `just test` (Rust unit tests, stdlib bootstrap tests, BUnit, Erlang runtime tests) — all green, no regressions
- [x] `just clippy` / `just fmt` — clean
- [x] New Rust unit tests for each bug (`block_facts.rs`, `block_analyzer.rs`, `control_flow.rs` codegen shape tests)
- [x] New end-to-end BUnit tests exercising each fix at runtime (`tier2_subexpr_and_conditional_block_test.bt`, `tier2_field_stored_block_test.bt`)
- [x] Manually verified BT-2809's diagnostic surfaces correctly via `beamtalk build` with source span + hint
- [x] 8-angle code review (correctness, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) — 2 correctness gaps found and fixed; remaining findings are pre-existing/architectural cleanup opportunities filed as review notes, not blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHhF87zXFhcAjJbetpCdQG)_