### PR TITLE
Block-literal callback params infer their arg type from a Union's Block(...) arm (BT-2864)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -4142,6 +4142,47 @@ impl TypeChecker {
         }
     }
 
+    /// Finds the `Block(...)` arm of a raw type-annotation string (BT-2864).
+    ///
+    /// Matches either a bare `Block(...)` type, or — when the declared type
+    /// is a Union — the single `Block(...)` member among its `" | "`-
+    /// separated arms (e.g. `Block(A, B) | Handler | Router`). Without this,
+    /// only a bare `Block(...)` param type propagated its expected signature
+    /// into a block-literal argument; a Union-typed param fell back to typing
+    /// every block param as `Dynamic`, even when exactly one arm was a
+    /// `Block(...)` whose signature could unambiguously be used.
+    ///
+    /// Returns `None` if no arm is a `Block(...)` type, or if more than one
+    /// arm is (ambiguous — which signature would apply is unclear, so this
+    /// conservatively falls back to the pre-fix Dynamic behaviour rather than
+    /// guessing).
+    ///
+    /// `pub(super)` so `type_checker::tests` can unit-test this directly
+    /// rather than only indirectly through diagnostics (a Dynamic receiver
+    /// never fires DNU, so a diagnostics-only test can't distinguish a
+    /// correctly-typed block param from a Dynamic one for every arm shape).
+    pub(super) fn find_block_arm(type_str: &str) -> Option<&str> {
+        // `split_union_respecting_parens` already handles the bare
+        // (non-Union) case — a string with no top-level `|` comes back as a
+        // single-element Vec — so both shapes share the matching loop below.
+        // Depth-aware splitting (rather than a naive `.split(" | ")`) matters
+        // here: a two-arm Union where every arm is itself a `Block(...)` —
+        // e.g. "Block(A, A) | Block(B, B)" — would otherwise still look like
+        // it starts with "Block(" and ends with ')' as a whole string, wrongly
+        // treating the entire ambiguous Union as one bare Block(...) type
+        // instead of correctly detecting the ambiguity.
+        let mut found: Option<&str> = None;
+        for member in Self::split_union_respecting_parens(type_str.trim()) {
+            if member.starts_with("Block(") && member.ends_with(')') {
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(member);
+            }
+        }
+        found
+    }
+
     /// Infer argument types, propagating block parameter types from the callee
     /// method's signature when the receiver type is known.
     ///
@@ -4223,10 +4264,11 @@ impl TypeChecker {
             );
         };
 
-        // Check if any param type is a Block(...) type
+        // Check if any param type is a Block(...) type, or a Union containing
+        // one (BT-2864: e.g. `Block(A, B) | Handler | Router`).
         let has_block_param = method.param_types.iter().any(|pt| {
             pt.as_ref()
-                .is_some_and(|t| t.starts_with("Block(") && t.ends_with(')'))
+                .is_some_and(|t| Self::find_block_arm(t).is_some())
         });
         if !has_block_param {
             return arguments
@@ -4268,7 +4310,7 @@ impl TypeChecker {
                     .param_types
                     .get(i)
                     .and_then(|pt| pt.as_ref())
-                    .filter(|t| t.starts_with("Block(") && t.ends_with(')'));
+                    .and_then(|t| Self::find_block_arm(t));
 
                 if let Some(block_type_str) = param_type_str {
                     // Parse Block(X, Y, Z) → params = [X, Y], return = Z

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2864_union_block_arg_type_inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2864_union_block_arg_type_inference.rs
@@ -1,0 +1,177 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Block-literal callback params now infer their arg type when the declared
+//! param type is a Union containing a `Block(...)` arm (BT-2864).
+//!
+//! Before this fix (BT-2864), propagating an expected type into a
+//! block-literal argument only recognised a bare `Block(...)` param type. A
+//! param typed as a Union whose arms include a `Block(...)` (e.g.
+//! `Block(HTTPRequest, HTTPResponse) | HTTPHandler | HTTPRouter`, matching
+//! `HTTPServer>>start:handler:` from the issue) fell back to typing every
+//! block param as `Dynamic`, requiring a manual `@expect type` annotation to
+//! narrow it, even though exactly one union arm was an unambiguous
+//! `Block(...)` signature.
+
+use super::common::*;
+
+/// Finds the first `Expression::Block` literal in `class_name`'s named
+/// method and returns its `InferredType` from `type_map`.
+///
+/// Diagnostics alone can't reliably distinguish "block param resolved to
+/// the expected class" from "block param stayed Dynamic": a Dynamic
+/// receiver never fires DNU (Dynamic suppresses that check entirely), and
+/// this codebase's BT-1914 "Dynamic in typed class" warning only fires for
+/// specific expression shapes — not for a Dynamic value used as a
+/// message-send receiver nested inside a block body. Reading the checker's
+/// own `TypeMap` for the block's span is the direct, shape-independent way
+/// to assert what it actually inferred.
+fn block_type_in_method<'a>(
+    module: &Module,
+    type_map: &'a TypeMap,
+    class_name: &str,
+    selector: &str,
+) -> &'a InferredType {
+    let class = module
+        .classes
+        .iter()
+        .find(|c| c.name.name == class_name)
+        .unwrap_or_else(|| panic!("class {class_name} not found"));
+    let method = class
+        .methods
+        .iter()
+        .find(|m| m.selector.name() == selector)
+        .unwrap_or_else(|| panic!("method {selector} not found on {class_name}"));
+    let block = method
+        .body
+        .iter()
+        .find_map(|stmt| find_block(&stmt.expression))
+        .unwrap_or_else(|| panic!("no block literal found in {class_name}>>{selector}"));
+    type_map
+        .get(block.span)
+        .unwrap_or_else(|| panic!("no type_map entry for block at {:?}", block.span))
+}
+
+/// Recursively searches an expression tree for the first block literal.
+/// Covers the shapes these fixtures use: a top-level keyword message send
+/// whose arguments include a block literal.
+fn find_block(expr: &Expression) -> Option<&Block> {
+    match expr {
+        Expression::Block(block) => Some(block),
+        Expression::MessageSend {
+            receiver,
+            arguments,
+            ..
+        } => find_block(receiver).or_else(|| arguments.iter().find_map(find_block)),
+        _ => None,
+    }
+}
+
+/// Asserts `ty` is `Block(HTTPRequest, ...)` — the block's first (and only)
+/// parameter resolved to the concrete `HTTPRequest` class, not `Dynamic`.
+fn assert_block_param_is_http_request(ty: &InferredType, context: &str) {
+    let InferredType::Known {
+        class_name,
+        type_args,
+        ..
+    } = ty
+    else {
+        panic!("{context}: expected a Known Block type, got: {ty:?}");
+    };
+    assert_eq!(class_name.as_str(), "Block", "{context}: got {ty:?}");
+    let param_ty = type_args
+        .first()
+        .unwrap_or_else(|| panic!("{context}: Block type has no type_args: {ty:?}"));
+    assert_eq!(
+        param_ty.as_known().map(ecow::EcoString::as_str),
+        Some("HTTPRequest"),
+        "{context}: block param should infer as HTTPRequest (from the Union's \
+         Block(...) arm), got: {param_ty:?}"
+    );
+}
+
+/// AC: a block literal passed inline at the call site to a Union-typed param
+/// gets its parameters typed from the Union's `Block(...)` arm — this is
+/// the exact repro shape from the issue (`HTTPServer start:handler:`).
+#[test]
+fn union_typed_block_param_inferred_from_single_block_arm_inline() {
+    let source = "\
+typed Object subclass: HTTPRequest\n\
+  respond -> HTTPRequest => self\n\
+typed Object subclass: HTTPHandler\n\
+typed Object subclass: HTTPRouter\n\
+typed Object subclass: HTTPServer\n\
+  start: port :: Integer handler: handler :: Block(HTTPRequest, HTTPRequest) | HTTPHandler | HTTPRouter -> HTTPServer => self\n\
+typed Object subclass: App\n\
+  m: server :: HTTPServer -> HTTPServer => server start: 8080 handler: [:req | req respond]\n";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let ty = block_type_in_method(&module, checker.type_map(), "App", "m:");
+    assert_block_param_is_http_request(ty, "BT-2864 (inline block, Union param)");
+}
+
+/// Regression guard: a bare (non-Union) `Block(...)` param still works
+/// unchanged (the pre-existing BT-2158 behaviour `find_block_arm` must
+/// preserve).
+#[test]
+fn bare_block_param_still_inferred_no_union() {
+    let source = "\
+typed Object subclass: HTTPRequest\n\
+  respond -> HTTPRequest => self\n\
+typed Object subclass: HTTPServer\n\
+  start: port :: Integer handler: handler :: Block(HTTPRequest, HTTPRequest) -> HTTPServer => self\n\
+typed Object subclass: App\n\
+  m: server :: HTTPServer -> HTTPServer => server start: 8080 handler: [:req | req respond]\n";
+    let module = parse_source(source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let mut checker = TypeChecker::new();
+    checker.check_module(&module, &hierarchy);
+
+    let ty = block_type_in_method(&module, checker.type_map(), "App", "m:");
+    assert_block_param_is_http_request(ty, "bare Block(...) param (no Union, BT-2158 baseline)");
+}
+
+/// Ambiguity guard: `find_block_arm` returns `None` for a Union with *two*
+/// `Block(...)` arms rather than guessing which signature applies (unit
+/// test on the helper directly — `tests` is a descendant module of
+/// `type_checker`, so private items are visible here).
+#[test]
+fn find_block_arm_none_for_ambiguous_union() {
+    assert_eq!(
+        TypeChecker::find_block_arm("Block(HTTPRequest, HTTPRequest) | Block(Integer, Integer)"),
+        None,
+        "two Block(...) arms is ambiguous — must not pick either"
+    );
+}
+
+/// `find_block_arm` finds the single `Block(...)` arm of a Union, matching
+/// the issue's exact repro shape.
+#[test]
+fn find_block_arm_finds_single_arm_in_union() {
+    assert_eq!(
+        TypeChecker::find_block_arm("Block(HTTPRequest, HTTPResponse) | HTTPHandler | HTTPRouter"),
+        Some("Block(HTTPRequest, HTTPResponse)")
+    );
+}
+
+/// `find_block_arm` still matches a bare (non-Union) `Block(...)` type.
+#[test]
+fn find_block_arm_matches_bare_block() {
+    assert_eq!(
+        TypeChecker::find_block_arm("Block(Integer, Integer)"),
+        Some("Block(Integer, Integer)")
+    );
+}
+
+/// `find_block_arm` returns `None` when no arm is a `Block(...)` type.
+#[test]
+fn find_block_arm_none_when_no_block_arm() {
+    assert_eq!(
+        TypeChecker::find_block_arm("HTTPHandler | HTTPRouter"),
+        None
+    );
+    assert_eq!(TypeChecker::find_block_arm("String"), None);
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
@@ -20,6 +20,7 @@ mod bt2843_binary_arg_union_check;
 mod bt2847_nested_union_type_args;
 mod bt2850_cascade_spawn_with_keys;
 mod bt2862_self_delegate_return_type;
+mod bt2864_union_block_arg_type_inference;
 mod bt2871_cascade_binary_arg_check;
 mod bt2872_and_not_nil_narrowing;
 mod bt2879_cascade_meta_branch;


### PR DESCRIPTION
## Summary
- When inferring a block-literal argument's parameter types from the call site's declared parameter type, only a bare `Block(...)` type propagated its expected signature into the literal. A param typed as a Union whose arms include a `Block(...)` (e.g. `Block(HTTPRequest, HTTPResponse) | HTTPHandler | HTTPRouter`, matching `HTTPServer>>start:handler:` from the issue) fell back to `Dynamic` for every block param, even when exactly one union arm was an unambiguous `Block(...)` signature.
- Adds `find_block_arm`, which searches a Union's arms (via the existing `split_union_respecting_parens` helper, which already handles nested parens correctly) for a single `Block(...)` member and uses it the same way a bare `Block(...)` param type already does.
- Two arms that are both `Block(...)` is ambiguous — conservatively stays `Dynamic` rather than guessing which signature applies.

## Test plan
- [x] New regression tests in `beamtalk-core`'s `bt2864_union_block_arg_type_inference.rs` (6 tests): inline Union-typed block param resolves to the concrete class (verified via direct `TypeMap` inspection, not diagnostics — a Dynamic receiver never fires DNU and this codebase's "Dynamic in typed class" warning doesn't fire for this expression shape either, so diagnostics-only assertions would pass vacuously), bare `Block(...)` regression guard, and 4 unit tests on `find_block_arm` directly (single arm, bare, ambiguous two-arm, no-arm)
- [x] Verified each fix site is independently load-bearing by reverting it in isolation and confirming the new test fails, then restoring
- [x] Full `beamtalk-core` test suite (4950 tests) passes
- [x] `just ci-changed` — full pass, 0 failures
- [x] `just clippy`, `cargo fmt --check`, `just lint-workaround-comments` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)