### PR TITLE
Validate `run-entry` selector shape server-side (reject multi-keyword) (BT-2699)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl
@@ -672,19 +672,34 @@ handle_run_entry_async(Msg, _SessionPid, State) ->
 
 %% Validate the `run-entry` op fields, returning the argv as a `List(String)`
 %% (a list of UTF-8 binaries) on success. `class`/`selector` must be non-empty
-%% binaries; `args` must be a (possibly empty) list of strings.
+%% binaries, `selector` must be a valid run-entry shape (see
+%% is_valid_run_entry_selector/1), and `args` must be a (possibly empty) list
+%% of strings.
 -spec validate_run_entry(term(), term(), term()) ->
     {ok, [binary()]} | {error, beamtalk_error:error()}.
 validate_run_entry(ClassBin, SelectorBin, RawArgs) when
     is_binary(ClassBin), ClassBin =/= <<>>, is_binary(SelectorBin), SelectorBin =/= <<>>
 ->
-    case run_entry_args(RawArgs, []) of
-        {ok, Argv} ->
-            {ok, Argv};
-        error ->
+    case is_valid_run_entry_selector(SelectorBin) of
+        true ->
+            case run_entry_args(RawArgs, []) of
+                {ok, Argv} ->
+                    {ok, Argv};
+                error ->
+                    Err = beamtalk_error:new(invalid_argument, 'Program'),
+                    Err1 = beamtalk_error:with_message(
+                        Err, <<"run-entry `args` must be a list of strings">>
+                    ),
+                    {error, Err1}
+            end;
+        false ->
             Err = beamtalk_error:new(invalid_argument, 'Program'),
             Err1 = beamtalk_error:with_message(
-                Err, <<"run-entry `args` must be a list of strings">>
+                Err,
+                <<
+                    "Invalid run-entry selector: only a unary selector (e.g. `run`) "
+                    "or a single arity-1 keyword selector (e.g. `main:`) is accepted"
+                >>
             ),
             {error, Err1}
     end;
@@ -694,6 +709,25 @@ validate_run_entry(_ClassBin, _SelectorBin, _RawArgs) ->
         Err, <<"run-entry requires non-empty `class` and `selector` strings">>
     ),
     {error, Err1}.
+
+-doc """
+BT-2699: True when `SelectorBin` has a valid run-entry shape — a unary
+selector (no `:`) or a single arity-1 keyword selector (exactly one `:`,
+trailing, e.g. `main:`). Mirrors the CLI's `validate_class_and_selector`
+(`crates/beamtalk-cli/src/commands/run.rs`) so a direct WebSocket client (or
+future MCP/LSP consumer) gets the same "only a unary or single arity-1
+keyword entry is accepted" rejection, rather than `do_dispatch/5` calling
+`class_send/3` with a mismatched selector/arity and surfacing a bare
+`badarg`/`undef` or a confusing DNU. Multi-keyword selectors (`move:to:`) and
+selectors with an interior colon (`at:put`) are rejected.
+""".
+-spec is_valid_run_entry_selector(binary()) -> boolean().
+is_valid_run_entry_selector(SelectorBin) ->
+    case binary:matches(SelectorBin, <<":">>) of
+        [] -> true;
+        [{Pos, _Len}] -> Pos =:= byte_size(SelectorBin) - 1;
+        _ -> false
+    end.
 
 -spec run_entry_args(term(), [binary()]) -> {ok, [binary()]} | error.
 run_entry_args([], Acc) -> {ok, lists:reverse(Acc)};

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_ws_handler_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_ws_handler_tests.erl
@@ -344,6 +344,67 @@ eval_when_already_pending_returns_busy_test() ->
     {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, State),
     ?assertMatch([{text, _} | _], Frames).
 
+%%% ===========================================================================
+%%% websocket_handle/2 — run-entry op (BT-2699 selector shape validation)
+%%% ===========================================================================
+
+run_entry_multi_keyword_selector_rejected_test() ->
+    %% BT-2699: a direct WebSocket client sending a multi-keyword selector
+    %% must get a clear rejection, not a bare badarg/DNU from class_send/3.
+    Json = op_json(<<"run-entry">>, #{
+        <<"class">> => <<"Greeter">>,
+        <<"selector">> => <<"run:with:">>,
+        <<"args">> => []
+    }),
+    {Frames, State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertEqual(undefined, State#ws_state.pending_eval),
+    Decoded = first_text(Frames),
+    ?assert(maps:is_key(<<"error">>, Decoded)),
+    ?assertNotEqual(
+        nomatch, binary:match(maps:get(<<"error">>, Decoded), <<"arity-1 keyword">>)
+    ).
+
+run_entry_interior_colon_selector_rejected_test() ->
+    %% A single colon that isn't trailing (`at:put`) is not a valid keyword
+    %% selector shape either.
+    Json = op_json(<<"run-entry">>, #{
+        <<"class">> => <<"Greeter">>,
+        <<"selector">> => <<"at:put">>,
+        <<"args">> => []
+    }),
+    {Frames, State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertEqual(undefined, State#ws_state.pending_eval),
+    Decoded = first_text(Frames),
+    ?assertNotEqual(
+        nomatch, binary:match(maps:get(<<"error">>, Decoded), <<"arity-1 keyword">>)
+    ).
+
+run_entry_unary_selector_accepted_test() ->
+    Json = op_json(<<"run-entry">>, #{
+        <<"class">> => <<"Greeter">>,
+        <<"selector">> => <<"run">>,
+        <<"args">> => []
+    }),
+    {ok, State1} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertNotEqual(undefined, State1#ws_state.pending_eval),
+    receive
+        {'$gen_cast', {dispatch_async, <<"Greeter">>, <<"run">>, [], _}} -> ok
+    after 0 -> ?assert(false)
+    end.
+
+run_entry_single_keyword_selector_accepted_test() ->
+    Json = op_json(<<"run-entry">>, #{
+        <<"class">> => <<"Greeter">>,
+        <<"selector">> => <<"main:">>,
+        <<"args">> => [<<"a">>, <<"b">>]
+    }),
+    {ok, State1} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),
+    ?assertNotEqual(undefined, State1#ws_state.pending_eval),
+    receive
+        {'$gen_cast', {dispatch_async, <<"Greeter">>, <<"main:">>, [<<"a">>, <<"b">>], _}} -> ok
+    after 0 -> ?assert(false)
+    end.
+
 stdin_without_pending_input_errors_test() ->
     Json = op_json(<<"stdin">>, #{<<"value">> => <<"hello\n">>}),
     {Frames, _State} = beamtalk_ws_handler:websocket_handle({text, Json}, authed_state()),


### PR DESCRIPTION
## Summary

Follow-up from BT-2691 (connected-mode `beamtalk run --connect`, PR #2772). The `run-entry` protocol op's `validate_run_entry/3` in `beamtalk_ws_handler.erl` only checked that `class`/`selector` were non-empty binaries — it didn't validate the *selector shape*. A direct WebSocket client (or a future MCP/LSP consumer) could send a multi-keyword selector like `run:with:` and get a bare `badarg`/`undef` or a confusing DNU from `class_send/3`, instead of a clear rejection.

This PR adds `is_valid_run_entry_selector/1`, mirroring the CLI's `validate_class_and_selector` rule (`crates/beamtalk-cli/src/commands/run.rs`): a selector must be either a unary selector (no `:`) or a single arity-1 keyword selector (exactly one trailing `:`, e.g. `main:`). Multi-keyword selectors (`move:to:`) and selectors with an interior colon (`at:put`) are rejected with a structured `#beamtalk_error{kind = invalid_argument}`.

Linear: https://linear.app/beamtalk/issue/BT-2699/validate-run-entry-selector-shape-server-side-reject-multi-keyword

## Key changes

- `runtime/apps/beamtalk_workspace/src/beamtalk_ws_handler.erl`: `validate_run_entry/3` now checks selector shape via new `is_valid_run_entry_selector/1` before validating `args`; rejection returns a clear `#beamtalk_error{}` message.
- `runtime/apps/beamtalk_workspace/test/beamtalk_ws_handler_tests.erl`: EUnit coverage exercising the full `websocket_handle/2` pipeline for the `run-entry` op — multi-keyword rejection, interior-colon rejection, unary acceptance, and single arity-1 keyword acceptance (asserting the resulting `dispatch_async` cast payload).

## Test plan

- [x] `just fmt-check-rust fmt-check-erlang` — clean
- [x] `just clippy` — clean
- [x] `rebar3 eunit --app=beamtalk_workspace` — 2567 tests, 0 failures (includes new coverage)
- [x] `just test-bunit` — 2722 passed, 0 failed
- [x] `just test-repl-protocol` — 3 passed
- [x] `just test` (Rust + stdlib) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MW992qobdVSMFP4cFqgwpF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MW992qobdVSMFP4cFqgwpF)_