### PR TITLE
Nested Union type-args inside a Known type now recurse instead of auto-passing (BT-2847)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2847_nested_union_type_args.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2847_nested_union_type_args.rs
@@ -91,6 +91,11 @@ fn bt2847_nested_union_incompatible_member_warns() {
         checker.diagnostics()
     );
     assert!(warnings[0].message.contains("Array(String)"));
+    assert!(
+        warnings[0].message.contains("Array(String | Nil)"),
+        "Warning should render the nested union in the actual type: {}",
+        warnings[0].message
+    );
 }
 
 /// AC: no regression — a nested `Union` type-arg whose every member is

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2847_nested_union_type_args.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2847_nested_union_type_args.rs
@@ -1,0 +1,169 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! `type_args_compatible` no longer treats a nested `Union` type-arg as
+//! automatically compatible (BT-2847).
+//!
+//! Before this fix, any non-`Known` shape (`Dynamic`, `Union`, `Never`)
+//! nested inside a generic's type arguments short-circuited to `true` on the
+//! assumption a "broader checker" handled it elsewhere. That premise didn't
+//! hold for `Union`: `check_union_body_return_type` (BT-2829) only validates
+//! a *top-level* Union body type, so a method declared `-> Array(String)`
+//! whose body infers `Array(String | Nil)` passed silently.
+//!
+//! Per the spec decision (issue comment): only the `Union` half changes —
+//! a nested `Union` type-arg now recurses with the same
+//! `classify_union_members`-style check used at the top level (BT-1832).
+//! Nested `Dynamic`/`Never` stay permissive, unchanged.
+
+use super::common::*;
+
+/// Build a hierarchy containing a single empty `typed` class named
+/// `class_name`, on top of the builtins. Mirrors the pattern in
+/// `bt2829_return_type_union_dynamic.rs`.
+fn typed_class_hierarchy(class_name: &str) -> ClassHierarchy {
+    let source = format!("typed Object subclass: {class_name}\n");
+    let module = parse_source(&source);
+    ClassHierarchy::build(&module).0.unwrap()
+}
+
+/// Build a minimal unary method with the given declared return type
+/// annotation. `body` is irrelevant — `check_return_type` is called
+/// directly with a hand-constructed `body_type`, bypassing inference.
+fn method_with_return_type(return_type: TypeAnnotation) -> MethodDefinition {
+    MethodDefinition {
+        selector: MessageSelector::Unary("probe".into()),
+        parameters: vec![],
+        body: vec![bare(int_lit(0))],
+        return_type: Some(return_type),
+        kind: MethodKind::Primary,
+        is_sealed: false,
+        is_internal: false,
+        is_class_method: false,
+        span: span(),
+        doc_comment: None,
+        expect: None,
+        comments: CommentAttachment::default(),
+    }
+}
+
+fn array_of(element: TypeAnnotation) -> TypeAnnotation {
+    TypeAnnotation::Generic {
+        base: ident("Array"),
+        parameters: vec![element],
+        span: span(),
+    }
+}
+
+fn type_mismatch_diagnostics(checker: &TypeChecker) -> Vec<&Diagnostic> {
+    checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("declares return type"))
+        .collect()
+}
+
+/// AC: `Array(String)` declared vs. a body inferring `Array(String | Nil)`
+/// now produces a diagnostic — `Nil` isn't assignable to the expected
+/// `String` element type. This is the exact repro from the issue (nested
+/// `List(String)` vs. `List(String | Nil)`, using `Array` to match the other
+/// BT-2022-family tests in this suite).
+#[test]
+fn bt2847_nested_union_incompatible_member_warns() {
+    let hierarchy = typed_class_hierarchy("Probe");
+    let method = method_with_return_type(array_of(TypeAnnotation::Simple(ident("String"))));
+    let body_type = InferredType::known_with_args(
+        "Array",
+        vec![InferredType::union_of(&[
+            InferredType::known("String"),
+            InferredType::known("Nil"),
+        ])],
+    );
+
+    let mut checker = TypeChecker::new();
+    checker.check_return_type(&method, &body_type, &eco_string("Probe"), &hierarchy);
+
+    let warnings = type_mismatch_diagnostics(&checker);
+    assert_eq!(
+        warnings.len(),
+        1,
+        "Array(String | Nil) body should warn against declared Array(String): {:?}",
+        checker.diagnostics()
+    );
+    assert!(warnings[0].message.contains("Array(String)"));
+}
+
+/// AC: no regression — a nested `Union` type-arg whose every member is
+/// compatible with the expected inner type produces no diagnostic.
+/// `String | Symbol` are both compatible with the declared `Object` element
+/// type via the class hierarchy.
+#[test]
+fn bt2847_nested_union_all_compatible_no_diagnostic() {
+    let hierarchy = typed_class_hierarchy("Probe");
+    let method = method_with_return_type(array_of(TypeAnnotation::Simple(ident("Object"))));
+    let body_type = InferredType::known_with_args(
+        "Array",
+        vec![InferredType::union_of(&[
+            InferredType::known("String"),
+            InferredType::known("Symbol"),
+        ])],
+    );
+
+    let mut checker = TypeChecker::new();
+    checker.check_return_type(&method, &body_type, &eco_string("Probe"), &hierarchy);
+
+    assert!(
+        type_mismatch_diagnostics(&checker).is_empty(),
+        "Array(String | Symbol) body should not warn against declared Array(Object): {:?}",
+        checker.diagnostics()
+    );
+}
+
+/// AC: nested `Dynamic` type args continue to be treated permissively,
+/// unchanged — the spec decision keeps `Dynamic` as the checker's universal
+/// escape hatch (generics are erased at runtime).
+#[test]
+fn bt2847_nested_dynamic_stays_permissive() {
+    let hierarchy = typed_class_hierarchy("Probe");
+    let method = method_with_return_type(array_of(TypeAnnotation::Simple(ident("String"))));
+    let body_type =
+        InferredType::known_with_args("Array", vec![InferredType::Dynamic(DynamicReason::Unknown)]);
+
+    let mut checker = TypeChecker::new();
+    checker.check_return_type(&method, &body_type, &eco_string("Probe"), &hierarchy);
+
+    assert!(
+        type_mismatch_diagnostics(&checker).is_empty(),
+        "Array(Dynamic) body should stay permissive against declared Array(String): {:?}",
+        checker.diagnostics()
+    );
+}
+
+/// Conservative skip: a nested `Union` type-arg with a non-`Known` member
+/// (nested `Dynamic`) can't be reliably compared, so the whole union is
+/// skipped — mirrors `classify_union_members`'s (BT-1832) conservative
+/// fallback at the top level.
+#[test]
+fn bt2847_nested_union_with_dynamic_member_skips() {
+    let hierarchy = typed_class_hierarchy("Probe");
+    let method = method_with_return_type(array_of(TypeAnnotation::Simple(ident("String"))));
+    let body_type = InferredType::known_with_args(
+        "Array",
+        vec![InferredType::Union {
+            members: vec![
+                InferredType::known("Integer"),
+                InferredType::Dynamic(DynamicReason::Unknown),
+            ],
+            provenance: TypeProvenance::Inferred(span()),
+        }],
+    );
+
+    let mut checker = TypeChecker::new();
+    checker.check_return_type(&method, &body_type, &eco_string("Probe"), &hierarchy);
+
+    assert!(
+        type_mismatch_diagnostics(&checker).is_empty(),
+        "Array(Integer | <dynamic>) body should be skipped conservatively: {:?}",
+        checker.diagnostics()
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
@@ -15,6 +15,7 @@ mod basic_inference;
 mod bt2826_block_param_types;
 mod bt2829_return_type_union_dynamic;
 mod bt2835_stream_collect_return_type;
+mod bt2847_nested_union_type_args;
 mod cast_and_sync_send;
 mod destructure_and_extension;
 mod dynamic_and_blocks;

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -796,15 +796,42 @@ impl TypeChecker {
     /// shapes like `Result(Array(Integer), Error)` vs `Result(Array(String),
     /// Error)` are detected as mismatches at the inner level.
     ///
-    /// Returns true (compatible) for any non-`Known` shape (Dynamic, Union,
-    /// Never) — those are handled by the broader checker and we don't want to
-    /// double-warn here. Generic type-param placeholders (T, E, K, V) are
-    /// treated as compatible since they're symbolic.
+    /// BT-2847: a nested `Union` on the `actual` (body-inferred) side is no
+    /// longer an automatic pass — every member must be compatible with
+    /// `expected`, recursing through this same function (mirroring the
+    /// `classify_union_members`-style check used at the top level, BT-1832).
+    /// So a declared `List(String)` against a body inferring `List(String |
+    /// Nil)` now warns, since `Nil` isn't assignable to `String`. Like
+    /// `classify_union_members`, the whole union is skipped (permissive) if
+    /// any member is itself non-`Known` (nested `Dynamic`/`Union`/`Never`/
+    /// etc.) — we can't reason about those precisely enough to warn without
+    /// risking a false positive.
+    ///
+    /// Nested `Dynamic`/`Never` on either side (outside of a `Union`) still
+    /// short-circuit to `true` — that stays permissive per the BT-2847 spec
+    /// decision: `Dynamic` is the checker's universal escape hatch and
+    /// Beamtalk generics are erased at runtime, so there's no runtime-safety
+    /// payoff to warning on nested `Dynamic` the way there is for a concrete
+    /// incompatible `Union` member like `Nil`. Generic type-param
+    /// placeholders (T, E, K, V) are treated as compatible since they're
+    /// symbolic.
     fn type_args_compatible(
         expected: &InferredType,
         actual: &InferredType,
         hierarchy: &ClassHierarchy,
     ) -> bool {
+        if let InferredType::Union { members, .. } = actual {
+            // Conservative skip (classify_union_members-style): a non-Known
+            // member (nested Dynamic/Union/Never/etc.) means we can't reason
+            // about the union precisely, so stay permissive for the whole
+            // thing rather than risk a false positive.
+            if members.iter().any(|m| m.as_known().is_none()) {
+                return true;
+            }
+            return members
+                .iter()
+                .all(|member| Self::type_args_compatible(expected, member, hierarchy));
+        }
         let (
             InferredType::Known {
                 class_name: exp_name,
@@ -818,7 +845,7 @@ impl TypeChecker {
             },
         ) = (expected, actual)
         else {
-            return true; // Dynamic / Union / Never on either side — skip
+            return true; // Dynamic / Never on either side — skip
         };
         if super::is_generic_type_param(exp_name) || super::is_generic_type_param(act_name) {
             return true;


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-2847

## Summary

`type_args_compatible` treated any non-`Known` shape (`Dynamic`, `Union`, `Never`) nested inside a generic's type arguments as automatically compatible, on the assumption a "broader checker" handles it elsewhere. That premise didn't hold for `Union`: `check_union_body_return_type` (BT-2829) only validates a *top-level* `Union` body type — there's no separate pass validating a `Union` nested *inside* a `Known` type's `type_args`. So a method declared `-> Array(String)` whose body inferred `Array(String | Nil)` passed silently.

Per the spec decision recorded on the issue: only the `Union` half changes.

- A nested `Union` type-arg on the body-inferred side now recurses with the same `classify_union_members`-style check used at the top level (BT-1832): every member must be compatible with the expected type, and the whole union is skipped conservatively (permissive) if any member is itself non-`Known` (nested `Dynamic`/`Union`/`Never`/etc.).
- Nested `Dynamic`/`Never` (outside of a `Union`) stay permissive, unchanged — `Dynamic` remains the checker's universal escape hatch, and Beamtalk generics are erased at runtime, so there's no runtime-safety payoff to warning there.

## Key changes

- `crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs`: `type_args_compatible` gains a `Union`-on-`actual` recursion arm.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2847_nested_union_type_args.rs` (new): regression tests for nested-Union-incompatible (warns), nested-Union-compatible (no diagnostic), nested-Dynamic (unchanged, no diagnostic), and nested-Union-with-a-Dynamic-member (conservative skip).

## Test plan

- [x] `cargo test -p beamtalk-core` — 4730 passed, 0 failed (includes 4 new BT-2847 tests)
- [x] `just test` — Rust, stdlib (223/223), BUnit (2722/2722), runtime (5300+1584), all 0 failed
- [x] `just clippy` / `just fmt` — clean
- [x] Manually verified the emitted diagnostic message renders the nested union cleanly: `Method 'probe' in Probe declares return type Array(String), but body returns Array(String | Nil)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)