### PR TITLE
Consolidate the three superclass-chain walk implementations (BT-2786)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -746,36 +746,30 @@ without a matching methods entry is not reachable from normal dispatch.
 
 Safe to call from within a gen_server `handle_call` because we only walk
 UP the hierarchy (no circular dependency possible).
+
+BT-2786: The walk itself (depth guard, cycle warning, advance-to-superclass)
+is `beamtalk_hierarchy:walk_ancestors/3`; this function supplies only the
+per-ancestor ETS probe.
 """.
 -spec find_class_method_in_chain(selector(), class_name()) ->
     {ok, class_name(), atom()} | not_found.
 find_class_method_in_chain(Selector, ClassName) ->
     SuperclassName = superclass_from_ets(ClassName),
-    find_class_method_in_ancestors(Selector, SuperclassName, 0).
-
--spec find_class_method_in_ancestors(selector(), class_name() | none, non_neg_integer()) ->
-    {ok, class_name(), atom()} | not_found.
-find_class_method_in_ancestors(_Selector, none, _Depth) ->
-    not_found;
-find_class_method_in_ancestors(_Selector, AncestorName, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    ?LOG_WARNING(
-        "find_class_method_in_ancestors: max hierarchy depth ~p exceeded at ~p — possible cycle",
-        [?MAX_HIERARCHY_DEPTH, AncestorName],
-        #{domain => [beamtalk, runtime]}
-    ),
-    not_found;
-find_class_method_in_ancestors(Selector, AncestorName, Depth) ->
-    case beamtalk_class_metadata:lookup_methods(AncestorName) of
-        {ok, AncestorModule, Selectors} ->
-            case lists:member(Selector, Selectors) of
-                true ->
-                    {ok, AncestorName, AncestorModule};
-                false ->
-                    Next = superclass_from_ets(AncestorName),
-                    find_class_method_in_ancestors(Selector, Next, Depth + 1)
-            end;
-        not_found ->
-            not_found
+    StepFun = fun(AncestorName, _Depth) ->
+        case beamtalk_class_metadata:lookup_methods(AncestorName) of
+            {ok, AncestorModule, Selectors} ->
+                case lists:member(Selector, Selectors) of
+                    true -> {found, {AncestorName, AncestorModule}};
+                    false -> {next, superclass_from_ets(AncestorName)}
+                end;
+            not_found ->
+                not_found
+        end
+    end,
+    case beamtalk_hierarchy:walk_ancestors(SuperclassName, StepFun, ?MAX_HIERARCHY_DEPTH) of
+        {found, {AncestorName, AncestorModule}} -> {ok, AncestorName, AncestorModule};
+        not_found -> not_found;
+        max_depth_exceeded -> not_found
     end.
 
 -doc "Read the superclass name from the hierarchy table (no gen_server call).".

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
@@ -247,30 +247,29 @@ the per-class `has_method/2` + `superclass/1` probe and method invocation.
 -spec lookup_in_class_chain(selector(), args(), bt_self(), state(), class_name()) ->
     dispatch_result().
 lookup_in_class_chain(Selector, Args, Self, State, ClassName) ->
-    case beamtalk_class_registry:whereis_class(ClassName) of
-        undefined ->
-            {error, beamtalk_error:new(class_not_found, ClassName, Selector)};
-        _ClassPid ->
-            StepFun = fun(CurrentClass, Depth) ->
-                class_chain_step(Selector, Args, Self, State, CurrentClass, Depth)
-            end,
-            case beamtalk_hierarchy:walk_ancestors(ClassName, StepFun, ?MAX_HIERARCHY_DEPTH) of
-                {found, Result} ->
-                    Result;
-                max_depth_exceeded ->
-                    {error,
-                        beamtalk_error:new(
-                            does_not_understand,
-                            ClassName,
-                            Selector,
-                            <<"Hierarchy depth limit exceeded — possible cycle in class hierarchy">>
-                        )};
-                not_found ->
-                    %% Unreachable: class_chain_step/6 always resolves to
-                    %% {found, _} or {next, _}, never a bare not_found. Kept
-                    %% for exhaustiveness against the generic walker's contract.
-                    {error, beamtalk_error:new(does_not_understand, ClassName, Selector)}
-            end
+    %% No separate whereis_class/1 pre-check here: class_chain_step/6 performs
+    %% that lookup for every node it visits (including ClassName itself, at
+    %% depth 0) and already produces the identical class_not_found error, so
+    %% a pre-check would just be a redundant registry lookup on the hot path.
+    StepFun = fun(CurrentClass, Depth) ->
+        class_chain_step(Selector, Args, Self, State, CurrentClass, Depth)
+    end,
+    case beamtalk_hierarchy:walk_ancestors(ClassName, StepFun, ?MAX_HIERARCHY_DEPTH) of
+        {found, Result} ->
+            Result;
+        max_depth_exceeded ->
+            {error,
+                beamtalk_error:new(
+                    does_not_understand,
+                    ClassName,
+                    Selector,
+                    <<"Hierarchy depth limit exceeded — possible cycle in class hierarchy">>
+                )};
+        not_found ->
+            %% Unreachable: class_chain_step/6 always resolves to
+            %% {found, _} or {next, _}, never a bare not_found. Kept
+            %% for exhaustiveness against the generic walker's contract.
+            {error, beamtalk_error:new(does_not_understand, ClassName, Selector)}
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
@@ -239,6 +239,10 @@ chain walk via has_method/2 + superclass/1. At max hierarchy depth of 6
 (typical 4), this means at most ~12 gen_server calls — microseconds on a
 local node. The flattened table cache was removed to eliminate BT-510's
 race window and O(N) rebuild broadcast cascade.
+
+BT-2786: The walk itself (depth guard, cycle warning, advance-to-superclass)
+is `beamtalk_hierarchy:walk_ancestors/3`; `class_chain_step/6` supplies only
+the per-class `has_method/2` + `superclass/1` probe and method invocation.
 """.
 -spec lookup_in_class_chain(selector(), args(), bt_self(), state(), class_name()) ->
     dispatch_result().
@@ -246,77 +250,97 @@ lookup_in_class_chain(Selector, Args, Self, State, ClassName) ->
     case beamtalk_class_registry:whereis_class(ClassName) of
         undefined ->
             {error, beamtalk_error:new(class_not_found, ClassName, Selector)};
-        ClassPid ->
-            lookup_in_class_chain_slow(Selector, Args, Self, State, ClassName, ClassPid, 0)
+        _ClassPid ->
+            StepFun = fun(CurrentClass, Depth) ->
+                class_chain_step(Selector, Args, Self, State, CurrentClass, Depth)
+            end,
+            case beamtalk_hierarchy:walk_ancestors(ClassName, StepFun, ?MAX_HIERARCHY_DEPTH) of
+                {found, Result} ->
+                    Result;
+                max_depth_exceeded ->
+                    {error,
+                        beamtalk_error:new(
+                            does_not_understand,
+                            ClassName,
+                            Selector,
+                            <<"Hierarchy depth limit exceeded — possible cycle in class hierarchy">>
+                        )};
+                not_found ->
+                    %% Unreachable: class_chain_step/6 always resolves to
+                    %% {found, _} or {next, _}, never a bare not_found. Kept
+                    %% for exhaustiveness against the generic walker's contract.
+                    {error, beamtalk_error:new(does_not_understand, ClassName, Selector)}
+            end
     end.
 
 -doc """
-Slow path: recursive hierarchy walk (O(depth)).
-
-Used when flattened table is missing, stale, or incomplete.
-This is the original ADR 0006 Phase 1 implementation.
+Per-node probe for the `beamtalk_hierarchy:walk_ancestors/3` walk: check
+whether `ClassName` has `Selector` locally and, if so, invoke it; otherwise
+advance to its superclass. Always resolves to `{found, dispatch_result()}` —
+this module never lets the generic walker's bare `not_found` escape, since
+every "not found here" branch already knows how to build a structured
+`#beamtalk_error{}`.
 """.
--spec lookup_in_class_chain_slow(
-    selector(), args(), bt_self(), state(), class_name(), pid(), non_neg_integer()
-) -> dispatch_result().
-lookup_in_class_chain_slow(Selector, _Args, _Self, _State, ClassName, _ClassPid, Depth) when
-    Depth > ?MAX_HIERARCHY_DEPTH
-->
-    ?LOG_WARNING("Max hierarchy depth exceeded — possible cycle", #{
-        max_depth => ?MAX_HIERARCHY_DEPTH,
-        class => ClassName,
-        selector => Selector,
-        domain => [beamtalk, runtime]
-    }),
-    {error,
-        beamtalk_error:new(
-            does_not_understand,
-            ClassName,
-            Selector,
-            <<"Hierarchy depth limit exceeded — possible cycle in class hierarchy">>
-        )};
-lookup_in_class_chain_slow(Selector, Args, Self, State, ClassName, ClassPid, Depth) ->
-    %% Check if this class has the method
-    case beamtalk_object_class:has_method(ClassPid, Selector) of
-        true ->
-            %% Found the method - invoke it
-            invoke_method(ClassName, ClassPid, Selector, Args, Self, State, Depth);
-        false ->
-            %% Not found in this class - try superclass
-            case beamtalk_object_class:superclass(ClassPid) of
-                none ->
-                    %% Reached root without finding method
-                    ?LOG_DEBUG("Method not found in hierarchy", #{
-                        selector => Selector,
-                        root => ClassName,
-                        domain => [beamtalk, runtime]
-                    }),
-                    %% BT-753: Derive class from Self when State is empty (class objects).
-                    ErrorClass = class_name_from(Self, State, ClassName),
-                    Error = beamtalk_error:new(
-                        does_not_understand,
-                        ErrorClass,
-                        Selector,
-                        <<"Check spelling or use 'respondsTo:' to verify method exists">>
-                    ),
-                    {error, Error};
-                SuperclassName ->
-                    %% Recurse to superclass
-                    case beamtalk_class_registry:whereis_class(SuperclassName) of
-                        undefined ->
-                            {error, beamtalk_error:new(class_not_found, SuperclassName, Selector)};
-                        SuperclassPid ->
-                            lookup_in_class_chain_slow(
+-spec class_chain_step(selector(), args(), bt_self(), state(), class_name(), non_neg_integer()) ->
+    beamtalk_hierarchy:step_result(dispatch_result()).
+class_chain_step(Selector, Args, Self, State, ClassName, _Depth) ->
+    case beamtalk_class_registry:whereis_class(ClassName) of
+        undefined ->
+            {found, {error, beamtalk_error:new(class_not_found, ClassName, Selector)}};
+        ClassPid ->
+            case beamtalk_object_class:has_method(ClassPid, Selector) of
+                true ->
+                    %% Found the method - invoke it
+                    invoke_step(ClassName, ClassPid, Selector, Args, Self, State);
+                false ->
+                    %% Not found in this class - try superclass
+                    case beamtalk_object_class:superclass(ClassPid) of
+                        none ->
+                            %% Reached root without finding method
+                            ?LOG_DEBUG("Method not found in hierarchy", #{
+                                selector => Selector,
+                                root => ClassName,
+                                domain => [beamtalk, runtime]
+                            }),
+                            %% BT-753: Derive class from Self when State is empty (class objects).
+                            ErrorClass = class_name_from(Self, State, ClassName),
+                            Error = beamtalk_error:new(
+                                does_not_understand,
+                                ErrorClass,
                                 Selector,
-                                Args,
-                                Self,
-                                State,
-                                SuperclassName,
-                                SuperclassPid,
-                                Depth + 1
-                            )
+                                <<"Check spelling or use 'respondsTo:' to verify method exists">>
+                            ),
+                            {found, {error, Error}};
+                        SuperclassName ->
+                            {next, SuperclassName}
                     end
             end
+    end.
+
+-doc """
+Invoke a method found in the hierarchy, adapting `invoke_method/6`'s
+`{continue, SuperclassName}` escape hatch (module-less / dispatch-less
+classes, BT-427) to the walker's step protocol.
+""".
+-spec invoke_step(class_name(), pid(), selector(), args(), bt_self(), state()) ->
+    beamtalk_hierarchy:step_result(dispatch_result()).
+invoke_step(ClassName, ClassPid, Selector, Args, Self, State) ->
+    case invoke_method(ClassName, ClassPid, Selector, Args, Self, State) of
+        {continue, none} ->
+            %% Reached root without finding a dispatchable method (BT-427).
+            %% BT-753: Derive class from Self when State is empty (class objects).
+            ErrorClass = class_name_from(Self, State, unknown),
+            Error = beamtalk_error:new(
+                does_not_understand,
+                ErrorClass,
+                Selector,
+                <<"Check spelling or use 'respondsTo:' to verify method exists">>
+            ),
+            {found, {error, Error}};
+        {continue, SuperclassName} ->
+            {next, SuperclassName};
+        Result ->
+            {found, Result}
     end.
 
 -doc """
@@ -328,16 +352,18 @@ This function handles invocation for both compiled and dynamic classes:
 
 The class process knows the module name, so we can determine which strategy to use.
 ClassPid is passed from the caller to avoid a redundant whereis_class lookup.
-Depth is threaded through for cycle detection in continue_to_superclass.
+Returns `{continue, SuperclassName | none}` when this class has no
+dispatchable module (BT-427) — the caller (`invoke_step/6`) advances the
+walk or raises `does_not_understand` accordingly.
 """.
--spec invoke_method(class_name(), pid(), selector(), args(), bt_self(), state(), non_neg_integer()) ->
-    dispatch_result().
-invoke_method(MethodOwner, ClassPid, Selector, Args, Self, State, Depth) ->
+-spec invoke_method(class_name(), pid(), selector(), args(), bt_self(), state()) ->
+    dispatch_result() | {continue, class_name() | none}.
+invoke_method(MethodOwner, ClassPid, Selector, Args, Self, State) ->
     %% Get the module name for this class
     case beamtalk_object_class:module_name(ClassPid) of
         undefined ->
             %% Dynamic class or no module — continue to superclass (BT-427)
-            continue_to_superclass(Selector, Args, Self, State, ClassPid, Depth);
+            {continue, beamtalk_object_class:superclass(ClassPid)};
         ModuleName ->
             %% Ensure the module is loaded before checking exports.
             %% BEAM lazy-loads modules, and function_exported/3 only checks
@@ -349,7 +375,7 @@ invoke_method(MethodOwner, ClassPid, Selector, Args, Self, State, Depth) ->
             case erlang:function_exported(ModuleName, dispatch, 4) of
                 false ->
                     %% Module exists but lacks dispatch/4 — continue to superclass (BT-427)
-                    continue_to_superclass(Selector, Args, Self, State, ClassPid, Depth);
+                    {continue, beamtalk_object_class:superclass(ClassPid)};
                 true ->
                     %% Intercept printString/displayString/inspect for actor
                     %% instances and route them to beamtalk_object_ops — but only
@@ -449,36 +475,6 @@ invoke_method(MethodOwner, ClassPid, Selector, Args, Self, State, Depth) ->
 -spec dispatch_context(selector(), bt_self(), state(), class_name()) -> map().
 dispatch_context(Selector, Self, State, MethodOwner) ->
     #{selector => Selector, class => class_name_from(Self, State, MethodOwner)}.
-
--doc """
-Continue hierarchy walk to superclass when current class can't dispatch.
-Used when a class has no module or its module lacks dispatch/4 (abstract classes).
-""".
--spec continue_to_superclass(selector(), args(), bt_self(), state(), pid(), non_neg_integer()) ->
-    dispatch_result().
-continue_to_superclass(Selector, Args, Self, State, ClassPid, Depth) ->
-    case beamtalk_object_class:superclass(ClassPid) of
-        none ->
-            %% Reached root without finding dispatchable method
-            %% BT-753: Derive class from Self when State is empty (class objects).
-            ClassName = class_name_from(Self, State, unknown),
-            Error = beamtalk_error:new(
-                does_not_understand,
-                ClassName,
-                Selector,
-                <<"Check spelling or use 'respondsTo:' to verify method exists">>
-            ),
-            {error, Error};
-        SuperclassName ->
-            case beamtalk_class_registry:whereis_class(SuperclassName) of
-                undefined ->
-                    {error, beamtalk_error:new(class_not_found, SuperclassName, Selector)};
-                SuperclassPid ->
-                    lookup_in_class_chain_slow(
-                        Selector, Args, Self, State, SuperclassName, SuperclassPid, Depth + 1
-                    )
-            end
-    end.
 
 -doc """
 Invoke an extension method.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy.erl
@@ -1,0 +1,86 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_hierarchy).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+Generic depth-guarded ancestor-chain walker (BT-2786).
+
+Before this module existed, `beamtalk_dispatch`, `beamtalk_method_resolver`,
+and `beamtalk_class_dispatch` each hand-rolled their own "walk up the
+superclass chain, bail out past `?MAX_HIERARCHY_DEPTH`" recursion — identical
+in shape, differing only in what they probed at each level (a `has_method/2`
++ `superclass/1` gen_server round-trip, a `{method, Selector}` gen_server
+call, or an ETS metadata read) and in the node type they walked over (a class
+name atom or a class process pid).
+
+`walk_ancestors/3` factors out the shared shape: start at a node, ask a
+caller-supplied `StepFun` what to do at that node, and either stop (found /
+not found) or advance to the next node — with the depth guard and cycle
+warning handled once, here.
+
+## Design
+
+The walk is intentionally untyped in the node it walks over: callers may
+walk class-name atoms (`beamtalk_class_dispatch`, `beamtalk_dispatch`) or
+class-process pids (`beamtalk_method_resolver`) — `walk_ancestors/3` only
+ever inspects a node for the sentinel `none`, which terminates the walk
+early (mirrors "no superclass").
+
+`StepFun` is invoked once per node and must return one of:
+
+- `{found, Result}` — stop, propagate `Result` to the caller.
+- `{next, NextNode}` — advance to `NextNode` (may itself be `none`).
+- `not_found` — stop, nothing found anywhere in the chain.
+
+Callers that need caller-specific behaviour at the max-depth boundary (e.g.
+a structured `#beamtalk_error{}` naming the class that triggered it) inspect
+the `max_depth_exceeded` return and build their own error; this module only
+owns the generic cycle-guard log line.
+""".
+
+-export([walk_ancestors/3]).
+
+-include_lib("kernel/include/logger.hrl").
+
+-type node_id() :: term().
+-type step_result(Result) :: {found, Result} | {next, node_id() | none} | not_found.
+-type step_fun(Result) :: fun((node_id(), non_neg_integer()) -> step_result(Result)).
+-type walk_result(Result) :: {found, Result} | not_found | max_depth_exceeded.
+
+-export_type([step_fun/1, walk_result/1]).
+
+-doc """
+Walk an ancestor chain starting at `StartNode`, applying `StepFun` at each
+node until it reports `{found, Result}` or `not_found`, or the walk exceeds
+`MaxDepth` levels.
+
+`StartNode` may be `none` (an empty chain — e.g. a class with no
+superclass), in which case the walk terminates immediately with `not_found`
+and `StepFun` is never invoked.
+""".
+-spec walk_ancestors(node_id() | none, step_fun(Result), non_neg_integer()) ->
+    walk_result(Result).
+walk_ancestors(StartNode, StepFun, MaxDepth) ->
+    walk_ancestors(StartNode, StepFun, MaxDepth, 0).
+
+-spec walk_ancestors(node_id() | none, step_fun(Result), non_neg_integer(), non_neg_integer()) ->
+    walk_result(Result).
+walk_ancestors(none, _StepFun, _MaxDepth, _Depth) ->
+    not_found;
+walk_ancestors(Node, _StepFun, MaxDepth, Depth) when Depth > MaxDepth ->
+    ?LOG_WARNING("walk_ancestors: max hierarchy depth ~p exceeded at ~p — possible cycle", [
+        MaxDepth, Node
+    ], #{domain => [beamtalk, runtime]}),
+    max_depth_exceeded;
+walk_ancestors(Node, StepFun, MaxDepth, Depth) ->
+    case StepFun(Node, Depth) of
+        {found, Result} ->
+            {found, Result};
+        {next, NextNode} ->
+            walk_ancestors(NextNode, StepFun, MaxDepth, Depth + 1);
+        not_found ->
+            not_found
+    end.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy.erl
@@ -50,7 +50,7 @@ owns the generic cycle-guard log line.
 -type step_fun(Result) :: fun((node_id(), non_neg_integer()) -> step_result(Result)).
 -type walk_result(Result) :: {found, Result} | not_found | max_depth_exceeded.
 
--export_type([step_fun/1, walk_result/1]).
+-export_type([step_result/1, step_fun/1, walk_result/1]).
 
 -doc """
 Walk an ancestor chain starting at `StartNode`, applying `StepFun` at each
@@ -71,9 +71,13 @@ walk_ancestors(StartNode, StepFun, MaxDepth) ->
 walk_ancestors(none, _StepFun, _MaxDepth, _Depth) ->
     not_found;
 walk_ancestors(Node, _StepFun, MaxDepth, Depth) when Depth > MaxDepth ->
-    ?LOG_WARNING("walk_ancestors: max hierarchy depth ~p exceeded at ~p — possible cycle", [
-        MaxDepth, Node
-    ], #{domain => [beamtalk, runtime]}),
+    ?LOG_WARNING(
+        "walk_ancestors: max hierarchy depth ~p exceeded at ~p — possible cycle",
+        [
+            MaxDepth, Node
+        ],
+        #{domain => [beamtalk, runtime]}
+    ),
     max_depth_exceeded;
 walk_ancestors(Node, StepFun, MaxDepth, Depth) ->
     case StepFun(Node, Depth) of

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl
@@ -92,14 +92,29 @@ Resolve a method, walking the superclass chain if not found locally.
 BT-2786: The walk itself (depth guard, cycle warning, advance-to-superclass)
 is `beamtalk_hierarchy:walk_ancestors/3`; this function supplies only the
 per-class `{method, Selector}` gen_server probe.
+
+`ClassPid`'s own method table is checked here, outside the depth-counted
+walk — matching the pre-BT-2786 behaviour where the receiver's own class was
+"free" and the `?MAX_HIERARCHY_DEPTH` budget applied only to the superclass
+chain above it (the same split `beamtalk_class_dispatch:find_class_method_in_chain/2`
+uses). The walk itself starts at the immediate superclass.
 """.
 -spec resolve_with_hierarchy(pid(), selector()) -> compiled_method() | 'nil'.
 resolve_with_hierarchy(ClassPid, Selector) ->
-    StepFun = fun(Pid, _Depth) -> method_step(Pid, Selector) end,
-    case beamtalk_hierarchy:walk_ancestors(ClassPid, StepFun, ?MAX_HIERARCHY_DEPTH) of
-        {found, Method} -> Method;
-        not_found -> nil;
-        max_depth_exceeded -> nil
+    case gen_server:call(ClassPid, {method, Selector}) of
+        nil ->
+            StepFun = fun(Pid, _Depth) -> method_step(Pid, Selector) end,
+            case
+                beamtalk_hierarchy:walk_ancestors(
+                    superclass_pid(ClassPid), StepFun, ?MAX_HIERARCHY_DEPTH
+                )
+            of
+                {found, Method} -> Method;
+                not_found -> nil;
+                max_depth_exceeded -> nil
+            end;
+        Method ->
+            Method
     end.
 
 -doc """
@@ -124,15 +139,26 @@ superclass's pid as the next node.
 method_step(ClassPid, Selector) ->
     case gen_server:call(ClassPid, {method, Selector}) of
         nil ->
-            case beamtalk_object_class:superclass(ClassPid) of
-                none ->
-                    not_found;
-                SuperName ->
-                    case beamtalk_class_registry:whereis_class(SuperName) of
-                        undefined -> not_found;
-                        SuperPid -> {next, SuperPid}
-                    end
+            case superclass_pid(ClassPid) of
+                none -> not_found;
+                SuperPid -> {next, SuperPid}
             end;
         Method ->
             {found, Method}
+    end.
+
+-doc """
+Resolve `ClassPid`'s immediate superclass to its process pid, or `none` if
+there is no superclass or its process is not registered.
+""".
+-spec superclass_pid(pid()) -> pid() | none.
+superclass_pid(ClassPid) ->
+    case beamtalk_object_class:superclass(ClassPid) of
+        none ->
+            none;
+        SuperName ->
+            case beamtalk_class_registry:whereis_class(SuperName) of
+                undefined -> none;
+                SuperPid -> SuperPid
+            end
     end.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl
@@ -21,7 +21,6 @@ See also: beamtalk_compiled_method_ops for CompiledMethod field access
 """.
 
 -include("beamtalk.hrl").
--include_lib("kernel/include/logger.hrl").
 
 -export([resolve/2]).
 
@@ -87,14 +86,20 @@ resolve(Other, _Selector) ->
     ),
     beamtalk_error:raise(Error2).
 
--doc "Resolve a method, walking the superclass chain if not found locally.".
+-doc """
+Resolve a method, walking the superclass chain if not found locally.
+
+BT-2786: The walk itself (depth guard, cycle warning, advance-to-superclass)
+is `beamtalk_hierarchy:walk_ancestors/3`; this function supplies only the
+per-class `{method, Selector}` gen_server probe.
+""".
 -spec resolve_with_hierarchy(pid(), selector()) -> compiled_method() | 'nil'.
 resolve_with_hierarchy(ClassPid, Selector) ->
-    case gen_server:call(ClassPid, {method, Selector}) of
-        nil ->
-            walk_superclass_chain(ClassPid, Selector, 0);
-        Method ->
-            Method
+    StepFun = fun(Pid, _Depth) -> method_step(Pid, Selector) end,
+    case beamtalk_hierarchy:walk_ancestors(ClassPid, StepFun, ?MAX_HIERARCHY_DEPTH) of
+        {found, Method} -> Method;
+        not_found -> nil;
+        max_depth_exceeded -> nil
     end.
 
 -doc """
@@ -111,33 +116,23 @@ resolve_class_side(ClassPid, Selector) ->
     gen_server:call(ClassPid, {class_method, Selector}).
 
 -doc """
-Walk the superclass chain to find an inherited method.
-
-Gets the superclass name from the current class, looks up its pid,
-and checks for the method. Recurses until the method is found or
-the chain is exhausted (superclass = none). Guarded by
-MAX_HIERARCHY_DEPTH to prevent infinite recursion on corrupted hierarchies.
+Per-node probe for the `beamtalk_hierarchy:walk_ancestors/3` walk: check
+`ClassPid`'s own method table for `Selector`, and if absent, resolve its
+superclass's pid as the next node.
 """.
--spec walk_superclass_chain(pid(), selector(), non_neg_integer()) -> compiled_method() | 'nil'.
-walk_superclass_chain(_ClassPid, _Selector, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    ?LOG_WARNING(">> hierarchy walk exceeded ~p levels", [?MAX_HIERARCHY_DEPTH], #{
-        domain => [beamtalk, runtime]
-    }),
-    nil;
-walk_superclass_chain(ClassPid, Selector, Depth) ->
-    case beamtalk_object_class:superclass(ClassPid) of
-        none ->
-            nil;
-        SuperName ->
-            case beamtalk_class_registry:whereis_class(SuperName) of
-                undefined ->
-                    nil;
-                SuperPid ->
-                    case gen_server:call(SuperPid, {method, Selector}) of
-                        nil ->
-                            walk_superclass_chain(SuperPid, Selector, Depth + 1);
-                        Method ->
-                            Method
+-spec method_step(pid(), selector()) -> beamtalk_hierarchy:step_result(compiled_method()).
+method_step(ClassPid, Selector) ->
+    case gen_server:call(ClassPid, {method, Selector}) of
+        nil ->
+            case beamtalk_object_class:superclass(ClassPid) of
+                none ->
+                    not_found;
+                SuperName ->
+                    case beamtalk_class_registry:whereis_class(SuperName) of
+                        undefined -> not_found;
+                        SuperPid -> {next, SuperPid}
                     end
-            end
+            end;
+        Method ->
+            {found, Method}
     end.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_method_resolver_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_method_resolver_tests.erl
@@ -44,7 +44,11 @@ resolver_test_() ->
             {"resolve with metaclass receiver looks up class-side methods",
                 fun test_resolve_with_metaclass/0},
             {"resolve with metaclass receiver returns nil for missing class method",
-                fun test_resolve_with_metaclass_missing/0}
+                fun test_resolve_with_metaclass_missing/0},
+            {"resolve finds an inherited method at the MAX_HIERARCHY_DEPTH boundary",
+                fun test_resolve_at_depth_boundary_found/0},
+            {"resolve returns nil for a method one level beyond MAX_HIERARCHY_DEPTH",
+                fun test_resolve_beyond_depth_boundary_returns_nil/0}
         ]
     end}.
 
@@ -130,3 +134,73 @@ test_resolve_with_metaclass_missing() ->
         MetaObj, 'classSideSelectorThatDoesNotExistXyzzy'
     ),
     ?assertEqual(nil, Result).
+
+%%====================================================================
+%% BT-2786: MAX_HIERARCHY_DEPTH boundary tests
+%%
+%% resolve_with_hierarchy/2 checks the receiver's own class "for free"
+%% (outside the depth-counted walk), then walks up to ?MAX_HIERARCHY_DEPTH
+%% superclasses above it — mirroring beamtalk_class_dispatch's split. These
+%% tests pin that boundary: a chain of 22 classes (base + 21 superclasses)
+%% has an inherited method reachable at the 21st superclass; a 23-class
+%% chain's 22nd superclass is one level beyond the budget and must resolve
+%% to nil instead of silently truncating the walk.
+%%====================================================================
+
+%% Starts a chain of NumClasses classes (class 1 is the base/leaf, class N
+%% has superclass `none`) and installs a trivial compiled method named
+%% `Selector` only on the last class in the chain. Returns {BaseClassName, Pids}.
+start_superclass_chain(NumClasses, Selector) ->
+    % elp:fixme W0023 intentional atom creation
+    ClassNames = [
+        list_to_atom("ResolverDepthTestClass" ++ integer_to_list(I))
+     || I <- lists:seq(1, NumClasses)
+    ],
+    Pids = lists:foldl(
+        fun(I, AccPids) ->
+            ClassName = lists:nth(I, ClassNames),
+            Super =
+                if
+                    I =:= NumClasses -> none;
+                    true -> lists:nth(I + 1, ClassNames)
+                end,
+            InstanceMethods =
+                case I of
+                    NumClasses ->
+                        #{Selector => #{arity => 0, block => fun() -> ok end}};
+                    _ ->
+                        #{}
+                end,
+            {ok, Pid} = beamtalk_object_class:start_link(ClassName, #{
+                superclass => Super,
+                instance_methods => InstanceMethods,
+                instance_variables => []
+            }),
+            AccPids ++ [Pid]
+        end,
+        [],
+        lists:seq(1, NumClasses)
+    ),
+    {hd(ClassNames), Pids}.
+
+test_resolve_at_depth_boundary_found() ->
+    Selector = resolverDepthBoundaryMethod,
+    {BaseClassName, Pids} = start_superclass_chain(22, Selector),
+    try
+        BasePid = beamtalk_class_registry:whereis_class(BaseClassName),
+        Result = beamtalk_method_resolver:resolve(BasePid, Selector),
+        ?assertMatch(#{'__selector__' := Selector}, Result)
+    after
+        lists:foreach(fun gen_server:stop/1, Pids)
+    end.
+
+test_resolve_beyond_depth_boundary_returns_nil() ->
+    Selector = resolverBeyondDepthMethod,
+    {BaseClassName, Pids} = start_superclass_chain(23, Selector),
+    try
+        BasePid = beamtalk_class_registry:whereis_class(BaseClassName),
+        Result = beamtalk_method_resolver:resolve(BasePid, Selector),
+        ?assertEqual(nil, Result)
+    after
+        lists:foreach(fun gen_server:stop/1, Pids)
+    end.


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2786

`beamtalk_dispatch.erl`, `beamtalk_method_resolver.erl`, and `beamtalk_class_dispatch.erl` each hand-rolled an identical depth-guarded "walk up the superclass chain" recursion, differing only in what they probed at each level (a `has_method/2` + `superclass/1` gen_server round-trip, a `{method, Selector}` gen_server call, or an ETS metadata read).

- Added `beamtalk_hierarchy:walk_ancestors/3` — a generic depth-guarded ancestor-chain walker parameterised by a per-level `StepFun` that returns `{found, Result} | {next, NextNode} | not_found`. Owns the `?MAX_HIERARCHY_DEPTH` guard and cycle-warning log in one place.
- `beamtalk_dispatch:lookup_in_class_chain/5` now supplies only its `has_method/2` + invoke-or-continue probe (`class_chain_step/6`, `invoke_step/6`); `continue_to_superclass/6` and `lookup_in_class_chain_slow/7` are gone.
- `beamtalk_method_resolver:resolve_with_hierarchy/2` now supplies only its `{method, Selector}` gen_server probe (`method_step/2`). Kept the original "receiver's own class is free, walk starts at the immediate superclass" split — an earlier draft of this refactor accidentally folded that free probe into the counted walk, shrinking the reachable-superclass budget by one level; restored to match the original and pinned with two new boundary tests.
- `beamtalk_class_dispatch:find_class_method_in_chain/2` now supplies only its ETS metadata probe (`walk_ancestors`'s `StepFun`); `find_class_method_in_ancestors/3` is gone.
- Per BT-2786's acceptance criteria: kept `beamtalk_method_resolver`'s `gen_server:call({method, Selector})` probe as-is rather than migrating it onto the ETS path from BT-2008 — that's a separate behavior change (method resolution semantics vs. class-method resolution semantics) out of scope for a pure consolidation. Noted here for visibility; can be tracked separately if desired.

## Key changes

- `runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy.erl` (new)
- `runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl`
- `runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl`
- `runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl`
- `runtime/apps/beamtalk_runtime/test/beamtalk_method_resolver_tests.erl` — added `MAX_HIERARCHY_DEPTH` boundary tests

## Test plan

- [x] `rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler` — 5287 tests, 0 failures
- [x] `rebar3 eunit --dir=apps/beamtalk_stdlib/test` — 1584 tests, 0 failures
- [x] `just test-rust` — all passing (incl. `cli_doctor`)
- [x] `just test-stdlib` — 223/223
- [x] `just test-bunit` — 2718/2718 (0 failed)
- [x] `just clippy`, `just fmt-check` — clean
- [x] Full pre-push CI hook (build, clippy, dialyzer, spec validation, fmt) — clean

This touches the hot dispatch path per the issue's note — landed alone, verified against the full EUnit + stdlib + BUnit suites, with an adversarial review pass that caught and fixed a depth-budget regression before push (see commit history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014qKdvh9EENW9eTNpRhfF9L)_