### PR TITLE
Fix Windows nightly CI: prevent PowerShell profile from aborting test-runtime

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -7,7 +7,7 @@
 
 # Use bash on Unix and PowerShell on Windows for all commands
 set shell := ["bash", "-uc"]
-set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-Command"]
 
 # Default recipe (list all tasks)
 default:
@@ -780,8 +780,8 @@ test-runtime: build-stdlib
 [working-directory: 'runtime']
 test-runtime: build-stdlib
     @echo "🧪 Running Erlang runtime unit tests..."
-    @$env:BEAMTALK_NO_FILE_LOG = "1"; $output = rebar3 eunit '--cover=false' '--app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler' 2>&1 | Out-String; $exitCode = $LASTEXITCODE; if ($exitCode -ne 0) { Write-Output $output; exit $exitCode } else { ($output -split "`n") | Select-Object -Last 3 }
-    @$env:BEAMTALK_NO_FILE_LOG = "1"; $output = rebar3 eunit '--cover=false' '--dir=apps/beamtalk_stdlib/test' 2>&1 | Out-String; $exitCode = $LASTEXITCODE; if ($exitCode -ne 0) { Write-Output $output; exit $exitCode } else { ($output -split "`n") | Select-Object -Last 3 }
+    @$ErrorActionPreference = 'Continue'; $env:BEAMTALK_NO_FILE_LOG = "1"; $output = rebar3 eunit '--cover=false' '--app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler' 2>&1 | Out-String; $exitCode = $LASTEXITCODE; if ($exitCode -ne 0) { Write-Output $output; exit $exitCode } else { ($output -split "`n") | Select-Object -Last 3 }
+    @$ErrorActionPreference = 'Continue'; $env:BEAMTALK_NO_FILE_LOG = "1"; $output = rebar3 eunit '--cover=false' '--dir=apps/beamtalk_stdlib/test' 2>&1 | Out-String; $exitCode = $LASTEXITCODE; if ($exitCode -ne 0) { Write-Output $output; exit $exitCode } else { ($output -split "`n") | Select-Object -Last 3 }
     @echo "✅ Runtime tests complete"
 
 # Run performance benchmarks (separate from unit tests, ~30s)


### PR DESCRIPTION
## Summary

The `windows` job's "Test Erlang runtime" step has failed on every nightly run since 2026-06-22 (20 consecutive nights). Root cause:

- EUnit tests that intentionally write diagnostic text to stderr to exercise error paths (e.g. `handle_read_specs_crash_caught_test`, `compile_core_file_missing` in `beamtalk_build_worker_tests.erl`) run fine on Linux/macOS.
- On Windows, `rebar3` is a one-line `.ps1` shim (`& escript.exe <path> ${args}`, generated by `erlef/setup-beam`) with no stderr handling of its own.
- When the nested `escript.exe` process writes to stderr, PowerShell surfaces it as a terminating `NativeCommandError` (visible in every failed run's log, e.g. `"escript.exe : Error reading /nonexistent/file.core: enoent" ... FullyQualifiedErrorId : NativeCommandError`), killing the whole step instantly — before rebar3 can print its pass/fail summary. The EUnit assertions themselves never fail; the process dies mid-run.
- This only happens when `$ErrorActionPreference` is `Stop`, which we never set explicitly. The most likely source is a machine-wide PowerShell profile on the GitHub-hosted `windows-2022` runner image, loaded because our `windows-shell` invocation (`powershell.exe -NoLogo -Command`) omits `-NoProfile`.

## Changes

- Add `-NoProfile` to `set windows-shell` in the `Justfile` so CI no longer depends on whatever profile the runner image happens to load.
- Explicitly force `$ErrorActionPreference = 'Continue'` around the `rebar3 eunit` invocations in the `test-runtime` Windows recipe, as an independent second guard against the same failure mode regardless of where `Stop` originates.

Confirmed 20/20 recent nightly Windows failures show the identical signature (same test, same `NativeCommandError`, log truncates at the same point), so this is deterministic, not flaky — and unrelated to the macOS x86_64 timeout seen in only the most recent run.

## Test plan

- [ ] Nightly CI run on `main` completes the `windows` job's Erlang runtime tests without a `NativeCommandError`
- [x] Local `just --list` confirms Justfile syntax is valid
- [x] Full pre-push CI (clippy, fmt, Dialyzer, Elixir lint) passed locally