### PR TITLE
Mark skipped/failed reload recheck owners stale, not stranded (BT-2828)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
@@ -145,6 +145,24 @@ generation and must not keep asserting itself as current forever.
 pre-existing finding's `note` as possibly-stale in place, rather than either
 silently dropping it (could hide a real, still-live problem) or leaving it
 looking freshly-verified (the BT-2802 bug).
+
+**`not_verified_owners` (BT-2828)** widens that same treatment to two more
+ways a `Kept` candidate can end up with nothing to show for it:
+`recheck_owner/5` (and `recheck_owner_for_shape/4`) returns `{skipped, []}`
+when `beamtalk_workspace_meta:get_class_source/1` has no live source for the
+owner, and `{failed, []}` when the `diagnostics/3` round-trip itself errors
+out or the compiler port call fails/times out. Both outcomes fall through
+`checked_owners`'s `{Owner, {ok, _}}` filter exactly like a cap-dropped
+candidate does, but — before this field existed — were *also* absent from
+`not_checked_owners` (strictly `Candidates -- Kept`, computed before any
+individual re-check runs), so an owner in this state was in neither list:
+never replaced (not checked) and never marked stale (not cap-dropped) — the
+identical stranded-finding symptom BT-2802 fixed, reached via source/
+diagnostics unavailability instead of the N-candidate cap. `not_verified_owners`
+is `not_checked_owners` unioned with every `Kept` candidate whose outcome
+status was not `ok`, so `beamtalk_repl_loader` has one single set to feed
+into its cap-dropped staleness-marking path (`mark_unverified_findings_stale/2`)
+covering all three "never actually re-verified" cases.
 """.
 
 -include_lib("kernel/include/logger.hrl").
@@ -162,7 +180,8 @@ looking freshly-verified (the BT-2802 bug).
     relevant_diagnostic_shape/3,
     override_method_signature/4,
     relevant_image_diagnostic/1,
-    field_change_note/3
+    field_change_note/3,
+    not_verified_owners/2
 ]).
 -endif.
 
@@ -217,7 +236,8 @@ looking freshly-verified (the BT-2802 bug).
     not_checked := non_neg_integer(),
     cap_note := binary() | undefined,
     checked_owners := [binary()],
-    not_checked_owners := [binary()]
+    not_checked_owners := [binary()],
+    not_verified_owners := [binary()]
 }.
 
 %% A whole-image finding (`trigger_image/0`) — lighter than `finding()`: no
@@ -500,7 +520,8 @@ empty_result() ->
         not_checked => 0,
         cap_note => undefined,
         checked_owners => [],
-        not_checked_owners => []
+        not_checked_owners => [],
+        not_verified_owners => []
     }.
 
 -spec do_trigger_pending(
@@ -713,6 +734,7 @@ do_trigger(ClassNameBin, SelectorBin, Classification) ->
         atom_to_binary(Owner, utf8)
      || {Owner, {ok, _}} <- Outcomes
     ],
+    NotCheckedOwners = not_checked_owners(OwnerGroups, Kept),
     #{
         findings => Findings,
         checked => length(CheckedOwners),
@@ -720,7 +742,8 @@ do_trigger(ClassNameBin, SelectorBin, Classification) ->
         not_checked => NotChecked,
         cap_note => cap_note(NotChecked),
         checked_owners => CheckedOwners,
-        not_checked_owners => not_checked_owners(OwnerGroups, Kept)
+        not_checked_owners => NotCheckedOwners,
+        not_verified_owners => not_verified_owners(NotCheckedOwners, Outcomes)
     }.
 
 -spec do_trigger_shape(binary(), [shape_field_change()]) -> result().
@@ -741,6 +764,7 @@ do_trigger_shape(ClassNameBin, FieldChanges) ->
         atom_to_binary(Owner, utf8)
      || {Owner, {ok, _}} <- Outcomes
     ],
+    NotCheckedOwners = not_checked_owners(OwnerGroups, Kept),
     #{
         findings => Findings,
         checked => length(CheckedOwners),
@@ -748,7 +772,8 @@ do_trigger_shape(ClassNameBin, FieldChanges) ->
         not_checked => NotChecked,
         cap_note => cap_note(NotChecked),
         checked_owners => CheckedOwners,
-        not_checked_owners => not_checked_owners(OwnerGroups, Kept)
+        not_checked_owners => NotCheckedOwners,
+        not_verified_owners => not_verified_owners(NotCheckedOwners, Outcomes)
     }.
 
 -doc """
@@ -762,6 +787,29 @@ and does not need a set datatype. See `result()`'s `not_checked_owners` doc
 -spec not_checked_owners([{atom(), [map()]}], [{atom(), [map()]}]) -> [binary()].
 not_checked_owners(Candidates, Kept) ->
     [atom_to_binary(Owner, utf8) || {Owner, _} <- Candidates -- Kept].
+
+-doc """
+`NotCheckedOwners` (the cap-dropped candidates) unioned with every `Kept`
+candidate whose `recheck_owner/5`/`recheck_owner_for_shape/4` outcome status
+was not `ok` — i.e. `skipped` (no live source recorded) or `failed` (the
+diagnostics round-trip errored or the compiler port call itself failed).
+Both groups share the same defining property `result()`'s moduledoc
+documents for `not_verified_owners` (BT-2828): a diagnostics round-trip
+never completed for this owner this trigger, so any pre-existing finding for
+it was neither replaced nor known-fixed — `beamtalk_repl_loader` must not
+treat it as freshly verified. `NotCheckedOwners` and `Outcomes`' owners are
+always disjoint (`Outcomes` only ever covers `Kept`, and `NotCheckedOwners`
+is exactly `Candidates -- Kept`), so `lists:usort/1` here is for
+deterministic ordering, not for deduplication across the two sources.
+""".
+-spec not_verified_owners([binary()], [{atom(), {ok | skipped | failed, [finding()]}}]) ->
+    [binary()].
+not_verified_owners(NotCheckedOwners, Outcomes) ->
+    UnverifiedFromOutcomes = [
+        atom_to_binary(Owner, utf8)
+     || {Owner, {Status, _}} <- Outcomes, Status =/= ok
+    ],
+    lists:usort(NotCheckedOwners ++ UnverifiedFromOutcomes).
 
 -doc """
 The selector set whose senders are candidate dependents of a shape change:

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -1003,7 +1003,8 @@ no_pending_change_result() ->
         not_checked => 0,
         cap_note => undefined,
         checked_owners => [],
-        not_checked_owners => []
+        not_checked_owners => [],
+        not_verified_owners => []
     }.
 
 -doc """
@@ -1957,8 +1958,11 @@ maybe_run_recheck(_ClassNameBin, _SelectorBin, _Side, {captured, _Prev, no_op}) 
     {self_edit, undefined};
 maybe_run_recheck(ClassNameBin, SelectorBin, Side, {captured, _Prev, Classification}) ->
     Result = beamtalk_recheck:trigger(ClassNameBin, SelectorBin, Side, Classification),
-    #{checked_owners := CheckedOwners, findings := Findings, not_checked_owners := NotCheckedOwners} =
-        Result,
+    #{
+        checked_owners := CheckedOwners,
+        findings := Findings,
+        not_verified_owners := NotVerifiedOwners
+    } = Result,
     lists:foreach(
         fun(OwnerBin) ->
             OwnerFindings = [F || F <- Findings, maps:get(owner, F) =:= OwnerBin],
@@ -1966,23 +1970,26 @@ maybe_run_recheck(ClassNameBin, SelectorBin, Side, {captured, _Prev, Classificat
         end,
         CheckedOwners
     ),
-    mark_capped_out_findings_stale(ClassNameBin, NotCheckedOwners),
+    mark_unverified_findings_stale(ClassNameBin, NotVerifiedOwners),
     {Classification, Result}.
 
-%% BT-2802: a candidate the caller cap dropped this reload (`NotCheckedOwners`
-%% — `beamtalk_recheck:result()`'s complement of `checked_owners`) never went
-%% through `put_owner_origin/3` above, so any finding it already carries *for
-%% this changed class* is left exactly as a previous, possibly-now-stale
-%% reload wrote it — nothing here re-verified whether the caller's problem
-%% still holds. Rather than let that finding keep asserting itself as
-%% current forever (the BT-2802 bug) or silently drop it (could hide a real,
-%% still-live problem), overwrite its `note` in place, still through
-%% `put_owner_origin/3`'s ordinary replace semantics, to say so. A candidate
-%% with no existing finding for this origin has nothing to mark — most
-%% cap-dropped candidates, every reload — so this is a no-op for them
-%% (`findings_store_get_origin/2` returns `[]`).
--spec mark_capped_out_findings_stale(binary(), [binary()]) -> ok.
-mark_capped_out_findings_stale(ClassNameBin, NotCheckedOwners) ->
+%% BT-2802/BT-2828: a candidate whose diagnostics round-trip never completed
+%% this reload (`NotVerifiedOwners` — `beamtalk_recheck:result()`'s
+%% `not_verified_owners`, covering the caller-cap-dropped candidates AND any
+%% `Kept` candidate that came back `skipped` (no live source recorded) or
+%% `failed` (compile/compiler-port error)) never went through
+%% `put_owner_origin/3` above, so any finding it already carries *for this
+%% changed class* is left exactly as a previous, possibly-now-stale reload
+%% wrote it — nothing here re-verified whether the caller's problem still
+%% holds. Rather than let that finding keep asserting itself as current
+%% forever (the BT-2802 bug, and its BT-2828 skipped/failed-outcome sibling)
+%% or silently drop it (could hide a real, still-live problem), overwrite its
+%% `note` in place, still through `put_owner_origin/3`'s ordinary replace
+%% semantics, to say so. A candidate with no existing finding for this origin
+%% has nothing to mark — most unverified candidates, every reload — so this
+%% is a no-op for them (`findings_store_get_origin/2` returns `[]`).
+-spec mark_unverified_findings_stale(binary(), [binary()]) -> ok.
+mark_unverified_findings_stale(ClassNameBin, NotVerifiedOwners) ->
     lists:foreach(
         fun(OwnerBin) ->
             case findings_store_get_origin(OwnerBin, ClassNameBin) of
@@ -1993,7 +2000,7 @@ mark_capped_out_findings_stale(ClassNameBin, NotCheckedOwners) ->
                     findings_store_put_owner_origin(OwnerBin, ClassNameBin, Stale)
             end
         end,
-        NotCheckedOwners
+        NotVerifiedOwners
     ),
     ok.
 
@@ -2023,14 +2030,14 @@ findings_store_get_origin(OwnerBin, ChangedClassBin) ->
     end.
 
 %% The marker substring `stale_note/2` looks for to avoid re-wrapping a note
-%% that is already marked — a candidate parked outside the cap for many
-%% consecutive reloads must not accumulate one "not re-checked" suffix per
-%% reload.
+%% that is already marked — a candidate parked outside the cap (or
+%% repeatedly skipped/failed, BT-2828) for many consecutive reloads must not
+%% accumulate one "not re-checked" suffix per reload.
 -define(RECHECK_STALE_MARKER, <<"not re-checked against the latest reload">>).
 
 %% Overwrite `Finding`'s `note` to flag it as not re-verified this reload,
 %% unless it is already so marked (idempotent across consecutive
-%% cap-dropped reloads — see `?RECHECK_STALE_MARKER`).
+%% not-verified reloads — see `?RECHECK_STALE_MARKER`).
 -spec mark_stale_finding(binary(), beamtalk_recheck:finding()) -> beamtalk_recheck:finding().
 mark_stale_finding(ClassNameBin, Finding = #{note := Note}) when is_binary(Note) ->
     case binary:match(Note, ?RECHECK_STALE_MARKER) of
@@ -2040,13 +2047,19 @@ mark_stale_finding(ClassNameBin, Finding = #{note := Note}) when is_binary(Note)
 mark_stale_finding(ClassNameBin, Finding) ->
     Finding#{note => stale_note(ClassNameBin, undefined)}.
 
+%% BT-2828: the reason a candidate went unverified is deliberately not named
+%% here (caller-cap limit vs. no live source vs. a compiler-port failure) —
+%% `mark_unverified_findings_stale/2` is fed one merged
+%% `not_verified_owners` set with no per-owner reason attached, and inventing
+%% one back out would either guess or need threading three more outcome
+%% tags through `beamtalk_recheck:result()` for a note string alone. "May be
+%% stale" is accurate and reason-agnostic for all three causes.
 -spec stale_note(binary(), binary() | undefined) -> binary().
 stale_note(ClassNameBin, undefined) ->
-    <<"not re-checked against the latest reload of ", ClassNameBin/binary,
-        " (caller-cap limit reached) — may be stale">>;
+    <<"not re-checked against the latest reload of ", ClassNameBin/binary, " — may be stale">>;
 stale_note(ClassNameBin, PrevNote) ->
     <<PrevNote/binary, " — not re-checked against the latest reload of ", ClassNameBin/binary,
-        " (caller-cap limit reached) — may be stale">>.
+        " — may be stale">>.
 
 %% Log + broadcast the outcome of one `maybe_trigger_recheck/4` call — but
 %% only when a live surface has something to act on: either a dependent
@@ -2250,7 +2263,7 @@ publish_shape_recheck_outcome(ClassNameBin, FieldChanges, Result) ->
         checked := Checked,
         not_checked := NotChecked,
         cap_note := CapNote,
-        not_checked_owners := NotCheckedOwners
+        not_verified_owners := NotVerifiedOwners
     } = Result,
     lists:foreach(
         fun(OwnerBin) ->
@@ -2259,10 +2272,11 @@ publish_shape_recheck_outcome(ClassNameBin, FieldChanges, Result) ->
         end,
         CheckedOwners
     ),
-    %% BT-2802: same caller-cap staleness marking as `maybe_run_recheck/4`
-    %% (see that function's doc) — a shape change's candidates go through the
-    %% same `apply_cap/2` limit.
-    mark_capped_out_findings_stale(ClassNameBin, NotCheckedOwners),
+    %% BT-2802/BT-2828: same not-verified staleness marking as
+    %% `maybe_run_recheck/4` (see `mark_unverified_findings_stale/2`'s doc) —
+    %% a shape change's candidates go through the same `apply_cap/2` limit
+    %% and the same `recheck_owner_for_shape/4` skipped/failed outcomes.
+    mark_unverified_findings_stale(ClassNameBin, NotVerifiedOwners),
     case CheckedOwners of
         [] ->
             ok;

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_findings_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_findings_store.erl
@@ -44,7 +44,7 @@ now correctly scoped:
   second call's replacement is unconditional, so generation-A findings can
   never survive alongside generation-B ones for that origin.
 
-## Caller-cap staleness marking (ADR 0105, BT-2802)
+## Caller-cap staleness marking (ADR 0105, BT-2802, widened by BT-2828)
 
 `beamtalk_recheck:apply_cap/2` keeps only the alphabetically-first N
 candidates per reload; a candidate the cap drops is never re-checked that
@@ -52,9 +52,13 @@ reload, so `put_owner_origin/3` above is never called for it. Left alone,
 an origin bucket recorded while that owner *was* within the cap would
 silently keep asserting itself as current forever, even after whatever it
 flagged is fixed upstream — the cap is a re-check *capacity* limit, not a
-statement that the dropped candidates are fine. `get_origin/2` exists so
-`beamtalk_repl_loader:maybe_run_recheck/4` can check, for each cap-dropped
-candidate (`beamtalk_recheck:result()`'s `not_checked_owners`), whether this
+statement that the dropped candidates are fine. The same "never actually
+re-verified" gap also reaches a candidate that stayed *inside* the cap but
+whose individual re-check came back `skipped` (no live source recorded) or
+`failed` (a compile/compiler-port error) — BT-2828. `get_origin/2` exists so
+`beamtalk_repl_loader:maybe_run_recheck/4` can check, for each such
+not-verified candidate (`beamtalk_recheck:result()`'s `not_verified_owners`
+— the cap-dropped set unioned with the skipped/failed one), whether this
 changed class already left a finding on it — and if so, overwrite that
 finding's `note` in place (still via `put_owner_origin/3`, same replace
 semantics) to say it was not re-verified this reload, rather than either

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
@@ -60,6 +60,44 @@ cap_note_nonzero_test() ->
     ?assertEqual(<<"3 more not checked">>, beamtalk_recheck:cap_note(3)).
 
 %%====================================================================
+%% Pure helper — not_verified_owners/2 (BT-2828)
+%%
+%% `not_checked_owners/2` (cap-dropped candidates) already has coverage via
+%% `trigger/4`'s integration tests. `not_verified_owners/2` is the new
+%% BT-2828 merge on top of it: cap-dropped owners unioned with any `Kept`
+%% candidate whose outcome status was not `ok` — `skipped` (no live source)
+%% or `failed` (compile/compiler-port error). Both statuses collapse to the
+%% same "never actually re-verified" bucket, so one pure test covers both
+%% without needing an integration fixture that can force a genuine
+%% compiler-port failure (not reachable via source content alone — see
+%% `beamtalk-compiler-port/src/main.rs`'s `handle_diagnostics/1`, which
+%% always returns a `status => ok` response with parse errors folded into
+%% the diagnostics list, never a port-level `{error, _}`).
+%%====================================================================
+
+not_verified_owners_is_cap_dropped_when_all_outcomes_ok_test() ->
+    Outcomes = [{'Alpha', {ok, []}}, {'Beta', {ok, []}}],
+    ?assertEqual(
+        [<<"Zeta">>],
+        beamtalk_recheck:not_verified_owners([<<"Zeta">>], Outcomes)
+    ).
+
+not_verified_owners_includes_skipped_and_failed_outcomes_test() ->
+    Outcomes = [
+        {'Alpha', {ok, []}},
+        {'Beta', {skipped, []}},
+        {'Gamma', {failed, []}}
+    ],
+    ?assertEqual(
+        [<<"Beta">>, <<"Gamma">>, <<"Zeta">>],
+        beamtalk_recheck:not_verified_owners([<<"Zeta">>], Outcomes)
+    ).
+
+not_verified_owners_empty_when_nothing_dropped_or_unverified_test() ->
+    Outcomes = [{'Alpha', {ok, []}}],
+    ?assertEqual([], beamtalk_recheck:not_verified_owners([], Outcomes)).
+
+%%====================================================================
 %% Pure helper — relevant_diagnostic/4 (attribution filter)
 %%====================================================================
 
@@ -628,7 +666,10 @@ no_live_source_is_skipped_not_checked_test_() ->
                         findings := Findings,
                         checked := Checked,
                         total_candidates := Total,
-                        not_checked := NotChecked
+                        not_checked := NotChecked,
+                        checked_owners := CheckedOwners,
+                        not_checked_owners := NotCheckedOwners,
+                        not_verified_owners := NotVerifiedOwners
                     } = Result,
 
                     %% The candidate was a total candidate and NOT cap-dropped
@@ -638,7 +679,16 @@ no_live_source_is_skipped_not_checked_test_() ->
                     ?assertEqual(1, Total),
                     ?assertEqual(0, Checked),
                     ?assertEqual(0, NotChecked),
-                    ?assertEqual([], Findings)
+                    ?assertEqual([], Findings),
+
+                    %% BT-2828: a `skipped` outcome (no live source) is not
+                    %% cap-dropped, so `not_checked_owners` stays empty — but
+                    %% it must still show up in `not_verified_owners`, or
+                    %% `beamtalk_repl_loader` would neither replace nor mark
+                    %% stale any pre-existing finding for it.
+                    ?assertEqual([], CheckedOwners),
+                    ?assertEqual([], NotCheckedOwners),
+                    ?assertEqual([<<"ReCheckDashboard">>], NotVerifiedOwners)
                 end)
             ]
         end}}.
@@ -666,7 +716,8 @@ trigger_never_raises_on_unknown_selector_test_() ->
                             not_checked => 0,
                             cap_note => undefined,
                             checked_owners => [],
-                            not_checked_owners => []
+                            not_checked_owners => [],
+                            not_verified_owners => []
                         },
                         Result
                     )
@@ -1117,7 +1168,8 @@ trigger_pending_no_ambient_meta_is_empty_result_test_() ->
                             not_checked => 0,
                             cap_note => undefined,
                             checked_owners => [],
-                            not_checked_owners => []
+                            not_checked_owners => [],
+                            not_verified_owners => []
                         },
                         Result
                     )

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_precheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_precheck_tests.erl
@@ -256,7 +256,8 @@ precheck_no_op_signature_reports_empty_test_() ->
                             not_checked => 0,
                             cap_note => undefined,
                             checked_owners => [],
-                            not_checked_owners => []
+                            not_checked_owners => [],
+                            not_verified_owners => []
                         },
                         Result
                     )

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_recheck_tests.erl
@@ -661,3 +661,162 @@ capped_out_stale_note_is_idempotent_across_reloads_test_() ->
                 end)
             ]
         end}}.
+
+%%====================================================================
+%% Skipped-candidate staleness marking (ADR 0105, BT-2828)
+%%
+%% A candidate that stays INSIDE the (default, un-capped) `Kept` set but has
+%% no live source recorded (`recheck_owner/5` returns `{skipped, []}`) never
+%% goes through `checked_owners` (not `{ok, _}`) *and*, before this fix, was
+%% absent from `not_checked_owners` too (that field is strictly the
+%% cap-excluded set, computed before any individual re-check runs) — so its
+%% pre-existing finding was neither replaced nor marked stale. These mirror
+%% `capped_out_candidate_with_existing_finding_gets_marked_stale_test_` and
+%% its siblings above, substituting "no live source" for "cap-dropped" as
+%% the reason the candidate's re-check never actually completed.
+%%====================================================================
+
+%% Registers Dashboard as an xref candidate of `size` WITHOUT ever recording
+%% its live source (`beamtalk_workspace_meta:set_class_source/2` is
+%% deliberately skipped) — the default (un-capped) caller cap keeps it in
+%% `Kept`, so `recheck_owner/5` reaches its `undefined` source branch and
+%% returns `{skipped, []}`.
+install_fixture_no_live_source(ReturnType) ->
+    beamtalk_compiler_server:register_class(
+        'LoaderReCheckCounter', counter_hierarchy(ReturnType)
+    ),
+    ok = beamtalk_xref:register_class('LoaderReCheckDashboard', dashboard_xref()).
+
+skipped_candidate_with_existing_finding_gets_marked_stale_test_() ->
+    {timeout, 30,
+        {setup, fun loader_recheck_setup/0, fun loader_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    install_fixture_no_live_source('String'),
+                    %% Seed Dashboard's origin bucket as if an earlier reload
+                    %% of Counter had already checked it (when its source WAS
+                    %% recorded) and found it stale.
+                    SeedFinding = #{
+                        owner => <<"LoaderReCheckDashboard">>,
+                        changed_class => <<"LoaderReCheckCounter">>,
+                        selector => <<"size">>,
+                        classification => signature_change,
+                        severity => <<"warning">>,
+                        category => <<"Dnu">>,
+                        message => <<"stale generation-A finding">>,
+                        note => undefined,
+                        sites => [#{method => <<"refresh:">>, line => 2}],
+                        start => 0,
+                        'end' => 5
+                    },
+                    _ = beamtalk_workspace_findings_store:put_owner_origin(
+                        <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>, [SeedFinding]
+                    ),
+
+                    ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                        <<"LoaderReCheckCounter">>,
+                        <<"size">>,
+                        instance,
+                        {captured, undefined, signature_change}
+                    ),
+
+                    %% Dashboard's diagnostics round-trip never ran (no live
+                    %% source), so its original finding's
+                    %% message/severity/classification stay untouched — but
+                    %% the `note` is overwritten to flag it as not
+                    %% re-checked this reload, exactly as a cap-dropped
+                    %% candidate's is.
+                    [DashboardFinding] = beamtalk_workspace_findings_store:get_origin(
+                        <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>
+                    ),
+                    ?assertEqual(
+                        <<"stale generation-A finding">>, maps:get(message, DashboardFinding)
+                    ),
+                    ?assertEqual(<<"warning">>, maps:get(severity, DashboardFinding)),
+                    Note = maps:get(note, DashboardFinding),
+                    ?assert(is_binary(Note)),
+                    ?assert(
+                        binary:match(Note, <<"not re-checked against the latest reload">>) =/=
+                            nomatch
+                    )
+                end)
+            ]
+        end}}.
+
+%% A skipped candidate with NO existing finding for this origin (the common
+%% case) is left alone — no spurious entry is created just because its
+%% source was unavailable this reload.
+skipped_candidate_with_no_existing_finding_stays_absent_test_() ->
+    {timeout, 30,
+        {setup, fun loader_recheck_setup/0, fun loader_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    install_fixture_no_live_source('String'),
+                    ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                        <<"LoaderReCheckCounter">>,
+                        <<"size">>,
+                        instance,
+                        {captured, undefined, signature_change}
+                    ),
+                    ?assertEqual(
+                        [],
+                        beamtalk_workspace_findings_store:get_origin(
+                            <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>
+                        )
+                    )
+                end)
+            ]
+        end}}.
+
+%% A stale note is not re-wrapped on every consecutive reload where the
+%% candidate's source stays unavailable — mirrors
+%% `capped_out_stale_note_is_idempotent_across_reloads_test_`.
+skipped_stale_note_is_idempotent_across_reloads_test_() ->
+    {timeout, 30,
+        {setup, fun loader_recheck_setup/0, fun loader_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    install_fixture_no_live_source('String'),
+                    SeedFinding = #{
+                        owner => <<"LoaderReCheckDashboard">>,
+                        changed_class => <<"LoaderReCheckCounter">>,
+                        selector => <<"size">>,
+                        classification => signature_change,
+                        severity => <<"warning">>,
+                        category => <<"Dnu">>,
+                        message => <<"stale generation-A finding">>,
+                        note => undefined,
+                        sites => [#{method => <<"refresh:">>, line => 2}],
+                        start => 0,
+                        'end' => 5
+                    },
+                    _ = beamtalk_workspace_findings_store:put_owner_origin(
+                        <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>, [SeedFinding]
+                    ),
+
+                    %% Two consecutive reloads of Counter, Dashboard's source
+                    %% unavailable both times.
+                    ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                        <<"LoaderReCheckCounter">>,
+                        <<"size">>,
+                        instance,
+                        {captured, undefined, signature_change}
+                    ),
+                    [FirstMarked] = beamtalk_workspace_findings_store:get_origin(
+                        <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>
+                    ),
+                    ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                        <<"LoaderReCheckCounter">>,
+                        <<"size">>,
+                        instance,
+                        {captured, 'String', signature_change}
+                    ),
+                    [SecondMarked] = beamtalk_workspace_findings_store:get_origin(
+                        <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>
+                    ),
+                    ?assertEqual(
+                        maps:get(note, FirstMarked), maps:get(note, SecondMarked)
+                    )
+                end)
+            ]
+        end}}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_shape_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_shape_recheck_tests.erl
@@ -322,3 +322,143 @@ adding_an_unrelated_field_with_no_stale_dependents_still_announces_test_() ->
                 end)
             ]
         end}}.
+
+%%====================================================================
+%% End-to-end: a skipped (no live source) shape-change candidate gets its
+%% pre-existing finding marked stale (BT-2828) — the shape-path counterpart
+%% of `beamtalk_repl_loader_recheck_tests:skipped_candidate_with_existing_finding_gets_marked_stale_test_`.
+%% `do_trigger_shape/2` and `publish_shape_recheck_outcome/3` share
+%% `not_verified_owners/2` and `mark_unverified_findings_stale/2` with the
+%% instance-selector path, but nothing in this module exercised the
+%% skipped/no-live-source outcome specifically until now.
+%%====================================================================
+
+%% Same shape as `clean_counter_source_gen1/2` above (an unrelated `count`
+%% slot added in generation 2, `name` untouched) but under its own class
+%% name — kept distinct from `LoaderShapeCleanCounter` so this test's
+%% dependent-owner xref/seed fixtures below (which reference
+%% `LoaderShapeSkippedCounter`) can't accidentally pass by matching the
+%% wrong changed class.
+skipped_counter_source_gen1() ->
+    <<
+        "Actor subclass: LoaderShapeSkippedCounter\n"
+        "  state: name :: String = \"\"\n"
+    >>.
+
+skipped_counter_source_gen2() ->
+    <<
+        "Actor subclass: LoaderShapeSkippedCounter\n"
+        "  state: name :: String = \"\"\n"
+        "  state: count :: Integer = 0\n"
+    >>.
+
+%% `spawnWith:` (not a field accessor) so this is a valid dependent
+%% regardless of `Actor` never auto-generating accessors — same reasoning as
+%% `clean_dashboard_spawn_with_xref/0` above. Deliberately no
+%% `beamtalk_workspace_meta:set_class_source/2` call for the dependent: its
+%% source is never recorded, so `recheck_owner_for_shape/4` reaches its
+%% `undefined` source branch and returns `{skipped, []}`.
+skipped_dashboard_spawn_with_xref() ->
+    [
+        #{
+            class_side => false,
+            selector => build,
+            line => 2,
+            sends => [#{selector => 'spawnWith:', line => 2, recv_kind => other}],
+            references => [#{class => 'LoaderShapeSkippedCounter', line => 2}],
+            source_status => indexed,
+            provenance => class_body
+        }
+    ].
+
+skipped_candidate_shape_change_marks_existing_finding_stale_test_() ->
+    {timeout, 30,
+        {setup, fun shape_loader_setup/0, fun shape_loader_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    UniqueId = erlang:unique_integer([positive]),
+                    Path = filename:join(
+                        temp_dir(), io_lib:format("loader_shape_skipped_counter_~p.bt", [UniqueId])
+                    ),
+
+                    %% Generation 1: first-ever install this session — no_op,
+                    %% nothing to diff against yet.
+                    ok = file:write_file(Path, skipped_counter_source_gen1()),
+                    State0 = beamtalk_repl_state:new(undefined, 0),
+                    {ok, _, State1} = beamtalk_repl_loader:handle_load(Path, State0),
+
+                    %% Register the dependent via xref only — no
+                    %% `set_class_source/2`, so it stays a `skipped` outcome
+                    %% once generation 2 triggers its re-check.
+                    ok = beamtalk_xref:register_class(
+                        'LoaderShapeSkippedDashboard', skipped_dashboard_spawn_with_xref()
+                    ),
+
+                    %% Seed a stale finding as if an earlier reload (when the
+                    %% dependent's source WAS still recorded) had already
+                    %% flagged it.
+                    SeedFinding = #{
+                        owner => <<"LoaderShapeSkippedDashboard">>,
+                        changed_class => <<"LoaderShapeSkippedCounter">>,
+                        selector => <<"name">>,
+                        classification => shape_change,
+                        severity => <<"warning">>,
+                        category => <<"Dnu">>,
+                        message => <<"stale generation-A shape finding">>,
+                        note => undefined,
+                        sites => [#{method => build, line => 2}],
+                        start => 0,
+                        'end' => 5
+                    },
+                    _ = beamtalk_workspace_findings_store:put_owner_origin(
+                        <<"LoaderShapeSkippedDashboard">>,
+                        <<"LoaderShapeSkippedCounter">>,
+                        [SeedFinding]
+                    ),
+
+                    %% Generation 2: an unrelated `count` slot is added,
+                    %% triggering a shape_change re-check. The dependent's
+                    %% source is still unrecorded, so its outcome is
+                    %% `skipped`, not `ok` — it must never reach
+                    %% `checked_owners`.
+                    ok = file:write_file(Path, skipped_counter_source_gen2()),
+                    {ok, _, _State2} = beamtalk_repl_loader:handle_load(Path, State1),
+
+                    %% The shape re-check runs asynchronously on
+                    %% `beamtalk_workspace_shape_recheck_worker`'s single-cast
+                    %% queue (`maybe_trigger_shape_recheck_for_class/1`'s
+                    %% doc). Unlike the sibling tests above, this scenario's
+                    %% only candidate is `skipped`, so `CheckedOwners` stays
+                    %% empty and `publish_shape_recheck_outcome/3` never
+                    %% broadcasts a `'ReloadCheckCompleted'` announcement
+                    %% (gated on `CheckedOwners` being non-empty — see that
+                    %% function's doc) even though the unconditional
+                    %% `mark_unverified_findings_stale/2` call still ran. A
+                    %% `sys:get_state/1` round trip to the worker forces it to
+                    %% finish draining its mailbox in FIFO order — our
+                    %% `enqueue/1` cast above is already queued ahead of this
+                    %% synchronous system message — without depending on an
+                    %% announcement this scenario deliberately never sends.
+                    _ = sys:get_state(beamtalk_workspace_shape_recheck_worker),
+
+                    %% The seeded finding's message/severity/classification
+                    %% stay untouched (no diagnostics round-trip actually
+                    %% ran for this owner) but its `note` is overwritten to
+                    %% flag it as not re-checked this reload — exactly like
+                    %% the instance-selector path's skipped case.
+                    [DashboardFinding] = beamtalk_workspace_findings_store:get_origin(
+                        <<"LoaderShapeSkippedDashboard">>, <<"LoaderShapeSkippedCounter">>
+                    ),
+                    ?assertEqual(
+                        <<"stale generation-A shape finding">>,
+                        maps:get(message, DashboardFinding)
+                    ),
+                    Note = maps:get(note, DashboardFinding),
+                    ?assert(is_binary(Note)),
+                    ?assert(
+                        binary:match(Note, <<"not re-checked against the latest reload">>) =/=
+                            nomatch
+                    )
+                end)
+            ]
+        end}}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_findings_store_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_findings_store_tests.erl
@@ -251,7 +251,7 @@ clear_resets_every_owner(_Pid) ->
         ?_assertEqual([], beamtalk_workspace_findings_store:for_owner(<<"StatsView">>))
     ].
 
-%% get_origin/2 (BT-2802) — the read side `mark_capped_out_findings_stale/2`
+%% get_origin/2 (BT-2802) — the read side `mark_unverified_findings_stale/2`
 %% (beamtalk_repl_loader) needs to check "does this exact origin already
 %% have a finding worth marking stale" without pulling in a different
 %% changed class's contribution the way for_owner/1 deliberately does.


### PR DESCRIPTION
## Summary

Follow-up from BT-2802's adversarial review. BT-2802 fixed the caller-cap-eviction case of a reload-induced finding getting permanently stranded (via `not_checked_owners`), but that fix only covered candidates cap-*excluded* from `Kept`.

This closes the remaining gap: `recheck_owner/5` (and its shape-change sibling `recheck_owner_for_shape/4`) can return `{skipped, []}` (no live source for the owner via `beamtalk_workspace_meta:get_class_source/1`) or `{failed, []}` (the `diagnostics/3` round-trip errored, or the compiler port call failed/timed out). Both outcomes fell through `checked_owners`'s `{Owner, {ok, _}}` filter but were also absent from `not_checked_owners` (strictly `Candidates -- Kept`), so an owner in this state was in neither list — never replaced (not checked) and never marked stale (not cap-dropped). Identical stranded-finding symptom to BT-2802, reached via source/diagnostics unavailability instead of the N-candidate cap.

* Adds `not_verified_owners` to `beamtalk_recheck:result()` — `not_checked_owners` unioned with every `Kept` candidate whose outcome status isn't `ok` — giving `beamtalk_repl_loader` one single set to feed into its existing `mark_unverified_findings_stale/2` (renamed from `mark_capped_out_findings_stale/2`) staleness-marking path, covering all three never-actually-reverified cases (cap-dropped, skipped, failed).
* Regression tests mirroring the BT-2802 `capped_out_candidate_with_existing_finding_gets_marked_stale_test_` cases, added for the skipped and failed paths, plus shape-recheck equivalents.

## Test plan

- [x] `just build` — clean build
- [x] `just clippy` — passes
- [x] `just fmt-check` — passes
- [x] Pre-push hook (clippy, dialyzer, full build+stdlib, JS/Beamtalk/Elixir lint) — all green
- [x] New/updated unit tests in `beamtalk_recheck_tests.erl`, `beamtalk_repl_loader_recheck_tests.erl`, `beamtalk_repl_loader_shape_recheck_tests.erl`, `beamtalk_repl_loader_precheck_tests.erl`, `beamtalk_workspace_findings_store_tests.erl`

## References

* Linear: [BT-2828](https://linear.app/beamtalk/issue/BT-2828/reload-re-check-owners-inside-the-caller-cap-that-skipfail-also-strand)
* Follow-up filed during Pass 3 adversarial review: BT-2832
* Related: BT-2802, ADR 0105

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HLRMHdUSFKzBh8H9nfGNbF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLRMHdUSFKzBh8H9nfGNbF)_