### PR TITLE
Type cache does not invalidate when spec-reader mapping logic changes (BT-2852)

### DIFF
--- a/crates/beamtalk-build/src/lib.rs
+++ b/crates/beamtalk-build/src/lib.rs
@@ -5,6 +5,9 @@
 //!
 //! Provides `emit_beamtalk_version` which reads the workspace `VERSION` file
 //! and git state, then exposes the `BEAMTALK_VERSION` compile-time env var.
+//! Also provides `emit_spec_mapping_stamp`, which hashes
+//! `beamtalk_spec_reader.erl` and exposes the result as
+//! `BEAMTALK_SPEC_MAPPING_STAMP` (BT-2852).
 //!
 //! # Usage
 //!
@@ -99,4 +102,80 @@ fn git_short_sha() -> Option<String> {
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+}
+
+/// Hash `runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl` and
+/// expose the result as the `BEAMTALK_SPEC_MAPPING_STAMP` compile-time env var
+/// (BT-2852).
+///
+/// The FFI type-spec cache (`_build/type_cache/`, and the shared
+/// OTP-version-keyed tier) keys cached specs by module name, `.beam` mtime,
+/// and OTP version only — none of which change just because the *compiler's*
+/// Erlang→Beamtalk type-mapping logic (`beamtalk_spec_reader.erl`'s
+/// `map_type/1` and friends) changed. Baking a content hash of that file into
+/// the binary at compile time gives cache entries a stamp to compare against:
+/// a build whose mapping logic differs produces a different stamp, so stale
+/// entries are detected as a miss rather than silently reused forever.
+///
+/// Deriving the stamp from a hash (rather than a hand-maintained constant)
+/// means there is nothing to remember to bump — any change to the reader's
+/// source, including comment-only edits, rotates the stamp automatically.
+/// The hash itself runs once per `cargo build` (via `rerun-if-changed`), not
+/// per `beamtalk` invocation, so comparing it at runtime is a cheap string
+/// comparison against a `&'static str` baked in via `env!()`.
+///
+/// # Panics
+///
+/// Panics if `beamtalk_spec_reader.erl` cannot be read — this file is
+/// committed source, so its absence indicates a broken checkout.
+pub fn emit_spec_mapping_stamp(workspace_root: &Path) {
+    let reader_path = workspace_root
+        .join("runtime")
+        .join("apps")
+        .join("beamtalk_compiler")
+        .join("src")
+        .join("beamtalk_spec_reader.erl");
+    println!("cargo:rerun-if-changed={}", reader_path.display());
+
+    let content = fs::read(&reader_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {e}", reader_path.display()));
+
+    let hash = fnv1a_64(&content);
+    println!("cargo:rustc-env=BEAMTALK_SPEC_MAPPING_STAMP={hash:016x}");
+}
+
+/// FNV-1a 64-bit hash. Not cryptographic — used only as a cheap, deterministic
+/// content fingerprint so the type-mapping stamp doesn't depend on the
+/// standard library's hasher (which offers no cross-version stability
+/// guarantee) or an external hashing crate.
+fn fnv1a_64(data: &[u8]) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = FNV_OFFSET_BASIS;
+    for &byte in data {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod fnv_tests {
+    use super::fnv1a_64;
+
+    #[test]
+    fn deterministic_for_same_input() {
+        assert_eq!(fnv1a_64(b"hello world"), fnv1a_64(b"hello world"));
+    }
+
+    #[test]
+    fn differs_for_different_input() {
+        assert_ne!(fnv1a_64(b"hello world"), fnv1a_64(b"hello worlds"));
+    }
+
+    #[test]
+    fn matches_known_fnv1a_64_vector() {
+        // Standard FNV-1a 64-bit test vector for the empty string.
+        assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+    }
 }

--- a/crates/beamtalk-cli/build.rs
+++ b/crates/beamtalk-cli/build.rs
@@ -3,8 +3,11 @@
 
 //! Build script for beamtalk-cli.
 //!
-//! Injects the `BEAMTALK_VERSION` compile-time env var from VERSION + git state.
-//! The Erlang runtime is built by `just build-erlang`, not here.
+//! Injects the `BEAMTALK_VERSION` compile-time env var from VERSION + git state,
+//! and the `BEAMTALK_SPEC_MAPPING_STAMP` env var (BT-2852) — a content hash of
+//! `beamtalk_spec_reader.erl` used to invalidate the FFI type-spec cache when
+//! the compiler's Erlang→Beamtalk type-mapping logic changes. The Erlang
+//! runtime is built by `just build-erlang`, not here.
 
 use std::env;
 use std::path::Path;
@@ -17,4 +20,5 @@ fn main() {
         .expect("Cannot find workspace root");
 
     beamtalk_build::emit_beamtalk_version(workspace_root);
+    beamtalk_build::emit_spec_mapping_stamp(workspace_root);
 }

--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -1022,9 +1022,30 @@ struct TypeCacheEntry {
     /// until the next build rewrites them with a path.
     #[serde(default)]
     beam_path: String,
+    /// The producing compiler's Erlang→Beamtalk type-mapping stamp — a
+    /// content hash of `beamtalk_spec_reader.erl` baked in at compile time
+    /// via `BEAMTALK_SPEC_MAPPING_STAMP` (BT-2852). Compared against
+    /// [`current_spec_mapping_stamp`] on read; a mismatch (including the
+    /// empty default for entries written before BT-2852) is a cache miss, so
+    /// a compiler upgrade that changes how Erlang types map to Beamtalk types
+    /// invalidates stale FFI signatures instead of waiting for an unrelated
+    /// `.beam` mtime or OTP-version change that may never happen.
+    #[serde(default)]
+    mapping_stamp: String,
     /// The raw `beamtalk-specs-module:...` protocol line (without newline).
     /// Empty string if the module had no specs or an error occurred.
     specs_line: String,
+}
+
+/// The current compiler's Erlang→Beamtalk type-mapping stamp (BT-2852) — see
+/// [`TypeCacheEntry::mapping_stamp`]. Baked in at compile time by
+/// `beamtalk-cli/build.rs` via `beamtalk_build::emit_spec_mapping_stamp`, so
+/// comparing it is a cheap `&str` comparison, not a per-build filesystem hash.
+///
+/// `pub(crate)` so `commands::lint`'s tests can stamp fixture cache entries
+/// with the running compiler's value.
+pub(crate) fn current_spec_mapping_stamp() -> &'static str {
+    env!("BEAMTALK_SPEC_MAPPING_STAMP")
 }
 
 /// Manages the type-spec cache for incremental spec extraction.
@@ -1165,6 +1186,11 @@ impl TypeCache {
     }
 
     /// Reads a fresh cache entry from `base`, or `None` if missing/stale.
+    ///
+    /// Freshness requires both the `.beam` mtime to match *and* the entry's
+    /// mapping stamp to match the running compiler's (BT-2852) — an entry
+    /// written before BT-2852 carries the empty default stamp, which never
+    /// matches a real hash, so it is a miss rather than a crash.
     fn read_fresh(
         base: &Utf8Path,
         module_name: &str,
@@ -1175,7 +1201,10 @@ impl TypeCache {
         let path = Self::entry_path(base, module_name, beam_path);
         let content = std::fs::read_to_string(path.as_std_path()).ok()?;
         let entry: TypeCacheEntry = serde_json::from_str(&content).ok()?;
-        if entry.beam_mtime_secs == beam_mtime_secs && entry.beam_mtime_nanos == beam_mtime_nanos {
+        if entry.beam_mtime_secs == beam_mtime_secs
+            && entry.beam_mtime_nanos == beam_mtime_nanos
+            && entry.mapping_stamp == current_spec_mapping_stamp()
+        {
             Some(entry.specs_line)
         } else {
             None
@@ -1226,6 +1255,7 @@ impl TypeCache {
             beam_mtime_secs,
             beam_mtime_nanos,
             beam_path: canonical_beam_path,
+            mapping_stamp: current_spec_mapping_stamp().to_string(),
             specs_line: specs_line.to_string(),
         };
         let path = Self::entry_path(base, module_name, beam_path);
@@ -1560,13 +1590,24 @@ fn sanitize_module_name(name: &str) -> &str {
 }
 
 /// Returns `true` if the cache entry still describes the live `.beam` file —
-/// i.e. the file at `beam_path` exists and its mtime matches what was cached.
+/// i.e. the file at `beam_path` exists and its mtime matches what was cached
+/// — *and* the entry's type-mapping stamp matches the running compiler's
+/// (BT-2852).
+///
+/// The mapping-stamp check is evaluated first: an entry written before
+/// BT-2852 carries the empty default stamp, which never matches a real hash,
+/// so every pre-BT-2852 entry is a miss (cache rebuild), never a crash —
+/// including legacy entries with an empty `beam_path` that the check below
+/// would otherwise pessimistically accept.
 ///
 /// Legacy entries written before BT-2139 carry an empty `beam_path`; we have
-/// no way to validate them, so they are pessimistically accepted as fresh.
-/// The next `beamtalk build` rewrites them with a path, which then enables
-/// validation on subsequent lint runs.
+/// no way to validate them, so — once the mapping stamp matches — they are
+/// pessimistically accepted as fresh. The next `beamtalk build` rewrites them
+/// with a path, which then enables validation on subsequent lint runs.
 fn is_cache_entry_fresh(entry: &TypeCacheEntry) -> bool {
+    if entry.mapping_stamp != current_spec_mapping_stamp() {
+        return false;
+    }
     if entry.beam_path.is_empty() {
         return true;
     }
@@ -2891,6 +2932,43 @@ end
         assert_eq!(
             cache.lookup("lists", beam_path, 200, 0),
             Some("line2".to_string())
+        );
+    }
+
+    /// BT-2852: A cache entry written by a *different* compiler build — same
+    /// module, same `.beam` mtime, same path, but a different
+    /// `mapping_stamp` — must be treated as a miss. This is the exact warm-cache
+    /// scenario the issue describes: a `beamtalk_spec_reader.erl` mapping-logic
+    /// change (e.g. BT-2817 widening `string()` to `String | List`) must
+    /// invalidate previously-cached specs even though nothing about the
+    /// `.beam` file itself changed.
+    #[test]
+    fn type_cache_invalidates_on_mapping_stamp_change() {
+        let temp = TempDir::new().unwrap();
+        let cache_dir = Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
+        let cache = TypeCache::new(cache_dir.clone());
+        let beam_path = Utf8Path::new("/usr/lib/erlang/lib/stdlib/ebin/lists.beam");
+
+        cache.store("lists", beam_path, 100, 0, "specs_line_v1");
+        assert_eq!(
+            cache.lookup("lists", beam_path, 100, 0),
+            Some("specs_line_v1".to_string()),
+            "freshly stored entry should be a hit"
+        );
+
+        // Simulate an older-build entry: rewrite the on-disk JSON with a
+        // different `mapping_stamp`, keeping module/mtime/path identical —
+        // i.e. everything the *old* cache key compared stays the same.
+        let entry_path = TypeCache::entry_path(&cache_dir, "lists", beam_path);
+        let content = std::fs::read_to_string(entry_path.as_std_path()).unwrap();
+        let mut entry: serde_json::Value = serde_json::from_str(&content).unwrap();
+        entry["mapping_stamp"] =
+            serde_json::Value::String("an-older-compiler-builds-stamp".to_string());
+        std::fs::write(entry_path.as_std_path(), entry.to_string()).unwrap();
+
+        assert!(
+            cache.lookup("lists", beam_path, 100, 0).is_none(),
+            "a stale mapping_stamp must invalidate an otherwise-fresh (matching mtime) entry"
         );
     }
 

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -1078,7 +1078,13 @@ mod tests {
         // Real cache entry — 16-hex hash matches `TypeCache::cache_path`.
         std::fs::write(
             cache_dir.join("gen_tcp_0123456789abcdef.json").as_std_path(),
-            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}]"}"#,
+            serde_json::json!({
+                "beam_mtime_secs": 0,
+                "beam_mtime_nanos": 0,
+                "mapping_stamp": crate::beam_compiler::current_spec_mapping_stamp(),
+                "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<"connect">>,params => [#{name => <<"sockaddr">>,type => <<"Symbol">>},#{name => <<"port">>,type => <<"Integer">>}],return_type => <<"Result(Dynamic | Tuple, Symbol)">>}]"#,
+            })
+            .to_string(),
         )
         .unwrap();
         // Foreign files that must be ignored: wrong extension, missing hash,
@@ -1138,7 +1144,13 @@ mod tests {
         let stale_path = cache_dir.join("gen_tcp_aaaaaaaaaaaaaaaa.json");
         std::fs::write(
             stale_path.as_std_path(),
-            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Symbol\">>}]"}"#,
+            serde_json::json!({
+                "beam_mtime_secs": 0,
+                "beam_mtime_nanos": 0,
+                "mapping_stamp": crate::beam_compiler::current_spec_mapping_stamp(),
+                "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<"connect">>,params => [#{name => <<"sockaddr">>,type => <<"Symbol">>},#{name => <<"port">>,type => <<"Integer">>}],return_type => <<"Symbol">>}]"#,
+            })
+            .to_string(),
         )
         .unwrap();
         // Force the stale entry's mtime backwards so the latest-mtime test
@@ -1156,7 +1168,13 @@ mod tests {
             cache_dir
                 .join("gen_tcp_bbbbbbbbbbbbbbbb.json")
                 .as_std_path(),
-            r#"{"beam_mtime_secs":1,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}]"}"#,
+            serde_json::json!({
+                "beam_mtime_secs": 1,
+                "beam_mtime_nanos": 0,
+                "mapping_stamp": crate::beam_compiler::current_spec_mapping_stamp(),
+                "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<"connect">>,params => [#{name => <<"sockaddr">>,type => <<"Symbol">>},#{name => <<"port">>,type => <<"Integer">>}],return_type => <<"Result(Dynamic | Tuple, Symbol)">>}]"#,
+            })
+            .to_string(),
         )
         .unwrap();
 
@@ -1205,6 +1223,7 @@ mod tests {
             "beam_mtime_secs": stale_secs,
             "beam_mtime_nanos": 0,
             "beam_path": beam_path.to_str().unwrap(),
+            "mapping_stamp": crate::beam_compiler::current_spec_mapping_stamp(),
             "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<"connect">>,params => [#{name => <<"sockaddr">>,type => <<"Symbol">>},#{name => <<"port">>,type => <<"Integer">>}],return_type => <<"Symbol">>}]"#,
         })
         .to_string();
@@ -1240,6 +1259,7 @@ mod tests {
             "beam_mtime_secs": 1,
             "beam_mtime_nanos": 0,
             "beam_path": missing_beam.to_str().unwrap(),
+            "mapping_stamp": crate::beam_compiler::current_spec_mapping_stamp(),
             "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 1,line => 1,name => <<"close">>,params => [#{name => <<"sock">>,type => <<"Object">>}],return_type => <<"Symbol">>}]"#,
         })
         .to_string();
@@ -1261,6 +1281,11 @@ mod tests {
     /// `beam_path`. Those must continue to load — pessimistically treated as
     /// fresh — so a `lint` immediately after upgrading does not blank out
     /// every FFI signature until the user re-runs `build`.
+    ///
+    /// This entry does carry a current `mapping_stamp` (BT-2852) so the test
+    /// isolates the `beam_path` leniency behaviour; see
+    /// `load_type_cache_registry_skips_entry_when_mapping_stamp_missing` for
+    /// the case where the stamp itself is absent.
     #[test]
     fn load_type_cache_registry_loads_legacy_entry_without_beam_path() {
         use crate::beam_compiler::load_type_cache_registry;
@@ -1272,7 +1297,13 @@ mod tests {
         // No `beam_path` field at all — what BT-2134 wrote.
         std::fs::write(
             cache_dir.join("gen_tcp_0123456789abcdef.json").as_std_path(),
-            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}]"}"#,
+            serde_json::json!({
+                "beam_mtime_secs": 0,
+                "beam_mtime_nanos": 0,
+                "mapping_stamp": crate::beam_compiler::current_spec_mapping_stamp(),
+                "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<"connect">>,params => [#{name => <<"sockaddr">>,type => <<"Symbol">>},#{name => <<"port">>,type => <<"Integer">>}],return_type => <<"Result(Dynamic | Tuple, Symbol)">>}]"#,
+            })
+            .to_string(),
         )
         .unwrap();
 
@@ -1280,6 +1311,63 @@ mod tests {
         assert!(
             registry.lookup("gen_tcp", "connect", 2).is_some(),
             "legacy entry without beam_path must be tolerated as fresh"
+        );
+    }
+
+    /// BT-2852: An entry written by a `beamtalk` build *before* this feature
+    /// shipped has no `mapping_stamp` field at all (the default, empty
+    /// string). It must be treated as a graceful cache miss — not a crash —
+    /// even though its `.beam` mtime and (absent) `beam_path` would otherwise
+    /// be accepted as fresh.
+    #[test]
+    fn load_type_cache_registry_skips_entry_when_mapping_stamp_missing() {
+        use crate::beam_compiler::load_type_cache_registry;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache_dir = camino::Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
+        std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
+
+        // Pre-BT-2852 shape: no `mapping_stamp` field at all.
+        std::fs::write(
+            cache_dir.join("gen_tcp_0123456789abcdef.json").as_std_path(),
+            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<\"connect\">>,params => [#{name => <<\"sockaddr\">>,type => <<\"Symbol\">>},#{name => <<\"port\">>,type => <<\"Integer\">>}],return_type => <<\"Result(Dynamic | Tuple, Symbol)\">>}]"}"#,
+        )
+        .unwrap();
+
+        assert!(
+            load_type_cache_registry(&cache_dir).is_none(),
+            "an entry with no mapping_stamp field must be a graceful miss, not a crash"
+        );
+    }
+
+    /// BT-2852: An entry stamped by a *different* compiler build (a stale
+    /// `mapping_stamp`) must be skipped even though its `.beam` mtime still
+    /// matches — this is the regression scenario the issue describes: a warm
+    /// cache surviving a change to `beamtalk_spec_reader.erl`'s type-mapping
+    /// logic must not keep serving the old mapping forever.
+    #[test]
+    fn load_type_cache_registry_skips_entry_when_mapping_stamp_differs() {
+        use crate::beam_compiler::load_type_cache_registry;
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let cache_dir = camino::Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
+        std::fs::create_dir_all(cache_dir.as_std_path()).unwrap();
+
+        std::fs::write(
+            cache_dir.join("gen_tcp_0123456789abcdef.json").as_std_path(),
+            serde_json::json!({
+                "beam_mtime_secs": 0,
+                "beam_mtime_nanos": 0,
+                "mapping_stamp": "stale-mapping-stamp-from-an-older-compiler-build",
+                "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<"connect">>,params => [#{name => <<"sockaddr">>,type => <<"Symbol">>},#{name => <<"port">>,type => <<"Integer">>}],return_type => <<"Result(Dynamic | Tuple, Symbol)">>}]"#,
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        assert!(
+            load_type_cache_registry(&cache_dir).is_none(),
+            "an entry stamped by a different compiler build must be a cache miss"
         );
     }
 
@@ -1302,6 +1390,7 @@ mod tests {
             "beam_mtime_secs": dur.as_secs(),
             "beam_mtime_nanos": dur.subsec_nanos(),
             "beam_path": beam_path.to_str().unwrap(),
+            "mapping_stamp": crate::beam_compiler::current_spec_mapping_stamp(),
             "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 2,line => 1,name => <<"connect">>,params => [#{name => <<"sockaddr">>,type => <<"Symbol">>},#{name => <<"port">>,type => <<"Integer">>}],return_type => <<"Result(Dynamic | Tuple, Symbol)">>}]"#,
         })
         .to_string();
@@ -1337,12 +1426,24 @@ mod tests {
             cache_dir
                 .join("gen_tcp_socket_1111111111111111.json")
                 .as_std_path(),
-            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp_socket:[#{arity => 1,line => 1,name => <<\"close\">>,params => [#{name => <<\"sock\">>,type => <<\"Object\">>}],return_type => <<\"Symbol\">>}]"}"#,
+            serde_json::json!({
+                "beam_mtime_secs": 0,
+                "beam_mtime_nanos": 0,
+                "mapping_stamp": crate::beam_compiler::current_spec_mapping_stamp(),
+                "specs_line": r#"beamtalk-specs-module:gen_tcp_socket:[#{arity => 1,line => 1,name => <<"close">>,params => [#{name => <<"sock">>,type => <<"Object">>}],return_type => <<"Symbol">>}]"#,
+            })
+            .to_string(),
         )
         .unwrap();
         std::fs::write(
             cache_dir.join("gen_tcp_2222222222222222.json").as_std_path(),
-            r#"{"beam_mtime_secs":0,"beam_mtime_nanos":0,"specs_line":"beamtalk-specs-module:gen_tcp:[#{arity => 1,line => 1,name => <<\"close\">>,params => [#{name => <<\"sock\">>,type => <<\"Object\">>}],return_type => <<\"Symbol\">>}]"}"#,
+            serde_json::json!({
+                "beam_mtime_secs": 0,
+                "beam_mtime_nanos": 0,
+                "mapping_stamp": crate::beam_compiler::current_spec_mapping_stamp(),
+                "specs_line": r#"beamtalk-specs-module:gen_tcp:[#{arity => 1,line => 1,name => <<"close">>,params => [#{name => <<"sock">>,type => <<"Object">>}],return_type => <<"Symbol">>}]"#,
+            })
+            .to_string(),
         )
         .unwrap();
 

--- a/docs/ADR/0075-erlang-ffi-type-definitions.md
+++ b/docs/ADR/0075-erlang-ffi-type-definitions.md
@@ -86,7 +86,7 @@ At build time, the compiler reads the `abstract_code` chunk from compiled `.beam
    - **EEP-48 docs are read separately at runtime** (not at build time) — see "Documentation" below.
 2. The Rust compiler invokes it via the existing `beamtalk_build_worker` pattern (same mechanism used for `.core` → `.beam` compilation)
 3. The Erlang→Beamtalk type mapping (reverse of `spec_codegen.rs`) converts Erlang abstract type representations to `InferredType` values, using spec variable names as keyword names
-4. Results are cached per module and invalidated when `.beam` file timestamps change
+4. Results are cached per module and invalidated when `.beam` file timestamps change, the OTP version changes, or the compiler's own Erlang→Beamtalk type-mapping logic changes (BT-2852: each entry carries a compile-time content stamp of `beamtalk_spec_reader.erl`, so a `beamtalk` upgrade that changes `map_type/1` invalidates stale specs even when the underlying `.beam` file never changes)
 
 **Parameter names come from specs, not source parsing:**
 

--- a/docs/beamtalk-tooling.md
+++ b/docs/beamtalk-tooling.md
@@ -99,7 +99,7 @@ The summary is suppressed when `--no-warnings` is passed.
 
 `beamtalk lint` prints the same summary at end of run. In `--format json` mode, a `summary` JSON object is emitted as the last line with `totals_by_severity`, `totals_by_category`, `files_checked`, and `total` fields for CI diffing.
 
-`beamtalk lint` also loads FFI type signatures from the build cache (`_build/type_cache/`) so that lint and build agree on Erlang FFI return types. Cache entries are validated against live `.beam` file mtimes — if the underlying module has been recompiled since the cache was written, the stale entry is skipped and lint falls back to untyped-FFI inference. If the project has never been built, lint proceeds without a cache (matching its pre-cache behaviour).
+`beamtalk lint` also loads FFI type signatures from the build cache (`_build/type_cache/`) so that lint and build agree on Erlang FFI return types. Cache entries are validated against live `.beam` file mtimes and against the producing compiler's Erlang→Beamtalk type-mapping stamp (BT-2852) — if the underlying module has been recompiled since the cache was written, or the entry was written by a `beamtalk` build with different type-mapping logic, the stale entry is skipped and lint falls back to untyped-FFI inference. If the project has never been built, lint proceeds without a cache (matching its pre-cache behaviour).
 
 ### Build Artifact Layout (`BuildLayout`)
 


### PR DESCRIPTION
## Summary

Fixes https://linear.app/beamtalk/issue/BT-2852

The FFI type-spec cache (`_build/type_cache/` and the shared OTP-version-keyed tier) keyed cached specs by module name, `.beam` mtime, and OTP version only — never by the compiler's own Erlang→Beamtalk type-mapping logic (`beamtalk_spec_reader.erl`'s `map_type/1`). A warm cache from before a mapping-logic change (e.g. BT-2817, which widened `string()`/`nonempty_string()` from `List` to `String | List`) could keep serving stale specs indefinitely — especially for OTP-bundled modules whose `.beam` mtimes never change.

## Changes

- `crates/beamtalk-build/src/lib.rs`: new `emit_spec_mapping_stamp()` — hashes `beamtalk_spec_reader.erl` (FNV-1a 64-bit, no external crate) at compile time and exposes the result as `BEAMTALK_SPEC_MAPPING_STAMP`. Deriving the stamp from a content hash means there's nothing to remember to manually bump.
- `crates/beamtalk-cli/build.rs`: calls the new function.
- `crates/beamtalk-cli/src/beam_compiler.rs`: `TypeCacheEntry` gains a `mapping_stamp` field; `TypeCache::read_fresh` (build path) and `is_cache_entry_fresh` (lint/LSP-mirror path) now require it to match the running compiler's stamp. Entries written before this change carry the empty default, which never matches a real hash, so they're a graceful cache miss + rebuild, not a crash.
- `crates/beamtalk-cli/src/commands/lint.rs`: updated existing raw-JSON fixture tests to carry the current stamp, plus two new tests covering the "field missing" and "field differs" legacy-cache scenarios.
- Docs: brief mentions in ADR 0075 and `docs/beamtalk-tooling.md`.

## Test plan

- [x] `just build` / `just clippy` / `just fmt` — clean
- [x] `just test` — 0 failures (Rust, stdlib, BUnit, Erlang runtime)
- [x] New regression test `type_cache_invalidates_on_mapping_stamp_change` — proves a stamp-only mismatch invalidates an otherwise-fresh (same module/mtime/OTP) entry
- [x] New tests `load_type_cache_registry_skips_entry_when_mapping_stamp_missing` / `_differs` — pre-feature and cross-build cache entries are gracefully skipped, not crashed on
- [x] Warm-cache perf sanity-checked (`beamtalk build-stdlib` warm run: ~0.06s total, negligible stamp-comparison overhead)
- [x] Full pre-push CI (build, clippy, fmt, dialyzer, spec validation, lint) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)