### PR TITLE
Use beamtalk_logging_config:set_domain/1 in beamtalk_workspace gen_servers

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_idle_monitor.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_idle_monitor.erl
@@ -79,7 +79,7 @@ mark_activity() ->
 %%% gen_server callbacks
 
 init(Config) ->
-    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    beamtalk_logging_config:set_domain(runtime),
     Enabled = maps:get(enabled, Config, true),
     MaxIdleSeconds = maps:get(max_idle_seconds, Config, 3600 * 4),
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_actors.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_actors.erl
@@ -197,7 +197,7 @@ get_pids_for_module(RegistryPid, ModuleName) ->
 %%% gen_server callbacks
 
 init([]) ->
-    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    beamtalk_logging_config:set_domain(runtime),
     {ok, #state{actors = #{}, monitors = #{}}}.
 
 handle_call({register, ActorPid, ClassName, ModuleName}, _From, State) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_server.erl
@@ -117,7 +117,7 @@ get_nonce() ->
 %%% gen_server callbacks
 
 init(Config) ->
-    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    beamtalk_logging_config:set_domain(runtime),
     Port = maps:get(port, Config),
     WorkspaceId = maps:get(workspace_id, Config, undefined),
     BindAddr = maps:get(bind_addr, Config, {127, 0, 0, 1}),

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_shell.erl
@@ -264,7 +264,7 @@ init(SessionId) when is_binary(SessionId) ->
     %% — default to empty origin metadata (→ `kind => unknown`).
     init({SessionId, #{}});
 init({SessionId, Meta}) when is_map(Meta) ->
-    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    beamtalk_logging_config:set_domain(runtime),
     %% Create session-specific REPL state
     %% We use undefined for listen_socket and port since session doesn't own TCP connection
     %%

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_bootstrap.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_bootstrap.erl
@@ -53,7 +53,7 @@ start_link(ProjectPath) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [ProjectPath], []).
 
 init([ProjectPath]) ->
-    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    beamtalk_logging_config:set_domain(runtime),
     %% Create the user-bindings ETS table here so that this long-lived process
     %% owns it. If created inside a short-lived eval worker instead, the table
     %% would be deleted when that worker exits (ETS tables are deleted on owner

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_findings_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_findings_store.erl
@@ -241,7 +241,7 @@ clear() ->
 %%====================================================================
 
 init([]) ->
-    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    beamtalk_logging_config:set_domain(runtime),
     {ok, #state{}}.
 
 handle_call(

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
@@ -405,7 +405,7 @@ set_git_toplevel(ProjectPath, Toplevel) when is_binary(ProjectPath), is_binary(T
 %%% gen_server callbacks
 
 init(InitialMetadata) ->
-    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    beamtalk_logging_config:set_domain(runtime),
     WorkspaceId = maps:get(workspace_id, InitialMetadata),
     ProjectPath = maps:get(project_path, InitialMetadata, undefined),
     %% BT-775: Auto-detect package name from beamtalk.toml at project_path

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_shape_recheck_worker.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_shape_recheck_worker.erl
@@ -119,7 +119,7 @@ enqueue_leaf_change(NewlyNonLeafSuperclasses) ->
 %%====================================================================
 
 init([]) ->
-    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    beamtalk_logging_config:set_domain(runtime),
     {ok, undefined}.
 
 handle_cast({leaf_change, Superclasses}, State) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_shape_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_shape_store.erl
@@ -164,7 +164,7 @@ clear() ->
 %%====================================================================
 
 init([]) ->
-    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    beamtalk_logging_config:set_domain(runtime),
     {ok, #state{}}.
 
 handle_call({prime, ClassNameBin}, _From, State = #state{shapes = Shapes}) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_signature_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_signature_store.erl
@@ -147,7 +147,7 @@ clear() ->
 %%====================================================================
 
 init([]) ->
-    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    beamtalk_logging_config:set_domain(runtime),
     {ok, #state{}}.
 
 handle_call({capture, ClassName, Selector, Side, NewSignature}, _From, State = #state{sigs = Sigs}) ->


### PR DESCRIPTION
## Summary

`beamtalk_logging_config:set_domain/1` exists in `beamtalk_runtime` specifically to avoid repeating the raw `logger:set_process_metadata(#{domain => [beamtalk, SubDomain]})` map literal in every gen_server `init/1`. Its module doc states: *"Call once from a gen_server `init/1` so every subsequent log call from that process inherits the domain without repeating the map literal."*

Seven `beamtalk_workspace` modules already used the helper correctly (`beamtalk_workspace_changelog`, `beamtalk_xref`, `beamtalk_trace_store`, `beamtalk_announcements`, `beamtalk_actor`, `beamtalk_reactive_subprocess`, `beamtalk_transcript_stream`). This PR brings the remaining ten into line.

## Changes

Each of the 10 files below has a one-line mechanical substitution in `init/1`:

```erlang
% Before:
logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
% After:
beamtalk_logging_config:set_domain(runtime),
```

Files changed (all in `runtime/apps/beamtalk_workspace/src/`):

1. `beamtalk_workspace_bootstrap.erl`
2. `beamtalk_workspace_shape_recheck_worker.erl`
3. `beamtalk_workspace_findings_store.erl`
4. `beamtalk_workspace_signature_store.erl`
5. `beamtalk_repl_shell.erl`
6. `beamtalk_workspace_meta.erl`
7. `beamtalk_idle_monitor.erl`
8. `beamtalk_repl_server.erl`
9. `beamtalk_repl_actors.erl`
10. `beamtalk_workspace_shape_store.erl`

## No new dependencies

`beamtalk_workspace` already lists `beamtalk_runtime` in its `{applications, [...]}` tuple (`beamtalk_workspace.app.src:6`), so this change requires no new OTP application dependency.

## Testing

- `just build` ✅
- `just test` ✅ (6,090+ Rust, 223 stdlib, 2,747 BUnit, 6,904 runtime tests — all green)
- Dialyzer ✅ (run by pre-push hook)
- erlfmt ✅ (run by pre-push hook)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jpm2Wieysi7TkDByKQ7Q1x)_