### PR TITLE
Mark caller-cap-evicted reload findings stale instead of stranding them (BT-2802)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
@@ -133,6 +133,18 @@ and `findings` alone omits clean classes entirely). `trigger/4` is
 synchronous and best-effort: any internal failure degrades to an empty
 result rather than raising, since a re-check failure must never affect the
 reload that triggered it (ADR 0105: "advisory, never blocking").
+
+`result()`'s `not_checked_owners` field exists for the same consumer, as
+`checked_owners`'s complement: it is the caller-cap-dropped candidates (the
+alphabetically-last owners `apply_cap/2` excluded from `Kept`), named rather
+than only counted (`not_checked`). BT-2802: a candidate dropped by the cap
+this reload may already have a stored finding from an earlier reload where
+it *was* checked — that finding was never re-verified against the current
+generation and must not keep asserting itself as current forever.
+`beamtalk_repl_loader:maybe_run_recheck/4` uses this field to mark any such
+pre-existing finding's `note` as possibly-stale in place, rather than either
+silently dropping it (could hide a real, still-live problem) or leaving it
+looking freshly-verified (the BT-2802 bug).
 """.
 
 -include_lib("kernel/include/logger.hrl").
@@ -204,7 +216,8 @@ reload that triggered it (ADR 0105: "advisory, never blocking").
     total_candidates := non_neg_integer(),
     not_checked := non_neg_integer(),
     cap_note := binary() | undefined,
-    checked_owners := [binary()]
+    checked_owners := [binary()],
+    not_checked_owners := [binary()]
 }.
 
 %% A whole-image finding (`trigger_image/0`) — lighter than `finding()`: no
@@ -486,7 +499,8 @@ empty_result() ->
         total_candidates => 0,
         not_checked => 0,
         cap_note => undefined,
-        checked_owners => []
+        checked_owners => [],
+        not_checked_owners => []
     }.
 
 -spec do_trigger_pending(
@@ -705,7 +719,8 @@ do_trigger(ClassNameBin, SelectorBin, Classification) ->
         total_candidates => length(OwnerGroups),
         not_checked => NotChecked,
         cap_note => cap_note(NotChecked),
-        checked_owners => CheckedOwners
+        checked_owners => CheckedOwners,
+        not_checked_owners => not_checked_owners(OwnerGroups, Kept)
     }.
 
 -spec do_trigger_shape(binary(), [shape_field_change()]) -> result().
@@ -732,8 +747,21 @@ do_trigger_shape(ClassNameBin, FieldChanges) ->
         total_candidates => length(OwnerGroups),
         not_checked => NotChecked,
         cap_note => cap_note(NotChecked),
-        checked_owners => CheckedOwners
+        checked_owners => CheckedOwners,
+        not_checked_owners => not_checked_owners(OwnerGroups, Kept)
     }.
+
+-doc """
+The candidates the caller cap dropped this trigger — `Candidates` (every
+group `group_by_owner/1` found) minus `Kept` (`apply_cap/2`'s survivors),
+named as owner binaries. `Candidates` arrives as `Kept`'s superset with
+`Kept` as its prefix (`apply_cap/2`'s contract), so list subtraction is exact
+and does not need a set datatype. See `result()`'s `not_checked_owners` doc
+(BT-2802) for why this is exposed rather than just counted.
+""".
+-spec not_checked_owners([{atom(), [map()]}], [{atom(), [map()]}]) -> [binary()].
+not_checked_owners(Candidates, Kept) ->
+    [atom_to_binary(Owner, utf8) || {Owner, _} <- Candidates -- Kept].
 
 -doc """
 The selector set whose senders are candidate dependents of a shape change:

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -1002,7 +1002,8 @@ no_pending_change_result() ->
         total_candidates => 0,
         not_checked => 0,
         cap_note => undefined,
-        checked_owners => []
+        checked_owners => [],
+        not_checked_owners => []
     }.
 
 -doc """
@@ -1956,7 +1957,8 @@ maybe_run_recheck(_ClassNameBin, _SelectorBin, _Side, {captured, _Prev, no_op}) 
     {self_edit, undefined};
 maybe_run_recheck(ClassNameBin, SelectorBin, Side, {captured, _Prev, Classification}) ->
     Result = beamtalk_recheck:trigger(ClassNameBin, SelectorBin, Side, Classification),
-    #{checked_owners := CheckedOwners, findings := Findings} = Result,
+    #{checked_owners := CheckedOwners, findings := Findings, not_checked_owners := NotCheckedOwners} =
+        Result,
     lists:foreach(
         fun(OwnerBin) ->
             OwnerFindings = [F || F <- Findings, maps:get(owner, F) =:= OwnerBin],
@@ -1964,7 +1966,87 @@ maybe_run_recheck(ClassNameBin, SelectorBin, Side, {captured, _Prev, Classificat
         end,
         CheckedOwners
     ),
+    mark_capped_out_findings_stale(ClassNameBin, NotCheckedOwners),
     {Classification, Result}.
+
+%% BT-2802: a candidate the caller cap dropped this reload (`NotCheckedOwners`
+%% — `beamtalk_recheck:result()`'s complement of `checked_owners`) never went
+%% through `put_owner_origin/3` above, so any finding it already carries *for
+%% this changed class* is left exactly as a previous, possibly-now-stale
+%% reload wrote it — nothing here re-verified whether the caller's problem
+%% still holds. Rather than let that finding keep asserting itself as
+%% current forever (the BT-2802 bug) or silently drop it (could hide a real,
+%% still-live problem), overwrite its `note` in place, still through
+%% `put_owner_origin/3`'s ordinary replace semantics, to say so. A candidate
+%% with no existing finding for this origin has nothing to mark — most
+%% cap-dropped candidates, every reload — so this is a no-op for them
+%% (`findings_store_get_origin/2` returns `[]`).
+-spec mark_capped_out_findings_stale(binary(), [binary()]) -> ok.
+mark_capped_out_findings_stale(ClassNameBin, NotCheckedOwners) ->
+    lists:foreach(
+        fun(OwnerBin) ->
+            case findings_store_get_origin(OwnerBin, ClassNameBin) of
+                [] ->
+                    ok;
+                Existing ->
+                    Stale = [mark_stale_finding(ClassNameBin, F) || F <- Existing],
+                    findings_store_put_owner_origin(OwnerBin, ClassNameBin, Stale)
+            end
+        end,
+        NotCheckedOwners
+    ),
+    ok.
+
+%% Best-effort wrapper around `beamtalk_workspace_findings_store:get_origin/2`
+%% — mirrors `findings_store_clear_owner/1`'s "store may legitimately be
+%% absent, degrade rather than crash" reasoning.
+-spec findings_store_get_origin(binary(), binary()) -> [beamtalk_recheck:finding()].
+findings_store_get_origin(OwnerBin, ChangedClassBin) ->
+    try
+        beamtalk_workspace_findings_store:get_origin(OwnerBin, ChangedClassBin)
+    catch
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                "Reload-findings store unavailable (staleness check skipped)",
+                #{
+                    error_class => Class,
+                    reason => Reason,
+                    stack => Stack,
+                    owner => OwnerBin,
+                    changed_class => ChangedClassBin,
+                    domain => [
+                        beamtalk, runtime
+                    ]
+                }
+            ),
+            []
+    end.
+
+%% The marker substring `stale_note/2` looks for to avoid re-wrapping a note
+%% that is already marked — a candidate parked outside the cap for many
+%% consecutive reloads must not accumulate one "not re-checked" suffix per
+%% reload.
+-define(RECHECK_STALE_MARKER, <<"not re-checked against the latest reload">>).
+
+%% Overwrite `Finding`'s `note` to flag it as not re-verified this reload,
+%% unless it is already so marked (idempotent across consecutive
+%% cap-dropped reloads — see `?RECHECK_STALE_MARKER`).
+-spec mark_stale_finding(binary(), beamtalk_recheck:finding()) -> beamtalk_recheck:finding().
+mark_stale_finding(ClassNameBin, Finding = #{note := Note}) when is_binary(Note) ->
+    case binary:match(Note, ?RECHECK_STALE_MARKER) of
+        nomatch -> Finding#{note => stale_note(ClassNameBin, Note)};
+        _ -> Finding
+    end;
+mark_stale_finding(ClassNameBin, Finding) ->
+    Finding#{note => stale_note(ClassNameBin, undefined)}.
+
+-spec stale_note(binary(), binary() | undefined) -> binary().
+stale_note(ClassNameBin, undefined) ->
+    <<"not re-checked against the latest reload of ", ClassNameBin/binary,
+        " (caller-cap limit reached) — may be stale">>;
+stale_note(ClassNameBin, PrevNote) ->
+    <<PrevNote/binary, " — not re-checked against the latest reload of ", ClassNameBin/binary,
+        " (caller-cap limit reached) — may be stale">>.
 
 %% Log + broadcast the outcome of one `maybe_trigger_recheck/4` call — but
 %% only when a live surface has something to act on: either a dependent
@@ -2167,7 +2249,8 @@ publish_shape_recheck_outcome(ClassNameBin, FieldChanges, Result) ->
         findings := Findings,
         checked := Checked,
         not_checked := NotChecked,
-        cap_note := CapNote
+        cap_note := CapNote,
+        not_checked_owners := NotCheckedOwners
     } = Result,
     lists:foreach(
         fun(OwnerBin) ->
@@ -2176,6 +2259,10 @@ publish_shape_recheck_outcome(ClassNameBin, FieldChanges, Result) ->
         end,
         CheckedOwners
     ),
+    %% BT-2802: same caller-cap staleness marking as `maybe_run_recheck/4`
+    %% (see that function's doc) — a shape change's candidates go through the
+    %% same `apply_cap/2` limit.
+    mark_capped_out_findings_stale(ClassNameBin, NotCheckedOwners),
     case CheckedOwners of
         [] ->
             ok;

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_findings_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_findings_store.erl
@@ -44,6 +44,23 @@ now correctly scoped:
   second call's replacement is unconditional, so generation-A findings can
   never survive alongside generation-B ones for that origin.
 
+## Caller-cap staleness marking (ADR 0105, BT-2802)
+
+`beamtalk_recheck:apply_cap/2` keeps only the alphabetically-first N
+candidates per reload; a candidate the cap drops is never re-checked that
+reload, so `put_owner_origin/3` above is never called for it. Left alone,
+an origin bucket recorded while that owner *was* within the cap would
+silently keep asserting itself as current forever, even after whatever it
+flagged is fixed upstream — the cap is a re-check *capacity* limit, not a
+statement that the dropped candidates are fine. `get_origin/2` exists so
+`beamtalk_repl_loader:maybe_run_recheck/4` can check, for each cap-dropped
+candidate (`beamtalk_recheck:result()`'s `not_checked_owners`), whether this
+changed class already left a finding on it — and if so, overwrite that
+finding's `note` in place (still via `put_owner_origin/3`, same replace
+semantics) to say it was not re-verified this reload, rather than either
+deleting it (could hide a real, still-live problem) or leaving it looking
+freshly-verified.
+
 `clear_owner/1` is the *other*, deliberately un-scoped operation: it wipes
 **every** origin bucket for one caller class, fired whenever that caller's
 *own* source changes (`beamtalk_repl_loader:maybe_trigger_recheck/4` calls
@@ -125,7 +142,7 @@ edge case on an already-advisory-only feature.
 
 -include_lib("kernel/include/logger.hrl").
 
--export([start_link/0, put_owner_origin/3, clear_owner/1, for_owner/1, all/0, clear/0]).
+-export([start_link/0, put_owner_origin/3, clear_owner/1, get_origin/2, for_owner/1, all/0, clear/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
@@ -183,6 +200,20 @@ for_owner(OwnerBin) when is_binary(OwnerBin) ->
     gen_server:call(?MODULE, {for_owner, OwnerBin}).
 
 -doc """
+Read-only lookup of the single `{OwnerBin, ChangedClassBin}` origin bucket
+(BT-2802) — `[]` when nothing is stored for that exact pair. Unlike
+`for_owner/1`, this does not flatten across origins: a caller
+(`beamtalk_repl_loader:maybe_run_recheck/4`) needs to know whether *this
+specific* changed class already left a finding on `OwnerBin` before deciding
+whether there is anything to mark stale when `OwnerBin` gets dropped by the
+caller cap on a later reload of the same changed class. Does not mutate the
+store.
+""".
+-spec get_origin(binary(), binary()) -> [finding()].
+get_origin(OwnerBin, ChangedClassBin) when is_binary(OwnerBin), is_binary(ChangedClassBin) ->
+    gen_server:call(?MODULE, {get_origin, OwnerBin, ChangedClassBin}).
+
+-doc """
 Every currently-live finding across every caller class and origin,
 flattened. Sorted by `{owner, selector, message}` for a deterministic order
 — callers that render this list (REPL notice, workspace UI) should not
@@ -232,6 +263,11 @@ handle_call({for_owner, OwnerBin}, _From, State = #state{by_origin = ByOrigin}) 
         F
      || {{Owner, _ChangedClass}, F} <- maps:to_list(ByOrigin), Owner =:= OwnerBin
     ]),
+    {reply, Findings, State};
+handle_call(
+    {get_origin, OwnerBin, ChangedClassBin}, _From, State = #state{by_origin = ByOrigin}
+) ->
+    Findings = maps:get({OwnerBin, ChangedClassBin}, ByOrigin, []),
     {reply, Findings, State};
 handle_call(all, _From, State = #state{by_origin = ByOrigin}) ->
     All = lists:append(maps:values(ByOrigin)),

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
@@ -665,7 +665,8 @@ trigger_never_raises_on_unknown_selector_test_() ->
                             total_candidates => 0,
                             not_checked => 0,
                             cap_note => undefined,
-                            checked_owners => []
+                            checked_owners => [],
+                            not_checked_owners => []
                         },
                         Result
                     )
@@ -1115,7 +1116,8 @@ trigger_pending_no_ambient_meta_is_empty_result_test_() ->
                             total_candidates => 0,
                             not_checked => 0,
                             cap_note => undefined,
-                            checked_owners => []
+                            checked_owners => [],
+                            not_checked_owners => []
                         },
                         Result
                     )

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_precheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_precheck_tests.erl
@@ -255,7 +255,8 @@ precheck_no_op_signature_reports_empty_test_() ->
                             total_candidates => 0,
                             not_checked => 0,
                             cap_note => undefined,
-                            checked_owners => []
+                            checked_owners => [],
+                            not_checked_owners => []
                         },
                         Result
                     )

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_recheck_tests.erl
@@ -467,3 +467,197 @@ no_op_install_with_nothing_to_clear_announces_nothing_test_() ->
                 end)
             ]
         end}}.
+
+%%====================================================================
+%% Caller-cap staleness marking (ADR 0105, BT-2802)
+%%====================================================================
+
+%% Second dependent, alphabetically AFTER Dashboard — with `recheck_caller_cap`
+%% set to 1, `apply_cap/2`'s alphabetically-first-N rule always keeps
+%% Dashboard and drops ListView.
+listview_xref() ->
+    [
+        #{
+            class_side => false,
+            selector => 'render:',
+            line => 2,
+            sends => [#{selector => size, line => 2, recv_kind => other}],
+            references => [#{class => 'LoaderReCheckCounter', line => 2}],
+            source_status => indexed,
+            provenance => class_body
+        }
+    ].
+
+listview_source() ->
+    <<
+        "Object subclass: LoaderReCheckListView\n"
+        "  render: c :: LoaderReCheckCounter -> Integer => (c size) + 1\n"
+    >>.
+
+%% Installs both dependents of `size`, with the caller cap set to 1 so
+%% Dashboard (alphabetically first) is always kept and ListView is always
+%% dropped. Restores the previous cap in a `try/after`.
+with_capped_fixture(ReturnType, Fun) ->
+    PrevCap = application:get_env(beamtalk_workspace, recheck_caller_cap, 20),
+    application:set_env(beamtalk_workspace, recheck_caller_cap, 1),
+    try
+        install_fixture(ReturnType),
+        ok = beamtalk_xref:register_class('LoaderReCheckListView', listview_xref()),
+        ok = beamtalk_workspace_meta:set_class_source(
+            <<"LoaderReCheckListView">>, listview_source()
+        ),
+        Fun()
+    after
+        application:set_env(beamtalk_workspace, recheck_caller_cap, PrevCap)
+    end.
+
+%% BT-2802 core bug scenario: ListView was flagged by an earlier reload of
+%% Counter (when it was still inside the cap, or the cap was higher then).
+%% This reload's candidate set is capped to 1, so ListView is dropped —
+%% never re-checked. Without the fix, ListView's stale, generation-A
+%% finding would sit in the store unchanged forever, indistinguishable from
+%% a freshly-verified one. With the fix, `maybe_trigger_recheck/4` marks it
+%% in place (same message/severity/classification, `note` now says it was
+%% not re-verified this reload).
+capped_out_candidate_with_existing_finding_gets_marked_stale_test_() ->
+    {timeout, 30,
+        {setup, fun loader_recheck_setup/0, fun loader_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    with_capped_fixture('String', fun() ->
+                        %% Seed ListView's origin bucket as if an earlier
+                        %% reload of Counter had already checked it and
+                        %% found it stale.
+                        SeedFinding = #{
+                            owner => <<"LoaderReCheckListView">>,
+                            changed_class => <<"LoaderReCheckCounter">>,
+                            selector => <<"size">>,
+                            classification => signature_change,
+                            severity => <<"warning">>,
+                            category => <<"Dnu">>,
+                            message => <<"stale generation-A finding">>,
+                            note => undefined,
+                            sites => [#{method => <<"render:">>, line => 2}],
+                            start => 0,
+                            'end' => 5
+                        },
+                        _ = beamtalk_workspace_findings_store:put_owner_origin(
+                            <<"LoaderReCheckListView">>, <<"LoaderReCheckCounter">>, [SeedFinding]
+                        ),
+
+                        ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                            <<"LoaderReCheckCounter">>,
+                            <<"size">>,
+                            instance,
+                            {captured, undefined, signature_change}
+                        ),
+
+                        %% Dashboard (kept by the cap) got a real, fresh
+                        %% re-check.
+                        DashboardFindings = beamtalk_workspace_findings_store:for_owner(
+                            <<"LoaderReCheckDashboard">>
+                        ),
+                        ?assertEqual(1, length(DashboardFindings)),
+
+                        %% ListView (dropped by the cap) keeps its original
+                        %% finding's message/severity/classification —
+                        %% untouched, since nothing re-verified it — but its
+                        %% `note` is overwritten to flag it as not
+                        %% re-checked this reload.
+                        [ListViewFinding] = beamtalk_workspace_findings_store:get_origin(
+                            <<"LoaderReCheckListView">>, <<"LoaderReCheckCounter">>
+                        ),
+                        ?assertEqual(
+                            <<"stale generation-A finding">>, maps:get(message, ListViewFinding)
+                        ),
+                        ?assertEqual(<<"warning">>, maps:get(severity, ListViewFinding)),
+                        Note = maps:get(note, ListViewFinding),
+                        ?assert(is_binary(Note)),
+                        ?assert(
+                            binary:match(Note, <<"not re-checked against the latest reload">>) =/=
+                                nomatch
+                        )
+                    end)
+                end)
+            ]
+        end}}.
+
+%% A cap-dropped candidate with NO existing finding for this origin (the
+%% common case — most candidates never had a problem) is left alone: no
+%% spurious entry is created just because the cap excluded it.
+capped_out_candidate_with_no_existing_finding_stays_absent_test_() ->
+    {timeout, 30,
+        {setup, fun loader_recheck_setup/0, fun loader_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    with_capped_fixture('String', fun() ->
+                        ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                            <<"LoaderReCheckCounter">>,
+                            <<"size">>,
+                            instance,
+                            {captured, undefined, signature_change}
+                        ),
+                        ?assertEqual(
+                            [],
+                            beamtalk_workspace_findings_store:get_origin(
+                                <<"LoaderReCheckListView">>, <<"LoaderReCheckCounter">>
+                            )
+                        )
+                    end)
+                end)
+            ]
+        end}}.
+
+%% A stale note is not re-wrapped on every consecutive capped-out reload —
+%% otherwise a candidate parked outside the cap for many reloads in a row
+%% would accumulate one "not re-checked" suffix per reload.
+capped_out_stale_note_is_idempotent_across_reloads_test_() ->
+    {timeout, 30,
+        {setup, fun loader_recheck_setup/0, fun loader_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    with_capped_fixture('String', fun() ->
+                        SeedFinding = #{
+                            owner => <<"LoaderReCheckListView">>,
+                            changed_class => <<"LoaderReCheckCounter">>,
+                            selector => <<"size">>,
+                            classification => signature_change,
+                            severity => <<"warning">>,
+                            category => <<"Dnu">>,
+                            message => <<"stale generation-A finding">>,
+                            note => undefined,
+                            sites => [#{method => <<"render:">>, line => 2}],
+                            start => 0,
+                            'end' => 5
+                        },
+                        _ = beamtalk_workspace_findings_store:put_owner_origin(
+                            <<"LoaderReCheckListView">>, <<"LoaderReCheckCounter">>, [SeedFinding]
+                        ),
+
+                        %% Two consecutive reloads of Counter, both capping
+                        %% ListView out.
+                        ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                            <<"LoaderReCheckCounter">>,
+                            <<"size">>,
+                            instance,
+                            {captured, undefined, signature_change}
+                        ),
+                        [FirstMarked] = beamtalk_workspace_findings_store:get_origin(
+                            <<"LoaderReCheckListView">>, <<"LoaderReCheckCounter">>
+                        ),
+                        ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                            <<"LoaderReCheckCounter">>,
+                            <<"size">>,
+                            instance,
+                            {captured, 'String', signature_change}
+                        ),
+                        [SecondMarked] = beamtalk_workspace_findings_store:get_origin(
+                            <<"LoaderReCheckListView">>, <<"LoaderReCheckCounter">>
+                        ),
+                        ?assertEqual(
+                            maps:get(note, FirstMarked), maps:get(note, SecondMarked)
+                        )
+                    end)
+                end)
+            ]
+        end}}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_findings_store_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_findings_store_tests.erl
@@ -84,7 +84,9 @@ store_test_() ->
         fun for_owner_flattens_every_origin/1,
         fun all_flattens_every_owner_and_origin/1,
         fun all_is_sorted_deterministically/1,
-        fun clear_resets_every_owner/1
+        fun clear_resets_every_owner/1,
+        fun get_origin_returns_empty_for_unknown_pair/1,
+        fun get_origin_is_scoped_to_exact_owner_and_changed_class/1
     ]}.
 
 fresh_store_has_no_findings(_Pid) ->
@@ -247,4 +249,43 @@ clear_resets_every_owner(_Pid) ->
         ?_assertEqual([], beamtalk_workspace_findings_store:all()),
         ?_assertEqual([], beamtalk_workspace_findings_store:for_owner(<<"Dashboard">>)),
         ?_assertEqual([], beamtalk_workspace_findings_store:for_owner(<<"StatsView">>))
+    ].
+
+%% get_origin/2 (BT-2802) — the read side `mark_capped_out_findings_stale/2`
+%% (beamtalk_repl_loader) needs to check "does this exact origin already
+%% have a finding worth marking stale" without pulling in a different
+%% changed class's contribution the way for_owner/1 deliberately does.
+get_origin_returns_empty_for_unknown_pair(_Pid) ->
+    [
+        ?_assertEqual(
+            [], beamtalk_workspace_findings_store:get_origin(<<"Dashboard">>, <<"Counter">>)
+        )
+    ].
+
+get_origin_is_scoped_to_exact_owner_and_changed_class(_Pid) ->
+    CounterFinding = finding(<<"Dashboard">>, <<"Counter">>, <<"getCount">>, <<"counter msg">>),
+    WidgetFinding = finding(<<"Dashboard">>, <<"Widget">>, <<"size">>, <<"widget msg">>),
+    OtherOwnerFinding = finding(<<"StatsView">>, <<"Counter">>, <<"getCount">>, <<"stats msg">>),
+    _ = beamtalk_workspace_findings_store:put_owner_origin(<<"Dashboard">>, <<"Counter">>, [
+        CounterFinding
+    ]),
+    _ = beamtalk_workspace_findings_store:put_owner_origin(<<"Dashboard">>, <<"Widget">>, [
+        WidgetFinding
+    ]),
+    _ = beamtalk_workspace_findings_store:put_owner_origin(<<"StatsView">>, <<"Counter">>, [
+        OtherOwnerFinding
+    ]),
+    [
+        ?_assertEqual(
+            [CounterFinding],
+            beamtalk_workspace_findings_store:get_origin(<<"Dashboard">>, <<"Counter">>)
+        ),
+        ?_assertEqual(
+            [WidgetFinding],
+            beamtalk_workspace_findings_store:get_origin(<<"Dashboard">>, <<"Widget">>)
+        ),
+        ?_assertEqual(
+            [],
+            beamtalk_workspace_findings_store:get_origin(<<"StatsView">>, <<"Widget">>)
+        )
     ].


### PR DESCRIPTION
## Summary

`beamtalk_recheck:apply_cap/2` keeps only the alphabetically-first N candidate callers per reload. A candidate the cap drops is never re-checked that reload, so a finding recorded for it in an earlier reload (when it was still inside the cap) was never revisited — it could assert itself as current forever, even after the real problem was fixed upstream, once BT-2779 made findings persistent.

- Expose the cap-dropped candidates as `beamtalk_recheck:result()`'s new `not_checked_owners` field.
- `beamtalk_repl_loader:maybe_run_recheck/4` / `publish_shape_recheck_outcome/3` overwrite any existing finding's `note` for those owners to flag it as not re-verified this reload, via the findings store's new scoped `get_origin/2` read plus the existing `put_owner_origin/3` write.
- Reuses the `note` field every surface (LSP/REPL/workspace UI) already renders, so no surface-specific wiring is needed, and never silently drops or falsely reasserts a finding — it only qualifies it.
- Idempotent across consecutive capped-out reloads via a marker-substring check, so the note doesn't accumulate suffixes.

Filed BT-2828 as a follow-up for a related-but-distinct gap found during review: owners that stay inside the cap but whose individual re-check is skipped (no live source) or fails (compiler-port error) land in neither `checked_owners` nor `not_checked_owners`, so their findings aren't marked either.

## Test plan

- [x] Full pre-push CI hook passed locally: clippy, cargo fmt, dialyzer, cargo build/test, stdlib build + spec validation, Erlang/JS/Beamtalk/Elixir formatting checks all green.
- [x] New/updated unit tests: `beamtalk_recheck_tests.erl`, `beamtalk_repl_loader_precheck_tests.erl`, `beamtalk_repl_loader_recheck_tests.erl`, `beamtalk_workspace_findings_store_tests.erl`.


---
_Generated by [Claude Code](https://claude.ai/code/session_014qKdvh9EENW9eTNpRhfF9L)_