### PR TITLE
Fix missing atom-length guard on class method self-send in dispatch_codegen

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -1278,11 +1278,15 @@ impl CoreErlangGenerator {
             let cv = self.current_class_var();
             let comma = if arguments.is_empty() { "" } else { ", " };
 
+            // BT-1408 follow-up: apply the same atom-length guard used by the
+            // keyword-constructor path below — long selectors must be hashed to
+            // stay within Erlang's 255-char atom limit.
+            let safe_fn = super::selector_mangler::safe_class_method_fn_name(&selector_atom);
             let call_doc = docvec![
                 "call ",
                 leaf::atom(module),
                 ":",
-                leaf::atom(format!("class_{selector_atom}")),
+                leaf::atom(safe_fn),
                 "(ClassSelf, ",
                 leaf::var(cv),
                 comma,

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -3294,3 +3294,33 @@ fn test_bt2276_class_methods_computed_fun_passes_compile() {
                classMethods: #{ #greet => someFun }; register";
     try_codegen(src).expect("computed classMethods fun must compile (validated at register time)");
 }
+
+#[test]
+fn test_class_method_self_send_long_selector_uses_hashed_atom() {
+    // BT-1408 follow-up (#3051): inside a class-side method, a self-send whose
+    // selector would form a 'class_<selector>' atom exceeding Erlang's 255-byte
+    // hard limit must hash via safe_class_method_fn_name, not emit the raw
+    // overlong atom that erlc's core_scan rejects at BEAM-compile time.
+    // The `class` keyword declares a class-side method; `self <sel>` inside it
+    // triggers generate_class_method_self_send → line 1267 → the fixed path.
+    // "class_" (6 bytes) + 250 'a's = 256 bytes — one over the limit.
+    let long_sel = "a".repeat(250);
+    let src = format!(
+        "Actor subclass: LongSel\n  state: x = 0\n\n  class {long_sel} => 42\n\n  class go => self {long_sel}\n"
+    );
+    let code = codegen_source(&src);
+
+    // The raw 'class_<selector>' atom (256 bytes) must NOT appear anywhere —
+    // erlc's atom scanner rejects atoms > 255 bytes at BEAM-compile time.
+    let raw_class_atom = format!("class_{long_sel}");
+    assert!(
+        !code.contains(&raw_class_atom),
+        "oversized 'class_<selector>' atom must not appear in generated code. Got:\n{code}"
+    );
+    // The self-send call in `go` must use the hashed 'class_kw_<hex>' form,
+    // not the raw oversized atom. codegen_source uses module name "test".
+    assert!(
+        code.contains("call 'test':'class_kw_"),
+        "class method self-send must use hashed call target 'class_kw_<hex>'. Got:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

- **Bug**: `dispatch_codegen.rs:1285` used a bare `format!("class_{selector_atom}")` to construct the call target atom for class-method self-sends. For selectors ≥ 250 characters, this produces a `class_<selector>` atom exceeding Erlang's hard 255-byte limit, which `erlc` rejects at BEAM-compile time.
- **Fix**: Replace the `format!()` call with `safe_class_method_fn_name(&selector_atom)`, exactly mirroring the guard already applied at line 1315 (the keyword-constructor path, fixed in BT-1408).
- **Regression test**: Added `test_class_method_self_send_long_selector_uses_hashed_atom` in `dispatch.rs`, which exercises a 250-char selector through a class-side `go => self <long_sel>` method and asserts the hashed `class_kw_<hex>` form appears in generated code instead of the overlong raw atom.

Fixes #3051.

## Changes

- `crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs` — apply `safe_class_method_fn_name` on the class-method self-send path (line ~1285), removing the `format!()` violation flagged by CLAUDE.md
- `crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs` — regression test for the fixed path

## Test plan

- [x] `just test` passes (Rust unit + BUnit + runtime)
- [x] `just clippy` clean
- [x] `just fmt-check` clean
- [x] New regression test `test_class_method_self_send_long_selector_uses_hashed_atom` passes
- [x] Normal-length selectors unaffected (safe_class_method_fn_name is identity for ≤249 char selectors)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoNhXhfWizonU3ou88aJjd)_