### PR TITLE
Replace placeholder :load assertions in workspace_native_api.btscript

### DIFF
--- a/tests/repl-protocol/cases/workspace_native_api.btscript
+++ b/tests/repl-protocol/cases/workspace_native_api.btscript
@@ -107,7 +107,7 @@ methodHelpText isNil
 
 // Load a fixture class
 :load tests/repl-protocol/fixtures/counter.bt
-// => _
+// => Loaded: Counter
 
 // Workspace classes includes the loaded Counter class
 wsClasses := Workspace classes
@@ -181,10 +181,10 @@ wsGlobals includesKey: #Counter
 // These give us controlled, test-owned classes/selectors so assertions do
 // not depend on live stdlib content that may churn across unrelated edits.
 :load tests/repl-protocol/fixtures/sysnavigation_fixture.bt
-// => _
+// => Loaded: SysnavFixture
 
 :load tests/repl-protocol/fixtures/sysnavigation_fixture_b.bt
-// => _
+// => Loaded: SysnavFixtureB
 
 // implementorsOf: returns a non-empty list for a selector with known implementors.
 // SysnavFixture and SysnavFixtureB both define #asString locally (see fixture),
@@ -500,13 +500,13 @@ Erlang ets delete: #beamtalk_extensions key: #(#String, #btTwoTwoOneSixBareRefEx
 // Load the announcement event fixtures first (the emitter references them),
 // then the emitter whose method bodies emit them.
 :load tests/repl-protocol/fixtures/announce_event_a.bt
-// => _
+// => Loaded: AnnounceEventA
 
 :load tests/repl-protocol/fixtures/announce_event_b.bt
-// => _
+// => Loaded: AnnounceEventB
 
 :load tests/repl-protocol/fixtures/announce_emitter.bt
-// => _
+// => Loaded: AnnounceEmitter
 
 // announcementsSentBy: returns the distinct Announcement subclasses the emitter
 // publishes (AnnounceEventA via announce:, AnnounceEventB via announceAndWait:),
@@ -616,10 +616,10 @@ Erlang ets delete: #beamtalk_extension_sources key: #(#AnnounceEmitter, #emitExt
 // Load the stable field fixtures (parent + subclass). These give
 // test-owned slots so assertions do not depend on live stdlib content.
 :load tests/repl-protocol/fixtures/field_fixture.bt
-// => _
+// => Loaded: FieldFixture
 
 :load tests/repl-protocol/fixtures/field_fixture_child.bt
-// => _
+// => Loaded: FieldChild
 
 // --- readers ---
 
@@ -943,13 +943,13 @@ SystemNavigation default selectorsMatching: "ZzZxYwQpPpNoSuchSelectorXyzzy"
 
 // Load fixtures: a deliberate typo, a DNU dispatcher, and a perform: caller.
 :load tests/repl-protocol/fixtures/typo_sender.bt
-// => _
+// => Loaded: TypoSender
 
 :load tests/repl-protocol/fixtures/dnu_dispatcher.bt
-// => _
+// => Loaded: DnuDispatcher
 
 :load tests/repl-protocol/fixtures/perform_sender.bt
-// => _
+// => Loaded: PerformSender
 
 // unimplementedSelectors returns a List of records (selector + sites).
 unimpl := SystemNavigation default unimplementedSelectors
@@ -1027,16 +1027,16 @@ unimplSelectors includes: #perform:
 // Load fixtures: a class with a used + an unused method, a runtime-called `hash`
 // override, a TestCase subclass, and a perform:-only caller.
 :load tests/repl-protocol/fixtures/unused_demo.bt
-// => _
+// => Loaded: UnusedDemo
 
 :load tests/repl-protocol/fixtures/unused_runtime_called.bt
-// => _
+// => Loaded: UnusedRuntimeCalled
 
 :load tests/repl-protocol/fixtures/unused_testcase.bt
-// => _
+// => Loaded: UnusedTestCaseFixture
 
 :load tests/repl-protocol/fixtures/unused_perform.bt
-// => _
+// => Loaded: UnusedPerform
 
 // unusedSelectors returns a List of #{#class, #selector} records.
 unused := SystemNavigation default unusedSelectors
@@ -1139,7 +1139,7 @@ unusedSelectors includes: #caller
 // Erlang functions through the `Erlang` bridge, so assertions do not depend on
 // live stdlib bodies.
 :load tests/repl-protocol/fixtures/ffi_fixture.bt
-// => _
+// => Loaded: FfiFixture
 
 // --- happy path: a real FFI call shows up with {#class, #selector, #line} ---
 


### PR DESCRIPTION
## Summary

All 16 `:load` lines in `tests/repl-protocol/cases/workspace_native_api.btscript` used `// => _` wildcards. Every other test file that exercises `:load` asserts `// => Loaded: ClassName` literally — `hot_reload.btscript`, `repl_commands.btscript`, `source_file_reload.btscript`, `class_collision_warning.btscript`, and others. The placeholder means a load failure (wrong class name, compile error, or nil response) would pass those assertions silently.

- Replace each of the 16 `// => _` load assertions with the concrete `// => Loaded: ClassName` value derived from the fixture file's class definition
- 16 lines changed, single file, no logic change, no fixtures modified
- `just test-repl-protocol` passes (3/3 tests, 163s)

## Fixtures updated

| Fixture | Class |
|---------|-------|
| `counter.bt` | `Counter` |
| `sysnavigation_fixture.bt` | `SysnavFixture` |
| `sysnavigation_fixture_b.bt` | `SysnavFixtureB` |
| `announce_event_a.bt` | `AnnounceEventA` |
| `announce_event_b.bt` | `AnnounceEventB` |
| `announce_emitter.bt` | `AnnounceEmitter` |
| `field_fixture.bt` | `FieldFixture` |
| `field_fixture_child.bt` | `FieldChild` |
| `typo_sender.bt` | `TypoSender` |
| `dnu_dispatcher.bt` | `DnuDispatcher` |
| `perform_sender.bt` | `PerformSender` |
| `unused_demo.bt` | `UnusedDemo` |
| `unused_runtime_called.bt` | `UnusedRuntimeCalled` |
| `unused_testcase.bt` | `UnusedTestCaseFixture` |
| `unused_perform.bt` | `UnusedPerform` |
| `ffi_fixture.bt` | `FfiFixture` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cc5BfL4UQ9uZ2C6nX7CoqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cc5BfL4UQ9uZ2C6nX7CoqC)_