### PR TITLE
chore: add just ci-changed for path-scoped local CI, add test-parity CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,59 @@ jobs:
             cat "$f"
           done
 
+  test-parity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Install Erlang/OTP
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Cache Erlang/rebar3 artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: |
+            ~/.cache/rebar3
+            runtime/_build
+            ~/.rebar3
+          key: ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config', 'runtime/apps/beamtalk_runtime/src/**', 'runtime/apps/beamtalk_runtime/include/**') }}-beam-${{ hashFiles('.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-erlang-${{ hashFiles('runtime/rebar.config') }}-beam-${{ hashFiles('.tool-versions') }}
+            ${{ runner.os }}-erlang-beam-${{ hashFiles('.tool-versions') }}-
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build
+        run: just build
+
+      - name: Test parity (REPL / MCP / CLI / LSP)
+        run: just test-parity
+
+      - name: Dump workspace startup logs
+        if: failure()
+        run: |
+          epmd -names || true
+          for f in $(ls -t "$HOME"/.beamtalk/workspaces/*/startup.log "$HOME"/.beamtalk/workspaces/*/workspace.log 2>/dev/null | head -10); do
+            echo "=== $f ==="
+            cat "$f"
+          done
+
   coverage:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -35,6 +35,75 @@ ci: build lint test test-integration test-mcp test-parity test-repl-protocol che
 [windows]
 ci: build clippy fmt-check-rust test test-integration test-mcp test-parity test-repl-protocol check-surface-drift
 
+# Run local CI checks, skipping the slow workspace/MCP/REPL-protocol/parity
+# suites when the diff (vs origin/main, plus uncommitted changes) doesn't touch
+# paths that could affect them. GitHub Actions runs test-integration and
+# test-parity as their own jobs in parallel with everything else regardless —
+# skipping them here trades a same-machine safety net for faster local
+# iteration, not a coverage gap. Force `just ci` instead when in doubt.
+[unix]
+ci-changed:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just build
+    just lint
+    just test
+    just check-corpus
+    just check-surface-drift
+
+    merge_base="$(git merge-base HEAD origin/main 2>/dev/null || true)"
+    if [[ -n "$merge_base" ]]; then
+      changed_files="$(git diff --name-only "$merge_base"...HEAD; git status --porcelain | awk '{print $2}')"
+    else
+      changed_files="$(git status --porcelain | awk '{print $2}')"
+    fi
+
+    matches_any() {
+      local file
+      while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        for pattern in "$@"; do
+          # shellcheck disable=SC2053
+          [[ "$file" == $pattern ]] && return 0
+        done
+      done <<< "$changed_files"
+      return 1
+    }
+
+    # Scoped to the actual workspace/REPL server surface, not all of runtime/
+    # or stdlib/ — those are already covered by `just test` (test-runtime,
+    # test-stdlib, test-bunit) above, which run regardless.
+    WORKSPACE_PATTERNS=(
+      'runtime/apps/beamtalk_workspace/*'
+      'crates/beamtalk-cli/src/commands/workspace/*'
+      'crates/beamtalk-cli/src/repl_startup.rs'
+      'crates/beamtalk-cli/tests/repl_protocol.rs'
+      'crates/beamtalk-mcp/*' 'tests/repl-protocol/*'
+    )
+    PARITY_PATTERNS=(
+      'crates/beamtalk-parity-tests/*' 'crates/beamtalk-lsp/*'
+      'crates/beamtalk-mcp/*' 'runtime/apps/beamtalk_workspace/*'
+      'crates/beamtalk-cli/src/commands/workspace/*'
+    )
+
+    if matches_any "${WORKSPACE_PATTERNS[@]}"; then
+      just test-integration
+      just test-mcp
+      just test-repl-protocol
+    else
+      echo "⏭️  workspace/MCP/REPL-protocol paths untouched — skipping test-integration/test-mcp/test-repl-protocol (CI's test-integration job still runs them)"
+    fi
+
+    if matches_any "${PARITY_PATTERNS[@]}"; then
+      just test-parity
+    else
+      echo "⏭️  REPL/MCP/CLI/LSP paths untouched — skipping test-parity (CI's test-parity job still runs it)"
+    fi
+
+# Windows: path-based skip logic below is unix-only for now — run the full suite.
+[windows]
+ci-changed: ci
+
 # Clean all build artifacts (Rust, Erlang, VS Code, caches, examples)
 [unix]
 clean: clean-rust clean-erlang clean-vscode


### PR DESCRIPTION
## Summary
- Adds `just ci-changed`: always runs build/lint/test/check-corpus/check-surface-drift, and only runs `test-integration`/`test-mcp`/`test-repl-protocol`/`test-parity` when the diff touches their actual surface (`runtime/apps/beamtalk_workspace/`, `crates/beamtalk-mcp/`, `crates/beamtalk-parity-tests/`, `crates/beamtalk-lsp/`, `crates/beamtalk-cli/src/commands/workspace/`, REPL-protocol test paths). GitHub Actions already runs those suites as parallel CI jobs regardless, so re-running them serially on one machine before every push is pure overhead when they're untouched — not additional safety.
- Adds a `test-parity` job to `.github/workflows/ci.yml`. `test-parity` previously only existed as a local recipe in `just ci` — nothing in CI actually ran it, so parity regressions (REPL/MCP/CLI/LSP) had no automated backstop at all.

Prompted by a `/insights` review of recurring friction: running the full local CI suite on every change regardless of what was touched, and a real gap where `test-parity` wasn't covered by CI.

## Test plan
- [x] Ran `just ci-changed` end-to-end locally (12m08s): all suites green, corpus/surface-drift checks passed, correctly skipped test-integration/mcp/repl-protocol/parity (diff only touches Justfile + ci.yml)
- [x] `just build && just clippy && just fmt-check` clean
- [ ] Confirm the new `test-parity` CI job runs and passes on this PR