### PR TITLE
Thread NativeTypeRegistry to return-type writeback, goto-def, and REPL completion fallback (BT-2887)

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -717,6 +717,7 @@ pub struct CompileContext<'a> {
 ///
 /// Returns an error if the module name is invalid, code generation fails,
 /// or the output file cannot be written.
+#[allow(clippy::too_many_arguments)]
 pub fn write_core_erlang_with_bindings(
     module: &beamtalk_core::ast::Module,
     module_name: &str,
@@ -725,6 +726,7 @@ pub fn write_core_erlang_with_bindings(
     bindings: &beamtalk_core::erlang::primitive_bindings::PrimitiveBindingTable,
     hierarchy: &ClassHierarchyContext,
     source: Option<(&str, Option<&str>)>,
+    native_type_registry: Option<std::sync::Arc<NativeTypeRegistry>>,
 ) -> Result<()> {
     if !is_valid_module_name(module_name) {
         miette::bail!(
@@ -748,6 +750,7 @@ pub fn write_core_erlang_with_bindings(
             .with_class_superclass_index(hierarchy.class_superclass_index.clone())
             .with_source_path_opt(source_path)
             .with_class_hierarchy(hierarchy.pre_loaded_classes.clone())
+            .with_native_type_registry(native_type_registry)
             // ADR 0098 Phase 3: bake the producing-toolchain identity into __beamtalk_meta.
             .with_provenance(
                 env!("BEAMTALK_VERSION"),
@@ -984,6 +987,7 @@ pub(crate) fn compile_source_with_bindings(
         bindings,
         &codegen_hierarchy,
         Some((&source, embed_source_path)),
+        ctx.native_type_registry.clone(),
     )
     .wrap_err_with(|| format!("Failed to generate Core Erlang for '{source_path}'"))?;
 

--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -1815,6 +1815,9 @@ fn handle_resolve_completion_type(request: &Map) -> Term {
     match beamtalk_core::queries::completion_provider::resolve_expression_type(
         &expression,
         &hierarchy,
+        // BT-2887: no NativeTypeRegistry is readily available in this REPL
+        // completion-fallback call chain.
+        None,
     ) {
         Some(class_name) => Term::from(Map::from([
             (atom("status"), atom("ok")),

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -355,6 +355,12 @@ pub struct CodegenOptions {
     /// ADR 0098 Phase 3: producing compound OTP version (`<release>-<erts>`) to
     /// bake into `__beamtalk_meta`. Set alongside `beamtalk_version`.
     otp_release: Option<String>,
+    /// BT-2887: optional FFI type registry (ADR 0075) threaded to the
+    /// return-type writeback pass so methods whose body type is inferred
+    /// purely via an FFI call (e.g. `foo => Erlang lists reverse: x`) get
+    /// `List` written back to `method_return_types` before codegen.
+    native_type_registry:
+        Option<std::sync::Arc<crate::semantic_analysis::type_checker::NativeTypeRegistry>>,
 }
 
 impl CodegenOptions {
@@ -373,6 +379,7 @@ impl CodegenOptions {
             codegen_diagnostics: None,
             beamtalk_version: None,
             otp_release: None,
+            native_type_registry: None,
         }
     }
 
@@ -474,6 +481,19 @@ impl CodegenOptions {
     #[must_use]
     pub fn with_stdlib_mode(mut self, enabled: bool) -> Self {
         self.stdlib_mode = enabled;
+        self
+    }
+
+    /// BT-2887: sets the native FFI type registry (ADR 0075) used by the
+    /// return-type writeback pass, from an optional value.
+    #[must_use]
+    pub fn with_native_type_registry(
+        mut self,
+        registry: Option<
+            std::sync::Arc<crate::semantic_analysis::type_checker::NativeTypeRegistry>,
+        >,
+    ) -> Self {
+        self.native_type_registry = registry;
         self
     }
 }
@@ -588,7 +608,11 @@ pub fn generate_module_with_warnings(
     // BT-1218: Also writeback supervisor_kind for Supervisor/DynamicSupervisor subclasses.
     // We clone to avoid mutating the caller's Module.
     let mut module_with_writeback = module.clone();
-    crate::semantic_analysis::apply_return_type_writeback(&mut module_with_writeback, &hierarchy);
+    crate::semantic_analysis::apply_return_type_writeback(
+        &mut module_with_writeback,
+        &hierarchy,
+        options.native_type_registry.as_deref(),
+    );
     crate::semantic_analysis::apply_supervisor_kind_writeback(
         &mut module_with_writeback,
         &hierarchy,

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -1595,6 +1595,7 @@ impl LanguageService for SimpleLanguageService {
                     offset.get(),
                     &selector_lookup,
                     self.project_index.hierarchy(),
+                    self.native_types.as_deref(),
                 );
             return crate::queries::definition_provider::find_method_definition_cross_file_with_receiver(
                 selector_lookup.selector_name.as_str(),

--- a/crates/beamtalk-core/src/queries/completion_provider.rs
+++ b/crates/beamtalk-core/src/queries/completion_provider.rs
@@ -1180,13 +1180,22 @@ fn deduplicate_completions(completions: &mut Vec<Completion>) {
 /// Used by the `resolve_completion_type` compiler port command to handle complex
 /// expressions that `tokenise_send_chain/1` cannot parse (parenthesised
 /// subexpressions, binary message chains, keyword sends mid-chain).
+///
+/// `native_type_registry` (BT-2887, ADR 0075) lets an expression whose type
+/// came from an FFI call resolve to its typed return. `None` when no registry
+/// is available to the caller — the `beamtalk-compiler-port` REPL completion
+/// path currently has none readily available in its call chain.
 #[must_use]
-pub fn resolve_expression_type(source: &str, hierarchy: &ClassHierarchy) -> Option<String> {
+pub fn resolve_expression_type(
+    source: &str,
+    hierarchy: &ClassHierarchy,
+    native_type_registry: Option<&NativeTypeRegistry>,
+) -> Option<String> {
     let tokens = crate::source_analysis::lex_with_eof(source);
     let (module, _diagnostics) = crate::source_analysis::parse(tokens);
     let last_expr = module.expressions.last()?;
     let span = last_expr.expression.span();
-    let type_map = crate::semantic_analysis::infer_types(&module, hierarchy, None);
+    let type_map = crate::semantic_analysis::infer_types(&module, hierarchy, native_type_registry);
     match type_map.get(span) {
         Some(InferredType::Known { class_name, .. }) => Some(class_name.to_string()),
         _ => None,
@@ -2029,53 +2038,53 @@ mod tests {
     #[test]
     fn resolve_expression_type_string_literal() {
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("\"hello\"", &hierarchy);
+        let result = resolve_expression_type("\"hello\"", &hierarchy, None);
         assert_eq!(result.as_deref(), Some("String"));
     }
     #[test]
     fn resolve_expression_type_integer_literal() {
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("42", &hierarchy);
+        let result = resolve_expression_type("42", &hierarchy, None);
         assert_eq!(result.as_deref(), Some("Integer"));
     }
     #[test]
     fn resolve_expression_type_parenthesized() {
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("(\"hello\")", &hierarchy);
+        let result = resolve_expression_type("(\"hello\")", &hierarchy, None);
         assert_eq!(result.as_deref(), Some("String"));
     }
     #[test]
     fn resolve_expression_type_binary_send() {
         // "foo" ++ "bar" should resolve to String (String#++: returns String)
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("\"foo\" ++ \"bar\"", &hierarchy);
+        let result = resolve_expression_type("\"foo\" ++ \"bar\"", &hierarchy, None);
         assert_eq!(result.as_deref(), Some("String"));
     }
     #[test]
     fn resolve_expression_type_parenthesized_binary_send() {
         // ("foo" ++ "bar") should resolve to String
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("(\"foo\" ++ \"bar\")", &hierarchy);
+        let result = resolve_expression_type("(\"foo\" ++ \"bar\")", &hierarchy, None);
         assert_eq!(result.as_deref(), Some("String"));
     }
     #[test]
     fn resolve_expression_type_chained_sends() {
         // "hello" size — String#size returns Integer
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("\"hello\" size", &hierarchy);
+        let result = resolve_expression_type("\"hello\" size", &hierarchy, None);
         assert_eq!(result.as_deref(), Some("Integer"));
     }
     #[test]
     fn resolve_expression_type_empty_source() {
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("", &hierarchy);
+        let result = resolve_expression_type("", &hierarchy, None);
         assert_eq!(result, None);
     }
     #[test]
     fn resolve_expression_type_unknown_variable() {
         // Bare variable with no bindings — type is Dynamic
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("x", &hierarchy);
+        let result = resolve_expression_type("x", &hierarchy, None);
         assert_eq!(result, None);
     }
     // --- BT-1070: parenthesised subexpression as receiver ---
@@ -2083,14 +2092,14 @@ mod tests {
     fn resolve_expression_type_parenthesized_unary_send() {
         // ("hello" size) — the result of String#size (Integer) wrapped in parens
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("(\"hello\" size)", &hierarchy);
+        let result = resolve_expression_type("(\"hello\" size)", &hierarchy, None);
         assert_eq!(result.as_deref(), Some("Integer"));
     }
     #[test]
     fn resolve_expression_type_parenthesized_unknown_variable() {
         // (myList size) — myList is untyped, graceful fallback
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("(myList size)", &hierarchy);
+        let result = resolve_expression_type("(myList size)", &hierarchy, None);
         assert_eq!(result, None);
     }
     // --- BT-1072: keyword sends mid-chain ---
@@ -2099,7 +2108,7 @@ mod tests {
         // #[1, 2, 3] collect: [:x | x * 2] — Array(E)#collect: returns Array(R)
         // BT-1576: Generic return types extract base class for completion.
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("#[1, 2, 3] collect: [:x | x * 2]", &hierarchy);
+        let result = resolve_expression_type("#[1, 2, 3] collect: [:x | x * 2]", &hierarchy, None);
         assert_eq!(result.as_deref(), Some("Array"));
     }
     #[test]
@@ -2108,16 +2117,57 @@ mod tests {
         // BT-1834: A is now resolved from the initial value argument (0 :: Integer)
         // via plain param type inference, so the return type is Integer.
         let hierarchy = ClassHierarchy::with_builtins();
-        let result =
-            resolve_expression_type("#[1, 2, 3] inject: 0 into: [:acc :x | acc + x]", &hierarchy);
+        let result = resolve_expression_type(
+            "#[1, 2, 3] inject: 0 into: [:acc :x | acc + x]",
+            &hierarchy,
+            None,
+        );
         assert_eq!(result.as_deref(), Some("Integer"));
     }
     #[test]
     fn resolve_expression_type_keyword_send_untyped_receiver_returns_none() {
         // myList collect: [...] — myList is untyped (Dynamic), graceful fallback
         let hierarchy = ClassHierarchy::with_builtins();
-        let result = resolve_expression_type("myList collect: [:x | x]", &hierarchy);
+        let result = resolve_expression_type("myList collect: [:x | x]", &hierarchy, None);
         assert_eq!(result, None);
+    }
+    #[test]
+    fn resolve_expression_type_with_native_registry_resolves_ffi_call() {
+        // BT-2887: with a NativeTypeRegistry, an FFI call's typed return
+        // resolves instead of staying Dynamic.
+        use crate::semantic_analysis::type_checker::TypeProvenance;
+        use crate::semantic_analysis::type_checker::native_type_registry::{
+            FunctionSignature, NativeTypeRegistry, ParamType,
+        };
+
+        let hierarchy = ClassHierarchy::with_builtins();
+        let mut registry = NativeTypeRegistry::new();
+        registry.register_module(
+            "lists",
+            vec![FunctionSignature {
+                name: "reverse".to_string(),
+                arity: 1,
+                params: vec![ParamType {
+                    keyword: Some(EcoString::from("list")),
+                    type_: InferredType::known("List"),
+                }],
+                return_type: InferredType::known("List"),
+                provenance: TypeProvenance::Extracted,
+                line: None,
+            }],
+        );
+
+        let result = resolve_expression_type(
+            "Erlang lists reverse: #(1, 2, 3)",
+            &hierarchy,
+            Some(&registry),
+        );
+        assert_eq!(result.as_deref(), Some("List"));
+
+        // Registry-blind default (None) preserves the previous behaviour.
+        let result_none =
+            resolve_expression_type("Erlang lists reverse: #(1, 2, 3)", &hierarchy, None);
+        assert_eq!(result_none, None);
     }
     // ── delegate completion filtering (BT-1215) ─────────────────────────────
     #[test]

--- a/crates/beamtalk-core/src/queries/definition_provider.rs
+++ b/crates/beamtalk-core/src/queries/definition_provider.rs
@@ -27,6 +27,7 @@
 
 use crate::ast::{Expression, MessageSelector, Module};
 use crate::language_service::{Location, ProjectIndex};
+use crate::semantic_analysis::type_checker::NativeTypeRegistry;
 use crate::semantic_analysis::{ClassHierarchy, InferredType, infer_types};
 use crate::source_analysis::Span;
 use camino::Utf8PathBuf;
@@ -406,15 +407,21 @@ pub fn resolve_enclosing_superclass_context(
 }
 
 /// Resolve receiver class context for a selector lookup at the given offset.
+///
+/// `native_types` (BT-2887, ADR 0075) lets a receiver whose type came from an
+/// FFI call (e.g. `x := Erlang lists reverse: y`) resolve to its typed
+/// return, so go-to-definition on `x someMethod` isn't left registry-blind.
+/// `None` preserves the previous behaviour.
 #[must_use]
 pub fn resolve_receiver_class_context(
     module: &Module,
     offset: u32,
     selector_lookup: &SelectorLookup,
     hierarchy: &ClassHierarchy,
+    native_types: Option<&NativeTypeRegistry>,
 ) -> Option<ReceiverClassContext> {
     let class_context = find_class_context(module, offset);
-    let type_map = infer_types(module, hierarchy, None);
+    let type_map = infer_types(module, hierarchy, native_types);
     match &selector_lookup.receiver_hint {
         ReceiverHint::ClassReference(name) => Some(ReceiverClassContext {
             class_name: name.clone(),
@@ -1489,6 +1496,71 @@ mod tests {
         let loc = loc.expect("name collision should still resolve");
         assert_eq!(loc.file, file_class, "real class should win over protocol");
         assert_eq!(loc.span, module_class.classes[0].name.span);
+    }
+
+    #[test]
+    fn resolve_receiver_class_context_with_native_registry_resolves_ffi_typed_receiver() {
+        // BT-2887: a receiver whose type came from an FFI call only resolves
+        // when a NativeTypeRegistry is supplied.
+        use crate::semantic_analysis::type_checker::TypeProvenance;
+        use crate::semantic_analysis::type_checker::native_type_registry::{
+            FunctionSignature, NativeTypeRegistry, ParamType,
+        };
+
+        let source = "x := Erlang lists reverse: #(1, 2, 3).\nx size";
+        let module = parse_source(source);
+        let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+
+        let mut registry = NativeTypeRegistry::new();
+        registry.register_module(
+            "lists",
+            vec![FunctionSignature {
+                name: "reverse".to_string(),
+                arity: 1,
+                params: vec![ParamType {
+                    keyword: Some(EcoString::from("list")),
+                    type_: InferredType::known("List"),
+                }],
+                return_type: InferredType::known("List"),
+                provenance: TypeProvenance::Extracted,
+                line: None,
+            }],
+        );
+
+        let size_offset =
+            u32::try_from(source.rfind("size").expect("source contains 'size'")).unwrap();
+        let selector_lookup =
+            find_selector_lookup_in_expr(&module.expressions[1].expression, size_offset)
+                .expect("cursor should be on the 'size' selector");
+
+        let context_with_registry = resolve_receiver_class_context(
+            &module,
+            size_offset,
+            &selector_lookup,
+            &hierarchy,
+            Some(&registry),
+        );
+        assert_eq!(
+            context_with_registry,
+            Some(ReceiverClassContext {
+                class_name: EcoString::from("List"),
+                class_side: false,
+            }),
+            "FFI-typed receiver should resolve when registry is provided"
+        );
+
+        // Registry-blind default (None) preserves the previous behaviour.
+        let context_without_registry = resolve_receiver_class_context(
+            &module,
+            size_offset,
+            &selector_lookup,
+            &hierarchy,
+            None,
+        );
+        assert!(
+            context_without_registry.is_none(),
+            "Without a registry, FFI-typed receiver should stay unresolved"
+        );
     }
 
     #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/return_type_writeback.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/return_type_writeback.rs
@@ -24,7 +24,9 @@
 
 use crate::ast::{Identifier, Module, TypeAnnotation};
 use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
-use crate::semantic_analysis::type_checker::{InferredType, infer_method_return_types};
+use crate::semantic_analysis::type_checker::{
+    InferredType, NativeTypeRegistry, infer_method_return_types,
+};
 use crate::source_analysis::Span;
 use ecow::EcoString;
 
@@ -77,8 +79,16 @@ fn writeback_annotation(ty: &InferredType, span: Span) -> Option<TypeAnnotation>
 ///
 /// * `module` - Mutable AST module to update in place.
 /// * `hierarchy` - Class hierarchy used for type inference.
-pub fn apply_return_type_writeback(module: &mut Module, hierarchy: &ClassHierarchy) {
-    let inferred = infer_method_return_types(module, hierarchy, None);
+/// * `native_type_registry` - BT-2887: optional FFI type registry (ADR 0075)
+///   so methods whose body type is inferred purely via an FFI call (e.g.
+///   `foo => Erlang lists reverse: x`) get their return type written back too.
+///   `None` preserves the previous registry-blind behaviour.
+pub fn apply_return_type_writeback(
+    module: &mut Module,
+    hierarchy: &ClassHierarchy,
+    native_type_registry: Option<&NativeTypeRegistry>,
+) {
+    let inferred = infer_method_return_types(module, hierarchy, native_type_registry);
 
     for class in &mut module.classes {
         for method in &mut class.methods {
@@ -158,7 +168,7 @@ mod tests {
         let src = "Object subclass: Foo\n  bar => 42";
         let mut module = parse_module(src);
         let hierarchy = build_hierarchy(&module);
-        apply_return_type_writeback(&mut module, &hierarchy);
+        apply_return_type_writeback(&mut module, &hierarchy, None);
         let return_type = &module.classes[0].methods[0].return_type;
         assert!(
             return_type.is_some(),
@@ -176,7 +186,7 @@ mod tests {
             original.is_some(),
             "Method should already have an explicit annotation"
         );
-        apply_return_type_writeback(&mut module, &hierarchy);
+        apply_return_type_writeback(&mut module, &hierarchy, None);
         assert_eq!(
             module.classes[0].methods[0].return_type, original,
             "Writeback should not overwrite an explicit type annotation"
@@ -189,11 +199,58 @@ mod tests {
         let src = "Object subclass: Foo\n  bar: x => x doSomething";
         let mut module = parse_module(src);
         let hierarchy = build_hierarchy(&module);
-        apply_return_type_writeback(&mut module, &hierarchy);
+        apply_return_type_writeback(&mut module, &hierarchy, None);
         let return_type = &module.classes[0].methods[0].return_type;
         assert!(
             return_type.is_none(),
             "Dynamic method should not get writeback, got: {return_type:?}"
+        );
+    }
+
+    #[test]
+    fn writeback_with_native_registry_sets_return_type_for_ffi_only_method() {
+        // BT-2887: a method whose body return type is inferred purely via an
+        // FFI call only writes back when a NativeTypeRegistry is supplied.
+        use crate::semantic_analysis::type_checker::TypeProvenance;
+        use crate::semantic_analysis::type_checker::native_type_registry::{
+            FunctionSignature, ParamType,
+        };
+
+        let src = "Object subclass: Foo\n  bar: x => Erlang lists reverse: x";
+        let mut module = parse_module(src);
+        let hierarchy = build_hierarchy(&module);
+
+        let mut registry = NativeTypeRegistry::new();
+        registry.register_module(
+            "lists",
+            vec![FunctionSignature {
+                name: "reverse".to_string(),
+                arity: 1,
+                params: vec![ParamType {
+                    keyword: Some(EcoString::from("list")),
+                    type_: InferredType::known("List"),
+                }],
+                return_type: InferredType::known("List"),
+                provenance: TypeProvenance::Extracted,
+                line: None,
+            }],
+        );
+
+        apply_return_type_writeback(&mut module, &hierarchy, Some(&registry));
+        let return_type = module.classes[0].methods[0].return_type.clone();
+        assert!(
+            return_type.is_some(),
+            "FFI-inferred return type should be written back when registry is provided, got None"
+        );
+
+        // Registry-blind default (None) preserves the previous behaviour.
+        let mut module_without_registry = parse_module(src);
+        apply_return_type_writeback(&mut module_without_registry, &hierarchy, None);
+        assert!(
+            module_without_registry.classes[0].methods[0]
+                .return_type
+                .is_none(),
+            "Without a registry, FFI-only inference should stay registry-blind"
         );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up from [BT-2867](https://linear.app/beamtalk/issue/BT-2867) (PR #3002 review). Three call sites were left registry-blind by design — this closes them by threading an `Option<&NativeTypeRegistry>` parameter through, mirroring the convention already used by `hover_provider.rs`/`signature_help_provider.rs`/`completion_provider.rs`'s `compute_completions`.

- **`apply_return_type_writeback`** (`return_type_writeback.rs`): now accepts a registry so a method whose body return type is inferred purely via an FFI call (e.g. `foo => Erlang lists reverse: x`) gets `List` written back to `MethodDefinition.return_type` before codegen. Threaded through a new `CodegenOptions::with_native_type_registry` builder method, wired from `CompileContext.native_type_registry` in `beamtalk-cli`'s `write_core_erlang_with_bindings`.
- **`resolve_receiver_class_context`** (`definition_provider.rs`): now accepts a registry so go-to-definition on a receiver typed via an FFI call (e.g. `x := Erlang lists reverse: y. x someMethod`) resolves. Wired from the LSP's existing `self.native_types` in `language_service/mod.rs`.
- **`resolve_expression_type`** (`completion_provider.rs`): gains the parameter for API parity, but the `beamtalk-compiler-port` REPL completion-fallback caller has no registry readily available in its call chain, so it passes `None` (documented in the doc comment, not a gap this change closes).

All three default to `None` where genuinely unavailable, preserving prior behaviour exactly (covered by new tests below).

## Test plan

- [x] `just clippy` passes
- [x] `just fmt` — no unexpected diffs
- [x] `just test` — Rust (398), stdlib (223), BUnit (2764), Erlang runtime (5320 + 1588) all passing, 0 failures
- [x] New unit tests added for each of the three call sites, each asserting both: the registry-provided case now resolves, and the `None` case preserves the exact prior (registry-blind) behaviour
- [x] Full pre-push CI hook (clippy, dialyzer, fmt checks across Rust/Erlang/JS/Elixir/Beamtalk) passed on push


---
_Generated by [Claude Code](https://claude.ai/code/session_01B5XAbcFVCx3gZ7KcCjV8pS)_