### PR TITLE
ifOk:ifError:'s R type param no longer polluted by a non-local return inside ifError: (BT-2866)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -4454,6 +4454,30 @@ impl TypeChecker {
             );
         }
         let body_ty = self.infer_stmts(&block.body, hierarchy, &mut block_env, in_abstract_method);
+        // BT-2866: a block whose body ends in a top-level non-local return
+        // (`^expr`) never produces a *local* value — it diverges out of the
+        // enclosing method entirely, and `^expr`'s type naturally matches
+        // whatever the enclosing method itself declares as its return type
+        // (that's what makes `^` type-check). `infer_stmts` reports that
+        // expression's type as the block's "body type" regardless, since for
+        // an ordinary method body that IS the right answer. But for a block
+        // passed to a combinator like `ifOk:ifError:` (`Block(T, R) ...
+        // Block(E, R) -> R`), treating a non-local-return branch's body type
+        // as a real contribution to `R` pollutes the union with the
+        // *enclosing method's* return type — unrelated to what this block's
+        // sibling argument (e.g. `ifOk:`'s block) actually produces locally.
+        // Override to `Never` (the `union_of` identity element — see
+        // `infer_method_local_params`/`merge_method_local_binding`) so only
+        // branches that genuinely produce a local value participate in `R`.
+        // `block_has_return` (not the deeper `block_has_any_return`) matches
+        // `infer_stmts`'s own top-level-only `break` check above exactly —
+        // a `^` buried inside a conditional the block might not take
+        // shouldn't force the whole block to `Never`.
+        let body_ty = if block_has_return(block) {
+            InferredType::Never
+        } else {
+            body_ty
+        };
         // Build Block type with resolved param types + inferred return type
         let mut block_type_args: Vec<InferredType> = param_types.to_vec();
         block_type_args.push(body_ty);

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2866_ifok_iferror_nonlocal_return.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2866_ifok_iferror_nonlocal_return.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ifOk:ifError:`'s `R` type param no longer gets polluted by a non-local
+//! return (`^`) inside the `ifError:` block (BT-2866).
+//!
+//! `Result(T, E)>>ifOk:ifError:` is declared:
+//!
+//! ```text
+//! sealed ifOk: okBlock :: Block(T, R) ifError: errorBlock :: Block(E, R) -> R
+//! ```
+//!
+//! The `ifOk:` branch genuinely produces a local value (`R` = whatever it
+//! returns). The `ifError:` branch in the issue's repro never "returns" a
+//! block value at all — it's a non-local return (`^Result error: ...`) that
+//! returns from the *enclosing method* directly. A non-local return
+//! shouldn't contribute a type to `R` (it's effectively bottom/`Never` — the
+//! block doesn't "return" in the local sense).
+//!
+//! Root cause: `infer_block_with_typed_params` used `infer_stmts`' reported
+//! body type unconditionally as the block's own inferred return type. For a
+//! block whose body is `^expr`, `infer_stmts` reports `expr`'s type — which
+//! naturally matches the *enclosing method's own* declared return type
+//! (that's what makes `^` type-check) — not something signalling "this
+//! block never produces a local value". That unrelated type then polluted
+//! `R`'s union with the *other* block argument's genuine local value.
+
+use super::common::*;
+
+/// Shared fixture: `MyResult(T, E)` with `ifOk:ifError:`, matching the
+/// stdlib `Result` shape closely enough to reproduce the bug without
+/// depending on the real stdlib class.
+const FIXTURE_PREFIX: &str = "\
+typed Object subclass: LinearError\n\
+  class unknownPayload: msg :: String -> LinearError => self\n\
+typed Value subclass: MyResult(T, E)\n\
+  class ok: v :: T -> MyResult(T, E) => self\n\
+  class error: e :: E -> MyResult(T, E) => self\n\
+  ifOk: okBlock :: Block(T, R) ifError: errorBlock :: Block(E, R) -> R => okBlock value: nil\n\
+typed Object subclass: HTTPResponse\n\
+  bodyAsJson -> MyResult(Dictionary, String) => MyResult ok: nil\n";
+
+/// AC / exact repro shape: the `ifOk:` branch produces `Dictionary`
+/// (via `@expect type` narrowing `v`), the `ifError:` branch is a bare
+/// non-local return. `jsonBody` must infer as `Dictionary` (from `ifOk:`
+/// alone), so `jsonBody at:ifAbsent:` (a real `Dictionary` selector) must
+/// not DNU. Before the fix, `R` was polluted to `MyResult(Dictionary,
+/// LinearError)` (the enclosing method's own return type, coincidentally
+/// matching the `^`-expression), producing a spurious "`MyResult` does not
+/// understand 'at:ifAbsent:'" hint.
+#[test]
+fn ifok_iferror_r_not_polluted_by_nonlocal_return_in_iferror_branch() {
+    let source = format!(
+        "{FIXTURE_PREFIX}\
+typed Object subclass: Repro\n\
+  parseResponse: resp :: HTTPResponse -> MyResult(Dictionary, LinearError) =>\n\
+    jsonBody := resp bodyAsJson\n\
+      ifOk: [:v |\n\
+        @expect type\n\
+        body :: Dictionary := v\n\
+        body\n\
+      ]\n\
+      ifError: [:e |\n\
+        ^MyResult error: (LinearError unknownPayload: e)\n\
+      ]\n\
+    jsonBody at: \"k\" ifAbsent: [nil]\n"
+    );
+    let module = parse_source(&source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let dnu: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .collect();
+    assert!(
+        dnu.is_empty(),
+        "jsonBody should infer as Dictionary (from ifOk: alone) — the ifError: \
+         branch's non-local return must not pollute R; got DNU: {dnu:?}"
+    );
+}
+
+/// Regression guard: when *neither* branch is a non-local return, `R` still
+/// correctly unifies both branches' local values (unchanged behaviour) —
+/// here both branches return `Dictionary`-compatible values, so no DNU.
+#[test]
+fn ifok_iferror_unifies_both_branches_when_neither_is_nonlocal_return() {
+    let source = format!(
+        "{FIXTURE_PREFIX}\
+typed Object subclass: Repro\n\
+  parseResponse: resp :: HTTPResponse -> Dictionary =>\n\
+    jsonBody := resp bodyAsJson\n\
+      ifOk: [:v |\n\
+        @expect type\n\
+        body :: Dictionary := v\n\
+        body\n\
+      ]\n\
+      ifError: [:e | Dictionary new]\n\
+    jsonBody at: \"k\" ifAbsent: [nil]\n"
+    );
+    let module = parse_source(&source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let dnu: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .collect();
+    assert!(
+        dnu.is_empty(),
+        "both branches produce Dictionary — jsonBody should infer as Dictionary, \
+         got DNU: {dnu:?}"
+    );
+}
+
+/// Regression guard: a non-local return in the *first* block argument
+/// (`ifOk:`) must be equally excluded from `R` — the fix isn't specific to
+/// `ifError:`'s position.
+#[test]
+fn ifok_iferror_r_not_polluted_by_nonlocal_return_in_ifok_branch() {
+    let source = format!(
+        "{FIXTURE_PREFIX}\
+typed Object subclass: Repro\n\
+  parseResponse: resp :: HTTPResponse -> MyResult(Dictionary, LinearError) =>\n\
+    jsonBody := resp bodyAsJson\n\
+      ifOk: [:v | ^MyResult ok: nil]\n\
+      ifError: [:e |\n\
+        @expect type\n\
+        body :: Dictionary := (Dictionary new)\n\
+        body\n\
+      ]\n\
+    jsonBody at: \"k\" ifAbsent: [nil]\n"
+    );
+    let module = parse_source(&source);
+    let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+    let diags = run_with_expect(&module, &hierarchy);
+    let dnu: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("does not understand"))
+        .collect();
+    assert!(
+        dnu.is_empty(),
+        "jsonBody should infer as Dictionary (from ifError: alone) — the ifOk: \
+         branch's non-local return must not pollute R; got DNU: {dnu:?}"
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
@@ -22,6 +22,7 @@ mod bt2850_cascade_spawn_with_keys;
 mod bt2862_self_delegate_return_type;
 mod bt2864_union_block_arg_type_inference;
 mod bt2865_dynamic_type_arg_iskindof;
+mod bt2866_ifok_iferror_nonlocal_return;
 mod bt2871_cascade_binary_arg_check;
 mod bt2872_and_not_nil_narrowing;
 mod bt2879_cascade_meta_branch;


### PR DESCRIPTION
## Summary
- `Result(T,E)>>ifOk:ifError:` is declared `sealed ifOk: okBlock :: Block(T, R) ifError: errorBlock :: Block(E, R) -> R`. The `ifOk:` branch genuinely produces a local value (`R` = whatever it returns). A block whose body is a non-local return (`^expr`) never "returns" a block value at all — it returns from the enclosing method directly.
- `infer_block_with_typed_params` used `infer_stmts`'s reported body type unconditionally as the block's own inferred return type. For a `^expr` body, that type naturally matches the enclosing method's own declared return type (that's what makes `^` type-check), not something signalling "this block never produces a local value". That unrelated type then polluted `R`'s union with the other block argument's genuine local value — so e.g. a `Dictionary` produced by `ifOk:` got swallowed into the bare `Result` the enclosing method declares, and downstream sends like `at:ifAbsent:` DNU'd.
- Reuses the existing `block_has_return` helper (`narrowing/visitors.rs`) to detect a top-level `^` return and override the block's contribution to `Never` (`union_of`'s identity element) in that case, so only branches that genuinely produce a local value participate in `R`.

## Test plan
- [x] New regression tests in `beamtalk-core`'s `bt2866_ifok_iferror_nonlocal_return.rs` (3 tests): exact repro shape (non-local return in `ifError:`), the symmetric case (non-local return in `ifOk:`), and a baseline confirming both-branches-produce-a-value still unifies correctly
- [x] Verified via revert-and-restore that the fix is load-bearing (DNU reappears without it)
- [x] Full `beamtalk-core` test suite (4969 tests) passes
- [x] `just build-stdlib` and full `just ci-changed` — clean pass, 0 failures across Rust/stdlib/BUnit/runtime suites
- [x] `just clippy`, `cargo fmt --check`, `just lint-workaround-comments` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)