### PR TITLE
beamtalk fmt silently deletes a class's leading doc comment when a type alias sits between it and the class (BT-2924)

### DIFF
--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -231,6 +231,24 @@ impl Comment {
             preceding_blank_line: false,
         }
     }
+
+    /// Creates a doc-style line comment (`/// text`).
+    ///
+    /// Used to preserve a `///` line as a *leading comment* on a
+    /// [`CommentAttachment`] rather than as a declaration's `doc_comment`
+    /// field — e.g. a `///` block that a blank line or another comment broke
+    /// away from the declaration it visually precedes (BT-2924). Keeping a
+    /// distinct kind (instead of re-encoding it as [`CommentKind::Line`])
+    /// lets it round-trip byte-for-byte as `///`, not `//`.
+    #[must_use]
+    pub fn doc(content: impl Into<EcoString>, span: Span) -> Self {
+        Self {
+            content: content.into(),
+            span,
+            kind: CommentKind::Doc,
+            preceding_blank_line: false,
+        }
+    }
 }
 
 /// The kind of comment.
@@ -240,6 +258,10 @@ pub enum CommentKind {
     Line,
     /// A block comment (`/* text */`).
     Block,
+    /// A `///` doc-style line comment that isn't attached to any
+    /// declaration's `doc_comment` field (BT-2924) — e.g. an earlier block
+    /// that a blank line broke away from the declaration it precedes.
+    Doc,
 }
 
 /// Comments attached to an AST node (ADR 0044).

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -747,6 +747,30 @@ pub(super) struct Parser {
     /// represent doc comments before non-declaration tokens, and a warning is
     /// emitted for each.
     unattached_doc_comment_indices: HashSet<usize>,
+    /// Result of the most recent `collect_doc_comment()` call: the token
+    /// index it ran on, paired with the positions (within *that* token's
+    /// `leading_trivia()`) of the `///` lines that ended up in the returned
+    /// doc comment (the last consecutive block immediately before the
+    /// token).
+    ///
+    /// A single token's leading trivia can contain *more than one*
+    /// blank-line-separated `///` block — e.g. a class's doc comment
+    /// followed by a blank line, then a `type` alias's own doc comment,
+    /// then the alias declaration itself. `collect_doc_comment()` only ever
+    /// returns the last block; earlier blocks are discarded from `lines` but
+    /// must not vanish from the source entirely. `collect_comment_attachment()`
+    /// — always called immediately after, on the same token (see its own
+    /// doc comment) — consults this to tell "already captured as the doc
+    /// comment" apart from "an earlier orphaned block that must round-trip
+    /// as a plain comment instead" (BT-2924).
+    ///
+    /// `None`, or a stale entry for a different token index, means
+    /// `collect_doc_comment()` was not just called for the current token
+    /// (e.g. leading trivia before a non-declaration expression) — in that
+    /// case every `///` line in the current token's leading trivia is
+    /// treated as unattached and preserved as a plain comment, matching the
+    /// pre-existing fallback behavior.
+    attached_doc_comment_positions: Option<(usize, HashSet<usize>)>,
 }
 
 impl Parser {
@@ -771,6 +795,7 @@ impl Parser {
             in_class_body: false,
             nesting_depth: 0,
             unattached_doc_comment_indices,
+            attached_doc_comment_positions: None,
         }
     }
 
@@ -875,9 +900,25 @@ impl Parser {
     /// the collection, so only the last consecutive block of `///` lines
     /// is returned.
     ///
-    /// When doc comment lines are found and then discarded because a blank
-    /// line or a regular `//` comment breaks the attachment, a
-    /// [`Severity::Warning`] diagnostic is emitted immediately.
+    /// A single leading-trivia run can contain more than one blank-line- or
+    /// comment-separated `///` block (e.g. a class's doc comment, a blank
+    /// line, then a `type` alias's own doc comment immediately before the
+    /// alias token). Only the *last* block ever attaches to this
+    /// declaration; earlier blocks are not this declaration's doc comment.
+    /// This method records (via `attached_doc_comment_positions`) exactly
+    /// which trivia positions made it into the returned block, so
+    /// [`Self::collect_comment_attachment`] — always called immediately
+    /// after, on the same token — can preserve any earlier block as a plain
+    /// comment instead of silently dropping it when the source is
+    /// reformatted (BT-2924).
+    ///
+    /// A [`Severity::Warning`] diagnostic is emitted only when *this*
+    /// declaration itself ends up with no doc comment at all (the returned
+    /// block is empty) because its own directly-adjacent `///` lines were
+    /// broken away by a blank line or `//` comment. An earlier, unrelated
+    /// block breaking away while this declaration's own adjacent block still
+    /// attaches cleanly is not a problem with this declaration's
+    /// documentation, so it does not warn (BT-2924).
     pub(super) fn collect_doc_comment(&mut self) -> Option<String> {
         // Clone leading trivia to release the shared borrow of `self` so we
         // can push to `self.diagnostics` inside the loop.
@@ -886,9 +927,10 @@ impl Parser {
         let current_idx = self.current;
 
         let mut lines: Vec<String> = Vec::new();
+        let mut block_positions: Vec<usize> = Vec::new();
         let mut had_unattached = false;
 
-        for trivia in &leading_trivia {
+        for (pos, trivia) in leading_trivia.iter().enumerate() {
             match trivia {
                 super::Trivia::DocComment(text) => {
                     let text = text.as_str();
@@ -897,6 +939,7 @@ impl Parser {
                         .strip_prefix("/// ")
                         .unwrap_or_else(|| text.strip_prefix("///").unwrap_or(text));
                     lines.push(stripped.to_string());
+                    block_positions.push(pos);
                 }
                 super::Trivia::Whitespace(ws) => {
                     // A blank line (>1 newline) breaks consecutive doc comments
@@ -905,6 +948,7 @@ impl Parser {
                             had_unattached = true;
                         }
                         lines.clear();
+                        block_positions.clear();
                     }
                 }
                 _ => {
@@ -913,11 +957,15 @@ impl Parser {
                         had_unattached = true;
                     }
                     lines.clear();
+                    block_positions.clear();
                 }
             }
         }
 
-        if had_unattached {
+        self.attached_doc_comment_positions =
+            Some((current_idx, block_positions.into_iter().collect()));
+
+        if had_unattached && lines.is_empty() {
             self.diagnostics.push(
                 Diagnostic::warning(
                     "doc comment not attached to any declaration \
@@ -926,16 +974,19 @@ impl Parser {
                 )
                 .with_category(DiagnosticCategory::Lint),
             );
-            // Remove from pre-scan set so the post-parse sweep does not
-            // emit a second warning for the same token.
+        }
+
+        if had_unattached || !lines.is_empty() {
+            // This token's doc-comment trivia have been fully handled — either
+            // warned about above, or successfully attached below — so remove
+            // it from the pre-scan set to prevent the post-parse sweep from
+            // emitting a second, differently-worded warning for it.
             self.unattached_doc_comment_indices.remove(&current_idx);
         }
 
         if lines.is_empty() {
             None
         } else {
-            // Successfully attached — remove from the pre-scan set.
-            self.unattached_doc_comment_indices.remove(&current_idx);
             Some(lines.join("\n"))
         }
     }
@@ -958,7 +1009,16 @@ impl Parser {
         let token_span = self.current_token().span();
         let mut leading = Vec::new();
         let mut saw_blank_line = false;
-        for trivia in self.current_token().leading_trivia() {
+        // Positions (within this token's leading trivia) already captured by
+        // the immediately-preceding `collect_doc_comment()` call, if any —
+        // see `attached_doc_comment_positions` for why this is positional
+        // rather than a single per-token flag (BT-2924).
+        let attached_positions = self
+            .attached_doc_comment_positions
+            .as_ref()
+            .filter(|(idx, _)| *idx == self.current)
+            .map(|(_, positions)| positions);
+        for (pos, trivia) in self.current_token().leading_trivia().iter().enumerate() {
             match trivia {
                 super::Trivia::LineComment(text) => {
                     // Strip `// ` (with space) or `//` — Comment.content is
@@ -994,22 +1054,23 @@ impl Parser {
                     }
                 }
                 // DocComment is normally handled by collect_doc_comment for
-                // declarations.  When it wasn't consumed (e.g. before module-level
-                // expressions), preserve it as a regular line comment so the
-                // formatter doesn't drop it.
+                // declarations.  When a `///` line wasn't part of the block
+                // collect_doc_comment() just attached to this declaration —
+                // either because it wasn't consumed at all (e.g. before
+                // module-level expressions) or because it belongs to an
+                // earlier, blank-line-separated block in the same leading
+                // trivia (BT-2924) — preserve it as a `Comment::doc` leading
+                // comment (renders back as `///`, not `//`) so the formatter
+                // doesn't drop or mangle it.
                 super::Trivia::DocComment(text) => {
-                    if self.unattached_doc_comment_indices.contains(&self.current) {
+                    let already_attached =
+                        attached_positions.is_some_and(|positions| positions.contains(&pos));
+                    if !already_attached {
                         let s = text.as_str();
                         let content = s
                             .strip_prefix("/// ")
                             .unwrap_or_else(|| s.strip_prefix("///").unwrap_or(s));
-                        // Prefix with "/" so it round-trips as `/// content`
-                        let prefixed = if content.is_empty() {
-                            "/".to_string()
-                        } else {
-                            format!("/ {content}")
-                        };
-                        let mut comment = Comment::line(&prefixed, token_span);
+                        let mut comment = Comment::doc(content, token_span);
                         comment.preceding_blank_line = saw_blank_line;
                         leading.push(comment);
                         saw_blank_line = false;

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/literal_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/literal_tests.rs
@@ -406,32 +406,27 @@ Actor subclass: Counter
 #[test]
 fn parse_doc_comment_resets_on_regular_comment() {
     // A `//` comment between `///` and the declaration orphans the first
-    // `///` block.  We now emit a warning for it.
-    let tokens = lex_with_eof(
+    // `///` block; only the last consecutive block attaches to the class.
+    //
+    // BT-2924: the class's own doc comment attaches cleanly here (no blank
+    // line or comment directly breaks *it*), so no warning fires — an
+    // earlier, unrelated orphaned block must not be misreported as "this
+    // declaration's doc comment is not attached" when it plainly is. (The
+    // orphaned block itself is preserved, not silently dropped — see
+    // `collect_comment_attachment` and the unparse-level regression tests.)
+    let module = parse_ok(
         "/// Orphaned doc comment.
 // Regular comment interrupts.
 /// Actual class doc.
 Actor subclass: Counter
   increment => 1",
     );
-    let (module, diagnostics) = parse(tokens);
 
     assert_eq!(module.classes.len(), 1);
     // Only the last consecutive block should be collected.
     assert_eq!(
         module.classes[0].doc_comment.as_deref(),
         Some("Actual class doc.")
-    );
-    // The orphaned `///` block must produce exactly one warning.
-    let warnings: Vec<_> = diagnostics
-        .iter()
-        .filter(|d| d.severity == Severity::Warning)
-        .collect();
-    assert_eq!(warnings.len(), 1);
-    assert!(
-        warnings[0].message.contains("not attached"),
-        "unexpected warning message: {}",
-        warnings[0].message,
     );
 }
 
@@ -454,32 +449,28 @@ abstract Actor subclass: Collection
 #[test]
 fn parse_doc_comment_blank_line_resets() {
     // A blank line between `///` and the declaration orphans the first
-    // `///` block.  We now emit a warning for it.
-    let tokens = lex_with_eof(
+    // `///` block; only the last consecutive block attaches to the class.
+    //
+    // BT-2924: same rationale as `parse_doc_comment_resets_on_regular_comment`
+    // above — the class's own doc comment attaches cleanly, so no warning
+    // fires for it. This exact shape (an earlier doc block, a blank line,
+    // then a directly-adjacent doc block that attaches) is also exercised by
+    // `type` alias declarations sandwiched between an outer class's doc
+    // comment and the class itself; see the `unparse` module's
+    // `type_alias_preceded_by_orphaned_class_doc_*` regression tests.
+    let module = parse_ok(
         "/// Orphaned doc comment.
 
 /// Actual class doc.
 Actor subclass: Counter
   increment => 1",
     );
-    let (module, diagnostics) = parse(tokens);
 
     assert_eq!(module.classes.len(), 1);
     // Blank line separates the two doc blocks; only the last is attached.
     assert_eq!(
         module.classes[0].doc_comment.as_deref(),
         Some("Actual class doc.")
-    );
-    // The orphaned `///` block must produce exactly one warning.
-    let warnings: Vec<_> = diagnostics
-        .iter()
-        .filter(|d| d.severity == Severity::Warning)
-        .collect();
-    assert_eq!(warnings.len(), 1);
-    assert!(
-        warnings[0].message.contains("not attached"),
-        "unexpected warning message: {}",
-        warnings[0].message,
     );
 }
 

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/type_alias_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/type_alias_tests.rs
@@ -101,6 +101,32 @@ fn parse_type_alias_doc_comment() {
 }
 
 #[test]
+fn parse_type_alias_own_adjacent_doc_comment_not_falsely_unattached() {
+    // BT-2924 regression (secondary bug): a `type` alias with a
+    // directly-adjacent `///` doc comment (no blank line) must attach
+    // cleanly and must NOT be reported as unattached, even when an earlier,
+    // unrelated `///` block (meant for a different declaration further down)
+    // shares the same leading trivia. `parse_ok` asserts zero
+    // `Severity::Warning` diagnostics, so this fails if the false-positive
+    // "doc comment not attached" lint fires.
+    let module = parse_ok(
+        "/// HTTPServer doc, meant for the class declared further below.
+
+/// Anything HTTPServer accepts as a request handler.
+type HTTPHandlerLike = Integer | String
+
+Actor subclass: HTTPServer
+  start => 1",
+    );
+    assert_eq!(module.type_aliases.len(), 1);
+    assert_eq!(
+        module.type_aliases[0].doc_comment.as_deref(),
+        Some("Anything HTTPServer accepts as a request handler.")
+    );
+    assert_eq!(module.classes.len(), 1);
+}
+
+#[test]
 fn parse_multiple_type_aliases() {
     let module = parse_ok("type Port = Integer\ntype Timeout = Integer | #infinity");
     assert_eq!(module.type_aliases.len(), 2);

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -1949,6 +1949,14 @@ fn unparse_comment_attachment_leading(ca: &CommentAttachment) -> Vec<Document<'s
 /// `state:`/`classState:`) have established, already-canonical stdlib source
 /// where such comments sit directly against the following doc comment or
 /// header with no blank line, and this must not force one in.
+///
+/// Checking only the *last* entry (not `any()` over the whole slice) is
+/// correct because a [`CommentKind::Doc`] entry can only ever be the last
+/// item in `comments.leading`, by construction: `collect_comment_attachment`
+/// appends orphaned `///` blocks as it scans trivia in source order, and the
+/// block that wins attachment (the one glued to the following declaration)
+/// always sits at the *end* of that trivia sequence — so no attached doc
+/// comment can trail after a preserved, unattached one.
 fn leading_ends_with_orphaned_doc_comment(comments: &CommentAttachment) -> bool {
     comments
         .leading

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -797,6 +797,21 @@ fn unparse_method_definition_inner(
         docs.extend(unparse_comment_attachment_leading(&method.comments));
     }
 
+    // A method with no doc comment of its own still needs a separator after
+    // a preserved, earlier `///` block that broke away from a different
+    // declaration (BT-2924) — otherwise the orphaned block re-attaches to
+    // this method as its doc comment on the next parse. When the method
+    // *does* have its own doc comment, the blank-line push inside the `if
+    // let Some(doc)` block below already covers this (it fires for any
+    // non-empty leading comments, orphaned or not) — do not also push here,
+    // or the separator doubles up.
+    if method.doc_comment.is_none()
+        && emit_leading
+        && leading_ends_with_orphaned_doc_comment(&method.comments)
+    {
+        docs.push(line());
+    }
+
     // Doc comment — emit `///` for empty lines (no trailing space)
     if let Some(doc) = &method.doc_comment {
         // Blank line between leading comments and doc comment (e.g. section separators)
@@ -3704,6 +3719,34 @@ mod tests {
         );
         assert!(
             formatted.contains("Orphaned block, meant for something else entirely."),
+            "the orphaned block's text must still be preserved somewhere:\n{formatted}"
+        );
+    }
+
+    #[test]
+    fn method_with_no_doc_comment_preceded_by_orphaned_doc_block_does_not_attach_it() {
+        // BT-2924 follow-up (review finding on the fix itself): a `///` block
+        // that breaks away from a different declaration must not attach to a
+        // *method with no doc comment of its own* on a format round-trip —
+        // the class/protocol/state cases were fixed, but the method case was
+        // missed since its blank-line guard lives inside `if let Some(doc)`.
+        let source = concat!(
+            "Object subclass: Foo\n",
+            "  /// Section header (orphaned — blank line below).\n",
+            "\n",
+            "  doSomething => 1\n",
+        );
+        let formatted = format_source(source).expect("format_source must succeed for valid source");
+        let module = parse_source(&formatted);
+        assert_eq!(module.classes.len(), 1);
+        let method = &module.classes[0].methods[0];
+        assert_eq!(
+            method.doc_comment, None,
+            "the orphaned block above must not attach as the method's own doc comment; \
+             formatted output:\n{formatted}"
+        );
+        assert!(
+            formatted.contains("Section header (orphaned"),
             "the orphaned block's text must still be preserved somewhere:\n{formatted}"
         );
     }

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -1951,12 +1951,13 @@ fn unparse_comment_attachment_leading(ca: &CommentAttachment) -> Vec<Document<'s
 /// header with no blank line, and this must not force one in.
 ///
 /// Checking only the *last* entry (not `any()` over the whole slice) is
-/// correct because a [`CommentKind::Doc`] entry can only ever be the last
-/// item in `comments.leading`, by construction: `collect_comment_attachment`
-/// appends orphaned `///` blocks as it scans trivia in source order, and the
-/// block that wins attachment (the one glued to the following declaration)
-/// always sits at the *end* of that trivia sequence — so no attached doc
-/// comment can trail after a preserved, unattached one.
+/// correct because a [`CommentKind::Doc`] entry that *needs* a blank-line
+/// separator (i.e., nothing in the original source separated it from what
+/// follows) will always be the last item in `comments.leading`. If a
+/// [`CommentKind::Line`] (`//` comment) follows an orphaned `///` block in
+/// the trivia, it is appended to `leading` *after* the `Doc` entry and
+/// already provides the separation — so this function correctly returns
+/// `false` and no extra blank line is inserted.
 fn leading_ends_with_orphaned_doc_comment(comments: &CommentAttachment) -> bool {
     comments
         .leading

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -569,6 +569,13 @@ fn unparse_type_alias_definition(type_alias: &TypeAliasDefinition) -> Document<'
     // Non-doc leading comments
     docs.extend(unparse_comment_attachment_leading(&type_alias.comments));
 
+    // Blank line between a preserved, earlier `///` block that broke away
+    // from a different declaration (BT-2924) and this alias's own doc
+    // comment — see `leading_ends_with_orphaned_doc_comment`.
+    if leading_ends_with_orphaned_doc_comment(&type_alias.comments) {
+        docs.push(line());
+    }
+
     // Doc comment
     if let Some(doc) = &type_alias.doc_comment {
         for line_text in doc.lines() {
@@ -608,6 +615,13 @@ fn unparse_protocol_definition(protocol: &ProtocolDefinition) -> Document<'stati
 
     // Non-doc leading comments
     docs.extend(unparse_comment_attachment_leading(&protocol.comments));
+
+    // Blank line between a preserved, earlier `///` block that broke away
+    // from a different declaration (BT-2924) and this protocol's own doc
+    // comment — see `leading_ends_with_orphaned_doc_comment`.
+    if leading_ends_with_orphaned_doc_comment(&protocol.comments) {
+        docs.push(line());
+    }
 
     // Doc comment
     if let Some(doc) = &protocol.doc_comment {
@@ -948,6 +962,13 @@ fn unparse_state_declaration_inner(state: &StateDeclaration, is_class: bool) -> 
 
     // Non-doc leading comments
     docs.extend(unparse_comment_attachment_leading(&state.comments));
+
+    // Blank line between a preserved, earlier `///` block that broke away
+    // from a different declaration (BT-2924) and this field's own doc
+    // comment — see `leading_ends_with_orphaned_doc_comment`.
+    if leading_ends_with_orphaned_doc_comment(&state.comments) {
+        docs.push(line());
+    }
 
     // Doc comment — emit `///` for empty lines (no trailing space)
     if let Some(doc) = &state.doc_comment {
@@ -1853,7 +1874,8 @@ fn unparse_expect_category(cat: ExpectCategory) -> Document<'static> {
 
 /// Builds a [`Document`] for a single [`Comment`].
 ///
-/// Line comments become `// content`, block comments become `/* content */`.
+/// Line comments become `// content`, block comments become `/* content */`,
+/// doc-style leading comments become `/// content` (BT-2924).
 fn unparse_comment(comment: &Comment) -> Document<'static> {
     match comment.kind {
         CommentKind::Line => {
@@ -1865,6 +1887,13 @@ fn unparse_comment(comment: &Comment) -> Document<'static> {
         }
         CommentKind::Block => {
             docvec!["/* ", leaf::raw_text(&comment.content), " */"]
+        }
+        CommentKind::Doc => {
+            if comment.content.is_empty() {
+                Document::Str("///")
+            } else {
+                docvec!["/// ", leaf::raw_text(&comment.content)]
+            }
         }
     }
 }
@@ -1885,6 +1914,31 @@ fn unparse_comment_attachment_leading(ca: &CommentAttachment) -> Vec<Document<'s
         docs.push(line());
     }
     docs
+}
+
+/// Whether a blank line must separate `comments.leading` from whatever
+/// follows (a doc comment, or the declaration header when there is no doc
+/// comment).
+///
+/// Only true when the *last* leading comment is [`CommentKind::Doc`] — a
+/// `///` block that `collect_comment_attachment` preserved because a blank
+/// line (or `//` comment) broke it away from the declaration it visually
+/// precedes (BT-2924). Such a block is, by construction, never adjacent to
+/// what follows in the original source — a blank line always separated it —
+/// so reinserting one here reconstructs that gap and stops the preserved
+/// block from visually gluing onto (and, on the next parse, merging into)
+/// this declaration's own doc comment.
+///
+/// Ordinary leading comments (license headers, section notes) are
+/// deliberately excluded: several declaration kinds (`Protocol define:`,
+/// `state:`/`classState:`) have established, already-canonical stdlib source
+/// where such comments sit directly against the following doc comment or
+/// header with no blank line, and this must not force one in.
+fn leading_ends_with_orphaned_doc_comment(comments: &CommentAttachment) -> bool {
+    comments
+        .leading
+        .last()
+        .is_some_and(|c| c.kind == CommentKind::Doc)
 }
 
 // --- Helper utilities ---
@@ -3512,6 +3566,146 @@ mod tests {
         // ADR 0071, ADR 0108 Phase 5, BT-2898.
         let source = "internal type ParserState = Integer | String\n";
         assert_identity(source);
+    }
+
+    // --- BT-2924 regression: `type` alias sandwiched between a class's doc
+    // comment and the class itself must not lose the class's doc comment. ---
+
+    /// The exact repro shape from BT-2924: a class's doc comment, a blank
+    /// line, a `type` alias with its own directly-adjacent doc comment, a
+    /// blank line, then the class declaration the first doc comment
+    /// describes.
+    ///
+    /// Before the fix, `format_source` deleted the class's doc comment
+    /// outright (it lives in the `type` alias token's leading trivia, and
+    /// `collect_doc_comment` kept only the alias's own — nearer — block,
+    /// discarding the earlier one without preserving it anywhere).
+    const HTTPSERVER_REPRO_SOURCE: &str = concat!(
+        "/// HTTPServer — cowboy-backed HTTP server actor for Beamtalk.\n",
+        "/// Some more description text here.\n",
+        "/// @see HTTPResponse (for building response objects)\n",
+        "\n",
+        "/// Anything `HTTPServer start:handler:` accepts as a request handler.\n",
+        "type HTTPHandlerLike = Integer | String\n",
+        "\n",
+        "Actor subclass: HTTPServer\n",
+        "  start => 1\n",
+    );
+
+    #[test]
+    fn type_alias_preceded_by_orphaned_class_doc_preserves_all_text() {
+        let formatted = format_source(HTTPSERVER_REPRO_SOURCE)
+            .expect("format_source must succeed for valid source");
+
+        // Neither doc comment's content may be dropped.
+        for line in [
+            "/// HTTPServer — cowboy-backed HTTP server actor for Beamtalk.",
+            "/// Some more description text here.",
+            "/// @see HTTPResponse (for building response objects)",
+            "/// Anything `HTTPServer start:handler:` accepts as a request handler.",
+        ] {
+            assert!(
+                formatted.contains(line),
+                "formatted output lost {line:?}:\n{formatted}"
+            );
+        }
+
+        // Formatting must be idempotent — a second pass changes nothing.
+        let formatted_again =
+            format_source(&formatted).expect("format_source must succeed on formatted output");
+        assert_eq!(
+            formatted, formatted_again,
+            "format_source is not idempotent for the BT-2924 repro shape"
+        );
+    }
+
+    #[test]
+    fn type_alias_preceded_by_orphaned_class_doc_reattaches_correctly_on_reparse() {
+        let formatted = format_source(HTTPSERVER_REPRO_SOURCE)
+            .expect("format_source must succeed for valid source");
+        let module = parse_source(&formatted);
+
+        assert_eq!(module.type_aliases.len(), 1);
+        assert_eq!(
+            module.type_aliases[0].doc_comment.as_deref(),
+            Some("Anything `HTTPServer start:handler:` accepts as a request handler."),
+            "the alias's own doc comment must still attach to the alias after a format round-trip"
+        );
+        assert_eq!(module.classes.len(), 1);
+        assert_eq!(module.classes[0].name.name, "HTTPServer");
+    }
+
+    #[test]
+    fn type_alias_with_directly_adjacent_doc_comment_has_no_unattached_warning() {
+        // BT-2924 secondary bug: the lint must not flag the alias's own
+        // directly-adjacent `///` comment as unattached just because an
+        // earlier, unrelated block shares the same leading trivia.
+        use crate::source_analysis::{Severity, lex_with_eof, parse};
+        let tokens = lex_with_eof(HTTPSERVER_REPRO_SOURCE);
+        let (_module, diagnostics) = parse(tokens);
+        let warnings: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Warning)
+            .collect();
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings for the BT-2924 repro shape, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn state_declaration_preceded_by_orphaned_doc_block_does_not_merge_into_own_doc_comment() {
+        // BT-2924 follow-up (found in adversarial review): a `///` block that
+        // breaks away from a *different* declaration must not get glued onto
+        // — and then silently merged into — a state field's own doc comment
+        // on a format round-trip.
+        let source = concat!(
+            "Object subclass: Foo\n",
+            "  /// Section header orphan.\n",
+            "\n",
+            "  /// The port to bind.\n",
+            "  state: port :: Integer = 0\n",
+        );
+        let formatted = format_source(source).expect("format_source must succeed for valid source");
+        let module = parse_source(&formatted);
+        assert_eq!(module.classes.len(), 1);
+        let field = &module.classes[0].state[0];
+        assert_eq!(
+            field.doc_comment.as_deref(),
+            Some("The port to bind."),
+            "the orphaned block above must not merge into the field's own doc comment; \
+             formatted output:\n{formatted}"
+        );
+        assert!(
+            formatted.contains("Section header orphan."),
+            "the orphaned block's text must still be preserved somewhere:\n{formatted}"
+        );
+    }
+
+    #[test]
+    fn protocol_preceded_by_orphaned_doc_block_does_not_merge_into_own_doc_comment() {
+        // BT-2924 follow-up (found in adversarial review): same shape as
+        // above, for a `Protocol define:` declaration.
+        let source = concat!(
+            "/// Orphaned block, meant for something else entirely.\n",
+            "\n",
+            "/// Things that can be printed.\n",
+            "Protocol define: Displayable\n",
+            "  asString -> String\n",
+        );
+        let formatted = format_source(source).expect("format_source must succeed for valid source");
+        let module = parse_source(&formatted);
+        assert_eq!(module.protocols.len(), 1);
+        assert_eq!(
+            module.protocols[0].doc_comment.as_deref(),
+            Some("Things that can be printed."),
+            "the orphaned block above must not merge into the protocol's own doc comment; \
+             formatted output:\n{formatted}"
+        );
+        assert!(
+            formatted.contains("Orphaned block, meant for something else entirely."),
+            "the orphaned block's text must still be preserved somewhere:\n{formatted}"
+        );
     }
 
     // --- escape_string_literal ---


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-2924

## Summary

`collect_doc_comment` in the parser only ever kept the *last* consecutive
`///` block in a token's leading trivia. When a blank line or `//` comment
broke an earlier block away, that earlier text was silently discarded —
never attached to any AST node, and never preserved as a plain comment
either — so `beamtalk fmt` just deleted it on reformat.

This surfaced acutely with ADR 0108 `type` alias declarations: a class's
doc comment written above a `type X = ...` (with its own adjacent doc
comment) ends up as leading trivia of the `type` token, not the class
token, so `fmt` wiped the class's doc comment out entirely. A companion
bug: the "doc comment not attached to any declaration" lint fired even
when the *current* declaration's own directly-adjacent doc comment
attached cleanly, purely because an unrelated earlier block was dropped
in the same leading trivia.

## Fix

- `collect_doc_comment` now tracks exactly which leading-trivia positions
  make up the block it attaches to a declaration, so
  `collect_comment_attachment` (called immediately after, on the same
  token) can tell "already captured as the doc comment" apart from "an
  earlier orphaned block" and preserve the latter as a plain comment
  (new `CommentKind::Doc`, renders back as `///`, not `//`) instead of
  losing it.
- The "doc comment not attached" warning now only fires when the
  declaration itself ends up with *no* doc comment at all — not merely
  because some earlier, unrelated block was dropped elsewhere in the same
  trivia.
- `unparse_type_alias_definition`, `unparse_protocol_definition`, and
  `unparse_state_declaration_inner` now insert a blank line before the
  declaration's own doc comment when the preceding leading comment is a
  preserved orphan block — otherwise the two glue together on reformat and
  silently *merge* into one doc comment on the next parse. This is gated
  specifically on the new `CommentKind::Doc` (not "any leading comment"),
  because several declaration kinds have established, already-canonical
  stdlib source where ordinary comments (license headers) sit directly
  against a doc comment or header with no blank line — an earlier,
  broader version of this fix reformatted real stdlib files
  (`Printable.bt`, `JsonRepresentable.bt`, protocol fixtures, etc.) before
  this was narrowed down during review.

Two pre-existing parser tests (`parse_doc_comment_resets_on_regular_comment`,
`parse_doc_comment_blank_line_resets`) asserted a warning fires in exactly
this "earlier orphaned block + later successfully-attached block" shape;
they're updated to reflect the corrected behavior (no warning when the
declaration's own adjacent doc attaches cleanly), with comments explaining
why.

## Testing

- New parser + unparse regression tests reproducing the exact BT-2924
  repro shape (class doc, blank line, type-alias-with-own-doc, blank line,
  class), plus companion tests for `Protocol define:` and `state:`/
  `classState:` declarations.
- `just build && just clippy && just fmt-check` clean.
- `just test-stdlib` (223/223), `just test-bunit` (2774/2776, 2 pre-existing
  skips unrelated to this change) both clean.
- `just check-corpus` and `just check-surface-drift` clean (no diffs).
- Full `cargo test --workspace` clean except one pre-existing,
  environment-caused failure unrelated to this diff
  (`bt2424_default_deployment_keeps_epmd_off_public_interfaces` — detects
  a real epmd process already bound on the shared dev machine; reproduces
  identically in isolation on unmodified `epmd.rs`).

## Follow-ups filed (out of scope here)

Two separate, pre-existing formatter bugs surfaced during investigation,
unrelated to doc-comment attachment:

- BT-2929: blank lines between top-level declarations get relocated/dropped
  by `beamtalk fmt` (reproduces with zero doc comments involved).
- BT-2930: leading `//`/`/* */` comments before a `ProtocolMethodSignature`
  are silently dropped by the formatter — `unparse_protocol_method_signature`
  never emits `sig.comments.leading`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)