### PR TITLE
Foundation: Pattern::Nil + Pattern::Type AST/parser/leaf-gate (BT-2854)

### DIFF
--- a/crates/beamtalk-core/src/ast/pattern.rs
+++ b/crates/beamtalk-core/src/ast/pattern.rs
@@ -67,6 +67,36 @@ pub enum Pattern {
     /// Variable binding pattern - binds to a name.
     Variable(Identifier),
 
+    /// Nil pattern - matches exactly the value that `isNil` returns true for.
+    ///
+    /// Example: `nil -> defaultValue`
+    ///
+    /// `nil` is a reserved identifier, not a `Literal` variant; this is a
+    /// dedicated pattern kind (ADR 0107 Phase A) that reuses the existing
+    /// atom-literal codegen path (`Document::Str("'nil'")`) — no new runtime
+    /// mechanism.
+    Nil(Span),
+
+    /// Type pattern - matches if the scrutinee's runtime class is exactly
+    /// `class`, binding the value (narrowed to `class` for the arm body) to
+    /// `binding`.
+    ///
+    /// Example: `path :: String -> self expandHome: path`
+    ///
+    /// Reuses the `::` token already established by ADR 0053 for
+    /// parameter/state type annotations, in a new grammatical position
+    /// (ADR 0107 Phase A). Phase A restricts `class` to concrete leaf
+    /// classes (no subclasses) — a class with subclasses is a compile
+    /// error, not silently-wrong behaviour; see ADR 0107 Phase B.
+    Type {
+        /// The name bound to the matched value inside the arm.
+        binding: Identifier,
+        /// The class the scrutinee's runtime class must equal.
+        class: Identifier,
+        /// Source location.
+        span: Span,
+    },
+
     /// Tuple pattern - matches tuple structure.
     ///
     /// Example: `{#ok, value}`
@@ -154,12 +184,14 @@ impl Pattern {
             Self::Variable(id) => id.span,
             Self::Wildcard(span)
             | Self::Literal(_, span)
+            | Self::Nil(span)
             | Self::Tuple { span, .. }
             | Self::Array { span, .. }
             | Self::List { span, .. }
             | Self::Binary { span, .. }
             | Self::Map { span, .. }
-            | Self::Constructor { span, .. } => *span,
+            | Self::Constructor { span, .. }
+            | Self::Type { span, .. } => *span,
         }
     }
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -2666,6 +2666,16 @@ impl CoreErlangGenerator {
     pub(super) fn generate_pattern(&mut self, pattern: &Pattern) -> Result<Document<'static>> {
         match pattern {
             Pattern::Wildcard(_) => Ok(Document::Str("_")),
+            // Reuses the existing atom-literal codegen path verbatim
+            // (ADR 0107 Phase A) — `nil` has one canonical runtime
+            // representation, no new mechanism needed.
+            Pattern::Nil(_) => Ok(Document::Str("'nil'")),
+            Pattern::Type { span, .. } => Err(CodeGenError::UnsupportedFeature {
+                feature: "Type pattern (`binding :: ClassName`) in match: is not yet supported \
+                          (ADR 0107 Phase A foundation only — codegen lands in BT-2855)"
+                    .to_string(),
+                span: Some(*span),
+            }),
             Pattern::Variable(id) => {
                 let var_name = Self::to_core_erlang_var(&id.name);
                 Ok(leaf::var(var_name))
@@ -3002,7 +3012,13 @@ impl CoreErlangGenerator {
                     Self::collect_pattern_variables_inner(binding, bind);
                 }
             }
-            Pattern::Wildcard(_) | Pattern::Literal(_, _) => {}
+            // Type pattern bindings are not wired up yet (BT-2855 — bindings,
+            // narrowing, and codegen). `generate_pattern` already rejects
+            // `Pattern::Type` arms before this would matter.
+            Pattern::Wildcard(_)
+            | Pattern::Literal(_, _)
+            | Pattern::Nil(_)
+            | Pattern::Type { .. } => {}
         }
     }
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -903,6 +903,44 @@ fn test_match_array_pattern_duplicate_variable_emits_equality_check() {
     );
 }
 
+// BT-2854 / ADR 0107 Phase A: `Pattern::Nil` and `Pattern::Type` codegen
+
+#[test]
+fn test_match_nil_pattern_compiles_to_atom_literal() {
+    // ADR 0107 Phase A: `nil` pattern reuses the existing atom-literal
+    // codegen path verbatim — no new runtime mechanism.
+    let src = "Object subclass: Foo\n  test: x =>\n    x match: [\n      nil -> 0;\n      _ -> 1\n    ]\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let code =
+        generate_module(&module, CodegenOptions::new("foo")).expect("codegen should succeed");
+
+    eprintln!("Generated code for nil pattern match:\n{code}");
+
+    assert!(
+        code.contains("<'nil'>"),
+        "nil pattern should compile to the atom-literal case pattern 'nil'. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_match_type_pattern_codegen_not_yet_supported() {
+    // ADR 0107 Phase A (BT-2854 foundation only): `Pattern::Type` parses and
+    // passes semantic analysis (for a known leaf class), but codegen doesn't
+    // exist yet — that lands in BT-2855. Must fail loudly, not silently emit
+    // wrong code.
+    let src = "Object subclass: Foo\n  test: x =>\n    x match: [\n      s :: String -> s;\n      _ -> \"none\"\n    ]\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let err = generate_module(&module, CodegenOptions::new("foo"))
+        .expect_err("Pattern::Type codegen should not be implemented yet (BT-2855)");
+    let message = err.to_string();
+    assert!(
+        message.contains("Type pattern"),
+        "error should mention the Type pattern is unsupported. Got: {message}"
+    );
+}
+
 // BT-2359: value-type outer-local threading for count:/detect: predicates and
 // threading constructs used as a (parenthesized) assignment RHS.
 

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -1327,6 +1327,11 @@ impl SimpleLanguageService {
                 if offset_val >= class.span.start() && offset_val < class.span.end() {
                     Some((class.clone(), class.span))
                 } else {
+                    // The binding (e.g. `path` in `path :: String`) is a
+                    // local variable, not a class reference — this function
+                    // only navigates class identifiers. Go-to-definition on
+                    // the binding itself is deferred to BT-2855, which is
+                    // when it becomes a fully navigable scope entry.
                     None
                 }
             }

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -1323,7 +1323,17 @@ impl SimpleLanguageService {
             Pattern::Binary { segments, .. } => segments
                 .iter()
                 .find_map(|seg| Self::find_identifier_in_pattern(&seg.value, offset_val)),
-            Pattern::Wildcard(_) | Pattern::Literal(_, _) | Pattern::Variable(_) => None,
+            Pattern::Type { class, .. } => {
+                if offset_val >= class.span.start() && offset_val < class.span.end() {
+                    Some((class.clone(), class.span))
+                } else {
+                    None
+                }
+            }
+            Pattern::Wildcard(_)
+            | Pattern::Literal(_, _)
+            | Pattern::Variable(_)
+            | Pattern::Nil(_) => None,
         }
     }
 

--- a/crates/beamtalk-core/src/lint/dead_block_assignment.rs
+++ b/crates/beamtalk-core/src/lint/dead_block_assignment.rs
@@ -454,7 +454,13 @@ fn collect_pattern_var_names_inner(pattern: &crate::ast::Pattern, names: &mut Ve
                 collect_pattern_var_names_inner(binding, names);
             }
         }
-        Pattern::Binary { .. } | Pattern::Wildcard(_) | Pattern::Literal(_, _) => {}
+        // Pattern::Type's binding is not wired into lint scope tracking yet
+        // (BT-2855 — bindings/scope land with narrowing and codegen).
+        Pattern::Binary { .. }
+        | Pattern::Wildcard(_)
+        | Pattern::Literal(_, _)
+        | Pattern::Nil(_)
+        | Pattern::Type { .. } => {}
     }
 }
 
@@ -494,7 +500,13 @@ fn define_pattern_vars_in_scope(pattern: &crate::ast::Pattern, scope: &mut LintS
                 define_pattern_vars_in_scope(binding, scope);
             }
         }
-        Pattern::Binary { .. } | Pattern::Wildcard(_) | Pattern::Literal(_, _) => {}
+        // Pattern::Type's binding is not wired into lint scope tracking yet
+        // (BT-2855 — bindings/scope land with narrowing and codegen).
+        Pattern::Binary { .. }
+        | Pattern::Wildcard(_)
+        | Pattern::Literal(_, _)
+        | Pattern::Nil(_)
+        | Pattern::Type { .. } => {}
     }
 }
 

--- a/crates/beamtalk-core/src/lint/shadowed_block_param.rs
+++ b/crates/beamtalk-core/src/lint/shadowed_block_param.rs
@@ -160,7 +160,13 @@ fn define_pattern_vars_in_scope(pattern: &crate::ast::Pattern, scope: &mut LintS
                 define_pattern_vars_in_scope(binding, scope);
             }
         }
-        Pattern::Binary { .. } | Pattern::Wildcard(_) | Pattern::Literal(_, _) => {}
+        // Pattern::Type's binding is not wired into lint scope tracking yet
+        // (BT-2855 — bindings/scope land with narrowing and codegen).
+        Pattern::Binary { .. }
+        | Pattern::Wildcard(_)
+        | Pattern::Literal(_, _)
+        | Pattern::Nil(_)
+        | Pattern::Type { .. } => {}
     }
 }
 

--- a/crates/beamtalk-core/src/queries/all_sends_query.rs
+++ b/crates/beamtalk-core/src/queries/all_sends_query.rs
@@ -456,7 +456,11 @@ fn collect_pattern_sends(pattern: &Pattern, source: &str, hits: &mut Vec<SendHit
                 collect_pattern_sends(inner, source, hits);
             }
         }
-        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) => {}
+        Pattern::Wildcard(..)
+        | Pattern::Literal(..)
+        | Pattern::Variable(..)
+        | Pattern::Nil(..)
+        | Pattern::Type { .. } => {}
     }
 }
 

--- a/crates/beamtalk-core/src/queries/announce_sites_query.rs
+++ b/crates/beamtalk-core/src/queries/announce_sites_query.rs
@@ -311,7 +311,11 @@ fn collect_pattern_announce_sites(pattern: &Pattern, source: &str, hits: &mut Ve
                 collect_pattern_announce_sites(inner, source, hits);
             }
         }
-        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) => {}
+        Pattern::Wildcard(..)
+        | Pattern::Literal(..)
+        | Pattern::Variable(..)
+        | Pattern::Nil(..)
+        | Pattern::Type { .. } => {}
     }
 }
 

--- a/crates/beamtalk-core/src/queries/ffi_sites_query.rs
+++ b/crates/beamtalk-core/src/queries/ffi_sites_query.rs
@@ -427,7 +427,11 @@ fn collect_pattern_ffi_sites(
                 collect_pattern_ffi_sites(inner, target, source, lines);
             }
         }
-        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) => {}
+        Pattern::Wildcard(..)
+        | Pattern::Literal(..)
+        | Pattern::Variable(..)
+        | Pattern::Nil(..)
+        | Pattern::Type { .. } => {}
     }
 }
 

--- a/crates/beamtalk-core/src/queries/field_accesses_query.rs
+++ b/crates/beamtalk-core/src/queries/field_accesses_query.rs
@@ -339,7 +339,11 @@ fn collect_pattern_access_lines(
                 collect_pattern_access_lines(inner, field_name, kind, source, lines);
             }
         }
-        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) => {}
+        Pattern::Wildcard(..)
+        | Pattern::Literal(..)
+        | Pattern::Variable(..)
+        | Pattern::Nil(..)
+        | Pattern::Type { .. } => {}
     }
 }
 

--- a/crates/beamtalk-core/src/queries/hover_provider.rs
+++ b/crates/beamtalk-core/src/queries/hover_provider.rs
@@ -625,6 +625,25 @@ fn find_hover_in_pattern(pattern: &Pattern, offset: u32, type_map: &TypeMap) -> 
                 .iter()
                 .find_map(|(_, p)| find_hover_in_pattern(p, offset, type_map))
         }
+        Pattern::Type { binding, class, .. } => {
+            if offset >= class.span.start() && offset < class.span.end() {
+                return Some(HoverInfo::new(
+                    format!("Type pattern: `{}`", class.name),
+                    class.span,
+                ));
+            }
+            if offset >= binding.span.start() && offset < binding.span.end() {
+                return Some(HoverInfo::new(
+                    format!(
+                        "Pattern variable: `{}` — Type: {}",
+                        binding.name, class.name
+                    ),
+                    binding.span,
+                ));
+            }
+            None
+        }
+        Pattern::Nil(span) => Some(HoverInfo::new("Nil pattern".to_string(), *span)),
         Pattern::Wildcard(_) | Pattern::Literal(_, _) => None,
     }
 }

--- a/crates/beamtalk-core/src/queries/references_provider.rs
+++ b/crates/beamtalk-core/src/queries/references_provider.rs
@@ -443,7 +443,12 @@ fn collect_pattern_class_refs(
                 collect_pattern_class_refs(&segment.value, class_name, file_path, results);
             }
         }
-        Pattern::Wildcard(_) | Pattern::Literal(_, _) | Pattern::Variable(_) => {}
+        Pattern::Type { class, .. } => {
+            if class.name == class_name {
+                results.push(Location::new(file_path.clone(), class.span));
+            }
+        }
+        Pattern::Wildcard(_) | Pattern::Literal(_, _) | Pattern::Variable(_) | Pattern::Nil(_) => {}
     }
 }
 

--- a/crates/beamtalk-core/src/queries/references_to_query.rs
+++ b/crates/beamtalk-core/src/queries/references_to_query.rs
@@ -331,7 +331,11 @@ fn collect_all_pattern_refs(pattern: &Pattern, source: &str, hits: &mut Vec<(Str
                 }
             }
         }
-        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) => {}
+        Pattern::Type { class, .. } => {
+            hits.push((class.name.to_string(), class.span.line_number(source)));
+        }
+        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) | Pattern::Nil(..) => {
+        }
     }
 }
 
@@ -532,7 +536,13 @@ fn collect_pattern_reference_lines(
                 }
             }
         }
-        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) => {}
+        Pattern::Type { class, .. } => {
+            if class.name.as_str() == class_name {
+                lines.push(class.span.line_number(source));
+            }
+        }
+        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) | Pattern::Nil(..) => {
+        }
     }
 }
 

--- a/crates/beamtalk-core/src/queries/senders_query.rs
+++ b/crates/beamtalk-core/src/queries/senders_query.rs
@@ -229,7 +229,11 @@ fn collect_pattern_send_lines(
                 collect_pattern_send_lines(inner, selector_name, source, lines);
             }
         }
-        Pattern::Wildcard(..) | Pattern::Literal(..) | Pattern::Variable(..) => {}
+        Pattern::Wildcard(..)
+        | Pattern::Literal(..)
+        | Pattern::Variable(..)
+        | Pattern::Nil(..)
+        | Pattern::Type { .. } => {}
     }
 }
 

--- a/crates/beamtalk-core/src/semantic_analysis/analyser.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/analyser.rs
@@ -366,7 +366,14 @@ impl Analyser {
                     self.define_pattern_variables_in_scope(binding);
                 }
             }
-            Pattern::Binary { .. } | Pattern::Wildcard(_) | Pattern::Literal(_, _) => {}
+            // `nil` binds nothing (ADR 0107 Phase A). `Pattern::Type`'s
+            // `binding` is not wired into scope tracking yet — that lands
+            // with narrowing and codegen in BT-2855.
+            Pattern::Binary { .. }
+            | Pattern::Wildcard(_)
+            | Pattern::Literal(_, _)
+            | Pattern::Nil(_)
+            | Pattern::Type { .. } => {}
         }
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/block_facts.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_facts.rs
@@ -416,7 +416,11 @@ fn collect_pattern_bindings(
 
         // Leaf patterns have no ordering constraints or size expressions.
         // Delegate to the canonical semantic analysis extractor.
-        Pattern::Variable(_) | Pattern::Wildcard(..) | Pattern::Literal(..) => {
+        Pattern::Variable(_)
+        | Pattern::Wildcard(..)
+        | Pattern::Literal(..)
+        | Pattern::Nil(..)
+        | Pattern::Type { .. } => {
             let (identifiers, _) = crate::semantic_analysis::extract_pattern_bindings(pattern);
             for id in identifiers {
                 let name = id.name.to_string();

--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -769,6 +769,17 @@ fn analyse_full(module: &Module, ctx: AnalysisContext<'_>) -> AnalysisResult {
             &mut result.diagnostics,
         );
     }
+    // BT-2854 / ADR 0107 Phase A: validate `Pattern::Type` class names in
+    // `match:` arms (unknown class, non-leaf class, `Character` exclusion).
+    // The unknown-class branch is internally gated on `has_cross_file_classes`,
+    // same open-world policy as `check_unresolved_classes` above; the
+    // leaf-class and `Character` checks run unconditionally.
+    validators::check_type_pattern_classes(
+        module,
+        &result.class_hierarchy,
+        has_cross_file_classes,
+        &mut result.diagnostics,
+    );
     // BT-1759: Warn when a workspace binding shadows a class name.
     // This check works against the full class hierarchy (including locally
     // defined classes), so it does not require cross-file metadata.

--- a/crates/beamtalk-core/src/semantic_analysis/pattern_bindings.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/pattern_bindings.rs
@@ -196,8 +196,11 @@ fn extract_pattern_bindings_impl(
             }
         }
 
-        // Wildcards and literals don't bind variables
-        Pattern::Wildcard(_) | Pattern::Literal(_, _) => {}
+        // Wildcards and literals don't bind variables. `nil` likewise binds
+        // nothing (ADR 0107 Phase A). `Pattern::Type`'s `binding` is not
+        // wired into scope/name-resolution yet — that lands with narrowing
+        // and codegen in BT-2855.
+        Pattern::Wildcard(_) | Pattern::Literal(_, _) | Pattern::Nil(_) | Pattern::Type { .. } => {}
     }
 }
 

--- a/crates/beamtalk-core/src/semantic_analysis/pattern_bindings.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/pattern_bindings.rs
@@ -70,6 +70,41 @@ pub fn extract_match_arm_bindings(
     (bindings, diagnostics)
 }
 
+/// Records a single identifier binding, emitting a duplicate-variable
+/// diagnostic if it collides with an earlier binding in the same pattern
+/// (unless `allow_duplicates` is set — see `extract_match_arm_bindings`).
+/// Shared by `Pattern::Variable` and `Pattern::Type`'s `binding`.
+fn record_binding(
+    id: &Identifier,
+    bindings: &mut Vec<Identifier>,
+    seen: &mut std::collections::HashMap<EcoString, Span>,
+    diagnostics: &mut Vec<crate::source_analysis::Diagnostic>,
+    allow_duplicates: bool,
+) {
+    use std::collections::hash_map::Entry;
+
+    match seen.entry(id.name.clone()) {
+        Entry::Occupied(entry) => {
+            if !allow_duplicates {
+                // Duplicate variable - emit diagnostic
+                let first_span = *entry.get();
+                diagnostics.push(crate::source_analysis::Diagnostic::error(
+                    format!(
+                        "Variable '{}' is bound multiple times in pattern (first bound at byte offset {})",
+                        id.name,
+                        first_span.start()
+                    ),
+                    id.span,
+                ).with_hint(format!("Rename one of the `{}` bindings — each variable can only appear once in a pattern", id.name)));
+            }
+        }
+        Entry::Vacant(entry) => {
+            entry.insert(id.span);
+        }
+    }
+    bindings.push(id.clone());
+}
+
 /// Internal implementation of pattern binding extraction.
 ///
 /// `allow_duplicates` suppresses the duplicate-variable diagnostic. It is set
@@ -85,29 +120,18 @@ fn extract_pattern_bindings_impl(
     match pattern {
         // Variable patterns bind the identifier
         Pattern::Variable(id) => {
-            // Use Entry API to avoid double lookup
-            use std::collections::hash_map::Entry;
+            record_binding(id, bindings, seen, diagnostics, allow_duplicates);
+        }
 
-            match seen.entry(id.name.clone()) {
-                Entry::Occupied(entry) => {
-                    if !allow_duplicates {
-                        // Duplicate variable - emit diagnostic
-                        let first_span = *entry.get();
-                        diagnostics.push(crate::source_analysis::Diagnostic::error(
-                            format!(
-                                "Variable '{}' is bound multiple times in pattern (first bound at byte offset {})",
-                                id.name,
-                                first_span.start()
-                            ),
-                            id.span,
-                        ).with_hint(format!("Rename one of the `{}` bindings — each variable can only appear once in a pattern", id.name)));
-                    }
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(id.span);
-                }
-            }
-            bindings.push(id.clone());
+        // Type patterns bind `binding` (ADR 0107 Phase A) — registering it
+        // here is what makes the name resolvable in the arm body/guard;
+        // narrowing its *type* to `class` is BT-2855's job (bindings/scope,
+        // narrowing, and codegen for `Pattern::Type` land together there).
+        // Without this, `path :: String -> path` would raise a spurious
+        // "Undefined variable: path" error even though the pattern is
+        // otherwise valid Phase A syntax.
+        Pattern::Type { binding, .. } => {
+            record_binding(binding, bindings, seen, diagnostics, allow_duplicates);
         }
 
         // Tuple patterns: recursively extract; duplicates are not allowed (native Core Erlang patterns)
@@ -197,10 +221,8 @@ fn extract_pattern_bindings_impl(
         }
 
         // Wildcards and literals don't bind variables. `nil` likewise binds
-        // nothing (ADR 0107 Phase A). `Pattern::Type`'s `binding` is not
-        // wired into scope/name-resolution yet — that lands with narrowing
-        // and codegen in BT-2855.
-        Pattern::Wildcard(_) | Pattern::Literal(_, _) | Pattern::Nil(_) | Pattern::Type { .. } => {}
+        // nothing (ADR 0107 Phase A).
+        Pattern::Wildcard(_) | Pattern::Literal(_, _) | Pattern::Nil(_) => {}
     }
 }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -878,6 +878,17 @@ impl TypeChecker {
                                     InferredType::known(WellKnownClass::UndefinedObject.as_str()),
                                 );
                             } else {
+                                // Deliberately overwrites whatever
+                                // `bind_pattern_vars` (above) just set for
+                                // this key: today that's always `Dynamic` for
+                                // a pattern-bound variable, so the residual
+                                // here is strictly more precise. If a future
+                                // phase (`Pattern::Type` narrowing, BT-2855)
+                                // makes `bind_pattern_vars` assign a real
+                                // narrowed type to a pattern variable that
+                                // happens to share the scrutinee's key, this
+                                // line will silently win over it — revisit
+                                // this ordering when that lands.
                                 arm_env.set(key.clone(), residual_scrutinee_ty.clone());
                             }
                         }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -21,7 +21,6 @@ use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
 use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
 use ecow::{EcoString, eco_format};
 
-#[cfg(test)]
 use super::narrowing::extract::extract_variable_name;
 use super::narrowing::extract::unwrap_parens;
 use super::narrowing::refinement::RefinementLayer;
@@ -851,15 +850,46 @@ impl TypeChecker {
                 } else {
                     self.check_singleton_match_exhaustiveness(&scrutinee_ty, arms, *span);
                 }
+
+                // BT-2854 / ADR 0107 Phase A: a `nil` arm narrows the
+                // scrutinee to `UndefinedObject` inside its own body (mirrors
+                // `x isNil ifTrue:`), and — when unguarded — removes `Nil`
+                // from what subsequent arms see (mirrors `x isNil ifFalse:`'s
+                // `non_nil_type`), reusing the exact narrowing algebra
+                // already established by `is_nil.rs`. A guarded `nil when:
+                // [...] ->` arm does not guarantee coverage, so it does not
+                // narrow the residual for later arms (same rule
+                // `singleton_match_residual` uses for guarded arms). Only
+                // applies when the scrutinee has a stable narrowable key
+                // (`extract_variable_name`) — an arbitrary expression
+                // scrutinee has nothing to narrow.
+                let scrutinee_key = extract_variable_name(unwrap_parens(value));
+                let mut residual_scrutinee_ty = scrutinee_ty.clone();
+
                 let arm_types: Vec<InferredType> = arms
                     .iter()
                     .map(|arm| {
                         let mut arm_env = env.child();
                         Self::bind_pattern_vars(&arm.pattern, &mut arm_env);
+                        if let Some(key) = &scrutinee_key {
+                            if matches!(arm.pattern, Pattern::Nil(_)) {
+                                arm_env.set(
+                                    key.clone(),
+                                    InferredType::known(WellKnownClass::UndefinedObject.as_str()),
+                                );
+                            } else {
+                                arm_env.set(key.clone(), residual_scrutinee_ty.clone());
+                            }
+                        }
                         if let Some(guard) = &arm.guard {
                             self.infer_expr(guard, hierarchy, &mut arm_env, in_abstract_method);
                         }
-                        self.infer_expr(&arm.body, hierarchy, &mut arm_env, in_abstract_method)
+                        let body_ty =
+                            self.infer_expr(&arm.body, hierarchy, &mut arm_env, in_abstract_method);
+                        if arm.guard.is_none() && matches!(arm.pattern, Pattern::Nil(_)) {
+                            residual_scrutinee_ty = Self::non_nil_type(&residual_scrutinee_ty);
+                        }
+                        body_ty
                     })
                     .collect();
                 if arm_types.is_empty() {
@@ -6231,6 +6261,107 @@ mod tests {
         };
         let ty = checker.infer_expr(&expr, &hierarchy, &mut env, false);
         assert_eq!(ty, InferredType::Dynamic(DynamicReason::Unknown));
+    }
+
+    // ---- BT-2854 / ADR 0107 Phase A: `Pattern::Nil` narrowing ----
+
+    /// A `nil` arm's body sees the scrutinee narrowed to `UndefinedObject`,
+    /// mirroring `x isNil ifTrue:` (reuses the same true-branch type as
+    /// `is_nil.rs`).
+    #[test]
+    fn infer_expr_match_nil_arm_narrows_scrutinee_to_undefined_object() {
+        let hierarchy = ClassHierarchy::with_builtins();
+        let mut checker = TypeChecker::new();
+        let mut env = TypeEnv::new();
+        env.set_local("x", InferredType::simple_union(&["String", "Nil"]));
+
+        // x match: [nil -> x; _ -> 0]
+        let expr = Expression::Match {
+            value: Box::new(var("x")),
+            arms: vec![
+                MatchArm::new(Pattern::Nil(span()), var("x"), span()),
+                MatchArm::new(Pattern::Wildcard(span()), int_lit(0), span()),
+            ],
+            exhaustive: false,
+            span: span(),
+        };
+        let ty = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+        // Arm types: [UndefinedObject (nil arm's `x`), Integer (wildcard arm)]
+        assert_eq!(
+            ty,
+            InferredType::union_of(&[
+                InferredType::known(WellKnownClass::UndefinedObject.as_str()),
+                InferredType::known("Integer"),
+            ])
+        );
+    }
+
+    /// An unguarded `nil` arm removes `Nil` from what subsequent arms see,
+    /// mirroring `x isNil ifFalse:`'s `non_nil_type` narrowing.
+    #[test]
+    fn infer_expr_match_unguarded_nil_arm_narrows_subsequent_arms() {
+        let hierarchy = ClassHierarchy::with_builtins();
+        let mut checker = TypeChecker::new();
+        let mut env = TypeEnv::new();
+        env.set_local("x", InferredType::simple_union(&["String", "Nil"]));
+
+        // x match: [nil -> 0; y -> x]  -- second arm's body reads `x`, which
+        // should be narrowed to non-nil (`String`) after the unguarded nil arm.
+        let expr = Expression::Match {
+            value: Box::new(var("x")),
+            arms: vec![
+                MatchArm::new(Pattern::Nil(span()), int_lit(0), span()),
+                MatchArm::new(
+                    Pattern::Variable(Identifier::new("y", span())),
+                    var("x"),
+                    span(),
+                ),
+            ],
+            exhaustive: false,
+            span: span(),
+        };
+        let ty = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+        // Arm types: [Integer (nil arm), String (narrowed `x` in 2nd arm)]
+        assert_eq!(
+            ty,
+            InferredType::union_of(&[
+                InferredType::known("Integer"),
+                InferredType::known("String")
+            ])
+        );
+    }
+
+    /// A *guarded* `nil when: [...] ->` arm does not guarantee coverage, so
+    /// it must not narrow away `Nil` for subsequent arms.
+    #[test]
+    fn infer_expr_match_guarded_nil_arm_does_not_narrow_subsequent_arms() {
+        let hierarchy = ClassHierarchy::with_builtins();
+        let mut checker = TypeChecker::new();
+        let mut env = TypeEnv::new();
+        env.set_local("x", InferredType::simple_union(&["String", "Nil"]));
+
+        let expr = Expression::Match {
+            value: Box::new(var("x")),
+            arms: vec![
+                MatchArm::with_guard(Pattern::Nil(span()), var("x"), int_lit(0), span()),
+                MatchArm::new(
+                    Pattern::Variable(Identifier::new("y", span())),
+                    var("x"),
+                    span(),
+                ),
+            ],
+            exhaustive: false,
+            span: span(),
+        };
+        let ty = checker.infer_expr(&expr, &hierarchy, &mut env, false);
+        // Second arm still sees `x` as `String | Nil` (unchanged residual).
+        assert_eq!(
+            ty,
+            InferredType::union_of(&[
+                InferredType::known("Integer"),
+                InferredType::simple_union(&["String", "Nil"]),
+            ])
+        );
     }
 
     // ---- build_substitution_map ----

--- a/crates/beamtalk-core/src/semantic_analysis/validators/match_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/match_validators.rs
@@ -292,15 +292,22 @@ fn check_pattern_type_classes(
         Pattern::Type { class, .. } => {
             validate_type_pattern_class(class, hierarchy, has_cross_file_classes, diagnostics);
         }
-        Pattern::Tuple { elements, .. } | Pattern::List { elements, .. } => {
+        Pattern::Tuple { elements, .. } => {
             for elem in elements {
                 check_pattern_type_classes(elem, hierarchy, has_cross_file_classes, diagnostics);
             }
-            if let Pattern::List {
-                tail: Some(tail), ..
-            } = pattern
-            {
-                check_pattern_type_classes(tail, hierarchy, has_cross_file_classes, diagnostics);
+        }
+        Pattern::List { elements, tail, .. } => {
+            for elem in elements {
+                check_pattern_type_classes(elem, hierarchy, has_cross_file_classes, diagnostics);
+            }
+            if let Some(tail_pat) = tail {
+                check_pattern_type_classes(
+                    tail_pat,
+                    hierarchy,
+                    has_cross_file_classes,
+                    diagnostics,
+                );
             }
         }
         Pattern::Array { elements, rest, .. } => {

--- a/crates/beamtalk-core/src/semantic_analysis/validators/match_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/match_validators.rs
@@ -7,7 +7,7 @@
 //!
 //! Validates pattern match exhaustiveness for sealed types (BT-1299).
 
-use crate::ast::{Expression, Module, Pattern};
+use crate::ast::{Expression, Identifier, Module, Pattern};
 use crate::ast_walker::walk_module;
 use crate::semantic_analysis::ClassHierarchy;
 use crate::source_analysis::{Diagnostic, DiagnosticCategory};
@@ -199,8 +199,38 @@ fn visit_assignment_in_match_arm(expr: &Expression, diagnostics: &mut Vec<Diagno
 
 // ── BT-2854 / ADR 0107 Phase A: `Pattern::Type` class validation ───────────
 
+/// Stdlib primitives ADR 0107 Phase A explicitly names as supported
+/// `Pattern::Type` classes (Decision §Phase A scope), each with its own
+/// dedicated BIF-test codegen strategy once BT-2855 lands.
+///
+/// These are exempted from the general hierarchy-based leaf check below:
+/// several of them are *nominally* non-leaf in `ClassHierarchy` for reasons
+/// that have nothing to do with runtime dispatch ambiguity — `Boolean` has
+/// stdlib subclasses `True`/`False` (`stdlib/src/True.bt`,
+/// `stdlib/src/False.bt`) purely to hang `ifTrue:`/`ifFalse:` double-dispatch
+/// methods off of, not because a plain `true`/`false` atom carries any
+/// distinguishing runtime tag — Phase A's `x :: Boolean` still means exactly
+/// "is this value `'true'` or `'false'`", tested as one BIF-style guard, not
+/// a class-tag test that could plausibly need Phase B's subclass dispatch.
+/// This list is the authority for which primitives get that treatment; it is
+/// intentionally not derived from the hierarchy (unlike the general leaf
+/// check), because "is a Phase A primitive" and "is a hierarchy leaf" are
+/// different questions that happen to coincide for ordinary user classes.
+const PHASE_A_PRIMITIVE_CLASSES: &[&str] = &[
+    "String",
+    "Integer",
+    "Float",
+    "List",
+    "Dictionary",
+    "Boolean",
+    "Symbol",
+];
+
 /// BT-2854 / ADR 0107 Phase A: validate the class name in every
-/// `Pattern::Type` (`binding :: ClassName`) arm of a `match:` expression.
+/// `Pattern::Type` (`binding :: ClassName`) arm of a `match:` expression,
+/// including type patterns nested inside container patterns (`Tuple`,
+/// `Array`, `List`, `Map`, `Constructor` keywords) — a `Pattern::Type` can
+/// appear anywhere a sub-pattern can, not just as an arm's top-level pattern.
 ///
 /// This is purely a semantic-analysis-stage check — `Pattern::Type` has no
 /// codegen yet (that lands with bindings/narrowing in BT-2855), so there is
@@ -209,7 +239,9 @@ fn visit_assignment_in_match_arm(expr: &Expression, diagnostics: &mut Vec<Diagno
 /// - **`Character`** is never accepted, known or not: it shares `Integer`'s
 ///   runtime representation with no distinct tag (ADR 0107 §Phase A scope),
 ///   so `x :: Character` could never be distinguished from `x :: Integer` at
-///   runtime.
+///   runtime. (Unlike `Boolean`, above, `Character` genuinely cannot be
+///   disambiguated from `Integer` by any runtime test — it compiles to a
+///   plain Erlang integer, not merely a nominal hierarchy child.)
 /// - **Unknown class name** reuses the existing unresolved-class diagnostic
 ///   verbatim (ADR 0100) — same `Warning` severity, same
 ///   [`DiagnosticCategory::UnresolvedClass`] category, and the same
@@ -220,7 +252,8 @@ fn visit_assignment_in_match_arm(expr: &Expression, diagnostics: &mut Vec<Diagno
 /// - **Non-leaf class** (has one or more subclasses) is a compile `Error` —
 ///   Phase A only supports concrete/leaf classes; matching on a class with
 ///   subclasses needs either compile-time subclass enumeration or a wrapped
-///   runtime dispatch call, deferred to ADR 0107 Phase B.
+///   runtime dispatch call, deferred to ADR 0107 Phase B. Classes in
+///   [`PHASE_A_PRIMITIVE_CLASSES`] are exempt from this check (see its doc).
 pub(crate) fn check_type_pattern_classes(
     module: &Module,
     hierarchy: &ClassHierarchy,
@@ -243,79 +276,142 @@ fn visit_type_pattern_classes(
     };
 
     for arm in arms {
-        let Pattern::Type { class, .. } = &arm.pattern else {
-            continue;
-        };
-        let class_name = class.name.as_str();
+        check_pattern_type_classes(&arm.pattern, hierarchy, has_cross_file_classes, diagnostics);
+    }
+}
 
-        // `Character` shares `Integer`'s runtime representation (no distinct
-        // tag) — never valid in a type pattern, regardless of whether it
-        // resolves in the hierarchy.
-        if class_name == "Character" {
-            diagnostics.push(
-                Diagnostic::error(
-                    "`Character` is not supported in a type pattern — it shares `Integer`'s \
-                     runtime representation with no distinct tag, so `x :: Character` can never \
-                     be distinguished from `x :: Integer` at runtime"
-                        .to_string(),
-                    class.span,
-                )
-                .with_hint("Use `x :: Integer` instead.".to_string())
-                .with_category(DiagnosticCategory::Type),
-            );
-            continue;
+/// Recursively finds every `Pattern::Type` in `pattern` (including ones
+/// nested inside container sub-patterns) and validates its class name.
+fn check_pattern_type_classes(
+    pattern: &Pattern,
+    hierarchy: &ClassHierarchy,
+    has_cross_file_classes: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    match pattern {
+        Pattern::Type { class, .. } => {
+            validate_type_pattern_class(class, hierarchy, has_cross_file_classes, diagnostics);
         }
-
-        if !hierarchy.has_class(class_name) {
-            // Unknown class — reuse the existing unresolved-class diagnostic
-            // (ADR 0100) verbatim, gated the same way as
-            // `check_unresolved_classes`: open-world assumption when
-            // cross-file metadata isn't loaded.
-            if has_cross_file_classes {
-                diagnostics.push(
-                    Diagnostic::warning(format!("Unresolved class `{class_name}`"), class.span)
-                        .with_hint(
-                            "This class is not defined in the current compilation unit or \
-                             standard library. Suppress with @expect unresolved_class if it \
-                             exists at runtime.",
-                        )
-                        .with_category(DiagnosticCategory::UnresolvedClass),
+        Pattern::Tuple { elements, .. } | Pattern::List { elements, .. } => {
+            for elem in elements {
+                check_pattern_type_classes(elem, hierarchy, has_cross_file_classes, diagnostics);
+            }
+            if let Pattern::List {
+                tail: Some(tail), ..
+            } = pattern
+            {
+                check_pattern_type_classes(tail, hierarchy, has_cross_file_classes, diagnostics);
+            }
+        }
+        Pattern::Array { elements, rest, .. } => {
+            for elem in elements {
+                check_pattern_type_classes(elem, hierarchy, has_cross_file_classes, diagnostics);
+            }
+            if let Some(rest_pat) = rest {
+                check_pattern_type_classes(
+                    rest_pat,
+                    hierarchy,
+                    has_cross_file_classes,
+                    diagnostics,
                 );
             }
-            continue;
         }
+        Pattern::Map { pairs, .. } => {
+            for pair in pairs {
+                check_pattern_type_classes(
+                    &pair.value,
+                    hierarchy,
+                    has_cross_file_classes,
+                    diagnostics,
+                );
+            }
+        }
+        Pattern::Binary { segments, .. } => {
+            for segment in segments {
+                check_pattern_type_classes(
+                    &segment.value,
+                    hierarchy,
+                    has_cross_file_classes,
+                    diagnostics,
+                );
+            }
+        }
+        Pattern::Constructor { keywords, .. } => {
+            for (_, binding) in keywords {
+                check_pattern_type_classes(binding, hierarchy, has_cross_file_classes, diagnostics);
+            }
+        }
+        Pattern::Wildcard(_) | Pattern::Literal(_, _) | Pattern::Variable(_) | Pattern::Nil(_) => {}
+    }
+}
 
-        // Non-leaf class — Phase A only supports concrete/leaf classes.
-        //
-        // `Character` is filtered out of the subclass count: it is a nominal
-        // (type-level) `Integer subclass:` in the stdlib, but shares
-        // `Integer`'s runtime representation exactly (no distinct tag,
-        // rejected on its own above) — so its existence doesn't make
-        // `Integer` itself ambiguous the way a real polymorphic subclass
-        // would. This is a targeted stdlib carve-out, not a general
-        // "ignore some subclasses" policy: every other subclass still counts.
-        let real_subclasses = hierarchy
-            .direct_subclasses(class_name)
-            .into_iter()
-            .filter(|s| s.as_str() != "Character")
-            .count();
-        if real_subclasses > 0 {
+fn validate_type_pattern_class(
+    class: &Identifier,
+    hierarchy: &ClassHierarchy,
+    has_cross_file_classes: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let class_name = class.name.as_str();
+
+    // `Character` shares `Integer`'s runtime representation (no distinct
+    // tag) — never valid in a type pattern, regardless of whether it
+    // resolves in the hierarchy.
+    if class_name == "Character" {
+        diagnostics.push(
+            Diagnostic::error(
+                "`Character` is not supported in a type pattern — it shares `Integer`'s \
+                 runtime representation with no distinct tag, so `x :: Character` can never \
+                 be distinguished from `x :: Integer` at runtime"
+                    .to_string(),
+                class.span,
+            )
+            .with_hint("Use `x :: Integer` instead.".to_string())
+            .with_category(DiagnosticCategory::Type),
+        );
+        return;
+    }
+
+    // Phase A's explicitly-named primitives are always valid — see
+    // `PHASE_A_PRIMITIVE_CLASSES`'s doc for why they skip the leaf check.
+    if PHASE_A_PRIMITIVE_CLASSES.contains(&class_name) {
+        return;
+    }
+
+    if !hierarchy.has_class(class_name) {
+        // Unknown class — reuse the existing unresolved-class diagnostic
+        // (ADR 0100) verbatim, gated the same way as
+        // `check_unresolved_classes`: open-world assumption when
+        // cross-file metadata isn't loaded.
+        if has_cross_file_classes {
             diagnostics.push(
-                Diagnostic::error(
-                    format!(
-                        "`{class_name}` has subclasses; type patterns are not yet supported \
-                         for non-leaf classes — see ADR 0107 Phase B"
-                    ),
-                    class.span,
-                )
-                .with_hint(
-                    "Match on the concrete subclasses instead, or use `isKindOf:` guard \
-                     clauses."
-                        .to_string(),
-                )
-                .with_category(DiagnosticCategory::Type),
+                Diagnostic::warning(format!("Unresolved class `{class_name}`"), class.span)
+                    .with_hint(
+                        "This class is not defined in the current compilation unit or \
+                         standard library. Suppress with @expect unresolved_class if it \
+                         exists at runtime.",
+                    )
+                    .with_category(DiagnosticCategory::UnresolvedClass),
             );
         }
+        return;
+    }
+
+    // Non-leaf class — Phase A only supports concrete/leaf classes.
+    if !hierarchy.direct_subclasses(class_name).is_empty() {
+        diagnostics.push(
+            Diagnostic::error(
+                format!(
+                    "`{class_name}` has subclasses; type patterns are not yet supported \
+                     for non-leaf classes — see ADR 0107 Phase B"
+                ),
+                class.span,
+            )
+            .with_hint(
+                "Match on the concrete subclasses instead, or use `isKindOf:` guard clauses."
+                    .to_string(),
+            )
+            .with_category(DiagnosticCategory::Type),
+        );
     }
 }
 
@@ -588,6 +684,27 @@ mod tests {
         );
     }
 
+    /// Regression test: referencing a `Pattern::Type` binding in its own arm
+    /// body must not raise a spurious "Undefined variable" error. The
+    /// binding is registered in `pattern_bindings.rs` even though narrowing
+    /// its type to `class` is deferred to BT-2855.
+    #[test]
+    fn type_pattern_binding_is_not_undefined_variable() {
+        let src = "Object subclass: Foo\n  test: x =>\n    x match: [path :: String -> path; _ -> \"\"]\n";
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "parse diags: {parse_diags:?}");
+        let result = crate::semantic_analysis::analyse(&module);
+        assert!(
+            !result
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("Undefined variable")),
+            "Expected no undefined-variable error for a Pattern::Type binding, got: {:?}",
+            result.diagnostics
+        );
+    }
+
     // ── BT-2854 / ADR 0107 Phase A: `Pattern::Type` class validation ────────
 
     fn hierarchy_for(src: &str) -> (crate::ast::Module, ClassHierarchy) {
@@ -610,17 +727,35 @@ mod tests {
         );
     }
 
-    /// `Integer` is a known Phase A leaf class even though `Character` is a
-    /// nominal `Integer subclass:` in the stdlib — `Character` must not count
-    /// against `Integer`'s leaf status.
+    /// `Integer` is a known Phase A primitive even though `Character` is a
+    /// nominal `Integer subclass:` in the stdlib — `PHASE_A_PRIMITIVE_CLASSES`
+    /// exempts it from the general hierarchy-based leaf check.
     #[test]
-    fn type_pattern_integer_not_flagged_non_leaf_by_character() {
+    fn type_pattern_integer_not_flagged_non_leaf() {
         let (module, hierarchy) = hierarchy_for("x match: [n :: Integer -> n; _ -> 0]");
         let mut diagnostics = Vec::new();
         check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
         assert!(
             diagnostics.is_empty(),
-            "Expected no diagnostics for Integer (Character doesn't count), got: {diagnostics:?}"
+            "Expected no diagnostics for Integer, got: {diagnostics:?}"
+        );
+    }
+
+    /// `Boolean` is an explicitly-named Phase A primitive (ADR 0107 Decision
+    /// §Phase A scope) even though it has nominal stdlib subclasses `True`/
+    /// `False` (`stdlib/src/True.bt`, `stdlib/src/False.bt`) — those exist to
+    /// hang `ifTrue:`/`ifFalse:` double-dispatch methods off of, not because
+    /// `true`/`false` atoms carry a distinguishing runtime tag. Regression
+    /// test for the bug where a naive hierarchy-only leaf check would wrongly
+    /// reject `x :: Boolean` as non-leaf.
+    #[test]
+    fn type_pattern_boolean_not_flagged_non_leaf() {
+        let (module, hierarchy) = hierarchy_for("x match: [b :: Boolean -> b; _ -> 0]");
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
+        assert!(
+            diagnostics.is_empty(),
+            "Expected no diagnostics for Boolean, got: {diagnostics:?}"
         );
     }
 
@@ -717,5 +852,42 @@ mod tests {
             diagnostics.is_empty(),
             "Expected no diagnostics when no Pattern::Type is present, got: {diagnostics:?}"
         );
+    }
+
+    /// A `Pattern::Type` nested inside a tuple sub-pattern is still
+    /// validated — the check must recurse into container patterns, not just
+    /// inspect the arm's top-level pattern.
+    #[test]
+    fn type_pattern_nested_in_tuple_is_validated() {
+        let (module, hierarchy) = hierarchy_for("x match: [{c :: Character, y} -> y; _ -> 0]");
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Expected the nested Character type pattern to be flagged, got: {diagnostics:?}"
+        );
+        assert!(diagnostics[0].message.contains("Character"));
+    }
+
+    /// A `Pattern::Type` nested inside an array sub-pattern is still
+    /// validated (same recursion path as the tuple case above; `Array`
+    /// elements also route through the general `parse_pattern`, unlike
+    /// `Constructor` keyword bindings and `Map` values, which don't yet
+    /// accept a `::` type pattern at the grammar level).
+    #[test]
+    fn type_pattern_nested_in_array_is_validated() {
+        let (module, hierarchy) = hierarchy_for(
+            "Object subclass: Shape\nShape subclass: Circle\n\
+             x match: [#[s :: Shape, y] -> y; _ -> 0]",
+        );
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Expected the nested non-leaf Shape type pattern to be flagged, got: {diagnostics:?}"
+        );
+        assert!(diagnostics[0].message.contains("Shape"));
     }
 }

--- a/crates/beamtalk-core/src/semantic_analysis/validators/match_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/match_validators.rs
@@ -9,6 +9,7 @@
 
 use crate::ast::{Expression, Module, Pattern};
 use crate::ast_walker::walk_module;
+use crate::semantic_analysis::ClassHierarchy;
 use crate::source_analysis::{Diagnostic, DiagnosticCategory};
 
 // ── BT-1299: Match exhaustiveness for sealed types ────────────────────────────
@@ -192,6 +193,128 @@ fn visit_assignment_in_match_arm(expr: &Expression, diagnostics: &mut Vec<Diagno
                 }
                 _ => {}
             }
+        }
+    }
+}
+
+// ── BT-2854 / ADR 0107 Phase A: `Pattern::Type` class validation ───────────
+
+/// BT-2854 / ADR 0107 Phase A: validate the class name in every
+/// `Pattern::Type` (`binding :: ClassName`) arm of a `match:` expression.
+///
+/// This is purely a semantic-analysis-stage check — `Pattern::Type` has no
+/// codegen yet (that lands with bindings/narrowing in BT-2855), so there is
+/// nothing to gate at codegen time. Three checks, in order:
+///
+/// - **`Character`** is never accepted, known or not: it shares `Integer`'s
+///   runtime representation with no distinct tag (ADR 0107 §Phase A scope),
+///   so `x :: Character` could never be distinguished from `x :: Integer` at
+///   runtime.
+/// - **Unknown class name** reuses the existing unresolved-class diagnostic
+///   verbatim (ADR 0100) — same `Warning` severity, same
+///   [`DiagnosticCategory::UnresolvedClass`] category, and the same
+///   open-world gating (`has_cross_file_classes`) as
+///   [`super::structural_validators::check_unresolved_classes`]: without
+///   cross-file metadata loaded, any class reference might be a
+///   not-yet-seen cross-file dependency, so the check stays silent.
+/// - **Non-leaf class** (has one or more subclasses) is a compile `Error` —
+///   Phase A only supports concrete/leaf classes; matching on a class with
+///   subclasses needs either compile-time subclass enumeration or a wrapped
+///   runtime dispatch call, deferred to ADR 0107 Phase B.
+pub(crate) fn check_type_pattern_classes(
+    module: &Module,
+    hierarchy: &ClassHierarchy,
+    has_cross_file_classes: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    walk_module(module, &mut |expr| {
+        visit_type_pattern_classes(expr, hierarchy, has_cross_file_classes, diagnostics);
+    });
+}
+
+fn visit_type_pattern_classes(
+    expr: &Expression,
+    hierarchy: &ClassHierarchy,
+    has_cross_file_classes: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Expression::Match { arms, .. } = expr else {
+        return;
+    };
+
+    for arm in arms {
+        let Pattern::Type { class, .. } = &arm.pattern else {
+            continue;
+        };
+        let class_name = class.name.as_str();
+
+        // `Character` shares `Integer`'s runtime representation (no distinct
+        // tag) — never valid in a type pattern, regardless of whether it
+        // resolves in the hierarchy.
+        if class_name == "Character" {
+            diagnostics.push(
+                Diagnostic::error(
+                    "`Character` is not supported in a type pattern — it shares `Integer`'s \
+                     runtime representation with no distinct tag, so `x :: Character` can never \
+                     be distinguished from `x :: Integer` at runtime"
+                        .to_string(),
+                    class.span,
+                )
+                .with_hint("Use `x :: Integer` instead.".to_string())
+                .with_category(DiagnosticCategory::Type),
+            );
+            continue;
+        }
+
+        if !hierarchy.has_class(class_name) {
+            // Unknown class — reuse the existing unresolved-class diagnostic
+            // (ADR 0100) verbatim, gated the same way as
+            // `check_unresolved_classes`: open-world assumption when
+            // cross-file metadata isn't loaded.
+            if has_cross_file_classes {
+                diagnostics.push(
+                    Diagnostic::warning(format!("Unresolved class `{class_name}`"), class.span)
+                        .with_hint(
+                            "This class is not defined in the current compilation unit or \
+                             standard library. Suppress with @expect unresolved_class if it \
+                             exists at runtime.",
+                        )
+                        .with_category(DiagnosticCategory::UnresolvedClass),
+                );
+            }
+            continue;
+        }
+
+        // Non-leaf class — Phase A only supports concrete/leaf classes.
+        //
+        // `Character` is filtered out of the subclass count: it is a nominal
+        // (type-level) `Integer subclass:` in the stdlib, but shares
+        // `Integer`'s runtime representation exactly (no distinct tag,
+        // rejected on its own above) — so its existence doesn't make
+        // `Integer` itself ambiguous the way a real polymorphic subclass
+        // would. This is a targeted stdlib carve-out, not a general
+        // "ignore some subclasses" policy: every other subclass still counts.
+        let real_subclasses = hierarchy
+            .direct_subclasses(class_name)
+            .into_iter()
+            .filter(|s| s.as_str() != "Character")
+            .count();
+        if real_subclasses > 0 {
+            diagnostics.push(
+                Diagnostic::error(
+                    format!(
+                        "`{class_name}` has subclasses; type patterns are not yet supported \
+                         for non-leaf classes — see ADR 0107 Phase B"
+                    ),
+                    class.span,
+                )
+                .with_hint(
+                    "Match on the concrete subclasses instead, or use `isKindOf:` guard \
+                     clauses."
+                        .to_string(),
+                )
+                .with_category(DiagnosticCategory::Type),
+            );
         }
     }
 }
@@ -462,6 +585,137 @@ mod tests {
         assert!(
             diagnostics.is_empty(),
             "Expected no warnings, got: {diagnostics:?}"
+        );
+    }
+
+    // ── BT-2854 / ADR 0107 Phase A: `Pattern::Type` class validation ────────
+
+    fn hierarchy_for(src: &str) -> (crate::ast::Module, ClassHierarchy) {
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+        let (hierarchy, _) = ClassHierarchy::build_with_options(&module, false);
+        (module, hierarchy.unwrap())
+    }
+
+    /// A known leaf stdlib class (`String`) → no diagnostics.
+    #[test]
+    fn type_pattern_known_leaf_class_no_diagnostics() {
+        let (module, hierarchy) = hierarchy_for("x match: [s :: String -> s; _ -> \"\"]");
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
+        assert!(
+            diagnostics.is_empty(),
+            "Expected no diagnostics for a known leaf class, got: {diagnostics:?}"
+        );
+    }
+
+    /// `Integer` is a known Phase A leaf class even though `Character` is a
+    /// nominal `Integer subclass:` in the stdlib — `Character` must not count
+    /// against `Integer`'s leaf status.
+    #[test]
+    fn type_pattern_integer_not_flagged_non_leaf_by_character() {
+        let (module, hierarchy) = hierarchy_for("x match: [n :: Integer -> n; _ -> 0]");
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
+        assert!(
+            diagnostics.is_empty(),
+            "Expected no diagnostics for Integer (Character doesn't count), got: {diagnostics:?}"
+        );
+    }
+
+    /// Unknown class name, cross-file metadata loaded → reuses the existing
+    /// unresolved-class diagnostic (ADR 0100) verbatim.
+    #[test]
+    fn type_pattern_unknown_class_warns_when_cross_file_loaded() {
+        let (module, hierarchy) = hierarchy_for("x match: [s :: Sting -> s; _ -> \"\"]");
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Expected 1 diagnostic for unknown class, got: {diagnostics:?}"
+        );
+        assert_eq!(diagnostics[0].severity, Severity::Warning);
+        assert_eq!(
+            diagnostics[0].category,
+            Some(DiagnosticCategory::UnresolvedClass)
+        );
+        assert!(diagnostics[0].message.contains("Sting"));
+    }
+
+    /// Unknown class name, no cross-file metadata → silent (open-world
+    /// policy, same gating as `check_unresolved_classes`).
+    #[test]
+    fn type_pattern_unknown_class_silent_without_cross_file() {
+        let (module, hierarchy) = hierarchy_for("x match: [s :: Sting -> s; _ -> \"\"]");
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, false, &mut diagnostics);
+        assert!(
+            diagnostics.is_empty(),
+            "Expected no diagnostics without cross-file metadata, got: {diagnostics:?}"
+        );
+    }
+
+    /// A class with subclasses → compile error (ADR 0107 Phase A leaf-only
+    /// restriction).
+    #[test]
+    fn type_pattern_non_leaf_class_is_error() {
+        let (module, hierarchy) = hierarchy_for(
+            "Object subclass: Shape\nShape subclass: Circle\nx match: [s :: Shape -> s; _ -> 0]",
+        );
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Expected 1 error for non-leaf class, got: {diagnostics:?}"
+        );
+        assert_eq!(diagnostics[0].severity, Severity::Error);
+        assert!(diagnostics[0].message.contains("Shape"));
+        assert!(diagnostics[0].message.contains("subclasses"));
+    }
+
+    /// A leaf class (no subclasses) → no diagnostics.
+    #[test]
+    fn type_pattern_leaf_user_class_no_diagnostics() {
+        let (module, hierarchy) =
+            hierarchy_for("Object subclass: Circle\nx match: [s :: Circle -> s; _ -> 0]");
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
+        assert!(
+            diagnostics.is_empty(),
+            "Expected no diagnostics for a leaf user class, got: {diagnostics:?}"
+        );
+    }
+
+    /// `Character` is never accepted, even though it resolves in the
+    /// hierarchy — it shares `Integer`'s runtime representation.
+    #[test]
+    fn type_pattern_character_is_rejected() {
+        let (module, hierarchy) = hierarchy_for("x match: [c :: Character -> c; _ -> 0]");
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Expected 1 error rejecting Character, got: {diagnostics:?}"
+        );
+        assert_eq!(diagnostics[0].severity, Severity::Error);
+        assert!(diagnostics[0].message.contains("Character"));
+        assert!(diagnostics[0].message.contains("Integer"));
+    }
+
+    /// A `nil` pattern arm alongside a `Constructor` pattern arm must not
+    /// trigger the type-pattern validator (no `Pattern::Type` present).
+    #[test]
+    fn type_pattern_validator_ignores_non_type_patterns() {
+        let (module, hierarchy) = hierarchy_for("x match: [nil -> 0; Result ok: v -> v; _ -> 1]");
+        let mut diagnostics = Vec::new();
+        check_type_pattern_classes(&module, &hierarchy, true, &mut diagnostics);
+        assert!(
+            diagnostics.is_empty(),
+            "Expected no diagnostics when no Pattern::Type is present, got: {diagnostics:?}"
         );
     }
 }

--- a/crates/beamtalk-core/src/semantic_analysis/validators/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/mod.rs
@@ -38,7 +38,9 @@ pub(crate) use lint_validators::{
     check_redundant_assignment, check_redundant_local_type_annotation,
     check_redundant_super_initialize,
 };
-pub(crate) use match_validators::{check_match_exhaustiveness, warn_assignment_in_match_arms};
+pub(crate) use match_validators::{
+    check_match_exhaustiveness, check_type_pattern_classes, warn_assignment_in_match_arms,
+};
 pub(crate) use native_validators::{
     check_native_delegate_reserved_word, check_native_delegate_return_type,
     check_native_state_fields,

--- a/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
@@ -1387,6 +1387,7 @@ impl Parser {
     /// - `identifier :: ClassName` — type pattern (ADR 0107 Phase A)
     /// - integer, float, string, symbol, character — literal
     /// - `{p1, p2, ...}` — tuple
+    #[allow(clippy::too_many_lines)] // one arm per pattern kind
     fn parse_pattern(&mut self) -> Pattern {
         // Guard against stack overflow from deeply nested tuple patterns
         let span = self.current_token().span();

--- a/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/expressions.rs
@@ -1382,7 +1382,9 @@ impl Parser {
     ///
     /// Supported patterns:
     /// - `_` — wildcard
+    /// - `nil` — nil pattern (ADR 0107 Phase A)
     /// - identifier — variable binding
+    /// - `identifier :: ClassName` — type pattern (ADR 0107 Phase A)
     /// - integer, float, string, symbol, character — literal
     /// - `{p1, p2, ...}` — tuple
     fn parse_pattern(&mut self) -> Pattern {
@@ -1408,12 +1410,44 @@ impl Parser {
                 self.parse_constructor_pattern()
             }
 
-            // Variable binding
+            // Nil pattern: `nil` (ADR 0107 Phase A) — a reserved identifier,
+            // recognized before the generic variable-binding case below.
+            TokenKind::Identifier(name) if name.as_str() == "nil" => {
+                let span = self.advance().span();
+                Pattern::Nil(span)
+            }
+
+            // Variable binding, or a type pattern if followed by `:: ClassName`
+            // (ADR 0107 Phase A: `binding :: ClassName`, reusing the `::`
+            // tokenization from ADR 0053's parameter-annotation parsing).
             TokenKind::Identifier(name) => {
                 let name = name.clone();
                 let token = self.advance();
                 let span = token.span();
-                Pattern::Variable(Identifier::new(name, span))
+                let binding = Identifier::new(name, span);
+
+                if matches!(self.current_kind(), TokenKind::DoubleColon) {
+                    self.advance(); // consume '::'
+                    if let TokenKind::Identifier(class_name) = self.current_kind() {
+                        let class_name = class_name.clone();
+                        let class_span = self.advance().span();
+                        let full_span = span.merge(class_span);
+                        Pattern::Type {
+                            binding,
+                            class: Identifier::new(class_name, class_span),
+                            span: full_span,
+                        }
+                    } else {
+                        let bad_span = self.current_token().span();
+                        self.diagnostics.push(Diagnostic::error(
+                            "Expected a class name after '::' in a type pattern",
+                            bad_span,
+                        ));
+                        Pattern::Wildcard(span.merge(bad_span))
+                    }
+                } else {
+                    Pattern::Variable(binding)
+                }
             }
 
             // Literal patterns: integer, float, string, character
@@ -2909,5 +2943,59 @@ mod tests {
             "expected a diagnostic instead of a panic, got: {:?}",
             parser.diagnostics
         );
+    }
+
+    // ── BT-2854 / ADR 0107 Phase A: `Pattern::Nil` and `Pattern::Type` ──────
+
+    #[test]
+    fn parse_nil_pattern() {
+        let (module, diags) = parse_source("x match: [nil -> 0; _ -> 1]");
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+        let Expression::Match { arms, .. } = &module.expressions[0].expression else {
+            panic!("expected Expression::Match");
+        };
+        assert!(
+            matches!(arms[0].pattern, Pattern::Nil(_)),
+            "expected Pattern::Nil, got: {:?}",
+            arms[0].pattern
+        );
+    }
+
+    #[test]
+    fn parse_type_pattern() {
+        let (module, diags) = parse_source("x match: [path :: String -> path; _ -> 1]");
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+        let Expression::Match { arms, .. } = &module.expressions[0].expression else {
+            panic!("expected Expression::Match");
+        };
+        match &arms[0].pattern {
+            Pattern::Type { binding, class, .. } => {
+                assert_eq!(binding.name, "path");
+                assert_eq!(class.name, "String");
+            }
+            other => panic!("expected Pattern::Type, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_type_pattern_missing_class_name_recovers() {
+        let (_module, diags) = parse_source("x match: [path :: -> path; _ -> 1]");
+        assert!(
+            diags.iter().any(|d| d.message.contains("class name")),
+            "expected a diagnostic about the missing class name, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn parse_nil_variable_and_type_patterns_together() {
+        // Combining all three pattern kinds in one match: (ADR 0107 example shape).
+        let (module, diags) = parse_source("x match: [nil -> 0; path :: String -> 1; other -> 2]");
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+        let Expression::Match { arms, .. } = &module.expressions[0].expression else {
+            panic!("expected Expression::Match");
+        };
+        assert!(matches!(arms[0].pattern, Pattern::Nil(_)));
+        assert!(matches!(arms[1].pattern, Pattern::Type { .. }));
+        assert!(matches!(arms[2].pattern, Pattern::Variable(_)));
     }
 }

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -1535,7 +1535,15 @@ fn unparse_pattern(pattern: &Pattern) -> Document<'static> {
     match pattern {
         Pattern::Wildcard(_) => Document::Str("_"),
         Pattern::Literal(lit, _) => unparse_literal(lit),
+        Pattern::Nil(_) => Document::Str("nil"),
         Pattern::Variable(id) => unparse_identifier(id),
+        Pattern::Type { binding, class, .. } => {
+            docvec![
+                unparse_identifier(binding),
+                " :: ",
+                leaf::ident(&class.name)
+            ]
+        }
         Pattern::Tuple { elements, .. } => {
             let elem_docs: Vec<Document<'static>> = elements.iter().map(unparse_pattern).collect();
             let joined = join_docs(elem_docs, ", ");
@@ -2683,6 +2691,31 @@ mod tests {
         assert!(
             output.contains("_ -> \"other\"\n"),
             "last arm should not have semicolon: {output}"
+        );
+    }
+
+    #[test]
+    fn match_nil_pattern_round_trips() {
+        // ADR 0107 Phase A: `nil` pattern round-trips through parse + unparse.
+        let source = "Actor subclass: A\n  m => x match: [nil -> \"none\"; _ -> \"other\"]";
+        let module = parse_source(source);
+        let output = unparse_module(&module);
+        assert!(
+            output.contains("nil -> \"none\""),
+            "nil pattern should round-trip: {output}"
+        );
+    }
+
+    #[test]
+    fn match_type_pattern_round_trips() {
+        // ADR 0107 Phase A: `binding :: ClassName` type pattern round-trips
+        // through parse + unparse.
+        let source = "Actor subclass: A\n  m => x match: [path :: String -> path; _ -> \"other\"]";
+        let module = parse_source(source);
+        let output = unparse_module(&module);
+        assert!(
+            output.contains("path :: String -> path"),
+            "type pattern should round-trip: {output}"
         );
     }
 


### PR DESCRIPTION
## Summary

Phase 1 of [ADR 0107](https://linear.app/beamtalk/issue/BT-2853) (BT-2853 Epic): [BT-2854](https://linear.app/beamtalk/issue/BT-2854).

- Lands `Pattern::Nil` end-to-end (parser, narrowing, codegen reusing the existing atom-literal path) as a low-risk vertical slice proving the new-pattern-kind wiring works.
- Lands the `Pattern::Type` (`binding :: ClassName`) AST/parser foundation and Phase A leaf-class gate the rest of the epic builds on. `Pattern::Type` codegen, real variable-binding/scope wiring, and narrowing are explicitly out of scope here — that's [BT-2855](https://linear.app/beamtalk/issue/BT-2855).

## Key changes

- `Pattern::Nil(Span)` and `Pattern::Type { binding, class, span }` added to `ast/pattern.rs`; every exhaustive `match pattern { ... }` site across the compiler (codegen, lint, queries, semantic analysis, unparse) updated by the Rust compiler's own exhaustiveness check
- Parser recognizes `nil` and `identifier :: ClassName` in pattern position
- `Pattern::Nil` codegen reuses the existing atom-literal path verbatim
- `Pattern::Nil` narrows the scrutinee to `UndefinedObject` inside its own arm, and strips `Nil` from what unguarded subsequent arms see — reuses `is_nil.rs`'s exact `non_nil_type` algebra
- New `check_type_pattern_classes` validator: unknown-class (reuses the ADR 0100 diagnostic verbatim), non-leaf-class compile error (with a `PHASE_A_PRIMITIVE_CLASSES` allowlist so `Boolean`/`Integer` aren't wrongly flagged by their nominal stdlib subclasses), and `Character` exclusion — recurses into container sub-patterns (Tuple/Array/List/Map/Binary)
- Parser round-trip (parse + unparse) tests for both new pattern kinds

## Test plan

- [x] `cargo build --workspace`
- [x] `just test` (Rust + stdlib + BUnit + runtime)
- [x] `just clippy` (workspace, `-D warnings`)
- [x] `just fmt-check`
- [x] Adversarial review pass (separate model) found and fixed: a `Boolean`-leaf-check false positive, nested-pattern validation bypass, and a spurious "Undefined variable" error on `Pattern::Type` bindings — all covered by new regression tests
- [x] Two minor, non-blocking parser polish items tracked as [BT-2860](https://linear.app/beamtalk/issue/BT-2860)

🤖 Generated with [Claude Code](https://claude.com/claude-code)