### PR TITLE
docs: daily refresh 2026-07-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Fix `match:` arm with a self-mutating multi-statement block inside an Actor method returning the internal state-threading tuple instead of the block's final value (BT-2880, #2983).
 - Fix `self delegate` method bodies with a declared return type inferring `Dynamic` (actors) or `Never` (objects) instead of the annotated return type (BT-2862, #2986).
 - Fix cascade continuation messages (`;`-chained sends) on a metatype receiver silently skipping argument type-checking and block parameter inference (BT-2879, #2982).
+- **`type Name = ...` — named type aliases (ADR 0108)** — a new top-level `type` declaration introduces a transparent type alias: `type RestartStrategy = #temporary | #transient | #permanent`. The alias expands to its structural annotation everywhere type annotations are used — parameter types, return types, typed locals, `match:`/`matchExhaustive:` exhaustiveness — so `heading :: Direction` behaves identically to spelling out the full union. `type` is a contextual keyword (three-token lookahead: `type` + uppercase name + `=`); it remains a legal identifier everywhere else. Single-letter names are rejected (reserved for type parameters). Alias names share the class/protocol namespace — collisions are diagnosed. The RHS accepts any type annotation (unions, singletons, generics, `\`/`&`). Parametric aliases (`type Foo(T) = ...`) are not yet supported (BT-2894, BT-2895, #3015, #3017).
 
 ### Standard Library
 
@@ -97,6 +98,7 @@
 
 ### Runtime
 
+- Fix `perform:`/`perform:withArguments:` on Block `value`/`value:`/`value:value:`/`value:value:value:` raising a confusing `does_not_understand` naming the wrong selector — pure (Tier 1) blocks now dispatch correctly via `erlang:apply`; stateful (Tier 2) blocks raise a clear `stateful_block_dispatch` error explaining that the block captures mutable state and must be invoked directly (BT-2812, #3013).
 - **`run-entry` server-side selector validation** — the WebSocket `run-entry` op now validates that the selector is either a unary selector (no `:`) or a single arity-1 keyword (exactly one trailing `:`). Multi-keyword selectors (e.g. `run:with:`) are rejected with a structured `#beamtalk_error{kind = invalid_argument}` instead of a confusing `badarg`/`undef` (BT-2699, #2951).
 - Fix self-dispatch error breadcrumb showing the defining superclass instead of the actual runtime class under inheritance — the `class` field in error messages from self-sends now reflects the runtime class (BT-2833, #2941).
 - Fix self-dispatch reraise missing `ClassName>>selector:` location prefix in error messages — self-send forwarding errors now carry the same breadcrumb context as cross-actor errors (BT-2822, #2931).
@@ -147,6 +149,9 @@
 
 ### Tooling
 
+- **`beamtalk run` routes status/progress to stderr** — `Building...`, `Running ClassName>>selector...`, and `Connecting to workspace...` lines now go to stderr instead of stdout. Stdout is program-output-only, matching Unix convention for piped/programmatic consumers (BT-2702, #3010).
+- **LSP return-type writeback and go-to-definition for FFI-typed receivers** — methods whose return type is inferred purely from an FFI call now get the resolved type written back before codegen, improving downstream inference. Go-to-definition on a receiver typed via an FFI call now resolves correctly (BT-2887, #3011).
+- **REPL tab-completion resolves FFI expression return types** — typing an FFI expression at the REPL prompt (e.g. `Erlang lists reverse: x`) and pressing tab now offers completions for the resolved return class instead of falling back to `Dynamic`. Requires a prior `beamtalk build` to populate `_build/type_cache/` (BT-2891, #3016).
 - Fix LSP not applying the `beamtalk.toml` `[diagnostics]` severity-override table — a category escalated to `"error"` now shows as `Error` in the editor, matching `beamtalk build` (surface-parity fix, BT-2800, #2935).
 - Fix REPL diagnostics not applying the `beamtalk.toml` `[diagnostics]` severity-override table — closes the last ADR 0100 Rule 3 surface-parity gap: a `dnu = "error"` override now shows as `Error` on all three surfaces (CLI build, LSP, REPL) (BT-2839, #2952).
 - Fix `@expect type` on FFI argument-type mismatches being falsely reported as stale by `beamtalk lint` — lint now uses the same live `.beam` type extractor as `beamtalk build`, so the two surfaces produce identical FFI diagnostics (BT-2851, #2953).

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -17,6 +17,7 @@ Language features for Beamtalk. See [beamtalk-principles.md](beamtalk-principles
   - [Erlang FFI](#erlang-ffi)
   - [Loading Code into the Workspace](#loading-code-into-the-workspace)
 - [Gradual Typing (ADR 0025)](#gradual-typing-adr-0025)
+  - [Named Type Aliases (`type` Declarations) (ADR 0108)](#named-type-aliases-type-declarations-adr-0108)
 - [Parametric Types — Generics (ADR 0068)](#parametric-types--generics-adr-0068)
 - [Structural Protocols (ADR 0068)](#structural-protocols-adr-0068)
   - [Printable Protocol and Display Methods](#printable-protocol-and-display-methods)
@@ -1112,6 +1113,45 @@ klass instanceCount         // resolves class-side method
 - Local variable annotations (`name :: Type := expr`) declare the binding's type at type-erasure boundaries. See [Local Variable Type Annotations](#local-variable-type-annotations) below.
 - Complex annotations (e.g., unions/generics) are parsed and accepted; deeper checking is phased in.
 - `Self` in return position resolves to the static receiver class. Using `Self` as a parameter type is an error (unsound with subclassing).
+
+### Named Type Aliases (`type` Declarations) (ADR 0108)
+
+A `type` declaration introduces a transparent type alias — a name for an existing type annotation:
+
+```beamtalk
+type RestartStrategy = #temporary | #transient | #permanent
+
+type OptionalString = String | Nil
+
+type JsonKey = String | Symbol
+```
+
+The alias expands to its structural annotation everywhere type annotations are used — parameter types, return types, typed locals, and `match:`/`matchExhaustive:` exhaustiveness checking. A type alias is purely compile-time; it is erased at codegen with no runtime representation.
+
+```beamtalk
+type Direction = #north | #south | #east | #west
+
+Object subclass: Compass
+  heading: h :: Direction =>
+    h matchExhaustive: [
+      #north -> 0;
+      #south -> 180;
+      #east  -> 90;
+      #west  -> 270
+    ]
+
+  defaultHeading -> Direction => #north
+```
+
+**`type` is a contextual keyword.** It is recognized only at top-level declaration position via a three-token lookahead (`type` + uppercase identifier + `=`). It remains a legal identifier everywhere else — `type := 5`, `foo type`, `type printString` are all unaffected.
+
+**Constraints:**
+
+- Single-letter names are rejected at parse time (reserved for ADR 0068's implicit method-local type parameters): `type T = Integer | Nil` produces an error.
+- Alias names share the class/protocol namespace — declaring an alias with the same name as an existing class or protocol is a compile error.
+- The RHS accepts any type annotation: unions (`|`), singletons (`#foo`), generics (`List(Integer)`), difference (`\`), intersection (`&`), and combinations.
+- Parametric aliases (`type Foo(T) = ...`) are not yet supported.
+- Doc comments (`///`) above a `type` declaration are preserved and shown by `:help`.
 
 ### Local Variable Type Annotations
 

--- a/docs/beamtalk-tooling.md
+++ b/docs/beamtalk-tooling.md
@@ -9,7 +9,7 @@ Tooling is part of the language, not an afterthought. Beamtalk is designed to be
 beamtalk new mylib          # Create new library project
 beamtalk new myapp --app    # Create new application project (supervisor + Main)
 beamtalk build              # Compile to BEAM
-beamtalk run                # Compile and start
+beamtalk run                # Compile and start (status to stderr, program output to stdout)
 beamtalk check              # Check for errors without compiling
 
 # Dependencies (see Package Management guide)
@@ -60,6 +60,8 @@ Every generated project includes a `Justfile` with these targets:
 | `release` | *(script)* | Tag a release from `beamtalk.toml` version |
 | `publish` | `git push origin --tags` | Push release tags |
 | `run` | `beamtalk run` | Run the application (**`--app` only**) |
+
+**`beamtalk run` output routing:** Status and progress lines (`Building...`, `Running ClassName>>selector...`, `Connecting to workspace...`) are written to **stderr**. Stdout carries only the dispatched program's own output, keeping it clean for piped/programmatic consumers (`beamtalk run MyApp run | head`).
 
 ## Build System
 


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 14 commits merged to `main` in the last 24 hours.

### Docs updated

- **`docs/beamtalk-language-features.md`** — new "Named Type Aliases (`type` Declarations)" subsection under Gradual Typing, with syntax, examples, constraints, and ToC entry (ADR 0108)
- **`docs/beamtalk-tooling.md`** — document `beamtalk run` stderr routing for status/progress lines
- **`CHANGELOG.md`** — 5 new entries:
  - Language: `type Name = ...` named type aliases (BT-2894, BT-2895, #3015, #3017)
  - Runtime: fix `perform:` on Block `value`/`value:` selectors (BT-2812, #3013)
  - Tooling: `beamtalk run` stderr routing (BT-2702, #3010)
  - Tooling: LSP return-type writeback + go-to-def for FFI-typed receivers (BT-2887, #3011)
  - Tooling: REPL tab-completion resolves FFI expression return types (BT-2891, #3016)

### Commits reviewed

| Commit | Classification | Doc change |
|--------|---------------|------------|
| `1915096` Alias table + resolve_type_annotation (BT-2895, #3017) | Language feature | CHANGELOG + language-features.md |
| `ffcf08a` REPL completion fallback NativeTypeRegistry (BT-2891, #3016) | Tooling | CHANGELOG |
| `4ea3d8e` `type Name = ...` AST/parser/unparse (BT-2894, #3015) | Language feature | CHANGELOG + language-features.md |
| `0a3d2a3` Fix perform:/dynamic dispatch on Block value (BT-2812, #3013) | Bug fix | CHANGELOG |
| `8a4486f` Thread NativeTypeRegistry to writeback/goto-def (BT-2887, #3011) | Tooling | CHANGELOG |
| `797a569` Route beamtalk run status to stderr (BT-2702, #3010) | Tooling | CHANGELOG + tooling.md |

### Skipped

| Commit | Reason |
|--------|--------|
| `0635397` docs: add implementation tracking to ADR 0108 | ADR-only (excluded) |
| `06da6a1` Draft ADR 0108 | ADR-only (excluded) |
| `8e6d05f` Fix check-corpus CI | `.github/` (excluded) |
| `9fadd3a` docs: re-audit stdlib-implementation-status.md | Prior doc refresh |
| `ecb12ac` docs: daily refresh 2026-07-15 | Prior doc refresh |
| `6698f66` refactor(tests): tighten placeholder assertions | Test-only (excluded) |
| `edc4183` Add edge-path tests for transcript_stream | Test-only (excluded) |
| `ef99940` refactor: use existing to_binary/1 helper | Internal refactor, no user surface |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3wq7aF8QUYv8SyKjnCBEM

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3wq7aF8QUYv8SyKjnCBEM)_