### PR TITLE
Batch leaf-change re-check sweeps and harden load-binary caller discipline (BT-2873)

### DIFF
--- a/docs/development/benchmarks.md
+++ b/docs/development/benchmarks.md
@@ -271,6 +271,141 @@ re-run alongside this benchmark, unaffected (~1400x speedup vs source-scan,
 consistent with prior measurement; workspace grew from 81 to 103 classes in
 the interim, expected).
 
+## Leaf-change re-check fan-out (ADR 0107 Phase A, BT-2856 follow-up, BT-2873)
+
+BT-2856 added `beamtalk_recheck:trigger_leaf_change/1`: when a live
+class-body reload gives a previously-leaf class its first subclass, this
+re-checks **every** live class's own recorded source against the updated
+hierarchy (the same "recompile everything" strategy as `trigger_image/0`,
+since no xref index exists yet for `Type`-pattern/`matchExhaustive:` sites —
+see the moduledoc). Unlike `trigger_image/0`, this fires *automatically*,
+once per distinct base class gaining its first subclass. BT-2873's
+adversarial-review follow-up asks whether that automatic fan-out is a real
+cost during a bulk `:load dir` of a project with a deep class hierarchy
+(finding #1), and whether a single reload introducing multiple new
+hierarchies at once pays for redundant independent sweeps (finding #2),
+following BT-2781's "measure, then decide" precedent.
+
+### Harness
+
+`runtime/perf/bench_leaf_change_fanout.escript`. Run from the `runtime/`
+directory after `just build`:
+
+```bash
+escript perf/bench_leaf_change_fanout.escript
+```
+
+Two parts:
+
+- **Part A (real hierarchy shape)** — walks the full loaded stdlib class
+  hierarchy and counts classes with >= 1 direct subclass: each one underwent
+  exactly one leaf -> non-leaf transition the first time its first subclass
+  loaded, so this count is the exact number of `trigger_leaf_change/1`
+  sweeps a from-scratch bulk load of this workspace already fires today.
+  Also checks finding #2 directly: does any stdlib source file declare more
+  than one class (real declarations only — `///` doc-comment examples like
+  `Actor.bt`'s `/// Actor subclass: Counter` are filtered out, since they
+  are not real class definitions)?
+- **Part B (sweep cost vs. live-class count)** — drives the real
+  `beamtalk_recheck:trigger_leaf_change/1` orchestration (real compiler
+  port, real `beamtalk_workspace_meta`) over a synthetic set of 5 / 20 / 50 /
+  100 / 200 live class sources, to measure the sweep's wall-clock cost as a
+  function of workspace size.
+
+### Workspace
+
+The loaded standard library: **104 classes** (1 more than BT-2781's 103 —
+stdlib grows over time).
+
+### Results
+
+**Part A — today's real hierarchy shape:**
+
+- **17 of 104 classes (16.3%)** have at least one direct subclass — i.e. a
+  from-scratch bulk load of the full stdlib fires **17** independent
+  `trigger_leaf_change/1` sweeps today.
+- **0 of 104 source files declare more than one class.** Every stdlib file
+  follows a strict one-class-per-file convention, so finding #2's scenario
+  (a single reload making two or more superclasses newly-non-leaf at once,
+  paying for N independent sweeps instead of one) **cannot occur via the
+  stdlib's own bulk-load path** — `superclasses_losing_leaf_status/1`'s
+  input list is a singleton on every real stdlib reload. It remains
+  reachable in principle via other call sites that can install multiple
+  classes from one compile unit (e.g. a REPL paste defining two `subclass:`
+  statements in one expression, feeding `load_compiled_module/6`), just not
+  demonstrated as occurring anywhere in the current codebase.
+
+**Part B — sweep cost vs. live-class count:**
+
+| live classes | checked | wall-clock | ms/checked |
+|---|---|---|---|
+| 5 | 5 | ~215 ms | ~43 ms |
+| 20 | 20 | ~684 ms | ~34 ms |
+| 50 | 50 | ~1740 ms | ~35 ms |
+| 100 | 100 | ~3620 ms | ~36 ms |
+| 200 | 200 | ~7440 ms | ~37 ms |
+
+### Interpretation
+
+- **Per-check cost is flat, ~34-43 ms/candidate**, consistent with
+  `trigger/4`'s own measured ~33-48 ms/candidate (BT-2781) — no
+  superlinear blowup; `trigger_leaf_change/1` costs scale linearly with the
+  live-class count, same shape as `trigger_image/0`.
+- **Projected worst-case cost of today's real stdlib bulk load:** 17 sweeps
+  at up to ~3.6 s each (the full 104-class workspace size, an upper bound
+  since earlier transitions in the load see a smaller live-class set) is up
+  to **~61 s of serialized background compiler-port work**; a more
+  realistic estimate (transitions roughly spread through the load, so the
+  average sweep sees about half the final live-class count) is **~25-30 s**.
+  This is not a *blocking* cost — `spawn_leaf_change_recheck/1` already
+  keeps every sweep off the reload's own response path, queued through
+  `beamtalk_workspace_shape_recheck_worker`'s single-worker serialisation
+  (bounding concurrent compiler-port contention from this path to 1, same as
+  every other ADR 0105 mechanism) — but it is a real, non-trivial tail of
+  background compiler-port contention that other clients' hover/completion/
+  save requests queue up behind for tens of seconds after a full bulk load
+  "finishes" from the loading client's point of view, and it grows linearly
+  with both hierarchy depth (more leaf-change events) and workspace size
+  (more expensive per sweep).
+- **Finding #2 has zero measured benefit today** (0 of 104 files could ever
+  trigger it) but remains cheap, mechanical, and strictly non-regressive to
+  fix given the code path already exists for other reload sites capable of
+  installing multiple classes at once.
+
+### Decision (BT-2873)
+
+**Cross-reload debouncing/batching for finding #1 (collapsing the 17
+separate bulk-load sweeps above into one) is not implemented now.** The
+measured cost (tens of seconds of serialized, off-response-path background
+work for a full from-scratch stdlib load) is real but bounded, self-healing
+(resolves once the bulk load's queued sweeps drain), and — unlike BT-2798's
+xref receiver-type-key finding — does not cause any *lost* findings or
+incorrect behaviour, only a temporary latency/contention tail. It also only
+manifests on a full/deep bulk load (`:load dir` of a whole project or a
+large chunk of it), not on the ordinary single-class-at-a-time edit loop
+interactive development mostly consists of. Implementing genuine
+cross-reload debouncing (coalescing multiple queued `{leaf_change, _}`
+messages arriving within a short window into one combined sweep) would
+require the worker to peek ahead in its own mailbox or add a delay/timer
+state machine — meaningfully more complexity than this proactively-filed,
+non-urgent finding currently justifies, mirroring BT-2798's own "quantify,
+document, defer" resolution for a similarly-shaped bounded cost. Revisit if
+real-world bulk loads of deep hierarchies are reported as actually
+regressing interactive responsiveness.
+
+**Finding #2's same-reload batching is implemented** (`beamtalk_recheck:
+trigger_leaf_change/1` now takes the full list of newly-non-leaf
+superclasses from one reload event and runs a single sweep attributing
+findings to whichever of them a diagnostic names, instead of
+`maybe_trigger_leaf_change_recheck/1`'s previous one-sweep-per-superclass
+`lists:foreach`) — free today given the stdlib's one-class-per-file
+convention (0 measured benefit), but a correct, low-risk fix for any other
+reload path capable of installing multiple classes at once.
+
+No regression: `bench_recheck_fanout.escript` (BT-2781) and
+`bench_senders_xref.escript` (BT-2299) unaffected by this change (neither
+touches `trigger_leaf_change/1` or its call sites).
+
 ## Self-hosting cost: pure-BT enumeration vs native primitives (BT-2692 / BT-2708)
 
 A spike for the de-primitivization direction: how much slower is a pure-BT

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
@@ -510,10 +510,27 @@ trigger_image() ->
     end.
 
 -doc """
-BT-2856 / ADR 0107 Phase A: re-check for a `SuperclassBin` that a live
-class-body reload just made non-leaf (gained its first subclass — see
+BT-2856 / ADR 0107 Phase A: re-check for every superclass in
+`SuperclassBins` that a live class-body reload just made non-leaf (gained
+its first subclass — see
 `beamtalk_repl_loader:superclasses_losing_leaf_status/1`, the detection
 half this composes with).
+
+**BT-2873:** `SuperclassBins` is the *whole* list a single reload event
+produced (`superclasses_losing_leaf_status/1` can return more than one name
+when one reload installs several classes at once, each subclassing a
+different previously-leaf superclass) — this runs **one** whole-image sweep
+covering all of them, not one independent sweep per superclass. Each live
+class's source is compiled exactly once; a diagnostic naming any superclass
+in the batch is attributed to that specific superclass
+(`recheck_owner_for_leaf_change/3`), so the `result()`'s `findings` list can
+mix `changed_class` values when the batch has more than one entry. This
+matters because `trigger_leaf_change/1` is already "at least as expensive as
+`trigger_image/0`" per this module's own doc — paying for N independent
+whole-image sweeps when N superclasses lose leaf status in the same reload
+would multiply that cost for no benefit, since every sweep would recompile
+the exact same candidate set against the exact same (already fully updated)
+hierarchy.
 
 ## Why this exists
 
@@ -581,10 +598,10 @@ follow-up alongside BT-2798's own recorded xref extension.
 Never raises: any internal failure degrades to an empty `result()`, exactly
 like every other trigger in this module.
 """.
--spec trigger_leaf_change(binary()) -> result().
-trigger_leaf_change(SuperclassBin) ->
+-spec trigger_leaf_change([binary()]) -> result().
+trigger_leaf_change(SuperclassBins) ->
     try
-        do_trigger_leaf_change(SuperclassBin)
+        do_trigger_leaf_change(SuperclassBins)
     catch
         Class:Reason:Stack ->
             ?LOG_WARNING(
@@ -593,7 +610,7 @@ trigger_leaf_change(SuperclassBin) ->
                     error_class => Class,
                     reason => Reason,
                     stack => Stack,
-                    superclass => SuperclassBin,
+                    superclasses => SuperclassBins,
                     domain => [beamtalk, runtime]
                 }
             ),
@@ -1356,24 +1373,27 @@ retyped_names_bin(FieldChanges) ->
 -doc """
 Re-check every live class's own recorded source against the current
 (already-updated, per `trigger_leaf_change/1`'s doc) hierarchy, keeping only
-diagnostics attributable to `SuperclassBin` losing its leaf status
-(`relevant_diagnostic_leaf_change/2`). Structurally mirrors
-`do_trigger_image/0` (same source, same per-class round trip) but returns a
-`result()` — not an `image_result()` — since `checked_owners`/
+diagnostics attributable to one of `SuperclassBins` losing its leaf status
+(`relevant_diagnostic_leaf_change/2`, applied per superclass in the batch —
+see `recheck_owner_for_leaf_change/3`). Structurally mirrors
+`do_trigger_image/0` (same source, same per-class round trip, run **once**
+regardless of how many superclasses are in `SuperclassBins` — BT-2873) but
+returns a `result()` — not an `image_result()` — since `checked_owners`/
 `not_verified_owners` are what the publish path
-(`beamtalk_repl_loader:publish_leaf_change_recheck_outcome/2`) needs to
+(`beamtalk_repl_loader:publish_leaf_change_recheck_outcome/2`, called once
+per superclass in the batch against this one shared `result()`) needs to
 reuse the exact same findings-store/announcement plumbing
 `publish_shape_recheck_outcome/3` already established. There is no
 xref-derived candidate set to cap here (see `trigger_leaf_change/1`'s doc),
 so `not_checked`/`not_checked_owners` are always empty/`[]` — every live
 class with a recorded source is a candidate, unconditionally.
 """.
--spec do_trigger_leaf_change(binary()) -> result().
-do_trigger_leaf_change(SuperclassBin) ->
+-spec do_trigger_leaf_change([binary()]) -> result().
+do_trigger_leaf_change(SuperclassBins) ->
     Sources = beamtalk_workspace_meta:all_class_sources(),
     Owners = lists:keysort(1, maps:to_list(Sources)),
     Outcomes = [
-        {OwnerBin, recheck_owner_for_leaf_change(OwnerBin, Source, SuperclassBin)}
+        {OwnerBin, recheck_owner_for_leaf_change(OwnerBin, Source, SuperclassBins)}
      || {OwnerBin, Source} <- Owners
     ],
     Findings = lists:flatmap(
@@ -1397,21 +1417,28 @@ do_trigger_leaf_change(SuperclassBin) ->
 
 -doc """
 Re-check one live class's own current source for diagnostics attributable
-to `SuperclassBin` — mirrors `recheck_image_class/2`'s compiler-port call
-(same `class_hierarchy => true` diagnostics round trip, same `{ok |
-failed, ...}` degrade-on-failure contract) but filters/builds findings via
-`relevant_diagnostic_leaf_change/2` / `to_finding_leaf_change/3` instead of
-`image_finding/2`.
+to any superclass in `SuperclassBins` — mirrors `recheck_image_class/2`'s
+compiler-port call (same `class_hierarchy => true` diagnostics round trip,
+same `{ok | failed, ...}` degrade-on-failure contract) but filters/builds
+findings via `relevant_diagnostic_leaf_change/2` / `to_finding_leaf_change/3`
+instead of `image_finding/2`.
+
+**BT-2873:** one `diagnostics/3` round trip covers every superclass in the
+batch — a diagnostic that happens to name more than one batch member (not
+observed in practice; every shipped diagnostic message names exactly one
+class) contributes one finding per matching superclass, rather than picking
+just the first match, since each is an independently real, independently
+attributable finding.
 """.
--spec recheck_owner_for_leaf_change(binary(), string(), binary()) -> {ok | failed, [finding()]}.
-recheck_owner_for_leaf_change(OwnerBin, Source, SuperclassBin) ->
+-spec recheck_owner_for_leaf_change(binary(), string(), [binary()]) -> {ok | failed, [finding()]}.
+recheck_owner_for_leaf_change(OwnerBin, Source, SuperclassBins) ->
     SourceBin = unicode:characters_to_binary(Source),
     try beamtalk_compiler:diagnostics(SourceBin, <<"expression">>, #{class_hierarchy => true}) of
         {ok, Diagnostics} ->
-            Findings = [
-                to_finding_leaf_change(OwnerBin, SuperclassBin, D)
-             || D <- Diagnostics, relevant_diagnostic_leaf_change(D, SuperclassBin)
-            ],
+            Findings = lists:flatmap(
+                fun(D) -> findings_for_leaf_change_diagnostic(OwnerBin, SuperclassBins, D) end,
+                Diagnostics
+            ),
             {ok, Findings};
         {error, Reason} ->
             ?LOG_WARNING(
@@ -1433,6 +1460,14 @@ recheck_owner_for_leaf_change(OwnerBin, Source, SuperclassBin) ->
             ),
             {failed, []}
     end.
+
+-spec findings_for_leaf_change_diagnostic(binary(), [binary()], map()) -> [finding()].
+findings_for_leaf_change_diagnostic(OwnerBin, SuperclassBins, Diagnostic) ->
+    [
+        to_finding_leaf_change(OwnerBin, SuperclassBin, Diagnostic)
+     || SuperclassBin <- SuperclassBins,
+        relevant_diagnostic_leaf_change(Diagnostic, SuperclassBin)
+    ].
 
 -doc """
 Is `Diagnostic` attributable to `SuperclassBin` losing its leaf status? A

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -192,12 +192,12 @@ load_class_module(ClassInfo, Expression, State) ->
     %% beamtalk_workspace_shape_store's moduledoc "Two-phase capture" for why
     %% this must run before code:load_binary, not after.
     prime_shape_capture(Classes),
-    %% BT-2856 / ADR 0107 Phase A: same "before code:load_binary" ordering
-    %% requirement as prime_shape_capture/1 above — see activate_module/4's
-    %% doc.
-    NewlyNonLeafSuperclasses = superclasses_losing_leaf_status(Classes),
-    case code:load_binary(ClassModName, "", Binary) of
-        {module, ClassModName} ->
+    %% BT-2856 / ADR 0107 Phase A, BT-2873 hardening: load_class_binary/4
+    %% bakes the "superclasses_losing_leaf_status/1 before code:load_binary/3"
+    %% ordering requirement into one call — see its own doc and
+    %% activate_module/4's doc for why.
+    case load_class_binary(ClassModName, "", Binary, Classes) of
+        {ok, NewlyNonLeafSuperclasses} ->
             activate_module(ClassModName, Classes, undefined, NewlyNonLeafSuperclasses),
             NewState1 = maybe_add_loaded_module(ClassModName, State),
             {ClassName, NewState2} = store_class_sources(
@@ -232,6 +232,41 @@ reload_method_definition(MethodInfo, Warnings, Expression, State) ->
             recompile_with_method(
                 ClassSource, MethodInfo, Expression, Warnings, State
             )
+    end.
+
+-doc """
+BT-2873 (ADR 0107 Phase A caller-discipline hardening, BT-2856 adversarial
+review finding #3): load a class-defining module's compiled `Binary` and
+compute `superclasses_losing_leaf_status/1` against `Classes` in the one
+required order, as a single call.
+
+Every generated class module's `on_load` hook (`register_class/0`,
+BT-1610) runs **synchronously inside** `code:load_binary/3` and registers
+any new subclass link before that call returns — so
+`superclasses_losing_leaf_status/1` MUST run against `Classes` *before*
+`code:load_binary/3`, never after (`activate_module/4`'s doc has the full
+mechanism). Every one of today's four class-defining call sites
+(`load_class_module/3`, `load_compiled_module/6`,
+`reload_compile_and_load/4`, `new_class_install/7`) already followed this
+exact two-step sequence by convention alone, with nothing enforcing it —
+this collapses the two steps into one call so a future call site (or a
+refactor of an existing one) cannot obtain a `{module, ModuleName}` result
+without `superclasses_losing_leaf_status/1` having already run first: there
+is no way to call this function and skip that step, unlike calling
+`code:load_binary/3` directly ever again would allow.
+
+Returns `{ok, NewlyNonLeafSuperclasses}` — feed straight into
+`activate_module/4`'s fourth argument — on a successful load, or
+`{error, Reason}` (the load itself failed; nothing installed, nothing to
+re-check) otherwise.
+""".
+-spec load_class_binary(atom(), string(), binary(), [map()]) ->
+    {ok, [binary()]} | {error, term()}.
+load_class_binary(ModuleName, LoadPath, Binary, Classes) ->
+    NewlyNonLeafSuperclasses = superclasses_losing_leaf_status(Classes),
+    case code:load_binary(ModuleName, LoadPath, Binary) of
+        {module, ModuleName} -> {ok, NewlyNonLeafSuperclasses};
+        {error, Reason} -> {error, Reason}
     end.
 
 -doc """
@@ -446,10 +481,9 @@ load_compiled_module(Binary, ClassNames, ModuleName, Source, SourcePath, State) 
         end,
     %% ADR 0105 Phase 2 (BT-2780): see load_class_module/3's identical comment.
     prime_shape_capture(ClassNames),
-    %% BT-2856 / ADR 0107 Phase A: see activate_module/4's doc.
-    NewlyNonLeafSuperclasses = superclasses_losing_leaf_status(ClassNames),
-    case code:load_binary(ModuleName, LoadPath, Binary) of
-        {module, ModuleName} ->
+    %% BT-2856 / ADR 0107 Phase A, BT-2873 hardening: see load_class_binary/4's doc.
+    case load_class_binary(ModuleName, LoadPath, Binary, ClassNames) of
+        {ok, NewlyNonLeafSuperclasses} ->
             activate_module(ModuleName, ClassNames, SourcePath, NewlyNonLeafSuperclasses),
             NewState1 = maybe_add_loaded_module(ModuleName, State),
             NewState2 = track_module_source(ModuleName, SourcePath, NewState1),
@@ -694,10 +728,10 @@ reload_compile_and_load(Source, Path, ModuleNameOverride, ExpectedClassName) ->
                     %% (the subsequent capture/1 always diffs an unchanged
                     %% shape to itself, `no_op`).
                     prime_shape_capture(ClassNames),
-                    %% BT-2856 / ADR 0107 Phase A: see activate_module/4's doc.
-                    NewlyNonLeafSuperclasses = superclasses_losing_leaf_status(ClassNames),
-                    case code:load_binary(ModuleName, Path, Binary) of
-                        {module, ModuleName} ->
+                    %% BT-2856 / ADR 0107 Phase A, BT-2873 hardening: see
+                    %% load_class_binary/4's doc.
+                    case load_class_binary(ModuleName, Path, Binary, ClassNames) of
+                        {ok, NewlyNonLeafSuperclasses} ->
                             activate_module(ModuleName, ClassNames, Path, NewlyNonLeafSuperclasses),
                             {ok, ClassNames};
                         {error, Reason} ->
@@ -1415,10 +1449,9 @@ new_class_validate_and_install(Source, TargetPath, AbsPath, Binary, ClassNames, 
     string(), string(), string(), binary(), [map()], atom(), binary()
 ) -> {ok, [#beamtalk_object{}]} | {error, #beamtalk_error{}}.
 new_class_install(Source, TargetPath, AbsPath, Binary, ClassNames, ModuleName, DeclaredName) ->
-    %% BT-2856 / ADR 0107 Phase A: see activate_module/4's doc.
-    NewlyNonLeafSuperclasses = superclasses_losing_leaf_status(ClassNames),
-    case code:load_binary(ModuleName, AbsPath, Binary) of
-        {module, ModuleName} ->
+    %% BT-2856 / ADR 0107 Phase A, BT-2873 hardening: see load_class_binary/4's doc.
+    case load_class_binary(ModuleName, AbsPath, Binary, ClassNames) of
+        {ok, NewlyNonLeafSuperclasses} ->
             activate_module(ModuleName, ClassNames, AbsPath, NewlyNonLeafSuperclasses),
             %% Record class source so subsequent `>>` / compile:source: patches
             %% against the new class resolve their span (mirrors the file-load path).
@@ -2467,27 +2500,46 @@ spawn_leaf_change_recheck(NewlyNonLeafSuperclasses) ->
     beamtalk_workspace_shape_recheck_worker:enqueue_leaf_change(NewlyNonLeafSuperclasses).
 
 -doc """
-Run the leaf-change re-check for every superclass in `Superclasses` and
-publish each one's findings. Reached in production only via
-`beamtalk_workspace_shape_recheck_worker`'s queue (mirrors
-`maybe_trigger_shape_recheck/1` exactly — see its doc — which is also why
-this is exported outside the `-ifdef(TEST)` block, same reason: the worker
-lives in a different module).
+Run the leaf-change re-check for `Superclasses` — the *whole* list one
+reload event produced — and publish each superclass's own findings.
+Reached in production only via `beamtalk_workspace_shape_recheck_worker`'s
+queue (mirrors `maybe_trigger_shape_recheck/1` exactly — see its doc — which
+is also why this is exported outside the `-ifdef(TEST)` block, same reason:
+the worker lives in a different module).
+
+**BT-2873:** `beamtalk_recheck:trigger_leaf_change/1` runs **one** shared
+whole-image sweep covering every superclass in `Superclasses` (never raises
+— see its own doc), instead of one independent sweep per superclass
+(`spawn_leaf_change_recheck/1`'s doc explains why paying for N sweeps when
+N superclasses transition in the same reload was wasteful: every sweep
+would recompile the identical candidate set against the identical,
+already-updated hierarchy). Publishing still happens once per superclass
+(`publish_leaf_change_recheck_outcome/2` filters the shared result's
+findings down to just the ones attributed to its own superclass), preserving
+the existing one-`'ReloadCheckCompleted'`-announcement-per-superclass
+contract every consumer already relies on — each publish call is
+independently try/catch-wrapped so a failure publishing one superclass's
+outcome cannot prevent another's from being published.
 """.
 -spec maybe_trigger_leaf_change_recheck([binary()]) -> ok.
+maybe_trigger_leaf_change_recheck([]) ->
+    ok;
 maybe_trigger_leaf_change_recheck(Superclasses) ->
-    lists:foreach(fun maybe_trigger_leaf_change_recheck_for_class/1, Superclasses),
+    Result = beamtalk_recheck:trigger_leaf_change(Superclasses),
+    lists:foreach(
+        fun(SuperclassBin) -> publish_leaf_change_recheck_outcome_safe(SuperclassBin, Result) end,
+        Superclasses
+    ),
     ok.
 
--spec maybe_trigger_leaf_change_recheck_for_class(binary()) -> ok.
-maybe_trigger_leaf_change_recheck_for_class(SuperclassBin) ->
+-spec publish_leaf_change_recheck_outcome_safe(binary(), beamtalk_recheck:result()) -> ok.
+publish_leaf_change_recheck_outcome_safe(SuperclassBin, Result) ->
     try
-        Result = beamtalk_recheck:trigger_leaf_change(SuperclassBin),
         publish_leaf_change_recheck_outcome(SuperclassBin, Result)
     catch
         Class:Reason:Stack ->
             ?LOG_WARNING(
-                "Leaf-change re-check trigger failed (reload unaffected)",
+                "Leaf-change re-check publish failed (reload unaffected)",
                 #{
                     error_class => Class,
                     reason => Reason,
@@ -2500,13 +2552,25 @@ maybe_trigger_leaf_change_recheck_for_class(SuperclassBin) ->
     end.
 
 -doc """
-Publish a leaf-change re-check's outcome — mirrors
+Publish a leaf-change re-check's outcome for `SuperclassBin` — mirrors
 `publish_shape_recheck_outcome/3`'s store-write/announce shape, reusing the
 exact same findings-store and `'ReloadCheckCompleted'` announcement schema
 so every existing surface renders a leaf-change finding without new wiring.
 `changedSelector` carries `SuperclassBin` itself (there is no single call
 site selector this is "about" — same reasoning `finding()`'s doc already
 gives for `shape_change`).
+
+**BT-2873:** `Result` may be a *shared* outcome covering several
+superclasses at once (`maybe_trigger_leaf_change_recheck/1`'s batched
+sweep) — `Findings` is filtered down to just the ones whose own
+`changed_class` is `SuperclassBin` before anything else runs, so a finding
+attributed to a sibling superclass in the same batch never leaks into this
+superclass's findings-store origin or announcement. `CheckedOwners`/
+`Checked`/`NotChecked`/`CapNote` are **not** filtered — they describe the
+one shared diagnostics sweep itself (identical for every superclass in the
+batch, since it is literally the same round trip), matching exactly what an
+unbatched single-superclass sweep would have reported for this superclass
+alone.
 
 Unlike `publish_shape_recheck_outcome/3`, the announce is gated on
 `Findings` being non-empty alone, not on `CheckedOwners` alone: a superclass
@@ -2523,12 +2587,13 @@ this reload's re-check comes back clean.
 publish_leaf_change_recheck_outcome(SuperclassBin, Result) ->
     #{
         checked_owners := CheckedOwners,
-        findings := Findings,
+        findings := AllFindings,
         checked := Checked,
         not_checked := NotChecked,
         cap_note := CapNote,
         not_verified_owners := NotVerifiedOwners
     } = Result,
+    Findings = [F || F <- AllFindings, maps:get(changed_class, F) =:= SuperclassBin],
     lists:foreach(
         fun(OwnerBin) ->
             OwnerFindings = [F || F <- Findings, maps:get(owner, F) =:= OwnerBin],

--- a/runtime/perf/bench_leaf_change_fanout.escript
+++ b/runtime/perf/bench_leaf_change_fanout.escript
@@ -1,0 +1,194 @@
+#!/usr/bin/env escript
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Benchmark: leaf-change re-check fan-out (ADR 0107 Phase A, BT-2856 follow-up,
+%% BT-2873).
+%%
+%% Measures whether `beamtalk_recheck:trigger_leaf_change/1`'s "recompile
+%% every live class" sweep (fired automatically once per distinct superclass
+%% that gains its first subclass, via
+%% `beamtalk_repl_loader:maybe_trigger_leaf_change_recheck/1`) is a real cost
+%% concern for a bulk `:load dir` of a project with a deep class hierarchy,
+%% following BT-2781's "measure, then decide" methodology
+%% (`bench_recheck_fanout.escript`).
+%%
+%% Two parts:
+%%
+%%   Part A ("real hierarchy shape") — walks the full loaded stdlib class
+%%   hierarchy and counts how many classes have at least one direct
+%%   subclass. Every such class underwent exactly one leaf -> non-leaf
+%%   transition the first time its first subclass was loaded — so this count
+%%   is the exact number of `trigger_leaf_change/1` sweeps a from-scratch
+%%   bulk load of this workspace already fires today. Also checks finding #2
+%%   (BT-2873): whether any single source file declares more than one class,
+%%   since a single-class-per-file convention means a single reload/activate
+%%   event can never make *two* superclasses newly-non-leaf at once (the
+%%   scenario `maybe_trigger_leaf_change_recheck/1`'s per-superclass
+%%   `lists:foreach` pays N independent sweeps for).
+%%
+%%   Part B ("sweep cost vs. live-class count") — drives the real
+%%   `beamtalk_recheck:trigger_leaf_change/1` orchestration (real compiler
+%%   port, real `beamtalk_workspace_meta`) with a synthetic set of N live
+%%   class sources (5/20/50/100/200), to measure the sweep's wall-clock cost
+%%   as a function of workspace size (it re-checks every live class with a
+%%   recorded source, so this should be linear in N per the module's own
+%%   documented "at least as expensive as trigger_image/0" claim).
+%%
+%% Run from the `runtime/` directory after `just build`:
+%%
+%%   escript perf/bench_leaf_change_fanout.escript
+
+-mode(compile).
+
+main(_) ->
+    code:add_pathsa(filelib:wildcard("_build/default/lib/*/ebin")),
+    code:add_pathsa(filelib:wildcard("apps/*/ebin")),
+    {ok, _} = application:ensure_all_started(compiler),
+    {ok, _} = application:ensure_all_started(beamtalk_compiler),
+    {ok, _} = application:ensure_all_started(beamtalk_runtime),
+    timer:sleep(500),
+    lists:foreach(
+        fun(Beam) ->
+            Mod = list_to_atom(filename:basename(Beam, ".beam")),
+            code:ensure_loaded(Mod)
+        end,
+        filelib:wildcard("apps/beamtalk_stdlib/ebin/bt@stdlib@*.beam")
+    ),
+    timer:sleep(1500),
+
+    part_a_real_hierarchy_shape(),
+    part_b_sweep_cost_vs_size(),
+    ok.
+
+%%====================================================================
+%% Part A: real stdlib hierarchy shape
+%%====================================================================
+
+part_a_real_hierarchy_shape() ->
+    io:format("~n=== Part A: real hierarchy shape (loaded stdlib) ===~n", []),
+    Classes = beamtalk_class_registry:live_class_entries(),
+    ClassNames = [Name || {Name, _Mod, _Pid} <- Classes],
+    io:format("Workspace: ~p loaded classes~n", [length(ClassNames)]),
+
+    NonLeaf = [
+        Name
+     || Name <- ClassNames, beamtalk_class_registry:direct_subclasses(Name) =/= []
+    ],
+    io:format(
+        "Classes with >= 1 direct subclass (each is exactly one\n"
+        "trigger_leaf_change/1 sweep during a from-scratch bulk load): ~p of ~p (~.1f%)~n",
+        [length(NonLeaf), length(ClassNames), 100 * length(NonLeaf) / max(1, length(ClassNames))]
+    ),
+
+    %% finding #2 (BT-2873): can one source file declare more than one class?
+    %% If not, no single reload/activate_module event can make two
+    %% superclasses newly-non-leaf at once, so
+    %% maybe_trigger_leaf_change_recheck/1's per-superclass foreach never
+    %% pays for more than one sweep per reload in practice.
+    BtFiles = filelib:wildcard("../stdlib/src/**/*.bt"),
+    PerFileClassCounts = [
+        {File, count_subclass_decls(File)}
+     || File <- BtFiles
+    ],
+    MultiClassFiles = [FC || {_File, N} = FC <- PerFileClassCounts, N > 1],
+    io:format(
+        "~nSource files declaring more than one class: ~p of ~p~n",
+        [length(MultiClassFiles), length(PerFileClassCounts)]
+    ),
+    lists:foreach(
+        fun({File, N}) -> io:format("  ~s: ~p classes~n", [File, N]) end,
+        MultiClassFiles
+    ),
+    ok.
+
+%% Counts real `subclass:` declarations only — stdlib doc comments (`///`
+%% lines) routinely show hypothetical subclass examples (e.g. `Actor.bt`
+%% documents `/// Actor subclass: Counter`) that are not actual class
+%% definitions and must not be counted as such.
+-spec count_subclass_decls(string()) -> non_neg_integer().
+count_subclass_decls(File) ->
+    case file:read_file(File) of
+        {ok, Bin} ->
+            Lines = binary:split(Bin, <<"\n">>, [global]),
+            CodeLines = [L || L <- Lines, not is_doc_comment_line(L)],
+            {ok, Re} = re:compile("\\bsubclass:"),
+            length([L || L <- CodeLines, re:run(L, Re) =/= nomatch]);
+        {error, _} ->
+            0
+    end.
+
+-spec is_doc_comment_line(binary()) -> boolean().
+is_doc_comment_line(Line) ->
+    case re:run(Line, "^\\s*///") of
+        {match, _} -> true;
+        nomatch -> false
+    end.
+
+%%====================================================================
+%% Part B: sweep cost vs. live-class count
+%%====================================================================
+
+part_b_sweep_cost_vs_size() ->
+    io:format("~n=== Part B: trigger_leaf_change/1 sweep cost vs. live-class count ===~n", []),
+    restart_workspace_meta(),
+
+    Sizes = [5, 20, 50, 100, 200],
+    io:format("~-10s ~-10s ~-12s ~-14s~n", ["size", "checked", "wall_ms", "ms/checked"]),
+    lists:foreach(fun run_round/1, Sizes),
+    ok.
+
+restart_workspace_meta() ->
+    case whereis(beamtalk_workspace_meta) of
+        undefined ->
+            {ok, _} = beamtalk_workspace_meta:start_link(#{
+                workspace_id => <<"bench_leaf_change_fanout_ws">>,
+                project_path => undefined,
+                created_at => erlang:system_time(second),
+                repl => false
+            }),
+            ok;
+        _Pid ->
+            ok
+    end.
+
+%% One round: register N synthetic live class sources (round-scoped names, so
+%% rounds accumulate rather than interfere -- trigger_leaf_change/1 sweeps
+%% *every* live class with a recorded source, so this models a workspace that
+%% has grown to size N through a bulk load), then time a real
+%% trigger_leaf_change/1 sweep for a superclass name none of the sources
+%% mention (so every diagnostic round-trip completes clean -- this measures
+%% sweep cost, not finding-production cost, matching trigger_image/0's own
+%% "checked" semantics).
+-spec run_round(pos_integer()) -> ok.
+run_round(N) ->
+    Tag = integer_to_list(N),
+    PrevCount = maps:size(beamtalk_workspace_meta:all_class_sources()),
+    ToAdd = N - PrevCount,
+    lists:foreach(
+        fun(I) -> register_candidate("BenchLeafCand" ++ Tag ++ "_" ++ integer_to_list(I)) end,
+        lists:seq(1, max(0, ToAdd))
+    ),
+    %% BT-2873: trigger_leaf_change/1 takes the whole superclass list from one
+    %% reload event (a single-element list here -- the batching win itself is
+    %% covered by Part A's "0 of 104 files declare more than one class"
+    %% finding, not by this sweep-cost-vs-size measurement).
+    SuperclassBins = [<<"BenchLeafUnrelatedSuperclass">>],
+    {WallUs, Result} = timer:tc(fun() ->
+        beamtalk_recheck:trigger_leaf_change(SuperclassBins)
+    end),
+    #{checked := Checked} = Result,
+    WallMs = WallUs / 1000,
+    MsPerChecked =
+        case Checked of
+            0 -> 0.0;
+            _ -> WallMs / Checked
+        end,
+    io:format("~10p ~10p ~12.2f ~14.2f~n", [N, Checked, WallMs, MsPerChecked]).
+
+-spec register_candidate(string()) -> ok.
+register_candidate(NameStr) ->
+    NameBin = list_to_binary(NameStr),
+    Source = <<"Object subclass: ", NameBin/binary, "\n  go: -> Integer => 1\n">>,
+    ok = beamtalk_workspace_meta:set_class_source(NameBin, Source),
+    ok.

--- a/runtime/perf/bench_leaf_change_fanout.escript
+++ b/runtime/perf/bench_leaf_change_fanout.escript
@@ -87,8 +87,9 @@ part_a_real_hierarchy_shape() ->
     %% maybe_trigger_leaf_change_recheck/1's per-superclass foreach never
     %% pays for more than one sweep per reload in practice.
     BtFiles = filelib:wildcard("../stdlib/src/**/*.bt"),
+    {ok, SubclassRe} = re:compile("\\bsubclass:"),
     PerFileClassCounts = [
-        {File, count_subclass_decls(File)}
+        {File, count_subclass_decls(File, SubclassRe)}
      || File <- BtFiles
     ],
     MultiClassFiles = [FC || {_File, N} = FC <- PerFileClassCounts, N > 1],
@@ -105,15 +106,16 @@ part_a_real_hierarchy_shape() ->
 %% Counts real `subclass:` declarations only — stdlib doc comments (`///`
 %% lines) routinely show hypothetical subclass examples (e.g. `Actor.bt`
 %% documents `/// Actor subclass: Counter`) that are not actual class
-%% definitions and must not be counted as such.
--spec count_subclass_decls(string()) -> non_neg_integer().
-count_subclass_decls(File) ->
+%% definitions and must not be counted as such. `SubclassRe` is compiled once
+%% by the caller and reused across every file, rather than recompiled per
+%% call.
+-spec count_subclass_decls(string(), re:mp()) -> non_neg_integer().
+count_subclass_decls(File, SubclassRe) ->
     case file:read_file(File) of
         {ok, Bin} ->
             Lines = binary:split(Bin, <<"\n">>, [global]),
             CodeLines = [L || L <- Lines, not is_doc_comment_line(L)],
-            {ok, Re} = re:compile("\\bsubclass:"),
-            length([L || L <- CodeLines, re:run(L, Re) =/= nomatch]);
+            length([L || L <- CodeLines, re:run(L, SubclassRe) =/= nomatch]);
         {error, _} ->
             0
     end.


### PR DESCRIPTION
## Summary

Follow-up from BT-2856's adversarial code review (ADR 0107 Phase A leaf-change re-check). Investigates and resolves the three findings tracked in BT-2873:

- **Finding #1 (bulk-load fan-out cost):** benchmarked with a new harness, `runtime/perf/bench_leaf_change_fanout.escript`. On the loaded stdlib (104 classes), 17 classes have >= 1 direct subclass, so a from-scratch bulk load fires 17 independent `trigger_leaf_change/1` sweeps at ~34-43 ms/candidate — projecting ~25-60s of serialized, off-response-path background compiler-port work. **Decision: not implemented now** — the cost is real but bounded, async, and self-healing (no lost findings, unlike BT-2798's xref finding), so cross-reload debouncing is deferred per BT-2798's own "quantify, document, defer" precedent. Full write-up in `docs/development/benchmarks.md`.
- **Finding #2 (same-reload batching):** `beamtalk_recheck:trigger_leaf_change/1` now takes the full list of newly-non-leaf superclasses from one reload event and runs a single shared sweep, instead of `maybe_trigger_leaf_change_recheck/1`'s previous one-sweep-per-superclass loop. Zero measured benefit today (stdlib's one-class-per-file convention means this never fires in practice), but a correct, low-risk fix for any reload path capable of installing multiple classes at once (e.g. a REPL paste).
- **Finding #3 (caller-discipline hardening):** added `beamtalk_repl_loader:load_class_binary/4`, combining `superclasses_losing_leaf_status/1` + `code:load_binary/3` into one call so a future 5th class-defining call site can't silently reintroduce the ordering bug the moduledoc describes. All four existing call sites (`load_class_module/3`, `load_compiled_module/6`, `reload_compile_and_load/4`, `new_class_install/7`) now go through this wrapper.

## Test plan

- [x] `just build` / `just clippy` clean
- [x] `beamtalk_recheck_tests` (64 tests) and `beamtalk_repl_loader_leaf_change_recheck_tests` (8 tests) pass
- [x] Full `beamtalk_workspace` eunit suite (2512 tests, 0 failures)
- [x] `just test` (Rust + stdlib + BUnit + runtime tests) passes
- [x] `just ci-changed` (build, lint, dialyzer, fmt, full test suite, corpus check, surface-parity check) passes
- [x] New benchmark re-run against the batched implementation — no regression vs. the pre-change measurement

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0136nfJ8ZhPruftN4baYfuzR

---
_Generated by [Claude Code](https://claude.ai/code/session_0136nfJ8ZhPruftN4baYfuzR)_