### PR TITLE
Cascade continuation messages skip argument type-checking entirely (BT-2845)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -716,7 +716,14 @@ impl TypeChecker {
                 let is_class_side_send = Self::is_class_side_receiver(cascade_target, env);
                 for msg in messages {
                     let selector_name = msg.selector.name();
-                    self.infer_args_with_block_context(
+                    // BT-2845: capture the inferred argument types so every
+                    // cascaded message (not just the first) can be run
+                    // through `check_argument_types` below — previously this
+                    // return value was discarded, so a mistyped argument to a
+                    // second-or-later cascade message went entirely
+                    // unchecked, unlike the same send written as its own
+                    // statement.
+                    let arg_types = self.infer_args_with_block_context(
                         &msg.arguments,
                         &dispatch_ty,
                         &selector_name,
@@ -727,6 +734,16 @@ impl TypeChecker {
                     );
                     if is_class_ref {
                         if let Expression::ClassReference { name, .. } = unwrapped_target {
+                            self.check_argument_types(
+                                &name.name,
+                                &selector_name,
+                                &arg_types,
+                                msg.span,
+                                hierarchy,
+                                true,
+                                Some(&msg.arguments),
+                                Some(env),
+                            );
                             self.check_class_side_send(
                                 &name.name,
                                 &selector_name,
@@ -738,6 +755,16 @@ impl TypeChecker {
                     } else if let InferredType::Known { ref class_name, .. } = dispatch_ty {
                         if env.in_class_method && Self::is_self_receiver(unwrapped_target) {
                             if !in_abstract_method {
+                                self.check_argument_types(
+                                    class_name,
+                                    &selector_name,
+                                    &arg_types,
+                                    msg.span,
+                                    hierarchy,
+                                    true,
+                                    Some(&msg.arguments),
+                                    Some(env),
+                                );
                                 self.check_class_side_send(
                                     class_name,
                                     &selector_name,
@@ -747,6 +774,25 @@ impl TypeChecker {
                                 );
                             }
                         } else {
+                            // Skip argument type check for binary messages —
+                            // `check_binary_operand_types` (run on the first
+                            // cascade send via `infer_message_send_with_receiver_ty`)
+                            // already provides more specific warnings for
+                            // arithmetic/comparison/concat; mirrors the
+                            // non-cascade skip at the bottom of
+                            // `infer_message_send_with_receiver_ty`.
+                            if !matches!(msg.selector, MessageSelector::Binary(_)) {
+                                self.check_argument_types(
+                                    class_name,
+                                    &selector_name,
+                                    &arg_types,
+                                    msg.span,
+                                    hierarchy,
+                                    false,
+                                    Some(&msg.arguments),
+                                    Some(env),
+                                );
+                            }
                             self.check_instance_selector(
                                 class_name,
                                 &selector_name,
@@ -755,7 +801,14 @@ impl TypeChecker {
                             );
                         }
                     } else if let InferredType::Union { ref members, .. } = dispatch_ty {
-                        // Union cascades: validate selector on all members
+                        // Union cascades: validate selector on all members.
+                        // Argument-type checking against a union *receiver* is
+                        // out of scope here — `infer_message_send_with_receiver_ty`
+                        // doesn't perform it for the first cascade message
+                        // either (see `infer_union_message_send`), so this
+                        // preserves parity rather than introducing new
+                        // behaviour beyond BT-2845's scope (unchecked
+                        // arguments on continuation messages).
                         self.infer_union_message_send(members, &selector_name, msg.span, hierarchy);
                     }
                 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/arg_return_checking.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/arg_return_checking.rs
@@ -767,3 +767,127 @@ fn test_all_type_warnings_are_severity_warning() {
         );
     }
 }
+
+// ---- BT-2845: cascade continuation messages (2nd+) run argument-type checking ----
+//
+// Prior to this fix, `Expression::Cascade`'s `for msg in messages` loop
+// inferred argument types purely for block-param propagation
+// (`infer_args_with_block_context`) but never fed the result into
+// `check_argument_types` — so a mistyped argument on the *second or later*
+// cascaded message went completely unchecked, unlike writing the same sends
+// as separate statements. These tests use the exact repro shape from the
+// issue: a `typed Value` class with two Integer-parameter methods sent in a
+// cascade from a class method.
+
+/// (a) A second cascade message with an incompatible `Known` (concrete)
+/// argument type must warn — mirrors the issue's exact repro.
+#[test]
+fn test_cascade_second_message_known_arg_mismatch_warns() {
+    let source = "\
+typed Value subclass: Thing
+  probeCascadeA: x :: Integer -> Thing => self
+  probeCascadeB: x :: Integer -> Integer => x + 1
+
+  class probeCascadeRun -> Nil =>
+    c := self new
+    c probeCascadeA: 1; probeCascadeB: \"wrong-type\"
+    nil
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let arg_warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expects Integer"))
+        .collect();
+    assert_eq!(
+        arg_warnings.len(),
+        1,
+        "second cascade message `probeCascadeB: \"wrong-type\"` should warn about the String argument, got: {diags:#?}"
+    );
+}
+
+/// (b) A second cascade message with an incompatible `Union`-typed argument
+/// (no member compatible with the declared parameter type) must warn too —
+/// the gap wasn't conditioned on `Union` vs `Known`, every argument type was
+/// unchecked for continuation messages.
+#[test]
+fn test_cascade_second_message_union_arg_mismatch_warns() {
+    let source = "\
+typed Value subclass: Thing
+  probeCascadeA: x :: Integer -> Thing => self
+  probeCascadeB: x :: Integer -> Integer => x + 1
+
+  class probeCascadeRun: y :: String | Symbol -> Nil =>
+    c := self new
+    c probeCascadeA: 1; probeCascadeB: y
+    nil
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let arg_warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expects Integer"))
+        .collect();
+    assert_eq!(
+        arg_warnings.len(),
+        1,
+        "second cascade message `probeCascadeB: y` (y :: String | Symbol) should warn — no union member is Integer, got: {diags:#?}"
+    );
+}
+
+/// (c) A fully-valid multi-message cascade — every message's arguments
+/// already match their declared parameter types — must stay diagnostic-free.
+/// No regression: adding the check must not fire false positives on correct code.
+#[test]
+fn test_cascade_all_messages_valid_no_warning() {
+    let source = "\
+typed Value subclass: Thing
+  probeCascadeA: x :: Integer -> Thing => self
+  probeCascadeB: x :: Integer -> Integer => x + 1
+
+  class probeCascadeRun -> Nil =>
+    c := self new
+    c probeCascadeA: 1; probeCascadeB: 2
+    nil
+";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    assert!(
+        diags.is_empty(),
+        "a fully-valid cascade should produce no diagnostics, got: {diags:#?}"
+    );
+}
+
+/// (d) Block-parameter propagation into cascaded messages (the reason
+/// `infer_args_with_block_context` exists, BT-2158) must keep working once
+/// `check_argument_types` also runs on those messages — the new check must
+/// not regress typed block params into "Dynamic" false warnings. Exercises
+/// the instance-side cascade path (`self.nums sort: [...]; yourself`) as a
+/// second BT-2845-focused example alongside the pre-existing BT-2158
+/// class-side coverage in `dynamic_and_blocks.rs`.
+#[test]
+fn test_cascade_block_param_propagation_still_works_with_arg_check() {
+    let source = "typed Object subclass: T\n  field: nums :: List(Integer)\n  m -> List(Integer) =>\n    self.nums\n      sort: [:a :b | a < b];\n      yourself";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let dynamic_warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expression inferred as Dynamic"))
+        .collect();
+    assert!(
+        dynamic_warnings.is_empty(),
+        "block params in a cascaded `sort:` should still be typed from List(Integer), got: {dynamic_warnings:?}"
+    );
+    let arg_warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expects"))
+        .collect();
+    assert!(
+        arg_warnings.is_empty(),
+        "correctly-typed cascaded block arg should not warn, got: {arg_warnings:?}"
+    );
+}


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-2845

## Summary
- `Expression::Cascade`'s continuation-message loop inferred argument types purely for block-param propagation (`infer_args_with_block_context`) and discarded the result — so `check_argument_types` never ran for any cascaded message after the first. `c foo: 1; bar: "wrong-type"` silently skipped type checking on `bar:`, unlike the same sends written as separate statements.
- Threaded the inferred `arg_types` into `check_argument_types` for all three dispatch branches (class-reference receiver, `self` inside a class method, known-instance receiver), mirroring exactly how `infer_message_send_with_receiver_ty` already checks the cascade's first send — including skipping the check for binary selectors (handled instead by `check_binary_operand_types`).
- Union-receiver cascades are left unchanged: the first cascade message doesn't get argument-type checking against a union *receiver* either (`infer_union_message_send` only does selector/DNU resolution), so this preserves parity rather than expanding scope.
- Verified end-to-end against the issue's exact repro via `beamtalk lint`: `probeCascadeB: "wrong-type"` now correctly warns `Argument 1 of 'probeCascadeB:' on Thing expects Integer, got String`.

## Test plan
- [x] New regression tests in `arg_return_checking.rs`: known-type mismatch on 2nd cascade message warns, union-type mismatch on 2nd cascade message warns, fully-valid cascade stays diagnostic-free, block-param propagation into cascaded messages (BT-2158) still works alongside the new check.
- [x] `just build && just clippy && just fmt-check` clean.
- [x] `just test` — all Rust (4729), stdlib (223), BUnit (2724), and Erlang runtime (5300+1584) tests pass.
- [x] Manual `beamtalk lint` against the issue's literal repro confirms the fix.

Filed a scoped follow-up for a structurally identical gap found during review: BT-2850 (`spawnWith:` literal-map key checking also skips cascade continuation messages) — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)