### PR TITLE
Resolve dependency classes in MCP offline lint tools (BT-2823)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ repository = "https://github.com/jamesc/beamtalk"
 [workspace.dependencies]
 # Workspace crates
 beamtalk-build = { path = "crates/beamtalk-build" }
+# why: beamtalk-mcp's offline lint/diagnostic_summary tools share
+# beamtalk-cli's manifest/build-layout/dependency-class-resolution logic
+# (BT-2823) via this lib target.
+beamtalk-cli = { path = "crates/beamtalk-cli" }
 beamtalk-core = { path = "crates/beamtalk-core" }
 beamtalk-etf = { path = "crates/beamtalk-etf" }
 beamtalk-examples = { path = "crates/beamtalk-examples" }

--- a/crates/beamtalk-cli/src/build_layout.rs
+++ b/crates/beamtalk-cli/src/build_layout.rs
@@ -5,6 +5,11 @@
 //!
 //! All `_build/dev/*` paths are constructed through [`BuildLayout`] to ensure
 //! consistency across commands (build, test, run, repl, deps).
+//!
+//! BT-2823: This module lives in the `beamtalk_cli` **library** crate (not
+//! the `beamtalk` binary) so `beamtalk-mcp` can depend on it too — see the
+//! same note in `crate::manifest` for why every item here must stay `pub`
+//! rather than `pub(crate)`.
 
 use camino::Utf8PathBuf;
 

--- a/crates/beamtalk-cli/src/commands/mod.rs
+++ b/crates/beamtalk-cli/src/commands/mod.rs
@@ -8,7 +8,12 @@ pub mod attach;
 pub mod beam_environment;
 pub mod build;
 pub(crate) mod build_cache;
-pub mod build_layout;
+// BT-2823: `build_layout` moved to the `beamtalk_cli` lib crate so
+// `beamtalk-mcp` can share it for offline dependency-class resolution.
+// Re-exported here so existing `crate::commands::build_layout` /
+// `super::build_layout` references throughout this module tree keep working
+// unchanged.
+pub use beamtalk_cli::build_layout;
 pub(crate) mod build_stamp;
 pub mod build_stdlib;
 pub mod clean;
@@ -24,7 +29,9 @@ pub mod fmt;
 pub mod generate;
 pub mod lint;
 pub mod logs;
-pub mod manifest;
+// BT-2823: `manifest` moved to the `beamtalk_cli` lib crate for the same
+// reason as `build_layout` above.
+pub use beamtalk_cli::manifest;
 pub mod new;
 pub mod protocol;
 pub mod repl;

--- a/crates/beamtalk-cli/src/dependency_classes.rs
+++ b/crates/beamtalk-cli/src/dependency_classes.rs
@@ -60,8 +60,18 @@ use tracing::warn;
 #[must_use]
 pub fn resolve_dependency_class_infos(project_root: &Utf8Path) -> (bool, Vec<ClassInfo>) {
     let manifest_path = project_root.join("beamtalk.toml");
-    if !manifest_path.exists() {
-        return (false, Vec::new());
+    match manifest_path.try_exists() {
+        Ok(true) => {}
+        Ok(false) => return (false, Vec::new()),
+        Err(e) => {
+            warn!(
+                error = %e,
+                path = %manifest_path,
+                "Failed to check for beamtalk.toml for offline dependency class resolution; \
+                 assuming no manifest"
+            );
+            return (false, Vec::new());
+        }
     }
 
     let parsed = match manifest::parse_manifest_full(&manifest_path) {

--- a/crates/beamtalk-cli/src/dependency_classes.rs
+++ b/crates/beamtalk-cli/src/dependency_classes.rs
@@ -1,0 +1,250 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Best-effort, offline resolution of a project's dependency classes (BT-2823).
+//!
+//! **DDD Context:** Build System
+//!
+//! `beamtalk build` / `beamtalk lint` merge each declared dependency's class
+//! metadata into the `ClassHierarchy` via [`crate::deps`]'s full resolution
+//! pipeline (`ensure_deps_resolved`), which can fetch missing git
+//! dependencies over the network and recompile stale ones. The MCP server's
+//! offline `lint` and `diagnostic_summary` tools are documented as working
+//! without a live REPL connection and must not trigger surprise network I/O
+//! or writes under `_build/` as a side effect of a diagnostics query.
+//!
+//! This module instead reads whatever dependency checkouts are *already*
+//! present on disk — under `_build/deps/<name>/` for git dependencies (the
+//! [`crate::build_layout::BuildLayout`] convention), or at their declared
+//! local path for path dependencies — exactly the state left behind by a
+//! prior `beamtalk build`. Dependencies that have never been fetched/built
+//! are silently skipped, matching the existing best-effort philosophy of
+//! `beamtalk lint`'s own dependency resolution (and BT-2134's native type
+//! registry, which likewise falls back to "no data" when its build artifact
+//! is missing).
+//!
+//! Without this, MCP `lint`/`diagnostic_summary` report false-positive
+//! `Unresolved class` diagnostics for every class defined only in a
+//! dependency, because [`beamtalk_core::project::package`] only walks the
+//! package's own `src/`/`test/` directories.
+//!
+//! **Known limitation:** only *direct* dependencies (the project's own
+//! `[dependencies]` table) are resolved — unlike `ensure_deps_resolved`,
+//! this does not walk transitive dependency graphs. A class defined only in
+//! a dependency-of-a-dependency (and referenced directly, which is unusual)
+//! is not covered. See BT-2823's follow-up for extending this if it proves
+//! necessary in practice.
+
+use crate::build_layout::BuildLayout;
+use crate::manifest;
+use beamtalk_core::compilation::DependencySource;
+use beamtalk_core::file_walker::FileWalker;
+use beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo;
+use beamtalk_core::source_analysis::{lex_with_eof, parse};
+use camino::Utf8Path;
+use tracing::warn;
+
+/// Resolve dependency class metadata for `project_root` without performing
+/// any network I/O.
+///
+/// Returns `(has_package_dependencies, class_infos)`:
+/// - `has_package_dependencies` mirrors `beamtalk lint`'s
+///   `resolve_dep_class_infos` flag (BT-2794): read from the manifest's
+///   `[dependencies]` table regardless of whether any individual dependency
+///   could actually be resolved on disk, so a dependency that hasn't been
+///   fetched yet doesn't flip diagnostic behaviour between runs.
+/// - `class_infos` contains every class defined in a dependency whose
+///   checkout is present on disk.
+///
+/// Returns `(false, Vec::new())` if `project_root` has no `beamtalk.toml`.
+#[must_use]
+pub fn resolve_dependency_class_infos(project_root: &Utf8Path) -> (bool, Vec<ClassInfo>) {
+    let manifest_path = project_root.join("beamtalk.toml");
+    if !manifest_path.exists() {
+        return (false, Vec::new());
+    }
+
+    let parsed = match manifest::parse_manifest_full(&manifest_path) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            warn!(
+                error = %e,
+                "Failed to parse beamtalk.toml for offline dependency class resolution; \
+                 conservatively assuming dependencies are declared"
+            );
+            return (true, Vec::new());
+        }
+    };
+
+    let has_package_dependencies = !parsed.dependencies.is_empty();
+    let layout = BuildLayout::new(project_root);
+    let mut class_infos = Vec::new();
+
+    for (name, spec) in &parsed.dependencies {
+        let dep_root = match &spec.source {
+            DependencySource::Path { path } => {
+                // Not normalized/sandboxed: a `..`-containing or absolute
+                // `path` can point outside `project_root`, matching the
+                // trust model of `beamtalk build`'s own path-dependency
+                // resolution (`deps/path.rs::canonicalize_dep_path`) —
+                // `beamtalk.toml` is authored by the project owner, not
+                // untrusted input.
+                let Some(relative) = Utf8Path::from_path(path) else {
+                    warn!(dep = %name, "Dependency path is not valid UTF-8; skipping");
+                    continue;
+                };
+                project_root.join(relative)
+            }
+            DependencySource::Git { .. } => layout.dep_checkout_dir(name),
+        };
+
+        if !dep_root.is_dir() {
+            // Not yet fetched/built — best-effort, skip silently.
+            continue;
+        }
+
+        collect_dep_class_infos(&dep_root, name, &mut class_infos);
+    }
+
+    (has_package_dependencies, class_infos)
+}
+
+/// Parse every `.bt` file under a dependency's `src/` directory (falling
+/// back to its root if there is no `src/`) and append its class metadata to
+/// `class_infos`.
+fn collect_dep_class_infos(dep_root: &Utf8Path, dep_name: &str, class_infos: &mut Vec<ClassInfo>) {
+    let src_dir = dep_root.join("src");
+    let search_dir = if src_dir.is_dir() {
+        src_dir.as_path()
+    } else {
+        dep_root
+    };
+
+    let files = match FileWalker::source_files().walk(search_dir) {
+        Ok(files) => files,
+        Err(e) => {
+            warn!(dep = %dep_name, error = %e, "Failed to walk dependency source directory");
+            return;
+        }
+    };
+
+    for file in files {
+        let source = match std::fs::read_to_string(&file) {
+            Ok(source) => source,
+            Err(e) => {
+                warn!(dep = %dep_name, file = %file, error = %e, "Failed to read dependency source file");
+                continue;
+            }
+        };
+
+        let tokens = lex_with_eof(&source);
+        let (module, _parse_diags) = parse(tokens);
+        class_infos
+            .extend(beamtalk_core::semantic_analysis::ClassHierarchy::extract_class_infos(&module));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write(path: &std::path::Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn no_manifest_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        let (has_deps, infos) = resolve_dependency_class_infos(root);
+        assert!(!has_deps);
+        assert!(infos.is_empty());
+    }
+
+    #[test]
+    fn no_dependencies_section_returns_false_and_empty() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        write(
+            tmp.path().join("beamtalk.toml").as_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\n",
+        );
+        let (has_deps, infos) = resolve_dependency_class_infos(root);
+        assert!(!has_deps);
+        assert!(infos.is_empty());
+    }
+
+    #[test]
+    fn git_dependency_checkout_present_resolves_classes() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        write(
+            tmp.path().join("beamtalk.toml").as_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nhttp = { git = \"https://example.com/http.git\", tag = \"v1.0.0\" }\n",
+        );
+        // Simulate a prior `beamtalk build` having already fetched the dep.
+        write(
+            tmp.path()
+                .join("_build/deps/http/src/http_server.bt")
+                .as_path(),
+            "Object subclass: HTTPServer\n",
+        );
+
+        let (has_deps, infos) = resolve_dependency_class_infos(root);
+        assert!(has_deps);
+        assert!(
+            infos.iter().any(|c| c.name == "HTTPServer"),
+            "expected HTTPServer in resolved class infos, got {infos:?}"
+        );
+    }
+
+    #[test]
+    fn git_dependency_not_yet_fetched_is_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        write(
+            tmp.path().join("beamtalk.toml").as_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nhttp = { git = \"https://example.com/http.git\", tag = \"v1.0.0\" }\n",
+        );
+
+        // No `_build/deps/http/` checkout — best-effort skip, not an error.
+        let (has_deps, infos) = resolve_dependency_class_infos(root);
+        assert!(has_deps);
+        assert!(infos.is_empty());
+    }
+
+    #[test]
+    fn path_dependency_resolves_classes() {
+        // Both the project and its sibling path dependency live inside the
+        // same `TempDir` (`<tmp>/app/` and `<tmp>/utils/`) so `../utils`
+        // resolves within the isolated tempdir rather than escaping into its
+        // shared parent, which would leak files outside the fixture and risk
+        // collisions between concurrent test runs.
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().join("app");
+        let root = Utf8Path::from_path(project_dir.as_path()).unwrap();
+        write(
+            project_dir.join("beamtalk.toml").as_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nutils = { path = \"../utils\" }\n",
+        );
+        write(
+            tmp.path().join("utils/src/utils.bt").as_path(),
+            "Object subclass: Utils\n",
+        );
+
+        let (has_deps, infos) = resolve_dependency_class_infos(root);
+        assert!(has_deps);
+        assert!(
+            infos.iter().any(|c| c.name == "Utils"),
+            "expected Utils in resolved class infos, got {infos:?}"
+        );
+    }
+}

--- a/crates/beamtalk-cli/src/lib.rs
+++ b/crates/beamtalk-cli/src/lib.rs
@@ -6,6 +6,13 @@
 //! Contains code shared between the CLI binary and its library target:
 //! - [`erlc`] — builder for `erlc` command invocations
 //! - [`repl_startup`] — canonical BEAM node startup configuration
+//! - [`manifest`] — `beamtalk.toml` parsing and validation
+//! - [`build_layout`] — centralised `_build/` path construction
+//! - [`dependency_classes`] — best-effort, offline dependency class
+//!   resolution shared with `beamtalk-mcp` (BT-2823)
 
+pub mod build_layout;
+pub mod dependency_classes;
 pub mod erlc;
+pub mod manifest;
 pub mod repl_startup;

--- a/crates/beamtalk-cli/src/manifest.rs
+++ b/crates/beamtalk-cli/src/manifest.rs
@@ -7,6 +7,17 @@
 //!
 //! Parses `beamtalk.toml` manifests that define a package's identity and metadata.
 //! See ADR 0026 for the package definition and manifest format.
+//!
+//! BT-2823: This module lives in the `beamtalk_cli` **library** crate (not
+//! the `beamtalk` binary) so `beamtalk-mcp` can depend on it too. The
+//! `beamtalk` binary's `crate::commands::manifest` is a `pub use
+//! beamtalk_cli::manifest;` re-export (see `commands/mod.rs`) that keeps
+//! existing `crate::commands::manifest`/`super::manifest` call sites
+//! throughout `commands/` compiling unchanged. Every item this module
+//! exposes to those call sites must therefore be `pub`, not `pub(crate)` —
+//! `pub(crate)` here would scope to the *library* crate only and become
+//! invisible to the binary crate, producing a confusing "private item"
+//! error far from this file.
 
 use beamtalk_core::compilation::{DependencyMap, DependencySource, DependencySpec, GitReference};
 use beamtalk_core::source_analysis::DiagnosticCategory;
@@ -621,6 +632,11 @@ pub struct ParsedManifest {
 ///
 /// Returns the parsed manifest, or an error if the file cannot be read or
 /// contains invalid TOML / missing required fields.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read, contains invalid TOML, is
+/// missing required `[package]` fields, or has an invalid package name.
 pub fn parse_manifest(path: &Utf8Path) -> Result<PackageManifest> {
     let manifest = parse_manifest_raw(path)?;
 
@@ -636,6 +652,12 @@ pub fn parse_manifest(path: &Utf8Path) -> Result<PackageManifest> {
 /// Returns the fully parsed manifest with validated package metadata and
 /// dependency specifications. Returns an error if the file cannot be read,
 /// contains invalid TOML, or has malformed dependency entries.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read, contains invalid TOML, has
+/// an invalid package name, or has a malformed `[dependencies]`,
+/// `[native.dependencies]`, or `[diagnostics]` section.
 pub fn parse_manifest_full(path: &Utf8Path) -> Result<ParsedManifest> {
     let manifest = parse_manifest_raw(path)?;
 
@@ -665,6 +687,11 @@ pub fn parse_manifest_full(path: &Utf8Path) -> Result<ParsedManifest> {
 ///
 /// Returns `None` if no manifest file exists. Returns an error if the file
 /// exists but is malformed.
+///
+/// # Errors
+///
+/// Returns an error if the manifest path cannot be stat'd, or the file
+/// exists but is malformed (see [`parse_manifest`]).
 pub fn find_manifest(project_root: &Utf8Path) -> Result<Option<PackageManifest>> {
     let manifest_path = project_root.join("beamtalk.toml");
     if manifest_path
@@ -683,6 +710,11 @@ pub fn find_manifest(project_root: &Utf8Path) -> Result<Option<PackageManifest>>
 ///
 /// Returns `None` if no manifest file exists. Returns an error if the file
 /// exists but is malformed.
+///
+/// # Errors
+///
+/// Returns an error if the manifest path cannot be stat'd, or the file
+/// exists but is malformed (see [`parse_manifest_full`]).
 pub fn find_manifest_full(project_root: &Utf8Path) -> Result<Option<ParsedManifest>> {
     let manifest_path = project_root.join("beamtalk.toml");
     if manifest_path
@@ -700,6 +732,12 @@ pub fn find_manifest_full(project_root: &Utf8Path) -> Result<Option<ParsedManife
 ///
 /// Returns `None` if no manifest file exists or no `[application]` section is present.
 /// Returns an error if the file exists but is malformed.
+///
+/// # Errors
+///
+/// Returns an error if the manifest path cannot be stat'd, or the file
+/// exists but is malformed (invalid TOML, missing required fields, or an
+/// invalid package name).
 pub fn find_application_config(project_root: &Utf8Path) -> Result<Option<ApplicationConfig>> {
     let manifest_path = project_root.join("beamtalk.toml");
     if !manifest_path
@@ -803,6 +841,15 @@ impl fmt::Display for PackageNameError {
 /// - 1–64 characters
 /// - Not a reserved Beamtalk name
 /// - Not an Erlang standard application name
+///
+/// # Errors
+///
+/// Returns a [`PackageNameError`] describing which rule `name` violates.
+///
+/// # Panics
+///
+/// Never panics: the internal `.unwrap()` on the first character is only
+/// reached after the preceding empty-name check has already returned.
 pub fn validate_package_name(name: &str) -> Result<(), PackageNameError> {
     if name.is_empty() {
         return Err(PackageNameError::Empty);

--- a/crates/beamtalk-mcp/Cargo.toml
+++ b/crates/beamtalk-mcp/Cargo.toml
@@ -35,6 +35,11 @@ clap.workspace = true
 # Core compiler for lint passes in the lint MCP tool
 beamtalk-core.workspace = true
 
+# why: shares manifest parsing / build-layout / dependency-class resolution
+# with `beamtalk lint` so the offline `lint` and `diagnostic_summary` tools
+# resolve git/path dependency classes the same way (BT-2823)
+beamtalk-cli.workspace = true
+
 # Shared REPL protocol types (request/response)
 beamtalk-repl-protocol.workspace = true
 

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -2325,10 +2325,16 @@ struct LintResult {
 /// `category.is_some()`, applies `@expect` directives, and returns the
 /// resulting diagnostics together with the `ClassHierarchy` (used by
 /// `compute_diagnostic_summary` for type inference).
+///
+/// `has_package_dependencies` mirrors `beamtalk lint`'s
+/// `CompilerOptions::has_package_dependencies` (BT-2794/BT-2823): true when
+/// the project's manifest declares `[dependencies]`, regardless of whether
+/// any of them could be resolved on disk.
 fn run_module_analysis(
     module: &beamtalk_core::ast::Module,
     all_class_infos: &[beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo],
     mut diags: Vec<beamtalk_core::source_analysis::Diagnostic>,
+    has_package_dependencies: bool,
 ) -> (
     Vec<beamtalk_core::source_analysis::Diagnostic>,
     beamtalk_core::semantic_analysis::ClassHierarchy,
@@ -2338,9 +2344,13 @@ fn run_module_analysis(
     diags.extend(beamtalk_core::lint::run_lint_passes(module));
 
     let cross_file_classes = ClassHierarchy::cross_file_class_infos(all_class_infos, module);
+    let options = beamtalk_core::CompilerOptions {
+        has_package_dependencies,
+        ..Default::default()
+    };
     let analysis_result = beamtalk_core::semantic_analysis::analyse_with_options_and_classes(
         module,
-        &beamtalk_core::CompilerOptions::default(),
+        &options,
         cross_file_classes,
     );
     diags.extend(
@@ -2427,6 +2437,11 @@ fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
         }
     }
 
+    // BT-2823: Merge dependency class metadata so cross-file references to
+    // classes defined only in a git/path dependency (declared in
+    // beamtalk.toml) resolve the same way `beamtalk build` does.
+    let has_package_dependencies = merge_dependency_class_infos(path, &mut all_class_infos);
+
     // Pass 2: Analyse each file and collect diagnostics + coverage.
     let mut all_diags = Vec::new();
     let mut coverage = CoverageReport {
@@ -2446,8 +2461,12 @@ fn compute_diagnostic_summary(path: &str) -> serde_json::Value {
             .cloned()
             .collect();
 
-        let (file_diags, class_hierarchy) =
-            run_module_analysis(module, &all_class_infos, initial_diags);
+        let (file_diags, class_hierarchy) = run_module_analysis(
+            module,
+            &all_class_infos,
+            initial_diags,
+            has_package_dependencies,
+        );
 
         all_diags.extend(file_diags);
 
@@ -2580,6 +2599,38 @@ fn resolve_extraction_files(
     )
 }
 
+/// BT-2823: Merge class metadata from `path`'s package dependencies (as
+/// declared in `beamtalk.toml`) into `all_class_infos`, so `Unresolved
+/// class` diagnostics see the same class hierarchy as `beamtalk
+/// build`/`beamtalk lint` for classes defined only in a dependency.
+///
+/// Delegates to [`beamtalk_cli::dependency_classes::resolve_dependency_class_infos`],
+/// which is filesystem-only and best-effort — it never fetches over the
+/// network, so this never turns an offline `lint`/`diagnostic_summary` call
+/// into one with network side effects. Dependencies that have never been
+/// fetched by a prior `beamtalk build` are silently skipped.
+///
+/// Returns whether the project's manifest declares any dependencies, for use
+/// as `CompilerOptions::has_package_dependencies` (BT-2794).
+fn merge_dependency_class_infos(
+    path: &str,
+    all_class_infos: &mut Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
+) -> bool {
+    let Some(project_root) =
+        beamtalk_core::project::package::find_package_root(std::path::Path::new(path))
+    else {
+        return false;
+    };
+    let Ok(project_root) = camino::Utf8PathBuf::from_path_buf(project_root) else {
+        return false;
+    };
+
+    let (has_package_dependencies, dep_class_infos) =
+        beamtalk_cli::dependency_classes::resolve_dependency_class_infos(&project_root);
+    all_class_infos.extend(dep_class_infos);
+    has_package_dependencies
+}
+
 /// Run lint passes on `path` (file or directory) and return structured results.
 ///
 /// BT-2052: Uses a two-pass pipeline mirroring CLI `beamtalk lint`:
@@ -2655,6 +2706,11 @@ fn run_lint_structured(path: &str) -> LintResult {
         }
     }
 
+    // BT-2823: Merge dependency class metadata so cross-file references to
+    // classes defined only in a git/path dependency (declared in
+    // beamtalk.toml) resolve the same way `beamtalk build` does.
+    let has_package_dependencies = merge_dependency_class_infos(path, &mut all_class_infos);
+
     // Pass 2: Analyse each target file with cross-file class context.
     for (file, source, module, parse_diags) in parsed_targets {
         // Include parse errors (syntax problems) and warnings so files with
@@ -2674,7 +2730,12 @@ fn run_lint_structured(path: &str) -> LintResult {
         // BT-1587 / BT-2052: run_module_analysis runs lint passes, semantic
         // analysis with cross-file class context (mirroring CLI `beamtalk lint`),
         // and applies @expect directives (BT-1476).
-        let (lint_diags, _) = run_module_analysis(&module, &all_class_infos, initial_diags);
+        let (lint_diags, _) = run_module_analysis(
+            &module,
+            &all_class_infos,
+            initial_diags,
+            has_package_dependencies,
+        );
 
         let file_name = file.to_string_lossy().into_owned();
         for diag in &lint_diags {
@@ -2910,6 +2971,97 @@ mod tests {
         assert!(
             !stale,
             "MCP lint with cross-file classes should not report @expect as stale, got: {result:?}",
+        );
+    }
+
+    /// Write a fixture project declaring a git dependency `http` in
+    /// `beamtalk.toml`, with the dependency's checkout already present under
+    /// `_build/deps/http/src/` (simulating the state left by a prior
+    /// `beamtalk build`, matching BT-2823's repro). The project's own
+    /// `src/app.bt` references the dependency's `HTTPServer` class. Returns
+    /// the project directory and the path to `src/app.bt`.
+    ///
+    /// `label` disambiguates the temp directory between the two callers of
+    /// this helper so parallel test execution doesn't collide.
+    fn write_git_dependency_fixture(label: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "beamtalk-mcp-lint-git-dep-{label}-{}",
+            std::process::id()
+        ));
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        std::fs::write(
+            dir.join("beamtalk.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nhttp = { git = \"https://example.com/http.git\", tag = \"v1.0.0\" }\n",
+        )
+        .unwrap();
+
+        // Simulate `beamtalk build` having already fetched the dependency.
+        let dep_src_dir = dir.join("_build").join("deps").join("http").join("src");
+        std::fs::create_dir_all(&dep_src_dir).unwrap();
+        std::fs::write(
+            dep_src_dir.join("http_server.bt"),
+            "Object subclass: HTTPServer\n",
+        )
+        .unwrap();
+
+        // A second project-local class so `has_cross_file_classes` is true
+        // independent of dependency resolution (matching the sentinel
+        // pattern `fixture_sourced_protocol_name_is_not_unresolved` uses in
+        // beamtalk-core). Without this, `check_unresolved_classes` would be
+        // skipped entirely for a single-file project and this test would
+        // pass vacuously regardless of whether the fix is in place.
+        std::fs::write(src_dir.join("other.bt"), "Object subclass: Other\n").unwrap();
+
+        let app_file = src_dir.join("app.bt");
+        std::fs::write(
+            &app_file,
+            "Object subclass: App\n\n  class run =>\n    HTTPServer new\n",
+        )
+        .unwrap();
+
+        (dir, app_file)
+    }
+
+    /// BT-2823: MCP `lint` must resolve classes from a project's git
+    /// dependencies (declared in `beamtalk.toml`) the same way `beamtalk
+    /// build`/`beamtalk lint` do, using whatever dependency checkout is
+    /// already on disk under `_build/deps/<name>/` — without a false-positive
+    /// `Unresolved class` diagnostic.
+    #[test]
+    fn run_lint_structured_resolves_git_dependency_classes() {
+        let (dir, app_file) = write_git_dependency_fixture("lint");
+        let result = run_lint_structured(app_file.to_str().unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let unresolved = result
+            .warnings
+            .iter()
+            .chain(result.errors.iter())
+            .any(|d| d.message.contains("Unresolved class"));
+        assert!(
+            !unresolved,
+            "MCP lint should resolve HTTPServer from the git dependency checkout, got: {result:?}",
+        );
+    }
+
+    /// BT-2823: Same as `run_lint_structured_resolves_git_dependency_classes`
+    /// but for the `diagnostic_summary` tool.
+    #[test]
+    fn compute_diagnostic_summary_resolves_git_dependency_classes() {
+        let (dir, app_file) = write_git_dependency_fixture("summary");
+        let result = compute_diagnostic_summary(app_file.to_str().unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let unresolved_class_total = result["totals_by_category"]["UnresolvedClass"]["total"]
+            .as_u64()
+            .unwrap_or(0);
+        assert_eq!(
+            unresolved_class_total, 0,
+            "diagnostic_summary should resolve HTTPServer from the git dependency \
+             checkout with zero UnresolvedClass diagnostics, got: {result:?}",
         );
     }
 

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -207,7 +207,7 @@ These CLI subcommands are build/tooling commands that operate offline (no worksp
 | `check` | -- | `textDocument/publishDiagnostics` | Offline syntax/type check; LSP provides diagnostics on save |
 | `fmt` | -- | `textDocument/formatting` | Format source files; LSP provides document formatting |
 | `fmt-check` | -- | -- | `surface-specific: CI formatting check` |
-| `lint` | `lint` | -- | Lint checks; MCP exposes for AI-assisted workflows |
+| `lint` | `lint` | -- | Lint checks; MCP exposes for AI-assisted workflows. **BT-2823:** both resolve dependency (`beamtalk.toml`) class metadata into the same `ClassHierarchy` so `Unresolved class` diagnostics match for classes defined only in a git/path dependency. Deliberate divergence: the CLI's `resolve_dep_class_infos` will fetch a missing/stale git dependency over the network (`ensure_deps_resolved`); the MCP tool stays fully offline and only reads whatever dependency checkout already exists under `_build/deps/<name>/` (as left by a prior `beamtalk build`) — an unfetched dependency's classes are silently skipped rather than triggering a fetch. |
 | `test-script` | -- | -- | `surface-specific: btscript expression tests (CI)` |
 | `test-docs` | -- | -- | `surface-specific: doctest runner (CI)` |
 | `doctor` | -- | -- | `surface-specific: environment health check` |
@@ -232,7 +232,7 @@ These MCP tools provide AI-assistant-specific capabilities that have no direct R
 
 | MCP tool | Notes |
 |----------|-------|
-| `diagnostic_summary` | `surface-specific: AI-facing diagnostic overview for a file/package` |
+| `diagnostic_summary` | `surface-specific: AI-facing diagnostic overview for a file/package`. Shares the same offline, best-effort dependency-class resolution as MCP `lint` (BT-2823) — see that row's note. |
 | `search_examples` | `surface-specific: offline corpus search for code examples` |
 | `search_classes` | `surface-specific: offline class discovery by keyword` |
 | `list_packages` | `surface-specific: list loaded Beamtalk packages` |


### PR DESCRIPTION
## Summary

Fixes [BT-2823](https://linear.app/beamtalk/issue/BT-2823/mcp-lintdiagnostic-summary-tools-report-false-positive-unresolved): the `beamtalk-mcp` server's offline `lint` and `diagnostic_summary` tools reported false-positive `Unresolved class` diagnostics for any class defined only in a project's git/path dependency (declared in `beamtalk.toml`), even though `beamtalk build`/`beamtalk lint` resolve those classes correctly. Root cause: the MCP handlers never merged dependency class metadata into the `ClassHierarchy` the way the CLI does.

- Moved `manifest.rs` and `build_layout.rs` from the `beamtalk` binary's private `commands` module into the `beamtalk_cli` **library** crate (re-exported from `commands/mod.rs` via `pub use`, so every existing `crate::commands::manifest`/`super::manifest` call site keeps compiling unchanged).
- Added `beamtalk_cli::dependency_classes::resolve_dependency_class_infos`: a filesystem-only, best-effort dependency-class resolver. It reads whatever dependency checkout already exists on disk — `_build/deps/<name>/` for git dependencies (via `BuildLayout`, matching `beamtalk build`'s own convention) or the declared path for path dependencies — and extracts `ClassInfo` the same way cross-file class extraction already works elsewhere. It **never fetches over the network**, so the MCP tools stay fully offline; a dependency that hasn't been built yet is silently skipped.
- Wired this into `beamtalk-mcp`'s `compute_diagnostic_summary` and `run_lint_structured`, and threaded `has_package_dependencies` through to `CompilerOptions` (matching CLI lint's BT-2794 behaviour).
- Added `beamtalk-cli` as a `beamtalk-mcp` dependency (workspace + crate `Cargo.toml`).
- Updated `docs/development/surface-parity.md` to document the resulting parity and the one deliberate divergence (MCP never fetches; CLI can).

**Known, documented limitations** (filed as follow-ups, not fixed here — out of scope for this bug's repro):
- [BT-2836](https://linear.app/beamtalk/issue/BT-2836): only *direct* dependencies are resolved, not transitive dependencies-of-dependencies.
- [BT-2837](https://linear.app/beamtalk/issue/BT-2837): no caching — every dependency file is re-lexed/re-parsed on every `lint`/`diagnostic_summary` call.

## Test plan

- [x] `just build`, `just clippy`, `just fmt-check-rust` all clean.
- [x] New regression tests in `crates/beamtalk-mcp/src/server.rs` (`run_lint_structured_resolves_git_dependency_classes`, `compute_diagnostic_summary_resolves_git_dependency_classes`) build a fixture project with a git dependency already checked out under `_build/deps/`, referencing the dependency's class from the project's own source — verified these fail with exactly the reported `Unresolved class` false positive when the fix is reverted, and pass with it applied.
- [x] New unit tests in `crates/beamtalk-cli/src/dependency_classes.rs` cover: no manifest, empty `[dependencies]`, git dependency present/not-yet-fetched, and a path dependency.
- [x] Full `just test` (Rust + stdlib + BUnit + Erlang runtime) passes, 0 failures.
- [x] Pre-push hook (full CI incl. Dialyzer) passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLRMHdUSFKzBh8H9nfGNbF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLRMHdUSFKzBh8H9nfGNbF)_