### PR TITLE
Address Claude review suggestions on BT-2861's ebin-dir fix

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -1732,12 +1732,19 @@ fn spawn_build_worker_for_specs(beam_files: &[Utf8PathBuf]) -> Result<std::proce
     // (`spawn_build_worker_node`), so a relative `beam_file` path (e.g. from
     // a CLI arg given as a relative path) would resolve against the wrong
     // directory if passed to `-pa` as-is.
+    let mut seen_dirs: std::collections::HashSet<std::path::PathBuf> =
+        ebin_dirs.iter().cloned().collect();
     for beam_file in beam_files {
-        let absolute = std::fs::canonicalize(beam_file.as_std_path())
-            .unwrap_or_else(|_| beam_file.as_std_path().to_path_buf());
+        let absolute = match std::fs::canonicalize(beam_file.as_std_path()) {
+            Ok(abs) => abs,
+            Err(e) => {
+                warn!("Failed to canonicalize '{beam_file}': {e}. Using path as-is.");
+                beam_file.as_std_path().to_path_buf()
+            }
+        };
         if let Some(parent) = absolute.parent() {
             let parent = parent.to_path_buf();
-            if !ebin_dirs.contains(&parent) {
+            if seen_dirs.insert(parent.clone()) {
                 ebin_dirs.push(parent);
             }
         }

--- a/crates/beamtalk-cli/tests/native_type_extraction.rs
+++ b/crates/beamtalk-cli/tests/native_type_extraction.rs
@@ -21,6 +21,11 @@ fn native_sibling_type_reference_resolves_after_build() {
 
     std::fs::create_dir_all(project.path().join("native")).unwrap();
 
+    // Writing `.erl` source (not a precompiled `.beam`) relies on `beamtalk
+    // build` compiling it itself: with no `[native.dependencies]` in
+    // beamtalk.toml, native/*.erl files are compiled directly via
+    // `compile:file/2` in the build worker (ADR 0072 Path A, no rebar3).
+
     // One native module exports a type tagged `'$beamtalk_class'` so the spec
     // reader recognises it as the Beamtalk class `NativeThingResponse`.
     std::fs::write(
@@ -70,7 +75,10 @@ fn native_sibling_type_reference_resolves_after_build() {
 
     let mut combined = String::new();
     for entry in entries.flatten() {
-        combined.push_str(&std::fs::read_to_string(entry.path()).unwrap());
+        let path = entry.path();
+        if path.is_file() {
+            combined.push_str(&std::fs::read_to_string(path).unwrap());
+        }
     }
 
     assert!(


### PR DESCRIPTION
Follow-up to #2955 (BT-2861), addressing suggestions from the Claude review that were posted as a plain issue comment on that PR and missed before merge.

## Changes
- `spawn_build_worker_for_specs`: log `tracing::warn!` when `std::fs::canonicalize` fails on a beam file's path, instead of silently falling back to the (possibly relative) original path — matches the existing pattern used elsewhere in this file (`write_core_erlang`).
- Replace the `Vec::contains` per-file linear scan with a `HashSet<PathBuf>` for O(n) ebin-dir dedup instead of O(n²).
- `native_type_extraction.rs`: guard the type-cache read with `is_file()` so a stray subdirectory under `_build/type_cache/` can't panic the test with `read_to_string`'s `Is a directory` error.
- `native_type_extraction.rs`: note the test's reliance on `beamtalk build` compiling `native/*.erl` itself via `compile:file/2` (ADR 0072 Path A, no hex deps) rather than a precompiled `.beam`.

## Test plan
- [x] `just clippy`, `just fmt-check-rust` — clean
- [x] `cargo test -p beamtalk-cli` — full suite green, including the updated `native_type_extraction.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)