### PR TITLE
Address 3 minor Claude-review nits from BT-2786 (superclass walk consolidation) (BT-2831)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -767,9 +767,17 @@ find_class_method_in_chain(Selector, ClassName) ->
         end
     end,
     case beamtalk_hierarchy:walk_ancestors(SuperclassName, StepFun, ?MAX_HIERARCHY_DEPTH) of
-        {found, {AncestorName, AncestorModule}} -> {ok, AncestorName, AncestorModule};
-        not_found -> not_found;
-        max_depth_exceeded -> not_found
+        {found, {AncestorName, AncestorModule}} ->
+            {ok, AncestorName, AncestorModule};
+        not_found ->
+            not_found;
+        max_depth_exceeded ->
+            ?LOG_WARNING(
+                "find_class_method_in_ancestors: max hierarchy depth ~p exceeded at ~p — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, ClassName],
+                #{domain => [beamtalk, runtime]}
+            ),
+            not_found
     end.
 
 -doc "Read the superclass name from the hierarchy table (no gen_server call).".

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
@@ -258,6 +258,12 @@ lookup_in_class_chain(Selector, Args, Self, State, ClassName) ->
         {found, Result} ->
             Result;
         max_depth_exceeded ->
+            ?LOG_WARNING("Max hierarchy depth exceeded — possible cycle", #{
+                max_depth => ?MAX_HIERARCHY_DEPTH,
+                class => ClassName,
+                selector => Selector,
+                domain => [beamtalk, runtime]
+            }),
             {error,
                 beamtalk_error:new(
                     does_not_understand,
@@ -267,9 +273,12 @@ lookup_in_class_chain(Selector, Args, Self, State, ClassName) ->
                 )};
         not_found ->
             %% Unreachable: class_chain_step/6 always resolves to
-            %% {found, _} or {next, _}, never a bare not_found. Kept
-            %% for exhaustiveness against the generic walker's contract.
-            {error, beamtalk_error:new(does_not_understand, ClassName, Selector)}
+            %% {found, _} or {next, _}, never a bare not_found. Assert the
+            %% invariant instead of silently returning a plausible-looking
+            %% does_not_understand — if class_chain_step/6 is ever changed to
+            %% violate its contract, this must fail loudly, not hide the bug
+            %% behind a normal-looking DNU.
+            erlang:error({unreachable, not_found, ClassName, Selector})
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy.erl
@@ -36,14 +36,13 @@ early (mirrors "no superclass").
 - `not_found` — stop, nothing found anywhere in the chain.
 
 Callers that need caller-specific behaviour at the max-depth boundary (e.g.
-a structured `#beamtalk_error{}` naming the class that triggered it) inspect
-the `max_depth_exceeded` return and build their own error; this module only
-owns the generic cycle-guard log line.
+a structured `#beamtalk_error{}` naming the class that triggered it, or a
+contextual `?LOG_WARNING` naming the selector) inspect the
+`max_depth_exceeded` return and build their own error/log line; this module
+only owns the depth guard itself, not the logging.
 """.
 
 -export([walk_ancestors/3]).
-
--include_lib("kernel/include/logger.hrl").
 
 -type node_id() :: term().
 -type step_result(Result) :: {found, Result} | {next, node_id() | none} | not_found.
@@ -70,14 +69,7 @@ walk_ancestors(StartNode, StepFun, MaxDepth) ->
     walk_result(Result).
 walk_ancestors(none, _StepFun, _MaxDepth, _Depth) ->
     not_found;
-walk_ancestors(Node, _StepFun, MaxDepth, Depth) when Depth > MaxDepth ->
-    ?LOG_WARNING(
-        "walk_ancestors: max hierarchy depth ~p exceeded at ~p — possible cycle",
-        [
-            MaxDepth, Node
-        ],
-        #{domain => [beamtalk, runtime]}
-    ),
+walk_ancestors(_Node, _StepFun, MaxDepth, Depth) when Depth > MaxDepth ->
     max_depth_exceeded;
 walk_ancestors(Node, StepFun, MaxDepth, Depth) ->
     case StepFun(Node, Depth) of

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl
@@ -21,6 +21,7 @@ See also: beamtalk_compiled_method_ops for CompiledMethod field access
 """.
 
 -include("beamtalk.hrl").
+-include_lib("kernel/include/logger.hrl").
 
 -export([resolve/2]).
 
@@ -109,9 +110,15 @@ resolve_with_hierarchy(ClassPid, Selector) ->
                     superclass_pid(ClassPid), StepFun, ?MAX_HIERARCHY_DEPTH
                 )
             of
-                {found, Method} -> Method;
-                not_found -> nil;
-                max_depth_exceeded -> nil
+                {found, Method} ->
+                    Method;
+                not_found ->
+                    nil;
+                max_depth_exceeded ->
+                    ?LOG_WARNING(">> hierarchy walk exceeded ~p levels", [?MAX_HIERARCHY_DEPTH], #{
+                        domain => [beamtalk, runtime]
+                    }),
+                    nil
             end;
         Method ->
             Method

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_method_resolver_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_method_resolver_tests.erl
@@ -156,7 +156,7 @@ start_superclass_chain(NumClasses, Selector) ->
         list_to_atom("ResolverDepthTestClass" ++ integer_to_list(I))
      || I <- lists:seq(1, NumClasses)
     ],
-    Pids = lists:foldl(
+    RevPids = lists:foldl(
         fun(I, AccPids) ->
             ClassName = lists:nth(I, ClassNames),
             Super =
@@ -176,12 +176,12 @@ start_superclass_chain(NumClasses, Selector) ->
                 instance_methods => InstanceMethods,
                 instance_variables => []
             }),
-            AccPids ++ [Pid]
+            [Pid | AccPids]
         end,
         [],
         lists:seq(1, NumClasses)
     ),
-    {hd(ClassNames), Pids}.
+    {hd(ClassNames), lists:reverse(RevPids)}.
 
 test_resolve_at_depth_boundary_found() ->
     Selector = resolverDepthBoundaryMethod,


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-2831/address-3-minor-claude-review-nits-from-bt-2786-superclass

## Summary

Follow-up to #2924 (BT-2786, superclass-chain walk consolidation), addressing 3 non-blocking findings left by the `Claude BeamTalk Review` CI bot that couldn't be pushed at the time because the agent's isolated worktree was removed mid-review.

1. `beamtalk_hierarchy:walk_ancestors/3` no longer logs on `max_depth_exceeded` itself. Each of the three call sites (`beamtalk_dispatch:lookup_in_class_chain/5`, `beamtalk_method_resolver:resolve_with_hierarchy/2`, `beamtalk_class_dispatch:find_class_method_in_chain/2`) now emits its own contextual `?LOG_WARNING`, restoring the original pre-BT-2786 messages/metadata exactly (selector included, and class name as structured metadata where applicable).
2. `beamtalk_dispatch:lookup_in_class_chain/5`'s documented-unreachable `not_found` branch now asserts the invariant via `erlang:error({unreachable, not_found, ClassName, Selector})` instead of silently returning a plausible-looking `does_not_understand`.
3. `beamtalk_method_resolver_tests:start_superclass_chain/2` builds its pid list with O(N) prepend + `lists:reverse/1` instead of O(N²) `AccPids ++ [Pid]`.

## Test plan

- [x] `just build`
- [x] `just clippy` — clean
- [x] `just fmt-check` — clean
- [x] `just test-runtime` (EUnit) — 5294 + 1584 tests, 0 failures
- [x] `just test-bunit` — 2718 tests, 0 failures
- [x] Full pre-push CI hook (clippy, rustfmt, dialyzer, spec validation) — passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01HLRMHdUSFKzBh8H9nfGNbF)_