### PR TITLE
refactor(tests): tighten placeholder assertions in nil-and-type-patterns.btscript

### DIFF
--- a/tests/repl-protocol/cases/nil-and-type-patterns.btscript
+++ b/tests/repl-protocol/cases/nil-and-type-patterns.btscript
@@ -19,7 +19,7 @@
 // ===========================================================================
 
 workspaceRoot := nil
-// => _
+// => nil
 
 workspaceRoot match: [
   nil -> "default_root";
@@ -29,7 +29,7 @@ workspaceRoot match: [
 // => default_root
 
 configuredRoot := "/custom/workspace"
-// => _
+// => /custom/workspace
 
 configuredRoot match: [
   nil -> "default_root";
@@ -44,7 +44,7 @@ configuredRoot match: [
 // ===========================================================================
 
 coll := nil
-// => _
+// => nil
 
 coll match: [
   nil -> "none";
@@ -54,7 +54,7 @@ coll match: [
 // => none
 
 populatedColl := #(1, 2, 3)
-// => _
+// => [1,2,3]
 
 populatedColl match: [
   nil -> "none";


### PR DESCRIPTION
## Summary

Replace 4 wildcard `// => _` assertions in `tests/repl-protocol/cases/nil-and-type-patterns.btscript` with their deterministic expected values. These expressions always produce the same output; the wildcards were hiding real values and reducing the diagnostic value of the test.

| Expression | Before | After |
|---|---|---|
| `workspaceRoot := nil` | `// => _` | `// => nil` |
| `configuredRoot := "/custom/workspace"` | `// => _` | `// => /custom/workspace` |
| `coll := nil` | `// => _` | `// => nil` |
| `populatedColl := #(1, 2, 3)` | `// => _` | `// => [1,2,3]` |

**Evidence for each expected value:**
- `nil` return format: confirmed by `Tracing disable // => nil` in `tracing.btscript`, `lc stop; lc isAlive // => nil` in `named-actors.btscript`, etc.
- String display (no quotes): confirmed by `result value // => hello ffi` in `ffi_result_conversion.btscript`, `md secret // => visible` in `repl_inline_class_superclass_index.btscript`.
- Array display format `[1,2,3]`: confirmed by `#(1, 2, 3) collect: ... // => [1001,1002,1003]` in `lazy_name_resolution.btscript`.

## Test plan

- [x] `just test-repl-protocol` passes with the new assertions (all 3 suites green, exit 0)

---
_Generated by [Claude Code](https://claude.ai/code/session_013sge3wbCWvHnuW8fJW7MPm)_