### PR TITLE
Fix lint-workaround-comments ratchet lint on main for 3 unreferenced comments (BT-2876)

### DIFF
--- a/crates/beamtalk-cli/src/dependency_classes.rs
+++ b/crates/beamtalk-cli/src/dependency_classes.rs
@@ -28,12 +28,12 @@
 //! dependency, because [`beamtalk_core::project::package`] only walks the
 //! package's own `src/`/`test/` directories.
 //!
-//! **Known limitation:** only *direct* dependencies (the project's own
-//! `[dependencies]` table) are resolved — unlike `ensure_deps_resolved`,
-//! this does not walk transitive dependency graphs. A class defined only in
-//! a dependency-of-a-dependency (and referenced directly, which is unusual)
-//! is not covered. See BT-2823's follow-up for extending this if it proves
-//! necessary in practice.
+//! **Known limitation (BT-2878):** only *direct* dependencies (the
+//! project's own `[dependencies]` table) are resolved — unlike
+//! `ensure_deps_resolved`, this does not walk transitive dependency graphs.
+//! A class defined only in a dependency-of-a-dependency (and referenced
+//! directly, which is unusual) is not covered. Tracked as a follow-up, to
+//! be picked up if it proves necessary in practice.
 //!
 //! **Caching (BT-2837):** the MCP server's `lint`/`diagnostic_summary` tools
 //! call [`resolve_dependency_class_infos`] on *every* request. Without

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2826_block_param_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2826_block_param_types.rs
@@ -10,7 +10,7 @@
 //! rebind to recover a concrete param type. With `Block(String, String)` on
 //! `String>>collect:` and `Block(Object, Object)` on `Actor>>onExit:`, the
 //! block parameter should now resolve to a concrete (non-Dynamic) type with
-//! no `@expect` workaround needed.
+//! no `@expect` workaround needed (BT-2826).
 
 use super::common::*;
 
@@ -64,7 +64,7 @@ typed Object subclass: Repro
 /// `worker onExit: [:reason | ...]` — the block param `reason` should be
 /// inferred as `Object` (the best available bound for an OTP exit reason),
 /// so no "unannotated parameter" Dynamic warning fires and no `@expect type`
-/// workaround is needed.
+/// workaround is needed (BT-2826).
 #[test]
 fn bt2826_actor_on_exit_infers_object_block_param() {
     let source = r"

--- a/scripts/ci/workaround-comments-allowlist.txt
+++ b/scripts/ci/workaround-comments-allowlist.txt
@@ -6,6 +6,7 @@ crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs	1793420816
 crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs	2346773361
 crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs	2986145653
 crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_iterable.rs	1945273604
+crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs	3460558164
 crates/beamtalk-core/src/source_analysis/parser/tests/class_tests.rs	3846721765
 crates/beamtalk-core/src/source_analysis/parser/tests/expression_tests.rs	1027809464
 fuzz/corpus/parse_arbitrary/011_class_reflection.bt	2213515280


### PR DESCRIPTION
## Summary

Fixes `scripts/ci/lint-workaround-comments.sh` (the workaround/limitation-comment ratchet lint from BT-2347) failing on `main` for 3 pre-existing offenders that were never added to the allowlist snapshot, silently breaking the local `just ci` gate for anyone who runs it.

- `crates/beamtalk-cli/src/dependency_classes.rs:31` — the "only direct dependencies" doc note was a genuine unfiled follow-up (it even said "See BT-2823's follow-up" without one existing). Filed BT-2878 to track it and referenced it directly on the flagged line.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2826_block_param_types.rs:13,67` — referenced BT-2826 (the issue this test file is named after) on both flagged doc-comment lines.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs:1248` ("does not thread") — true false positive: describes an already-handled special case (`receiver_type_for_class`), not an unfiled defect. Snapshotted via `lint-workaround-comments.sh --update`; the allowlist diff adds exactly this one entry.

## Test plan

- [x] `bash scripts/ci/lint-workaround-comments.sh` exits 0
- [x] `cargo clippy` / `cargo fmt --check` clean on touched files
- [x] `just check-corpus` passes (corpus.json unaffected)
- [x] `just test` — Rust/stdlib/BUnit/runtime tests all green
- [x] Full pre-push CI hook (`just ci`, dialyzer, spec validation, all fmt/lint checks) passed on push

Linear: https://linear.app/beamtalk/issue/BT-2876

🤖 Generated with [Claude Code](https://claude.com/claude-code)