### PR TITLE
Spec-extraction worker missing project's own native ebin dir on code path (BT-2861)

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -1595,7 +1595,7 @@ fn beam_mtime(path: &Utf8Path) -> (u64, u32) {
 /// raw protocol line for successful modules, or an empty string for modules that
 /// had errors (`no_debug_info`, etc.).
 fn extract_specs_via_build_worker(beam_files: &[Utf8PathBuf]) -> Result<Vec<(String, String)>> {
-    let mut child = spawn_build_worker_for_specs()?;
+    let mut child = spawn_build_worker_for_specs(beam_files)?;
 
     let result = extract_specs_from_child(&mut child, beam_files);
 
@@ -1679,7 +1679,13 @@ fn spawn_build_worker_node(pa_args: &[String]) -> Result<std::process::Child> {
 }
 
 /// Spawns a `beamtalk_build_worker` BEAM node for spec extraction.
-fn spawn_build_worker_for_specs() -> Result<std::process::Child> {
+///
+/// `beam_files` are the `.beam` files about to be read for specs; their parent
+/// directories are added to the `-pa` list alongside the runtime's own ebin
+/// dirs so that sibling modules (e.g. a package's own `native/` ebin dir, per
+/// ADR 0075 "package-bundled native code") can be resolved by `code:which/1`
+/// when a `-spec` references one of their remote types (BT-2861).
+fn spawn_build_worker_for_specs(beam_files: &[Utf8PathBuf]) -> Result<std::process::Child> {
     use beamtalk_cli::repl_startup;
 
     let (runtime_dir, layout) = repl_startup::find_runtime_dir_with_layout().map_err(|_| {
@@ -1710,12 +1716,33 @@ fn spawn_build_worker_for_specs() -> Result<std::process::Child> {
     // Add all runtime ebin directories to the code path so the spec reader
     // can resolve remote types (e.g., `beamtalk_result:t()` needs the
     // beamtalk_stdlib ebin on the path for `code:which/1` to find it).
-    let ebin_dirs = [
-        &paths.compiler_ebin,
-        &paths.runtime_ebin,
-        &paths.stdlib_erlang_ebin,
-        &paths.workspace_ebin,
+    let mut ebin_dirs: Vec<std::path::PathBuf> = vec![
+        paths.compiler_ebin.clone(),
+        paths.runtime_ebin.clone(),
+        paths.stdlib_erlang_ebin.clone(),
+        paths.workspace_ebin.clone(),
     ];
+
+    // Also add the ebin directories the beam files themselves live in (BT-2861).
+    // A package's own native/ ebin dir isn't one of the runtime dirs above, so
+    // without this a module's `-spec` referencing a sibling native module's
+    // type (e.g. `beamtalk_http_response:t()`) can't be resolved by
+    // `code:which/1`, and falls back to `Dynamic`. Canonicalize first: the
+    // worker node runs with its cwd set to the system temp dir
+    // (`spawn_build_worker_node`), so a relative `beam_file` path (e.g. from
+    // a CLI arg given as a relative path) would resolve against the wrong
+    // directory if passed to `-pa` as-is.
+    for beam_file in beam_files {
+        let absolute = std::fs::canonicalize(beam_file.as_std_path())
+            .unwrap_or_else(|_| beam_file.as_std_path().to_path_buf());
+        if let Some(parent) = absolute.parent() {
+            let parent = parent.to_path_buf();
+            if !ebin_dirs.contains(&parent) {
+                ebin_dirs.push(parent);
+            }
+        }
+    }
+
     let mut pa_args = Vec::new();
     for ebin in &ebin_dirs {
         if ebin.exists() {

--- a/crates/beamtalk-cli/tests/native_type_extraction.rs
+++ b/crates/beamtalk-cli/tests/native_type_extraction.rs
@@ -1,0 +1,81 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression test for BT-2861: the spec-extraction worker's `-pa` list must
+//! include the current project's own native ebin directory.
+//!
+//! A package's native Erlang code can be split across sibling modules (ADR
+//! 0072 "package-bundled native code") where one module's `-spec` references
+//! another module's exported `-type t()` (tagged with `'$beamtalk_class'`,
+//! ADR 0075). Before the fix, `spawn_build_worker_for_specs` only added the
+//! Beamtalk runtime's own ebin directories to the extraction worker's code
+//! path, so `code:which/1` could not find the sibling module and the
+//! reference collapsed to `Dynamic` — degrading `{ok, T} | {error, E}` to a
+//! bare `Result` instead of the parameterized `Result(T, E)`.
+
+mod cli_common;
+
+#[test]
+fn native_sibling_type_reference_resolves_after_build() {
+    let project = cli_common::fixture_project();
+
+    std::fs::create_dir_all(project.path().join("native")).unwrap();
+
+    // One native module exports a type tagged `'$beamtalk_class'` so the spec
+    // reader recognises it as the Beamtalk class `NativeThingResponse`.
+    std::fs::write(
+        project.path().join("native/native_thing_response.erl"),
+        "%% Copyright 2026 James Casey\n\
+         %% SPDX-License-Identifier: Apache-2.0\n\
+         -module(native_thing_response).\n\
+         -export([make/0]).\n\
+         \n\
+         -type t() :: #{\n\
+         \x20\x20\x20\x20'$beamtalk_class' := 'NativeThingResponse',\n\
+         \x20\x20\x20\x20'value' := integer()\n\
+         }.\n\
+         -export_type([t/0]).\n\
+         \n\
+         -spec make() -> t().\n\
+         make() -> #{'$beamtalk_class' => 'NativeThingResponse', value => 42}.\n",
+    )
+    .unwrap();
+
+    // A sibling native module whose `-spec` references the other module's
+    // type in an `{ok, T} | {error, E}` return — the pattern that should
+    // resolve to a parameterized `Result(NativeThingResponse)`.
+    std::fs::write(
+        project.path().join("native/native_thing.erl"),
+        "%% Copyright 2026 James Casey\n\
+         %% SPDX-License-Identifier: Apache-2.0\n\
+         -module(native_thing).\n\
+         -export([get/0]).\n\
+         \n\
+         -spec get() -> {ok, native_thing_response:t()} | {error, term()}.\n\
+         get() -> {ok, native_thing_response:make()}.\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("build")
+        .assert()
+        .success();
+
+    // The project-local type cache should have resolved `native_thing:get/0`
+    // to `Result(NativeThingResponse)`, not a bare `Result` or `Dynamic`.
+    let cache_dir = project.path().join("_build/type_cache");
+    let entries = std::fs::read_dir(&cache_dir)
+        .unwrap_or_else(|e| panic!("expected {cache_dir:?} to exist: {e}"));
+
+    let mut combined = String::new();
+    for entry in entries.flatten() {
+        combined.push_str(&std::fs::read_to_string(entry.path()).unwrap());
+    }
+
+    assert!(
+        combined.contains("Result(NativeThingResponse)"),
+        "expected native_thing:get/0 to resolve to Result(NativeThingResponse); \
+         type cache contents:\n{combined}"
+    );
+}


### PR DESCRIPTION
https://linear.app/beamtalk/issue/BT-2861

## Summary
- `spawn_build_worker_for_specs()` in `crates/beamtalk-cli/src/beam_compiler.rs` only added the Beamtalk runtime's own ebin dirs to the spec-extraction worker's `erl -pa` list, never the current project's own native ebin dir (e.g. a package's `_build/dev/native/ebin`, per ADR 0072's "package-bundled native code" pattern).
- When a package's native Erlang code is split across sibling modules where one module's `-spec` references another's exported `-type t()` (tagged `'$beamtalk_class'`, ADR 0075), `code:which/1` couldn't find the sibling module on the extraction worker's code path, so the reference fell back to `Dynamic` — degrading `{ok, T} | {error, E}` to a bare `Result` instead of the parameterized `Result(T, E)`.
- Fix: add the canonicalized parent directories of the `.beam` files being read to the `-pa` list. Canonicalization is required because the worker node's cwd is the system temp dir, not the caller's cwd, so a relative beam-file path (the common case for `beamtalk build`, whose default project root is `.`) would otherwise resolve against the wrong directory.

## Test plan
- [x] `crates/beamtalk-cli/tests/native_type_extraction.rs` (new): builds a fixture package with two sibling native `.erl` modules (mirroring `beamtalk_http`/`beamtalk_http_response` from the issue) via the real `beamtalk build` CLI, and asserts the type cache resolves `Result(NativeThingResponse)` instead of bare `Result`/`Dynamic`. Verified it fails without the fix and passes with it.
- [x] `just test` — full Rust/stdlib/BUnit/Erlang runtime suite green
- [x] `just clippy`, `just fmt-check-rust`, `test-integration`, `check-surface-drift`, `test-repl-protocol` — all green
- [x] `just ci`'s `lint-workaround-comments` step fails, but on a pre-existing, unrelated gap (confirmed via `git blame` — introduced by already-merged PRs BT-2823/BT-2826/BT-2829); filed as BT-2863

🤖 Generated with [Claude Code](https://claude.com/claude-code)