### PR TITLE
Alias table + resolve_type_annotation integration (BT-2895)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
@@ -1,0 +1,603 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Type alias registry (ADR 0108 Phase 2, BT-2895).
+//!
+//! **DDD Context:** Semantic Analysis
+//!
+//! Mirrors [`ProtocolRegistry`](crate::semantic_analysis::protocol_registry::ProtocolRegistry)'s
+//! shape: a name → metadata map built once per compile from `Module::type_aliases`,
+//! consulted by [`resolve_type_annotation`](crate::semantic_analysis::type_checker::resolve_type_annotation)
+//! at annotation-resolution time (ADR 0108 Semantics: `subst` → alias table →
+//! nominal class).
+//!
+//! **Batch registration order** (ADR 0108 Semantics/Implementation):
+//! classes, then protocols (today's order), then aliases last — so
+//! [`register_module`](AliasRegistry::register_module) assumes the
+//! [`ClassHierarchy`] and [`ProtocolRegistry`] it is given are already fully
+//! built for the current module. An alias colliding with either a class or a
+//! protocol always has a fully-formed registry to check against, giving
+//! bidirectional collision detection *within a single batch compile* for
+//! free: since the whole module is parsed up front, a class or protocol that
+//! textually follows a `type` declaration in source is still registered
+//! first in *processing* order, so the alias side always sees it. (A live
+//! REPL/hot-reload session can arrive in the opposite order — a `type Foo`
+//! declared in one turn, then a live `class Foo` redefinition in a later
+//! turn — which is out of scope here; see ADR 0108 Semantics and BT-2899.)
+//!
+//! **References:**
+//! - `docs/ADR/0108-named-union-type-aliases.md` — Semantics (Namespace,
+//!   Single-letter names), Implementation
+//! - `docs/ADR/0068-parametric-types-and-protocols.md` — the namespace and
+//!   `TypeAnnotation` machinery this extends
+
+use std::collections::HashMap;
+
+use ecow::EcoString;
+
+use crate::ast::{Module, TypeAliasDefinition, TypeAnnotation};
+use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
+use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
+use crate::semantic_analysis::type_checker::is_generic_type_param;
+use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
+
+/// Information about a type alias in the registry.
+///
+/// **DDD Context:** Semantic Analysis — Value Object
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AliasInfo {
+    /// The alias name (e.g., `RestartStrategy`).
+    pub name: EcoString,
+    /// The declared right-hand-side annotation — stored unresolved (ADR
+    /// 0108: eager expansion happens at *reference* resolution time, not at
+    /// registration time, so a chain of aliases referencing each other
+    /// still resolves through the same `resolve_type_annotation` recursion
+    /// used for every other annotation).
+    pub annotation: TypeAnnotation,
+    /// Source span of the `type Name = ...` declaration (for diagnostics).
+    pub span: Span,
+}
+
+impl AliasInfo {
+    fn from_definition(def: &TypeAliasDefinition) -> Self {
+        Self {
+            name: def.name.name.clone(),
+            annotation: def.annotation.clone(),
+            span: def.span,
+        }
+    }
+}
+
+/// Registry of type alias declarations for compile-time annotation
+/// resolution (ADR 0108 Phase 2).
+///
+/// **DDD Context:** Semantic Analysis — Domain Service
+///
+/// Maps alias names to the [`TypeAnnotation`] they name. Built during
+/// semantic analysis alongside the [`ClassHierarchy`] and [`ProtocolRegistry`]
+/// — see module docs for the required batch registration order.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AliasRegistry {
+    aliases: HashMap<EcoString, AliasInfo>,
+}
+
+impl AliasRegistry {
+    /// Creates an empty alias registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            aliases: HashMap::new(),
+        }
+    }
+
+    /// Registers type aliases from a parsed module.
+    ///
+    /// Must be called *after* `hierarchy` and `protocol_registry` are fully
+    /// populated for the current module (ADR 0108: classes → protocols →
+    /// aliases) — see module docs.
+    ///
+    /// Returns diagnostics for:
+    /// - Namespace collisions (alias name matches an existing class or
+    ///   protocol name — ADR 0108 Semantics: aliases share the single
+    ///   class/protocol namespace)
+    /// - Duplicate alias definitions
+    /// - Unbound single-letter type variables on the RHS (ADR 0108: a bare
+    ///   unbound single letter on an alias RHS, e.g. `type Timeout = Integer
+    ///   | T`, is a declaration error rather than a phantom class named `T`
+    ///   — checked via its own pass, since a top-level `type` declaration
+    ///   has no enclosing method and `subst` is always empty there)
+    ///
+    /// A colliding or duplicate name is skipped entirely (not inserted), so
+    /// later resolution cannot pick it up — mirroring
+    /// [`ProtocolRegistry::register_module`]'s skip-on-collision behaviour.
+    /// An unbound-type-variable error is non-fatal: the alias still
+    /// registers so the rest of the declaration (and any following
+    /// declarations) still get checked.
+    pub fn register_module(
+        &mut self,
+        module: &Module,
+        hierarchy: &ClassHierarchy,
+        protocol_registry: &ProtocolRegistry,
+    ) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+
+        for alias_def in &module.type_aliases {
+            let name = &alias_def.name.name;
+
+            // Namespace collision: alias name matches a class name.
+            if hierarchy.has_class(name) {
+                diagnostics.push(
+                    Diagnostic::error(
+                        format!(
+                            "`{name}` is already defined as a class — \
+                             type aliases share the class/protocol namespace"
+                        ),
+                        alias_def.name.span,
+                    )
+                    .with_hint(format!(
+                        "Rename the type alias to avoid conflicting with class `{name}`"
+                    ))
+                    .with_category(DiagnosticCategory::Type),
+                );
+                continue;
+            }
+
+            // Namespace collision: alias name matches a protocol name.
+            if protocol_registry.has_protocol(name) {
+                diagnostics.push(
+                    Diagnostic::error(
+                        format!(
+                            "`{name}` is already defined as a protocol — \
+                             type aliases share the class/protocol namespace"
+                        ),
+                        alias_def.name.span,
+                    )
+                    .with_hint(format!(
+                        "Rename the type alias to avoid conflicting with protocol `{name}`"
+                    ))
+                    .with_category(DiagnosticCategory::Type),
+                );
+                continue;
+            }
+
+            // Duplicate alias definition.
+            if self.aliases.contains_key(name) {
+                diagnostics.push(
+                    Diagnostic::error(
+                        format!("Duplicate type alias definition: `{name}`"),
+                        alias_def.name.span,
+                    )
+                    .with_hint(
+                        "Remove the duplicate definition — each type alias can only be \
+                         defined once",
+                    )
+                    .with_category(DiagnosticCategory::Type),
+                );
+                continue;
+            }
+
+            // ADR 0108 Semantics / Implementation: unbound single-letter
+            // type-variable check on the RHS, its own validation pass run
+            // alongside (not as a byproduct of) `resolve_type_annotation`.
+            check_unbound_type_vars(&alias_def.annotation, hierarchy, name, &mut diagnostics);
+
+            self.aliases
+                .insert(name.clone(), AliasInfo::from_definition(alias_def));
+        }
+
+        diagnostics
+    }
+
+    /// Looks up an alias by name.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&AliasInfo> {
+        self.aliases.get(name)
+    }
+
+    /// Checks if an alias exists in the registry.
+    #[must_use]
+    pub fn has_alias(&self, name: &str) -> bool {
+        self.aliases.contains_key(name)
+    }
+
+    /// Returns an iterator over all alias names in the registry.
+    pub fn alias_names(&self) -> impl Iterator<Item = &EcoString> {
+        self.aliases.keys()
+    }
+
+    /// Returns an iterator over all aliases in the registry.
+    pub fn aliases(&self) -> impl Iterator<Item = (&EcoString, &AliasInfo)> {
+        self.aliases.iter()
+    }
+
+    /// Register an alias directly for testing purposes.
+    ///
+    /// Bypasses the module registration path — useful for unit tests (and
+    /// [`resolve_type_annotation`](crate::semantic_analysis::type_checker::resolve_type_annotation)'s
+    /// own tests) that need an alias table without constructing a full
+    /// `Module` AST.
+    #[cfg(test)]
+    pub fn register_test_alias(&mut self, info: AliasInfo) {
+        self.aliases.insert(info.name.clone(), info);
+    }
+}
+
+/// Walks a type annotation's structure, reporting "unbound type parameter"
+/// diagnostics for bare single-letter identifiers not covered by a class in
+/// `hierarchy` (ADR 0068's reserved-for-type-parameters convention).
+///
+/// Checks the class hierarchy *first* — a class literally named `T` is
+/// legal and resolves as a nominal class exactly as
+/// [`resolve_type_annotation`](crate::semantic_analysis::type_checker::resolve_type_annotation)
+/// would — only emitting the diagnostic when the name is not found there.
+/// Mirrors `infer_method_local_params`'s existing
+/// `!hierarchy.has_class(name)` guard (ADR 0108 Semantics).
+///
+/// Only [`TypeAnnotation::Simple`] positions are checked — a bare
+/// single-letter identifier standing alone in type position is exactly
+/// ADR 0068's implicit-type-parameter shape. A [`TypeAnnotation::Generic`]
+/// base name (e.g. the `Result` in `Result(T, E)`) is always a concrete type
+/// constructor, never a bare parameter reference, so it is not checked; its
+/// `parameters` are walked recursively like every other nested position.
+fn check_unbound_type_vars(
+    ann: &TypeAnnotation,
+    hierarchy: &ClassHierarchy,
+    alias_name: &EcoString,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    match ann {
+        TypeAnnotation::Simple(type_id) => {
+            let name = &type_id.name;
+            if is_generic_type_param(name) && !hierarchy.has_class(name) {
+                diagnostics.push(
+                    Diagnostic::error(
+                        format!(
+                            "unbound type parameter `{name}` in type alias `{alias_name}`; \
+                             parametric aliases (`type Name(T) = ...`) are not yet supported"
+                        ),
+                        type_id.span,
+                    )
+                    .with_category(DiagnosticCategory::Type),
+                );
+            }
+        }
+        TypeAnnotation::Generic { parameters, .. } => {
+            for param in parameters {
+                check_unbound_type_vars(param, hierarchy, alias_name, diagnostics);
+            }
+        }
+        TypeAnnotation::Union { types, .. } => {
+            for member in types {
+                check_unbound_type_vars(member, hierarchy, alias_name, diagnostics);
+            }
+        }
+        TypeAnnotation::FalseOr { inner, .. } => {
+            check_unbound_type_vars(inner, hierarchy, alias_name, diagnostics);
+        }
+        TypeAnnotation::Difference { base, excluded, .. } => {
+            check_unbound_type_vars(base, hierarchy, alias_name, diagnostics);
+            check_unbound_type_vars(excluded, hierarchy, alias_name, diagnostics);
+        }
+        TypeAnnotation::Intersection { left, right, .. } => {
+            check_unbound_type_vars(left, hierarchy, alias_name, diagnostics);
+            check_unbound_type_vars(right, hierarchy, alias_name, diagnostics);
+        }
+        // SelfType / SelfClass / ClassOf / Singleton have no nested
+        // identifier position that could be a bare type parameter.
+        TypeAnnotation::SelfType { .. }
+        | TypeAnnotation::SelfClass { .. }
+        | TypeAnnotation::ClassOf { .. }
+        | TypeAnnotation::Singleton { .. } => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::Identifier;
+
+    fn span() -> Span {
+        Span::new(0, 1)
+    }
+
+    fn ident(name: &str) -> Identifier {
+        Identifier {
+            name: name.into(),
+            span: span(),
+        }
+    }
+
+    fn alias_def(name: &str, annotation: TypeAnnotation) -> TypeAliasDefinition {
+        TypeAliasDefinition {
+            name: ident(name),
+            annotation,
+            comments: crate::ast::CommentAttachment::default(),
+            doc_comment: None,
+            span: span(),
+        }
+    }
+
+    fn singleton_union(names: &[&str]) -> TypeAnnotation {
+        TypeAnnotation::Union {
+            types: names
+                .iter()
+                .map(|n| TypeAnnotation::Singleton {
+                    name: (*n).into(),
+                    span: span(),
+                })
+                .collect(),
+            span: span(),
+        }
+    }
+
+    fn empty_module() -> Module {
+        Module::new(vec![], span())
+    }
+
+    // ---- Basic registration ----
+
+    #[test]
+    fn register_simple_alias() {
+        let module = Module {
+            type_aliases: vec![alias_def(
+                "RestartStrategy",
+                singleton_union(&["temporary", "transient", "permanent"]),
+            )],
+            ..empty_module()
+        };
+        let hierarchy = ClassHierarchy::with_builtins();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+        assert!(registry.has_alias("RestartStrategy"));
+        let info = registry.get("RestartStrategy").unwrap();
+        assert_eq!(info.name.as_str(), "RestartStrategy");
+    }
+
+    #[test]
+    fn register_multiple_aliases() {
+        let module = Module {
+            type_aliases: vec![
+                alias_def("TimeoutMs", TypeAnnotation::Simple(ident("Integer"))),
+                alias_def("JsonKey", singleton_union(&["a", "b"])),
+            ],
+            ..empty_module()
+        };
+        let hierarchy = ClassHierarchy::with_builtins();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+        assert!(registry.has_alias("TimeoutMs"));
+        assert!(registry.has_alias("JsonKey"));
+    }
+
+    // ---- Namespace collision: alias vs. class / protocol (bidirectional) ----
+
+    #[test]
+    fn namespace_collision_alias_vs_builtin_class() {
+        // `Integer` is a built-in class — an alias of the same name must be
+        // rejected and must not shadow the class in resolution.
+        let module = Module {
+            type_aliases: vec![alias_def(
+                "Integer",
+                TypeAnnotation::Simple(ident("String")),
+            )],
+            ..empty_module()
+        };
+        let hierarchy = ClassHierarchy::with_builtins();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("already defined as a class"));
+        assert!(!registry.has_alias("Integer"));
+    }
+
+    #[test]
+    fn namespace_collision_alias_vs_protocol() {
+        // A protocol `Printable` already registered — an alias of the same
+        // name must be rejected. This is the "new plumbing" direction the
+        // pre-existing `protocol_registry.rs:296-334` check (class vs.
+        // protocol only) cannot see.
+        let printable = crate::ast::ProtocolDefinition {
+            name: ident("Printable"),
+            type_params: vec![],
+            extending: None,
+            method_signatures: vec![],
+            class_method_signatures: vec![],
+            comments: crate::ast::CommentAttachment::default(),
+            doc_comment: None,
+            span: span(),
+        };
+        let proto_module = Module {
+            protocols: vec![printable],
+            ..empty_module()
+        };
+        let hierarchy = ClassHierarchy::with_builtins();
+        let mut protocol_registry = ProtocolRegistry::new();
+        let proto_diags = protocol_registry.register_module(&proto_module, &hierarchy);
+        assert!(proto_diags.is_empty());
+
+        let module = Module {
+            type_aliases: vec![alias_def(
+                "Printable",
+                TypeAnnotation::Simple(ident("String")),
+            )],
+            ..empty_module()
+        };
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("already defined as a protocol"));
+        assert!(!registry.has_alias("Printable"));
+    }
+
+    #[test]
+    fn namespace_collision_is_order_independent_within_a_module() {
+        // ADR 0108: batch registration order (classes → protocols →
+        // aliases) means a class/protocol that *textually* follows a `type`
+        // declaration in the same module still collides — the whole module
+        // is parsed up front, so processing order (not textual order)
+        // determines what the alias side sees. This demonstrates the
+        // "vice versa" bidirectionality the AC calls for within a batch
+        // compile: it doesn't matter that a user wrote `type Foo = ...`
+        // above `Object subclass: Foo` in the source file.
+        let module = Module {
+            classes: vec![crate::ast::ClassDefinition::new(
+                ident("Foo"),
+                ident("Object"),
+                vec![],
+                vec![],
+                span(),
+            )],
+            type_aliases: vec![alias_def("Foo", TypeAnnotation::Simple(ident("String")))],
+            ..empty_module()
+        };
+        let (hierarchy, hierarchy_diags) = ClassHierarchy::build(&module);
+        let hierarchy = hierarchy.unwrap();
+        assert!(hierarchy_diags.is_empty());
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+
+        assert_eq!(diags.len(), 1, "expected collision, got: {diags:?}");
+        assert!(diags[0].message.contains("already defined as a class"));
+        assert!(!registry.has_alias("Foo"));
+    }
+
+    #[test]
+    fn duplicate_alias_definition() {
+        let module = Module {
+            type_aliases: vec![
+                alias_def("TimeoutMs", TypeAnnotation::Simple(ident("Integer"))),
+                alias_def("TimeoutMs", TypeAnnotation::Simple(ident("String"))),
+            ],
+            ..empty_module()
+        };
+        let hierarchy = ClassHierarchy::with_builtins();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("Duplicate type alias"));
+        // First definition wins.
+        assert_eq!(
+            registry.get("TimeoutMs").unwrap().annotation,
+            TypeAnnotation::Simple(ident("Integer"))
+        );
+    }
+
+    // ---- Unbound type-variable check on RHS ----
+
+    #[test]
+    fn unbound_single_letter_on_rhs_errors() {
+        // `type Timeout = Integer | T` — ADR 0108 Error examples.
+        let module = Module {
+            type_aliases: vec![alias_def(
+                "Timeout",
+                TypeAnnotation::Union {
+                    types: vec![
+                        TypeAnnotation::Simple(ident("Integer")),
+                        TypeAnnotation::Simple(ident("T")),
+                    ],
+                    span: span(),
+                },
+            )],
+            ..empty_module()
+        };
+        let hierarchy = ClassHierarchy::with_builtins();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+
+        assert_eq!(diags.len(), 1, "expected one diagnostic, got: {diags:?}");
+        assert!(diags[0].message.contains("unbound type parameter `T`"));
+        assert!(diags[0].message.contains("Timeout"));
+        // Non-fatal: the alias still registers.
+        assert!(registry.has_alias("Timeout"));
+    }
+
+    #[test]
+    fn single_letter_matching_real_class_is_not_unbound() {
+        // A class literally named `T` is legal and must resolve as a
+        // nominal class, not trigger the unbound-type-parameter error
+        // (ADR 0108 Semantics — mirrors `infer_method_local_params`'s
+        // `!hierarchy.has_class(name)` guard).
+        let module = Module {
+            classes: vec![crate::ast::ClassDefinition::new(
+                ident("T"),
+                ident("Object"),
+                vec![],
+                vec![],
+                span(),
+            )],
+            type_aliases: vec![alias_def("Wrapper", TypeAnnotation::Simple(ident("T")))],
+            ..empty_module()
+        };
+        let (hierarchy, _) = ClassHierarchy::build(&module);
+        let hierarchy = hierarchy.unwrap();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+        assert!(registry.has_alias("Wrapper"));
+    }
+
+    #[test]
+    fn unbound_type_var_nested_in_intersection_and_difference() {
+        // `type Weird = (A & String) \ B` — both nested positions must be
+        // walked, not just the top-level annotation shape.
+        let module = Module {
+            type_aliases: vec![alias_def(
+                "Weird",
+                TypeAnnotation::difference(
+                    TypeAnnotation::intersection(
+                        TypeAnnotation::Simple(ident("A")),
+                        TypeAnnotation::Simple(ident("String")),
+                        span(),
+                    ),
+                    TypeAnnotation::Simple(ident("B")),
+                    span(),
+                ),
+            )],
+            ..empty_module()
+        };
+        let hierarchy = ClassHierarchy::with_builtins();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+
+        assert_eq!(diags.len(), 2, "expected A and B unbound, got: {diags:?}");
+        assert!(diags.iter().any(|d| d.message.contains('A')));
+        assert!(diags.iter().any(|d| d.message.contains('B')));
+    }
+
+    #[test]
+    fn multi_letter_unknown_rhs_name_is_not_flagged_here() {
+        // Multi-letter unknown names are unaffected by this check (ADR 0108)
+        // — they fall through to ordinary `resolve_type_annotation` at
+        // reference-resolution time, unrelated to this registration-time
+        // pass.
+        let module = Module {
+            type_aliases: vec![alias_def(
+                "Wrapper",
+                TypeAnnotation::Simple(ident("TotallyUnknownClass")),
+            )],
+            ..empty_module()
+        };
+        let hierarchy = ClassHierarchy::with_builtins();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+    }
+}

--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -19,6 +19,7 @@ use crate::source_analysis::{Diagnostic, Span};
 use ecow::EcoString;
 use std::collections::HashMap;
 
+pub mod alias_registry;
 mod block_analyzer;
 pub(crate) mod block_context;
 pub mod block_facts;
@@ -47,6 +48,7 @@ mod property_tests;
 #[cfg(test)]
 pub mod test_helpers;
 
+pub use alias_registry::{AliasInfo, AliasRegistry};
 pub use block_facts::BlockMutationAnalysis;
 pub use block_facts::analyze_block;
 pub use class_hierarchy::ClassHierarchy;
@@ -95,6 +97,9 @@ pub struct AnalysisResult {
 
     /// Protocol registry (ADR 0068 Phase 2b).
     pub protocol_registry: ProtocolRegistry,
+
+    /// Type alias registry (ADR 0108 Phase 2, BT-2895).
+    pub alias_registry: AliasRegistry,
 }
 
 impl AnalysisResult {
@@ -106,6 +111,7 @@ impl AnalysisResult {
             block_info: HashMap::new(),
             class_hierarchy: ClassHierarchy::with_builtins(),
             protocol_registry: ProtocolRegistry::new(),
+            alias_registry: AliasRegistry::new(),
         }
     }
 }
@@ -588,6 +594,21 @@ fn analyse_full(module: &Module, ctx: AnalysisContext<'_>) -> AnalysisResult {
         result.diagnostics.extend(proto_diags);
     }
 
+    // Phase 0.6: Type Alias Registration (ADR 0108 Phase 2, BT-2895)
+    // Must happen after both the class hierarchy and protocol registry are
+    // fully built for the current module — aliases share the class/protocol
+    // namespace, and this ordering (classes → protocols → aliases) is what
+    // gives `AliasRegistry::register_module` bidirectional collision
+    // detection within a single batch compile (see its doc comment).
+    if !module.type_aliases.is_empty() {
+        let alias_diags = result.alias_registry.register_module(
+            module,
+            &result.class_hierarchy,
+            &result.protocol_registry,
+        );
+        result.diagnostics.extend(alias_diags);
+    }
+
     // Phase 1: Name Resolution
     let mut name_resolver = NameResolver::new();
     name_resolver.define_known_vars(known_vars, module.span);
@@ -613,10 +634,11 @@ fn analyse_full(module: &Module, ctx: AnalysisContext<'_>) -> AnalysisResult {
     if let Some(registry) = native_type_registry {
         type_checker.set_native_type_registry(registry);
     }
-    type_checker.check_module_with_protocols(
+    type_checker.check_module_with_protocols_and_aliases(
         module,
         &result.class_hierarchy,
         &result.protocol_registry,
+        &result.alias_registry,
     );
     result.diagnostics.extend(type_checker.take_diagnostics());
     let type_map = type_checker.take_type_map();

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -123,6 +123,7 @@ impl TypeChecker {
                     &mut method_env,
                     &method.parameters,
                     self.protocol_registry.as_ref(),
+                    self.alias_registry.as_ref(),
                 );
                 let body_type =
                     self.infer_stmts(&method.body, hierarchy, &mut method_env, is_abstract);
@@ -170,6 +171,7 @@ impl TypeChecker {
                     &mut method_env,
                     &method.parameters,
                     self.protocol_registry.as_ref(),
+                    self.alias_registry.as_ref(),
                 );
                 let body_type =
                     self.infer_stmts(&method.body, hierarchy, &mut method_env, is_abstract);
@@ -235,6 +237,7 @@ impl TypeChecker {
                 &mut method_env,
                 &standalone.method.parameters,
                 self.protocol_registry.as_ref(),
+                self.alias_registry.as_ref(),
             );
             let body_type = self.infer_stmts(
                 &standalone.method.body,
@@ -298,17 +301,25 @@ impl TypeChecker {
     /// `protocol_registry` (ADR 0102 §1/§3, BT-2743) is passed straight
     /// through to the resolver so a parameter typed `:: P1 & P2` resolves
     /// class ∩ protocol correctly; pass `None` when no registry is available.
+    ///
+    /// `alias_registry` (ADR 0108, BT-2895) is likewise passed straight
+    /// through so a parameter typed `:: RestartStrategy` expands to its
+    /// declared union; pass `None` when no registry is available.
     pub(super) fn set_param_types(
         env: &mut TypeEnv,
         parameters: &[crate::ast::ParameterDefinition],
         protocol_registry: Option<&crate::semantic_analysis::protocol_registry::ProtocolRegistry>,
+        alias_registry: Option<&crate::semantic_analysis::alias_registry::AliasRegistry>,
     ) {
         let subst = super::type_resolver::SubstitutionMap::new();
         for param in parameters {
             let ty = match &param.type_annotation {
-                Some(ann) => {
-                    super::type_resolver::resolve_type_annotation(ann, &subst, protocol_registry)
-                }
+                Some(ann) => super::type_resolver::resolve_type_annotation(
+                    ann,
+                    &subst,
+                    protocol_registry,
+                    alias_registry,
+                ),
                 None => InferredType::Dynamic(DynamicReason::UnannotatedParam), // preserve parameter shadowing of state fields
             };
             env.set_local(param.name.name.clone(), ty);
@@ -319,16 +330,21 @@ impl TypeChecker {
     ///
     /// Thin wrapper around
     /// [`super::type_resolver::resolve_type_annotation`] that supplies an
-    /// empty substitution map and no protocol registry. Call sites that need
-    /// method-local / class-level type-parameter substitution, or correct
-    /// resolution of `&`-typed protocol intersections (ADR 0102 §1/§3,
-    /// BT-2743), should call the resolver function directly with a populated
-    /// [`super::type_resolver::SubstitutionMap`] / protocol registry.
+    /// empty substitution map and no protocol registry or alias registry
+    /// (ADR 0108, BT-2895). Test-only: every production call site needs at
+    /// least one of method-local / class-level type-parameter substitution,
+    /// correct resolution of `&`-typed protocol intersections (ADR 0102
+    /// §1/§3, BT-2743), or type-alias expansion, so they all call the
+    /// resolver function directly with a populated
+    /// [`super::type_resolver::SubstitutionMap`] / protocol registry / alias
+    /// registry instead. Kept as a convenience for tests that only care
+    /// about the "no registries" resolution path.
     ///
     /// **References:** BT-2025 — centralised parametric type resolution.
+    #[cfg(test)]
     pub(super) fn resolve_type_annotation(ann: &TypeAnnotation) -> InferredType {
         let subst = super::type_resolver::SubstitutionMap::new();
-        super::type_resolver::resolve_type_annotation(ann, &subst, None)
+        super::type_resolver::resolve_type_annotation(ann, &subst, None, None)
     }
 
     /// BT-2862: When a method body is exactly `self delegate` (the ADR 0056 /
@@ -354,13 +370,14 @@ impl TypeChecker {
     /// overwrites the `self delegate` expression's `type_map` entry so LSP
     /// hover and `beamtalk type-coverage` see the trusted type too.
     ///
-    /// Limitation: non-`Self`/`Self class`/`X class` annotations resolve via
-    /// the thin [`Self::resolve_type_annotation`] wrapper, which supplies an
-    /// empty substitution map and no protocol registry — an ADR 0102
+    /// Limitation: non-`Self`/`Self class`/`X class` annotations resolve
+    /// with an empty substitution map and no protocol registry — an ADR 0102
     /// intersection (`A & B`) or difference (`A \ B`) return-type annotation
-    /// on a `self delegate` body won't resolve precisely (that limitation
-    /// lives in the wrapper, not here). This is a narrow case with no known
-    /// `self delegate` use today.
+    /// on a `self delegate` body won't resolve precisely. This is a narrow
+    /// case with no known `self delegate` use today. Alias resolution (ADR
+    /// 0108, BT-2895) *is* threaded through via `self.alias_registry`, so a
+    /// `self delegate` method declaring `-> RestartStrategy` resolves
+    /// correctly.
     pub(super) fn resolve_self_delegate_return_type(
         &mut self,
         method: &crate::ast::MethodDefinition,
@@ -384,7 +401,12 @@ impl TypeChecker {
             TypeAnnotation::SelfClass { .. } | TypeAnnotation::ClassOf { .. } => {
                 return body_type;
             }
-            _ => Self::resolve_type_annotation(declared),
+            _ => super::type_resolver::resolve_type_annotation(
+                declared,
+                &super::type_resolver::SubstitutionMap::new(),
+                None,
+                self.alias_registry.as_ref(),
+            ),
         };
         // The method body is exactly one statement (`self delegate`) per
         // `is_self_delegate`'s definition — record the trusted type against
@@ -621,10 +643,16 @@ impl TypeChecker {
                     // ADR 0102 §1/§3 (BT-2743): thread the protocol registry
                     // through so a local `x :: P1 & P2` annotation resolves
                     // class ∩ protocol correctly rather than falling to `Never`.
+                    // ADR 0108 (BT-2895): thread the alias registry through so
+                    // a local `heading :: Direction := ...` annotation
+                    // expands to its declared union, feeding the exact same
+                    // `InferredType` a spelled-out union would into
+                    // downstream narrowing/exhaustiveness.
                     let declared = super::type_resolver::resolve_type_annotation(
                         ann,
                         &super::type_resolver::SubstitutionMap::new(),
                         self.protocol_registry.as_ref(),
+                        self.alias_registry.as_ref(),
                     );
                     // Check for type mismatch: known RHS that doesn't match declared type.
                     // Dynamic RHS (the primary use case for annotations) is accepted silently.
@@ -6656,7 +6684,7 @@ mod tests {
     fn set_param_types_untyped() {
         let params = vec![ParameterDefinition::new(ident("x"))];
         let mut env = TypeEnv::new();
-        TypeChecker::set_param_types(&mut env, &params, None);
+        TypeChecker::set_param_types(&mut env, &params, None, None);
         assert_eq!(
             env.get_local("x"),
             Some(InferredType::Dynamic(DynamicReason::Unknown))
@@ -6670,7 +6698,7 @@ mod tests {
             type_annotation: Some(TypeAnnotation::Simple(ident("Integer"))),
         }];
         let mut env = TypeEnv::new();
-        TypeChecker::set_param_types(&mut env, &params, None);
+        TypeChecker::set_param_types(&mut env, &params, None, None);
         assert_eq!(env.get_local("x"), Some(InferredType::known("Integer")));
     }
 
@@ -6684,7 +6712,7 @@ mod tests {
             ParameterDefinition::new(ident("y")),
         ];
         let mut env = TypeEnv::new();
-        TypeChecker::set_param_types(&mut env, &params, None);
+        TypeChecker::set_param_types(&mut env, &params, None, None);
         assert_eq!(env.get_local("x"), Some(InferredType::known("String")));
         assert_eq!(
             env.get_local("y"),

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/mod.rs
@@ -19,6 +19,7 @@
 //! - `docs/ADR/0025-gradual-typing-and-protocols.md` — Phase 1
 
 use crate::ast::Module;
+use crate::semantic_analysis::alias_registry::AliasRegistry;
 use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
 use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
 use crate::source_analysis::{Diagnostic, Span};
@@ -374,6 +375,16 @@ pub struct TypeChecker {
     /// requires the tested selector. Set by `check_module_with_protocols`
     /// before running the main type checking pass.
     pub(super) protocol_registry: Option<ProtocolRegistry>,
+    /// Type alias registry (ADR 0108 Phase 2, BT-2895).
+    ///
+    /// When set, [`super::type_resolver::resolve_type_annotation`] expands a
+    /// `Simple` annotation naming a registered alias to its declared
+    /// expansion (resolution order: `subst` → alias table → nominal class).
+    /// Set by [`Self::check_module_with_protocols_and_aliases`] before
+    /// running the main type checking pass; `None` means "no aliases in
+    /// this compile" and every `Simple` name resolves as an ordinary
+    /// nominal class, matching pre-ADR-0108 behaviour.
+    pub(super) alias_registry: Option<AliasRegistry>,
     /// Native type registry for FFI call inference (ADR 0075).
     ///
     /// When set, enables return type inference and keyword mismatch warnings
@@ -397,6 +408,7 @@ impl TypeChecker {
             method_return_types: HashMap::new(),
             current_package: None,
             protocol_registry: None,
+            alias_registry: None,
             native_type_registry: None,
             typed_class_context: None,
         }
@@ -414,6 +426,7 @@ impl TypeChecker {
             method_return_types: HashMap::new(),
             current_package: Some(EcoString::from(package)),
             protocol_registry: None,
+            alias_registry: None,
             native_type_registry: None,
             typed_class_context: None,
         }
@@ -466,6 +479,10 @@ impl TypeChecker {
     /// are present. It delegates to `check_module` for the main type checking pass
     /// and then performs protocol conformance checking on type annotations.
     ///
+    /// Thin wrapper around [`Self::check_module_with_protocols_and_aliases`]
+    /// with an empty [`AliasRegistry`] — callers that don't have (or don't
+    /// need) alias resolution keep working unchanged.
+    ///
     /// **References:** ADR 0068 Phase 2b
     pub fn check_module_with_protocols(
         &mut self,
@@ -473,15 +490,47 @@ impl TypeChecker {
         hierarchy: &ClassHierarchy,
         protocol_registry: &ProtocolRegistry,
     ) {
+        self.check_module_with_protocols_and_aliases(
+            module,
+            hierarchy,
+            protocol_registry,
+            &AliasRegistry::new(),
+        );
+    }
+
+    /// [`Self::check_module_with_protocols`], additionally threading a type
+    /// alias registry (ADR 0108 Phase 2, BT-2895) so annotations referencing
+    /// a `type Name = ...` declaration resolve to their structural expansion
+    /// everywhere `resolve_type_annotation` is consulted during the main
+    /// type-checking pass (parameter types, return types, typed local
+    /// assignments).
+    ///
+    /// **References:** ADR 0068 Phase 2b, ADR 0108 Phase 2
+    pub fn check_module_with_protocols_and_aliases(
+        &mut self,
+        module: &Module,
+        hierarchy: &ClassHierarchy,
+        protocol_registry: &ProtocolRegistry,
+        alias_registry: &AliasRegistry,
+    ) {
         // Store protocol registry for respondsTo: narrowing (BT-1833).
         // This allows detect_narrowing to refine Dynamic → protocol type.
         self.protocol_registry = Some(protocol_registry.clone());
+        // ADR 0108 / BT-2895: store the alias table for the duration of this
+        // whole method (unlike `protocol_registry`, which the Phase 2b/2d/2f
+        // passes below take as a direct parameter and so don't need it on
+        // `self`) — `check_type_param_bounds_in_module` reads
+        // `self.alias_registry` to resolve alias-named generic type
+        // arguments (e.g. `Logger(Small)` where `type Small = Integer`)
+        // before checking them against a declared bound.
+        self.alias_registry = Some(alias_registry.clone());
 
         // Run the standard type checking pass first
         self.check_module(module, hierarchy);
 
-        // Clear the registry after the main pass (it's borrowed by the caller
-        // for the remaining protocol-specific passes below).
+        // Clear the protocol registry after the main pass — it's borrowed by
+        // the caller for the remaining protocol-specific passes below via
+        // the `protocol_registry` parameter directly, not `self`.
         self.protocol_registry = None;
 
         // Phase 2b: Protocol conformance checking on type annotations.
@@ -492,7 +541,8 @@ impl TypeChecker {
         // Phase 2d: Type parameter bounds checking (ADR 0068).
         // When a type annotation uses a generic class with bounded type params
         // (e.g., `Logger(Integer)` where Logger has `T :: Printable`), check
-        // that the concrete type args conform to their bounds.
+        // that the concrete type args conform to their bounds. Still consults
+        // `self.alias_registry` (ADR 0108) — cleared below, after this call.
         self.check_type_param_bounds_in_module(module, hierarchy, protocol_registry);
 
         // Phase 2f: Generic variance checking (ADR 0068).
@@ -500,6 +550,10 @@ impl TypeChecker {
         // and the argument is the same generic class with different type args
         // (e.g., `Array(Integer)`), check covariance for sealed Value classes.
         self.check_generic_variance_in_module(module, hierarchy, protocol_registry);
+
+        // ADR 0108 / BT-2895: clear the alias table now that every phase
+        // that consults it has run.
+        self.alias_registry = None;
     }
 }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
@@ -306,10 +306,24 @@ impl TypeChecker {
                 parameters,
                 span,
             } => {
-                // Resolve the type args to InferredTypes
+                // Resolve the type args to InferredTypes. ADR 0108 (BT-2895):
+                // thread the alias registry (unlike the thin
+                // `Self::resolve_type_annotation` wrapper this replaced) so
+                // a type argument that is itself an alias name — e.g.
+                // `Logger(Small)` where `type Small = Integer` — resolves to
+                // its structural expansion before being checked against the
+                // class's declared bound, instead of an opaque unknown
+                // class that would silently skip the bound check.
                 let type_args: Vec<InferredType> = parameters
                     .iter()
-                    .map(Self::resolve_type_annotation)
+                    .map(|p| {
+                        super::type_resolver::resolve_type_annotation(
+                            p,
+                            &super::type_resolver::SubstitutionMap::new(),
+                            None,
+                            self.alias_registry.as_ref(),
+                        )
+                    })
                     .collect();
 
                 // BT-1861: Warn when type args are provided for a class with no type params.

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/generics_substitution.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/generics_substitution.rs
@@ -156,7 +156,7 @@ fn set_param_types_resolves_generic_annotation() {
     }];
 
     let mut env = TypeEnv::new();
-    TypeChecker::set_param_types(&mut env, &params, None);
+    TypeChecker::set_param_types(&mut env, &params, None, None);
 
     let r_type = env.get_local("r").expect("r should be in env");
     match r_type {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/mod.rs
@@ -55,6 +55,7 @@ mod singleton_match_exhaustiveness;
 mod spawn_with_keys;
 mod state_fields;
 mod super_and_binary;
+mod type_alias_exhaustiveness;
 mod typed_class;
 mod union_types;
 mod unions_checking;

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_exhaustiveness.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_exhaustiveness.rs
@@ -1,0 +1,272 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! ADR 0108 / BT-2895: exhaustiveness regression — an alias-annotated
+//! `match:`/`matchExhaustive:` scrutinee must behave *identically* to the
+//! spelled-out union, because the exhaustiveness checker itself is
+//! unchanged (`check_singleton_match_exhaustiveness` / `matchExhaustive:`
+//! operate purely on the resolved `InferredType`, computed by the same
+//! `resolve_type_annotation` every other annotation goes through — ADR 0108
+//! Implementation: "no changes" to the exhaustiveness checker).
+//!
+//! This is verification, not new machinery: every test here has a spelled-
+//! out-union sibling already pinned in `asserted_match_exhaustiveness.rs` /
+//! `singleton_match_exhaustiveness.rs` — the assertions below mirror those
+//! exact diagnostic shapes, but reached through a `type Direction = ...`
+//! declaration and a `Direction`-typed local instead.
+
+use super::common::*;
+
+use crate::source_analysis::Severity;
+
+/// Parses `source`, runs the full `analyse_with_options_and_classes`
+/// pipeline (so `type` declarations get registered into an `AliasRegistry`
+/// exactly as they would for a real compile — see `semantic_analysis::mod`'s
+/// `analyse_full`), and returns every diagnostic.
+fn analyse_diagnostics(source: &str) -> Vec<crate::source_analysis::Diagnostic> {
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+
+    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+        &module,
+        &crate::CompilerOptions::default(),
+        vec![],
+    );
+    result.diagnostics
+}
+
+// ── Advisory `match:` over an alias-typed local (BT-2745 sibling) ───────
+
+#[test]
+fn alias_typed_local_advisory_match_warns_on_missing_member() {
+    // `type Direction = #north | #south | #east | #west` — same gap
+    // (`#west` missing) that `asserted_match_exhaustiveness.rs`'s spelled-out
+    // union sibling pins as a single `Warning` under plain `match:`.
+    let source = r"
+type Direction = #north | #south | #east | #west
+
+heading :: Direction := #east
+heading match: [
+  #north -> 0;
+  #south -> 180;
+  #east -> 90
+]
+";
+    let diags = analyse_diagnostics(source);
+    let warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("non-exhaustive"))
+        .collect();
+    assert_eq!(warnings.len(), 1, "expected one warning, got: {diags:?}");
+    assert_eq!(warnings[0].severity, Severity::Warning);
+    assert!(warnings[0].message.contains("#west"));
+    assert!(!warnings[0].message.contains("matchExhaustive:"));
+}
+
+#[test]
+fn alias_typed_local_advisory_match_silent_on_full_coverage() {
+    let source = r"
+type Direction = #north | #south | #east | #west
+
+heading :: Direction := #east
+heading match: [
+  #north -> 0;
+  #south -> 180;
+  #east -> 90;
+  #west -> 270
+]
+";
+    let diags = analyse_diagnostics(source);
+    let warnings: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("non-exhaustive"))
+        .collect();
+    assert!(
+        warnings.is_empty(),
+        "full coverage through an alias must stay silent, got: {diags:?}"
+    );
+}
+
+// ── Asserted `matchExhaustive:` over an alias-typed local (BT-2763 sibling) ──
+
+#[test]
+fn alias_typed_local_matchexhaustive_errors_naming_missing_member() {
+    // The asserted counterpart: same missing `#west`, `Error` not `Warning`,
+    // reached through the alias instead of the spelled-out union — pins
+    // that `matchExhaustive:` "sees" exactly the same residual type either
+    // way.
+    let source = r"
+type Direction = #north | #south | #east | #west
+
+heading :: Direction := #east
+heading matchExhaustive: [
+  #north -> 0;
+  #south -> 180;
+  #east -> 90
+]
+";
+    let diags = analyse_diagnostics(source);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("matchExhaustive:"))
+        .collect();
+    assert_eq!(errors.len(), 1, "expected one error, got: {diags:?}");
+    assert_eq!(errors[0].severity, Severity::Error);
+    assert!(errors[0].message.contains("#west"));
+    assert!(errors[0].message.contains("residual type"));
+}
+
+#[test]
+fn alias_typed_local_matchexhaustive_silent_on_full_coverage() {
+    let source = r"
+type Direction = #north | #south | #east | #west
+
+heading :: Direction := #east
+heading matchExhaustive: [
+  #north -> 0;
+  #south -> 180;
+  #east -> 90;
+  #west -> 270
+]
+";
+    let diags = analyse_diagnostics(source);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("matchExhaustive:"))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "full coverage through an alias must satisfy matchExhaustive: silently, got: {diags:?}"
+    );
+}
+
+#[test]
+fn alias_typed_local_matchexhaustive_unguarded_wildcard_satisfies() {
+    let source = r"
+type Direction = #north | #south | #east | #west
+
+heading :: Direction := #west
+heading matchExhaustive: [
+  #north -> 0;
+  _ -> -1
+]
+";
+    let diags = analyse_diagnostics(source);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("matchExhaustive:"))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "unguarded wildcard must satisfy the assertion through an alias too, got: {diags:?}"
+    );
+}
+
+// ── Method parameter / return type positions (ADR 0108's flagship examples) ──
+
+#[test]
+fn alias_typed_method_param_matchexhaustive_behaves_like_spelled_out_union() {
+    // ADR 0108's motivating signature shape: `restart: policy :: Direction`.
+    let source = r"
+type Direction = #north | #south | #east | #west
+
+Object subclass: Compass
+  heading: h :: Direction =>
+    h matchExhaustive: [
+      #north -> 0;
+      #south -> 180;
+      #east -> 90
+    ]
+";
+    let diags = analyse_diagnostics(source);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("matchExhaustive:"))
+        .collect();
+    assert_eq!(errors.len(), 1, "expected one error, got: {diags:?}");
+    assert!(errors[0].message.contains("#west"));
+}
+
+#[test]
+fn alias_typed_method_return_resolves_to_structural_union() {
+    // ADR 0108's other motivating shape: `defaultHeading -> Direction`. A
+    // mismatched return (returning a value outside the union) must be
+    // caught exactly as it would be against the spelled-out union — proving
+    // `check_return_type` (validation.rs) also expands the alias, not just
+    // parameter positions.
+    let source = r"
+type Direction = #north | #south | #east | #west
+
+Object subclass: Compass
+  defaultHeading -> Direction => 42
+";
+    let diags = analyse_diagnostics(source);
+    let type_mismatches: Vec<_> = diags
+        .iter()
+        .filter(|d| d.category == Some(DiagnosticCategory::Type))
+        .collect();
+    assert!(
+        !type_mismatches.is_empty(),
+        "returning Integer from a Direction-declared method should warn, got: {diags:?}"
+    );
+}
+
+// ── Namespace collision surfaces from the full pipeline ──────────────────
+
+#[test]
+fn alias_colliding_with_class_reports_diagnostic_end_to_end() {
+    let source = r"
+type Foo = String
+
+Object subclass: Foo
+";
+    let diags = analyse_diagnostics(source);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.message.contains("already defined as a class")),
+        "expected a namespace-collision diagnostic, got: {diags:?}"
+    );
+}
+
+// ── Type parameter bounds see through an alias-named type argument ───────
+//
+// Not exhaustiveness, but the same underlying fix: `check_type_param_bounds_
+// in_module` (protocol.rs) used to resolve a `Generic`'s type args through
+// the thin, registry-less `Self::resolve_type_annotation` wrapper, so an
+// alias-named type argument (e.g. `Logger(NotFrobnicatable)`) resolved to an
+// opaque unknown class. `receiver_knowledge::classify_receiver` treats an
+// unknown class as open-world and conforms by default (ADR 0100 Rule 1), so
+// the bound violation was silently skipped — a false negative, not a false
+// positive, which is why it needed its own end-to-end regression test rather
+// than only a unit test on the resolver.
+
+#[test]
+fn alias_named_type_arg_is_checked_against_declared_bound() {
+    let source = r"
+Protocol define: Frobnicatable
+  frobnicate -> Object
+
+type NotFrobnicatable = Integer
+
+Actor subclass: Logger(T :: Frobnicatable)
+  log: item :: T => item
+
+Object subclass: Holder
+  state: thing :: Logger(NotFrobnicatable) = nil
+";
+    let diags = analyse_diagnostics(source);
+    let bound_violations: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("does not conform to"))
+        .collect();
+    assert_eq!(
+        bound_violations.len(),
+        1,
+        "NotFrobnicatable expands to Integer, which lacks `frobnicate` — expected exactly \
+         one bound-violation diagnostic, got: {diags:?}"
+    );
+    assert!(bound_violations[0].message.contains("Integer"));
+    assert!(bound_violations[0].message.contains("Frobnicatable"));
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 use ecow::{EcoString, eco_format};
 
 use crate::ast::TypeAnnotation;
+use crate::semantic_analysis::alias_registry::AliasRegistry;
 use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
 use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
 
@@ -51,7 +52,15 @@ pub(in crate::semantic_analysis) type SubstitutionMap = HashMap<EcoString, Infer
 ///   `true`, `false` are mapped to `UndefinedObject`, `True`, `False`. The
 ///   keyword `Never` becomes [`InferredType::Never`]. If the name appears in
 ///   `subst`, the substituted value wins (method-local / class-level type
-///   parameters resolve to their concrete bindings).
+///   parameters resolve to their concrete bindings). Otherwise, if the name
+///   is registered in `alias_registry` (ADR 0108, BT-2895), the reference
+///   expands *eagerly* to the alias's declared annotation, recursively
+///   resolved through this same function — so a `RestartStrategy` annotation
+///   resolves to the exact `InferredType::Union` its expansion would. This
+///   makes the resolution order `subst` → alias table → nominal class,
+///   disjoint by construction: ADR 0108 reserves every bare single-letter
+///   name for `subst`/generic type parameters and forbids it as an alias
+///   name, so the two lookups never contend for the same identifier.
 /// * [`TypeAnnotation::Generic`] — builds `Known { class_name: base, type_args }`
 ///   with every argument recursively resolved through the same rules. Provenance
 ///   is marked `Declared(span)` since the annotation is user-written.
@@ -94,8 +103,7 @@ pub(in crate::semantic_analysis) type SubstitutionMap = HashMap<EcoString, Infer
 ///
 /// The class hierarchy is *not* consulted during annotation resolution —
 /// "does this class exist?" is a call-site decision that happens *after* the
-/// annotation resolves, not during. A future evolution may thread one in for
-/// type-alias resolution; no current caller needs it.
+/// annotation resolves, not during.
 ///
 /// `protocol_registry` (ADR 0102 §1/§3, BT-2743) is threaded through purely
 /// for [`TypeAnnotation::Intersection`] resolution — every other variant
@@ -103,10 +111,68 @@ pub(in crate::semantic_analysis) type SubstitutionMap = HashMap<EcoString, Infer
 /// still resolves; `&`-typed protocol intersections just won't recognise a
 /// protocol name and will conservatively fall to `Never`, matching
 /// [`InferredType::intersect`]'s documented `None` behaviour).
+///
+/// `alias_registry` (ADR 0108, BT-2895) is consulted only by
+/// [`TypeAnnotation::Simple`] — see that variant's doc above. Pass `None`
+/// when no registry is available (a `Simple` name that would otherwise be an
+/// alias reference just resolves as an ordinary nominal class, matching
+/// pre-ADR-0108 behaviour).
 pub(in crate::semantic_analysis) fn resolve_type_annotation(
     ann: &TypeAnnotation,
     subst: &SubstitutionMap,
     protocol_registry: Option<&ProtocolRegistry>,
+    alias_registry: Option<&AliasRegistry>,
+) -> InferredType {
+    let mut expanding = Vec::new();
+    let mut memo = HashMap::new();
+    resolve_type_annotation_inner(
+        ann,
+        subst,
+        protocol_registry,
+        alias_registry,
+        &mut expanding,
+        &mut memo,
+    )
+}
+
+/// The actual resolution recursion, guarded by `expanding` — the stack of
+/// alias names currently being expanded on the current path — and cached by
+/// `memo` — every alias name already *fully* resolved earlier in this same
+/// top-level call.
+///
+/// Cycle detection *itself* (rejecting a cyclic alias at declaration time,
+/// e.g. `type A = B`, `type B = A`) is BT-2896, deliberately out of scope
+/// here (ADR 0108 "No recursion" explicitly assigns it to a later issue).
+/// But eager expansion means a cycle that slips past declaration-time
+/// checking (or simply hasn't been checked yet, since BT-2896 hasn't landed)
+/// would otherwise recurse forever the first time it's *referenced* — this
+/// guard is the "expansion itself carries a visited-set guard so a cycle
+/// that slips through is a diagnostic, never a hang" promise from that same
+/// ADR section, satisfied here defensively: a name already being expanded on
+/// this path resolves to `Dynamic` instead of recursing again.
+///
+/// `memo` exists for a different reason: without it, a *legal, acyclic*
+/// chain of aliases that each reference the previous one twice —
+/// `type L1 = L0 | L0`, `type L2 = L1 | L1`, …, `type Ln = L(n-1) | L(n-1)`
+/// — re-expands `L(n-1)` from scratch on both sides of every `|`, doubling
+/// the work at each level (`O(2ⁿ)` total). `expanding` (a path stack) does
+/// not prevent this — it only rejects a name that is an *ancestor* of
+/// itself, and `L(n-1)`'s two references here are siblings, not nested.
+/// Since resolution is a pure function of `(annotation, subst,
+/// alias_registry)` and `subst` never changes across a single top-level
+/// [`resolve_type_annotation`] call (every recursive call above threads the
+/// same `subst` unchanged), caching by alias name alone is sound *within*
+/// one call: the first full resolution of a name is reused verbatim for
+/// every subsequent reference, turning the exponential re-walk into one
+/// resolution per distinct alias name.
+#[allow(clippy::too_many_lines)] // one match arm per TypeAnnotation variant — see resolve_type_annotation's doc
+fn resolve_type_annotation_inner(
+    ann: &TypeAnnotation,
+    subst: &SubstitutionMap,
+    protocol_registry: Option<&ProtocolRegistry>,
+    alias_registry: Option<&AliasRegistry>,
+    expanding: &mut Vec<EcoString>,
+    memo: &mut HashMap<EcoString, InferredType>,
 ) -> InferredType {
     match ann {
         TypeAnnotation::Simple(type_id) => {
@@ -135,6 +201,41 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation(
             if let Some(resolved) = subst.get(name) {
                 return resolved.clone();
             }
+            // ADR 0108 / BT-2895: alias table comes next in the resolution
+            // order (`subst` → alias table → nominal class). A reference to
+            // an alias name expands eagerly to its declared annotation,
+            // recursively resolved through this same function so a chain of
+            // aliases (`type B = A | #z`, `type A = #x | #y`) resolves all
+            // the way down to a plain structural `InferredType`.
+            if let Some(registry) = alias_registry {
+                if let Some(alias_info) = registry.get(name) {
+                    // See `resolve_type_annotation_inner`'s doc: a name
+                    // already fully resolved earlier in this call is reused
+                    // verbatim, avoiding the exponential re-walk a chain of
+                    // doubling aliases would otherwise trigger.
+                    if let Some(cached) = memo.get(name) {
+                        return cached.clone();
+                    }
+                    if expanding.contains(name) {
+                        // A cycle slipped through (BT-2896 not yet landed, or
+                        // not yet re-checked on a live redefinition) — never
+                        // hang. See `resolve_type_annotation_inner`'s doc.
+                        return InferredType::Dynamic(DynamicReason::Unknown);
+                    }
+                    expanding.push(name.clone());
+                    let resolved = resolve_type_annotation_inner(
+                        &alias_info.annotation,
+                        subst,
+                        protocol_registry,
+                        alias_registry,
+                        expanding,
+                        memo,
+                    );
+                    expanding.pop();
+                    memo.insert(name.clone(), resolved.clone());
+                    return resolved;
+                }
+            }
             let resolved_name = resolve_type_keyword(name);
             InferredType::Known {
                 class_name: resolved_name,
@@ -147,7 +248,16 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation(
         } => {
             let type_args: Vec<InferredType> = parameters
                 .iter()
-                .map(|p| resolve_type_annotation(p, subst, protocol_registry))
+                .map(|p| {
+                    resolve_type_annotation_inner(
+                        p,
+                        subst,
+                        protocol_registry,
+                        alias_registry,
+                        expanding,
+                        memo,
+                    )
+                })
                 .collect();
             InferredType::Known {
                 class_name: base.name.clone(),
@@ -158,12 +268,28 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation(
         TypeAnnotation::Union { types, .. } => {
             let members: Vec<InferredType> = types
                 .iter()
-                .map(|t| resolve_type_annotation(t, subst, protocol_registry))
+                .map(|t| {
+                    resolve_type_annotation_inner(
+                        t,
+                        subst,
+                        protocol_registry,
+                        alias_registry,
+                        expanding,
+                        memo,
+                    )
+                })
                 .collect();
             InferredType::union_of(&members)
         }
         TypeAnnotation::FalseOr { inner, .. } => {
-            let inner_ty = resolve_type_annotation(inner, subst, protocol_registry);
+            let inner_ty = resolve_type_annotation_inner(
+                inner,
+                subst,
+                protocol_registry,
+                alias_registry,
+                expanding,
+                memo,
+            );
             InferredType::union_of(&[inner_ty, InferredType::known("False")])
         }
         TypeAnnotation::Difference { base, excluded, .. } => {
@@ -171,8 +297,22 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation(
             // `difference` set operation (BT-2739). Reducible cases normalise —
             // e.g. an excluded member that drops a union member, or `T \ T`
             // collapsing to `Never`.
-            let base_ty = resolve_type_annotation(base, subst, protocol_registry);
-            let excluded_ty = resolve_type_annotation(excluded, subst, protocol_registry);
+            let base_ty = resolve_type_annotation_inner(
+                base,
+                subst,
+                protocol_registry,
+                alias_registry,
+                expanding,
+                memo,
+            );
+            let excluded_ty = resolve_type_annotation_inner(
+                excluded,
+                subst,
+                protocol_registry,
+                alias_registry,
+                expanding,
+                memo,
+            );
             InferredType::difference(
                 &base_ty,
                 &excluded_ty,
@@ -186,8 +326,22 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation(
             // resolver never consults it); `protocol_registry` is passed
             // through so class ∩ protocol resolves to the stored
             // `Intersection` instead of falling through to `Never`.
-            let left_ty = resolve_type_annotation(left, subst, protocol_registry);
-            let right_ty = resolve_type_annotation(right, subst, protocol_registry);
+            let left_ty = resolve_type_annotation_inner(
+                left,
+                subst,
+                protocol_registry,
+                alias_registry,
+                expanding,
+                memo,
+            );
+            let right_ty = resolve_type_annotation_inner(
+                right,
+                subst,
+                protocol_registry,
+                alias_registry,
+                expanding,
+                memo,
+            );
             InferredType::intersect(
                 &left_ty,
                 &right_ty,
@@ -406,6 +560,7 @@ pub(in crate::semantic_analysis) fn base_name_of_string(type_name: &str) -> &str
 mod tests {
     use super::*;
     use crate::ast::{Identifier, TypeAnnotation};
+    use crate::semantic_analysis::alias_registry::{AliasInfo, AliasRegistry};
     use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
     use crate::source_analysis::Span;
 
@@ -438,14 +593,14 @@ mod tests {
     #[test]
     fn simple_class_name_resolves_to_known() {
         let ann = TypeAnnotation::Simple(ident("Integer"));
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::known("Integer"));
     }
 
     #[test]
     fn simple_nil_keyword_resolves_to_undefined_object() {
         let ann = TypeAnnotation::Simple(ident("nil"));
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::known("UndefinedObject"));
     }
 
@@ -455,7 +610,7 @@ mod tests {
         // canonicalize to the same class as lowercase `nil` so narrowing under
         // `isNil` works regardless of which the user typed.
         let ann = TypeAnnotation::Simple(ident("Nil"));
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::known("UndefinedObject"));
     }
 
@@ -464,11 +619,11 @@ mod tests {
         let true_ann = TypeAnnotation::Simple(ident("true"));
         let false_ann = TypeAnnotation::Simple(ident("false"));
         assert_eq!(
-            resolve_type_annotation(&true_ann, &empty_subst(), None),
+            resolve_type_annotation(&true_ann, &empty_subst(), None, None),
             InferredType::known("True")
         );
         assert_eq!(
-            resolve_type_annotation(&false_ann, &empty_subst(), None),
+            resolve_type_annotation(&false_ann, &empty_subst(), None, None),
             InferredType::known("False")
         );
     }
@@ -476,7 +631,7 @@ mod tests {
     #[test]
     fn simple_never_keyword_resolves_to_never() {
         let ann = TypeAnnotation::Simple(ident("Never"));
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::Never);
     }
 
@@ -487,7 +642,7 @@ mod tests {
         let ann = TypeAnnotation::Simple(ident("T"));
         let mut subst = SubstitutionMap::new();
         subst.insert("T".into(), InferredType::known("Integer"));
-        let result = resolve_type_annotation(&ann, &subst, None);
+        let result = resolve_type_annotation(&ann, &subst, None, None);
         assert_eq!(result, InferredType::known("Integer"));
     }
 
@@ -497,7 +652,7 @@ mod tests {
         // downstream code (e.g. `is_generic_type_param`-aware call sites) can
         // decide whether to fall back to Dynamic.
         let ann = TypeAnnotation::Simple(ident("T"));
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::known("T"));
     }
 
@@ -513,7 +668,7 @@ mod tests {
             ],
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         match result {
             InferredType::Known {
                 class_name,
@@ -545,7 +700,7 @@ mod tests {
             parameters: vec![inner],
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         let InferredType::Known {
             class_name,
             type_args,
@@ -584,7 +739,7 @@ mod tests {
         let mut subst = SubstitutionMap::new();
         subst.insert("T".into(), InferredType::known("Integer"));
         subst.insert("E".into(), InferredType::known("String"));
-        let result = resolve_type_annotation(&ann, &subst, None);
+        let result = resolve_type_annotation(&ann, &subst, None, None);
         let InferredType::Known {
             class_name,
             type_args,
@@ -610,7 +765,7 @@ mod tests {
             ],
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         let InferredType::Union { members, .. } = result else {
             panic!("expected Union");
         };
@@ -636,7 +791,7 @@ mod tests {
             ],
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         let InferredType::Union { members, .. } = result else {
             panic!("expected Union");
         };
@@ -662,7 +817,7 @@ mod tests {
             inner: Box::new(TypeAnnotation::Simple(ident("Integer"))),
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         let InferredType::Union { members, .. } = result else {
             panic!("expected Union, got {result:?}");
         };
@@ -684,7 +839,7 @@ mod tests {
             },
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         let InferredType::Negation { base, excluded, .. } = result else {
             panic!("expected Negation, got {result:?}");
         };
@@ -700,7 +855,7 @@ mod tests {
             TypeAnnotation::Simple(ident("Integer")),
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::Never);
     }
 
@@ -719,7 +874,7 @@ mod tests {
             TypeAnnotation::Simple(ident("String")),
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::known("Integer"));
     }
 
@@ -762,7 +917,7 @@ mod tests {
             TypeAnnotation::Simple(ident("Integer")),
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::known("Integer"));
     }
 
@@ -776,7 +931,7 @@ mod tests {
             TypeAnnotation::Simple(ident("String")),
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::Never);
     }
 
@@ -792,7 +947,7 @@ mod tests {
             TypeAnnotation::Simple(ident("Comparable")),
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst(), Some(&registry));
+        let result = resolve_type_annotation(&ann, &empty_subst(), Some(&registry), None);
         let InferredType::Intersection { members, .. } = result else {
             panic!("expected Intersection, got {result:?}");
         };
@@ -813,7 +968,7 @@ mod tests {
             TypeAnnotation::Simple(ident("Comparable")),
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::Never);
     }
 
@@ -826,7 +981,7 @@ mod tests {
             TypeAnnotation::Simple(ident("Comparable")),
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst(), Some(&registry));
+        let result = resolve_type_annotation(&ann, &empty_subst(), Some(&registry), None);
         assert!(
             matches!(result, InferredType::Intersection { .. }),
             "expected Intersection, got {result:?}"
@@ -852,7 +1007,7 @@ mod tests {
             },
             span(),
         );
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         let InferredType::Negation { base, excluded, .. } = result else {
             panic!("expected Negation, got {result:?}");
         };
@@ -865,7 +1020,7 @@ mod tests {
     #[test]
     fn self_type_resolves_to_dynamic() {
         let ann = TypeAnnotation::SelfType { span: span() };
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert!(matches!(result, InferredType::Dynamic(_)));
     }
 
@@ -875,7 +1030,7 @@ mod tests {
         // reserved `Self` subst key. Without it (the free-function default),
         // it still falls back to Dynamic so existing patterns keep working.
         let ann = TypeAnnotation::SelfClass { span: span() };
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert!(matches!(result, InferredType::Dynamic(_)));
     }
 
@@ -886,7 +1041,7 @@ mod tests {
         let ann = TypeAnnotation::SelfClass { span: span() };
         let mut subst = SubstitutionMap::new();
         subst.insert("Self".into(), InferredType::known("Counter"));
-        let result = resolve_type_annotation(&ann, &subst, None);
+        let result = resolve_type_annotation(&ann, &subst, None, None);
         assert_eq!(result.as_meta().map(EcoString::as_str), Some("Counter"));
     }
 
@@ -899,7 +1054,7 @@ mod tests {
             class_name: ident("Actor"),
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result.as_meta().map(EcoString::as_str), Some("Actor"));
     }
 
@@ -911,8 +1066,252 @@ mod tests {
             name: "ok".into(),
             span: span(),
         };
-        let result = resolve_type_annotation(&ann, &empty_subst(), None);
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
         assert_eq!(result, InferredType::known("#ok"));
+    }
+
+    // ---- resolve_type_annotation: type alias expansion (ADR 0108, BT-2895) ----
+
+    /// Builds an `AliasRegistry` containing a single alias `name = annotation`.
+    fn alias_registry_with(name: &str, annotation: TypeAnnotation) -> AliasRegistry {
+        let mut registry = AliasRegistry::new();
+        registry.register_test_alias(AliasInfo {
+            name: name.into(),
+            annotation,
+            span: span(),
+        });
+        registry
+    }
+
+    #[test]
+    fn alias_reference_expands_to_singleton_union() {
+        // `type RestartStrategy = #temporary | #transient | #permanent` —
+        // referencing `RestartStrategy` must resolve to the exact same
+        // `InferredType::Union` the spelled-out union would.
+        let expansion = TypeAnnotation::Union {
+            types: vec![
+                TypeAnnotation::Singleton {
+                    name: "temporary".into(),
+                    span: span(),
+                },
+                TypeAnnotation::Singleton {
+                    name: "transient".into(),
+                    span: span(),
+                },
+                TypeAnnotation::Singleton {
+                    name: "permanent".into(),
+                    span: span(),
+                },
+            ],
+            span: span(),
+        };
+        let registry = alias_registry_with("RestartStrategy", expansion.clone());
+
+        let ann = TypeAnnotation::Simple(ident("RestartStrategy"));
+        let aliased_result = resolve_type_annotation(&ann, &empty_subst(), None, Some(&registry));
+        let spelled_out_result = resolve_type_annotation(&expansion, &empty_subst(), None, None);
+
+        assert_eq!(
+            aliased_result, spelled_out_result,
+            "an alias reference must resolve identically to its spelled-out expansion"
+        );
+        let InferredType::Union { members, .. } = aliased_result else {
+            panic!("expected Union, got {aliased_result:?}");
+        };
+        assert_eq!(members.len(), 3);
+        assert!(members.contains(&InferredType::known("#temporary")));
+    }
+
+    #[test]
+    fn alias_reference_without_registry_resolves_as_nominal_class() {
+        // Pre-ADR-0108 behaviour is preserved when no alias registry is
+        // supplied: a `Simple` name just resolves as an ordinary (unknown)
+        // nominal class.
+        let ann = TypeAnnotation::Simple(ident("RestartStrategy"));
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, None);
+        assert_eq!(result, InferredType::known("RestartStrategy"));
+    }
+
+    #[test]
+    fn alias_reference_inside_union_member_expands() {
+        // `type Timeout = Integer | #infinity`, referenced as one member of
+        // a larger annotation (`Timeout | Nil`) — nested `Simple` positions
+        // must also consult the alias table.
+        let timeout_expansion = TypeAnnotation::Union {
+            types: vec![
+                TypeAnnotation::Simple(ident("Integer")),
+                TypeAnnotation::Singleton {
+                    name: "infinity".into(),
+                    span: span(),
+                },
+            ],
+            span: span(),
+        };
+        let registry = alias_registry_with("Timeout", timeout_expansion);
+
+        let ann = TypeAnnotation::Union {
+            types: vec![
+                TypeAnnotation::Simple(ident("Timeout")),
+                TypeAnnotation::Simple(ident("nil")),
+            ],
+            span: span(),
+        };
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, Some(&registry));
+        let InferredType::Union { members, .. } = result else {
+            panic!("expected Union, got {result:?}");
+        };
+        assert_eq!(members.len(), 3, "Integer, #infinity, UndefinedObject");
+        assert!(members.contains(&InferredType::known("Integer")));
+        assert!(members.contains(&InferredType::known("#infinity")));
+        assert!(members.contains(&InferredType::known("UndefinedObject")));
+    }
+
+    #[test]
+    fn chained_alias_reference_expands_through_both_levels() {
+        // `type B = A | #z`, `type A = #x | #y` — referencing `B` must
+        // expand all the way down to `#x | #y | #z`, not stop at `A`.
+        let a_expansion = TypeAnnotation::Union {
+            types: vec![
+                TypeAnnotation::Singleton {
+                    name: "x".into(),
+                    span: span(),
+                },
+                TypeAnnotation::Singleton {
+                    name: "y".into(),
+                    span: span(),
+                },
+            ],
+            span: span(),
+        };
+        let b_expansion = TypeAnnotation::Union {
+            types: vec![
+                TypeAnnotation::Simple(ident("A")),
+                TypeAnnotation::Singleton {
+                    name: "z".into(),
+                    span: span(),
+                },
+            ],
+            span: span(),
+        };
+        let mut registry = alias_registry_with("A", a_expansion);
+        registry.register_test_alias(AliasInfo {
+            name: "B".into(),
+            annotation: b_expansion,
+            span: span(),
+        });
+
+        let ann = TypeAnnotation::Simple(ident("B"));
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, Some(&registry));
+        let InferredType::Union { members, .. } = result else {
+            panic!("expected Union, got {result:?}");
+        };
+        assert_eq!(members.len(), 3);
+        assert!(members.contains(&InferredType::known("#x")));
+        assert!(members.contains(&InferredType::known("#y")));
+        assert!(members.contains(&InferredType::known("#z")));
+    }
+
+    #[test]
+    fn subst_wins_over_alias_table_for_same_name() {
+        // ADR 0108 resolution order: `subst` (type params) → alias table →
+        // nominal class. Disjoint by construction (single-letter alias names
+        // are a declaration error), but the resolver itself must still
+        // honour the documented order if a caller ever supplies both for
+        // the same key.
+        let registry = alias_registry_with("Shadowed", TypeAnnotation::Simple(ident("String")));
+        let mut subst = SubstitutionMap::new();
+        subst.insert("Shadowed".into(), InferredType::known("Integer"));
+
+        let ann = TypeAnnotation::Simple(ident("Shadowed"));
+        let result = resolve_type_annotation(&ann, &subst, None, Some(&registry));
+        assert_eq!(
+            result,
+            InferredType::known("Integer"),
+            "subst must win over the alias table"
+        );
+    }
+
+    #[test]
+    fn cyclic_alias_reference_resolves_to_dynamic_instead_of_hanging() {
+        // ADR 0108 "No recursion": full cycle *detection* at declaration
+        // time is BT-2896, out of scope here — but expansion itself must
+        // never hang if a cycle slips through. `type A = B`, `type B = A`.
+        let mut registry = AliasRegistry::new();
+        registry.register_test_alias(AliasInfo {
+            name: "A".into(),
+            annotation: TypeAnnotation::Simple(ident("B")),
+            span: span(),
+        });
+        registry.register_test_alias(AliasInfo {
+            name: "B".into(),
+            annotation: TypeAnnotation::Simple(ident("A")),
+            span: span(),
+        });
+
+        let ann = TypeAnnotation::Simple(ident("A"));
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, Some(&registry));
+        assert!(
+            matches!(result, InferredType::Dynamic(_)),
+            "a cyclic alias must resolve to Dynamic, not hang: {result:?}"
+        );
+    }
+
+    #[test]
+    fn doubling_alias_chain_does_not_blow_up_exponentially() {
+        // A legal, acyclic chain where each level references the previous
+        // one *twice* — `type L1 = L0 | L0`, `type L2 = L1 | L1`, … — has no
+        // cycle for `expanding` to catch, but re-expanding `L(n-1)` from
+        // scratch on both sides of every `|` is `O(2ⁿ)` work without
+        // memoization. 40 levels finishes near-instantly with the `memo`
+        // cache; without it, this test would not complete in this suite's
+        // lifetime. Asserts both a bounded runtime and a correct result
+        // (the union always dedups down to the same two singleton members).
+        let mut registry = AliasRegistry::new();
+        registry.register_test_alias(AliasInfo {
+            name: "L0".into(),
+            annotation: TypeAnnotation::Union {
+                types: vec![
+                    TypeAnnotation::Singleton {
+                        name: "a".into(),
+                        span: span(),
+                    },
+                    TypeAnnotation::Singleton {
+                        name: "b".into(),
+                        span: span(),
+                    },
+                ],
+                span: span(),
+            },
+            span: span(),
+        });
+        for level in 1..=40 {
+            let prev = format!("L{}", level - 1);
+            registry.register_test_alias(AliasInfo {
+                name: format!("L{level}").into(),
+                annotation: TypeAnnotation::Union {
+                    types: vec![
+                        TypeAnnotation::Simple(ident(&prev)),
+                        TypeAnnotation::Simple(ident(&prev)),
+                    ],
+                    span: span(),
+                },
+                span: span(),
+            });
+        }
+
+        let ann = TypeAnnotation::Simple(ident("L40"));
+        let start = std::time::Instant::now();
+        let result = resolve_type_annotation(&ann, &empty_subst(), None, Some(&registry));
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(5),
+            "resolving a 40-level doubling alias chain must stay near-instant with memoization"
+        );
+        let InferredType::Union { members, .. } = result else {
+            panic!("expected Union, got {result:?}");
+        };
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&InferredType::known("#a")));
+        assert!(members.contains(&InferredType::known("#b")));
     }
 
     // ---- receiver_type_for_class ----

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1251,13 +1251,22 @@ impl TypeChecker {
         // validate this, so skip (BT-1952).
         //
         // BT-2025: All other arms — including `Generic` — go through the
-        // central `resolve_type_annotation` resolver.
+        // central `resolve_type_annotation` resolver. ADR 0108 (BT-2895):
+        // thread the alias registry (but not the protocol registry — this
+        // mirrors `Self::resolve_type_annotation`'s existing, unchanged
+        // scope) so a declared `-> RestartStrategy` return type expands to
+        // its structural union instead of an opaque unknown class.
         let expected = match declared {
             TypeAnnotation::SelfType { .. } => {
                 super::type_resolver::receiver_type_for_class(class_name, hierarchy)
             }
             TypeAnnotation::SelfClass { .. } | TypeAnnotation::ClassOf { .. } => return,
-            _ => Self::resolve_type_annotation(declared),
+            _ => super::type_resolver::resolve_type_annotation(
+                declared,
+                &super::type_resolver::SubstitutionMap::new(),
+                None,
+                self.alias_registry.as_ref(),
+            ),
         };
 
         let InferredType::Known {

--- a/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
@@ -593,9 +593,15 @@ pub(crate) fn check_redundant_local_type_annotation(
             return;
         };
 
+        // ADR 0108 (BT-2895): no alias registry threaded here — this lint
+        // only fires on an exact `Known` match between annotation and RHS,
+        // so an alias-typed local (e.g. `heading :: Direction := ...`)
+        // simply resolves as an opaque unknown class, never spuriously
+        // matches the RHS, and the lint stays silent (no false positive).
         let resolved = crate::semantic_analysis::type_checker::resolve_type_annotation(
             annotation,
             &empty_subst,
+            None,
             None,
         );
         let InferredType::Known {


### PR DESCRIPTION
## Summary

Phase 2 of ADR 0108 (named union type aliases, epic BT-2893). Wires the `type Name = ...` declarations added in BT-2894 (AST/parser/unparse) into semantic analysis, so a reference to an alias resolves to its structural expansion everywhere `resolve_type_annotation` is consulted.

Linear: https://linear.app/beamtalk/issue/BT-2895/alias-table-resolve-type-annotation-integration

- New `AliasRegistry` (name → declared `TypeAnnotation`), registered from `Module.type_aliases` after the class hierarchy and protocol registry are built (batch order: classes → protocols → aliases), with bidirectional namespace collision checks (alias vs. class, alias vs. protocol) and an unbound-type-parameter validation pass on the RHS (checks the class hierarchy first, per ADR 0068).
- `resolve_type_annotation` gains an `alias_registry` parameter; resolution order is `subst` (type params) → alias table → nominal class, disjoint by construction. Expansion is eager and recursive, with a per-call memo cache (avoids exponential blowup on legal doubling alias chains found during adversarial review) and a defensive cycle guard (full cycle *detection* is BT-2896).
- Threaded through parameter types, return types, typed local assignments, `self delegate` return types, and type-parameter-bound checking (also found and fixed during adversarial review — an alias-named generic type argument was silently skipping its declared bound check).
- Exhaustiveness regression tests confirm an alias-annotated `match:`/`matchExhaustive:` scrutinee behaves identically to the spelled-out union — the exhaustiveness checker itself is unchanged, per the ADR.

## Test plan
- [x] `just build && just clippy && just fmt-check` — all clean
- [x] `just test` — Rust (5039 tests), stdlib (223), BUnit (2770), Erlang runtime (5320 + 1588) all passing
- [x] `just ci-changed` — full local CI green
- [x] New unit tests: `alias_registry.rs` (10), `type_resolver.rs` (9 new, incl. chained/cyclic/exponential-chain cases)
- [x] New end-to-end tests: `type_alias_exhaustiveness.rs` (9), parsing real Beamtalk source through the full `analyse_with_options_and_classes` pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)