### PR TITLE
Extend isKindOf: control-flow narrowing to post-guard early-return shapes (BT-2825)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -4009,6 +4009,13 @@ impl TypeChecker {
             // argument is the false block. If it diverges, execution
             // reaching the next statement proves the guard's test held,
             // so the variable narrows to the *true*-branch type.
+            //
+            // For `isKindOf:` this is `compute_class_narrowing`'s resolved
+            // `true_type` (set above). For plain `isNil` checks, `info` was
+            // never routed through `compute_class_narrowing` — `true_type`
+            // instead comes straight from `detect_narrowing`'s `isNil` rule,
+            // which sets it to `InferredType::known("UndefinedObject")`
+            // (see `narrowing/rules/is_nil.rs`).
             let Some(Expression::Block(false_block)) = arguments.first() else {
                 return;
             };

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -2464,18 +2464,70 @@ impl TypeChecker {
     ///
     /// `detect` only sees the AST, so it records the tested class name in
     /// `class_test` and leaves `true_type` provisional. Here we resolve the
-    /// variable's current type and route the **true** branch through the
-    /// hierarchy-aware `intersect(current, C)` for *both* idioms, and the
-    /// **false** branch through `difference(current, C)` for `isKindOf:`
-    /// *only* — see `ClassTestKind` for why `class =:=`'s false branch must
-    /// stay unnarrowed.
+    /// variable's current type and delegate to the diagnostic-free
+    /// [`Self::compute_class_narrowing`] (BT-2825 factored this out so
+    /// [`Self::apply_early_return_narrowing`] can reuse the same math without
+    /// re-emitting the "comparison can never be true" hint below for a guard
+    /// that was already fully type-checked), then reports that hint using
+    /// the resolved true branch.
+    pub(super) fn refine_class_narrowing(
+        &mut self,
+        info: NarrowingInfo,
+        env: &TypeEnv,
+        hierarchy: &ClassHierarchy,
+        test_span: Span,
+    ) -> NarrowingInfo {
+        let Some(ClassTestInfo { class_name, .. }) = info.class_test.clone() else {
+            return info;
+        };
+        let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+        let refined_info = Self::compute_class_narrowing(
+            info,
+            &current_ty,
+            hierarchy,
+            self.protocol_registry.as_ref(),
+        );
+        self.check_impossible_class_comparison(
+            &current_ty,
+            &class_name,
+            &refined_info.true_type,
+            test_span,
+        );
+        refined_info
+    }
+
+    /// Pure narrowing math for a `class = C` / `isKindOf: C` test — no
+    /// diagnostics (BT-2825). Shared by [`Self::refine_class_narrowing`] (the
+    /// primary `ifTrue:`/`ifFalse:` dispatch site, which additionally emits
+    /// the "comparison can never be true" hint) and
+    /// [`Self::apply_early_return_narrowing`] (the guard-and-early-return
+    /// post-guard case, which must *not* re-emit that hint since the guard
+    /// expression was already fully type-checked by the time post-guard
+    /// narrowing runs).
     ///
-    /// The true branch is a deliberate refinement over the previous
-    /// unconditional `true_type = C` — a subclass test now narrows precisely
-    /// (`x :: Number; x isKindOf: Integer` true branch is `Integer`, not
-    /// `Number`), and a test against a hierarchy-unrelated class types the
-    /// (unreachable) true branch `Never`, reported via
-    /// `check_impossible_class_comparison`.
+    /// Routes the **true** branch through the hierarchy-and-protocol-aware
+    /// `intersect(current, C)` for *both* idioms, and the **false** branch
+    /// through `difference(current, C)` for `isKindOf:` *only* — see
+    /// `ClassTestKind` for why `class =:=`'s false branch must stay
+    /// unnarrowed.
+    ///
+    /// The true branch narrows precisely (`x :: Number; x isKindOf: Integer`
+    /// true branch is `Integer`, not `Number`), and a test against a
+    /// hierarchy-unrelated class types the (unreachable) true branch `Never`
+    /// (reported by the caller via `check_impossible_class_comparison`).
+    ///
+    /// **Protocol collapse (BT-2825):** when `current` is a protocol (or a
+    /// union containing one) and `C` is an unrelated concrete class,
+    /// `intersect` conservatively returns the irreducible `current & C`
+    /// (ADR 0102 §1/§3) — sound for a *declared* `P1 & P2` annotation, but
+    /// `isKindOf: C` is a positive **runtime** proof that the value literally
+    /// is a `C` (or subclass), which is strictly stronger. The true branch
+    /// collapses that `Intersection` down to the bare `C` so downstream
+    /// assignability (`is_assignable_to`, which has no notion of `&`) and DNU
+    /// checks see a plain nominal type instead of a compound one they don't
+    /// otherwise understand — this is what lets a `Printable`-declared local
+    /// satisfy a `List`-typed assignment after `(x isKindOf: List) ifTrue:
+    /// [...]` / `ifFalse: [^...]` without an `@expect type` escape hatch.
     ///
     /// The `isKindOf:` false branch closes the group-2 gap ADR 0102 §1
     /// deliberately left open (nominal-class difference needed its own
@@ -2483,27 +2535,30 @@ impl TypeChecker {
     /// to `Number \ Integer` (previously untouched — `false_type` stayed
     /// `None`, and `ifFalse:`/the else-arm of `ifTrue:ifFalse:` fell back to
     /// no narrowing). `class =:=`'s false branch stays `None`, exactly as
-    /// before this issue.
-    pub(super) fn refine_class_narrowing(
-        &mut self,
+    /// before BT-2744.
+    fn compute_class_narrowing(
         mut info: NarrowingInfo,
-        env: &TypeEnv,
+        current_ty: &InferredType,
         hierarchy: &ClassHierarchy,
-        test_span: Span,
+        protocol_registry: Option<&crate::semantic_analysis::protocol_registry::ProtocolRegistry>,
     ) -> NarrowingInfo {
         let Some(ClassTestInfo { class_name, kind }) = info.class_test.clone() else {
             return info;
         };
-        let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
         let pattern = InferredType::known(class_name.clone());
         let provenance = super::TypeProvenance::Inferred(Span::default());
-        // No protocol registry: a `class = C` / `isKindOf: C` pattern is always
-        // a nominal class, never a protocol intersection (matches the other
-        // narrowing call sites).
-        let refined =
-            InferredType::intersect(&current_ty, &pattern, provenance, Some(hierarchy), None);
-        self.check_impossible_class_comparison(&current_ty, &class_name, &refined, test_span);
-        info.true_type = refined;
+        let refined = InferredType::intersect(
+            current_ty,
+            &pattern,
+            provenance,
+            Some(hierarchy),
+            protocol_registry,
+        );
+        info.true_type = if matches!(refined, InferredType::Intersection { .. }) {
+            pattern.clone()
+        } else {
+            refined
+        };
         // BT-2744: only `isKindOf:`'s false branch can be narrowed via
         // nominal-class `difference` — `Negation{base, excluded}` always
         // excludes `excluded`'s *entire* subtree, which matches `isKindOf:`'s
@@ -2514,7 +2569,7 @@ impl TypeChecker {
         // `ClassTestKind`.
         if kind == ClassTestKind::KindOf {
             info.false_type = Some(InferredType::difference(
-                &current_ty,
+                current_ty,
                 &pattern,
                 provenance,
                 Some(hierarchy),
@@ -3860,71 +3915,131 @@ impl TypeChecker {
 
     /// Apply early-return narrowing to the environment after a statement.
     ///
-    /// Detects `x isNil ifTrue: [<diverge>]` — if the true-block cannot fall
-    /// through (either a non-local return `^` or a diverging call such as
-    /// `self error: "..."` whose inferred type is `Never`), the variable must
-    /// be non-nil in subsequent statements.  Covers both local variables and
-    /// synthetic `self.field` keys via
+    /// Detects `x isNil ifTrue: [<diverge>]` and, since BT-2825, `x isKindOf:
+    /// C ifTrue: [<diverge>]` / `ifFalse: [<diverge>]` / `ifTrue: [<diverge>]
+    /// ifFalse: [...]` — if the branch whose test is *not* the one we fall
+    /// through cannot fall through (either a non-local return `^` or a
+    /// diverging call such as `self error: "..."` whose inferred type is
+    /// `Never`), the variable is narrowed for subsequent statements. Covers
+    /// both local variables and synthetic `self.field` keys via
     /// [`Self::resolve_narrowing_variable_type`] (BT-2049).
     fn apply_early_return_narrowing(
-        &self,
+        &mut self,
         expr: &Expression,
         env: &mut TypeEnv,
         hierarchy: &ClassHierarchy,
     ) {
-        // Match: `<receiver> ifTrue: [diverging block]` or
-        //         `<receiver> ifTrue: [diverging] ifFalse: [...]` — if the
-        // true branch diverges, any execution reaching the next statement
-        // came through the false branch and the variable is non-nil.
-        if let Expression::MessageSend {
+        // Match: `<receiver> ifTrue: [diverging]`, `<receiver> ifFalse:
+        // [diverging]` (BT-2825), or `<receiver> ifTrue: [diverging]
+        // ifFalse: [...]` — whichever block diverges, any execution reaching
+        // the next statement came through the *other* path, narrowing the
+        // variable accordingly.
+        let Expression::MessageSend {
             receiver,
             selector: MessageSelector::Keyword(parts),
             arguments,
             ..
         } = expr
-        {
-            let is_if_true = parts.len() == 1 && parts[0].keyword == "ifTrue:";
-            let is_if_true_if_false =
-                parts.len() == 2 && parts[0].keyword == "ifTrue:" && parts[1].keyword == "ifFalse:";
-            if !(is_if_true || is_if_true_if_false) {
+        else {
+            return;
+        };
+        let is_if_true = parts.len() == 1 && parts[0].keyword == "ifTrue:";
+        let is_if_false = parts.len() == 1 && parts[0].keyword == "ifFalse:";
+        let is_if_true_if_false =
+            parts.len() == 2 && parts[0].keyword == "ifTrue:" && parts[1].keyword == "ifFalse:";
+        if !(is_if_true || is_if_false || is_if_true_if_false) {
+            return;
+        }
+        let Some(mut info) = Self::detect_narrowing(receiver) else {
+            return;
+        };
+        if !info.is_nil_check && info.class_test.is_none() {
+            return;
+        }
+        if info.class_test.is_some() {
+            // BT-2825: resolve `true_type`/`false_type` the same way the
+            // primary `ifTrue:`/`ifFalse:` dispatch does
+            // (`refine_class_narrowing`), but through the diagnostic-free
+            // `compute_class_narrowing` — `expr` (this exact guard) was
+            // already fully type-checked by `infer_stmts` above, so the
+            // "comparison can never be true" hint already fired once.
+            let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+            info = Self::compute_class_narrowing(
+                info,
+                &current_ty,
+                hierarchy,
+                self.protocol_registry.as_ref(),
+            );
+        }
+
+        if is_if_true || is_if_true_if_false {
+            // In both shapes, the true block is argument 0.
+            let Some(Expression::Block(true_block)) = arguments.first() else {
+                return;
+            };
+            if !self.block_diverges(true_block) {
                 return;
             }
-            if let Some(info) = Self::detect_narrowing(receiver) {
-                if !info.is_nil_check {
-                    return;
-                }
-                // In both shapes, the true block is argument 0.
-                let Some(Expression::Block(true_block)) = arguments.first() else {
-                    return;
-                };
-                if !self.block_diverges(true_block) {
-                    return;
-                }
-                // For `ifTrue:ifFalse:`, execution may reach the next
-                // statement through the `ifFalse:` block. If that block
-                // reassigns the tested variable (e.g. `[self.user := nil]`
-                // or `[x := nil]`), the post-statement narrowing would be
-                // unsound — skip it.
-                if is_if_true_if_false {
-                    if let Some(Expression::Block(false_block)) = arguments.get(1) {
-                        if block_may_reassign(false_block, &info.variable) {
-                            return;
-                        }
+            // For `ifTrue:ifFalse:`, execution may reach the next
+            // statement through the `ifFalse:` block. If that block
+            // reassigns the tested variable (e.g. `[self.user := nil]`
+            // or `[x := nil]`), the post-statement narrowing would be
+            // unsound — skip it.
+            if is_if_true_if_false {
+                if let Some(Expression::Block(false_block)) = arguments.get(1) {
+                    if block_may_reassign(false_block, &info.variable) {
+                        return;
                     }
                 }
-                // BT-2050: after this statement, the variable is non-nil.
-                // Use method-remainder scope: the refinement outlives the
-                // guard send and applies to the rest of the enclosing method
-                // body (unlike the block-scoped narrowings pushed inside
-                // `infer_block_with_narrowing`).
-                let current_ty =
-                    Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
-                let non_nil = Self::non_nil_type(&current_ty);
-                env.push_refinement(RefinementLayer::method_remainder(
-                    info.variable.clone(),
-                    non_nil,
-                ));
             }
+            let Some(narrowed) = Self::early_return_false_branch_type(&info, env, hierarchy) else {
+                return;
+            };
+            // BT-2050: after this statement, the variable is narrowed.
+            // Use method-remainder scope: the refinement outlives the
+            // guard send and applies to the rest of the enclosing method
+            // body (unlike the block-scoped narrowings pushed inside
+            // `infer_block_with_narrowing`).
+            env.push_refinement(RefinementLayer::method_remainder(
+                info.variable.clone(),
+                narrowed,
+            ));
+        } else if is_if_false {
+            // BT-2825: `<receiver> ifFalse: [diverging]` — the sole
+            // argument is the false block. If it diverges, execution
+            // reaching the next statement proves the guard's test held,
+            // so the variable narrows to the *true*-branch type.
+            let Some(Expression::Block(false_block)) = arguments.first() else {
+                return;
+            };
+            if !self.block_diverges(false_block) {
+                return;
+            }
+            env.push_refinement(RefinementLayer::method_remainder(
+                info.variable.clone(),
+                info.true_type.clone(),
+            ));
+        }
+    }
+
+    /// The type the tested variable takes in the "complementary" (false)
+    /// branch of a narrowing, mirroring `infer_args_with_narrowing`'s
+    /// `ifFalse:` arm (BT-2825): an explicit `false_type` (class test /
+    /// Result / singleton) if set, else non-nil for `isNil` checks, else
+    /// `None` (no useful narrowing — e.g. `class =:=`'s false branch, which
+    /// deliberately stays unnarrowed per `ClassTestKind`).
+    fn early_return_false_branch_type(
+        info: &NarrowingInfo,
+        env: &TypeEnv,
+        hierarchy: &ClassHierarchy,
+    ) -> Option<InferredType> {
+        if let Some(ref false_ty) = info.false_type {
+            Some(false_ty.clone())
+        } else if info.is_nil_check {
+            let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+            Some(Self::non_nil_type(&current_ty))
+        } else {
+            None
         }
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_post_guard.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_post_guard.rs
@@ -544,3 +544,40 @@ typed Object subclass: Caller
             .collect::<Vec<_>>()
     );
 }
+
+/// BT-2825 review follow-up: `apply_early_return_narrowing`'s new
+/// `is_if_false` arm is gated on `info.is_nil_check || info.class_test.is_some()`,
+/// so it also fires for plain `isNil` guards, not just `isKindOf:` — `x isNil
+/// ifFalse: [^...]` is the mirror of the already-covered `isNil ifTrue:
+/// [^...]` case, and narrows `x` to `Nil` (only the nil case falls through)
+/// for the rest of the method. Locks in this implicit-but-correct behavior.
+#[test]
+fn bt2825_is_nil_if_false_diverge_narrows_to_nil() {
+    let source = r"
+typed Object subclass: Receiver
+  class process: v :: Nil => v
+
+typed Object subclass: Caller
+  run: x :: Integer | Nil =>
+    x isNil ifFalse: [^nil]
+    Receiver process: x
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let type_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "`x` should narrow to Nil after `x isNil ifFalse: [^nil]`, got: {type_warnings:?}"
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_post_guard.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_post_guard.rs
@@ -424,6 +424,45 @@ typed Object subclass: Caller
     );
 }
 
+/// BT-2825 review follow-up: the combined `ifTrue: [<diverge>] ifFalse:
+/// [...]` shape (`is_if_true_if_false` in `apply_early_return_narrowing`)
+/// shares its code path with the solo `ifTrue: [<diverge>]` case above, but
+/// had no dedicated `isKindOf:` test — only the solo-`ifTrue:` and
+/// solo-`ifFalse:` shapes were covered. Locks in that `x` still narrows to
+/// the complement after the combined form, matching the docs table row
+/// `x isKindOf: Foo ifTrue: [^...] ifFalse: [...]`.
+#[test]
+fn bt2825_is_kind_of_if_true_if_false_diverge_narrows_to_complement() {
+    let source = r#"
+typed Object subclass: Receiver
+  class process: v :: String => v
+
+typed Object subclass: Caller
+  run: x :: Integer | String =>
+    (x isKindOf: Integer) ifTrue: [self error: "was integer"] ifFalse: [Transcript show: "ok"]
+    Receiver process: x
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let type_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "`x` should narrow to String (the complement of Integer) after the \
+         combined `ifTrue: [<diverge>] ifFalse: [...]` guard, got: {type_warnings:?}"
+    );
+}
+
 /// BT-2825 AC (c): `isKindOf:` used directly as an `ifTrue:`/`ifFalse:`
 /// branch condition (not a guard-and-return) already narrows within the
 /// branch (BT-1573/BT-2741/BT-2744) — this locks that behaviour in as an

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_post_guard.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_post_guard.rs
@@ -1,7 +1,8 @@
 // Copyright 2026 James Casey
 // SPDX-License-Identifier: Apache-2.0
 
-//! Post-guard narrowing of nullable locals/fields after divergent `isNil ifTrue: [^err]` (BT-2049).
+//! Post-guard narrowing of nullable locals/fields after divergent `isNil ifTrue: [^err]` (BT-2049),
+//! extended to `isKindOf:` class-test guards (BT-2825).
 
 use super::common::*;
 
@@ -303,4 +304,243 @@ typed Object subclass: Caller
             d.message
         );
     }
+}
+
+// ── BT-2825: Post-guard narrowing for `isKindOf:` class-test guards ──
+
+/// BT-2825 AC (a): `(x isKindOf: Integer) ifFalse: [^default]` should narrow
+/// a union-typed local to `Integer` for the rest of the method — the
+/// concrete guard-and-early-return shape from the issue
+/// (`(coll isKindOf: List) ifFalse: [^""]`), which `apply_early_return_narrowing`
+/// previously only handled for `isNil`, never for `isKindOf:`, and never for
+/// a solo `ifFalse:` at all.
+#[test]
+fn bt2825_union_narrows_after_is_kind_of_if_false_guard() {
+    let source = r"
+typed Object subclass: Receiver
+  class process: v :: Integer => v
+
+typed Object subclass: Caller
+  run: x :: Integer | String =>
+    (x isKindOf: Integer) ifFalse: [^nil]
+    Receiver process: x
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let type_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "`x` should narrow to Integer after `(x isKindOf: Integer) ifFalse: [^nil]`, got: {type_warnings:?}"
+    );
+}
+
+/// BT-2825 AC (b): a Protocol-typed local narrowed by an `isKindOf:` guard
+/// against a concrete class must be assignable to that concrete class
+/// afterward without an `@expect type` escape hatch — the exact
+/// `prompt_renderer.bt` shape from the issue (`coll :: Printable | Nil`,
+/// `(coll isKindOf: List) ifFalse: [^""]`, `items :: List := coll`).
+#[test]
+fn bt2825_protocol_narrows_after_is_kind_of_if_false_guard_no_expect_needed() {
+    let source = r#"
+Protocol define: Printable
+  asString -> String
+
+typed Object subclass: MyList
+  asString => "a list"
+
+typed Object subclass: Caller
+  run: coll :: Printable | Nil -> String =>
+    coll isNil ifTrue: [^""]
+    (coll isKindOf: MyList) ifFalse: [^""]
+    items :: MyList := coll
+    items asString
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let type_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "`coll` narrowed to MyList should be assignable to `items :: MyList` \
+         without `@expect type`, got: {type_warnings:?}"
+    );
+}
+
+/// BT-2825: `(x isKindOf: Integer) ifTrue: [<diverge>]` should narrow `x` to
+/// the *complement* (`String`, via `difference`) for the rest of the
+/// method — the mirror image of the `ifFalse:` guard, extending the
+/// existing `ifTrue: [<diverge>]` machinery (previously `isNil`-only)
+/// to `isKindOf:`.
+#[test]
+fn bt2825_is_kind_of_if_true_diverge_narrows_to_complement() {
+    let source = r#"
+typed Object subclass: Receiver
+  class process: v :: String => v
+
+typed Object subclass: Caller
+  run: x :: Integer | String =>
+    (x isKindOf: Integer) ifTrue: [self error: "was integer"]
+    Receiver process: x
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let type_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "`x` should narrow to String (the complement of Integer) after the \
+         diverging `ifTrue:` guard, got: {type_warnings:?}"
+    );
+}
+
+/// BT-2825 AC (c): `isKindOf:` used directly as an `ifTrue:`/`ifFalse:`
+/// branch condition (not a guard-and-return) already narrows within the
+/// branch (BT-1573/BT-2741/BT-2744) — this locks that behaviour in as an
+/// end-to-end regression alongside the new post-guard cases above.
+#[test]
+fn bt2825_is_kind_of_narrows_inside_if_true_branch() {
+    let source = r"
+typed Object subclass: Receiver
+  class process: v :: Integer => v
+
+typed Object subclass: Caller
+  run: x :: Integer | String =>
+    (x isKindOf: Integer) ifTrue: [Receiver process: x]
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let type_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
+        .collect();
+    assert!(
+        type_warnings.is_empty(),
+        "`x` should narrow to Integer inside the `ifTrue:` branch, got: {type_warnings:?}"
+    );
+}
+
+/// BT-2825: A non-diverging `ifFalse:` block (no `^`, last expression is not
+/// `Never`) must NOT narrow the variable — the binding may still fail the
+/// `isKindOf:` test when control falls through.
+#[test]
+fn bt2825_non_diverging_is_kind_of_if_false_guard_does_not_narrow() {
+    let source = r"
+typed Object subclass: Receiver
+  class process: v :: Integer => v
+
+typed Object subclass: Caller
+  run: x :: Integer | String =>
+    (x isKindOf: Integer) ifFalse: [42]
+    Receiver process: x
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let mismatch_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| {
+            d.category == Some(DiagnosticCategory::Type) && d.message.contains("'process:'")
+        })
+        .collect();
+    assert!(
+        !mismatch_warnings.is_empty(),
+        "non-diverging `ifFalse:` guard must leave `x` as `Integer | String` \
+         and warn at `process:`; got diagnostics: {:?}",
+        result
+            .diagnostics
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// BT-2825 / ADR 0102 §5 (BT-2744): `x class =:= Integer`'s false branch
+/// stays unnarrowed (a `Character` subclass could still be "not exactly
+/// Integer" yet satisfy `isKindOf: Integer`) — so the post-guard case must
+/// NOT narrow `x` after `ifTrue: [<diverge>]` either, unlike `isKindOf:`.
+/// This locks in the `ClassTestKind::Exact` vs `KindOf` distinction for the
+/// new post-guard path added by this issue.
+#[test]
+fn bt2825_class_eq_exact_if_true_diverge_does_not_narrow() {
+    let source = r#"
+typed Object subclass: Receiver
+  class process: v :: Integer => v
+
+typed Object subclass: Caller
+  run: x :: Number =>
+    (x class =:= Integer) ifTrue: [self error: "was exactly integer"]
+    Receiver process: x
+"#;
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    let mismatch_warnings: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| {
+            d.category == Some(DiagnosticCategory::Type) && d.message.contains("'process:'")
+        })
+        .collect();
+    assert!(
+        !mismatch_warnings.is_empty(),
+        "`class =:=`'s false branch must stay unnarrowed even post-guard; \
+         `x` should still be `Number` at `process:`; got diagnostics: {:?}",
+        result
+            .diagnostics
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
 }

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -1718,6 +1718,13 @@ process: x :: Object =>
 validate: x :: Object =>
   x isNil ifTrue: [^nil]
   x doSomething    // x is non-nil for the remainder
+
+// isKindOf: guard-and-return also narrows the rest of the method (BT-2825)
+render: coll :: Printable | Nil -> String =>
+  coll isNil ifTrue: [^""]
+  (coll isKindOf: List) ifFalse: [^""]
+  items :: List := coll   // no `@expect type` needed — coll is List here
+  items inject: "" into: [:acc :item | acc ++ item asString]
 ```
 
 **Supported narrowing patterns:**
@@ -1727,6 +1734,9 @@ validate: x :: Object =>
 | `x class =:= Foo ifTrue: [...]` | `x` is `Foo` in true block | True block only |
 | `x isKindOf: Foo ifTrue: [...]` | `x` is `Foo` in true block | True block only |
 | `x isKindOf: Foo ifFalse: [...]` | `x` is `T \ Foo` in false block | False block only |
+| `x isKindOf: Foo ifFalse: [^...]` | `x` is `Foo` after the statement | Rest of method |
+| `x isKindOf: Foo ifTrue: [^...]` | `x` is `T \ Foo` after the statement | Rest of method |
+| `x isKindOf: Foo ifTrue: [^...] ifFalse: [...]` | `x` is `T \ Foo` after the statement | Rest of method |
 | `x isNil ifTrue: [^...]` | `x` is non-nil after the statement | Rest of method |
 | `x isNil ifTrue: [self error: "..."]` | `x` is non-nil after the statement | Rest of method |
 | `x isNil ifFalse: [...]` | `x` is non-nil in false block | False block |
@@ -1735,6 +1745,8 @@ validate: x :: Object =>
 | `x ifNil: [...] ifNotNil: [:v \| ...]` | `v` is non-nil in notNil block | NotNil block |
 
 The diverging-guard pattern (`isNil ifTrue: [self error: "..."]`) recognises any block whose body infers as `Never` — including calls to `error:`, `notImplemented`, or any `-> Never` method — not just non-local returns (`^`). Narrowing also works on `self.field` reads: inside `self.field isNil ifFalse: [...]`, the field narrows to non-nil within the block.
+
+**`isKindOf:` guard-and-return (BT-2825):** the same diverging-guard treatment `isNil` gets also applies to `isKindOf:` — `(x isKindOf: Foo) ifFalse: [^default]` proves `x` is `Foo` for the rest of the method, and `(x isKindOf: Foo) ifTrue: [^default]` proves `x` is `T \ Foo`. This also closes a related gap: when `x`'s declared type is a Protocol (e.g. `Printable`) and `Foo` is a concrete class, the narrowed type collapses to the bare `Foo` — a runtime `isKindOf: Foo` check is a stronger proof than the protocol annotation, so the narrowed value is assignable to a `Foo`-typed local without an `@expect type` escape hatch.
 
 ### Conditional Return Type Inference
 

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -1740,6 +1740,7 @@ render: coll :: Printable | Nil -> String =>
 | `x isNil ifTrue: [^...]` | `x` is non-nil after the statement | Rest of method |
 | `x isNil ifTrue: [self error: "..."]` | `x` is non-nil after the statement | Rest of method |
 | `x isNil ifFalse: [...]` | `x` is non-nil in false block | False block |
+| `x isNil ifFalse: [^...]` | `x` is nil after the statement | Rest of method |
 | `x isNil ifTrue: [^...] ifFalse: [...]` | `x` is non-nil in false block | False block |
 | `x ifNotNil: [:v \| ...]` | `v` is non-nil in block | Block only |
 | `x ifNil: [...] ifNotNil: [:v \| ...]` | `v` is non-nil in notNil block | NotNil block |


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2825

`(x isKindOf: Foo) ifFalse: [^default]` — the guard-and-early-return idiom already handled for `isNil` (BT-2049) — previously left `x` unnarrowed for the rest of the method, because `apply_early_return_narrowing` only recognised `isNil` checks and only the `ifTrue:`/`ifTrue:ifFalse:` shapes (never a solo `ifFalse:`). This closes that gap for `isKindOf:` and `class =:=` guards.

- **`(x isKindOf: Foo) ifFalse: [^default]`** now narrows `x` to `Foo` for the rest of the method (previously required an `@expect type` escape hatch or produced a false type-mismatch warning downstream).
- **`(x isKindOf: Foo) ifTrue: [<diverge>]`** now narrows `x` to the complement (`T \ Foo`) for the rest of the method — the mirror image.
- **Protocol collapse**: when the pre-guard type is a Protocol (e.g. `Printable`) and the `isKindOf:` target is an unrelated concrete class, the narrowed type collapses the resulting `Intersection` down to the bare concrete class, so it satisfies a concrete-class-typed assignment (`items :: List := coll`) without an `@expect type` escape hatch.
- **`class =:=`'s false branch stays unnarrowed**, exactly as before (BT-2744) — a `Character` subclass could still be "not exactly Integer" yet satisfy `isKindOf: Integer`, so narrowing it away would be unsound.

### Key changes

- `crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs`: factored `refine_class_narrowing`'s narrowing math into a diagnostic-free `compute_class_narrowing` helper shared with `apply_early_return_narrowing` (which was previously `isNil`-only and had no solo-`ifFalse:` shape at all). `refine_class_narrowing` keeps emitting the "comparison can never be true" hint (unchanged); the new post-guard path does not re-emit it, since the guard expression was already fully type-checked.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_post_guard.rs`: 6 new tests covering the union-narrows-after-`ifFalse:` case, the Protocol-collapse case (the exact `prompt_renderer.bt` shape from the issue), the `ifTrue:`-diverge complement case, a regression lock-in for `isKindOf:` inside an `ifTrue:` branch, and two soundness negatives (a non-diverging guard must not narrow; `class =:=`'s false branch must stay unnarrowed even post-guard).
- `docs/beamtalk-language-features.md`: documented the new post-guard `isKindOf:` patterns in the Control Flow Narrowing table.

### Tests

- `cargo test -p beamtalk-core --lib`: 4666 passed, 0 failed (includes the 6 new BT-2825 tests plus the full existing `narrowing_post_guard` / `type_checker` suite — 985 type_checker tests, all green).
- `cargo clippy -p beamtalk-core --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `git push` ran the repo's lint gate (clippy + fmt) clean on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLRMHdUSFKzBh8H9nfGNbF)_