### PR TITLE
browse-type-aliases misses packages with only type declarations (BT-2915)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_package.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_package.erl
@@ -160,7 +160,8 @@ classes(Name) when is_binary(Name) ->
 Returns the list of dependency package names (binaries) for a package.
 
 Reads the OTP application dependency list and filters to only those
-applications that are themselves Beamtalk packages (have a `classes` env).
+applications that are themselves Beamtalk packages (have a non-empty
+`classes` env or a non-empty `type_aliases` env).
 Returns an empty list if the package is not found.
 """.
 -spec dependencies(binary() | atom()) -> [binary()].

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_package.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_package.erl
@@ -161,7 +161,8 @@ Returns the list of dependency package names (binaries) for a package.
 
 Reads the OTP application dependency list and filters to only those
 applications that are themselves Beamtalk packages (have a non-empty
-`classes` env or a non-empty `type_aliases` env).
+`classes` env, or — when `classes` is absent/empty — a non-empty
+`type_aliases` env).
 Returns an empty list if the package is not found.
 """.
 -spec dependencies(binary() | atom()) -> [binary()].

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_package.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_package.erl
@@ -230,6 +230,10 @@ name by construction for `beamtalk build`'s generated `.app` files).
 -spec package_name_for_app(atom()) -> binary() | undefined.
 package_name_for_app(AppName) ->
     case application:get_env(AppName, classes) of
+        %% A non-empty but malformed classes list (no `package` key on any
+        %% entry) intentionally does NOT fall through to type_aliases below:
+        %% a non-empty classes env means "not types-only", so this app is
+        %% correctly reported as undiscoverable rather than misidentified.
         {ok, ClassList} when is_list(ClassList), ClassList =/= [] ->
             package_name_from_classes(ClassList);
         _ ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_package.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_package.erl
@@ -11,8 +11,14 @@ Package reflection for Beamtalk.
 Provides runtime access to package metadata backed by OTP application
 environment and the `bt@{pkg}@{class}` BEAM module naming convention.
 
-Packages map 1:1 to OTP applications whose env contains a `classes` key
-(the metadata format defined by ADR 0070 Phase 4).
+Packages map 1:1 to OTP applications whose env contains a non-empty
+`classes` key (the metadata format defined by ADR 0070 Phase 4) *or* a
+non-empty `type_aliases` key (ADR 0108 Phase 8) — the latter covers a
+"types-only" package with `type` alias declarations and zero classes
+(BT-2915), which has no class entry to derive a package name from, so its
+name is instead taken from the OTP application's own atom name (app name
+== package name by construction for `beamtalk build`'s generated `.app`
+files).
 
 ## Responsibilities
 
@@ -21,6 +27,10 @@ Packages map 1:1 to OTP applications whose env contains a `classes` key
 - Reverse-lookup: which package owns a class? (`package_name/1`)
 - List classes within a package (`classes/1`)
 - List dependencies of a package (`dependencies/1`)
+- Find the OTP application hosting a package (`find_app_for_package/1`) —
+  exported so other package-discovery consumers (e.g.
+  `beamtalk_repl_ops_browse:browse_type_aliases/0`) share this logic
+  instead of re-deriving it against only `classes`.
 
 See also: docs/ADR/0070-package-namespaces-and-dependencies.md Section 8
 """.
@@ -31,6 +41,7 @@ See also: docs/ADR/0070-package-namespaces-and-dependencies.md Section 8
     package_name/1,
     classes/1,
     dependencies/1,
+    find_app_for_package/1,
     %% Beamtalk FFI shim: `Package packageNameFor: #ClassName`
     packageNameFor/1
 ]).
@@ -42,24 +53,19 @@ See also: docs/ADR/0070-package-namespaces-and-dependencies.md Section 8
 -doc """
 Returns a list of loaded package names (binaries).
 
-A "package" is any OTP application whose env includes `{classes, [...]}`.
-The stdlib package is always present; user packages appear after their
-OTP application is loaded.
+A "package" is any OTP application whose env includes a non-empty
+`{classes, [...]}` list, or (BT-2915) a non-empty `{type_aliases, [...]}`
+list with no classes. The stdlib package is always present; user packages
+appear after their OTP application is loaded.
 """.
 -spec all() -> [binary()].
 all() ->
     Apps = application:loaded_applications(),
     lists:filtermap(
         fun({AppName, _Desc, _Vsn}) ->
-            case application:get_env(AppName, classes) of
-                {ok, ClassList} when is_list(ClassList), ClassList =/= [] ->
-                    PkgName = package_name_from_classes(ClassList),
-                    case PkgName of
-                        undefined -> false;
-                        Name -> {true, Name}
-                    end;
-                _ ->
-                    false
+            case package_name_for_app(AppName) of
+                undefined -> false;
+                Name -> {true, Name}
             end
         end,
         Apps
@@ -167,15 +173,9 @@ dependencies(Name) when is_binary(Name) ->
                 {ok, DepApps} ->
                     lists:filtermap(
                         fun(DepApp) ->
-                            case application:get_env(DepApp, classes) of
-                                {ok, ClassList} when is_list(ClassList), ClassList =/= [] ->
-                                    PkgName = package_name_from_classes(ClassList),
-                                    case PkgName of
-                                        undefined -> false;
-                                        N -> {true, N}
-                                    end;
-                                _ ->
-                                    false
+                            case package_name_for_app(DepApp) of
+                                undefined -> false;
+                                N -> {true, N}
                             end
                         end,
                         DepApps
@@ -214,7 +214,40 @@ package_name_from_classes([#{package := Pkg} | _]) when is_binary(Pkg) ->
 package_name_from_classes(_) ->
     undefined.
 
--doc "Find the OTP application that hosts a given package name.".
+-doc """
+Returns the package name (binary) an OTP application hosts, or `undefined`
+if it is not a Beamtalk package.
+
+Prefers a non-empty `classes` env key (ADR 0070), deriving the name from
+the class entries via `package_name_from_classes/1`. Falls back to a
+non-empty `type_aliases` env key (BT-2915) when there are no classes to
+derive a name from — a types-only package has no class entry at all, so
+the OTP application's own atom name is used instead (app name == package
+name by construction for `beamtalk build`'s generated `.app` files).
+""".
+-spec package_name_for_app(atom()) -> binary() | undefined.
+package_name_for_app(AppName) ->
+    case application:get_env(AppName, classes) of
+        {ok, ClassList} when is_list(ClassList), ClassList =/= [] ->
+            package_name_from_classes(ClassList);
+        _ ->
+            case application:get_env(AppName, type_aliases) of
+                {ok, Aliases} when is_list(Aliases), Aliases =/= [] ->
+                    atom_to_binary(AppName, utf8);
+                _ ->
+                    undefined
+            end
+    end.
+
+-doc """
+Find the OTP application that hosts a given package name.
+
+Exported so other package-discovery consumers (e.g.
+`beamtalk_repl_ops_browse:browse_type_aliases/0`,
+`browse_native_modules/0`) can resolve a package name back to its OTP
+application without re-deriving the classes-or-type_aliases discovery
+signal themselves.
+""".
 -spec find_app_for_package(binary()) -> {ok, atom()} | error.
 find_app_for_package(PkgName) ->
     Apps = application:loaded_applications(),
@@ -223,14 +256,9 @@ find_app_for_package(PkgName) ->
 find_app_for_package(_PkgName, []) ->
     error;
 find_app_for_package(PkgName, [{AppName, _Desc, _Vsn} | Rest]) ->
-    case application:get_env(AppName, classes) of
-        {ok, ClassList} when is_list(ClassList), ClassList =/= [] ->
-            case package_name_from_classes(ClassList) of
-                PkgName -> {ok, AppName};
-                _ -> find_app_for_package(PkgName, Rest)
-            end;
-        _ ->
-            find_app_for_package(PkgName, Rest)
+    case package_name_for_app(AppName) of
+        PkgName -> {ok, AppName};
+        _ -> find_app_for_package(PkgName, Rest)
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
@@ -361,7 +361,9 @@ named_resolves_types_only_package_test() ->
     try
         Info = beamtalk_package:named(<<"bt_fake_types_only_pkg3">>),
         ?assertEqual(<<"bt_fake_types_only_pkg3">>, maps:get(name, Info)),
-        ?assertEqual([], maps:get(classes, Info))
+        ?assertEqual([], maps:get(classes, Info)),
+        ?assertEqual(<<"1.0.0">>, maps:get(version, Info)),
+        ?assertEqual([], maps:get(dependencies, Info))
     after
         _ = application:unload(App)
     end.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
@@ -367,3 +367,24 @@ named_resolves_types_only_package_test() ->
     after
         _ = application:unload(App)
     end.
+
+%% package_name_for_app/1 must NOT fall through to type_aliases when classes
+%% is non-empty but malformed (no `package` key on any entry) — a non-empty
+%% classes env means "not types-only", even if type_aliases is also present.
+types_only_not_used_when_classes_env_nonempty_test() ->
+    setup(),
+    App = bt_fake_malformed_classes_pkg,
+    load_fake_app(
+        App,
+        [
+            {env, [
+                {classes, [#{name => 'X'}]},
+                {type_aliases, [#{name => 'Y', internal => false}]}
+            ]}
+        ]
+    ),
+    try
+        ?assertNot(lists:member(atom_to_binary(App, utf8), beamtalk_package:all()))
+    after
+        _ = application:unload(App)
+    end.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
@@ -297,3 +297,71 @@ package_name_for_delegates_to_package_name_test() ->
         beamtalk_package:package_name('Object'),
         beamtalk_package:packageNameFor('Object')
     ).
+
+%%% ============================================================================
+%%% Types-only package tests (BT-2915) — a package with zero classes and a
+%%% non-empty `type_aliases` env key must still be discoverable.
+%%% ============================================================================
+
+%% all/0 discovers a package that declares only `type_aliases`, no `classes`,
+%% deriving the package name from the OTP application's own atom name (app
+%% name == package name by construction for `beamtalk build`'s `.app` files).
+all_includes_types_only_app_test() ->
+    setup(),
+    App = bt_fake_types_only_pkg,
+    load_fake_app(
+        App,
+        [{env, [{type_aliases, [#{name => 'RestartStrategy', internal => false}]}]}]
+    ),
+    try
+        ?assert(lists:member(<<"bt_fake_types_only_pkg">>, beamtalk_package:all()))
+    after
+        _ = application:unload(App)
+    end.
+
+%% all/0 excludes an app with neither `classes` nor `type_aliases` (or with
+%% both empty) — no discovery signal at all.
+all_excludes_app_with_no_classes_or_aliases_test() ->
+    setup(),
+    App = bt_fake_empty_pkg,
+    load_fake_app(App, [{env, [{classes, []}, {type_aliases, []}]}]),
+    try
+        ?assertNot(lists:member(<<"bt_fake_empty_pkg">>, beamtalk_package:all()))
+    after
+        _ = application:unload(App)
+    end.
+
+%% find_app_for_package/1 resolves a types-only package's name back to its
+%% OTP application — exercised by `browse-type-aliases`
+%% (`beamtalk_repl_ops_browse:type_aliases_of_package/1`).
+find_app_for_package_resolves_types_only_app_test() ->
+    setup(),
+    App = bt_fake_types_only_pkg2,
+    load_fake_app(
+        App,
+        [{env, [{type_aliases, [#{name => 'JsonValue', internal => false}]}]}]
+    ),
+    try
+        ?assertEqual(
+            {ok, App}, beamtalk_package:find_app_for_package(<<"bt_fake_types_only_pkg2">>)
+        )
+    after
+        _ = application:unload(App)
+    end.
+
+%% named/1 builds a Package info map for a types-only package — `classes` is
+%% empty but the package itself still resolves (no `package_not_found`).
+named_resolves_types_only_package_test() ->
+    setup(),
+    App = bt_fake_types_only_pkg3,
+    load_fake_app(
+        App,
+        [{env, [{type_aliases, [#{name => 'JsonValue', internal => false}]}]}]
+    ),
+    try
+        Info = beamtalk_package:named(<<"bt_fake_types_only_pkg3">>),
+        ?assertEqual(<<"bt_fake_types_only_pkg3">>, maps:get(name, Info)),
+        ?assertEqual([], maps:get(classes, Info))
+    after
+        _ = application:unload(App)
+    end.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
@@ -814,7 +814,8 @@ native_module_editable_target(Module) when is_atom(Module) ->
 %% module a Beamtalk package *declares* it ships, never the whole code path:
 %%
 %%   1. Walk `beamtalk_package:all/0` — every loaded OTP application that is a
-%%      Beamtalk package (has a non-empty `classes` env, ADR 0070).
+%%      Beamtalk package (has a non-empty `classes` env, ADR 0070, or a
+%%      non-empty `type_aliases` env with no classes, BT-2915).
 %%   2. For each package's app, take its declared native modules:
 %%        * user / dependency packages: the generated `{native_modules, [...]}`
 %%          app-env key (ADR 0072 Phase 1; the `native/*.erl` stems);
@@ -859,38 +860,12 @@ browse_native_modules() ->
 %% name + origin. A package whose app cannot be resolved contributes nothing.
 -spec native_modules_of_package(binary()) -> [map()].
 native_modules_of_package(PkgName) ->
-    case find_app_for_package(PkgName) of
+    case beamtalk_package:find_app_for_package(PkgName) of
         {ok, App} ->
             Origin = package_origin(App, PkgName),
             [native_module_row(Mod, PkgName, Origin) || Mod <- package_native_modules(App)];
         error ->
             []
-    end.
-
-%% The OTP application hosting a Beamtalk package (mirrors
-%% `beamtalk_package:find_app_for_package/1`, which is not exported).
--spec find_app_for_package(binary()) -> {ok, atom()} | error.
-find_app_for_package(PkgName) ->
-    Apps = application:loaded_applications(),
-    find_app_for_package(PkgName, Apps).
-
--spec find_app_for_package(binary(), [{atom(), term(), term()}]) -> {ok, atom()} | error.
-find_app_for_package(_PkgName, []) ->
-    error;
-find_app_for_package(PkgName, [{App, _Desc, _Vsn} | Rest]) ->
-    case app_package_name(App) of
-        PkgName -> {ok, App};
-        _ -> find_app_for_package(PkgName, Rest)
-    end.
-
-%% The package name an app hosts (the package segment of its declared classes),
-%% or `undefined` for a non-Beamtalk app.
--spec app_package_name(atom()) -> binary() | undefined.
-app_package_name(App) ->
-    case application:get_env(App, classes) of
-        {ok, [#{package := Pkg} | _]} when is_atom(Pkg) -> atom_to_binary(Pkg, utf8);
-        {ok, [#{package := Pkg} | _]} when is_binary(Pkg) -> Pkg;
-        _ -> undefined
     end.
 
 %% An app's declared native modules. User / dependency packages carry the
@@ -1067,18 +1042,14 @@ backing_source_file(Backing) ->
 %% deduping here would silently hide one package's real declaration instead
 %% of surfacing both, distinguished by their `package`/`source_origin` tags.
 %%
-%% **Known gap — a package with only `type` declarations (no classes) is
-%% invisible here (BT-2915):** discovery walks `beamtalk_package:all/0`,
-%% which recognises a package solely by a non-empty `classes` app-env key
-%% (ADR 0070) — a hypothetical types-only "shared vocabulary" package with
-%% zero classes would never be enumerated, so its aliases (even public ones)
-%% never appear, regardless of the seeding-boundary logic above. Every
-%% concrete consumer this ADR ships against (stdlib's `RestartStrategy`,
-%% `JsonValue`) declares aliases alongside real classes, so this has not
-%% bitten a real package yet; broadening `beamtalk_package:all/0`'s discovery
-%% signal is shared infra touching every other consumer of that function
-%% (`browse-native-modules`, `Package packageNameFor:`, …), so it is tracked
-%% as a follow-up rather than folded into this op.
+%% **Types-only packages (BT-2915):** discovery walks `beamtalk_package:all/0`,
+%% which recognises a package via a non-empty `classes` app-env key (ADR 0070)
+%% *or* a non-empty `type_aliases` app-env key with no classes — a types-only
+%% "shared vocabulary" package with zero classes is enumerated the same as any
+%% other package, deriving its name from the OTP application's own atom name
+%% (app name == package name by construction). Its aliases (public ones, and
+%% internal ones from the current project) surface here the same as any other
+%% package's, subject to the seeding-boundary logic above.
 -spec browse_type_aliases() -> [map()].
 browse_type_aliases() ->
     Packages =
@@ -1113,7 +1084,7 @@ browse_type_aliases() ->
 -spec type_aliases_of_package(binary()) -> [map()].
 type_aliases_of_package(PkgName) ->
     try
-        case find_app_for_package(PkgName) of
+        case beamtalk_package:find_app_for_package(PkgName) of
             {ok, App} ->
                 Origin = package_origin(App, PkgName),
                 [

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
@@ -587,6 +587,37 @@ type_aliases_malformed_entry_does_not_crash_test() ->
         end
     ).
 
+%% A package with zero classes and one or more `type` declarations is
+%% discoverable via `beamtalk_package:all/0` and its aliases appear here
+%% end to end (BT-2915) — unlike `with_stdlib_aliases`, this constructs a
+%% real second OTP application (stdlib always carries `classes`, so it can't
+%% exercise the types-only discovery path) with only a `type_aliases` env
+%% key, no `classes` key at all.
+type_aliases_surfaces_types_only_package_test() ->
+    with_types_only_fixture_app(
+        bt_fake_types_only_browse_pkg,
+        [
+            #{
+                name => 'RestartStrategy',
+                expansion => "#temporary | #transient | #permanent",
+                doc => undefined,
+                source_file => "src/restart_strategy.bt",
+                internal => false
+            }
+        ],
+        fun() ->
+            Row = find_alias_row(type_aliases(), <<"RestartStrategy">>),
+            ?assertEqual(
+                <<"#temporary | #transient | #permanent">>,
+                maps:get(<<"expansion">>, Row)
+            ),
+            ?assertEqual(
+                <<"bt_fake_types_only_browse_pkg">>, maps:get(<<"package">>, Row)
+            ),
+            ?assertEqual(<<"dependency">>, maps:get(<<"source_origin">>, Row))
+        end
+    ).
+
 %% alias_visible/2 — pure seeding-boundary decision (BT-2903).
 alias_visible_internal_project_is_visible_test() ->
     ?assert(beamtalk_repl_ops_browse:alias_visible(#{internal => true}, <<"project">>)).
@@ -649,15 +680,17 @@ find_alias_row(Rows, Name) ->
 %% Temporarily set `beamtalk_stdlib`'s `type_aliases` env to `Aliases`, run
 %% `Fun`, then restore the original env (`undefined` → unset).
 %%
-%% Stands in for a real second fixture package: `beamtalk_package:all/0` only
-%% discovers apps with a non-empty `classes` env, and stdlib is the one app
-%% always loaded under the EUnit harness (see `ensure_stdlib/0`) — no test in
-%% this suite constructs a second real loaded OTP application even for
-%% `browse-native-modules` (project/dependency classification there is tested
-%% at the pure-function level instead, see `source_origin_of/2` tests below).
-%% `application:set_env/3` on stdlib is the minimal, precedent-consistent way
-%% to fixture a package's alias env for enumeration tests without building a
-%% real `.app` file end-to-end.
+%% Stands in for a real second fixture package for most tests in this
+%% describe block: stdlib is the one app always loaded under the EUnit
+%% harness (see `ensure_stdlib/0`), and `application:set_env/3` on it is the
+%% minimal, precedent-consistent way to fixture a package's alias env for
+%% enumeration tests without building a real `.app` file end-to-end
+%% (`browse-native-modules`'s project/dependency classification is likewise
+%% tested at the pure-function level, see `source_origin_of/2` tests below).
+%% The types-only discovery path (BT-2915) can't be exercised this way,
+%% since stdlib always carries a non-empty `classes` env — see
+%% `with_types_only_fixture_app/3` below for the real second OTP application
+%% that path needs.
 with_stdlib_aliases(Aliases, Fun) ->
     ensure_stdlib(),
     Previous = application:get_env(beamtalk_stdlib, type_aliases),
@@ -669,6 +702,26 @@ with_stdlib_aliases(Aliases, Fun) ->
             {ok, V} -> application:set_env(beamtalk_stdlib, type_aliases, V);
             undefined -> application:unset_env(beamtalk_stdlib, type_aliases)
         end
+    end.
+
+%% Load a throwaway OTP application declaring only `{type_aliases, Aliases}`
+%% (no `classes` key at all), run `Fun`, then unload it (mirrors
+%% `beamtalk_package_tests:load_fake_app/2`, the precedent for fixturing a
+%% real second OTP application rather than piggybacking on stdlib's env).
+with_types_only_fixture_app(App, Aliases, Fun) ->
+    ensure_stdlib(),
+    _ = application:unload(App),
+    ok = application:load(
+        {application, App, [
+            {description, "fake types-only package"},
+            {vsn, "1.0.0"},
+            {env, [{type_aliases, Aliases}]}
+        ]}
+    ),
+    try
+        Fun()
+    after
+        _ = application:unload(App)
     end.
 
 %%====================================================================


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2915

## Summary

`beamtalk_package:all/0` only recognized an OTP application as a Beamtalk "package" when its `.app` env had a non-empty `classes` key (ADR 0070). A hypothetical package containing **only** `type` alias declarations and zero classes was never enumerated, so `browse-type-aliases` (and the LiveView/VS Code UIs built on it) would show none of its aliases, even public ones.

## Key changes

- `runtime/apps/beamtalk_runtime/src/beamtalk_package.erl`:
  - `all/0`, `find_app_for_package/1`, and `dependencies/1` now also recognize a package via a non-empty `type_aliases` env key when there are no classes to derive a name from.
  - New `package_name_for_app/1` helper centralizes the classes-or-type_aliases discovery signal; a types-only package's name is derived from the OTP application's own atom name (app name == package name by construction for `beamtalk build`'s generated `.app` files).
  - `find_app_for_package/1` is now exported so other package-discovery consumers can share this logic instead of re-deriving it.
- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl`:
  - Removed the module's own classes-only duplicate of `find_app_for_package/1,2` / `app_package_name/1` (previously undocumented as "mirrors `beamtalk_package:find_app_for_package/1`, which is not exported") — `browse-type-aliases` and `browse-native-modules` now both delegate to `beamtalk_package:find_app_for_package/1`. This mattered: without this change, a types-only package would still have been invisible to `browse-type-aliases` even after fixing `beamtalk_package:all/0`, since this duplicate only matched apps via `classes`.
  - Replaced the "Known gap — BT-2915" doc comment on `browse_type_aliases/0` with a description of the fixed behavior.
- Tests: new EUnit fixtures constructing a real second OTP application with only a `type_aliases` env key (no `classes`), covering `beamtalk_package:all/0`, `find_app_for_package/1`, `named/1`, and an end-to-end `browse-type-aliases` row.

## Test plan

- [x] `just test` (Rust, stdlib, BUnit, runtime) all pass
- [x] `just ci-changed` — build, clippy, fmt-check, dialyzer, spec validation, corpus check, surface-drift check, plus `test-integration`/`test-mcp`/`test-repl-protocol`/`test-parity` (triggered since `beamtalk_workspace` was touched) all pass
- [x] New EUnit tests for the types-only package discovery path in both `beamtalk_package_tests.erl` and `beamtalk_repl_ops_browse_tests.erl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz)_