### PR TITLE
Boolean is abstract but not sealed — close the ifTrue:/ifFalse: solo-inference soundness gap (BT-2886)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
@@ -733,7 +733,7 @@ pub(super) fn generated_builtin_classes() -> HashMap<EcoString, ClassInfo> {
         ClassInfo {
             name: "Boolean".into(),
             superclass: Some("Value".into()),
-            is_sealed: false,
+            is_sealed: true,
             is_abstract: true,
             is_typed: false,
             is_internal: false,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -4080,6 +4080,20 @@ impl TypeChecker {
     /// type, `class_name` isn't `Boolean`, or the stdlib contract this
     /// function relies on no longer matches, so the caller falls back to the
     /// generic Dynamic classification for those cases.
+    ///
+    /// Soundness also depends on a second, closed-world assumption that this
+    /// function does *not* verify structurally: that `True` and `False` are
+    /// the *only* concrete classes that can appear at runtime under a
+    /// `Boolean`-typed receiver. That's what makes the "self branch returns
+    /// `Boolean`" reasoning above valid — if a third subclass existed and
+    /// overrode `ifTrue:`/`ifFalse:` to return something outside `True |
+    /// False | R`, the inferred union here would be unsound for it. This is
+    /// enforced by `Boolean` being declared `sealed` in `stdlib/src/Boolean.bt`
+    /// (BT-2886), which closes it to exactly its two existing `sealed`
+    /// subclasses, `True` and `False`. Unlike the `ifNil:`/`ifNotNil:`
+    /// self-branch check above, there's no `hierarchy.find_method(...)` guard
+    /// for this half of the assumption — it relies on the parser/semantic
+    /// analysis rejecting any attempt to subclass a `sealed` class.
     fn if_true_false_solo_boolean_ret_ty(
         selector_name: &str,
         class_name: &str,

--- a/stdlib/src/Boolean.bt
+++ b/stdlib/src/Boolean.bt
@@ -5,6 +5,8 @@
 ///
 /// Provides shared boolean protocol. Cannot be instantiated directly.
 /// In the stdlib, True and False are the concrete boolean subclasses.
+/// Sealed: user code cannot add further subclasses, so True and False
+/// are guaranteed to be the only concrete classes under Boolean (BT-2886).
 ///
 /// ## Examples
 /// ```beamtalk
@@ -13,7 +15,7 @@
 /// true and: [false]       // => false
 /// false or: [true]        // => true
 /// ```
-abstract Value subclass: Boolean
+abstract sealed Value subclass: Boolean
 
   // === Abstract protocol (subclasses must implement) ===
 


### PR DESCRIPTION
https://linear.app/beamtalk/issue/BT-2886

## Summary

Follow-up from the adversarial code review pass on BT-2868 (solo `ifTrue:`/`ifFalse:` on `Boolean` infers `Boolean | R`).

`if_true_false_solo_boolean_ret_ty` infers a solo `ifTrue:`/`ifFalse:` send on a `Boolean`-typed receiver as `Boolean | R`, which is sound only if `True` and `False` are the only concrete classes that can appear under a `Boolean`-typed receiver at runtime. `Boolean` was `abstract` but not `sealed`, so nothing structurally enforced that closed-world assumption.

Implements Option 1 from the issue (the preferred fix): seal `Boolean`.

- `stdlib/src/Boolean.bt`: `abstract Value subclass: Boolean` → `abstract sealed Value subclass: Boolean`, closing it to its two existing sealed subclasses, `True` and `False`.
- `crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs`: documented the closed-world assumption in `if_true_false_solo_boolean_ret_ty`'s doc comment and how it's now structurally satisfied.
- `generated_builtins.rs` regenerated via `just build` to reflect `is_sealed: true` for `Boolean`.

No behavior change to the inference logic itself — this is purely a soundness-guarantee fix, per the issue's acceptance criteria.

## Test plan

- [x] `just ci-changed` passes (Rust, stdlib, BUnit 2766 tests, Erlang runtime 5320+1584 tests, clippy, dialyzer, formatting, corpus, surface-drift)
- [x] Verified no code subclasses `Boolean` directly outside `True`/`False`, so sealing introduces no breakage
- [x] Sealed-subclass rejection is covered by existing generic tests (`sealed Object subclass: Foo` pattern), so no Boolean-specific test was needed