### PR TITLE
BT-2899 follow-up: alias hot-reload re-check test coverage gaps (BT-2916)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/tests.rs
@@ -4465,6 +4465,94 @@ fn pre_loaded_internal_alias_from_same_package_is_still_seeded() {
     );
 }
 
+// BT-2916 (BT-2899 follow-up, ADR 0108 hot-reload re-check trigger): a
+// cross-package `referenced_aliases`/`beamtalk_alias_xref` dependency edge
+// must be recorded when a *seeded* (pre-loaded, from a dependency package)
+// alias is referenced by the current module — and a foreign `internal`
+// alias must never appear as such an edge, since `add_pre_loaded`'s
+// seeding-boundary exclusion (see its doc) means it was never seeded into
+// the consumer's alias table in the first place, so a reference to it
+// resolves as an ordinary unknown-class annotation, not an alias
+// dependency. Both halves matter for BT-2899's live-redefinition re-check:
+// only a *recorded* dependency edge lets `beamtalk_alias_xref` find the
+// dependent class when the alias is later redefined live.
+#[test]
+fn referenced_aliases_records_a_seeded_cross_package_alias_and_excludes_a_foreign_internal_one() {
+    use crate::semantic_analysis::alias_registry::AliasInfo;
+
+    // Two classes in the *consuming* (`app`) package: one references the
+    // dependency's public exported alias `Timeout`, the other attempts to
+    // reference a *different* dependency's `internal` alias `ParserState`
+    // — which `add_pre_loaded` never seeds because it is `internal` and
+    // belongs to a package (`other_pkg`) other than the current compile.
+    let src = "Object subclass: TimeoutUser\n  wait: t :: Timeout => t\n\n\
+               Object subclass: ParserStateUser\n  parse: s :: ParserState => s\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _parse_diags) = crate::source_analysis::parse(tokens);
+
+    let public_dependency_alias = AliasInfo {
+        name: EcoString::from("Timeout"),
+        annotation: TypeAnnotation::Simple(Identifier {
+            name: EcoString::from("Integer"),
+            span: Span::default(),
+        }),
+        is_internal: false,
+        package: Some(EcoString::from("net")),
+        span: Span::default(),
+    };
+    let foreign_internal_alias = AliasInfo {
+        name: EcoString::from("ParserState"),
+        annotation: TypeAnnotation::Simple(Identifier {
+            name: EcoString::from("Integer"),
+            span: Span::default(),
+        }),
+        is_internal: true,
+        package: Some(EcoString::from("other_pkg")),
+        span: Span::default(),
+    };
+
+    let options = crate::CompilerOptions {
+        current_package: Some("app".to_string()),
+        ..Default::default()
+    };
+    let result = analyse_with_natives_and_protocols_and_aliases(
+        &module,
+        &options,
+        vec![],
+        vec![],
+        vec![public_dependency_alias, foreign_internal_alias],
+        None,
+        &crate::compilation::extension_index::ExtensionIndex::new(),
+    );
+
+    // (a) The public dependency alias is seeded and, once referenced by
+    // `TimeoutUser`'s parameter, recorded as a dependency edge — exactly
+    // what `beamtalk_alias_xref` needs to find `TimeoutUser` as a dependent
+    // when `Timeout` is later redefined live.
+    assert!(result.alias_registry.has_alias("Timeout"));
+    assert!(
+        result
+            .referenced_aliases
+            .contains(&EcoString::from("Timeout")),
+        "expected Timeout in referenced_aliases, got: {:?}",
+        result.referenced_aliases
+    );
+
+    // (b) The foreign internal alias is never seeded — the seeding-boundary
+    // exclusion in `add_pre_loaded` runs before any reference to it is ever
+    // resolved, so it can never appear in `referenced_aliases` for any
+    // class, including one (`ParserStateUser`) that names it directly.
+    assert!(!result.alias_registry.has_alias("ParserState"));
+    assert!(
+        !result
+            .referenced_aliases
+            .contains(&EcoString::from("ParserState")),
+        "a never-seeded internal alias from another package must never appear \
+         as a referenced_aliases entry, got: {:?}",
+        result.referenced_aliases
+    );
+}
+
 // BT-2898: end-to-end wiring check — the E0402 alias-leak checks (Phase 8)
 // must fire through the full `analyse_with_options` pipeline, not just when
 // the validator functions are called directly in `visibility_validators.rs`.

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -66,6 +66,11 @@ to avoid temp files on disk (BT-48).
     %% ADR 0050 Phase 3: Accumulated class metadata cache.
     %% Maps class name atom → __beamtalk_meta/0 map.
     %% Populated via register_class/2 casts and crash recovery on init.
+    %% Accumulates entries from every session that has ever called
+    %% register_class/2, with no removal on session disconnect — the
+    %% `aliases` field below (ADR 0108, BT-2899) was modeled on this same
+    %% cache and shares this exact limitation (BT-2916); see its doc for the
+    %% full rationale, which applies here unchanged.
     classes = #{} :: #{atom() => map()},
     %% ADR 0108 hot-reload re-check trigger (BT-2899): ambient session type
     %% alias cache, keyed by alias name -> its reparseable `type Name =
@@ -92,7 +97,13 @@ to avoid temp files on disk (BT-48).
     %% (`maps:put/3` in `register_class/2`'s cast handler) rather than
     %% diverging from that precedent. Like `classes`, there is no removal on
     %% session disconnect — an accepted limitation this shares with every
-    %% ambient cache in this module.
+    %% ambient cache in this module. Not a regression introduced here: it is
+    %% the pre-existing, already-accepted `classes` limitation carried over
+    %% unchanged (BT-2916 tracks this as a cross-reference, not a bug —
+    %% `beamtalk_session_sup` termination pruning a departing session's
+    %% names from either cache would need to weigh the same cost/benefit for
+    %% both, so a fix to one without the other would just leave them
+    %% inconsistent).
     aliases = #{} :: #{binary() => binary()},
     %% BT-2832 (test-only): when set (via inject_diagnostics_failure/1, only
     %% exported in TEST builds), the *next* diagnostics/3 call fails with this

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_alias_change_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_alias_change_recheck_tests.erl
@@ -417,7 +417,7 @@ live_redefinition_of_a_deeply_transitive_alias_triggers_recheck_test_() ->
                         ])
                     ),
                     ok = file:write_file(UserPath, deep_chain_user_source()),
-                    {ok, _, _State4} = beamtalk_repl_loader:handle_load(UserPath, State3),
+                    {ok, _, State4} = beamtalk_repl_loader:handle_load(UserPath, State3),
 
                     %% The class only ever wrote `:: AliasChangeDeepC`, but
                     %% the innermost name of the chain, `AliasChangeDeepA`,
@@ -432,6 +432,11 @@ live_redefinition_of_a_deeply_transitive_alias_triggers_recheck_test_() ->
                         [<<"AliasChangeDeepChainUser">>],
                         beamtalk_alias_xref:dependents_of(<<"AliasChangeDeepB">>)
                     ),
+                    %% And the directly written annotation name.
+                    ?assertEqual(
+                        [<<"AliasChangeDeepChainUser">>],
+                        beamtalk_alias_xref:dependents_of(<<"AliasChangeDeepC">>)
+                    ),
 
                     subscribe_self_to_reload_check(),
 
@@ -443,7 +448,7 @@ live_redefinition_of_a_deeply_transitive_alias_triggers_recheck_test_() ->
                     _State5 = declare_alias(
                         <<"AliasChangeDeepA">>,
                         <<"#north | #south | #east | #west">>,
-                        State3
+                        State4
                     ),
                     wait_for_alias_change_worker(),
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_alias_change_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_alias_change_recheck_tests.erl
@@ -339,3 +339,137 @@ compile_method_patch_registers_alias_dependency_test_() ->
                 end)
             ]
         end}}.
+
+%%====================================================================
+%% End-to-end (BT-2916, BT-2899 follow-up): a live redefinition of a
+%% *deeply* (3-level) transitively referenced alias still fires the
+%% dependent's re-check.
+%%
+%% `type AliasChangeDeepC = AliasChangeDeepB`,
+%% `type AliasChangeDeepB = AliasChangeDeepA` — the dependent class's only
+%% written annotation is `:: AliasChangeDeepC`, yet its compile's
+%% `referenced_aliases` must span the *full* transitive walk (all three
+%% names — see `resolve_type_annotation_with_alias_deps`'s doc and the
+%% Rust-level `alias_deps_records_both_levels_of_a_chained_alias` unit test
+%% for the 2-level version of this same guarantee), so
+%% `beamtalk_alias_xref` records the class as a dependent of the
+%% *innermost* name too. Redefining only `AliasChangeDeepA` (never
+%% `AliasChangeDeepB`/`AliasChangeDeepC` themselves) must still trigger
+%% `beamtalk_recheck:trigger_alias_change/1` for that class — proving the
+%% chain-recording guarantee actually reaches the live hot-reload trigger,
+%% not just the recording logic in isolation.
+%%====================================================================
+
+deep_chain_user_source() ->
+    <<
+        "Object subclass: AliasChangeDeepChainUser\n"
+        "  test: x :: AliasChangeDeepC => x matchExhaustive: [\n"
+        "    #north -> 0;\n"
+        "    #south -> 1;\n"
+        "    #east -> 2\n"
+        "  ]\n"
+    >>.
+
+live_redefinition_of_a_deeply_transitive_alias_triggers_recheck_test_() ->
+    {timeout, 30,
+        {setup, fun alias_recheck_setup/0, fun alias_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    %% Turn 1-3: build the 3-level chain
+                    %% C -> B -> A, innermost first so each declaration's RHS
+                    %% resolves against an already-known name.
+                    State0 = beamtalk_repl_state:new(undefined, 0),
+                    State1 = declare_alias(
+                        <<"AliasChangeDeepA">>,
+                        <<"#north | #south | #east">>,
+                        State0
+                    ),
+                    State2 = declare_alias(
+                        <<"AliasChangeDeepB">>,
+                        <<"AliasChangeDeepA">>,
+                        State1
+                    ),
+                    State3 = declare_alias(
+                        <<"AliasChangeDeepC">>,
+                        <<"AliasChangeDeepB">>,
+                        State2
+                    ),
+
+                    %% Sanity check: the dependent's matchExhaustive: (written
+                    %% against `:: AliasChangeDeepC`) compiles clean while the
+                    %% chain still bottoms out at exactly the three members it
+                    %% matches against.
+                    {ok, SanityDiagnostics} = beamtalk_compiler:diagnostics(
+                        deep_chain_user_source(), <<"expression">>, #{class_hierarchy => true}
+                    ),
+                    ?assertEqual(
+                        [],
+                        [D || D <- SanityDiagnostics, maps:get(severity, D) =:= <<"error">>]
+                    ),
+
+                    %% Load the dependent for real so its referenced_aliases
+                    %% (all three chain names, per the full-transitive-walk
+                    %% guarantee) land in beamtalk_alias_xref's index.
+                    UserPath = filename:join(
+                        temp_dir(),
+                        io_lib:format("alias_recheck_deep_chain_user_~p.bt", [
+                            erlang:unique_integer([positive])
+                        ])
+                    ),
+                    ok = file:write_file(UserPath, deep_chain_user_source()),
+                    {ok, _, _State4} = beamtalk_repl_loader:handle_load(UserPath, State3),
+
+                    %% The class only ever wrote `:: AliasChangeDeepC`, but
+                    %% the innermost name of the chain, `AliasChangeDeepA`,
+                    %% must still have it recorded as a dependent — this is
+                    %% the crux of the deep-chain guarantee.
+                    ?assertEqual(
+                        [<<"AliasChangeDeepChainUser">>],
+                        beamtalk_alias_xref:dependents_of(<<"AliasChangeDeepA">>)
+                    ),
+                    %% And so must the middle name.
+                    ?assertEqual(
+                        [<<"AliasChangeDeepChainUser">>],
+                        beamtalk_alias_xref:dependents_of(<<"AliasChangeDeepB">>)
+                    ),
+
+                    subscribe_self_to_reload_check(),
+
+                    %% Turn 4: redefine only the innermost alias, adding
+                    %% `#west` — never touching `AliasChangeDeepB` or
+                    %% `AliasChangeDeepC` directly. The dependent's
+                    %% matchExhaustive: (still only covering north/south/east)
+                    %% is now newly non-exhaustive.
+                    _State5 = declare_alias(
+                        <<"AliasChangeDeepA">>,
+                        <<"#north | #south | #east | #west">>,
+                        State3
+                    ),
+                    wait_for_alias_change_worker(),
+
+                    Event = receive_reload_check_announcement(),
+                    ?assertEqual(
+                        <<"AliasChangeDeepA">>, maps:get(changedClass, Event)
+                    ),
+                    ?assertEqual(alias_change, maps:get(classification, Event)),
+                    ?assert(
+                        lists:member(
+                            <<"AliasChangeDeepChainUser">>, maps:get(checkedOwners, Event)
+                        )
+                    ),
+
+                    Findings = beamtalk_workspace_findings_store:for_owner(
+                        <<"AliasChangeDeepChainUser">>
+                    ),
+                    ?assert(length(Findings) > 0),
+                    ?assert(
+                        lists:any(
+                            fun(F) ->
+                                binary:match(maps:get(message, F), <<"exhaustive">>) =/= nomatch
+                            end,
+                            Findings
+                        )
+                    )
+                end)
+            ]
+        end}}.


### PR DESCRIPTION
## Summary

Closes the three test-coverage gaps flagged during BT-2899's adversarial `/review-code` pass (ADR 0108 alias-name → annotation-site hot-reload re-check trigger). None of these are known bugs — they were coverage/documentation gaps judged reasonable to defer out of BT-2899's PR.

Linear issue: https://linear.app/beamtalk/issue/BT-2916

## Changes

- **Cross-package alias export interaction** (`crates/beamtalk-core/src/semantic_analysis/tests.rs`): new test `referenced_aliases_records_a_seeded_cross_package_alias_and_excludes_a_foreign_internal_one` proving (a) a public alias exported from a dependency is recorded as a `referenced_aliases`/`beamtalk_alias_xref` dependency edge when referenced, and (b) an `internal` alias from a dependency is never seeded by `AliasRegistry::add_pre_loaded`, so it can never appear as a `referenced_aliases` entry.
- **3-level transitive alias chain e2e** (`runtime/apps/beamtalk_workspace/test/beamtalk_repl_alias_change_recheck_tests.erl`): new test `live_redefinition_of_a_deeply_transitive_alias_triggers_recheck_test_`, mirroring the existing `live_alias_redefinition_invalidates_a_matchexhaustive_proof_test_/0` but with a `type C = B`, `type B = A` chain — a class only ever writes `:: C`, and only `A` (the innermost alias) is redefined; confirms `beamtalk_recheck:trigger_alias_change/1` still fires for that class.
- **Ambient alias-cache doc note** (`runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl`): cross-referencing comments tying the `classes` and `aliases` ambient caches' identical "no removal on session disconnect" limitation together, so a future reader landing on either field doesn't rediscover it as a "new" bug.

## Test plan

- [x] `cargo test -p beamtalk-core semantic_analysis::tests::` — new Rust test passes alongside the other 111 semantic-analysis tests
- [x] `rebar3 eunit --module=beamtalk_repl_alias_change_recheck_tests` — all 4 tests pass (3 existing + 1 new deep-chain test)
- [x] `just ci-changed` — full local CI (stdlib, BUnit, runtime eunit, integration, MCP, REPL protocol, parity, corpus, surface-drift) green
- [x] `cargo clippy` / `cargo fmt --check` / erlfmt — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz)_