### PR TITLE
Fix Windows CI: quote characters embedded in git test temp dir names

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_git_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_git_tests.erl
@@ -718,8 +718,11 @@ with_repo_root_project(Fun) ->
 
 %% Create a unique empty temp dir (not a git repo).
 make_temp_dir() ->
+    %% os:getpid/0 returns a string; ~p renders strings as quoted literals
+    %% (embedding literal `"` characters), which is a legal POSIX filename
+    %% byte but a forbidden Windows filename character -- use ~s instead.
     Unique = lists:flatten(
-        io_lib:format("repo_~p_~p", [erlang:unique_integer([positive]), os:getpid()])
+        io_lib:format("repo_~p_~s", [erlang:unique_integer([positive]), os:getpid()])
     ),
     Dir = filename:join(binary_to_list(beamtalk_file:'tempDirectory'()), Unique),
     ok = filelib:ensure_dir(filename:join(Dir, "x")),


### PR DESCRIPTION
## Summary

- Follow-up to #2971. A fresh nightly run (https://github.com/jamesc/beamtalk/actions/runs/29266785587) after merging #2971 confirmed `Test BUnit` passes, but the same 13 `beamtalk_git_tests` still failed in `Test Erlang runtime` — now failing at the `filelib:ensure_dir` call instead of `file:make_dir`, meaning the basedir → `tempDirectory()` switch alone didn't fix the real problem.
- Root cause, finally isolated: `os:getpid/0` returns a string, and `io_lib:format`'s `~p` directive renders printable-character lists (i.e. strings) as **quoted literals** — so `io_lib:format("repo_~p_~p", [N, os:getpid()])` produces something like `repo_42_"4414"`, with literal `"` characters embedded in the directory name. Verified directly:
  ```
  1> io_lib:format("repo_~p_~p", [42, os:getpid()]).
  "repo_42_\"4414\""
  ```
  `"` is a legal POSIX filename byte, which is exactly why this was invisible in local testing and on macOS/Linux CI — but it's one of Windows' reserved/forbidden filename characters, so `mkdir`/`ensure_dir` has been failing on Windows the entire time this test file has existed, regardless of which base-directory scheme was used.
- Fix: use `~s` instead of `~p` for the PID in the format string, since it's already a string and doesn't need term-quoting.

## Test plan

- [x] `rebar3 eunit --module=beamtalk_git_tests` — 54/54 tests pass (Linux)
- [x] `just test-runtime` — full suite (5311 + 1584 tests), 0 failures
- [x] `rebar3 fmt --check` (erlfmt) clean
- [x] Directly verified the `~p` vs `~s` quoting behavior in an `erl` shell (see above)
- [ ] Windows nightly CI passes for `Test Erlang runtime` (can't reproduce Windows filename restrictions locally on Linux; relying on CI to confirm — this should be the one that finally closes out the investigation)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XZsosZdh94Ww1r8AWMoCGM)_