### PR TITLE
ADR 0105: e2e killer-demo test + docs + status flip to Accepted (BT-2783)

### DIFF
--- a/docs/ADR/0105-live-image-recheck-on-reload.md
+++ b/docs/ADR/0105-live-image-recheck-on-reload.md
@@ -1,7 +1,8 @@
 # ADR 0105: Live Image Re-Checking on Hot Reload
 
 ## Status
-Proposed (2026-07-05)
+Accepted (2026-07-11) — implemented via Epic BT-2775 (Phases 0–4,
+BT-2776…BT-2783).
 
 ## Implementation Tracking
 
@@ -19,9 +20,41 @@ Proposed (2026-07-05)
 | 3 | [BT-2782](https://linear.app/beamtalk/issue/BT-2782) | Pre-save advisory + `:recheck image` command | S | BT-2778 |
 | 4 | [BT-2783](https://linear.app/beamtalk/issue/BT-2783) | E2E killer-demo test + docs + status flip | S | BT-2779, BT-2780, BT-2782 |
 
-Deferred / recorded follow-ups: xref receiver-type-key extension (decided by BT-2781, filed as [BT-2798](https://linear.app/beamtalk/issue/BT-2798)), transitive re-check refinement, proxy meta-dependent tracking, single-method check API. Enabling ADRs (all landed): 0087 (xref), 0082 (edit/save), 0100 (severity), 0022 (compiler port), 0104 (actor/`spawnWith:` checking).
+Deferred / recorded follow-ups: xref receiver-type-key extension (decided by
+BT-2781, filed as [BT-2798](https://linear.app/beamtalk/issue/BT-2798)),
+transitive re-check refinement, proxy meta-dependent tracking, single-method
+check API. Also filed during the epic: [BT-2801](https://linear.app/beamtalk/issue/BT-2801)
+(LSP/CLI show no reload-induced findings until the next reload — no initial
+snapshot, unlike the workspace/cockpit UI's `reload_findings` read op; from
+BT-2779), [BT-2802](https://linear.app/beamtalk/issue/BT-2802) (the per-reload
+caller cap can permanently strand a stale finding for an evicted caller that
+no later reload happens to re-check; from BT-2779), [BT-2805](https://linear.app/beamtalk/issue/BT-2805)
+(`retyped_fallback/1` misattributes a shape-recheck finding to the first
+retyped field, by list order, when a single reload retypes two or more
+fields; from BT-2780), and [BT-2806](https://linear.app/beamtalk/issue/BT-2806)
+(BT-2782's pre-save advisory: an untested compiler-port-exit degradation path
+in `recheck_image_class/2`, and a non-self-healing race where the precheck's
+ambient-cache restore can clobber a genuinely concurrent `register_class/2`
+commit). Enabling ADRs (all landed): 0087 (xref), 0082 (edit/save), 0100
+(severity), 0022 (compiler port), 0104 (actor/`spawnWith:` checking).
 
-**Status:** Planned
+**Status:** Implemented — all five phases (BT-2776…BT-2783) landed: the
+walking skeleton proving signature-capture-at-patch-time, selector-keyed
+dependent lookup, and batched compiler-port re-check (Phase 0); the
+per-selector signature-generation store, re-check orchestration, and
+cross-surface publish with clearing-by-replacement (Phase 1); `state:`/
+`field:` shape-change re-check integrated with ADR 0104's `spawnWith:`/
+accessor checking, plus fan-out benchmarks (Phase 2); the pre-save advisory
+and `:recheck image` command (Phase 3); and this issue's e2e killer-demo
+test, language-features documentation, and status flip (Phase 4). The
+fan-out benchmarks (BT-2781) decided *against* extending xref with a
+receiver-type key today — only 1 of 416 real stdlib selectors currently
+exceeds the caller cap, so the per-reload cap remains the interim guard —
+but a controlled benchmark showing the cap silently drops up to 90% of real
+findings once fan-out reaches 10x the cap made the extension worth tracking
+regardless of whether any selector hits that today: it is filed as
+[BT-2798](https://linear.app/beamtalk/issue/BT-2798), a proactive,
+non-blocking follow-up, not a wait-and-see one.
 
 ## Context
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -130,8 +130,8 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0101](0101-unified-erlang-interop-native-objects.md) | Unified Erlang Interop — `native:` for Stateless Objects, Wrap-by-Default FFI, Clean `@primitive`/`@intrinsic`/`native:` Split | Accepted | 2026-06-28 |
 | [0102](0102-set-theoretic-type-operators.md) | Set-Theoretic Type Operators (Intersection and Negation) for Narrowing and Atom Exhaustiveness | Implemented (Phases 1, 2, 4, 5; Phase 1b deferred) | 2026-07-06 |
 | [0103](0103-sendability-typing-from-class-kinds.md) | Sendability Typing from Class Kinds | Proposed | 2026-07-05 |
-| [0104](0104-typed-actor-protocols.md) | Typed Actor Protocols — the Class Interface Is the Protocol | Proposed | 2026-07-05 |
-| [0105](0105-live-image-recheck-on-reload.md) | Live Image Re-Checking on Hot Reload | Proposed | 2026-07-05 |
+| [0104](0104-typed-actor-protocols.md) | Typed Actor Protocols — the Class Interface Is the Protocol | Accepted | 2026-07-07 |
+| [0105](0105-live-image-recheck-on-reload.md) | Live Image Re-Checking on Hot Reload | Accepted | 2026-07-11 |
 | [0106](0106-opt-in-match-exhaustiveness-assertion.md) | Opt-In Asserted `match:` Exhaustiveness (`matchExhaustive:`) | Implemented | 2026-07-07 |
 
 > ADR 0086 was originally numbered 0069 (a collision with *Actor Observability and Tracing*) and was renumbered on 2026-05-25.

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -29,6 +29,7 @@ Language features for Beamtalk. See [beamtalk-principles.md](beamtalk-principles
 - [Live Patching](#live-patching)
   - [Keyword Method Patching — `compile:source:` and `tryCompile:source:` (ADR 0082)](#keyword-method-patching--compilesource-and-trycompilesource-adr-0082)
   - [ChangeLog — Tracking In-Memory Changes (ADR 0082)](#changelog--tracking-in-memory-changes-adr-0082)
+  - [Live Re-Checking on Reload (ADR 0105)](#live-re-checking-on-reload-adr-0105)
 - [Actor Observability and Tracing (ADR 0069)](#actor-observability-and-tracing-adr-0069)
 - [Announcements — Typed Events (ADR 0093)](#announcements--typed-events-adr-0093)
 - [Namespace and Class Visibility](#namespace-and-class-visibility)
@@ -3132,6 +3133,87 @@ Every operation above is reachable via the REPL meta-commands, MCP tools, LSP
 over the Beamtalk language — see [REPL shortcuts](#repl-shortcuts--commands-are-thin-wrappers)
 below and the [Tooling guide](beamtalk-tooling.md#changelog-and-flush-adr-0082)
 for the surface tables.
+
+### Live Re-Checking on Reload (ADR 0105)
+
+A live edit doesn't just change the class being patched — it can invalidate
+every existing caller in the image. Every save above (`>>`, class-body
+redefinition, `:load`) triggers an **incremental re-check of known
+dependents**: the compiler re-checks the callers `beamtalk_xref` (ADR 0087)
+already knows about, using the same type checker that runs at compile time,
+and publishes what it finds as live diagnostics — no rebuild, no manual
+"find senders" required.
+
+```beamtalk
+:load counter.bt
+counter := Counter spawn
+counter getCount + 1          // => 1
+
+// ... change `getCount -> Integer` to `getCount -> String`, save
+// (a plain `Counter >> getCount -> String => ...` live patch) ...
+
+⚠ reload check: Counter>>getCount signature changed;
+   2 callers re-checked, 1 stale
+   Dashboard>>refresh (dashboard.bt:14): `+` expects a number, `getCount` now returns String
+```
+
+Only genuinely-affected callers surface. If `StatsView>>render` also calls
+`getCount` but only stringifies the result, it re-checks *clean* against the
+new signature and stays silent — the header's "2 re-checked, 1 stale" is its
+only trace.
+
+A **removed** selector is a `does_not_understand` waiting to happen, reported
+at `Hint` severity (ADR 0100 Rule 1 — a single closed-complete receiver):
+
+```beamtalk
+ℹ reload check: Counter>>reset was removed; 1 caller remains
+   AdminPanel>>onClick (admin.bt:9): `counter reset` will raise
+   does_not_understand at runtime
+   (Hint severity per ADR 0100 Rule 1 — single closed receiver)
+```
+
+A `state:`/`field:` slot added, removed, or retyped re-checks `spawnWith:`
+call sites and the changed slots' generated accessors the same way, under a
+`shape_change` classification.
+
+**Advisory, never blocking.** The reload already happened — a finding informs,
+it never vetoes. Findings are workspace-session state (LSP diagnostics,
+REPL/workspace-UI notices), never persisted, and never fail a build; they
+disappear on workspace restart. **Clearing is by replacement**: every
+re-check of a caller replaces *all* of its findings attributed to that
+changed class with the fresh result — clean or different — so back-to-back
+reloads of the same method never leave a stale finding sitting alongside a
+current one (supersession), and a later reload that fixes the callee clears
+the caller's finding with no edit to the caller at all.
+
+Two related, on-demand operations round out the surface:
+
+- **Pre-save advisory** — `aClass precheckCompile: #selector source: "..."`
+  compiles a *pending* edit and reports would-be-stale dependents without
+  installing it, so an editor can warn before you save. Never touches the
+  live image, the ChangeLog, or the findings store.
+- **`Workspace recheckImage`** (also `:recheck image`) — the "complete but
+  unbounded" whole-image sweep kept out of the automatic per-reload trigger:
+  re-checks every live class the workspace has a recorded source for and
+  returns a `checked`/`stale`/`findings` report, on demand.
+
+```beamtalk
+(Counter precheckCompile: #getCount source: "getCount -> String => self.value printString")
+// => a Dictionary shaped like the reload_check report — findings without installing
+
+Workspace recheckImage
+// => _  (checked/stale summary across the whole live image)
+```
+
+The dependent lookup is selector-keyed (ADR 0087's xref schema has no
+receiver-class component), so it re-checks every candidate caller and lets
+the checker's own type inference decide relevance — a `size` sender on an
+unrelated class simply re-checks clean. Fan-out is capped per reload (with a
+"N more not checked" note); one level of fan-out only, not transitive; and
+proxy-routed calls (ADR 0104 §4 forwarding) are invisible to xref, so a
+proxy-wrapped caller can go unflagged — see
+[ADR 0105](ADR/0105-live-image-recheck-on-reload.md) for the full mechanism,
+severity rules, and accepted gaps.
 
 ---
 

--- a/docs/internal/positioning.md
+++ b/docs/internal/positioning.md
@@ -110,7 +110,7 @@ section of the north-star doc). Small ADR, distinctive capability.
 
 ### Seed 3 — Types × hot reload: the killer demo
 
-*Drafted as [ADR 0105](../ADR/0105-live-image-recheck-on-reload.md).*
+*Shipped as [ADR 0105](../ADR/0105-live-image-recheck-on-reload.md) (Accepted, Epic BT-2775).*
 
 The unsolved question in the whole ecosystem: what happens to "checked" when a
 module is redefined live? ADR 0100's knowledge-graded severity is the

--- a/tests/repl-protocol/cases/adr_0105_killer_demo.btscript
+++ b/tests/repl-protocol/cases/adr_0105_killer_demo.btscript
@@ -1,0 +1,207 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E "killer demo" for ADR 0105 (Live Image Re-Checking on Hot Reload,
+// Epic BT-2775, this issue BT-2783): load a class, spawn/use it, change a
+// live method's return type via a real method-level hot reload (ADR 0082),
+// and watch the stale caller light up — from the running image, no rebuild.
+//
+// This drives the exact mechanism the ADR's "demo" and "removal" examples
+// describe (`docs/ADR/0105-live-image-recheck-on-reload.md`): every `>>`
+// redefinition below goes through the real reload path
+// (`beamtalk_repl_loader:maybe_trigger_recheck/4`) and fires the same
+// `reload_check`/`completed` push the CLI prints inline. The REPL-protocol
+// test harness intentionally discards push frames (see
+// `crates/beamtalk-cli/tests/repl_protocol.rs`, `handle_push`) — there is no
+// `// =>`-assertable request/response pair for an asynchronous push — so,
+// following the precedent set by `recheck_image_and_precheck.btscript`
+// (BT-2782), this file observes outcomes through `Workspace recheckImage`,
+// a synchronous whole-image re-check that recomputes live findings on
+// demand (`beamtalk_recheck:trigger_image/0`). It shares the exact
+// Dnu/Type-category, non-error-severity filter the automatic per-reload
+// check uses, so a finding here is a finding the real push would also have
+// reported. Store-level mechanics this surface cannot observe directly
+// (per-origin clearing-by-replacement, concurrent-reload edge cases) are
+// covered by the isolated EUnit suites: `beamtalk_workspace_findings_store_tests.erl`,
+// `beamtalk_repl_loader_recheck_tests.erl` (incl.
+// `supersession_replaces_not_accumulates_test_`), `beamtalk_recheck_tests.erl`.
+//
+// IMPORTANT: REPL-protocol cases share one long-lived workspace session
+// (see `repl_flush_changes_dirty.btscript`'s note) — class names here are
+// unique to this file to avoid collisions with other cases, and every
+// assertion filters `Workspace recheckImage`'s findings down to this file's
+// `KillerDemo*` classes before counting, since the shared image may carry
+// unrelated findings from other test files.
+
+// ===========================================================================
+// SETUP — the callee (spawned actor) and its typed dependents.
+// ===========================================================================
+
+// The callee: an actor with a typed accessor, matching the ADR's `Counter`.
+Actor subclass: KillerDemoCounter
+  state: count = 0
+  increment => self.count := self.count + 1
+// => _
+
+KillerDemoCounter >> getCount -> Integer => self.count
+// => _
+
+KillerDemoCounter >> cleanup => self.count := 0
+// => _
+
+// The stale caller: assumes `getCount` still answers an Integer (`+ 1`) —
+// the ADR's `Dashboard>>refresh`.
+Object subclass: KillerDemoDashboard
+  refresh: c :: KillerDemoCounter -> Integer => (c getCount) + 1
+// => _
+
+// The genuinely-unaffected caller: only stringifies the result, so it
+// re-checks clean whatever `getCount` returns — the ADR's `StatsView>>render`.
+Object subclass: KillerDemoStatsView
+  render: c :: KillerDemoCounter -> String => (c getCount) printString
+// => _
+
+// The removal target: calls a selector that will be deleted from the class —
+// the ADR's `AdminPanel>>onClick` / `Counter>>reset` example.
+Object subclass: KillerDemoAdminPanel
+  onClick: c :: KillerDemoCounter -> Object => c cleanup
+// => _
+
+// ===========================================================================
+// LOAD + SPAWN + USE — the live image before any edit.
+// ===========================================================================
+
+counter := KillerDemoCounter spawn
+// => Actor(KillerDemoCounter, _)
+
+counter increment
+// => 1
+
+counter getCount + 1
+// => 2
+
+// Helper: this file's findings, freshly recomputed each call (`recheckImage`
+// re-runs diagnostics against the *current* live source of every class with
+// a recorded source — nothing here is read from a cache or accumulated
+// across calls).
+killerDemoFindings := [((Workspace recheckImage) at: #findings) select: [:f | (f at: #owner) printString includesSubstring: "KillerDemo"]]
+// => _
+
+// Baseline: every KillerDemo* class type-checks clean before any live edit.
+(killerDemoFindings value) size
+// => 0
+
+// ===========================================================================
+// THE DEMO — change `getCount`'s return type live (method save); the stale
+// caller lights up, with location + wording; the unaffected caller stays
+// silent (only the summary count below proves it was even considered).
+// ===========================================================================
+
+KillerDemoCounter >> getCount -> String => self.count printString
+// => _
+
+// Existing actor picks up the new method immediately — no restart, no rebuild.
+// count is still 1 (untouched by this edit); now stringified.
+counter getCount
+// => 1
+
+// Exactly one stale caller: Dashboard. StatsView and AdminPanel stay silent —
+// this count would be 2 or 3 if either had also lit up.
+(killerDemoFindings value) size
+// => 1
+
+((killerDemoFindings value) first at: #owner) printString includesSubstring: "KillerDemoDashboard"
+// => true
+
+// Wording: the checker reports the now-`String` return breaking `+` as an
+// unresolved-selector (Dnu) diagnostic on the new type — confirmed empirically
+// in `beamtalk_recheck.erl`'s moduledoc ("String does not understand '+'").
+((killerDemoFindings value) first at: #message) includesSubstring: "does not understand"
+// => true
+
+((killerDemoFindings value) first at: #message) includesSubstring: "String"
+// => true
+
+((killerDemoFindings value) first at: #category) printString includesSubstring: "Dnu"
+// => true
+
+// Location: a byte-offset span into Dashboard's own live source, `start < end`.
+((killerDemoFindings value) first at: #start) < ((killerDemoFindings value) first at: #end)
+// => true
+
+// ===========================================================================
+// SUPERSESSION — a second, back-to-back reload of the SAME method replaces
+// the finding; it does not accumulate alongside the first one.
+// ===========================================================================
+
+KillerDemoCounter >> getCount -> Symbol => #done
+// => _
+
+// Still exactly one Dashboard finding — generation B replaced generation A,
+// it did not stack a second contradictory finding on top of it.
+(killerDemoFindings value) size
+// => 1
+
+// The wording now reflects the CURRENT (Symbol) generation, not the stale
+// (String) one — proof this is a replacement, not a leftover.
+((killerDemoFindings value) first at: #message) includesSubstring: "Symbol"
+// => true
+
+((killerDemoFindings value) first at: #message) includesSubstring: "String"
+// => false
+
+// ===========================================================================
+// RELOAD-FIXES-RELOAD — restoring the original signature clears the finding
+// with no edit to the caller at all.
+// ===========================================================================
+
+KillerDemoCounter >> getCount -> Integer => self.count
+// => _
+
+(killerDemoFindings value) size
+// => 0
+
+// ===========================================================================
+// REMOVAL — deleting a selector flags its caller as DNU-at-runtime, at
+// `Hint` severity (ADR 0100 Rule 1: a single statically-known receiver).
+// A full class-body redefinition (dropping `cleanup`) is how a selector is
+// actually removed from a live class — `>>` only adds/replaces, matching
+// `MethodDropActor`'s pattern in `inline_class_hot_reload.btscript`.
+// ===========================================================================
+
+Actor subclass: KillerDemoCounter
+  state: count = 0
+  increment => self.count := self.count + 1
+// => _
+
+KillerDemoCounter >> getCount -> Integer => self.count
+// => _
+
+// AdminPanel is now the sole stale caller — Dashboard/StatsView are clean
+// again (both survived the `getCount` round-trip back to `Integer`).
+(killerDemoFindings value) size
+// => 1
+
+((killerDemoFindings value) first at: #owner) printString includesSubstring: "KillerDemoAdminPanel"
+// => true
+
+((killerDemoFindings value) first at: #message) includesSubstring: "does not understand"
+// => true
+
+((killerDemoFindings value) first at: #message) includesSubstring: "cleanup"
+// => true
+
+// Hint severity — never escalated just because a reload caused it (ADR
+// 0105 §Severity: "Reload adds attribution, not severity").
+((killerDemoFindings value) first at: #severity) printString includesSubstring: "hint"
+// => true
+
+// The actor spawned before any of this still runs, with its state intact —
+// hot reload never restarts a live instance (count was 1 all along; the
+// full class-body redefinition above only resets the *default* for new
+// instances, not this actor's own field).
+counter increment
+// => 2
+
+counter getCount
+// => 2


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2783/adr-0105-e2e-killer-demo-test-docs-status-flip-to-accepted-adr-0105

Final issue (Phase 4) of the ADR 0105 epic (BT-2775, live image re-checking on hot reload). All four blockers (BT-2779, BT-2780, BT-2782, plus BT-2776/BT-2777/BT-2778/BT-2781) are merged to main; this closes out the ADR.

- **E2E killer-demo test** (`tests/repl-protocol/cases/adr_0105_killer_demo.btscript`): drives the ADR's demo end to end against a real running workspace — load a class, spawn/use it, change a method's return type live (`>>` hot reload) and assert the stale caller lights up with the right location + wording; back-to-back reload supersession (replaces, doesn't accumulate); reload-fixes-reload clearing; selector removal flagged as DNU-at-runtime at `Hint` severity (ADR 0100 Rule 1); a genuinely-unaffected caller stays silent. Assertions go through `Workspace recheckImage` — the deterministic, synchronous surface — since the repl-protocol test harness intentionally discards async `reload_check` push frames by design (see the file's header comment for why, and precedent in `recheck_image_and_precheck.btscript`).
- **Docs**: new "Live Re-Checking on Reload (ADR 0105)" section in `docs/beamtalk-language-features.md` documenting the demo, removal example, severity/clearing-by-replacement rules, and the `precheckCompile:source:`/`Workspace recheckImage` surfaces. `docs/development/surface-parity.md` was already up to date from BT-2779/BT-2780/BT-2782 — verified via `cargo run -p beamtalk-surface-drift` (OK, no changes needed).
- **ADR 0105 status flip**: `Proposed (2026-07-05)` → `Accepted (2026-07-11)`; Implementation Tracking table's trailing summary updated from `Planned` to `Implemented`, with the deferred/follow-up items recorded (BT-2798 xref receiver-key, BT-2801 LSP/CLI initial-snapshot gap, BT-2802 caller-cap eviction staleness, BT-2805 multi-field-retyped misattribution, BT-2806 untested compiler-port exit path + restore-clobbers-commit race).
- Also fixed two stale status entries noticed while touching `docs/ADR/README.md`: ADR 0104's row was still "Proposed" despite the ADR itself being `Accepted (2026-07-07)`; `docs/internal/positioning.md`'s Seed 3 reference updated from "Drafted as ADR 0105" to "Shipped as ADR 0105 (Accepted, Epic BT-2775)".

## Testing

- `just build`, `just test-repl-protocol` (1877/1877, including the new file), `just test` (Rust/stdlib/BUnit — one pre-existing, unrelated `epmd` network-posture test failure confirmed environmental, not caused by this docs/test-only change), `just test-stdlib`, `just clippy`, `just fmt-check`, `just lint`, `cargo run -p beamtalk-surface-drift` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j5UBhVKaBHzM89fmSYXxy

---
_Generated by [Claude Code](https://claude.ai/code/session_019j5UBhVKaBHzM89fmSYXxy)_