### PR TITLE
refactor: use existing to_binary/1 helper at 5 inline-duplicate sites

### DIFF
--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
@@ -213,11 +213,7 @@ found or the source cannot be parsed.
 findSendersIn(Source, Selector) when
     is_binary(Source), (is_atom(Selector) orelse is_binary(Selector))
 ->
-    SelectorBin =
-        case Selector of
-            A when is_atom(A) -> atom_to_binary(A, utf8);
-            B when is_binary(B) -> B
-        end,
+    SelectorBin = to_binary(Selector),
     case beamtalk_compiler:find_senders_in_source(Source, SelectorBin) of
         {ok, Lines} ->
             Lines;
@@ -358,11 +354,7 @@ found or the source cannot be parsed.
 findReferencesToIn(Source, ClassName) when
     is_binary(Source), (is_atom(ClassName) orelse is_binary(ClassName))
 ->
-    ClassNameBin =
-        case ClassName of
-            A when is_atom(A) -> atom_to_binary(A, utf8);
-            B when is_binary(B) -> B
-        end,
+    ClassNameBin = to_binary(ClassName),
     case beamtalk_compiler:find_references_to_in_source(Source, ClassNameBin) of
         {ok, Lines} ->
             Lines;
@@ -439,11 +431,7 @@ logged and degraded to `[]` rather than aborting the caller's whole iteration.
 find_field_access(Source, Field, Kind, Selector) when
     is_binary(Source), (is_atom(Field) orelse is_binary(Field))
 ->
-    IVarBin =
-        case Field of
-            A when is_atom(A) -> atom_to_binary(A, utf8);
-            B when is_binary(B) -> B
-        end,
+    IVarBin = to_binary(Field),
     Result =
         case Kind of
             readers -> beamtalk_compiler:find_field_readers_in_source(Source, IVarBin);
@@ -649,11 +637,7 @@ handle_erlang_help(_ModuleArg) ->
 handle_erlang_help(ModuleBin, SelectorArg) when
     is_binary(ModuleBin), (is_atom(SelectorArg) orelse is_binary(SelectorArg))
 ->
-    FunctionBin =
-        case SelectorArg of
-            A when is_atom(A) -> atom_to_binary(A, utf8);
-            B when is_binary(B) -> B
-        end,
+    FunctionBin = to_binary(SelectorArg),
     try binary_to_existing_atom(ModuleBin, utf8) of
         Module ->
             case beamtalk_erlang_help:format_function_help(Module, FunctionBin) of
@@ -1278,11 +1262,7 @@ group_by_class(Methods) ->
 -doc "Build a structured error for a class not found.".
 -spec make_class_not_found_error(atom() | binary()) -> #beamtalk_error{}.
 make_class_not_found_error(ClassName) ->
-    NameBin =
-        case ClassName of
-            A when is_atom(A) -> atom_to_binary(A, utf8);
-            B when is_binary(B) -> B
-        end,
+    NameBin = to_binary(ClassName),
     Err0 = beamtalk_error:new(class_not_found, 'BeamtalkInterface'),
     Err1 = beamtalk_error:with_message(
         Err0,


### PR DESCRIPTION
## Summary

`beamtalk_interface.erl` already defines a private `to_binary/1` helper (lines 529–531 before this change) that normalises `atom() | binary()` arguments to `binary()`. It was called correctly in `ffiSitesIn/4`, but five other functions in the same file copy-pasted the identical three-line `case` expression inline instead of calling the helper.

This PR replaces all five inline copies with a single call to `to_binary/1`:

| Function | Inline variable replaced |
|---|---|
| `findSendersIn/2` | `SelectorBin` |
| `findReferencesToIn/2` | `ClassNameBin` |
| `find_field_access/4` | `IVarBin` |
| `handle_erlang_help/2` | `FunctionBin` |
| `make_class_not_found_error/1` | `NameBin` |

## Changes

- **Single file:** `runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl`
- **-25 lines / +5 lines** — net -20 lines, zero behaviour change
- No new helpers, no interface changes, no API impact

## Testing

- `just build` ✅
- `just test` ✅ (223 stdlib, 2764 BUnit, 6904 runtime tests — all pass)
- `just clippy` ✅
- `just dialyzer` ✅ — spec `atom() | binary() -> binary()` unchanged
- `erlfmt --check` ✅
- Pre-push hook (full CI) ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_0181noEDHDQTH7SRe98CD65H)_