### PR TITLE
E2E btscript test for type alias declaration, exhaustiveness, and hot reload (BT-2905)

### DIFF
--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -30525,6 +30525,24 @@
       "explanation": "Hot reload counter - version 2 with modified increment (adds 10) and new field 'step'"
     },
     {
+      "id": "tests-repl-protocol-fixtures-hot-reload-alias-switch",
+      "title": "HotReloadColorSwitch",
+      "category": "repl-protocol-fixtures",
+      "tags": [
+        "HotReloadColorSwitch",
+        "Object",
+        "extends",
+        "hot_reload_alias_switch",
+        "inherit",
+        "inheritance",
+        "labelFor:",
+        "object",
+        "subclassing"
+      ],
+      "source": "// Fixture for the BT-2905 alias hot-reload re-check E2E test\n// (tests/repl-protocol/cases/type_alias_repl.btscript).\n//\n// `labelFor:`'s `matchExhaustive:` is sound against `HotReloadColor`'s\n// three-member expansion at load time (the alias is declared in the REPL\n// session, not in this file — `:: HotReloadColor` resolves against\n// `beamtalk_compiler_server`'s ambient alias cache, kept in sync with the\n// session's alias table). Loading this file (not typing the class directly\n// at the REPL) is required so the compile goes through\n// `beamtalk_repl_compiler:compile_file_core/4`, the path that registers\n// alias-name -> annotation-site edges into `beamtalk_alias_xref` — a class\n// definition typed directly at the REPL does not.\n\nObject subclass: HotReloadColorSwitch\n\n  labelFor: c :: HotReloadColor -> Integer =>\n    c matchExhaustive: [\n      #red -> 1;\n      #green -> 2;\n      #blue -> 3\n    ]",
+      "explanation": "Fixture for the BT-2905 alias hot-reload re-check E2E test (tests/repl-protocol/cases/type_alias_repl.btscript).  `labelFor:`'s `matchExhaustive:` is sound against `HotReloadColor`'s three-member expansion at load time (the alias is declared in the REPL session, not in this file — `:: HotReloadColor` resolves against `beamtalk_compiler_server`'s ambient alias cache, kept in sync with the session's alias table). Loading this file (not typing the class directly at the REPL) is required so the compile goes through `beamtalk_repl_compiler:compile_file_core/4`, the path that registers alias-name -> annotation-site edges into `beamtalk_alias_xref` — a class definition typed directly at the REPL does not."
+    },
+    {
       "id": "tests-repl-protocol-fixtures-incremental-project-src-adder",
       "title": "Adder",
       "category": "repl-protocol-fixtures",

--- a/tests/repl-protocol/cases/type_alias_repl.btscript
+++ b/tests/repl-protocol/cases/type_alias_repl.btscript
@@ -3,7 +3,11 @@
 
 // E2E tests for `type Name = ...` declarations typed directly at the REPL,
 // `:help <Alias>`, and cross-turn alias persistence within a session
-// (ADR 0108 Phase 8, BT-2902).
+// (ADR 0108 Phase 8, BT-2902), plus (final section below) the alias
+// hot-reload re-check trigger verified end-to-end from a live REPL session
+// (ADR 0108 Phase 10, BT-2905 — the epic's required final E2E validation
+// phase; per CLAUDE.md, "EUnit and BUnit alone are insufficient for
+// user-facing features").
 //
 // REPL display-value decision (flagged for maintainer sign-off — see the
 // PR description and CLAUDE.md's REPL-output rule): a `type` declaration
@@ -18,6 +22,14 @@
 // a `///` comment followed by its declaration as a single multi-line REPL
 // input the way real multi-line class bodies are typed (a `///`-prefixed
 // line is indistinguishable here from a plain in-file comment line).
+//
+// Hover on an alias name/reference (BT-2905's other REPL-protocol-untestable
+// leaf — there is no `textDocument/hover`-equivalent op in this harness) is
+// covered end-to-end against the same query layer the LSP server's
+// `textDocument/hover` handler calls: `hover_on_alias_declaration_name_shows_expansion`
+// and `hover_resolves_alias_through_project_wide_registry` in
+// crates/beamtalk-core/src/queries/hover_provider.rs and
+// crates/beamtalk-core/src/language_service/mod.rs respectively (BT-2901).
 
 // ===========================================================================
 // Declaring a type alias directly at the REPL echoes its name.
@@ -80,3 +92,58 @@ e :: Direction := #up. e matchExhaustive: [#north -> 0; #south -> 1; #east -> 2;
 
 :help Direction
 // => type Direction = #north | #south | #east | #west | #up | #down__Declared in: REPL
+
+// ===========================================================================
+// Alias hot-reload re-check trigger (BT-2899), verified end-to-end (BT-2905):
+// live-redefining an alias must invalidate a `matchExhaustive:` proof a
+// *compiled class method* holds against the alias's OLD member set — the
+// ADR 0108 headline scenario, and the gap flagged immediately above
+// ("Re-checking sites... is BT-2899's separate hot-reload concern").
+//
+// Unlike the ad-hoc `missing :: Direction := ...` top-level expressions
+// above (freshly re-resolved every REPL turn, never indexed into
+// `beamtalk_alias_xref`), the re-check trigger is keyed off alias-name ->
+// annotation-site edges that only a real class COMPILE populates — and,
+// per `beamtalk_repl_compiler.erl`, only the FILE-compile path
+// (`compile_file_core/4`, reached via `:load`) and the `>>` method-patch
+// path register those edges; a class typed directly at the REPL
+// (`compile_class_definition_result/2`) does not. So the dependent class
+// below is loaded from a fixture file, not typed inline.
+//
+// The re-check itself runs asynchronously on
+// `beamtalk_workspace_shape_recheck_worker` and publishes into
+// `beamtalk_workspace_findings_store` — NOT `Workspace recheckImage`,
+// whose whole-image sweep deliberately drops error-severity diagnostics
+// (`beamtalk_recheck.erl`'s `relevant_image_diagnostic/1`), so a genuinely
+// non-exhaustive `matchExhaustive:` would never surface there. We poll the
+// findings store directly via the Erlang FFI escape, mirroring the
+// whileTrue:/Timer sleep: poll idiom `announcements.btscript` uses to
+// await another asynchronous completion.
+// ===========================================================================
+
+type HotReloadColor = #red | #green | #blue
+// => HotReloadColor
+
+:load tests/repl-protocol/fixtures/hot_reload_alias_switch.bt
+// => Loaded: HotReloadColorSwitch
+
+// Sanity: no stale-alias finding yet — the compiled method's
+// matchExhaustive: proof is still sound against the alias's current
+// (exhaustive) three-member set.
+((Erlang beamtalk_workspace_findings_store) for_owner: "HotReloadColorSwitch") isEmpty
+// => true
+
+// Redefine the alias to add a member: `labelFor:`'s matchExhaustive:
+// (still only covering red/green/blue) is now stale — newly non-exhaustive.
+type HotReloadColor = #red | #green | #blue | #alpha
+// => HotReloadColor
+
+// Poll the findings store until the async re-check worker has posted a
+// finding for the dependent class (capped retries, ~2s).
+_hrPollCount := 0. [((Erlang beamtalk_workspace_findings_store) for_owner: "HotReloadColorSwitch") isEmpty and: [_hrPollCount < 100]] whileTrue: [Timer sleep: 20. _hrPollCount := _hrPollCount + 1]. ((Erlang beamtalk_workspace_findings_store) for_owner: "HotReloadColorSwitch") isEmpty
+// => false
+
+// The finding is classified as an alias-change re-check and names the
+// exhaustiveness gap — proof the proof re-fired as newly non-exhaustive.
+((Erlang beamtalk_workspace_findings_store) for_owner: "HotReloadColorSwitch") anySatisfy: [:f | ((Erlang maps) get: #message with: f) includesSubstring: "exhaustive"]
+// => true

--- a/tests/repl-protocol/fixtures/hot_reload_alias_switch.bt
+++ b/tests/repl-protocol/fixtures/hot_reload_alias_switch.bt
@@ -1,0 +1,24 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// Fixture for the BT-2905 alias hot-reload re-check E2E test
+// (tests/repl-protocol/cases/type_alias_repl.btscript).
+//
+// `labelFor:`'s `matchExhaustive:` is sound against `HotReloadColor`'s
+// three-member expansion at load time (the alias is declared in the REPL
+// session, not in this file — `:: HotReloadColor` resolves against
+// `beamtalk_compiler_server`'s ambient alias cache, kept in sync with the
+// session's alias table). Loading this file (not typing the class directly
+// at the REPL) is required so the compile goes through
+// `beamtalk_repl_compiler:compile_file_core/4`, the path that registers
+// alias-name -> annotation-site edges into `beamtalk_alias_xref` — a class
+// definition typed directly at the REPL does not.
+
+Object subclass: HotReloadColorSwitch
+
+  labelFor: c :: HotReloadColor -> Integer =>
+    c matchExhaustive: [
+      #red -> 1;
+      #green -> 2;
+      #blue -> 3
+    ]


### PR DESCRIPTION
Closes the epic's required final E2E validation phase for ADR 0108 (named/union type aliases).

Linear: https://linear.app/beamtalk/issue/BT-2905

## Summary

- Extends `tests/repl-protocol/cases/type_alias_repl.btscript` (added by BT-2902, which already covered declaration, use in an annotation, `matchExhaustive:` exhaustiveness, and `:help`) with the one remaining scenario: **live-redefining an alias must invalidate a `matchExhaustive:` proof a compiled class method holds against the alias's old member set** — the ADR 0108 headline scenario, and the BT-2899 hot-reload re-check trigger verified end-to-end from a live REPL session (not just EUnit).
- Adds a new fixture `tests/repl-protocol/fixtures/hot_reload_alias_switch.bt` — the dependent class is loaded via `:load` rather than typed inline, because only the file-compile path (`compile_file_core/4`) and the `>>` method-patch path register alias-name → annotation-site edges into `beamtalk_alias_xref`; a class typed directly at the REPL does not.
- The test polls `beamtalk_workspace_findings_store` directly via the Erlang FFI escape (not `Workspace recheckImage`, whose whole-image sweep deliberately drops error-severity diagnostics and would never surface a non-exhaustive `matchExhaustive:` finding), mirroring the `whileTrue:`/`Timer sleep:` poll idiom `announcements.btscript` already uses for other async completions.
- Hover coverage (the other REPL-protocol-untestable AC bullet — there's no `textDocument/hover`-equivalent op in this harness) is confirmed already covered end-to-end by BT-2901's `hover_provider.rs`/`language_service/mod.rs` tests, which exercise the same query layer the LSP server's hover handler calls; documented in the file header rather than duplicated.
- Regenerated `crates/beamtalk-examples/corpus.json` for the new fixture (`just build-corpus`).

Per CLAUDE.md: "EUnit and BUnit alone are insufficient for user-facing features" — this test proves declaration, annotation use, exhaustiveness, `:help`, and hot-reload re-check actually work end-to-end from a live REPL session, not just in isolated unit tests. Codegen (BT-2900) intentionally left its named `-type` primitives unwired pending BT-2909, so this test does not assert on generated Erlang `-type` attributes — only REPL-observable behavior, per BT-2905's actual acceptance criteria.

## Test plan

- [x] `just test-repl-protocol` passes (including the new hot-reload section)
- [x] `just test-stdlib`, `just test-bunit`, `just test-runtime`, `just test-integration`, `just test-mcp` pass
- [x] `just check-corpus`, `just check-surface-drift` pass
- [x] `just clippy`, fmt checks, dialyzer pass
- [x] `just test-rust` — all green except one pre-existing, environment-dependent failure (`bt2424_default_deployment_keeps_epmd_off_public_interfaces`) confirmed to fail identically on unmodified `main` in this sandbox — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)