### PR TITLE
test: tighten 11 placeholder assertions in adr_0105_killer_demo.btscript

### DIFF
--- a/tests/repl-protocol/cases/adr_0105_killer_demo.btscript
+++ b/tests/repl-protocol/cases/adr_0105_killer_demo.btscript
@@ -41,31 +41,31 @@
 Actor subclass: KillerDemoCounter
   state: count = 0
   increment => self.count := self.count + 1
-// => _
+// => KillerDemoCounter
 
 KillerDemoCounter >> getCount -> Integer => self.count
-// => _
+// => KillerDemoCounter>>getCount
 
 KillerDemoCounter >> cleanup => self.count := 0
-// => _
+// => KillerDemoCounter>>cleanup
 
 // The stale caller: assumes `getCount` still answers an Integer (`+ 1`) —
 // the ADR's `Dashboard>>refresh`.
 Object subclass: KillerDemoDashboard
   refresh: c :: KillerDemoCounter -> Integer => (c getCount) + 1
-// => _
+// => KillerDemoDashboard
 
 // The genuinely-unaffected caller: only stringifies the result, so it
 // re-checks clean whatever `getCount` returns — the ADR's `StatsView>>render`.
 Object subclass: KillerDemoStatsView
   render: c :: KillerDemoCounter -> String => (c getCount) printString
-// => _
+// => KillerDemoStatsView
 
 // The removal target: calls a selector that will be deleted from the class —
 // the ADR's `AdminPanel>>onClick` / `Counter>>reset` example.
 Object subclass: KillerDemoAdminPanel
   onClick: c :: KillerDemoCounter -> Object => c cleanup
-// => _
+// => KillerDemoAdminPanel
 
 // ===========================================================================
 // LOAD + SPAWN + USE — the live image before any edit.
@@ -98,7 +98,7 @@ killerDemoFindings := [((Workspace recheckImage) at: #findings) select: [:f | (f
 // ===========================================================================
 
 KillerDemoCounter >> getCount -> String => self.count printString
-// => _
+// => KillerDemoCounter>>getCount
 
 // Existing actor picks up the new method immediately — no restart, no rebuild.
 // count is still 1 (untouched by this edit); now stringified.
@@ -135,7 +135,7 @@ counter getCount
 // ===========================================================================
 
 KillerDemoCounter >> getCount -> Symbol => #done
-// => _
+// => KillerDemoCounter>>getCount
 
 // Still exactly one Dashboard finding — generation B replaced generation A,
 // it did not stack a second contradictory finding on top of it.
@@ -156,7 +156,7 @@ KillerDemoCounter >> getCount -> Symbol => #done
 // ===========================================================================
 
 KillerDemoCounter >> getCount -> Integer => self.count
-// => _
+// => KillerDemoCounter>>getCount
 
 (killerDemoFindings value) size
 // => 0
@@ -172,10 +172,10 @@ KillerDemoCounter >> getCount -> Integer => self.count
 Actor subclass: KillerDemoCounter
   state: count = 0
   increment => self.count := self.count + 1
-// => _
+// => KillerDemoCounter
 
 KillerDemoCounter >> getCount -> Integer => self.count
-// => _
+// => KillerDemoCounter>>getCount
 
 // AdminPanel is now the sole stale caller — Dashboard/StatsView are clean
 // again (both survived the `getCount` round-trip back to `Integer`).


### PR DESCRIPTION
## Summary

- Replace 11 `// => _` placeholder assertions with their concrete expected values in `tests/repl-protocol/cases/adr_0105_killer_demo.btscript`
- Class definitions (`Actor/Object subclass: Foo`) return `ClassName`; method-extension definitions (`Foo >> bar => ...`) return `ClassName>>selector` — both deterministic, matching the pattern used in `extension_type_annotations.btscript`, `class_builder_capstone.btscript`, and `recheck_image_and_precheck.btscript`
- The one `// => _` that remains (line 88, block literal assignment) is genuinely non-deterministic

## Changes

| Line | Expression | Before | After |
|------|-----------|--------|-------|
| 44 | `Actor subclass: KillerDemoCounter` | `// => _` | `// => KillerDemoCounter` |
| 47 | `KillerDemoCounter >> getCount -> Integer` | `// => _` | `// => KillerDemoCounter>>getCount` |
| 50 | `KillerDemoCounter >> cleanup` | `// => _` | `// => KillerDemoCounter>>cleanup` |
| 56 | `Object subclass: KillerDemoDashboard` | `// => _` | `// => KillerDemoDashboard` |
| 62 | `Object subclass: KillerDemoStatsView` | `// => _` | `// => KillerDemoStatsView` |
| 68 | `Object subclass: KillerDemoAdminPanel` | `// => _` | `// => KillerDemoAdminPanel` |
| 101 | `KillerDemoCounter >> getCount -> String` | `// => _` | `// => KillerDemoCounter>>getCount` |
| 138 | `KillerDemoCounter >> getCount -> Symbol` | `// => _` | `// => KillerDemoCounter>>getCount` |
| 159 | `KillerDemoCounter >> getCount -> Integer` (restore) | `// => _` | `// => KillerDemoCounter>>getCount` |
| 175 | `Actor subclass: KillerDemoCounter` (redefinition) | `// => _` | `// => KillerDemoCounter` |
| 178 | `KillerDemoCounter >> getCount -> Integer` (post-removal) | `// => _` | `// => KillerDemoCounter>>getCount` |

## Verification

`just test-repl-protocol` passes: **3 passed, 0 failed** (finished in 151s).

_Nightly test-quality routine — no Linear issue (Linear MCP unavailable in this session)._

---
_Generated by [Claude Code](https://claude.ai/code/session_019g7gnCjekGcejdgxwRF2fp)_