### PR TITLE
FFI argument type-checking has no Union arm — check_ffi_argument_types (BT-2846)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1462,6 +1462,7 @@ impl TypeChecker {
                     arguments,
                     &arg_types,
                     span,
+                    hierarchy,
                 );
             }
 
@@ -1762,6 +1763,7 @@ impl TypeChecker {
     /// the registry's declared parameter names (ADR 0075 — footgun prevention).
     ///
     /// **References:** ADR 0075 — Type Checker Integration, Keyword mismatch warning
+    #[allow(clippy::too_many_arguments)] // BT-2846: hierarchy needed for Union-arm compatibility checks
     fn infer_ffi_call(
         &mut self,
         receiver_type_args: &[InferredType],
@@ -1770,6 +1772,7 @@ impl TypeChecker {
         arguments: &[Expression],
         arg_types: &[InferredType],
         span: Span,
+        hierarchy: &ClassHierarchy,
     ) -> InferredType {
         // Extract the module name from the receiver's type args.
         // ErlangModule<lists> → module_name = "lists"
@@ -1802,7 +1805,14 @@ impl TypeChecker {
         self.check_ffi_keyword_mismatch(module_name, &function_name, arity, selector, &sig, span);
 
         // Check argument types positionally against declared params
-        self.check_ffi_argument_types(module_name, &function_name, &sig, arg_types, span);
+        self.check_ffi_argument_types(
+            module_name,
+            &function_name,
+            &sig,
+            arg_types,
+            span,
+            hierarchy,
+        );
 
         // BT-2023(C): Propagate call-site type_args into the FFI return type.
         // Erlang specs with polymorphic types (e.g., `[T] -> [T]` for lists:reverse/1)
@@ -1837,13 +1847,14 @@ impl TypeChecker {
     /// Checks argument types against declared parameter types in an FFI signature.
     ///
     /// Types are matched positionally (ADR 0075 — FFI calls are positional).
-    fn check_ffi_argument_types(
+    pub(super) fn check_ffi_argument_types(
         &mut self,
         module_name: &str,
         function_name: &str,
         sig: &super::native_type_registry::FunctionSignature,
         arg_types: &[InferredType],
         span: Span,
+        hierarchy: &ClassHierarchy,
     ) {
         for (i, (param, arg_ty)) in sig.params.iter().zip(arg_types.iter()).enumerate() {
             // Skip Dynamic args — we don't know the type
@@ -1855,39 +1866,88 @@ impl TypeChecker {
                 continue;
             }
 
-            if let (
-                InferredType::Known {
-                    class_name: expected,
-                    ..
-                },
+            let InferredType::Known {
+                class_name: expected,
+                ..
+            } = &param.type_
+            else {
+                continue;
+            };
+
+            let param_pos = i + 1;
+            let fallback_label = format!("parameter {param_pos}");
+            let param_label = param.keyword.as_deref().unwrap_or(&fallback_label);
+            // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
+            let expected_display = InferredType::class_name_for_diagnostic(expected.as_str());
+
+            // Object is the root of the BT class hierarchy — any class is a
+            // subtype. This arises when Erlang specs use beamtalk_object()
+            // (which maps to Object) and the call site passes a concrete class.
+            let expected_is_object =
+                WellKnownClass::from_str(expected) == Some(WellKnownClass::Object);
+
+            match arg_ty {
                 InferredType::Known {
                     class_name: actual, ..
-                },
-            ) = (&param.type_, arg_ty)
-            {
-                if expected == actual {
-                    continue;
+                } => {
+                    if actual == expected || expected_is_object {
+                        continue;
+                    }
+                    let actual_display = InferredType::class_name_for_diagnostic(actual.as_str());
+                    self.diagnostics.push(Diagnostic::warning(
+                        format!(
+                            "{module_name}:{function_name}/{arity} {param_label} expects {expected_display}, got {actual_display}",
+                            arity = sig.arity,
+                        ),
+                        span,
+                    ).with_hint("Use `@expect type` to suppress if the call is intentional")
+                    .with_category(DiagnosticCategory::Type));
                 }
-                // Object is the root of the BT class hierarchy — any class is
-                // a subtype. This arises when Erlang specs use beamtalk_object()
-                // (which maps to Object) and the call site passes a concrete class.
-                if WellKnownClass::from_str(expected) == Some(WellKnownClass::Object) {
-                    continue;
-                }
-                let param_pos = i + 1;
-                let fallback_label = format!("parameter {param_pos}");
-                let param_label = param.keyword.as_deref().unwrap_or(&fallback_label);
-                // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
-                let expected_display = InferredType::class_name_for_diagnostic(expected.as_str());
-                let actual_display = InferredType::class_name_for_diagnostic(actual.as_str());
-                self.diagnostics.push(Diagnostic::warning(
-                    format!(
-                        "{module_name}:{function_name}/{arity} {param_label} expects {expected_display}, got {actual_display}",
+                InferredType::Union { members, .. } => {
+                    // BT-2846: mirrors check_argument_types's Union handling
+                    // (BT-1832) — every member of the argument's union is
+                    // checked against the declared FFI parameter type.
+                    if expected_is_object {
+                        continue;
+                    }
+                    let Some((compat, total, incompatible)) =
+                        Self::classify_union_members(members, |m| {
+                            Self::is_type_compatible(m, expected, hierarchy)
+                        })
+                    else {
+                        continue; // Contains Dynamic/Union/Meta/Never member — skip conservatively
+                    };
+                    if compat == total {
+                        continue; // All members compatible → pass
+                    }
+                    let union_display = arg_ty
+                        .display_for_diagnostic()
+                        .unwrap_or_else(|| EcoString::from("Dynamic"));
+                    let base_message = format!(
+                        "{module_name}:{function_name}/{arity} {param_label} expects {expected_display}, got {union_display}",
                         arity = sig.arity,
-                    ),
-                    span,
-                ).with_hint("Use `@expect type` to suppress if the call is intentional")
-                .with_category(DiagnosticCategory::Type));
+                    );
+                    let diag = if compat == 0 {
+                        Diagnostic::warning(base_message, span).with_hint(format!(
+                            "No member of {union_display} is compatible with {expected_display}"
+                        ))
+                    } else {
+                        let list = incompatible
+                            .iter()
+                            .map(|m| InferredType::class_name_for_diagnostic(m.as_str()))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        Diagnostic::hint(base_message, span).with_hint(format!(
+                            "Some members of the union are not compatible with {expected_display}: {list}"
+                        ))
+                    };
+                    self.diagnostics
+                        .push(diag.with_category(DiagnosticCategory::Type));
+                }
+                _ => {
+                    // Meta/Negation/Intersection/Never argument shapes are not
+                    // handled by this check — same conservative skip as before.
+                }
             }
         }
     }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/ffi.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/ffi.rs
@@ -814,6 +814,171 @@ fn test_erlang_module_proxy_equality_uses_normal_dispatch() {
     );
 }
 
+// ---- BT-2846: Union arm for check_ffi_argument_types ----
+
+/// Helper: a `FunctionSignature` for a single-param FFI function `mod:fun/1`
+/// whose declared parameter type is `param_type`.
+fn single_param_sig(param_type: InferredType) -> FunctionSignature {
+    FunctionSignature {
+        name: "fun".to_string(),
+        arity: 1,
+        params: vec![ParamType {
+            keyword: Some(ecow::EcoString::from("arg")),
+            type_: param_type,
+        }],
+        return_type: InferredType::Dynamic(DynamicReason::DynamicSpec),
+        provenance: TypeProvenance::Extracted,
+        line: None,
+    }
+}
+
+#[test]
+fn ffi_union_arg_incompatible_member_warns() {
+    // `String | Integer` passed to a param declared `String` — the `Integer`
+    // member is incompatible, so a diagnostic must fire.
+    let sig = single_param_sig(InferredType::known("String"));
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    checker.check_ffi_argument_types(
+        "mymod",
+        "fun",
+        &sig,
+        &[InferredType::simple_union(&["String", "Integer"])],
+        span(),
+        &hierarchy,
+    );
+    assert_eq!(
+        checker.diagnostics().len(),
+        1,
+        "Union with an incompatible member should emit a diagnostic. Got: {:?}",
+        checker.diagnostics()
+    );
+    assert!(checker.diagnostics()[0].message.contains("expects String"));
+}
+
+#[test]
+fn ffi_union_arg_all_members_compatible_no_warning() {
+    // `String | String` (degenerate but valid) — every member matches the
+    // declared `String` param, so no diagnostic should fire.
+    let sig = single_param_sig(InferredType::known("String"));
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    checker.check_ffi_argument_types(
+        "mymod",
+        "fun",
+        &sig,
+        &[InferredType::simple_union(&["String", "String"])],
+        span(),
+        &hierarchy,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "All union members compatible with declared param — no diagnostic expected, got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn ffi_union_arg_object_param_accepts_any_member() {
+    // A param declared `Object` accepts any union of concrete classes —
+    // mirrors the existing Known/Known Object shortcut.
+    let sig = single_param_sig(InferredType::known("Object"));
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    checker.check_ffi_argument_types(
+        "mymod",
+        "fun",
+        &sig,
+        &[InferredType::simple_union(&["String", "Integer"])],
+        span(),
+        &hierarchy,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "Object param should accept any union member. Got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn ffi_union_arg_singleton_symbol_members_compatible_with_symbol_param() {
+    // BT-2846 regression: an FFI param declared `Symbol` (e.g. Erlang spec
+    // `atom()`) must accept a call-site union of singleton symbols like
+    // `#emergency | #alert | ...` (typed:: annotations on Beamtalk-side
+    // wrapper methods, e.g. BeamtalkInterface>>logLevel:). Singletons are
+    // subtypes of Symbol (mirrors `is_type_compatible`'s `#foo` handling),
+    // so this must NOT warn.
+    let sig = single_param_sig(InferredType::known("Symbol"));
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    checker.check_ffi_argument_types(
+        "mymod",
+        "fun",
+        &sig,
+        &[InferredType::simple_union(&[
+            "#emergency",
+            "#alert",
+            "#critical",
+            "#error",
+            "#warning",
+            "#notice",
+            "#info",
+            "#debug",
+        ])],
+        span(),
+        &hierarchy,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "Singleton symbol union members should be compatible with a Symbol param. Got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn ffi_dynamic_arg_unchanged_no_warning() {
+    // A `Dynamic` argument continues to short-circuit — same as before this
+    // ticket's Union arm was added.
+    let sig = single_param_sig(InferredType::known("String"));
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    checker.check_ffi_argument_types(
+        "mymod",
+        "fun",
+        &sig,
+        &[InferredType::Dynamic(DynamicReason::Unknown)],
+        span(),
+        &hierarchy,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "Dynamic argument should still be skipped. Got: {:?}",
+        checker.diagnostics()
+    );
+}
+
+#[test]
+fn ffi_known_known_call_unchanged_no_regression() {
+    // A plain `Known`/`Known` compatible call stays silent (no regression
+    // from restructuring the Dynamic/Known/Union match).
+    let sig = single_param_sig(InferredType::known("String"));
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    checker.check_ffi_argument_types(
+        "mymod",
+        "fun",
+        &sig,
+        &[InferredType::known("String")],
+        span(),
+        &hierarchy,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "Known/Known compatible call should stay silent. Got: {:?}",
+        checker.diagnostics()
+    );
+}
+
 #[test]
 fn test_erlang_lists_still_infers_ffi() {
     // Sanity check: `Erlang lists reverse: xs` should still go through FFI inference.

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -44,7 +44,7 @@ impl TypeChecker {
     /// whole union when any member is `Dynamic`/`Union`/`Meta`/`Never`.
     ///
     /// [`inferred_type_to_string`]: Self::inferred_type_to_string
-    fn classify_union_members<F>(
+    pub(super) fn classify_union_members<F>(
         members: &[InferredType],
         pred: F,
     ) -> Option<(usize, usize, Vec<EcoString>)>


### PR DESCRIPTION
Fixes [BT-2846](https://linear.app/beamtalk/issue/BT-2846).

## Summary

`check_ffi_argument_types` special-cased `Dynamic` but had no `Union` arm at all, unlike `check_argument_types` (which has had one since BT-1832). A `Union` argument (e.g. `String | Nil`) fell through the `Known`/`Known` `if let` silently — no diagnostic, no fallback handling — so passing a nilable value to an FFI parameter declared as a concrete non-nilable type went unchecked at the Erlang-interop boundary.

## Changes

- `crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs`: restructured `check_ffi_argument_types`'s `if let` into a `match` on the argument type, adding a `Union` arm that mirrors `check_argument_types`'s `classify_union_members` handling — every member of the argument's union is checked against the declared FFI parameter type, with a diagnostic if any member is incompatible. `Dynamic` and `Known`/`Known` (incl. the `Object` shortcut) behavior is unchanged.
- Threaded `ClassHierarchy` through `infer_ffi_call` / `check_ffi_argument_types` so the `Union` arm can reuse `is_type_compatible` (hierarchy-aware, and correctly treats singleton symbols like `#emergency` as subtypes of `Symbol`). This was required — a naive bare-class-name comparison produced a false positive on `BeamtalkInterface`'s existing `logLevel:`/`logFormat:` FFI calls (`#emergency | #alert | ... -> Symbol`), caught by rebuilding the stdlib during verification.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs`: `classify_union_members` → `pub(super)` so `inference.rs` can reuse it.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/tests/ffi.rs`: regression tests — incompatible union member warns, all-compatible union member is silent, `Object` param accepts any union member, singleton-symbol union members are compatible with a `Symbol` param (the stdlib regression case), `Dynamic` argument is unchanged, and a plain `Known`/`Known` compatible call stays silent (no regression).

## Test plan

- [x] `cargo test -p beamtalk-core ffi::` — 30/30 pass, including 6 new regression tests
- [x] `just test` — Rust, stdlib (223 tests), BUnit (2722 tests), runtime (5300+1584 tests) all pass
- [x] `just build` — stdlib rebuilds cleanly with no new diagnostics (this caught and fixed the singleton-symbol regression before it shipped)
- [x] `just clippy` / `just fmt-check` — clean
- [x] `just check-surface-drift`, `just check-corpus`, `just test-integration`, `just test-mcp`, `just test-repl-protocol` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)