### PR TITLE
MCP offline lint/diagnostic_summary walks transitive dependencies (BT-2836)

### DIFF
--- a/crates/beamtalk-cli/src/commands/deps/mod.rs
+++ b/crates/beamtalk-cli/src/commands/deps/mod.rs
@@ -156,6 +156,14 @@ struct DiscoveredDep {
 /// Returns all deps (direct + transitive) without compilation or ebin checks.
 /// Used by both `deps_are_fresh` and `collect_fresh_deps` to handle the full
 /// transitive graph rather than just direct deps.
+///
+/// Note (BT-2836): `dependency_classes.rs`'s offline MCP
+/// `lint`/`diagnostic_summary` dependency-class resolution needs the same
+/// transitive-walk reachability but cannot call this function directly — it
+/// lives in the library crate (`lib.rs`) while this module is compiled only
+/// into the `beamtalk-cli` binary (`mod commands;` in `main.rs`). It
+/// reimplements an equivalent walk instead; keep the two in sync if this
+/// algorithm changes.
 fn discover_all_dep_roots(
     project_root: &Utf8Path,
     manifest: &manifest::ParsedManifest,

--- a/crates/beamtalk-cli/src/commands/deps/path.rs
+++ b/crates/beamtalk-cli/src/commands/deps/path.rs
@@ -268,17 +268,20 @@ fn normalize_path(path: &Utf8Path) -> Utf8PathBuf {
             Utf8Component::CurDir => {
                 // Skip `.`
             }
-            Utf8Component::ParentDir => {
-                // Pop the last component if possible
-                if !components.is_empty() {
-                    let last = components.last().copied();
-                    if last != Some(Utf8Component::ParentDir) {
-                        components.pop();
-                        continue;
-                    }
+            Utf8Component::ParentDir => match components.last().copied() {
+                // Already at the filesystem root — an extra `..` is a no-op
+                // rather than something to pop or accumulate (BT-2836 review
+                // finding: popping `RootDir` here would turn `/foo/../..`
+                // into `.` instead of `/`).
+                Some(Utf8Component::RootDir) => {}
+                // Nothing to pop yet, or a run of leading `..`s in a
+                // relative path — accumulate.
+                None | Some(Utf8Component::ParentDir) => components.push(component),
+                // A real component precedes it — cancel the two out.
+                Some(_) => {
+                    components.pop();
                 }
-                components.push(component);
-            }
+            },
             _ => {
                 components.push(component);
             }
@@ -654,6 +657,15 @@ mod tests {
     fn test_normalize_path_multiple_parents() {
         let path = Utf8PathBuf::from("/home/user/project/../../dep");
         assert_eq!(normalize_path(&path), Utf8PathBuf::from("/home/dep"));
+    }
+
+    #[test]
+    fn test_normalize_path_parent_at_root() {
+        // A `..` chain that consumes every real component and then hits
+        // root must not pop `RootDir` itself — `/foo/../..` is still `/`,
+        // not `.` (BT-2836 review finding).
+        let path = Utf8PathBuf::from("/foo/../..");
+        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/"));
     }
 
     #[test]

--- a/crates/beamtalk-cli/src/dependency_classes.rs
+++ b/crates/beamtalk-cli/src/dependency_classes.rs
@@ -186,14 +186,20 @@ fn normalize_path(path: &Utf8Path) -> Utf8PathBuf {
             Utf8Component::CurDir => {
                 // Skip `.`
             }
-            Utf8Component::ParentDir => {
-                let last = components.last().copied();
-                if !components.is_empty() && last != Some(Utf8Component::ParentDir) {
+            Utf8Component::ParentDir => match components.last().copied() {
+                // Already at the filesystem root — an extra `..` is a no-op
+                // rather than something to pop or accumulate (BT-2836 review
+                // finding: popping `RootDir` here would turn `/foo/../..`
+                // into `.` instead of `/`).
+                Some(Utf8Component::RootDir) => {}
+                // Nothing to pop yet, or a run of leading `..`s in a
+                // relative path — accumulate.
+                None | Some(Utf8Component::ParentDir) => components.push(component),
+                // A real component precedes it — cancel the two out.
+                Some(_) => {
                     components.pop();
-                    continue;
                 }
-                components.push(component);
-            }
+            },
             _ => {
                 components.push(component);
             }
@@ -356,6 +362,15 @@ mod tests {
     fn normalize_path_multiple_parents() {
         let path = Utf8PathBuf::from("/home/user/project/../../dep");
         assert_eq!(normalize_path(&path), Utf8PathBuf::from("/home/dep"));
+    }
+
+    #[test]
+    fn normalize_path_parent_at_root() {
+        // A `..` chain that consumes every real component and then hits
+        // root must not pop `RootDir` itself — `/foo/../..` is still `/`,
+        // not `.` (review finding on PR #2989).
+        let path = Utf8PathBuf::from("/foo/../..");
+        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/"));
     }
 
     // BT-2837: `resolve_dependency_class_infos` now reads/writes a

--- a/crates/beamtalk-cli/src/dependency_classes.rs
+++ b/crates/beamtalk-cli/src/dependency_classes.rs
@@ -28,12 +28,21 @@
 //! dependency, because [`beamtalk_core::project::package`] only walks the
 //! package's own `src/`/`test/` directories.
 //!
-//! **Known limitation (BT-2878):** only *direct* dependencies (the
-//! project's own `[dependencies]` table) are resolved — unlike
-//! `ensure_deps_resolved`, this does not walk transitive dependency graphs.
-//! A class defined only in a dependency-of-a-dependency (and referenced
-//! directly, which is unusual) is not covered. Tracked as a follow-up, to
-//! be picked up if it proves necessary in practice.
+//! **Transitive dependencies (BT-2836):** [`resolve_dependency_class_infos`]
+//! walks the full transitive dependency graph — not just the project's own
+//! direct `[dependencies]` table — by recursively reading each discovered
+//! dependency's own `beamtalk.toml` (when its checkout is already present on
+//! disk) and queuing its dependencies in turn. This mirrors
+//! `discover_all_dep_roots` in `crate::commands::deps` (the CLI's own
+//! transitive-walk logic for `ensure_deps_resolved`'s freshness checks), but
+//! is reimplemented rather than shared: `discover_all_dep_roots` lives in
+//! the `beamtalk-cli` *binary* crate (`mod commands;` in `main.rs`), while
+//! this module is part of the `beamtalk-cli` *library* crate that
+//! `beamtalk-mcp` links against, so it cannot call into the binary's private
+//! modules. Keep the two algorithms in sync if either changes. As with
+//! direct dependencies, a checkout that hasn't been fetched yet (missing
+//! `_build/deps/<name>/`) is silently skipped rather than fetched — no
+//! network I/O.
 //!
 //! **Caching (BT-2837):** the MCP server's `lint`/`diagnostic_summary` tools
 //! call [`resolve_dependency_class_infos`] on *every* request. Without
@@ -48,12 +57,12 @@
 
 use crate::build_layout::BuildLayout;
 use crate::manifest;
-use beamtalk_core::compilation::DependencySource;
+use beamtalk_core::compilation::{DependencyMap, DependencySource};
 use beamtalk_core::file_walker::FileWalker;
 use beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo;
 use beamtalk_core::source_analysis::{lex_with_eof, parse};
-use camino::{Utf8Path, Utf8PathBuf};
-use std::collections::HashMap;
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Mutex, OnceLock, PoisonError};
 use std::time::SystemTime;
 use tracing::warn;
@@ -104,33 +113,102 @@ pub fn resolve_dependency_class_infos(project_root: &Utf8Path) -> (bool, Vec<Cla
     let layout = BuildLayout::new(project_root);
     let mut class_infos = Vec::new();
 
-    for (name, spec) in &parsed.dependencies {
-        let dep_root = match &spec.source {
-            DependencySource::Path { path } => {
-                // Not normalized/sandboxed: a `..`-containing or absolute
-                // `path` can point outside `project_root`, matching the
-                // trust model of `beamtalk build`'s own path-dependency
-                // resolution (`deps/path.rs::canonicalize_dep_path`) —
-                // `beamtalk.toml` is authored by the project owner, not
-                // untrusted input.
-                let Some(relative) = Utf8Path::from_path(path) else {
-                    warn!(dep = %name, "Dependency path is not valid UTF-8; skipping");
-                    continue;
-                };
-                project_root.join(relative)
+    // BFS over the transitive dependency graph (BT-2836), matching
+    // `discover_all_dep_roots`'s reachability: a queue of
+    // `(declaring_root, deps_to_visit)` pairs, seeded with the project's own
+    // direct `[dependencies]` table. `visited` dedups by name only (not
+    // path), matching the CLI's single-version policy — a diamond dependency
+    // (reached via two different parents) is resolved once.
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<(Utf8PathBuf, DependencyMap)> =
+        VecDeque::from([(project_root.to_path_buf(), parsed.dependencies)]);
+
+    while let Some((declaring_root, deps)) = queue.pop_front() {
+        for (name, spec) in deps {
+            if !visited.insert(name.clone()) {
+                continue; // Already discovered via another path (diamond dep).
             }
-            DependencySource::Git { .. } => layout.dep_checkout_dir(name),
-        };
 
-        if !dep_root.is_dir() {
-            // Not yet fetched/built — best-effort, skip silently.
-            continue;
+            let dep_root = match &spec.source {
+                DependencySource::Path { path } => {
+                    // Not sandboxed: a `..`-containing or absolute `path` can
+                    // point outside `project_root`, matching the trust model
+                    // of `beamtalk build`'s own path-dependency resolution
+                    // (`deps/path.rs::canonicalize_dep_path`) — `beamtalk.toml`
+                    // is authored by the project owner, not untrusted input.
+                    // Relative to `declaring_root` (the package whose
+                    // manifest declared this dependency), not necessarily
+                    // `project_root` — a transitive path dep is relative to
+                    // its own declaring package.
+                    let Some(relative) = Utf8Path::from_path(path) else {
+                        warn!(dep = %name, "Dependency path is not valid UTF-8; skipping");
+                        continue;
+                    };
+                    normalize_path(&declaring_root.join(relative))
+                }
+                DependencySource::Git { .. } => layout.dep_checkout_dir(&name),
+            };
+
+            if !dep_root.is_dir() {
+                // Not yet fetched/built — best-effort, skip silently. Its own
+                // dependencies (if any) can't be discovered either, since
+                // there's no checkout to read a `beamtalk.toml` from.
+                continue;
+            }
+
+            collect_dep_class_infos(&dep_root, &name, &mut class_infos);
+
+            // Queue this dependency's own dependencies for discovery,
+            // reading whatever checkout is already on disk — still no
+            // network I/O.
+            let dep_manifest_path = dep_root.join("beamtalk.toml");
+            if let Ok(dep_parsed) = manifest::parse_manifest_full(&dep_manifest_path) {
+                if !dep_parsed.dependencies.is_empty() {
+                    queue.push_back((dep_root, dep_parsed.dependencies));
+                }
+            }
         }
-
-        collect_dep_class_infos(&dep_root, name, &mut class_infos);
     }
 
     (has_package_dependencies, class_infos)
+}
+
+/// Normalize a path by resolving `.` and `..` components without filesystem
+/// access (mirrors `commands::deps::path::normalize_path`, duplicated here
+/// per the module doc's note on the binary/library crate split — BT-2836).
+///
+/// Unlike `std::fs::canonicalize`, this does not require the path to exist
+/// and does not resolve symlinks.
+fn normalize_path(path: &Utf8Path) -> Utf8PathBuf {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Utf8Component::CurDir => {
+                // Skip `.`
+            }
+            Utf8Component::ParentDir => {
+                let last = components.last().copied();
+                if !components.is_empty() && last != Some(Utf8Component::ParentDir) {
+                    components.pop();
+                    continue;
+                }
+                components.push(component);
+            }
+            _ => {
+                components.push(component);
+            }
+        }
+    }
+
+    if components.is_empty() {
+        return Utf8PathBuf::from(".");
+    }
+
+    let mut result = Utf8PathBuf::new();
+    for component in components {
+        result.push(component.as_str());
+    }
+    result
 }
 
 /// Cheap staleness signal for a dependency's source tree (BT-2837): the
@@ -255,6 +333,29 @@ mod tests {
             fs::create_dir_all(parent).unwrap();
         }
         fs::write(path, contents).unwrap();
+    }
+
+    // BT-2836: direct unit coverage for the duplicated `normalize_path`
+    // (mirrors `commands::deps::path`'s own `test_normalize_path_*` tests).
+    #[test]
+    fn normalize_path_resolves_parent() {
+        let path = Utf8PathBuf::from("/home/user/project/../dep");
+        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/home/user/dep"));
+    }
+
+    #[test]
+    fn normalize_path_resolves_dot() {
+        let path = Utf8PathBuf::from("/home/user/./project");
+        assert_eq!(
+            normalize_path(&path),
+            Utf8PathBuf::from("/home/user/project")
+        );
+    }
+
+    #[test]
+    fn normalize_path_multiple_parents() {
+        let path = Utf8PathBuf::from("/home/user/project/../../dep");
+        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/home/dep"));
     }
 
     // BT-2837: `resolve_dependency_class_infos` now reads/writes a
@@ -466,6 +567,153 @@ mod tests {
         assert!(
             infos2.iter().any(|c| c.name == "B"),
             "expected newly added file's class to be picked up, got {infos2:?}"
+        );
+    }
+
+    // BT-2836: transitive dependency walk regression tests.
+
+    #[test]
+    #[serial_test::serial(dependency_class_cache)]
+    fn transitive_git_dependency_class_is_resolved() {
+        // app -> a (direct, declared in app's own manifest) -> b (transitive,
+        // declared only in a's checked-out manifest). Both checkouts already
+        // exist under `_build/deps/`, simulating a prior `beamtalk build`.
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        write(
+            tmp.path().join("beamtalk.toml").as_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\na = { git = \"https://example.com/a.git\", tag = \"v1.0.0\" }\n",
+        );
+        write(
+            tmp.path().join("_build/deps/a/beamtalk.toml").as_path(),
+            "[package]\nname = \"a\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nb = { git = \"https://example.com/b.git\", tag = \"v1.0.0\" }\n",
+        );
+        write(
+            tmp.path().join("_build/deps/a/src/a_class.bt").as_path(),
+            "Object subclass: AClass\n",
+        );
+        // `b` is never declared in app's own beamtalk.toml — only reachable
+        // by walking `a`'s manifest.
+        write(
+            tmp.path().join("_build/deps/b/src/b_class.bt").as_path(),
+            "Object subclass: BClass\n",
+        );
+
+        let (has_deps, infos) = resolve_dependency_class_infos(root);
+        assert!(has_deps);
+        assert!(
+            infos.iter().any(|c| c.name == "AClass"),
+            "expected direct dependency's class, got {infos:?}"
+        );
+        assert!(
+            infos.iter().any(|c| c.name == "BClass"),
+            "expected transitive dependency's class to be resolved, got {infos:?}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(dependency_class_cache)]
+    fn transitive_path_dependency_class_is_resolved() {
+        // app -> a (path dep of app) -> b (path dep of a, relative to a's
+        // own directory, not app's).
+        let tmp = TempDir::new().unwrap();
+        let app_dir = tmp.path().join("app");
+        let root = Utf8Path::from_path(app_dir.as_path()).unwrap();
+        write(
+            app_dir.join("beamtalk.toml").as_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\na = { path = \"../a\" }\n",
+        );
+        write(
+            tmp.path().join("a/beamtalk.toml").as_path(),
+            "[package]\nname = \"a\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nb = { path = \"../b\" }\n",
+        );
+        write(
+            tmp.path().join("a/src/a_class.bt").as_path(),
+            "Object subclass: AClass\n",
+        );
+        write(
+            tmp.path().join("b/src/b_class.bt").as_path(),
+            "Object subclass: BClass\n",
+        );
+
+        let (has_deps, infos) = resolve_dependency_class_infos(root);
+        assert!(has_deps);
+        assert!(
+            infos.iter().any(|c| c.name == "BClass"),
+            "expected transitive path dependency's class to be resolved, got {infos:?}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(dependency_class_cache)]
+    fn unfetched_transitive_dependency_is_skipped() {
+        // `a` is checked out and declares a dependency on `b`, but `b`
+        // itself has never been fetched — best-effort skip, not an error.
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        write(
+            tmp.path().join("beamtalk.toml").as_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\na = { git = \"https://example.com/a.git\", tag = \"v1.0.0\" }\n",
+        );
+        write(
+            tmp.path().join("_build/deps/a/beamtalk.toml").as_path(),
+            "[package]\nname = \"a\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nb = { git = \"https://example.com/b.git\", tag = \"v1.0.0\" }\n",
+        );
+        write(
+            tmp.path().join("_build/deps/a/src/a_class.bt").as_path(),
+            "Object subclass: AClass\n",
+        );
+        // No `_build/deps/b/` checkout.
+
+        let (has_deps, infos) = resolve_dependency_class_infos(root);
+        assert!(has_deps);
+        assert!(infos.iter().any(|c| c.name == "AClass"));
+        assert!(!infos.iter().any(|c| c.name == "BClass"));
+    }
+
+    #[test]
+    #[serial_test::serial(dependency_class_cache)]
+    fn diamond_transitive_dependency_is_resolved_once() {
+        // app depends directly on both `p` and `q`; both `p` and `q` depend
+        // on the same `shared` package. `shared`'s classes must appear
+        // exactly once despite being reachable via two paths.
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        write(
+            tmp.path().join("beamtalk.toml").as_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\n\
+             p = { git = \"https://example.com/p.git\", tag = \"v1.0.0\" }\n\
+             q = { git = \"https://example.com/q.git\", tag = \"v1.0.0\" }\n",
+        );
+        write(
+            tmp.path().join("_build/deps/p/beamtalk.toml").as_path(),
+            "[package]\nname = \"p\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nshared = { git = \"https://example.com/shared.git\", tag = \"v1.0.0\" }\n",
+        );
+        write(
+            tmp.path().join("_build/deps/q/beamtalk.toml").as_path(),
+            "[package]\nname = \"q\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nshared = { git = \"https://example.com/shared.git\", tag = \"v1.0.0\" }\n",
+        );
+        write(
+            tmp.path()
+                .join("_build/deps/shared/src/shared_class.bt")
+                .as_path(),
+            "Object subclass: SharedClass\n",
+        );
+
+        let (_, infos) = resolve_dependency_class_infos(root);
+        let shared_count = infos.iter().filter(|c| c.name == "SharedClass").count();
+        assert_eq!(
+            shared_count, 1,
+            "diamond-reachable dependency's class should appear exactly once, got {infos:?}"
         );
     }
 }

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -3047,6 +3047,110 @@ mod tests {
         );
     }
 
+    /// Write a fixture project declaring a *direct* git dependency `http` in
+    /// `beamtalk.toml`, where `http`'s own checked-out `beamtalk.toml`
+    /// declares a *transitive* git dependency `net` (BT-2836) — never
+    /// mentioned in the project's own manifest. Both checkouts are already
+    /// present under `_build/deps/`, simulating a prior `beamtalk build`. The
+    /// project's own `src/app.bt` references `net`'s `NetClient` class
+    /// directly, which is only reachable by walking `http`'s manifest.
+    /// Returns the fixture's `TempDir` (keep it alive for the duration of the
+    /// test) and the path to `src/app.bt`.
+    fn write_transitive_git_dependency_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let dir = temp.path();
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        std::fs::write(
+            dir.join("beamtalk.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nhttp = { git = \"https://example.com/http.git\", tag = \"v1.0.0\" }\n",
+        )
+        .unwrap();
+
+        // Simulate `beamtalk build` having already fetched the direct
+        // dependency, whose own manifest declares a transitive dependency.
+        let http_dir = dir.join("_build").join("deps").join("http");
+        std::fs::create_dir_all(http_dir.join("src")).unwrap();
+        std::fs::write(
+            http_dir.join("beamtalk.toml"),
+            "[package]\nname = \"http\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nnet = { git = \"https://example.com/net.git\", tag = \"v1.0.0\" }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            http_dir.join("src").join("http_server.bt"),
+            "Object subclass: HTTPServer\n",
+        )
+        .unwrap();
+
+        // The transitive dependency's checkout, never declared in app's own
+        // `beamtalk.toml` — only discoverable by walking `http`'s manifest.
+        let net_src_dir = dir.join("_build").join("deps").join("net").join("src");
+        std::fs::create_dir_all(&net_src_dir).unwrap();
+        std::fs::write(
+            net_src_dir.join("net_client.bt"),
+            "Object subclass: NetClient\n",
+        )
+        .unwrap();
+
+        // Sentinel class so `has_cross_file_classes` isn't vacuously true/false
+        // independent of dependency resolution, matching
+        // `write_git_dependency_fixture`'s pattern.
+        std::fs::write(src_dir.join("other.bt"), "Object subclass: Other\n").unwrap();
+
+        let app_file = src_dir.join("app.bt");
+        std::fs::write(
+            &app_file,
+            "Object subclass: App\n\n  class run =>\n    NetClient new\n",
+        )
+        .unwrap();
+
+        (temp, app_file)
+    }
+
+    /// BT-2836: MCP `lint` must resolve classes from a *transitive*
+    /// dependency (declared only in a direct dependency's own
+    /// `beamtalk.toml`, not the project's) the same way `beamtalk
+    /// build`/`beamtalk lint` do, using whatever checkout is already on disk
+    /// under `_build/deps/<name>/` — without a false-positive `Unresolved
+    /// class` diagnostic.
+    #[test]
+    fn run_lint_structured_resolves_transitive_git_dependency_classes() {
+        let (_temp, app_file) = write_transitive_git_dependency_fixture();
+        let result = run_lint_structured(app_file.to_str().unwrap());
+
+        let unresolved = result
+            .warnings
+            .iter()
+            .chain(result.errors.iter())
+            .any(|d| d.message.contains("Unresolved class"));
+        assert!(
+            !unresolved,
+            "MCP lint should resolve NetClient from the transitive git dependency \
+             checkout, got: {result:?}",
+        );
+    }
+
+    /// BT-2836: Same as
+    /// `run_lint_structured_resolves_transitive_git_dependency_classes` but
+    /// for the `diagnostic_summary` tool.
+    #[test]
+    fn compute_diagnostic_summary_resolves_transitive_git_dependency_classes() {
+        let (_temp, app_file) = write_transitive_git_dependency_fixture();
+        let result = compute_diagnostic_summary(app_file.to_str().unwrap());
+
+        let unresolved_class_total = result["totals_by_category"]["UnresolvedClass"]["total"]
+            .as_u64()
+            .unwrap_or(0);
+        assert_eq!(
+            unresolved_class_total, 0,
+            "diagnostic_summary should resolve NetClient from the transitive git \
+             dependency checkout with zero UnresolvedClass diagnostics, got: {result:?}",
+        );
+    }
+
     /// BT-2056: When a package-extraction file in src/ cannot be read, MCP lint
     /// must surface a warning rather than silently dropping it from the
     /// extraction set.


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2836

`resolve_dependency_class_infos` (in `crates/beamtalk-cli/src/dependency_classes.rs`) is the offline, filesystem-only dependency-class resolution used by the MCP server's `lint`/`diagnostic_summary` tools. It previously only iterated a project's own *direct* `[dependencies]` table, so a class defined only in a dependency-of-a-dependency (not declared in the project's own `beamtalk.toml`) still produced a false-positive `Unresolved class` diagnostic — even though `beamtalk build`/`beamtalk lint` resolve it correctly via `ensure_deps_resolved`'s transitive walk (`discover_all_dep_roots`). This was called out as a known limitation left over from BT-2823.

- `resolve_dependency_class_infos` now does a BFS over the full transitive dependency graph (dedup'd by name for diamond deps), reading each discovered dependency's own `beamtalk.toml` when its checkout is already present under `_build/deps/<name>/` — still no network I/O, matching the "never fetch" offline guarantee.
- `discover_all_dep_roots` in `commands/deps/mod.rs` lives in the `beamtalk-cli` **binary** crate, while `dependency_classes.rs` is part of the **library** crate that `beamtalk-mcp` links against, so the algorithm is reimplemented (mirroring the same BFS/visited-set/dedup approach) rather than shared — documented in both places.
- Added regression tests in `dependency_classes.rs` (transitive git/path deps, unfetched-transitive-dep skip, diamond-dep dedup, `normalize_path` unit tests) and end-to-end MCP-level tests in `beamtalk-mcp/src/server.rs` (`run_lint_structured_resolves_transitive_git_dependency_classes`, `compute_diagnostic_summary_resolves_transitive_git_dependency_classes`) asserting zero `UnresolvedClass` diagnostics for a fixture where the project depends on `http`, which itself depends on `net`, with a class referenced only from `net`.

## Test plan

- [x] `just test` — Rust + stdlib + BUnit + runtime tests, all green
- [x] `just ci-changed` — build/clippy/fmt/corpus/surface-drift + integration/MCP/REPL-protocol/parity suites (touched MCP surface), all green
- [x] New unit tests in `dependency_classes.rs` covering transitive git deps, transitive path deps, unfetched-transitive skip, diamond dedup
- [x] New MCP-level tests in `server.rs` asserting no false-positive `UnresolvedClass` diagnostic for a transitive dependency
- [x] Pre-push hook (full lint incl. Dialyzer) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)