### PR TITLE
Fix alias/class find-references warning gap for unindexed declaring files BT-2919

### DIFF
--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -4137,7 +4137,7 @@ mod tests {
             !service.is_project_complete(),
             "preload hasn't run in this test; project_complete defaults to false"
         );
-        // "  restart: policy :: Foo => policy" — `Foo` starts at column 21.
+        // "  restart: policy :: Foo => policy" — `Foo` occupies columns 21-23.
         assert_eq!(
             service.unresolved_type_reference_at(&file_b, Position::new(1, 22)),
             Some(EcoString::from("Foo")),

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -178,6 +178,25 @@ struct FileData {
     diagnostics: Vec<Diagnostic>,
 }
 
+/// Tags whether an identifier match from [`SimpleLanguageService::find_identifier_at_position`]
+/// came from a syntactic type-reference position or a plain expression.
+///
+/// This is a purely syntactic classification — it doesn't require the name to
+/// resolve to anything. `TypeReference` covers every AST position where the
+/// grammar guarantees a name can only denote a class, protocol, or alias: type
+/// annotations (state/class-var/param/return, alias RHS), superclass clauses,
+/// `extending:` targets, type-parameter bounds, and constructor/type-pattern
+/// class names. `Expression` covers everything else (locals, message args,
+/// fields, class-literal references, declaration names). BT-2919: this lets
+/// callers like [`SimpleLanguageService::unresolved_type_reference_at`] detect
+/// "cursor is on a name that must be a class/alias, but isn't a known one yet"
+/// without waiting for the name to resolve.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IdentifierContext {
+    TypeReference,
+    Expression,
+}
+
 impl SimpleLanguageService {
     /// Creates a new language service with an empty `ProjectIndex`.
     #[must_use]
@@ -493,7 +512,7 @@ impl SimpleLanguageService {
         ) {
             return Some(NavQuery::SendersOf(selector_name));
         }
-        let (ident, _span) = self.find_identifier_at_position(file, position)?;
+        let (ident, _span, _ctx) = self.find_identifier_at_position(file, position)?;
         if self.project_index.hierarchy().has_class(&ident.name) {
             return Some(NavQuery::ReferencesTo(ident.name));
         }
@@ -527,11 +546,43 @@ impl SimpleLanguageService {
     /// `ast_declarations_for_cursor` route never fires for one.
     #[must_use]
     pub fn alias_name_at(&self, file: &Utf8PathBuf, position: Position) -> Option<EcoString> {
-        let (ident, _span) = self.find_identifier_at_position(file, position)?;
+        let (ident, _span, _ctx) = self.find_identifier_at_position(file, position)?;
         self.project_index
             .alias_registry()
             .has_alias(&ident.name)
             .then_some(ident.name)
+    }
+
+    /// Returns the name at `position` when the cursor sits on an identifier in
+    /// a syntactic type-reference position (a type annotation, superclass
+    /// clause, `extending:` target, type-param bound, or constructor/type
+    /// pattern class name) that does **not** resolve to any known class,
+    /// protocol, or alias (BT-2919).
+    ///
+    /// This is the counterpart to [`Self::alias_name_at`] for the case that
+    /// issue misses: `alias_name_at` (and the `has_class`/`has_alias` routing
+    /// gate in [`Self::find_references`]) can only recognize a name that's
+    /// *already* registered in the project index — but if the name's own
+    /// declaring file hasn't been indexed yet (preload hasn't reached it, or
+    /// the preload budget ran out first), the name looks like a plain unknown
+    /// identifier even though the cursor position proves it can only be a
+    /// class, protocol, or alias reference. The LSP genuinely cannot tell
+    /// whether this is a typo or an as-yet-unindexed name, so callers use this
+    /// to decide whether an empty or short find-references result needs the
+    /// same "coverage may be incomplete" warning that a *resolved* alias gets.
+    #[must_use]
+    pub fn unresolved_type_reference_at(
+        &self,
+        file: &Utf8PathBuf,
+        position: Position,
+    ) -> Option<EcoString> {
+        let (ident, _span, ctx) = self.find_identifier_at_position(file, position)?;
+        if ctx != IdentifierContext::TypeReference {
+            return None;
+        }
+        let known = self.project_index.hierarchy().has_class(&ident.name)
+            || self.project_index.alias_registry().has_alias(&ident.name);
+        (!known).then_some(ident.name)
     }
 
     /// BT-2240: Find the **declaration sites** (method-definition headers)
@@ -669,7 +720,7 @@ impl SimpleLanguageService {
         // Re-use the identifier walker the references handler uses — it
         // already rejects selectors and parameter names, and returns the
         // identifier *and* its span at the cursor.
-        let (ident, _span) = self.find_identifier_at_position(file, position)?;
+        let (ident, _span, _ctx) = self.find_identifier_at_position(file, position)?;
         if !self.project_index.hierarchy().has_class(&ident.name) {
             return None;
         }
@@ -982,7 +1033,7 @@ impl SimpleLanguageService {
         &self,
         file: &Utf8PathBuf,
         position: Position,
-    ) -> Option<(Identifier, Span)> {
+    ) -> Option<(Identifier, Span, IdentifierContext)> {
         let file_data = self.get_file(file)?;
         let offset = position.to_byte_offset(&file_data.source)?;
         let offset_val = offset.get();
@@ -1007,7 +1058,11 @@ impl SimpleLanguageService {
         // ...` or a reference to another alias inside the RHS.
         for alias in &file_data.module.type_aliases {
             if offset_val >= alias.name.span.start() && offset_val < alias.name.span.end() {
-                return Some((alias.name.clone(), alias.name.span));
+                return Some((
+                    alias.name.clone(),
+                    alias.name.span,
+                    IdentifierContext::TypeReference,
+                ));
             }
             if let Some(ident) =
                 Self::find_identifier_in_type_annotation(&alias.annotation, offset_val)
@@ -1042,13 +1097,21 @@ impl SimpleLanguageService {
         class: &crate::ast::ClassDefinition,
         offset: ByteOffset,
         offset_val: u32,
-    ) -> Option<(Identifier, Span)> {
+    ) -> Option<(Identifier, Span, IdentifierContext)> {
         if offset_val >= class.name.span.start() && offset_val < class.name.span.end() {
-            return Some((class.name.clone(), class.name.span));
+            return Some((
+                class.name.clone(),
+                class.name.span,
+                IdentifierContext::TypeReference,
+            ));
         }
         if let Some(ref superclass) = class.superclass {
             if offset_val >= superclass.span.start() && offset_val < superclass.span.end() {
-                return Some((superclass.clone(), superclass.span));
+                return Some((
+                    superclass.clone(),
+                    superclass.span,
+                    IdentifierContext::TypeReference,
+                ));
             }
         }
         if let Some(ident) = Self::find_identifier_in_type_params(&class.type_params, offset_val) {
@@ -1084,13 +1147,21 @@ impl SimpleLanguageService {
     fn find_identifier_in_protocol(
         protocol: &crate::ast::ProtocolDefinition,
         offset_val: u32,
-    ) -> Option<(Identifier, Span)> {
+    ) -> Option<(Identifier, Span, IdentifierContext)> {
         if offset_val >= protocol.name.span.start() && offset_val < protocol.name.span.end() {
-            return Some((protocol.name.clone(), protocol.name.span));
+            return Some((
+                protocol.name.clone(),
+                protocol.name.span,
+                IdentifierContext::TypeReference,
+            ));
         }
         if let Some(ref extending) = protocol.extending {
             if offset_val >= extending.span.start() && offset_val < extending.span.end() {
-                return Some((extending.clone(), extending.span));
+                return Some((
+                    extending.clone(),
+                    extending.span,
+                    IdentifierContext::TypeReference,
+                ));
             }
         }
         if let Some(ident) = Self::find_identifier_in_type_params(&protocol.type_params, offset_val)
@@ -1127,9 +1198,13 @@ impl SimpleLanguageService {
         smd: &crate::ast::StandaloneMethodDefinition,
         offset: ByteOffset,
         offset_val: u32,
-    ) -> Option<(Identifier, Span)> {
+    ) -> Option<(Identifier, Span, IdentifierContext)> {
         if offset_val >= smd.class_name.span.start() && offset_val < smd.class_name.span.end() {
-            return Some((smd.class_name.clone(), smd.class_name.span));
+            return Some((
+                smd.class_name.clone(),
+                smd.class_name.span,
+                IdentifierContext::TypeReference,
+            ));
         }
         Self::find_identifier_in_method_signature_and_body(
             &smd.method.parameters,
@@ -1148,7 +1223,7 @@ impl SimpleLanguageService {
         body: &[crate::ast::ExpressionStatement],
         offset: ByteOffset,
         offset_val: u32,
-    ) -> Option<(Identifier, Span)> {
+    ) -> Option<(Identifier, Span, IdentifierContext)> {
         for parameter in parameters {
             if let Some(type_annotation) = &parameter.type_annotation {
                 if let Some(ident) =
@@ -1181,11 +1256,11 @@ impl SimpleLanguageService {
     fn find_identifier_in_type_params(
         type_params: &[crate::ast::TypeParamDecl],
         offset_val: u32,
-    ) -> Option<(Identifier, Span)> {
+    ) -> Option<(Identifier, Span, IdentifierContext)> {
         for param in type_params {
             if let Some(bound) = &param.bound {
                 if offset_val >= bound.span.start() && offset_val < bound.span.end() {
-                    return Some((bound.clone(), bound.span));
+                    return Some((bound.clone(), bound.span, IdentifierContext::TypeReference));
                 }
             }
         }
@@ -1195,11 +1270,15 @@ impl SimpleLanguageService {
     fn find_identifier_in_type_annotation(
         annotation: &TypeAnnotation,
         offset_val: u32,
-    ) -> Option<(Identifier, Span)> {
+    ) -> Option<(Identifier, Span, IdentifierContext)> {
         match annotation {
             TypeAnnotation::Simple(identifier) => {
                 if offset_val >= identifier.span.start() && offset_val < identifier.span.end() {
-                    Some((identifier.clone(), identifier.span))
+                    Some((
+                        identifier.clone(),
+                        identifier.span,
+                        IdentifierContext::TypeReference,
+                    ))
                 } else {
                     None
                 }
@@ -1211,7 +1290,7 @@ impl SimpleLanguageService {
                 base, parameters, ..
             } => {
                 if offset_val >= base.span.start() && offset_val < base.span.end() {
-                    return Some((base.clone(), base.span));
+                    return Some((base.clone(), base.span, IdentifierContext::TypeReference));
                 }
                 parameters
                     .iter()
@@ -1230,7 +1309,11 @@ impl SimpleLanguageService {
             }
             TypeAnnotation::ClassOf { class_name, .. } => {
                 if offset_val >= class_name.span.start() && offset_val < class_name.span.end() {
-                    Some((class_name.clone(), class_name.span))
+                    Some((
+                        class_name.clone(),
+                        class_name.span,
+                        IdentifierContext::TypeReference,
+                    ))
                 } else {
                     None
                 }
@@ -1245,7 +1328,7 @@ impl SimpleLanguageService {
     fn find_identifier_in_expr(
         expr: &Expression,
         offset: ByteOffset,
-    ) -> Option<(Identifier, Span)> {
+    ) -> Option<(Identifier, Span, IdentifierContext)> {
         let offset_val = offset.get();
         let span = expr.span();
         if offset_val < span.start() || offset_val >= span.end() {
@@ -1255,14 +1338,14 @@ impl SimpleLanguageService {
         match expr {
             Expression::Identifier(ident) => {
                 if offset_val >= ident.span.start() && offset_val < ident.span.end() {
-                    Some((ident.clone(), ident.span))
+                    Some((ident.clone(), ident.span, IdentifierContext::Expression))
                 } else {
                     None
                 }
             }
             Expression::ClassReference { name, .. } => {
                 if offset_val >= name.span.start() && offset_val < name.span.end() {
-                    Some((name.clone(), name.span))
+                    Some((name.clone(), name.span, IdentifierContext::Expression))
                 } else {
                     None
                 }
@@ -1292,7 +1375,7 @@ impl SimpleLanguageService {
                 receiver, field, ..
             } => {
                 if offset_val >= field.span.start() && offset_val < field.span.end() {
-                    Some((field.clone(), field.span))
+                    Some((field.clone(), field.span, IdentifierContext::Expression))
                 } else {
                     Self::find_identifier_in_expr(receiver, offset)
                 }
@@ -1346,7 +1429,7 @@ impl SimpleLanguageService {
     fn find_identifier_in_pattern(
         pattern: &Pattern,
         offset_val: u32,
-    ) -> Option<(Identifier, Span)> {
+    ) -> Option<(Identifier, Span, IdentifierContext)> {
         let span = pattern.span();
         if offset_val < span.start() || offset_val >= span.end() {
             return None;
@@ -1356,7 +1439,11 @@ impl SimpleLanguageService {
                 class, keywords, ..
             } => {
                 if offset_val >= class.span.start() && offset_val < class.span.end() {
-                    return Some((class.clone(), class.span));
+                    return Some((
+                        class.clone(),
+                        class.span,
+                        IdentifierContext::TypeReference,
+                    ));
                 }
                 keywords
                     .iter()
@@ -1387,7 +1474,7 @@ impl SimpleLanguageService {
                 .find_map(|seg| Self::find_identifier_in_pattern(&seg.value, offset_val)),
             Pattern::Type { class, .. } => {
                 if offset_val >= class.span.start() && offset_val < class.span.end() {
-                    Some((class.clone(), class.span))
+                    Some((class.clone(), class.span, IdentifierContext::TypeReference))
                 } else {
                     // The binding (e.g. `path` in `path :: String`) is a
                     // local variable, not a class reference — this function
@@ -1718,7 +1805,7 @@ impl LanguageService for SimpleLanguageService {
         }
 
         // 3. Try identifier-based go-to-definition (cursor on a name)
-        let (ident, _span) = self.find_identifier_at_position(file, position)?;
+        let (ident, _span, _ctx) = self.find_identifier_at_position(file, position)?;
 
         // Cross-file definition lookup via definition provider
         crate::queries::definition_provider::find_definition_cross_file(
@@ -1767,7 +1854,7 @@ impl LanguageService for SimpleLanguageService {
         }
 
         // 3. Try identifier-based references (cursor on a name)
-        let Some((ident, _span)) = self.find_identifier_at_position(file, position) else {
+        let Some((ident, _span, ctx)) = self.find_identifier_at_position(file, position) else {
             return Vec::new();
         };
 
@@ -1779,8 +1866,21 @@ impl LanguageService for SimpleLanguageService {
         // `find_class_references` itself walks `module.type_aliases` (both
         // the declaration site and RHS references), so it already handles
         // an alias name correctly once routed here.
+        //
+        // BT-2919: also route here when the cursor is in a syntactic
+        // type-reference position (annotation, superclass, `extending:`,
+        // type-param bound, constructor/type pattern) even if the name
+        // *doesn't* resolve to a known class/protocol/alias yet — e.g. the
+        // name's declaring file hasn't been indexed. `find_class_references`
+        // matches by name text across every indexed file rather than
+        // requiring the name to be pre-registered, so it's always a superset
+        // of what the identifier-only fallback below could find for this
+        // position; that fallback only walks `Expression` nodes and never
+        // looks at type annotations at all, so it was structurally
+        // guaranteed to return nothing here.
         if self.project_index.hierarchy().has_class(&ident.name)
             || self.project_index.alias_registry().has_alias(&ident.name)
+            || ctx == IdentifierContext::TypeReference
         {
             return crate::queries::references_provider::find_class_references(
                 &ident.name,
@@ -4019,6 +4119,51 @@ mod tests {
             Some(EcoString::from("RestartStrategy"))
         );
         assert_eq!(service.alias_name_at(&file, Position::new(2, 20)), None);
+    }
+
+    /// BT-2919: a cursor on `Foo` in `policy :: Foo` (parameter-annotation
+    /// position) must be recognized as an unresolved type reference even
+    /// though the file declaring `type Foo = ...` is deliberately never
+    /// passed to `update_file` here — this simulates workspace preload not
+    /// having reached that file yet (or the preload budget exhausting
+    /// first). `alias_name_at` alone misses this case because it requires
+    /// the alias to already be registered in the project-wide index.
+    #[test]
+    fn unresolved_type_reference_at_detects_annotation_position_before_declaring_file_indexed() {
+        let mut service = SimpleLanguageService::new();
+        let file_b = Utf8PathBuf::from("supervisor.bt");
+        service.update_file(
+            file_b.clone(),
+            "Object subclass: Supervisor\n  restart: policy :: Foo => policy\n".to_string(),
+        );
+
+        assert!(
+            !service.is_project_complete(),
+            "preload hasn't run in this test; project_complete defaults to false"
+        );
+        // "  restart: policy :: Foo => policy" — `Foo` starts at column 21.
+        assert_eq!(
+            service.unresolved_type_reference_at(&file_b, Position::new(1, 22)),
+            Some(EcoString::from("Foo")),
+            "cursor on `Foo` in annotation position must be flagged as an \
+             unresolved type reference even though no file declares it yet"
+        );
+        assert_eq!(
+            service.alias_name_at(&file_b, Position::new(1, 22)),
+            None,
+            "alias_name_at only recognizes already-registered aliases"
+        );
+
+        // find_references must route through the class-aware walker (which
+        // matches by name text, not registry membership) instead of
+        // silently falling through to the identifier-only fallback, which
+        // never looks at type annotations and would return nothing here.
+        let refs = service.find_references(&file_b, Position::new(1, 22));
+        assert_eq!(
+            refs.len(),
+            1,
+            "expected the annotation-site reference itself, got {refs:?}"
+        );
     }
 
     /// BT-2027: `SimpleLanguageService::diagnostics` must hand off the

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -559,8 +559,8 @@ impl SimpleLanguageService {
     /// pattern class name) that does **not** resolve to any known class,
     /// protocol, or alias (BT-2919).
     ///
-    /// This is the counterpart to [`Self::alias_name_at`] for the case that
-    /// issue misses: `alias_name_at` (and the `has_class`/`has_alias` routing
+    /// This is the counterpart to [`Self::alias_name_at`] for the gap BT-2919
+    /// identified: `alias_name_at` (and the `has_class`/`has_alias` routing
     /// gate in [`Self::find_references`]) can only recognize a name that's
     /// *already* registered in the project index — but if the name's own
     /// declaring file hasn't been indexed yet (preload hasn't reached it, or

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -570,6 +570,31 @@ impl SimpleLanguageService {
     /// whether this is a typo or an as-yet-unindexed name, so callers use this
     /// to decide whether an empty or short find-references result needs the
     /// same "coverage may be incomplete" warning that a *resolved* alias gets.
+    /// Single-AST-walk combination of [`Self::alias_name_at`] and
+    /// [`Self::unresolved_type_reference_at`] for the LSP `references()`
+    /// incompleteness-warning gate (BT-2919).
+    ///
+    /// The two checks are mutually exclusive at a given cursor — an alias
+    /// name that already resolves can't also count as "unresolved" — so
+    /// calling both separately runs [`Self::find_identifier_at_position`]'s
+    /// full AST walk twice per request for no benefit. This does the walk
+    /// once and evaluates both conditions against the same match.
+    #[must_use]
+    pub fn has_incomplete_reference_coverage_at(
+        &self,
+        file: &Utf8PathBuf,
+        position: Position,
+    ) -> bool {
+        let Some((ident, _span, ctx)) = self.find_identifier_at_position(file, position) else {
+            return false;
+        };
+        if self.project_index.alias_registry().has_alias(&ident.name) {
+            return true;
+        }
+        ctx == IdentifierContext::TypeReference
+            && !self.project_index.hierarchy().has_class(&ident.name)
+    }
+
     #[must_use]
     pub fn unresolved_type_reference_at(
         &self,
@@ -4160,6 +4185,46 @@ mod tests {
             1,
             "expected the annotation-site reference itself, got {refs:?}"
         );
+    }
+
+    /// BT-2919: `has_incomplete_reference_coverage_at` must agree with the
+    /// two checks it combines (`alias_name_at` for an already-resolved
+    /// alias, `unresolved_type_reference_at` for a not-yet-indexed one) —
+    /// it's a single-AST-walk optimization, not a behavior change.
+    #[test]
+    fn has_incomplete_reference_coverage_at_matches_split_checks() {
+        let mut service = SimpleLanguageService::new();
+        let file_a = Utf8PathBuf::from("aliases.bt");
+        let file_b = Utf8PathBuf::from("supervisor.bt");
+        service.update_file(
+            file_a,
+            "type RestartStrategy = #temporary | #transient | #permanent\n".to_string(),
+        );
+        service.update_file(
+            file_b.clone(),
+            "Object subclass: Supervisor\n  restart: policy :: RestartStrategy => policy\n"
+                .to_string(),
+        );
+
+        // Resolved alias reference (RestartStrategy is indexed via file_a).
+        assert!(service.has_incomplete_reference_coverage_at(&file_b, Position::new(1, 22)));
+
+        // Unresolved type-reference position (Foo, at columns 19-21, is
+        // never declared anywhere).
+        let file_c = Utf8PathBuf::from("unresolved.bt");
+        service.update_file(
+            file_c.clone(),
+            "Object subclass: Widget\n  render: shape :: Foo => shape\n".to_string(),
+        );
+        assert!(service.has_incomplete_reference_coverage_at(&file_c, Position::new(1, 20)));
+
+        // Plain local identifier (bar, at columns 2-4): neither check fires.
+        let file_d = Utf8PathBuf::from("plain.bt");
+        service.update_file(
+            file_d.clone(),
+            "Object subclass: Plain\n  bar => 1\n".to_string(),
+        );
+        assert!(!service.has_incomplete_reference_coverage_at(&file_d, Position::new(1, 3)));
     }
 
     /// BT-2027: `SimpleLanguageService::diagnostics` must hand off the

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -553,23 +553,10 @@ impl SimpleLanguageService {
             .then_some(ident.name)
     }
 
-    /// Returns the name at `position` when the cursor sits on an identifier in
-    /// a syntactic type-reference position (a type annotation, superclass
-    /// clause, `extending:` target, type-param bound, or constructor/type
-    /// pattern class name) that does **not** resolve to any known class,
-    /// protocol, or alias (BT-2919).
+    /// Returns `true` when the cursor at `position` sits on an identifier that
+    /// either resolves to a known alias, or is in a syntactic type-reference
+    /// position that doesn't resolve to any known class, protocol, or alias.
     ///
-    /// This is the counterpart to [`Self::alias_name_at`] for the gap BT-2919
-    /// identified: `alias_name_at` (and the `has_class`/`has_alias` routing
-    /// gate in [`Self::find_references`]) can only recognize a name that's
-    /// *already* registered in the project index — but if the name's own
-    /// declaring file hasn't been indexed yet (preload hasn't reached it, or
-    /// the preload budget ran out first), the name looks like a plain unknown
-    /// identifier even though the cursor position proves it can only be a
-    /// class, protocol, or alias reference. The LSP genuinely cannot tell
-    /// whether this is a typo or an as-yet-unindexed name, so callers use this
-    /// to decide whether an empty or short find-references result needs the
-    /// same "coverage may be incomplete" warning that a *resolved* alias gets.
     /// Single-AST-walk combination of [`Self::alias_name_at`] and
     /// [`Self::unresolved_type_reference_at`] for the LSP `references()`
     /// incompleteness-warning gate (BT-2919).
@@ -595,6 +582,23 @@ impl SimpleLanguageService {
             && !self.project_index.hierarchy().has_class(&ident.name)
     }
 
+    /// Returns the name at `position` when the cursor sits on an identifier in
+    /// a syntactic type-reference position (a type annotation, superclass
+    /// clause, `extending:` target, type-param bound, or constructor/type
+    /// pattern class name) that does **not** resolve to any known class,
+    /// protocol, or alias (BT-2919).
+    ///
+    /// This is the counterpart to [`Self::alias_name_at`] for the gap BT-2919
+    /// identified: `alias_name_at` (and the `has_class`/`has_alias` routing
+    /// gate in [`Self::find_references`]) can only recognize a name that's
+    /// *already* registered in the project index — but if the name's own
+    /// declaring file hasn't been indexed yet (preload hasn't reached it, or
+    /// the preload budget ran out first), the name looks like a plain unknown
+    /// identifier even though the cursor position proves it can only be a
+    /// class, protocol, or alias reference. The LSP genuinely cannot tell
+    /// whether this is a typo or an as-yet-unindexed name, so callers use this
+    /// to decide whether an empty or short find-references result needs the
+    /// same "coverage may be incomplete" warning that a *resolved* alias gets.
     #[must_use]
     pub fn unresolved_type_reference_at(
         &self,
@@ -4218,7 +4222,8 @@ mod tests {
         );
         assert!(service.has_incomplete_reference_coverage_at(&file_c, Position::new(1, 20)));
 
-        // Plain local identifier (bar, at columns 2-4): neither check fires.
+        // Method selector (bar, at columns 2-4): neither check fires — method
+        // headers are not walked by find_identifier_at_position.
         let file_d = Utf8PathBuf::from("plain.bt");
         service.update_file(
             file_d.clone(),

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -1439,11 +1439,7 @@ impl SimpleLanguageService {
                 class, keywords, ..
             } => {
                 if offset_val >= class.span.start() && offset_val < class.span.end() {
-                    return Some((
-                        class.clone(),
-                        class.span,
-                        IdentifierContext::TypeReference,
-                    ));
+                    return Some((class.clone(), class.span, IdentifierContext::TypeReference));
                 }
                 keywords
                     .iter()

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -1959,7 +1959,7 @@ impl LanguageServer for Backend {
         // Compute everything that depends on `svc` up front so the lock is
         // released before any async runtime call (delegate_nav_query awaits
         // a runtime round-trip when the flag is on).
-        let (pos, runtime_query, alias_incomplete_warning) = {
+        let (pos, runtime_query, incomplete_coverage_warning) = {
             let svc = self.service.lock().expect("service lock poisoned");
             let Some(source) = svc.file_source(&path) else {
                 return Ok(None);
@@ -1979,18 +1979,28 @@ impl LanguageServer for Backend {
             // a caller trusting it could delete an alias a not-yet-compiled
             // file still uses. Surface that via `window/showMessage` below
             // rather than staying silent.
-            let alias_incomplete_warning =
-                !svc.is_project_complete() && svc.alias_name_at(&path, pos).is_some();
-            (pos, runtime_query, alias_incomplete_warning)
+            //
+            // BT-2919: `alias_name_at` alone misses the case where the
+            // *alias's own declaring file* hasn't been indexed yet — `Foo`
+            // in `policy :: Foo` doesn't look like a known alias if `type
+            // Foo = ...` hasn't been compiled, even though the cursor
+            // position proves it can only be a class/protocol/alias
+            // reference. `unresolved_type_reference_at` closes that gap (and
+            // the equivalent one for not-yet-indexed class names) without
+            // needing the name to resolve first.
+            let incomplete_coverage_warning = !svc.is_project_complete()
+                && (svc.alias_name_at(&path, pos).is_some()
+                    || svc.unresolved_type_reference_at(&path, pos).is_some());
+            (pos, runtime_query, incomplete_coverage_warning)
         };
 
-        if alias_incomplete_warning {
+        if incomplete_coverage_warning {
             self.client
                 .show_message(
                     MessageType::WARNING,
-                    "Find-references for this type alias may be incomplete: not all workspace \
-                     files have been compiled yet, so references in uncompiled files aren't \
-                     included in this result.",
+                    "Find-references for this name may be incomplete: not all workspace files \
+                     have been compiled yet, so references in uncompiled files aren't included \
+                     in this result.",
                 )
                 .await;
         }
@@ -6538,6 +6548,44 @@ mod tests {
             pending.is_none(),
             "expected no notification when the project is complete, got {pending:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn references_warns_on_unresolved_type_reference_when_declaring_file_unindexed() {
+        // BT-2919: `Foo` is referenced in parameter-annotation position
+        // (`policy :: Foo`) but no file declaring `type Foo = ...` (or
+        // `Object subclass: Foo`) has ever been opened/indexed in this test.
+        // `alias_name_at` alone would return `None` here (it only recognizes
+        // already-registered aliases), which used to mean the incompleteness
+        // warning never fired for this case — even though the cursor
+        // position proves `Foo` can only be a class/protocol/alias
+        // reference, and the project isn't known-complete. The handler must
+        // still surface the `window/showMessage` warning via
+        // `unresolved_type_reference_at`.
+        use futures_util::StreamExt;
+
+        const UNRESOLVED_TYPE_REF_SOURCE: &str =
+            "Object subclass: Supervisor\n  restart: policy :: Foo => policy\n";
+
+        let (service, mut socket) = tower_lsp::LspService::new(Backend::new);
+        let backend: &Backend = service.inner();
+        let path = Utf8PathBuf::from_path_buf(
+            unique_temp_dir("bt-2919-unresolved-type-ref").with_extension("bt"),
+        )
+        .expect("temp path is UTF-8");
+        let uri = open_test_file(backend, &path, UNRESOLVED_TYPE_REF_SOURCE);
+
+        // "  restart: policy :: Foo => policy" — `Foo` starts at column 21.
+        backend
+            .references(references_params(uri, 1, 22, true))
+            .await
+            .expect("rpc ok");
+
+        let notification = socket
+            .next()
+            .await
+            .expect("expected a window/showMessage notification");
+        assert_eq!(notification.method(), "window/showMessage");
     }
 
     #[test]

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -6575,7 +6575,7 @@ mod tests {
         .expect("temp path is UTF-8");
         let uri = open_test_file(backend, &path, UNRESOLVED_TYPE_REF_SOURCE);
 
-        // "  restart: policy :: Foo => policy" — `Foo` starts at column 21.
+        // "  restart: policy :: Foo => policy" — `Foo` occupies columns 21-23.
         backend
             .references(references_params(uri, 1, 22, true))
             .await

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -1980,17 +1980,17 @@ impl LanguageServer for Backend {
             // file still uses. Surface that via `window/showMessage` below
             // rather than staying silent.
             //
-            // BT-2919: `alias_name_at` alone misses the case where the
-            // *alias's own declaring file* hasn't been indexed yet — `Foo`
-            // in `policy :: Foo` doesn't look like a known alias if `type
-            // Foo = ...` hasn't been compiled, even though the cursor
+            // BT-2919: a plain `alias_name_at` check alone misses the case
+            // where the *alias's own declaring file* hasn't been indexed yet
+            // — `Foo` in `policy :: Foo` doesn't look like a known alias if
+            // `type Foo = ...` hasn't been compiled, even though the cursor
             // position proves it can only be a class/protocol/alias
-            // reference. `unresolved_type_reference_at` closes that gap (and
-            // the equivalent one for not-yet-indexed class names) without
-            // needing the name to resolve first.
-            let incomplete_coverage_warning = !svc.is_project_complete()
-                && (svc.alias_name_at(&path, pos).is_some()
-                    || svc.unresolved_type_reference_at(&path, pos).is_some());
+            // reference. `has_incomplete_reference_coverage_at` closes that
+            // gap (and the equivalent one for not-yet-indexed class names)
+            // without needing the name to resolve first, in a single AST
+            // walk of the cursor position.
+            let incomplete_coverage_warning =
+                !svc.is_project_complete() && svc.has_incomplete_reference_coverage_at(&path, pos);
             (pos, runtime_query, incomplete_coverage_warning)
         };
 


### PR DESCRIPTION
Add IdentifierContext to tag whether an identifier match at the cursor
comes from a syntactic type-reference position (annotation, superclass,
extending: target, type-param bound, constructor/type pattern) or a
plain expression, purely structurally, without requiring the name to
resolve. Use it to add unresolved_type_reference_at, which detects a
type-reference-position cursor that isn't yet a known class/protocol/alias
(e.g. because its declaring file hasn't been indexed yet).

The LSP references handler now fires its incompleteness warning on this
signal too, not just on an already-resolved alias, closing the gap for
both aliases and classes referenced from a not-yet-indexed file.
find_references also routes any type-reference-position cursor through
the class-aware walker (which matches by name text, not registry
membership) instead of silently falling through to the identifier-only
fallback, which never looks at type annotations at all.