### PR TITLE
Self-send error breadcrumb: fix class mismatch under inheritance + add sealed/tier2 test coverage (BT-2833)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -73,24 +73,44 @@ impl CoreErlangGenerator {
     /// `#{selector => Selector, class => Class}` construction — so a raw
     /// Erlang error escaping a self-send forwarding hop gets the same
     /// `ClassName>>selector: ...` location prefix (via `wrap_raw/2` /
-    /// `located/3`) as the cross-actor equivalent. Both `selector_atom` and
-    /// the enclosing class name are known at compile time, so the breadcrumb
-    /// is emitted as literal atoms, not runtime lookups.
+    /// `located/3`) as the cross-actor equivalent.
     ///
-    /// Known gap (BT-2833): `class_name()` is the compile-time *defining*
-    /// class of the method body, not the actor's runtime class. For a
-    /// self-send inside a method a subclass inherits without overriding,
-    /// this yields the superclass name instead of the actual instance's
-    /// class — unlike `sync_send_remote/3`, which resolves the runtime class
-    /// via `lookup_class/1`. Cosmetic only (location-prefix text, not
-    /// classification), tracked in BT-2833.
+    /// BT-2833: `class` is resolved via a *runtime* `beamtalk_actor:lookup_class/1`
+    /// call on `self()`, not a compile-time literal atom. For a self-send inside
+    /// a method a subclass inherits without overriding, the inherited method's
+    /// code lives in the superclass module, so a literal `class_name()` atom
+    /// would yield the superclass instead of the actor's actual runtime class —
+    /// unlike `sync_send_remote/3`, which resolves the runtime class via the
+    /// same `lookup_class/1` ETS reverse-lookup on `beamtalk_instance_registry`.
+    /// Emitting the same runtime lookup here keeps the self-send breadcrumb's
+    /// `class` value in parity with the cross-actor path for inherited methods.
+    /// `selector_atom` is still known at compile time and stays a literal atom.
+    ///
+    /// Known caveat: `lookup_class/1` reads `beamtalk_instance_registry`,
+    /// which the *spawner* populates only after `beamtalk_actor:safe_spawn/2`'s
+    /// `await_initialize/1` confirms `handle_continue(initialize, _)` has
+    /// finished (see `gen_server/spawn.rs`'s `instance_registration_doc`). A
+    /// self-send that raises *during* `initialize` therefore runs before this
+    /// actor's own registry entry exists, so `lookup_class(self())` falls
+    /// back to `'unknown'` for that narrow window — trading a guaranteed-
+    /// correct compile-time atom (for non-inherited classes only) for a
+    /// safe-but-less-specific fallback, in exchange for a correct answer in
+    /// every other case (including all inherited-method self-sends, the
+    /// actual bug this fixes). `lookup_class/1` never crashes either way.
+    ///
+    /// Core Erlang map literals (`~{...}~`) cannot contain `call` expressions
+    /// (see `lifecycle_start_telemetry_doc` in `gen_server/callbacks.rs` for the
+    /// same constraint), so the lookup is hoisted into a `let` binding inside
+    /// the clause body before the map is constructed. This only runs on the
+    /// error path — no overhead on the success path.
     ///
     /// # Generated Code
     ///
     /// ```erlang
     /// <{'error', {Type, Reason, Stacktrace}, _}> when 'true' ->
+    ///     let Class = call 'beamtalk_actor':'lookup_class'(call 'erlang':'self'()) in
     ///     call 'beamtalk_exception_handler':'reraise'(Type, Reason, Stacktrace,
-    ///         ~{'selector' => 'selector:', 'class' => 'ClassName'}~)
+    ///         ~{'selector' => 'selector:', 'class' => Class}~)
     /// <{'error', Error, _}> when 'true' -> call 'beamtalk_error':'raise'(Error)
     /// ```
     fn generate_self_dispatch_error_clause(
@@ -98,11 +118,11 @@ impl CoreErlangGenerator {
         var_prefix: &str,
         selector_atom: &str,
     ) -> Document<'static> {
-        let class_name = self.class_name();
         let type_var = self.fresh_var(&format!("{var_prefix}Type"));
         let reason_var = self.fresh_var(&format!("{var_prefix}Reason"));
         let stack_var = self.fresh_var(&format!("{var_prefix}Stack"));
         let plain_error_var = self.fresh_var(&format!("{var_prefix}Plain"));
+        let class_var = self.fresh_var(&format!("{var_prefix}Class"));
         docvec![
             "<{'error', {",
             leaf::var(type_var.clone()),
@@ -110,7 +130,10 @@ impl CoreErlangGenerator {
             leaf::var(reason_var.clone()),
             ", ",
             leaf::var(stack_var.clone()),
-            "}, _}> when 'true' -> call 'beamtalk_exception_handler':'reraise'(",
+            "}, _}> when 'true' -> let ",
+            leaf::var(class_var.clone()),
+            " = call 'beamtalk_actor':'lookup_class'(call 'erlang':'self'()) in ",
+            "call 'beamtalk_exception_handler':'reraise'(",
             leaf::var(type_var),
             ", ",
             leaf::var(reason_var),
@@ -119,7 +142,7 @@ impl CoreErlangGenerator {
             ", ~{'selector' => ",
             leaf::atom(selector_atom.to_string()),
             ", 'class' => ",
-            leaf::atom(class_name),
+            leaf::var(class_var),
             "}~) ",
             "<{'error', ",
             leaf::var(plain_error_var.clone()),

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -2853,6 +2853,25 @@ fn test_self_call_error_branch_threads_selector_class_breadcrumb() {
     // beamtalk_actor:sync_send_remote/3's cross-actor Context construction —
     // so a raw Erlang error escaping a forwarded self-send gets the same
     // `ClassName>>selector: ...` location prefix as the cross-actor case.
+    //
+    // BT-2833: `class` is now resolved via a runtime `lookup_class/1` call
+    // on `self()` — not a compile-time literal atom baked in from
+    // `class_name()` — so a self-send inside a method a subclass inherits
+    // without overriding still reports the actor's actual runtime class,
+    // not the compile-time defining class. Since the fix makes the
+    // breadcrumb codegen entirely class-name-agnostic (it never emits a
+    // literal atom for 'class' at all, regardless of which class is being
+    // compiled), a single compile of one class is sufficient to prove the
+    // mechanism.
+    //
+    // A BUnit e2e test (subclass instance invoking a purely-inherited,
+    // non-overridden self-dispatch method that raises) was attempted but is
+    // currently blocked by a separate, pre-existing bug: the runtime
+    // hierarchy-walk fallback (`generate_hierarchy_walk` in
+    // `gen_server/dispatch.rs`) discards the real error returned by
+    // `beamtalk_dispatch:super/5` whenever an inherited method raises,
+    // fabricating a bogus `does_not_understand` instead — masking this
+    // fix's effect for any selector not matched locally. Tracked in BT-2842.
     let src = concat!(
         "Actor subclass: Srv\n",
         "  state: value = 0\n\n",
@@ -2865,18 +2884,128 @@ fn test_self_call_error_branch_threads_selector_class_breadcrumb() {
     let code = codegen_source(src);
 
     // reraise/4 (four args: Type, Reason, Stacktrace, Context) is used, not
-    // the context-free reraise/3. The 4th arg is a literal
-    // ~{'selector' => 'setup', 'class' => 'Srv'}~ breadcrumb map — the
-    // selector/class are known at compile time so no variable names are
-    // involved (their exact fresh-var numbering is an implementation detail).
+    // the context-free reraise/3. The 4th arg is a breadcrumb map whose
+    // 'selector' is a literal atom (known at compile time) and whose 'class'
+    // is a variable bound just above from a runtime lookup_class/1 call —
+    // the exact fresh-var numbering is an implementation detail. Note the
+    // capture group is `\w+` (no quotes) — this would fail to match a
+    // literal quoted atom like 'Srv', so a successful match here already
+    // proves 'class' is a variable, not a compile-time literal.
     let reraise_with_breadcrumb = regex::Regex::new(
-        r"call 'beamtalk_exception_handler':'reraise'\(\w+, \w+, \w+, ~\{'selector' => 'setup', 'class' => 'Srv'\}~\)",
+        r"call 'beamtalk_exception_handler':'reraise'\(\w+, \w+, \w+, ~\{'selector' => 'setup', 'class' => (\w+)\}~\)",
+    )
+    .unwrap();
+    let captures = reraise_with_breadcrumb.captures(&code).unwrap_or_else(|| {
+        panic!(
+            "Self-dispatch error branch must call reraise/4 with a \
+             #{{selector => 'setup', class => <runtime-lookup var>}} \
+             breadcrumb map. Got:\n{code}"
+        )
+    });
+    let class_var = &captures[1];
+
+    // The 'class' value must come from a runtime lookup, not a literal
+    // 'Srv' atom — BT-2833 fixes the inheritance mismatch by resolving the
+    // actor's actual runtime class via beamtalk_actor:lookup_class/1.
+    let lookup_binding = regex::Regex::new(&format!(
+        r"let {class_var} = call 'beamtalk_actor':'lookup_class'\(call 'erlang':'self'\(\)\) in"
+    ))
+    .unwrap();
+    assert!(
+        lookup_binding.is_match(&code),
+        "Breadcrumb 'class' variable {class_var} must be bound from a \
+         runtime beamtalk_actor:lookup_class(self()) call. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_self_call_error_branch_sealed_direct_call_breadcrumb() {
+    // BT-2833: generate_direct_sealed_call (a sealed class self-sending one
+    // of its own sealed methods, in *closed* expression position — e.g. as
+    // the receiver of another message) had no breadcrumb coverage at all.
+    // A self-send nested inside a binary op forces codegen through the
+    // closed generate_self_dispatch -> generate_sealed_self_dispatch ->
+    // generate_direct_sealed_call path (the most optimized sealed-method
+    // call, bypassing safe_dispatch/dispatch entirely) rather than the
+    // top-level-statement generate_self_dispatch_open path already covered
+    // by test_self_call_error_branch_threads_selector_class_breadcrumb.
+    let src = concat!(
+        "sealed Actor subclass: Srv\n",
+        "  state: value = 0\n\n",
+        "  setup => 42\n\n",
+        "  doWork =>\n",
+        "    self setup + 1\n",
+    );
+    let code = codegen_source(src);
+
+    // Confirm this actually reached the direct __sealed_setup standalone
+    // function call — otherwise the test wouldn't be exercising
+    // generate_direct_sealed_call at all.
+    assert!(
+        code.contains("'__sealed_setup'"),
+        "Test setup must exercise generate_direct_sealed_call (direct \
+         __sealed_setup call), not a different self-dispatch path. Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_actor':'lookup_class'(call 'erlang':'self'())"),
+        "generate_direct_sealed_call's error branch must resolve the \
+         breadcrumb 'class' via a runtime lookup_class(self()) call. Got:\n{code}"
+    );
+    let reraise_with_breadcrumb = regex::Regex::new(
+        r"call 'beamtalk_exception_handler':'reraise'\(\w+, \w+, \w+, ~\{'selector' => 'setup', 'class' => \w+\}~\)",
     )
     .unwrap();
     assert!(
         reraise_with_breadcrumb.is_match(&code),
-        "Self-dispatch error branch must call reraise/4 with a literal \
-         #{{selector => 'setup', class => 'Srv'}} breadcrumb map. Got:\n{code}"
+        "generate_direct_sealed_call must thread the selector/class \
+         breadcrumb into reraise/4. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_self_call_error_branch_tier2_self_send_breadcrumb() {
+    // BT-2833: generate_tier2_self_send_open (a self-send passing a
+    // stateful block argument — one that captures and mutates an outer
+    // local, e.g. a user-defined HOM invocation like
+    // `self eachItem: [:x | count := count + x]`) had no breadcrumb
+    // coverage at all. Mirrors the real-world pattern verified in
+    // stdlib/test/fixtures/hom_composability_actor.bt's
+    // testMutatingBlockInCustomLoop.
+    let src = concat!(
+        "Actor subclass: Srv\n",
+        "  state: value = 0\n\n",
+        "  eachItem: aBlock =>\n",
+        "    last := nil\n",
+        "    #(1, 2, 3) do: [:each | last := aBlock value: each]\n",
+        "    last\n\n",
+        "  doWork =>\n",
+        "    count := 0\n",
+        "    self eachItem: [:x | count := count + x]\n",
+        "    count\n",
+    );
+    let code = codegen_source(src);
+
+    // Sanity: the Tier 2 stateful-block plumbing (StateAcc threading) is
+    // present, proving this test exercises generate_tier2_self_send_open
+    // and not a plain self-dispatch path.
+    assert!(
+        code.contains("StateAcc"),
+        "Test setup must exercise the Tier 2 stateful self-send path \
+         (generate_tier2_self_send_open). Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_actor':'lookup_class'(call 'erlang':'self'())"),
+        "generate_tier2_self_send_open's error branch must resolve the \
+         breadcrumb 'class' via a runtime lookup_class(self()) call. Got:\n{code}"
+    );
+    let reraise_with_breadcrumb = regex::Regex::new(
+        r"call 'beamtalk_exception_handler':'reraise'\(\w+, \w+, \w+, ~\{'selector' => 'eachItem:', 'class' => \w+\}~\)",
+    )
+    .unwrap();
+    assert!(
+        reraise_with_breadcrumb.is_match(&code),
+        "generate_tier2_self_send_open must thread the selector/class \
+         breadcrumb into reraise/4. Got:\n{code}"
     );
 }
 

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -187,6 +187,12 @@ handle_getValue([], State) ->
 %% Internal dispatch
 -export([dispatch/4, make_self/1]).
 
+%% BT-2833: exported so generated self-dispatch error breadcrumbs
+%% (dispatch_codegen.rs's generate_self_dispatch_error_clause) can resolve
+%% the actor's actual runtime class at the error-wrap boundary, matching
+%% sync_send_remote/3's cross-actor Context construction.
+-export([lookup_class/1]).
+
 %% BT-2524: per-object change publish hook, called from compiled actor
 %% gen_server callbacks after a method commits new state.
 %% BT-2717: strip_local_temps/1 cleans codegen-internal `__local__` threading

--- a/test-package-compiler/tests/snapshots/compiler_tests__abstract_class_spawn_codegen.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__abstract_class_spawn_codegen.snap
@@ -85,7 +85,7 @@ module 'abstract_class_spawn' ['start_link'/1, 'start_link'/2, 'init'/1, 'handle
 'dispatch'/4 = fun (Selector, Args, Self, State) ->
     case Selector of
         <'area'> when 'true' ->
-            let _SD1 = case call 'abstract_class_spawn':'safe_dispatch'('subclassResponsibility', [], State) of <{'reply', _SDResult2, _SDState3}> when 'true' -> {_SDResult2, _SDState3} <{'error', {_SDErrorType4, _SDErrorReason5, _SDErrorStack6}, _}> when 'true' -> call 'beamtalk_exception_handler':'reraise'(_SDErrorType4, _SDErrorReason5, _SDErrorStack6, ~{'selector' => 'subclassResponsibility', 'class' => 'Shape'}~) <{'error', _SDErrorPlain7, _}> when 'true' -> call 'beamtalk_error':'raise'(_SDErrorPlain7) end in let State1 = call 'erlang':'element'(2, _SD1) in {'reply', call 'erlang':'element'(1, _SD1), State1}
+            let _SD1 = case call 'abstract_class_spawn':'safe_dispatch'('subclassResponsibility', [], State) of <{'reply', _SDResult2, _SDState3}> when 'true' -> {_SDResult2, _SDState3} <{'error', {_SDErrorType4, _SDErrorReason5, _SDErrorStack6}, _}> when 'true' -> let _SDErrorClass8 = call 'beamtalk_actor':'lookup_class'(call 'erlang':'self'()) in call 'beamtalk_exception_handler':'reraise'(_SDErrorType4, _SDErrorReason5, _SDErrorStack6, ~{'selector' => 'subclassResponsibility', 'class' => _SDErrorClass8}~) <{'error', _SDErrorPlain7, _}> when 'true' -> call 'beamtalk_error':'raise'(_SDErrorPlain7) end in let State1 = call 'erlang':'element'(2, _SD1) in {'reply', call 'erlang':'element'(1, _SD1), State1}
         <OtherSelector> when 'true' ->
             %% BT-229/ADR 0005: Check extension registry before hierarchy walk
             let ExtLookup = try call 'beamtalk_extensions':'lookup'('Shape', OtherSelector)


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2833

Follow-up from BT-2822's adversarial code review. `generate_self_dispatch_error_clause` (the shared helper behind all 5 self-dispatch error-branch call sites) baked in the compile-time *defining* class as a literal Core Erlang atom for the `class` breadcrumb field, instead of the actor's actual *runtime* class. For a self-send inside a method a subclass inherits without overriding, this showed the superclass name instead of the real instance's class — inconsistent with the cross-actor equivalent (`sync_send_remote/3`), which always resolves the runtime class via `lookup_class/1`.

- `generate_self_dispatch_error_clause` now emits a runtime `beamtalk_actor:lookup_class(self())` call, hoisted into a `let` binding (Core Erlang map literals can't contain `call` expressions), instead of a literal atom — bringing self-dispatch breadcrumbs into parity with the cross-actor path.
- Exported `beamtalk_actor:lookup_class/1` (already had a `-spec`; dialyzer clean) so generated code can call it.
- Added Rust codegen unit tests for the two previously-uncovered call sites: `generate_direct_sealed_call` (sealed class, self-send to one of its own sealed methods) and `generate_tier2_self_send_open` (Tier 2 stored-block self-send).

**Known caveat** (documented in the code): a self-send that raises *during* `initialize` runs before the spawner registers the actor in `beamtalk_instance_registry`, so `lookup_class(self())` falls back to `'unknown'` for that narrow window. This trades a guaranteed-but-only-sometimes-correct compile-time atom for a safe (never-crashing), less-specific fallback in exchange for correctness in every other case — including all inherited-method self-sends, the actual bug this fixes.

**Filed BT-2842** for a separate, pre-existing bug discovered while building the inheritance regression test: the runtime hierarchy-walk fallback (`generate_hierarchy_walk`) discards the real error whenever an inherited method raises, fabricating a bogus `does_not_understand` instead. This blocks full end-to-end BUnit coverage of "a subclass instance invokes an inherited method that raises" — the BUnit e2e test originally planned for this scenario is not achievable until BT-2842 is fixed, so this PR ships with Rust-level codegen test coverage instead (proving the breadcrumb mechanism is correct and inheritance-agnostic).

## Key changes

- `crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs` — runtime `lookup_class` breadcrumb
- `runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl` — export `lookup_class/1`
- `crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs` — updated + 2 new tests

## Test plan

- [x] `cargo test -p beamtalk-core` — 4699 passed
- [x] `just test-bunit` — 2721 passed
- [x] Erlang eunit (`beamtalk_runtime,beamtalk_workspace,beamtalk_compiler`) — 5297 passed
- [x] `rebar3 dialyzer` — clean
- [x] `just clippy` / `just fmt-check` — clean
- [x] 3-pass code review (diff, system, adversarial via independent Opus review) completed; findings addressed or documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MW992qobdVSMFP4cFqgwpF)_