### PR TITLE
Drop the legacy `=` equality alias; keep `=` as field/state initializer (BT-2759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Language
 
+- **Bare `=` equality alias fully removed (breaking)** — `=` used as an equality comparison (`x = y`) was already rejected by the parser as of BT-2762; this closes the remaining loose ends: the redundant `beamtalk lint` warning on `x = true` / `x = false` is gone (superseded by the parser diagnostic), and the spec no longer describes `=` as a "legacy alias." The `=` token's other role — the `state:` / `field:` / `classState:` default-value separator (`state: count = 0`) — is unaffected and unchanged. Use `=:=` for value equality or `==` for reference equality (BT-2759).
+
 - **Character literal dispatch** — character literals (`$A`, `$a`, etc.) now dispatch through the Character method table instead of Integer's. `$A asString` returns `"A"` (not `"65"`), `$A class` returns `Character`, and methods like `uppercase`, `lowercase`, `printString` work correctly on character literals. `Character value: 65` class-method sends also work (BT-2095).
 - **`@expect inheritance` diagnostic category** — sealed-class and sealed-method constraint diagnostics are now categorized as `Inheritance`, so they reach CLI and MCP lint surfaces that filter to categorized diagnostics. Previously these diagnostics were uncategorized and only appeared in the LSP (BT-2087).
 - **Class-side block parameter type propagation** — the type checker now infers block parameter types from class-side method signatures (e.g., `ClassName build: [:r | ...]` where the method declares `Block(RouteBuilder, R)` correctly types `r` as `RouteBuilder`), eliminating the need for `@expect type` pragmas on class-side sends and cascades (BT-2158).

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/class_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/class_tests.rs
@@ -1827,6 +1827,62 @@ fn double_colon_type_annotation_no_diagnostic() {
     );
 }
 
+/// BT-2759: the `=` token still plays its original role as the
+/// field/state/classState default-value separator — only its role as an
+/// equality *binary selector* was removed (BT-2762). Regression-test all
+/// three declaration forms in one place so a future change to `=` handling
+/// can't silently regress the initializer path.
+#[test]
+fn equals_default_value_initializer_all_declaration_forms() {
+    let source = "Actor subclass: Account
+  state: balance = 0
+  classState: rate = 5
+  deposit: amount => nil
+
+Value subclass: Label
+  field: text = \"acct\"";
+    let tokens = lex_with_eof(source);
+    let (module, diagnostics) = parse(tokens);
+    assert!(
+        diagnostics.is_empty(),
+        "Expected no diagnostics for `=` default-value initializers, got: {diagnostics:?}"
+    );
+    assert_eq!(module.classes.len(), 2, "Expected exactly two classes");
+    let account = &module.classes[0];
+
+    // `state: balance = 0`
+    assert_eq!(
+        account.state.len(),
+        1,
+        "Expected exactly one state variable"
+    );
+    assert_eq!(account.state[0].declared_keyword, DeclaredKeyword::State);
+    assert!(
+        account.state[0].default_value.is_some(),
+        "Expected `state: balance = 0` to carry a default value"
+    );
+
+    // `classState: rate = 5`
+    assert_eq!(
+        account.class_variables.len(),
+        1,
+        "Expected exactly one classState variable"
+    );
+    assert!(
+        account.class_variables[0].default_value.is_some(),
+        "Expected `classState: rate = 5` to carry a default value"
+    );
+
+    let label = &module.classes[1];
+    // `field: text = "acct"`
+    assert_eq!(label.state.len(), 1, "Expected exactly one field variable");
+    assert_eq!(label.state[0].declared_keyword, DeclaredKeyword::Field);
+    assert!(
+        label.state[0].default_value.is_some(),
+        "Expected `field: text = \\\"acct\\\"` to carry a default value"
+    );
+}
+
 #[test]
 fn parse_binary_method() {
     let module = parse_ok(

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -1629,7 +1629,7 @@ withTimeout: ms :: Integer | #infinity => ...
 restart: policy :: #temporary | #transient | #permanent => ...
 ```
 
-A singleton receiver resolves methods against `Symbol`'s protocol — `#infinity asString` infers `String`, and an unknown selector produces a DNU hint naming the singleton (e.g. `#infinity does not understand 'frobnicate'`). Binary sends (`=:=`, `=`) are excluded from this redirect so statically-decidable comparison hints still fire.
+A singleton receiver resolves methods against `Symbol`'s protocol — `#infinity asString` infers `String`, and an unknown selector produces a DNU hint naming the singleton (e.g. `#infinity does not understand 'frobnicate'`). Equality comparisons (`=:=`, `==`, `/=`, `=/=`) are excluded from this redirect so statically-decidable comparison hints still fire.
 
 Discriminate a singleton union with `=:=` (identity) and the branches narrow — see [Control Flow Narrowing](#control-flow-narrowing).
 


### PR DESCRIPTION
Implements [BT-2759](https://linear.app/beamtalk/issue/BT-2759/drop-the-legacy-equality-alias-require-keep-as-fieldstate-initializer).

## Summary

Auditing this issue's acceptance criteria against the current codebase found that **BT-2762** (merged earlier, #2868) already implemented nearly all of this issue's scope as a side effect of its own dead-code removal:

- `=` as an equality binary selector was already removed from the parser (`x = y` produces `Unexpected token: expected expression, found =` with an actionable hint: `"'=' is not an operator in Beamtalk; use '=:=' for value equality or '==' for reference equality"`).
- `is_pure_binary_op` in `lint_validators.rs` no longer lists `"="`.
- `inference.rs` (`is_equality_comparison_op`) and `ast/well_known.rs` no longer treat `Binary("=")` as equality.
- `docs/beamtalk-language-features.md` already states bare `=` doesn't parse and equality is `=:=`/`==`.
- The `state:`/`field:`/`classState:` default-value initializer role of `=` was never touched (`declarations.rs`) and remains fully functional.

This PR closes the remaining gaps found during the audit:

- **Regression test** (`equals_default_value_initializer_all_declaration_forms` in `crates/beamtalk-core/src/source_analysis/parser/tests/class_tests.rs`) covering the `=` default-value initializer across all three declaration forms (`state:`, `field:`, `classState:`) in one place, per the issue's explicit AC.
- **Doc fix**: a stale line in `beamtalk-language-features.md` still listed bare `=` as one of the binary sends excluded from singleton-receiver method redirection; corrected to the actual exclusion list (`=:=`, `==`, `/=`, `=/=`).
- **CHANGELOG entry**: dropping a language operator is user-visible, so it's documented even though the parser-level rejection shipped in BT-2762.
- **Migration audit**: re-confirmed no real `=`-as-equality usages exist in `stdlib/` or test fixtures (grep-verified; matches the issue's own initial scan).

## ADR question

The issue asked reviewers to flag whether dropping `=` as a language operator warrants a retroactive ADR rather than a direct issue. Raising that question here per the issue's instructions — the change itself (already substantially shipped via BT-2762) is small and surgical, but it is a user-visible removal of a previously-working alias. No ADR was written; flagging for reviewer judgment.

## Testing

- New parser regression test passes (`cargo test -p beamtalk-core equals_default_value_initializer_all_declaration_forms`).
- Existing `bare_equals_is_not_an_operator` regression test (from BT-2762) still passes.
- `cargo clippy --all-targets -- -D warnings` clean (workspace-wide).
- `cargo fmt --all -- --check` clean.
- Grep-based migration audit of `stdlib/` and test fixtures: no real `=`-as-equality usages found.
- Pre-push hook (full CI incl. Erlang/Elixir lint + Dialyzer) passed.

Note: `beam_compiler::tests::discover_otp_beam_files_includes_erts` fails in this sandbox on a clean `origin/main` checkout too (missing OTP `erts` install path) — confirmed unrelated to this change and pre-existing in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014qKdvh9EENW9eTNpRhfF9L)_