### PR TITLE
Deterministic test coverage for beamtalk_recheck's failed (compiler-port error) outcome (BT-2832)

### DIFF
--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -54,7 +54,8 @@ to avoid temp files on disk (BT-48).
     handle_compile_response/1,
     handle_diagnostics_response/1,
     handle_version_response/1,
-    clear_classes/0
+    clear_classes/0,
+    inject_diagnostics_failure/1
 ]).
 -endif.
 
@@ -63,7 +64,13 @@ to avoid temp files on disk (BT-48).
     %% ADR 0050 Phase 3: Accumulated class metadata cache.
     %% Maps class name atom → __beamtalk_meta/0 map.
     %% Populated via register_class/2 casts and crash recovery on init.
-    classes = #{} :: #{atom() => map()}
+    classes = #{} :: #{atom() => map()},
+    %% BT-2832 (test-only): when set (via inject_diagnostics_failure/1, only
+    %% exported in TEST builds), the *next* diagnostics/3 call fails with this
+    %% reason instead of reaching the real compiler port, then self-clears.
+    %% Always `undefined` in production — nothing outside TEST builds can set
+    %% it. See inject_diagnostics_failure/1's doc for why this exists.
+    diagnostics_fault = undefined :: undefined | binary()
 }).
 
 %%% Public API
@@ -205,6 +212,28 @@ clean class cache. Synchronous so the next compile sees an empty cache.
 -spec clear_classes() -> ok.
 clear_classes() ->
     gen_server:call(?MODULE, clear_classes, 5000).
+
+-doc """
+Force the *next* `diagnostics/3' call to fail with `{error, [#{message =>
+Reason}]}' instead of reaching the real compiler port (BT-2832, test use
+only).
+
+`beamtalk_recheck:recheck_owner/5' (and `recheck_owner_for_shape/4')'s
+`{failed, []}' outcome fires only on a genuine port-level failure — the
+compiler port's `handle_diagnostics' always replies `status => ok', even for
+source with parse/type errors (those come back as ordinary diagnostics in the
+list, never a port-level `{error, _}'). That makes `failed' unreachable via
+source content alone, and this codebase has no mocking library — so this is
+a deterministic, self-clearing substitute: it flips a flag `handle_call/3'
+checks on the *next* `{diagnostics, ...}' request only (any `Mode'/`Options'),
+after which the flag resets to `undefined' and every following call reaches
+the real port again. Never touches the port itself, so unrelated requests
+(`compile_expression', `compile', ...) — and any diagnostics call after the
+one consumed — are unaffected.
+""".
+-spec inject_diagnostics_failure(binary()) -> ok.
+inject_diagnostics_failure(Reason) ->
+    gen_server:call(?MODULE, {inject_diagnostics_failure, Reason}, 5000).
 -endif.
 
 -doc """
@@ -569,6 +598,16 @@ handle_call({resolve_completion_type, Expression}, _From, State) ->
         State#state.port, Expression, State#state.classes
     ),
     {reply, Result, State};
+handle_call(
+    {diagnostics, _Source, _Mode, _Options}, _From, #state{diagnostics_fault = Fault} = State
+) when
+    Fault =/= undefined
+->
+    %% BT-2832 (test-only fault injection, see inject_diagnostics_failure/1):
+    %% consumed by exactly this one request — the real port is never touched,
+    %% and the flag clears itself so every following diagnostics call (this
+    %% one included, on retry) reaches the real port again.
+    {reply, {error, [#{message => Fault}]}, State#state{diagnostics_fault = undefined}};
 handle_call({diagnostics, Source, Mode, Options}, _From, State) ->
     %% ADR 0105 Phase 1 (BT-2778): only thread the ambient class cache when
     %% explicitly requested (see diagnostics/3's moduledoc) — the default
@@ -631,6 +670,8 @@ handle_call(version, _From, State) ->
     {reply, Result, State};
 handle_call(clear_classes, _From, State) ->
     {reply, ok, State#state{classes = #{}}};
+handle_call({inject_diagnostics_failure, Reason}, _From, State) ->
+    {reply, ok, State#state{diagnostics_fault = Reason}};
 handle_call(get_classes, _From, State) ->
     {reply, State#state.classes, State};
 handle_call(_Request, _From, State) ->

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
@@ -208,6 +208,42 @@ unknown_info() ->
     ?assert(is_pid(whereis(beamtalk_compiler_server))).
 
 %%% ---------------------------------------------------------------
+%%% BT-2832: inject_diagnostics_failure/1 (test-only fault injection)
+%%%
+%%% Direct, isolated coverage of the mechanism itself — one-shot consumption
+%%% and self-clearing — independent of `beamtalk_repl_loader_recheck_tests`'s
+%%% higher-level integration tests (which exercise it as a means to reach
+%%% `beamtalk_recheck`'s otherwise-unreachable `failed` outcome).
+%%% ---------------------------------------------------------------
+
+diagnostics_fault_injection_test_() ->
+    {setup, fun start_compiler/0, fun stop_compiler/1, [
+        {"armed fault fails the next diagnostics call", fun fault_fails_next_call/0},
+        {"fault self-clears after being consumed", fun fault_self_clears/0},
+        {"unarmed diagnostics call reaches the real port", fun no_fault_reaches_port/0}
+    ]}.
+
+fault_fails_next_call() ->
+    ok = beamtalk_compiler_server:inject_diagnostics_failure(<<"BT-2832 test fault">>),
+    Result = beamtalk_compiler_server:diagnostics(<<"1 + 2">>),
+    ?assertMatch({error, [#{message := <<"BT-2832 test fault">>}]}, Result).
+
+fault_self_clears() ->
+    ok = beamtalk_compiler_server:inject_diagnostics_failure(<<"BT-2832 test fault">>),
+    FaultedResult = beamtalk_compiler_server:diagnostics(<<"1 + 2">>),
+    ?assertMatch({error, _}, FaultedResult),
+    %% The fault was consumed by the call above — this one must reach the
+    %% real port and succeed normally, proving the flag is one-shot, not
+    %% "stuck on" for the rest of the process's life.
+    RecoveredResult = beamtalk_compiler_server:diagnostics(<<"1 + 2">>),
+    ?assertMatch({ok, _}, RecoveredResult).
+
+no_fault_reaches_port() ->
+    %% No fault armed — an ordinary diagnostics call is unaffected.
+    Result = beamtalk_compiler_server:diagnostics(<<"1 + 2">>),
+    ?assertMatch({ok, _}, Result).
+
+%%% ---------------------------------------------------------------
 %%% Helpers
 %%% ---------------------------------------------------------------
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_recheck_tests.erl
@@ -820,3 +820,183 @@ skipped_stale_note_is_idempotent_across_reloads_test_() ->
                 end)
             ]
         end}}.
+
+%%====================================================================
+%% Failed-candidate staleness marking (ADR 0105, BT-2828 / BT-2832)
+%%
+%% A candidate that stays INSIDE the (default, un-capped) `Kept` set, HAS a
+%% live source recorded, but whose diagnostics round-trip itself errors out
+%% (`recheck_owner/5` returns `{failed, []}`) is the third way a `Kept`
+%% candidate can end up unverified — same stranded-finding symptom the
+%% skipped-candidate tests above cover, just reached via a genuine
+%% compiler-port failure instead of missing source. Unlike the `skipped`
+%% case, this is NOT triggerable via source content alone: the compiler
+%% port's `handle_diagnostics` always replies `status => ok`, even for source
+%% with parse/type errors (those come back as ordinary diagnostics, never a
+%% port-level `{error, _}`) — see `crates/beamtalk-compiler-port/src/main.rs`.
+%% With no mocking library in this codebase and no existing fault-injection
+%% precedent, these tests use `beamtalk_compiler_server:inject_diagnostics_failure/1`
+%% (BT-2832, TEST-only) to deterministically force the *next* `diagnostics/3`
+%% call to return `{error, _}` without touching the real compiler port.
+%%
+%% One instance-path test is sufficient coverage for both re-check triggers:
+%% `trigger/4` (instance-selector path, exercised here via
+%% `maybe_trigger_recheck/4`) and `trigger_shape/2` (shape-change path,
+%% `publish_shape_recheck_outcome/3`) both fold their `Kept`-but-not-`ok`
+%% outcomes into the exact same `beamtalk_recheck:not_verified_owners/2`
+%% union before ever reaching `beamtalk_repl_loader`, and both then call the
+%% identical `mark_unverified_findings_stale/2` on that merged set — the
+%% shape path has no `failed`-specific branch to miss. Duplicating this test
+%% for the shape path would re-exercise the same `beamtalk_repl_loader` code
+%% through a different (already-covered) trigger, not new behaviour.
+%%====================================================================
+
+failed_candidate_with_existing_finding_gets_marked_stale_test_() ->
+    {timeout, 30,
+        {setup, fun loader_recheck_setup/0, fun loader_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    %% Live source IS recorded here (unlike
+                    %% `install_fixture_no_live_source/1`) — `recheck_owner/5`
+                    %% must reach its diagnostics call for the injected fault
+                    %% to be what fails it, not the "no live source" branch.
+                    install_fixture('String'),
+                    SeedFinding = #{
+                        owner => <<"LoaderReCheckDashboard">>,
+                        changed_class => <<"LoaderReCheckCounter">>,
+                        selector => <<"size">>,
+                        classification => signature_change,
+                        severity => <<"warning">>,
+                        category => <<"Dnu">>,
+                        message => <<"stale generation-A finding">>,
+                        note => undefined,
+                        sites => [#{method => <<"refresh:">>, line => 2}],
+                        start => 0,
+                        'end' => 5
+                    },
+                    _ = beamtalk_workspace_findings_store:put_owner_origin(
+                        <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>, [SeedFinding]
+                    ),
+
+                    ok = beamtalk_compiler_server:inject_diagnostics_failure(
+                        <<"BT-2832: injected compiler-port failure (test)">>
+                    ),
+                    ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                        <<"LoaderReCheckCounter">>,
+                        <<"size">>,
+                        instance,
+                        {captured, undefined, signature_change}
+                    ),
+
+                    %% Dashboard's diagnostics round-trip errored out
+                    %% (`{failed, []}`), so its original finding's
+                    %% message/severity/classification stay untouched — but
+                    %% the `note` is overwritten to flag it as not
+                    %% re-checked this reload, exactly as a cap-dropped or
+                    %% skipped candidate's is.
+                    [DashboardFinding] = beamtalk_workspace_findings_store:get_origin(
+                        <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>
+                    ),
+                    ?assertEqual(
+                        <<"stale generation-A finding">>, maps:get(message, DashboardFinding)
+                    ),
+                    ?assertEqual(<<"warning">>, maps:get(severity, DashboardFinding)),
+                    Note = maps:get(note, DashboardFinding),
+                    ?assert(is_binary(Note)),
+                    ?assert(
+                        binary:match(Note, <<"not re-checked against the latest reload">>) =/=
+                            nomatch
+                    )
+                end)
+            ]
+        end}}.
+
+%% A failed candidate with NO existing finding for this origin (the common
+%% case) is left alone — no spurious entry is created just because its
+%% diagnostics round-trip errored out this reload. Mirrors
+%% `skipped_candidate_with_no_existing_finding_stays_absent_test_`.
+failed_candidate_with_no_existing_finding_stays_absent_test_() ->
+    {timeout, 30,
+        {setup, fun loader_recheck_setup/0, fun loader_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    install_fixture('String'),
+                    ok = beamtalk_compiler_server:inject_diagnostics_failure(
+                        <<"BT-2832: injected compiler-port failure (test)">>
+                    ),
+                    ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                        <<"LoaderReCheckCounter">>,
+                        <<"size">>,
+                        instance,
+                        {captured, undefined, signature_change}
+                    ),
+                    ?assertEqual(
+                        [],
+                        beamtalk_workspace_findings_store:get_origin(
+                            <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>
+                        )
+                    )
+                end)
+            ]
+        end}}.
+
+%% A stale note is not re-wrapped on every consecutive reload where the
+%% candidate's diagnostics round-trip keeps failing — mirrors
+%% `skipped_stale_note_is_idempotent_across_reloads_test_`. Each reload
+%% re-arms the fault (it is one-shot, consumed by the previous reload's own
+%% diagnostics call) so both reloads independently hit the `failed` branch.
+failed_stale_note_is_idempotent_across_reloads_test_() ->
+    {timeout, 30,
+        {setup, fun loader_recheck_setup/0, fun loader_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    install_fixture('String'),
+                    SeedFinding = #{
+                        owner => <<"LoaderReCheckDashboard">>,
+                        changed_class => <<"LoaderReCheckCounter">>,
+                        selector => <<"size">>,
+                        classification => signature_change,
+                        severity => <<"warning">>,
+                        category => <<"Dnu">>,
+                        message => <<"stale generation-A finding">>,
+                        note => undefined,
+                        sites => [#{method => <<"refresh:">>, line => 2}],
+                        start => 0,
+                        'end' => 5
+                    },
+                    _ = beamtalk_workspace_findings_store:put_owner_origin(
+                        <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>, [SeedFinding]
+                    ),
+
+                    %% Two consecutive reloads of Counter, Dashboard's
+                    %% diagnostics round-trip failing both times.
+                    ok = beamtalk_compiler_server:inject_diagnostics_failure(
+                        <<"BT-2832: injected compiler-port failure (test, reload A)">>
+                    ),
+                    ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                        <<"LoaderReCheckCounter">>,
+                        <<"size">>,
+                        instance,
+                        {captured, undefined, signature_change}
+                    ),
+                    [FirstMarked] = beamtalk_workspace_findings_store:get_origin(
+                        <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>
+                    ),
+                    ok = beamtalk_compiler_server:inject_diagnostics_failure(
+                        <<"BT-2832: injected compiler-port failure (test, reload B)">>
+                    ),
+                    ok = beamtalk_repl_loader:maybe_trigger_recheck(
+                        <<"LoaderReCheckCounter">>,
+                        <<"size">>,
+                        instance,
+                        {captured, 'String', signature_change}
+                    ),
+                    [SecondMarked] = beamtalk_workspace_findings_store:get_origin(
+                        <<"LoaderReCheckDashboard">>, <<"LoaderReCheckCounter">>
+                    ),
+                    ?assertEqual(
+                        maps:get(note, FirstMarked), maps:get(note, SecondMarked)
+                    )
+                end)
+            ]
+        end}}.


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2832

`beamtalk_recheck:recheck_owner/5` (and `recheck_owner_for_shape/4`)'s `{failed, []}` outcome — fired when the `diagnostics/3` round-trip errors out or the compiler-port call itself fails/times out — had no integration test coverage. Unlike the `skipped` outcome (no live source, trivially triggerable by omitting `set_class_source/2`), `failed` is not reachable via source content alone: the compiler port's `handle_diagnostics` always replies `status => ok`, folding parse/type errors into the diagnostics list rather than a port-level `{error, _}`. This codebase has no mocking library and no existing fault-injection precedent for this kind of test.

- Added `beamtalk_compiler_server:inject_diagnostics_failure/1` — a `-ifdef(TEST)`-gated, self-clearing fault-injection hook. It forces the *next* `diagnostics/3` call to return `{error, _}` without ever touching the real compiler port, then automatically resets. Zero production behavior change: the new state field defaults to `undefined` and the setter function doesn't exist outside TEST builds.
- Added 3 direct unit tests in `beamtalk_compiler_server_tests.erl` proving the fault fires exactly once and self-clears.
- Added 3 integration tests in `beamtalk_repl_loader_recheck_tests.erl` exercising the `failed` outcome end-to-end through `beamtalk_repl_loader:maybe_trigger_recheck/4`, mirroring the existing `skipped_candidate_*` coverage from BT-2828: a pre-existing finding gets marked stale (not stranded), a candidate with no existing finding stays absent, and the stale-note marker is idempotent across consecutive failed reloads.
- Documented (in the new tests' header comment) why the shape-change path (`publish_shape_recheck_outcome/3`) needs no duplicate test: it funnels through the exact same `mark_unverified_findings_stale/2` call on the same `not_verified_owners` union.

## Key changes

- `runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl` — fault-injection mechanism
- `runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl` — direct unit tests for the mechanism
- `runtime/apps/beamtalk_workspace/test/beamtalk_repl_loader_recheck_tests.erl` — integration tests for the `failed` outcome

## Test plan

- [x] `rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler` — 5300 tests, 0 failures (run twice for stability)
- [x] `rebar3 dialyzer` — clean, no warnings
- [x] `rebar3 fmt --check` — clean
- [x] `just build && just clippy && just fmt-check` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MW992qobdVSMFP4cFqgwpF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MW992qobdVSMFP4cFqgwpF)_