### PR TITLE
check_state_defaults has no Union arm for class-body default values (BT-2848)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/state_fields.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/state_fields.rs
@@ -283,6 +283,114 @@ fn test_state_default_value_match_no_warn() {
     );
 }
 
+// --- BT-2848: Union-typed state defaults ---
+
+#[test]
+fn test_state_default_union_incompatible_member_warns() {
+    // helper -> String | Integer => 42.  state: value :: String = self helper.
+    // The default's inferred type is Union(String, Integer); Integer is not
+    // assignable to the declared String, so a diagnostic should fire.
+    let helper_method = MethodDefinition::with_return_type(
+        MessageSelector::Unary("helper".into()),
+        vec![],
+        vec![bare(int_lit(42))],
+        TypeAnnotation::union(
+            vec![
+                TypeAnnotation::simple("String", span()),
+                TypeAnnotation::simple("Integer", span()),
+            ],
+            span(),
+        ),
+        span(),
+    );
+    let state = vec![StateDeclaration::with_type_and_default(
+        ident("value"),
+        TypeAnnotation::simple("String", span()),
+        msg_send(var("self"), MessageSelector::Unary("helper".into()), vec![]),
+        span(),
+    )];
+    let class = counter_class_with_typed_state(vec![helper_method], state);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let warnings: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("Type mismatch") && d.message.contains("value"))
+        .collect();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "Expected 1 type mismatch for union default with incompatible member, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn test_state_default_union_all_compatible_no_warn() {
+    // helper -> Integer | Number => 42.  state: value :: Number = self helper.
+    // Both union members (Integer, Number) are assignable to the declared
+    // Number, so no diagnostic should fire.
+    let helper_method = MethodDefinition::with_return_type(
+        MessageSelector::Unary("helper".into()),
+        vec![],
+        vec![bare(int_lit(42))],
+        TypeAnnotation::union(
+            vec![
+                TypeAnnotation::simple("Integer", span()),
+                TypeAnnotation::simple("Number", span()),
+            ],
+            span(),
+        ),
+        span(),
+    );
+    let state = vec![StateDeclaration::with_type_and_default(
+        ident("value"),
+        TypeAnnotation::simple("Number", span()),
+        msg_send(var("self"), MessageSelector::Unary("helper".into()), vec![]),
+        span(),
+    )];
+    let class = counter_class_with_typed_state(vec![helper_method], state);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    assert!(
+        checker.diagnostics().is_empty(),
+        "Union default with all-compatible members should not warn, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn test_state_default_dynamic_no_warn() {
+    // state: count: Integer = unknownVar → unknownVar is unbound, so the
+    // default's inferred type is Dynamic. Dynamic defaults must remain
+    // unchecked (BT-2848 AC (c)) — same behaviour as before the Union arm
+    // was added.
+    let state = vec![StateDeclaration::with_type_and_default(
+        ident("count"),
+        TypeAnnotation::simple("Integer", span()),
+        var("unknownVar"),
+        span(),
+    )];
+    let class = counter_class_with_typed_state(vec![], state);
+    let module = make_module_with_classes(vec![], vec![class]);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+    let type_mismatches: Vec<_> = checker
+        .diagnostics()
+        .iter()
+        .filter(|d| d.message.contains("Type mismatch"))
+        .collect();
+    assert!(
+        type_mismatches.is_empty(),
+        "Dynamic default value should not produce a type mismatch warning, got: {type_mismatches:?}"
+    );
+}
+
 #[test]
 fn test_dynamic_expression_no_warn() {
     // Assigning a dynamic expression (unknown variable) to a typed field → no assignment warning

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -2306,8 +2306,12 @@ impl TypeChecker {
                     self.diagnostics
                         .push(diag.with_category(DiagnosticCategory::Type));
                 }
-                // Dynamic / Never / Meta / Negation / Intersection defaults —
-                // skip conservatively, matching `check_field_assignment`.
+                // Dynamic / Never / Negation / Intersection defaults — skip
+                // conservatively, matching `check_field_assignment`. `Meta`
+                // (`C class` as a default value) is left unchecked here too;
+                // `check_field_assignment`'s explicit `Meta` handling (ADR
+                // 0083, metatype-vs-`Class` assignability) is out of scope
+                // for this ticket (BT-2848), which only adds the `Union` arm.
                 _ => {}
             }
         }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -2229,31 +2229,86 @@ impl TypeChecker {
             let mut env = TypeEnv::new();
             env.set_local("self", InferredType::known(class.name.name.clone()));
             let inferred = self.infer_expr(default_value, hierarchy, &mut env, false);
-            let InferredType::Known {
-                class_name: value_type,
-                ..
-            } = &inferred
-            else {
-                continue; // Dynamic defaults are fine
-            };
-            if !Self::is_assignable_to(value_type, &declared_type, hierarchy) {
-                // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
-                let declared_display =
-                    InferredType::class_name_for_diagnostic(declared_type.as_str());
-                let value_display = InferredType::class_name_for_diagnostic(value_type.as_str());
-                self.diagnostics.push(
-                    Diagnostic::warning(
-                        format!(
-                            "Type mismatch: state `{}` declared as {declared_display}, default is {value_display}",
-                            decl.name.name
-                        ),
-                        decl.span,
-                    )
-                    .with_category(DiagnosticCategory::Type)
-                    .with_hint(format!(
-                        "Default value type {value_display} is not compatible with {declared_display}"
-                    )),
-                );
+            match &inferred {
+                InferredType::Known {
+                    class_name: value_type,
+                    ..
+                } => {
+                    if !Self::is_assignable_to(value_type, &declared_type, hierarchy) {
+                        // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+                        let declared_display =
+                            InferredType::class_name_for_diagnostic(declared_type.as_str());
+                        let value_display =
+                            InferredType::class_name_for_diagnostic(value_type.as_str());
+                        self.diagnostics.push(
+                            Diagnostic::warning(
+                                format!(
+                                    "Type mismatch: state `{}` declared as {declared_display}, default is {value_display}",
+                                    decl.name.name
+                                ),
+                                decl.span,
+                            )
+                            .with_category(DiagnosticCategory::Type)
+                            .with_hint(format!(
+                                "Default value type {value_display} is not compatible with {declared_display}"
+                            )),
+                        );
+                    }
+                }
+                InferredType::Union { members, .. } => {
+                    // BT-2848: Check all union members against the declared field
+                    // type, mirroring `check_field_assignment`'s handling
+                    // (BT-1832).
+                    let Some((compat, total, incompatible)) =
+                        Self::classify_union_members(members, |m| {
+                            Self::is_assignable_to(m, &declared_type, hierarchy)
+                        })
+                    else {
+                        continue; // Contains Dynamic — skip
+                    };
+                    if compat == total {
+                        continue; // All members compatible
+                    }
+                    let union_display = inferred
+                        .display_for_diagnostic()
+                        .unwrap_or_else(|| EcoString::from("Dynamic"));
+                    // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+                    let declared_display =
+                        InferredType::class_name_for_diagnostic(declared_type.as_str());
+                    let diag = if compat == 0 {
+                        Diagnostic::warning(
+                            format!(
+                                "Type mismatch: state `{}` declared as {declared_display}, default is {union_display}",
+                                decl.name.name
+                            ),
+                            decl.span,
+                        )
+                        .with_hint(format!(
+                            "No member of {union_display} is compatible with {declared_display}"
+                        ))
+                    } else {
+                        let list = incompatible
+                            .iter()
+                            .map(|m| InferredType::class_name_for_diagnostic(m.as_str()))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        Diagnostic::hint(
+                            format!(
+                                "Type mismatch: state `{}` declared as {declared_display}, default is {union_display}",
+                                decl.name.name
+                            ),
+                            decl.span,
+                        )
+                        .with_hint(format!(
+                            "Some members of the union are not compatible with {declared_display}: {list}"
+                        ))
+                    };
+                    self.diagnostics
+                        .push(diag.with_category(DiagnosticCategory::Type));
+                }
+                // Dynamic / Never / Meta / Negation / Intersection defaults —
+                // skip conservatively, matching `check_field_assignment`.
+                _ => {}
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes [BT-2848](https://linear.app/beamtalk/issue/BT-2848): `check_state_defaults` only handled `InferredType::Known` and silently skipped everything else (including `Union`), so a class-body field default value that infers to a `Union` type (e.g. via a helper method with a `|` return type) was never checked against the declared field type.

- Add an `InferredType::Union` arm to `check_state_defaults`, mirroring `check_field_assignment`/`check_spawn_with_value`'s existing handling (BT-1832): each union member is checked against the declared field type via `classify_union_members`, producing a `warning` when no member is compatible and a `hint` when only some are.
- `Dynamic` defaults remain unchecked, as before.
- Clarified the catch-all comment: `Meta` defaults are left unchecked here too (out of scope for this ticket) even though `check_field_assignment` validates `Meta` explicitly — noted so the comment doesn't overstate parity.

## Test plan

- [x] `test_state_default_union_incompatible_member_warns` — Union default with an incompatible member fires a diagnostic
- [x] `test_state_default_union_all_compatible_no_warn` — Union default where all members are compatible produces no diagnostic
- [x] `test_state_default_dynamic_no_warn` — Dynamic default remains unchecked (no regression)
- [x] `test_state_default_value_mismatch_warns` / `test_state_default_value_match_no_warn` (pre-existing) still pass — no regression for `Known`-typed defaults
- [x] `cargo test -p beamtalk-core --lib semantic_analysis::type_checker` — 1026 passed
- [x] `just test` — full fast suite green (Rust, stdlib, BUnit, runtime)
- [x] `cargo clippy -p beamtalk-core --all-targets` — clean
- [x] `cargo fmt --check` — clean

Note: `just ci`'s `lint-workaround-comments` step failed, but on lines in files this branch does not touch (`crates/beamtalk-cli/src/dependency_classes.rs`, `bt2826_block_param_types.rs`) — confirmed pre-existing on `origin/main` (verified via `git diff origin/main` showing no changes to those files), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)