### PR TITLE
Verify Rust vs runtime class-hierarchy consistency for actor/supervisor type-pattern tagging across file boundaries (BT-2882)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -2713,6 +2713,14 @@ impl CoreErlangGenerator {
                 // map — the tagged-class `is_map` check would never match a
                 // live actor instance, silently miscompiling the single
                 // most common kind of leaf class in real Beamtalk programs.
+                //
+                // BT-2882: `is_actor_subclass`/`is_supervisor_subclass`/
+                // `is_dynamic_supervisor_subclass` are verified to resolve
+                // correctly even when `other`'s Actor/Supervisor ancestor is
+                // declared in a different file (or several files away) —
+                // see their doc comments in `hierarchy_queries.rs` and the
+                // `..._resolves_through_cross_file_stub_chain` codegen tests
+                // in `tests/control_flow.rs`.
                 let is_actor = self
                     .class_hierarchy
                     .as_ref()

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -1213,6 +1213,94 @@ fn test_match_type_pattern_dynamic_supervisor_subclass_uses_tuple_tag_check_and_
 }
 
 #[test]
+fn test_match_type_pattern_actor_subclass_resolves_through_cross_file_stub_chain() {
+    // BT-2882: `LeafActor`'s superclass `MidActor` is *not* declared
+    // anywhere in this compilation unit — only `LeafActor subclass:`
+    // itself is parsed here. `MidActor` and its own superclass `BaseActor`
+    // are supplied purely as `add_external_superclasses` stubs (simulating
+    // both ancestors living in separate files), exactly the multi-hop
+    // shape `class_superclass_index` produces from a whole-project Pass 1.
+    // `is_actor_subclass` must still walk stub -> stub -> builtin `Actor`
+    // and dispatch to the actor tuple-tag strategy, not silently fall back
+    // to the tagged-map strategy that would never match a live actor.
+    let src = "Object subclass: Foo\n  test: x =>\n    x match: [\n      c :: LeafActor -> c;\n      _ -> \"none\"\n    ]\n\nMidActor subclass: LeafActor\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+
+    let mut superclass_index = std::collections::HashMap::new();
+    superclass_index.insert("MidActor".to_string(), "BaseActor".to_string());
+    superclass_index.insert("BaseActor".to_string(), "Actor".to_string());
+
+    let code = generate_module(
+        &module,
+        CodegenOptions::new("leaf_actor").with_class_superclass_index(superclass_index),
+    )
+    .expect("codegen should succeed");
+
+    eprintln!("Generated code for cross-file actor type pattern match:\n{code}");
+
+    assert!(
+        code.contains("'erlang':'is_tuple'"),
+        "Actor-class type pattern should test is_tuple even through a cross-file stub chain. \
+         Got:\n{code}"
+    );
+    assert!(
+        code.contains("'beamtalk_object'"),
+        "Actor-class type pattern should check the 'beamtalk_object' tag even through a \
+         cross-file stub chain. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'LeafActor'"),
+        "Actor-class type pattern should match the class name atom. Got:\n{code}"
+    );
+
+    crate::test_helpers::assert_compiles_through_erlc("leaf_actor", &code);
+}
+
+#[test]
+fn test_match_type_pattern_supervisor_subclass_resolves_through_cross_file_stub_chain() {
+    // BT-2882: same concern as the actor test above, for the Supervisor
+    // strategy. `LeafSupervisor`'s superclass `MidSupervisor` and *its*
+    // superclass `BaseSupervisor` are both supplied only as cross-file
+    // stubs — neither is declared in this compilation unit. If
+    // `is_supervisor_subclass` failed to walk through two stub hops, this
+    // would silently fall back to the tagged-map strategy, which never
+    // matches a live supervisor reference (a 4-tuple).
+    let src = "Object subclass: Foo\n  test: x =>\n    x match: [\n      s :: LeafSupervisor -> s;\n      _ -> \"none\"\n    ]\n\nMidSupervisor subclass: LeafSupervisor\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+
+    let mut superclass_index = std::collections::HashMap::new();
+    superclass_index.insert("MidSupervisor".to_string(), "BaseSupervisor".to_string());
+    superclass_index.insert("BaseSupervisor".to_string(), "Supervisor".to_string());
+
+    let code = generate_module(
+        &module,
+        CodegenOptions::new("leaf_supervisor").with_class_superclass_index(superclass_index),
+    )
+    .expect("codegen should succeed");
+
+    eprintln!("Generated code for cross-file supervisor type pattern match:\n{code}");
+
+    assert!(
+        code.contains("'erlang':'is_tuple'"),
+        "Supervisor-class type pattern should test is_tuple even through a cross-file stub \
+         chain. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'beamtalk_supervisor'"),
+        "Supervisor-class type pattern should check the 'beamtalk_supervisor' tag even through \
+         a cross-file stub chain. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'LeafSupervisor'"),
+        "Supervisor-class type pattern should match the class name atom. Got:\n{code}"
+    );
+
+    crate::test_helpers::assert_compiles_through_erlc("leaf_supervisor", &code);
+}
+
+#[test]
 fn test_match_type_pattern_dictionary_and_tagged_class_arms_interleave_in_one_case() {
     // `Dictionary` and an exact tagged class both use an `is_map`-based
     // strategy; a `match:` mixing the two must still compile into one

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/hierarchy_queries.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/hierarchy_queries.rs
@@ -136,6 +136,23 @@ impl ClassHierarchy {
     }
 
     /// Returns true if the named class is Actor or a subclass of Actor.
+    ///
+    /// BT-2882: codegen (`dispatch_type_pattern_strategy`) trusts this to
+    /// decide the actor-tuple tag-test strategy for `x :: SomeClass`, and
+    /// relies on it staying consistent with the runtime's own
+    /// `beamtalk_supervisor:is_supervisor/1`-style classification of a
+    /// *live* value. That consistency holds even when `Actor` is several
+    /// hops up the chain and every intermediate ancestor is declared in a
+    /// different file: `superclass_chain` walks through the stub `ClassInfo`
+    /// entries `add_external_superclasses` inserts for cross-file parents
+    /// exactly the same way it walks real ones, and package-wide
+    /// compilation always backfills the *whole* project's class → superclass
+    /// edges (not just the current file's direct references) before
+    /// codegen runs — see `crates/beamtalk-cli/src/commands/build.rs`'s
+    /// Pass 1 (`build_class_module_index`). The chain only fails to resolve
+    /// (see `has_cross_file_parent`) when an ancestor is missing entirely —
+    /// a distinct, pre-existing failure mode this function does not guard
+    /// against.
     #[must_use]
     pub fn is_actor_subclass(&self, class_name: &str) -> bool {
         if class_name == "Actor" {
@@ -147,6 +164,9 @@ impl ClassHierarchy {
     }
 
     /// Returns true if the named class is Supervisor or a subclass of Supervisor (BT-1218).
+    ///
+    /// BT-2882: same cross-file-stub-chain invariant as
+    /// [`Self::is_actor_subclass`] — see its doc comment.
     #[must_use]
     pub fn is_supervisor_subclass(&self, class_name: &str) -> bool {
         if class_name == "Supervisor" {
@@ -169,6 +189,9 @@ impl ClassHierarchy {
     }
 
     /// Returns true if the named class is `DynamicSupervisor` or a subclass (BT-1218).
+    ///
+    /// BT-2882: same cross-file-stub-chain invariant as
+    /// [`Self::is_actor_subclass`] — see its doc comment.
     #[must_use]
     pub fn is_dynamic_supervisor_subclass(&self, class_name: &str) -> bool {
         if class_name == "DynamicSupervisor" {


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2882

Follow-up research issue from BT-2870's code review: verifies that the Rust compiler's `ClassHierarchy::is_actor_subclass`/`is_supervisor_subclass`/`is_dynamic_supervisor_subclass` — which `generate_type_pattern`'s dispatch uses to pick the actor-tuple vs supervisor-tuple vs tagged-map codegen strategy for `x :: SomeClass` — stays consistent with the runtime's own classification even when the relevant `Actor`/`Supervisor` ancestor is declared in a different file than the `match:` performing the type test.

**Outcome: verified correct, no behavior change needed.** Added regression tests + doc comments recording the invariant (per the issue's "downgrade to documentation only" acceptance-criteria branch).

- Added two cross-file codegen tests (`test_match_type_pattern_actor_subclass_resolves_through_cross_file_stub_chain`, `test_match_type_pattern_supervisor_subclass_resolves_through_cross_file_stub_chain`) that build a 2-hop chain where *every* intermediate ancestor is only present as an `add_external_superclasses` stub, and confirm codegen still emits the correct tuple-tag test rather than silently falling back to the tagged-map strategy.
- Confirmed the tests are meaningful (not vacuously true) by temporarily breaking one hop of the stub chain locally and observing the expected failure before restoring it.
- Documented the invariant and *why* it holds (whole-project Pass 1 backfills every class's direct superclass across all files before codegen, and `superclass_chain` walks stub-to-stub links like real ones) on `is_actor_subclass`/`is_supervisor_subclass`/`is_dynamic_supervisor_subclass` and at the `dispatch_type_pattern_strategy` call site.

## Test plan

- [x] `cargo test -p beamtalk-core --lib codegen::core_erlang::tests::control_flow` — new + existing tests pass
- [x] `cargo test -p beamtalk-core --lib class_hierarchy` — pass
- [x] `cargo fmt -p beamtalk-core -- --check` — clean
- [x] `cargo clippy -p beamtalk-core --lib -- -D warnings` — clean
- [x] Pre-push hook (full lint/dialyzer/build) — passed


---
_Generated by [Claude Code](https://claude.ai/code/session_0186PeKtXaVULXoWDha6QRou)_