### PR TITLE
Fix Windows CI: beamtalk_git_tests temp-dir and shell-quoting portability

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_git_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_git_tests.erl
@@ -706,13 +706,11 @@ with_repo_root_project(Fun) ->
 
 %% Create a unique empty temp dir (not a git repo).
 make_temp_dir() ->
-    Base = filename:basedir(user_cache, "beamtalk_git_test"),
-    ok = filelib:ensure_dir(filename:join(Base, "x")),
     Unique = lists:flatten(
         io_lib:format("repo_~p_~p", [erlang:unique_integer([positive]), os:getpid()])
     ),
-    Dir = filename:join(Base, Unique),
-    ok = file:make_dir(Dir),
+    Dir = filename:join(binary_to_list(beamtalk_file:'tempDirectory'()), Unique),
+    ok = filelib:ensure_dir(filename:join(Dir, "x")),
     Dir.
 
 %% Create a unique temp dir and `git init` it with a deterministic identity.
@@ -736,8 +734,15 @@ git_in(Dir, Args) ->
     _ = os:cmd(Cmd),
     ok.
 
+%% os:cmd/1 never runs a POSIX shell on Windows (it shells out via `cmd /c`,
+%% which does not strip single quotes), so quoting must be platform-aware.
 shell_quote(S) ->
-    "'" ++ lists:flatten(string:replace(S, "'", "'\\''", all)) ++ "'".
+    case os:type() of
+        {win32, _} ->
+            "\"" ++ S ++ "\"";
+        _ ->
+            "'" ++ lists:flatten(string:replace(S, "'", "'\\''", all)) ++ "'"
+    end.
 
 rm_rf(Dir) ->
     _ = os:cmd("rm -rf " ++ shell_quote(Dir)),

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_git_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_git_tests.erl
@@ -646,7 +646,11 @@ canonical(Path) ->
             %% No macOS-style /tmp -> /private/tmp symlink indirection to
             %% resolve on Windows, and `pwd` isn't on PATH under `cmd /c`
             %% (Git for Windows' usr/bin is reachable only via Git Bash).
-            Path;
+            %% nativename/1 still normalizes drive-letter case and mixed
+            %% separators, since `Path` (git's raw, un-normalized stdout
+            %% for `Resolved`) never goes through filename:join the way
+            %% `Top` does in make_temp_dir/0.
+            filename:nativename(Path);
         _ ->
             string:trim(os:cmd("cd " ++ shell_quote(Path) ++ " && pwd -P"))
     end.
@@ -758,7 +762,7 @@ shell_quote(S) ->
 rm_rf(Dir) ->
     _ =
         case os:type() of
-            {win32, _} -> os:cmd("rmdir /s /q " ++ shell_quote(Dir));
+            {win32, _} -> os:cmd("rmdir /s /q " ++ shell_quote(Dir) ++ " 2>nul");
             _ -> os:cmd("rm -rf " ++ shell_quote(Dir))
         end,
     ok.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_git_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_git_tests.erl
@@ -641,7 +641,15 @@ git_revert_file_discards_change_test() ->
 canonical(Path) when is_binary(Path) ->
     list_to_binary(canonical(binary_to_list(Path)));
 canonical(Path) ->
-    string:trim(os:cmd("cd " ++ shell_quote(Path) ++ " && pwd -P")).
+    case os:type() of
+        {win32, _} ->
+            %% No macOS-style /tmp -> /private/tmp symlink indirection to
+            %% resolve on Windows, and `pwd` isn't on PATH under `cmd /c`
+            %% (Git for Windows' usr/bin is reachable only via Git Bash).
+            Path;
+        _ ->
+            string:trim(os:cmd("cd " ++ shell_quote(Path) ++ " && pwd -P"))
+    end.
 
 %% Create a throwaway git repo with a committed file inside a *subdirectory*
 %% project, modify that file, run Fun(Toplevel, ProjectDir, RepoRelFile), then
@@ -739,13 +747,20 @@ git_in(Dir, Args) ->
 shell_quote(S) ->
     case os:type() of
         {win32, _} ->
-            "\"" ++ S ++ "\"";
+            "\"" ++ lists:flatten(string:replace(S, "\"", "\\\"", all)) ++ "\"";
         _ ->
             "'" ++ lists:flatten(string:replace(S, "'", "'\\''", all)) ++ "'"
     end.
 
+%% `rm`/`pwd`/etc. from Git for Windows' usr/bin are not on PATH under
+%% `cmd /c` on Windows runners (only reachable via Git Bash), so `rm -rf`
+%% silently no-ops there; use the cmd.exe builtin instead.
 rm_rf(Dir) ->
-    _ = os:cmd("rm -rf " ++ shell_quote(Dir)),
+    _ =
+        case os:type() of
+            {win32, _} -> os:cmd("rmdir /s /q " ++ shell_quote(Dir));
+            _ -> os:cmd("rm -rf " ++ shell_quote(Dir))
+        end,
     ok.
 
 %% Join records with a trailing NUL after each, matching `-z` output.


### PR DESCRIPTION
## Summary

- Follow-up to #2968: after that fix landed, a fresh nightly run (https://github.com/jamesc/beamtalk/actions/runs/29259880059) confirmed `Test BUnit` now passes on Windows, but the pipeline advanced far enough to expose a second, previously-hidden Windows-only failure: all 13 `beamtalk_git_tests` that spawn a real git repo failed in `Test Erlang runtime` with `{badmatch,{error,enoent}}`.
- Root cause: `make_temp_dir/0` computed its scratch directory via `filename:basedir(user_cache, "beamtalk_git_test")` + `file:make_dir/1`, unlike every other test file in `beamtalk_workspace/test/*.erl`, which uses the established `beamtalk_file:'tempDirectory'()` + `ensure_dir` convention (see `docs/development/testing-strategy.md` / CLAUDE.md's cross-platform-temp-path rule). Switched to that pattern, mirroring `beamtalk_repl_ops_browse_tests:make_project_dir/1`.
- While tracing this, also found `shell_quote/1` (used by the test helper `git_in/2` to run real `git` commands via `os:cmd/1`) uses POSIX-style single-quote escaping. `os:cmd/1` never runs a POSIX shell on Windows — it shells out via `cmd /c`, which does not strip single quotes — so this would have broken every `git` invocation in this test file as soon as `make_temp_dir` stopped crashing. Added a Windows branch using double-quote wrapping.

## Test plan

- [x] `rebar3 eunit --module=beamtalk_git_tests` — 54/54 tests pass (Linux)
- [x] `just test-runtime` — full suite (5311 + 1584 tests), 0 failures
- [x] `rebar3 fmt --check` (erlfmt) clean
- [ ] Windows nightly CI passes for `Test Erlang runtime` (can't reproduce the Windows-specific `cmd.exe` quoting behavior locally on Linux; relying on CI to confirm)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XZsosZdh94Ww1r8AWMoCGM)_