### PR TITLE
CLI build/lint never set current_package, so E0401/E0402 visibility checks never fire (BT-2920)

### DIFF
--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -236,6 +236,12 @@ pub fn build(path: &str, options: &beamtalk_core::CompilerOptions, force: bool) 
         .full_manifest
         .as_ref()
         .is_some_and(|m| !m.dependencies.is_empty());
+    // BT-2920: Set the current package so E0401/E0402 visibility checks
+    // (`check_class_visibility`/`check_alias_leaked_visibility`) actually run
+    // — they're gated on `current_package: Some(_)` and silently emit zero
+    // diagnostics otherwise. `None` for single-file/manifest-less builds,
+    // which have no package boundary to enforce.
+    options.current_package = env.pkg_manifest().map(|m| m.name.clone());
     let options = &options;
 
     let dep_ctx = resolve_and_validate_dependencies(&env, options)?;
@@ -1567,6 +1573,16 @@ pub(crate) fn build_class_module_index(
                 info.surface_incomplete = true;
             }
         }
+        // BT-2920: Stamp the package now, while each file's classes are still
+        // isolated — `analyse_full`'s `stamp_package` only reaches classes
+        // built from the *current* module's own AST, never the cross-file
+        // `ClassInfo` this Pass 1 index injects into every other file's
+        // compilation. Without this, E0401/E0402 treat a same-package class
+        // from a sibling file as package-less and never flag it as a leak.
+        beamtalk_core::semantic_analysis::ClassHierarchy::stamp_package_on_infos(
+            &mut class_infos,
+            pkg_name,
+        );
         all_class_infos.extend(class_infos);
 
         // BT-2795: Collect standalone extension definitions

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -36,6 +36,7 @@ use tracing::warn;
 /// project so that cross-file type/DNU diagnostics match what `build` emits.
 /// Without this, `@expect type` / `@expect all` annotations that suppress real
 /// diagnostics during build would be reported as stale by lint.
+#[allow(clippy::too_many_arguments)] // BT-2920 added `current_package`; each param is load-bearing context
 fn collect_diagnostics(
     module: &beamtalk_core::ast::Module,
     parse_diags: Vec<beamtalk_core::source_analysis::Diagnostic>,
@@ -46,6 +47,7 @@ fn collect_diagnostics(
     knowledge_scope: beamtalk_core::semantic_analysis::KnowledgeScope,
     cross_file_extensions: &beamtalk_core::compilation::extension_index::ExtensionIndex,
     has_package_dependencies: bool,
+    current_package: Option<&str>,
 ) -> Vec<beamtalk_core::source_analysis::Diagnostic> {
     // Collect parser-level lint diagnostics (e.g. unnecessary `.` — BT-948)
     // plus AST-level lint passes.
@@ -70,9 +72,13 @@ fn collect_diagnostics(
     // FFI call falls back to `Dynamic(UntypedFfi)` and lint emits a
     // "Dynamic in typed class" warning that build does not — leaving the user
     // with no `@expect` configuration that satisfies both passes.
+    // BT-2920: Set current_package so E0401/E0402 visibility checks fire in
+    // `beamtalk lint`, matching `beamtalk build` — both gate on
+    // `current_package: Some(_)` (see `check_class_visibility`).
     let options = beamtalk_core::CompilerOptions {
         knowledge_scope,
         has_package_dependencies,
+        current_package: current_package.map(str::to_string),
         ..Default::default()
     };
     let analysis_result = beamtalk_core::semantic_analysis::analyse_with_natives_and_extensions(
@@ -100,6 +106,7 @@ fn collect_diagnostics(
 /// Run lint passes on the given path (file or directory).
 ///
 /// Prints each lint diagnostic and returns an error if any are found.
+#[allow(clippy::too_many_lines)] // BT-2920 added current_package resolution; orchestration function
 pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
     let source_path = Utf8PathBuf::from(path);
     let (source_files, erl_files) = collect_lint_files(&source_path, path)?;
@@ -115,8 +122,24 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
     // visible. Otherwise a test file that references a `src/` class produces
     // spurious `Unresolved class` diagnostics.
     let package_root = find_package_root(&source_path);
-    let (mut all_class_infos, extension_index, parsed_files) =
-        parse_and_extract_class_infos(&source_files, package_root.as_deref())?;
+
+    // BT-2920: Resolve the package name so E0401/E0402 visibility checks fire
+    // in lint the same way they do in `beamtalk build` — both are gated on
+    // `current_package: Some(_)` (see `check_class_visibility`). Resolved
+    // before extraction so cross-file `ClassInfo` can be package-stamped too
+    // (see `parse_and_extract_class_infos`'s `stamp_package_on_infos` call).
+    let current_package = package_root.as_deref().and_then(|root| {
+        super::manifest::find_manifest_full(root)
+            .ok()
+            .flatten()
+            .map(|m| m.package.name)
+    });
+
+    let (mut all_class_infos, extension_index, parsed_files) = parse_and_extract_class_infos(
+        &source_files,
+        package_root.as_deref(),
+        current_package.as_deref(),
+    )?;
 
     // Resolve dependency class metadata so lint sees the same class hierarchy
     // as build. Without this, @expect annotations that suppress real cross-package
@@ -173,6 +196,7 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
             knowledge_scope,
             &extension_index,
             has_package_dependencies,
+            current_package.as_deref(),
         );
 
         for diag in &lint_diags {
@@ -419,6 +443,7 @@ type ParsedLintFile = (
 fn parse_and_extract_class_infos(
     source_files: &[Utf8PathBuf],
     package_root: Option<&Utf8Path>,
+    current_package: Option<&str>,
 ) -> Result<(
     Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
     beamtalk_core::compilation::extension_index::ExtensionIndex,
@@ -460,6 +485,15 @@ fn parse_and_extract_class_infos(
             for info in &mut class_infos {
                 info.surface_incomplete = true;
             }
+        }
+        // BT-2920: Stamp the package per-file, same as build's Pass 1 — see
+        // `stamp_package_on_infos`'s doc comment for why this can't wait
+        // until each file's own analysis pass.
+        if let Some(pkg) = current_package {
+            beamtalk_core::semantic_analysis::ClassHierarchy::stamp_package_on_infos(
+                &mut class_infos,
+                pkg,
+            );
         }
         all_class_infos.extend(class_infos);
 
@@ -612,6 +646,7 @@ fn collect_lint_diagnostics(source: &str) -> Vec<beamtalk_core::source_analysis:
         beamtalk_core::semantic_analysis::KnowledgeScope::default(),
         &beamtalk_core::compilation::extension_index::ExtensionIndex::new(),
         false,
+        None,
     )
 }
 
@@ -705,6 +740,7 @@ mod tests {
             beamtalk_core::semantic_analysis::KnowledgeScope::default(),
             &beamtalk_core::compilation::extension_index::ExtensionIndex::new(),
             false,
+            None,
         );
         let stale = diags.iter().any(|d| d.message.contains("stale @expect"));
         assert!(
@@ -904,6 +940,7 @@ mod tests {
             beamtalk_core::semantic_analysis::KnowledgeScope::default(),
             &beamtalk_core::compilation::extension_index::ExtensionIndex::new(),
             false,
+            None,
         );
 
         let unresolved: Vec<_> = diags
@@ -1010,6 +1047,7 @@ mod tests {
             beamtalk_core::semantic_analysis::KnowledgeScope::default(),
             &beamtalk_core::compilation::extension_index::ExtensionIndex::new(),
             false,
+            None,
         );
 
         let has_untyped_ffi = diags.iter().any(|d| d.message.contains("untyped FFI"));
@@ -1057,6 +1095,7 @@ mod tests {
             beamtalk_core::semantic_analysis::KnowledgeScope::default(),
             &beamtalk_core::compilation::extension_index::ExtensionIndex::new(),
             false,
+            None,
         );
 
         let untyped_ffi: Vec<_> = diags
@@ -1118,6 +1157,7 @@ mod tests {
             beamtalk_core::semantic_analysis::KnowledgeScope::default(),
             &beamtalk_core::compilation::extension_index::ExtensionIndex::new(),
             false,
+            None,
         );
         let stale = diags.iter().any(|d| d.message.contains("stale @expect"));
         assert!(

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -123,32 +123,49 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
     // spurious `Unresolved class` diagnostics.
     let package_root = find_package_root(&source_path);
 
-    // BT-2920: Resolve the package name so E0401/E0402 visibility checks fire
-    // in lint the same way they do in `beamtalk build` — both are gated on
-    // `current_package: Some(_)` (see `check_class_visibility`). Resolved
-    // before extraction so cross-file `ClassInfo` can be package-stamped too
-    // (see `parse_and_extract_class_infos`'s `stamp_package_on_infos` call).
-    let current_package = package_root.as_deref().and_then(|root| {
-        super::manifest::find_manifest_full(root)
-            .ok()
-            .flatten()
-            .map(|m| m.package.name)
-    });
+    // BT-2920 (review S1): parse beamtalk.toml exactly once, deriving both
+    // `current_package` (E0401/E0402 gating, see `check_class_visibility`)
+    // and `has_package_dependencies` from the same read. Previously these
+    // were two independent re-parses with inconsistent error handling — a
+    // malformed manifest silently disabled visibility checks (`.ok()`) while
+    // only `has_package_dependencies` warned on the same parse failure.
+    // `package_root` (when `Some`) is only ever produced by `find_package_root`
+    // finding a `beamtalk.toml`, so the manifest is known to exist here; the
+    // only outcome left to distinguish is "parses" vs "malformed".
+    let (current_package, has_package_dependencies) = match package_root.as_deref() {
+        Some(root) => match super::manifest::find_manifest_full(root) {
+            Ok(Some(m)) => {
+                let has_deps = !m.dependencies.is_empty();
+                (Some(m.package.name), has_deps)
+            }
+            Ok(None) => (None, false),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "Failed to parse beamtalk.toml for lint; E0401/E0402 visibility \
+                     checks disabled and dependencies conservatively assumed present"
+                );
+                (None, true)
+            }
+        },
+        None => (None, false),
+    };
 
+    // Resolved before extraction so cross-file `ClassInfo` can be
+    // package-stamped too (see `parse_and_extract_class_infos`'s
+    // `stamp_package_on_infos` call).
     let (mut all_class_infos, extension_index, parsed_files) = parse_and_extract_class_infos(
         &source_files,
         package_root.as_deref(),
         current_package.as_deref(),
     )?;
 
-    // Resolve dependency class metadata so lint sees the same class hierarchy
+    // Merge dependency class metadata so lint sees the same class hierarchy
     // as build. Without this, @expect annotations that suppress real cross-package
     // diagnostics would be reported as stale.
-    let has_package_dependencies = if let Some(ref project_root) = package_root {
-        resolve_dep_class_infos(project_root, &mut all_class_infos)
-    } else {
-        false
-    };
+    if let Some(ref project_root) = package_root {
+        merge_dependency_class_infos(project_root, &mut all_class_infos);
+    }
 
     // BT-2134 / BT-2851: Populate the FFI type registry via the same
     // `extract_type_specs` that `beamtalk build` calls, instead of only
@@ -529,31 +546,17 @@ pub(crate) fn find_package_root(start: &Utf8Path) -> Option<Utf8PathBuf> {
 ///
 /// Best-effort: if dependency resolution fails (e.g. network error for a git
 /// dep), lint continues without dep classes rather than failing entirely.
-/// Returns whether the package *declares* dependencies (BT-2794), read from
-/// the manifest rather than the resolution outcome so that a transient
-/// resolution failure (network, git) cannot flip diagnostic behaviour
-/// between runs. Conservatively true when the manifest cannot be parsed.
-fn resolve_dep_class_infos(
+///
+/// BT-2920 (review S1): `has_package_dependencies` (BT-2794) used to be
+/// computed here from its own re-parse of `beamtalk.toml`, independently of
+/// `run_lint`'s `current_package` resolution — two reads of the same file
+/// with inconsistent error handling. `run_lint` now parses the manifest once
+/// and derives both from that single read; this function's only remaining
+/// job is the dependency-class side effect on `all_class_infos`.
+fn merge_dependency_class_infos(
     project_root: &Utf8Path,
     all_class_infos: &mut Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
-) -> bool {
-    let manifest_path = project_root.join("beamtalk.toml");
-    if !manifest_path.exists() {
-        return false;
-    }
-
-    let has_package_dependencies = match super::manifest::parse_manifest_full(&manifest_path) {
-        Ok(manifest) => !manifest.dependencies.is_empty(),
-        Err(e) => {
-            warn!(
-                error = %e,
-                "Failed to parse beamtalk.toml for lint; \
-                 conservatively assuming dependencies are declared"
-            );
-            true
-        }
-    };
-
+) {
     let options = beamtalk_core::CompilerOptions::default();
     match super::deps::ensure_deps_resolved(project_root, &options) {
         Ok(resolved_deps) => {
@@ -569,8 +572,6 @@ fn resolve_dep_class_infos(
             );
         }
     }
-
-    has_package_dependencies
 }
 
 /// Output format for lint diagnostics.

--- a/crates/beamtalk-cli/src/dependency_classes.rs
+++ b/crates/beamtalk-cli/src/dependency_classes.rs
@@ -71,8 +71,8 @@ use tracing::warn;
 /// any network I/O.
 ///
 /// Returns `(has_package_dependencies, class_infos)`:
-/// - `has_package_dependencies` mirrors `beamtalk lint`'s
-///   `resolve_dep_class_infos` flag (BT-2794): read from the manifest's
+/// - `has_package_dependencies` mirrors `beamtalk lint`'s `run_lint`-computed
+///   flag (BT-2794): read from the manifest's
 ///   `[dependencies]` table regardless of whether any individual dependency
 ///   could actually be resolved on disk, so a dependency that hasn't been
 ///   fetched yet doesn't flip diagnostic behaviour between runs.

--- a/crates/beamtalk-cli/tests/cli_build.rs
+++ b/crates/beamtalk-cli/tests/cli_build.rs
@@ -77,6 +77,80 @@ fn build_force_recompiles_unchanged_sources() {
 }
 
 // ---------------------------------------------------------------------------
+// BT-2920: E0401/E0402 visibility checks must fire at build time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_fails_with_e0402_for_cross_file_internal_class_leak() {
+    // Regression for BT-2920: `current_package` was never threaded into the
+    // CLI build path, so `check_class_visibility` silently emitted zero
+    // diagnostics. Mirrors docs/beamtalk-language-features.md's
+    // TokenBuffer/Parser example — the internal class lives in a *sibling*
+    // file from the public method that leaks it, exercising the cross-file
+    // package-stamping fix (`ClassHierarchy::stamp_package_on_infos`), not
+    // just same-file visibility.
+    let project = cli_common::fixture_project();
+    std::fs::write(
+        project.path().join("src/TokenBuffer.bt"),
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         internal Object subclass: TokenBuffer\n\
+         \x20\x20data => nil\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project.path().join("src/Parser.bt"),
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         Object subclass: Parser\n\
+         \x20\x20tokenize: input :: String -> TokenBuffer => nil\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("build")
+        .assert()
+        .failure()
+        // miette word-wraps the message to terminal width, so match the two
+        // halves separately rather than the exact single-line string.
+        .stderr(
+            contains("Internal class 'TokenBuffer' appears in public signature of")
+                .and(contains("tokenize:'")),
+        );
+}
+
+#[test]
+fn build_fails_with_e0402_for_internal_type_alias_leak() {
+    // Regression for BT-2920 (ADR 0108 Semantics, BT-2898): a public type
+    // alias whose expansion transitively reaches an internal alias must fail
+    // the build with E0402, not just an LSP squiggle.
+    let project = cli_common::fixture_project();
+    std::fs::write(
+        project.path().join("src/Types.bt"),
+        "// Copyright 2026 James Casey\n\
+         // SPDX-License-Identifier: Apache-2.0\n\
+         \n\
+         internal type Priv = Integer\n\
+         type Pub = Priv | String\n",
+    )
+    .unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("build")
+        .assert()
+        .failure()
+        // See the comment in the class-leak test above re: miette wrapping.
+        .stderr(
+            contains("Internal type alias 'Priv' appears in the expansion of public type alias")
+                .and(contains("'Pub'")),
+        );
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
@@ -456,6 +456,27 @@ impl ClassHierarchy {
             .map(ClassInfo::from_class_definition)
             .collect()
     }
+    /// Set the `package` field on every entry in `class_infos` that doesn't
+    /// already have one (ADR 0071, BT-1700 / BT-2920).
+    ///
+    /// [`Self::extract_class_infos`] builds `ClassInfo` purely from a single
+    /// file's AST, with `package: None` — it has no project-wide context. A
+    /// project's Pass 1 (`beamtalk build`'s cross-file class index, `beamtalk
+    /// lint`'s package walk) collects these across every source file *before*
+    /// injecting them into any file's `ClassHierarchy`, so [`Self::stamp_package`]
+    /// (which stamps a live hierarchy's own AST-derived classes) never reaches
+    /// them. Without this, `check_class_visibility`/`check_alias_leaked_visibility`
+    /// (E0401/E0402) silently treat a same-package class defined in a *sibling*
+    /// file as package-less — same as a builtin or REPL class — and never flag
+    /// it as a leak.
+    pub fn stamp_package_on_infos(class_infos: &mut [ClassInfo], package: &str) {
+        let pkg: EcoString = EcoString::from(package);
+        for info in class_infos {
+            if info.package.is_none() && !Self::is_builtin_class(&info.name) {
+                info.package = Some(pkg.clone());
+            }
+        }
+    }
     /// Filter `all_class_infos` to exclude classes defined in `module`,
     /// returning only cross-file class metadata suitable for injection into
     /// semantic analysis.

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/tests.rs
@@ -2441,6 +2441,62 @@ fn stamp_package_does_not_overwrite_existing_package() {
     );
 }
 #[test]
+fn stamp_package_on_infos_sets_package_on_non_builtin_classes() {
+    // BT-2920: `stamp_package_on_infos` is `stamp_package`'s counterpart for
+    // Pass 1's cross-file `ClassInfo` extraction (build's class index,
+    // lint's package walk) — a plain `Vec<ClassInfo>` collected before any
+    // `ClassHierarchy` exists, so `stamp_package` itself can't reach it.
+    let source = "Actor subclass: TokenBuffer\n  data => nil\n";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, _) = crate::source_analysis::parse(tokens);
+    let mut infos = ClassHierarchy::extract_class_infos(&module);
+    assert_eq!(
+        infos[0].package, None,
+        "freshly extracted infos start unpackaged"
+    );
+
+    ClassHierarchy::stamp_package_on_infos(&mut infos, "json");
+
+    assert_eq!(
+        infos[0].package.as_deref(),
+        Some("json"),
+        "stamp_package_on_infos should set package on AST-derived infos"
+    );
+}
+#[test]
+fn stamp_package_on_infos_does_not_overwrite_existing_package() {
+    let mut infos = vec![ClassInfo {
+        surface_incomplete: false,
+        name: EcoString::from("RemoteClass"),
+        superclass: Some(EcoString::from("Object")),
+        is_sealed: false,
+        is_abstract: false,
+        is_typed: false,
+        is_internal: false,
+        package: Some(EcoString::from("other_pkg")),
+        is_value: false,
+        is_native: false,
+        handle_scope: None,
+        state: vec![],
+        state_types: HashMap::new(),
+        state_has_default: HashMap::new(),
+        methods: vec![],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        type_param_bounds: vec![],
+        superclass_type_args: vec![],
+    }];
+
+    ClassHierarchy::stamp_package_on_infos(&mut infos, "myapp");
+
+    assert_eq!(
+        infos[0].package.as_deref(),
+        Some("other_pkg"),
+        "stamp_package_on_infos should not overwrite an already-set package"
+    );
+}
+#[test]
 fn add_from_beam_meta_preserves_is_internal_and_package() {
     let mut h = ClassHierarchy::with_builtins();
     let info = ClassInfo {

--- a/docs/beamtalk-language-features.md
+++ b/docs/beamtalk-language-features.md
@@ -4332,16 +4332,11 @@ internal Actor subclass: ConnectionPool
   release: conn => ...
 ```
 
-Cross-package references to internal classes produce a compile error:
+Cross-package references to internal classes produce a compile error (`E0401`):
 
 ```text
-error[E0401]: Class 'ConnectionPool' is internal to package 'http' and cannot be referenced from 'my_app'
-  --> src/app.bt:5:12
-   |
- 5 |     http@ConnectionPool new
-   |          ^^^^^^^^^^^^^^
-   |
-   = note: 'ConnectionPool' is declared 'internal' in package 'http'
+Class 'ConnectionPool' is internal to package 'http' and cannot be referenced from 'my_app'
+  help: 'ConnectionPool' is declared 'internal' in package 'http'
 ```
 
 #### Method-Level `internal`
@@ -4361,14 +4356,11 @@ Actor subclass: HttpClient
   internal retryWithBackoff: block maxAttempts: n => ...
 ```
 
-When the compiler can determine the receiver type (via type annotations, literal class references, or type inference), cross-package sends to internal methods produce a compile error:
+When the compiler can determine the receiver type (via type annotations, literal class references, or type inference), cross-package sends to internal methods produce a compile error (`E0403`):
 
 ```text
-error[E0403]: Method 'buildHeaders:' is internal to package 'http' and cannot be called from 'my_app'
-  --> src/app.bt:10:5
-   |
-10 |     client buildHeaders: req
-   |            ^^^^^^^^^^^^^^
+Method 'buildHeaders:' is internal to package 'http' and cannot be called from 'my_app'
+  help: 'buildHeaders:' is declared 'internal' in 'HttpClient'
 ```
 
 For untyped dynamic sends where the receiver type is unknown, no enforcement — the message send succeeds at runtime, consistent with the "visibility controls dependency, not knowledge" principle.
@@ -4428,16 +4420,11 @@ internal Value subclass: TokenBuffer
   field: tokens = #()
 ```
 
-**Leaked visibility** — if an internal class appears in the public signature of a public method, the compiler emits a hard error. This prevents accidentally exposing implementation types:
+**Leaked visibility** — if an internal class appears in the public signature of a public method, the compiler emits a hard error (`E0402`). This prevents accidentally exposing implementation types:
 
 ```text
-error[E0402]: Internal class 'TokenBuffer' appears in public signature of 'Parser >> tokenize:'
-  --> src/parser.bt:12:3
-   |
-12 |   tokenize: input :: String -> TokenBuffer =>
-   |                                ^^^^^^^^^^^
-   |
-   = note: 'TokenBuffer' is declared 'internal' — make it public, or change the return type
+Internal class 'TokenBuffer' appears in public signature of 'Parser >> tokenize:'
+  help: 'TokenBuffer' is declared 'internal' — make it public, or change the type
 ```
 
 All methods on an internal class are effectively internal. The method-level modifier is only meaningful on public classes.


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2920

## Summary

- `beamtalk build` never constructed a package-aware `CompilerOptions`, and `beamtalk lint` built one without `current_package` set, so `check_class_visibility`/`check_alias_leaked_visibility` (E0401/E0402) — gated on `current_package: Some(_)` — silently produced zero diagnostics outside the LSP. Fixed both call sites in `crates/beamtalk-cli/src/commands/{build,lint}.rs`.
- Found a second, deeper gap while reproducing the docs' own cross-file example: Pass 1's cross-file `ClassInfo` extraction never stamped a `package`, so even with `current_package` set, a same-package class defined in a *sibling* file was indistinguishable from a builtin/REPL class and never flagged as a leak. Added `ClassHierarchy::stamp_package_on_infos` (`crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs`) and wired it into both build's and lint's Pass 1 extraction.
- Corrected the E0401/E0402/E0403 example blocks in `docs/beamtalk-language-features.md`, which showed invented rustc-style `error[E0xxx]: ... --> file:line:col` renderings — the actual CLI output uses miette's own format with no error code and a plain `help:` line. Verified the corrected text against live `beamtalk build` output.
- Filed BT-2921 as a follow-up: the MCP `lint`/`diagnostic_summary` tools have the identical `current_package`-never-set gap, but fixing it needs its own package-resolution wiring and MCP-specific tests — out of scope for this CLI-focused issue.

## Test plan

- [x] New regression tests in `crates/beamtalk-cli/tests/cli_build.rs`: cross-file internal-class leak and internal-type-alias leak both fail `beamtalk build` with E0402
- [x] New unit tests for `ClassHierarchy::stamp_package_on_infos` in `crates/beamtalk-core/src/semantic_analysis/class_hierarchy/tests.rs`
- [x] `just test` — full suite (Rust, stdlib, BUnit, Erlang runtime) passes
- [x] `just ci-changed` — build, clippy, fmt, corpus check, surface-drift check all pass
- [x] Manually verified E0401 (cross-package), E0402 (cross-file class leak, alias leak), and E0403 (cross-package internal method call) all produce the exact message/hint text now documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0173SypWtHsgx1prqQJgG9jk)_