### PR TITLE
dependencies/1 has no end-to-end test for a types-only OTP dependency (BT-2934)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
@@ -288,8 +288,7 @@ dependencies_includes_types_only_dep_test() ->
     try
         Deps = beamtalk_package:dependencies(<<"main3p">>),
         %% Binary name is the app-atom-derived name, not a classes `package` key.
-        ?assertEqual(<<"bt_fake_types_only_dep">>, atom_to_binary(Dep, utf8)),
-        ?assert(lists:member(atom_to_binary(Dep, utf8), Deps))
+        ?assert(lists:member(<<"bt_fake_types_only_dep">>, Deps))
     after
         _ = application:unload(Main),
         _ = application:unload(Dep)

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl
@@ -267,6 +267,34 @@ dependencies_excludes_unpackaged_dep_test() ->
         _ = application:unload(Dep)
     end.
 
+%% dependencies/1 includes a types-only dep app (non-empty `type_aliases`,
+%% no `classes`) — mirrors dependencies_includes_beamtalk_package_deps_test/0
+%% but the dependency has no class entries to extract a `#{package := ...}`
+%% key from, so its binary name must come from `package_name_for_app/1`'s
+%% type_aliases fallback (the OTP application's own atom name via
+%% `atom_to_binary/2`), not a classes-derived package key (BT-2934).
+dependencies_includes_types_only_dep_test() ->
+    setup(),
+    Dep = bt_fake_types_only_dep,
+    Main = bt_fake_main3_pkg,
+    load_fake_app(
+        Dep,
+        [{env, [{type_aliases, [#{name => 'JsonValue', internal => false}]}]}]
+    ),
+    load_fake_app(
+        Main,
+        [{applications, [Dep]}, {env, [{classes, [#{package => main3p, name => 'M3'}]}]}]
+    ),
+    try
+        Deps = beamtalk_package:dependencies(<<"main3p">>),
+        %% Binary name is the app-atom-derived name, not a classes `package` key.
+        ?assertEqual(<<"bt_fake_types_only_dep">>, atom_to_binary(Dep, utf8)),
+        ?assert(lists:member(atom_to_binary(Dep, utf8), Deps))
+    after
+        _ = application:unload(Main),
+        _ = application:unload(Dep)
+    end.
+
 %% classes/1 accepts the legacy `{Mod, Name, Super}` tuple entry shape alongside
 %% the map shape (class_entry_name/1 tuple clause).
 classes_handles_legacy_tuple_entries_test() ->


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-2934

## Summary

Follow-up from Claude review bot feedback on #3047 (BT-2915 — `browse-type-aliases` misses packages with only type declarations). BT-2915's refactor switched `beamtalk_package:dependencies/1` to use `package_name_for_app/1`, which means a types-only package (non-empty `type_aliases` env, no `classes`) listed as an OTP `{applications, [...]}` dependency now correctly appears in `dependencies/1` results — but this behavior had no dedicated end-to-end test.

## Key changes

- `runtime/apps/beamtalk_runtime/test/beamtalk_package_tests.erl`: added `dependencies_includes_types_only_dep_test/0`, mirroring `dependencies_includes_beamtalk_package_deps_test/0` but with a types-only dependency app (non-empty `type_aliases`, no `classes`) instead of a class-based one. Confirms:
  - The types-only dependency app is included in `dependencies/1`'s result.
  - The binary name is derived from the OTP application's own atom name via `atom_to_binary/2` (the `package_name_for_app/1` type_aliases fallback), not a class-derived `#{package := ...}` map key — since a types-only package has no class entries to extract one from.

## Test plan

- [x] `just test` (Rust, stdlib, BUnit, runtime) all pass
- [x] `just ci-changed` — build, lint, test, check-corpus, check-surface-drift all pass
- [x] New EUnit test targeted-run: `beamtalk_package_tests` 34 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz)_