### PR TITLE
Route beamtalk run's status/progress lines to stderr (BT-2702)

### DIFF
--- a/crates/beamtalk-cli/src/commands/run.rs
+++ b/crates/beamtalk-cli/src/commands/run.rs
@@ -217,7 +217,7 @@ fn prepare_eval_environment(
     selector: &str,
     args: &[String],
 ) -> Result<Vec<OsString>> {
-    println!("Building...");
+    eprintln!("Building...");
     super::build::build(
         project_root.as_str(),
         &beamtalk_core::CompilerOptions::default(),
@@ -299,7 +299,7 @@ fn run_script(
 
     let args = prepare_eval_environment(project_root, class_name, selector, program_args)?;
 
-    println!("\nRunning {class_name}>>{selector}...");
+    eprintln!("\nRunning {class_name}>>{selector}...");
 
     let mut cmd = Command::new("erl");
     cmd.arg("-noshell")
@@ -416,10 +416,10 @@ fn run_connected(
     let host = node_info.connect_host().to_string();
     let port = node_info.port;
 
-    println!("Connecting to workspace {workspace_id} (port {port})...");
+    eprintln!("Connecting to workspace {workspace_id} (port {port})...");
     let mut client = connect_with_retries(&host, port, &cookie)?;
 
-    println!("Running {class_name}>>{selector} (connected)...\n");
+    eprintln!("Running {class_name}>>{selector} (connected)...\n");
 
     // Ctrl-C interrupts the dispatched job (parity with the REPL eval path).
     let interrupted = Arc::new(AtomicBool::new(false));

--- a/crates/beamtalk-cli/tests/cli_run.rs
+++ b/crates/beamtalk-cli/tests/cli_run.rs
@@ -34,7 +34,9 @@ fn run_script_mode_invokes_class_method() {
         // BT-2702: status/progress lines go to stderr, keeping stdout clean for
         // the program's own output (the entry's return value is discarded here).
         .stdout(contains("Running Smoke>>run").not())
-        .stderr(contains("Running Smoke>>run"));
+        .stdout(contains("Building...").not())
+        .stderr(contains("Running Smoke>>run"))
+        .stderr(contains("Building..."));
 }
 
 #[test]

--- a/crates/beamtalk-cli/tests/cli_run.rs
+++ b/crates/beamtalk-cli/tests/cli_run.rs
@@ -31,7 +31,10 @@ fn run_script_mode_invokes_class_method() {
         .args(["run", "Smoke", "run"])
         .assert()
         .success()
-        .stdout(contains("Running Smoke>>run").or(contains("Smoke")));
+        // BT-2702: status/progress lines go to stderr, keeping stdout clean for
+        // the program's own output (the entry's return value is discarded here).
+        .stdout(contains("Running Smoke>>run").not())
+        .stderr(contains("Running Smoke>>run"));
 }
 
 #[test]


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2702/keep-beamtalk-run-stdout-clean-route-statusprogress-to-stderr

## Summary

BT-2702 was a `needs-spec` issue: `beamtalk run`'s human status/progress lines were written to **stdout**, interleaving with the dispatched program's own `Console` output — a problem for programmatic/piped consumers (CI scripts, tests asserting on stdout, `prog | head`). ADR 0099 frames `beamtalk run` as a real CLI-application story, so a clean stdout (program output only) matters.

## Decision

Resolved needs-spec in favor of **Option 1: route status/progress to stderr**, applied consistently to run-mode and connected mode. No new `--verbose`/`--quiet` flag — stdout is always program-output-only, matching Unix convention.

## Key changes

- `crates/beamtalk-cli/src/commands/run.rs`: `Building...` and `Running ClassName>>selector...` (`run_script` / `prepare_eval_environment`), and `Connecting to workspace...` / `Running ClassName>>selector (connected)...` (`run_connected`) now go to stderr instead of stdout.
- `crates/beamtalk-cli/tests/cli_run.rs`: `run_script_mode_invokes_class_method` now asserts stdout does **not** contain the status line and stderr does.

## Scope note

Service mode (`beamtalk run .` / `run_package_as_otp_application`) was out of scope for BT-2702 (only `run_script`/`run_connected` were listed) and still prints its status lines to stdout. Code review flagged this as a real inconsistency within the same file; filed as a follow-up: BT-2889.

## Verification

- `cargo build -p beamtalk-cli` ✓
- `cargo test -p beamtalk-cli --bins -- test_run` (11 unit tests) ✓
- `cargo test -p beamtalk-cli --test cli_run` (4 integration tests) ✓
- `just clippy` ✓
- `cargo fmt -p beamtalk-cli -- --check` ✓
- Independent multi-angle code review (correctness, removed-behavior, cross-file, reuse/simplification/efficiency/altitude/conventions) — no correctness bugs found; one consistency finding filed as BT-2889 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqXUaJgUB1CWEiCH55aCZL)_