### PR TITLE
ci: wire lint-workaround-comments ratchet into GitHub Actions (BT-2841)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,9 @@ jobs:
         # build first so clippy and test-rust reuse its artifacts.
         # Full test-stdlib/test-bunit/test-runtime run only in the Linux-only 'test' job.
         # On Windows, fmt-check skips Erlang/JS checks (platform-agnostic, Linux covers them).
-        run: just build clippy fmt-check test-rust
+        # lint-workaround-comments (BT-2347 ratchet) is a no-op on Windows and enforces
+        # the same allowlist gate here that `just ci` enforces locally (BT-2841).
+        run: just build clippy fmt-check test-rust lint-workaround-comments
 
       - name: Surface parity drift check (BT-2082)
         # Verifies REPL ops × CLI × MCP × LSP coverage matches


### PR DESCRIPTION
## Summary
- The `lint-workaround-comments` ratchet (BT-2347) only ran locally via `just lint`/`just ci`, so it silently drifted out of sync with the allowlist and gave PRs no signal — BT-2823/BT-2826/BT-2829 each landed without CI catching the gap.
- Wire it into the existing "Build, lint, and fast tests" step in `.github/workflows/ci.yml`. It's a no-op on Windows via the platform-specific `just` recipe, so it's safe across the whole check-job matrix.

## Test plan
- [x] `just lint-workaround-comments` passes locally on this branch
- [x] `just lint` (full local pre-push hook) passes
- [ ] CI green on this PR (confirms the new step runs cleanly on ubuntu/macos/windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)