### PR TITLE
Fix check-corpus hanging as a required status check on doc-only PRs

### DIFF
--- a/.github/workflows/ci-docs-only.yml
+++ b/.github/workflows/ci-docs-only.yml
@@ -1,0 +1,49 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+# Companion to ci.yml's paths-ignore (BT-2737 follow-up).
+#
+# ci.yml doesn't trigger at all for doc-only changes, so it never reports a
+# status for the `check-corpus` job. If `check-corpus` is a required status
+# check in branch protection, GitHub then waits forever for a status that
+# will never arrive, blocking merge on doc-only PRs.
+#
+# This workflow triggers on the exact inverse paths and reports an
+# immediate success for the same job name, satisfying the required check.
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-branches-and-tags
+
+name: CI (docs-only)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'SECURITY.md'
+      - '.github/skills/**'
+      - '.devcontainer/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'SECURITY.md'
+      - '.github/skills/**'
+      - '.devcontainer/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-corpus:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No Rust/corpus-affecting changes in this diff
+        run: echo "Doc-only change — skipping corpus.json drift check."


### PR DESCRIPTION
## Summary

- `ci.yml` has a workflow-level `paths-ignore` for doc-only changes (`*.md`, `docs/**`, etc.), so the whole workflow — including the `check-corpus` job — never runs on doc-only PRs.
- If `check-corpus` is configured as a required status check, GitHub then waits indefinitely for a status that will never be reported, which looks like the check "hangs" and blocks merging.
- Adds `.github/workflows/ci-docs-only.yml`, a companion workflow that triggers on the inverse path set and immediately reports success for a job named `check-corpus`, satisfying the required check. This is GitHub's documented workaround for this exact problem.

## Test plan

- [ ] Open/observe a doc-only PR and confirm `check-corpus` reports success promptly instead of staying pending.
- [ ] Confirm a PR touching Rust/corpus sources still runs the real `check-corpus` job in `ci.yml` as before.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MRQaPco5YR6mNPzVNo6ews)_