### PR TITLE
refactor: deduplicate erlang_function_name/erlang_arity in beamtalk-core

### DIFF
--- a/crates/beamtalk-core/src/queries/ffi_sites_query.rs
+++ b/crates/beamtalk-core/src/queries/ffi_sites_query.rs
@@ -57,6 +57,7 @@
 
 use super::selector_span;
 use crate::ast::{Expression, MessageSelector, Pattern, StringSegment};
+use crate::semantic_analysis::validators::{erlang_arity, erlang_function_name};
 use crate::source_analysis::{Span, lex_with_eof, parse};
 
 /// Number of newlines in the synthetic class header that wraps the input.
@@ -175,34 +176,6 @@ fn extract_erlang_module(expr: &Expression) -> Option<&str> {
         }
     }
     None
-}
-
-/// Derive the Erlang function name from a Beamtalk selector.
-///
-/// Keyword selectors like `seq:to:` use the first keyword part (`seq`). Unary
-/// selectors use the name directly. Binary selectors do not map to Erlang
-/// function calls (they are Beamtalk operators), so they yield `None`. Mirrors
-/// `structural_validators::erlang_function_name` and the codegen lowering.
-fn erlang_function_name(selector: &MessageSelector) -> Option<String> {
-    match selector {
-        MessageSelector::Unary(name) => Some(name.to_string()),
-        MessageSelector::Keyword(parts) => parts
-            .first()
-            .map(|kp| kp.keyword.trim_end_matches(':').to_string()),
-        MessageSelector::Binary(_) => None,
-    }
-}
-
-/// Compute the Erlang arity for a message send.
-///
-/// Unary FFI sends lower to zero-argument Erlang calls; keyword/binary sends use
-/// the Beamtalk argument count (`seq: 1 to: 10` → arity 2). Mirrors
-/// `structural_validators::erlang_arity`.
-fn erlang_arity(selector: &MessageSelector, argument_count: usize) -> usize {
-    match selector {
-        MessageSelector::Unary(_) => 0,
-        _ => argument_count,
-    }
 }
 
 /// Determine the line number to report for a matching FFI call site. Uses the

--- a/crates/beamtalk-core/src/semantic_analysis/validators/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/mod.rs
@@ -52,7 +52,7 @@ pub(crate) use sendability_validators::{
 };
 pub(crate) use structural_validators::{
     check_ffi_arity, check_unresolved_classes, check_unresolved_ffi_modules,
-    check_workspace_shadows,
+    check_workspace_shadows, erlang_arity, erlang_function_name,
 };
 pub(crate) use supervision_validators::{
     check_children_supervision_policy, check_supervision_policy_override,

--- a/crates/beamtalk-core/src/semantic_analysis/validators/structural_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/structural_validators.rs
@@ -461,7 +461,7 @@ fn extract_erlang_module(expr: &Expression) -> Option<&str> {
 /// Keyword selectors like `seq:to:` become the first keyword part (`seq`).
 /// Unary selectors use the name directly. Binary selectors don't map to
 /// Erlang functions (they're Beamtalk operators).
-fn erlang_function_name(selector: &MessageSelector) -> Option<String> {
+pub(crate) fn erlang_function_name(selector: &MessageSelector) -> Option<String> {
     match selector {
         MessageSelector::Unary(name) => Some(name.to_string()),
         MessageSelector::Keyword(parts) => parts
@@ -476,7 +476,7 @@ fn erlang_function_name(selector: &MessageSelector) -> Option<String> {
 /// For direct Erlang FFI calls, the arity is the number of Beamtalk arguments
 /// for keyword messages (e.g. `seq: 1 to: 10` has arity 2), and 0 for unary
 /// messages (they lower to zero-argument Erlang function calls).
-fn erlang_arity(selector: &MessageSelector, argument_count: usize) -> usize {
+pub(crate) fn erlang_arity(selector: &MessageSelector, argument_count: usize) -> usize {
     match selector {
         MessageSelector::Unary(_) => 0,
         _ => argument_count,


### PR DESCRIPTION
## Summary

`erlang_function_name` and `erlang_arity` were defined verbatim twice inside `beamtalk-core`. The copy in `ffi_sites_query.rs` even had a doc comment explicitly noting the duplication ("Mirrors `structural_validators::erlang_function_name`"). Any future change to the selector→Erlang name/arity mapping (e.g. how binary selectors are handled) would have needed to be applied in both places to stay correct.

**Fix:** make both functions `pub(crate)` at their canonical home in `structural_validators.rs`, re-export them through `validators/mod.rs`, and import them in `ffi_sites_query.rs` instead of redeclaring.

## Changes

- `structural_validators.rs`: `fn erlang_function_name` / `fn erlang_arity` → `pub(crate) fn`
- `validators/mod.rs`: add both to the `pub(crate) use structural_validators::{ … }` re-export block
- `ffi_sites_query.rs`: remove the ~27-line duplicate definitions; add a one-line import

**Net diff:** 4 insertions, 31 deletions — pure removal of duplication, zero behaviour change.

## Verification

- All 4794 `beamtalk-core` tests pass
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- Pre-push hook (clippy + fmt + dialyzer + spec validation) passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfJvoVXzVbENaUKiMGQ9Kh)_