### PR TITLE
Unparse: preserve trailing comment on type alias/protocol declarations (BT-2906)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -1839,7 +1839,7 @@ impl Parser {
     pub(super) fn parse_type_alias_definition(&mut self) -> TypeAliasDefinition {
         let start = self.current_token().span();
         let doc_comment = self.collect_doc_comment();
-        let comments = self.collect_comment_attachment();
+        let mut comments = self.collect_comment_attachment();
 
         let is_internal =
             matches!(self.current_kind(), TokenKind::Identifier(name) if name == "internal");
@@ -1878,6 +1878,11 @@ impl Parser {
         let annotation = self.parse_type_annotation();
         let span = start.merge(annotation.span());
 
+        // Collect a trailing end-of-line comment on the declaration line
+        // (e.g. `type Port = Integer // comment`), mirroring the state
+        // declaration handling above (BT-2906).
+        comments.trailing = self.collect_trailing_comment();
+
         TypeAliasDefinition {
             name,
             annotation,
@@ -1908,7 +1913,7 @@ impl Parser {
     pub(super) fn parse_protocol_definition(&mut self) -> ProtocolDefinition {
         let start = self.current_token().span();
         let doc_comment = self.collect_doc_comment();
-        let comments = self.collect_comment_attachment();
+        let mut comments = self.collect_comment_attachment();
 
         // Consume `Protocol`
         self.advance();
@@ -1934,6 +1939,13 @@ impl Parser {
 
         // Parse optional type parameters: `Collection(E)`, `Mapping(K, V)`
         let type_params = self.parse_optional_type_params();
+
+        // Collect a trailing end-of-line comment on the declaration header
+        // line (e.g. `Protocol define: Sortable // comment`), mirroring the
+        // identical fix for `type` declarations (BT-2906). Collected before
+        // `extending:`/the body since those start on their own indented
+        // lines and aren't part of the header.
+        comments.trailing = self.collect_trailing_comment();
 
         // Parse optional `extending:` clause
         let extending = if matches!(self.current_kind(), TokenKind::Keyword(k) if k == "extending:")

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -616,13 +616,23 @@ fn unparse_type_alias_definition(type_alias: &TypeAliasDefinition) -> Document<'
     } else {
         Document::Nil
     };
-    docs.push(docvec![
+    let header = docvec![
         internal_prefix,
         "type ",
         leaf::ident(&type_alias.name.name),
         " = ",
         unparse_type_annotation(&type_alias.annotation),
-    ]);
+    ];
+
+    // Trailing end-of-line comment on the declaration line, e.g.
+    // `type Port = Integer // comment` (BT-2906).
+    let header = if let Some(trail) = &type_alias.comments.trailing {
+        docvec![header, "  ", unparse_comment(trail)]
+    } else {
+        header
+    };
+
+    docs.push(header);
 
     concat(docs)
 }
@@ -676,6 +686,15 @@ fn unparse_protocol_definition(protocol: &ProtocolDefinition) -> Document<'stati
     }
 
     docs.push(Document::Vec(header));
+
+    // Trailing end-of-line comment on the declaration header line, e.g.
+    // `Protocol define: Sortable // comment` (BT-2906). Emitted right after
+    // the header, matching where the parser collects it — before
+    // `extending:`/the body, which start on their own indented lines.
+    if let Some(trail) = &protocol.comments.trailing {
+        docs.push(Document::Str("  "));
+        docs.push(unparse_comment(trail));
+    }
 
     // `extending: ParentProtocol`
     if let Some(ext) = &protocol.extending {
@@ -3572,6 +3591,18 @@ mod tests {
         assert_identity(source);
     }
 
+    #[test]
+    fn protocol_trailing_comment_round_trip() {
+        // BT-2906: a trailing end-of-line comment on the `Protocol define:`
+        // declaration line must round-trip losslessly, mirroring the
+        // identical fix for `type` declarations below.
+        let source = concat!(
+            "Protocol define: Sortable  // comment\n",
+            "  sortKey -> Object\n",
+        );
+        assert_identity(source);
+    }
+
     // --- Type alias round-trip (ADR 0108, Phase 1, BT-2894) ---
 
     #[test]
@@ -3611,6 +3642,14 @@ mod tests {
     fn internal_type_alias_round_trip() {
         // ADR 0071, ADR 0108 Phase 5, BT-2898.
         let source = "internal type ParserState = Integer | String\n";
+        assert_identity(source);
+    }
+
+    #[test]
+    fn type_alias_trailing_comment_round_trip() {
+        // BT-2906: a trailing end-of-line comment on the declaration line
+        // must round-trip losslessly instead of being dropped.
+        let source = "type Port = Integer  // comment\n";
         assert_identity(source);
     }
 


### PR DESCRIPTION
## Summary

Linear issue: https://linear.app/beamtalk/issue/BT-2906

`unparse_type_alias_definition` and `unparse_protocol_definition` both silently dropped a trailing end-of-line comment on the declaration line (e.g. `type Port = Integer // comment`). Not a regression — this mirrors a pre-existing gap shared by both unparse functions.

- The parser now collects the trailing comment into `comments.trailing` for both `TypeAliasDefinition` and `ProtocolDefinition` (mirroring the existing `state:`/`classState:` trailing-comment handling), scoped to the declaration header line (before `extending:`/the body for protocols, which start on their own indented lines).
- The unparser re-emits the trailing comment on the header line for both node types, so it now round-trips losslessly.

## Key changes

- `crates/beamtalk-core/src/source_analysis/parser/declarations.rs`: `parse_type_alias_definition`, `parse_protocol_definition` now call `collect_trailing_comment()`.
- `crates/beamtalk-core/src/unparse/mod.rs`: `unparse_type_alias_definition`, `unparse_protocol_definition` now emit `comments.trailing` if present; regression tests added for both.

## Follow-up filed

While investigating, found that `unparse_class_definition`'s existing trailing-comment branch (`class.comments.trailing`) is actually dead code today — `parse_class_definition` never populates it, so `Object subclass: Foo // comment` silently drops the comment too. Out of scope for this issue (BT-2906's acceptance criteria and files-to-modify are scoped to type alias/protocol only); filed as [BT-2933](https://linear.app/beamtalk/issue/BT-2933).

## Test plan

- [x] `cargo test -p beamtalk-core --lib -- type_alias protocol` — 217 passed, including 2 new regression tests
- [x] `just test` — Rust, stdlib, BUnit, and runtime tests all pass
- [x] `just clippy` — clean
- [x] `just fmt` — no unrelated changes
- [x] Manual CLI verification (`beamtalk fmt-check`) for doc-comment + trailing, extending-clause + header-trailing, and type-params + header-trailing combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz)_