### PR TITLE
fix: cross-file/package type-alias resolution for build.rs Pass 1 and LSP diagnostics

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -673,6 +673,12 @@ pub struct ClassHierarchyContext {
     /// recognise protocol names defined outside the current module (BT-2006).
     pub pre_loaded_protocols:
         Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo>,
+    /// Type alias declarations (`type Name = ...`) from other source files in
+    /// the same package (BT-2928, ADR 0108). Seeded into the `AliasRegistry`
+    /// during semantic analysis so a cross-file alias reference resolves
+    /// through `resolve_type_annotation` instead of staying an opaque,
+    /// unresolved name — mirrors `pre_loaded_protocols` immediately above.
+    pub pre_loaded_aliases: Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo>,
     /// Project-wide standalone extension definitions from Pass 1 (BT-2795).
     /// Registered into each file's class hierarchy during Pass 2 so
     /// same-project cross-file extensions resolve instead of producing
@@ -864,6 +870,12 @@ pub(crate) fn compile_source_with_bindings(
         options: options.clone(),
         cross_file_classes: cross_file_classes.clone(),
         pre_loaded_protocols: ctx.hierarchy.pre_loaded_protocols.clone(),
+        // BT-2928: cross-file/package type aliases from Pass 1 — see
+        // `ClassHierarchyContext::pre_loaded_aliases`'s doc. `analyse_full`
+        // filters out any name the current module redeclares itself, so no
+        // "current file's own aliases" pre-filter is needed here (mirrors
+        // `pre_loaded_protocols` immediately above).
+        pre_loaded_aliases: ctx.hierarchy.pre_loaded_aliases.clone(),
         cross_file_extensions: ctx.hierarchy.extension_index.clone(),
         native_type_registry: ctx.native_type_registry.clone(),
         dep_registry: ctx.dep_registry,

--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -677,7 +677,13 @@ pub struct ClassHierarchyContext {
     /// the same package (BT-2928, ADR 0108). Seeded into the `AliasRegistry`
     /// during semantic analysis so a cross-file alias reference resolves
     /// through `resolve_type_annotation` instead of staying an opaque,
-    /// unresolved name — mirrors `pre_loaded_protocols` immediately above.
+    /// unresolved name. Structurally a `ctx.hierarchy.*` field like
+    /// `pre_loaded_protocols` above, but populated differently in practice:
+    /// the CLI build path (`execute_build_passes`) leaves `pre_loaded_protocols`
+    /// empty while fully populating `pre_loaded_aliases` from every source
+    /// file in the compilation unit, including the file being compiled —
+    /// `analyse_full`'s merge order lets the module's own declaration take
+    /// precedence over its duplicate pre-loaded entry.
     pub pre_loaded_aliases: Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo>,
     /// Project-wide standalone extension definitions from Pass 1 (BT-2795).
     /// Registered into each file's class hierarchy during Pass 2 so

--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -384,6 +384,12 @@ struct ClassIndexResult {
     class_superclass_index: HashMap<String, String>,
     /// Unified collection of all `ClassInfo` from source and dependency classes.
     all_class_infos: Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
+    /// BT-2928: Type alias declarations (`type Name = ...`) collected from
+    /// every project source file, for cross-file/package alias resolution
+    /// during Pass 2. See `collect_project_alias_infos`'s doc for why this
+    /// is a plain full scan rather than threaded through the incremental
+    /// Pass 1 cache the way `all_class_infos` is.
+    all_alias_infos: Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo>,
     /// Project-wide standalone extension index from Pass 1 (BT-2795).
     extension_index: beamtalk_core::compilation::extension_index::ExtensionIndex,
     /// Dependency registry for cross-package collision detection.
@@ -497,10 +503,22 @@ fn build_class_index(
         check_stdlib_reservations(&dep_registry)?;
     }
 
+    // BT-2928: Same-package cross-file type-alias resolution. Only runs for
+    // manifest-based package builds (matching `pre_loaded_classes`'s existing
+    // scope) — a manifest-less directory/single-file build has no package
+    // boundary and keeps today's same-file-only alias resolution. Dependency
+    // (cross-package) alias export is deferred — see the BT-2928 follow-up
+    // filed for `dependency_classes.rs`.
+    let all_alias_infos = match pkg_manifest {
+        Some(pkg) => collect_project_alias_infos(&env.source_files, &pkg.name),
+        None => Vec::new(),
+    };
+
     Ok(ClassIndexResult {
         class_module_index,
         class_superclass_index,
         all_class_infos,
+        all_alias_infos,
         extension_index,
         dep_registry,
         cached_asts,
@@ -778,6 +796,7 @@ fn execute_build_passes(
             class_superclass_index: index.class_superclass_index.clone(),
             pre_loaded_classes: index.all_class_infos.clone(),
             pre_loaded_protocols: Vec::new(),
+            pre_loaded_aliases: index.all_alias_infos.clone(),
             extension_index: index.extension_index.clone(),
         },
         dep_registry: registry_ref,
@@ -1632,6 +1651,49 @@ pub(crate) fn build_class_module_index(
         extension_index,
         cached_asts,
     ))
+}
+
+/// Extracts type-alias declarations (`type Name = ...`) from every project
+/// source file, for cross-file/package alias resolution during Pass 2
+/// (BT-2928).
+///
+/// Unlike `ClassInfo`, alias metadata is *not* threaded through the
+/// incremental Pass 1 cache (`build_cache.rs`'s `.beamtalk-pass1-cache.json`):
+/// `AliasInfo` embeds an unresolved `TypeAnnotation`, which (unlike
+/// `ClassInfo`'s stringly-typed method signatures) has no `serde` support —
+/// adding it would mean threading `Serialize`/`Deserialize` through the AST's
+/// `TypeAnnotation` tree purely to satisfy the cache format, a disproportionate
+/// blast radius for this fix (tracked as a BT-2928 follow-up for anyone who
+/// wants the incremental-cache perf win later). Lexing and parsing every
+/// project source file just to pull out `type` declarations is cheap relative
+/// to the rest of a build, so this always does a full, uncached scan
+/// regardless of per-file change detection — every call re-derives the
+/// project's alias table from scratch rather than risking staleness.
+///
+/// Parse errors on an individual file are non-fatal here: that file simply
+/// contributes no aliases to the merged set, and the same parse error is
+/// already reported through the normal Pass 1 diagnostics path.
+pub(crate) fn collect_project_alias_infos(
+    source_files: &[Utf8PathBuf],
+    pkg_name: &str,
+) -> Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo> {
+    let mut all_aliases = Vec::new();
+    for file in source_files {
+        let Ok(source) = fs::read_to_string(file) else {
+            continue;
+        };
+        let tokens = beamtalk_core::source_analysis::lex_with_eof(&source);
+        let (module, _diagnostics) = beamtalk_core::source_analysis::parse(tokens);
+        let mut infos =
+            beamtalk_core::semantic_analysis::alias_registry::AliasRegistry::extract_alias_infos(
+                &module,
+            );
+        for info in &mut infos {
+            info.package = Some(pkg_name.into());
+        }
+        all_aliases.extend(infos);
+    }
+    all_aliases
 }
 
 // ── BT-1730: Class module header generation ─────────────────────────────────
@@ -3170,6 +3232,126 @@ mod tests {
         .expect("Cross-file inheritance should compile without errors");
 
         assert!(core_file.exists());
+    }
+
+    /// BT-2928: cross-file/package type-alias resolution for a manifest-based
+    /// package build's Pass 1.
+    ///
+    /// File A declares `type Direction = ...` and a method returning it;
+    /// file B calls that method and passes the result as an argument to a
+    /// parameter typed with the *same* union spelled out directly (mirroring
+    /// the real `stdlib/src/Actor.bt` / `stdlib/src/SupervisionSpec.bt`
+    /// `RestartStrategy` bug this issue fixes: the declared parameter side
+    /// already resolved correctly same-file, but the cross-file argument's
+    /// inferred type — read back from `A`'s `ClassInfo`/`MethodInfo` as an
+    /// opaque `"Direction"` string — never expanded through the alias table,
+    /// so it never matched the union's members). Before BT-2928's
+    /// `resolve_type_name_string` alias-awareness fix, this produced a
+    /// spurious "Argument 1 of 'useDirection:' ... expects ..., got
+    /// Direction" warning; after the fix, `A new heading`'s type expands to
+    /// the same union and no warning fires.
+    #[test]
+    fn test_cross_file_alias_resolution_no_false_type_mismatch() {
+        let temp = TempDir::new().unwrap();
+        let project_path = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let src_path = project_path.join("src");
+        fs::create_dir_all(&src_path).unwrap();
+
+        // File 1: declares the alias and a method that returns it. `A` is a
+        // `Value` subclass so `A new` is instantiable (Object classes are
+        // abstract and not directly instantiable).
+        write_test_file(
+            &src_path.join("a.bt"),
+            "type Direction = #north | #south | #east | #west\n\
+             Value subclass: A\n  heading -> Direction => #north\n",
+        );
+
+        // File 2: consumes A's alias-typed return value as an argument to a
+        // parameter typed with the spelled-out equivalent union.
+        write_test_file(
+            &src_path.join("b.bt"),
+            "Object subclass: B\n  \
+             useDirection: d :: #north | #south | #east | #west => d\n  \
+             test => self useDirection: A new heading\n",
+        );
+
+        let build_dir = project_path.join("_build/dev/ebin");
+        fs::create_dir_all(&build_dir).unwrap();
+
+        let source_files = vec![src_path.join("a.bt"), src_path.join("b.bt")];
+        let (
+            class_module_index,
+            class_superclass_index,
+            all_class_infos,
+            _extensions,
+            _cached_asts,
+        ) = build_class_module_index(&source_files, Some(&src_path), "test_pkg").unwrap();
+        let all_alias_infos = collect_project_alias_infos(&source_files, "test_pkg");
+
+        assert!(
+            all_alias_infos.iter().any(|a| a.name == "Direction"),
+            "Pass 1 should extract the Direction alias from a.bt"
+        );
+
+        // Compile B with cross-file class infos AND cross-file alias infos —
+        // should produce no "Type mismatch" / "Argument ... expects" warning.
+        let core_file = build_dir.join("bt@test_pkg@b.core");
+        let options = default_options();
+        let diagnostics = compile_file(
+            &src_path.join("b.bt"),
+            "bt@test_pkg@b",
+            &core_file,
+            &options,
+            &CompileContext {
+                hierarchy: ClassHierarchyContext {
+                    class_module_index: class_module_index.clone(),
+                    class_superclass_index: class_superclass_index.clone(),
+                    pre_loaded_classes: all_class_infos.clone(),
+                    pre_loaded_aliases: all_alias_infos.clone(),
+                    ..ClassHierarchyContext::default()
+                },
+                ..CompileContext::default()
+            },
+            None,
+        )
+        .expect("Cross-file alias-typed argument should compile without errors");
+
+        assert!(core_file.exists());
+        assert!(
+            diagnostics.iter().all(|d| !d.message.contains("Argument")),
+            "Expected no false argument-type-mismatch diagnostic once cross-file \
+             aliases are seeded, got: {diagnostics:?}"
+        );
+
+        // Negative control: WITHOUT `pre_loaded_aliases`, the same compile
+        // reproduces the pre-BT-2928 false positive — proving this test
+        // actually exercises the fix rather than a scenario that never warned.
+        let core_file_unfixed = build_dir.join("bt@test_pkg@b_unfixed.core");
+        let diagnostics_unfixed = compile_file(
+            &src_path.join("b.bt"),
+            "bt@test_pkg@b_unfixed",
+            &core_file_unfixed,
+            &options,
+            &CompileContext {
+                hierarchy: ClassHierarchyContext {
+                    class_module_index,
+                    class_superclass_index,
+                    pre_loaded_classes: all_class_infos,
+                    // No pre_loaded_aliases — reproduces the pre-fix gap.
+                    ..ClassHierarchyContext::default()
+                },
+                ..CompileContext::default()
+            },
+            None,
+        )
+        .expect("Compile should still succeed (warning, not error)");
+        assert!(
+            diagnostics_unfixed
+                .iter()
+                .any(|d| d.message.contains("Argument") && d.message.contains("Direction")),
+            "Expected the negative control (no pre_loaded_aliases) to reproduce \
+             the false positive, got: {diagnostics_unfixed:?}"
+        );
     }
 
     #[test]

--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -3354,6 +3354,74 @@ mod tests {
         );
     }
 
+    /// BT-2928 (review follow-up): `collect_project_alias_infos` scans every
+    /// source file in the compilation unit, including the one currently being
+    /// compiled — unlike `ClassHierarchy::cross_file_class_infos`, which
+    /// explicitly filters out the current file's own classes before
+    /// injection. So compiling `a.bt` (which declares `type Direction = ...`)
+    /// with `pre_loaded_aliases` that *also* contains `a.bt`'s own `Direction`
+    /// entry must not raise a "Duplicate type alias definition" diagnostic —
+    /// `analyse_full`'s merge order must let the module's own declaration take
+    /// precedence over its duplicate pre-loaded entry.
+    #[test]
+    fn test_cross_file_alias_resolution_no_false_duplicate_for_own_alias() {
+        let temp = TempDir::new().unwrap();
+        let project_path = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let src_path = project_path.join("src");
+        fs::create_dir_all(&src_path).unwrap();
+
+        write_test_file(
+            &src_path.join("a.bt"),
+            "type Direction = #north | #south | #east | #west\n\
+             Value subclass: A\n  heading -> Direction => #north\n",
+        );
+
+        let build_dir = project_path.join("_build/dev/ebin");
+        fs::create_dir_all(&build_dir).unwrap();
+
+        let source_files = vec![src_path.join("a.bt")];
+        let (
+            class_module_index,
+            class_superclass_index,
+            all_class_infos,
+            _extensions,
+            _cached_asts,
+        ) = build_class_module_index(&source_files, Some(&src_path), "test_pkg").unwrap();
+        // Includes a.bt's own `Direction` alias, exactly as the real Pass 1
+        // scan would when compiling a.bt itself.
+        let all_alias_infos = collect_project_alias_infos(&source_files, "test_pkg");
+
+        let core_file = build_dir.join("bt@test_pkg@a.core");
+        let options = default_options();
+        let diagnostics = compile_file(
+            &src_path.join("a.bt"),
+            "bt@test_pkg@a",
+            &core_file,
+            &options,
+            &CompileContext {
+                hierarchy: ClassHierarchyContext {
+                    class_module_index,
+                    class_superclass_index,
+                    pre_loaded_classes: all_class_infos,
+                    pre_loaded_aliases: all_alias_infos,
+                    ..ClassHierarchyContext::default()
+                },
+                ..CompileContext::default()
+            },
+            None,
+        )
+        .expect("Compiling a file whose own alias is also pre-loaded should succeed");
+
+        assert!(core_file.exists());
+        assert!(
+            diagnostics
+                .iter()
+                .all(|d| !d.message.contains("Duplicate type alias")),
+            "Expected no false duplicate-alias diagnostic when a file's own \
+             alias is also present in pre_loaded_aliases, got: {diagnostics:?}"
+        );
+    }
+
     #[test]
     fn test_clean_stale_artifacts_removes_orphaned_beam() {
         let temp = TempDir::new().unwrap();

--- a/crates/beamtalk-cli/src/commands/deps/path.rs
+++ b/crates/beamtalk-cli/src/commands/deps/path.rs
@@ -418,6 +418,14 @@ fn compile_dependency_with_context(
         }
     }
 
+    // BT-2928: Same-package cross-file type-alias resolution within the
+    // dependency's own multi-file compilation — mirrors `all_class_infos`
+    // immediately above. Exporting these aliases to *consumers* of this
+    // dependency (cross-package alias resolution) is deferred — see the
+    // BT-2928 follow-up filed for this module.
+    let all_alias_infos =
+        crate::commands::build::collect_project_alias_infos(&source_files, dep_name);
+
     // Compile .bt sources to .core files
     let compile_ctx = crate::beam_compiler::CompileContext {
         hierarchy: crate::beam_compiler::ClassHierarchyContext {
@@ -425,6 +433,7 @@ fn compile_dependency_with_context(
             class_superclass_index: class_superclass_index.clone(),
             pre_loaded_classes: all_class_infos.clone(),
             pre_loaded_protocols: Vec::new(),
+            pre_loaded_aliases: all_alias_infos,
             // BT-2795: The dep's own project-wide extensions — its files see
             // each other's extensions during its own compilation. (Exporting
             // them to consumers is WS3 / the ADR 0070 amendment.)

--- a/crates/beamtalk-core/src/language_service/mod.rs
+++ b/crates/beamtalk-core/src/language_service/mod.rs
@@ -1696,9 +1696,15 @@ impl LanguageService for SimpleLanguageService {
                 // passed so a same-project `ClassName >> selector` defined in
                 // another file resolves instead of producing a false Dnu hint.
                 let cross_file_extensions = self.project_index.cross_file_extensions_for(file);
+                // BT-2928: Cross-file type aliases from the ProjectIndex, so a
+                // `type Name = ...` declared in another project file resolves
+                // instead of leaving `Dynamic (dynamic receiver)` behind —
+                // mirrors `cross_file_classes` immediately above.
+                let pre_loaded_aliases = self.project_index.cross_file_alias_infos_for(file);
                 let ctx = crate::queries::diagnostic_provider::ProjectDiagnosticContext {
                     options,
                     cross_file_classes,
+                    pre_loaded_aliases,
                     cross_file_extensions,
                     native_type_registry: self.native_types.clone(),
                     // BT-2800: apply the same `beamtalk.toml` `[diagnostics]`

--- a/crates/beamtalk-core/src/language_service/project_index.rs
+++ b/crates/beamtalk-core/src/language_service/project_index.rs
@@ -403,6 +403,22 @@ impl ProjectIndex {
             .collect()
     }
 
+    /// Returns cross-file `AliasInfo` entries for diagnostic computation
+    /// (BT-2928) — the alias-namespace analogue of
+    /// [`Self::cross_file_class_infos_for`]. Returns every tracked alias
+    /// declaration from files other than `file`, for seeding into
+    /// `ProjectDiagnosticContext::pre_loaded_aliases` so a `type Name = ...`
+    /// declared in a different project file resolves during LSP diagnostics
+    /// the same way a cross-file class reference already does.
+    #[must_use]
+    pub fn cross_file_alias_infos_for(&self, file: &Utf8PathBuf) -> Vec<AliasInfo> {
+        self.file_aliases
+            .iter()
+            .filter(|(path, _)| *path != file)
+            .flat_map(|(_, infos)| infos.iter().cloned())
+            .collect()
+    }
+
     /// Returns the package name for a file, if determinable.
     ///
     /// Uses the file-local hierarchy (not the merged hierarchy) so that

--- a/crates/beamtalk-core/src/queries/diagnostic_provider.rs
+++ b/crates/beamtalk-core/src/queries/diagnostic_provider.rs
@@ -51,6 +51,14 @@ pub struct ProjectDiagnosticContext<'a> {
     pub cross_file_classes: Vec<crate::semantic_analysis::class_hierarchy::ClassInfo>,
     /// Pre-loaded protocol definitions from other source files.
     pub pre_loaded_protocols: Vec<crate::semantic_analysis::protocol_registry::ProtocolInfo>,
+    /// Pre-loaded type alias definitions from other source files in the same
+    /// package (BT-2928, ADR 0108). Mirrors `pre_loaded_protocols` — seeded
+    /// into the `AliasRegistry` before the current module's own aliases are
+    /// registered, so a `type Name = ...` declared in a different file
+    /// resolves cross-file the same way a cross-file class reference already
+    /// does. Empty for callers that don't (yet) supply project-wide alias
+    /// metadata — the pipeline degrades to today's same-file-only resolution.
+    pub pre_loaded_aliases: Vec<crate::semantic_analysis::AliasInfo>,
     /// Project-wide standalone extension definitions (BT-2795, ADR 0066).
     /// Registered into the class hierarchy so cross-file
     /// `ClassName >> selector` extensions resolve instead of producing
@@ -102,11 +110,15 @@ pub fn compute_project_diagnostics(
     let mut diagnostics = initial_diagnostics;
 
     // Run semantic analysis with the richest available entry point.
-    let analysis_result = crate::semantic_analysis::analyse_with_natives_and_protocols(
+    // BT-2928: thread `pre_loaded_aliases` through so a cross-file/package
+    // type alias resolves the same way a cross-file class reference already
+    // does — see `AnalysisContext::pre_loaded_aliases`'s doc.
+    let analysis_result = crate::semantic_analysis::analyse_with_natives_and_protocols_and_aliases(
         module,
         &ctx.options,
         ctx.cross_file_classes.clone(),
         ctx.pre_loaded_protocols.clone(),
+        ctx.pre_loaded_aliases.clone(),
         ctx.native_type_registry.clone(),
         &ctx.cross_file_extensions,
     );

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -464,14 +464,30 @@ impl TypeChecker {
         }
     }
 
-    /// Converts a type name string (from `ClassHierarchy::state_field_type`)
-    /// to a proper `InferredType`, splitting unions on `|`.
+    /// Converts a type name string (from `ClassHierarchy::state_field_type` or
+    /// a cross-file `MethodInfo::return_type`/`param_types` entry) to a proper
+    /// `InferredType`, splitting unions on `|`.
     ///
     /// Examples:
     /// - `"Integer"` → `Known("Integer")`
     /// - `"String | nil"` → `Union(["String", "UndefinedObject"])`
     /// - `"List(String)"` → `Known("List", type_args: [Known("String")])`
-    pub(super) fn resolve_type_name_string(type_name: &EcoString) -> InferredType {
+    ///
+    /// `alias_registry` (BT-2928, ADR 0108) is consulted for the bare-name
+    /// case only — an alias is never itself parametric, so a `Base(Args...)`
+    /// generic's base name is resolved as an ordinary nominal class, matching
+    /// `type_resolver::resolve_type_annotation`'s equivalent restriction.
+    /// This is what makes a *cross-file* method/field signature — stored here
+    /// as an opaque string extracted once at Pass 1, not a live
+    /// `TypeAnnotation` re-resolved against the current file's alias table —
+    /// expand a same-package alias declared in another file, instead of
+    /// treating the alias name as an unknown nominal class (the literal
+    /// `A new heading` cross-file repro this fixes). Pass `None` when no
+    /// registry is available, matching this function's pre-BT-2928 behaviour.
+    pub(super) fn resolve_type_name_string(
+        type_name: &EcoString,
+        alias_registry: Option<&crate::semantic_analysis::alias_registry::AliasRegistry>,
+    ) -> InferredType {
         if WellKnownClass::from_str(type_name) == Some(WellKnownClass::Never) {
             return InferredType::Never;
         }
@@ -492,7 +508,7 @@ impl TypeChecker {
             if members.len() > 1 {
                 let resolved: Vec<InferredType> = members
                     .into_iter()
-                    .map(|s| Self::resolve_type_name_string(&EcoString::from(s)))
+                    .map(|s| Self::resolve_type_name_string(&EcoString::from(s), alias_registry))
                     .collect();
                 return InferredType::union_of(&resolved);
             }
@@ -506,7 +522,7 @@ impl TypeChecker {
             let base = Self::resolve_type_keyword(&EcoString::from(base_str));
             let type_args: Vec<InferredType> = Self::split_type_params(inner)
                 .into_iter()
-                .map(|p| Self::resolve_type_name_string(&EcoString::from(p)))
+                .map(|p| Self::resolve_type_name_string(&EcoString::from(p), alias_registry))
                 .collect();
             InferredType::Known {
                 class_name: base,
@@ -514,6 +530,24 @@ impl TypeChecker {
                 provenance: super::TypeProvenance::Declared(crate::source_analysis::Span::default()),
             }
         } else {
+            // BT-2928: consult the alias registry before falling back to a
+            // bare nominal class — mirrors `type_resolver::resolve_type_annotation`'s
+            // `subst → alias table → nominal class` order (ADR 0108
+            // Semantics). Resolves through the alias's own stored
+            // `TypeAnnotation` (not this string-based function) so chained
+            // aliases, cycle-guarding, and hover-display tagging all reuse
+            // the same machinery every other alias reference goes through.
+            if let Some(registry) = alias_registry {
+                if let Some(alias_info) = registry.get(type_name) {
+                    let resolved = super::type_resolver::resolve_type_annotation(
+                        &alias_info.annotation,
+                        &super::type_resolver::SubstitutionMap::new(),
+                        None,
+                        alias_registry,
+                    );
+                    return resolved.tag_alias_expansion(type_name.clone(), alias_info.span);
+                }
+            }
             InferredType::known(Self::resolve_type_keyword(type_name))
         }
     }
@@ -561,7 +595,10 @@ impl TypeChecker {
                                 } else if let Some(field_type) =
                                     hierarchy.state_field_type(&class_name, name)
                                 {
-                                    Self::resolve_type_name_string(&field_type)
+                                    Self::resolve_type_name_string(
+                                        &field_type,
+                                        self.alias_registry.as_ref(),
+                                    )
                                 } else {
                                     InferredType::Dynamic(DynamicReason::Unknown)
                                 }
@@ -610,7 +647,10 @@ impl TypeChecker {
                             if let Some(field_type) =
                                 hierarchy.state_field_type(&class_name, &field.name)
                             {
-                                result = Self::resolve_type_name_string(&field_type);
+                                result = Self::resolve_type_name_string(
+                                    &field_type,
+                                    self.alias_registry.as_ref(),
+                                );
                             }
                         }
                     }
@@ -2075,7 +2115,10 @@ impl TypeChecker {
                     //  * Plain class names — pass through to `Known(name, [])`.
                     //  * Nested generics — `Result(List(String), Error)`
                     //    keeps both layers.
-                    return Self::resolve_type_name_string(ret_ty);
+                    //  * BT-2928: a cross-file alias name expands to its
+                    //    declared union/structural type instead of staying
+                    //    an opaque nominal class.
+                    return Self::resolve_type_name_string(ret_ty, self.alias_registry.as_ref());
                 }
 
                 // BT-2868: `ret_ty` is None — the method exists but declares
@@ -2603,7 +2646,11 @@ impl TypeChecker {
         if super::is_generic_type_param(ret_ty) && !hierarchy.has_class(ret_ty) {
             return None;
         }
-        Some(Self::resolve_type_name_string(ret_ty))
+        // No alias registry threaded here: `ret_ty` comes from the built-in
+        // Metaclass/Class/Behaviour/Object/ProtoObject tower, which never
+        // declares an alias-typed return (BT-2928 follow-up covers the
+        // general case; this call site is out of scope for it).
+        Some(Self::resolve_type_name_string(ret_ty, None))
     }
 
     /// Returns true if `expr` resolves to a class-side receiver — either a
@@ -2836,7 +2883,10 @@ impl TypeChecker {
                                 // parametric type args (`List(String)` keeps
                                 // its element type) and parse union return
                                 // types into `InferredType::Union`.
-                                return_types.push(Self::resolve_type_name_string(ret_ty));
+                                return_types.push(Self::resolve_type_name_string(
+                                    ret_ty,
+                                    self.alias_registry.as_ref(),
+                                ));
                             }
                         }
                     } else if let Some(ty) = Self::if_true_false_solo_boolean_ret_ty(
@@ -2893,7 +2943,7 @@ impl TypeChecker {
                     } else if WellKnownClass::from_str(ret_ty) == Some(WellKnownClass::Never) {
                         InferredType::Never
                     } else {
-                        Self::resolve_type_name_string(ret_ty)
+                        Self::resolve_type_name_string(ret_ty, self.alias_registry.as_ref())
                     };
                     return_types.push(nil_contribution);
                 } else {
@@ -5054,7 +5104,14 @@ impl TypeChecker {
         if let EnvKey::SelfField(field_name) = var_key {
             if let Some(InferredType::Known { class_name, .. }) = env.get_local("self") {
                 if let Some(field_type) = hierarchy.state_field_type(&class_name, field_name) {
-                    return Self::resolve_type_name_string(&field_type);
+                    // No alias registry threaded here — this free function's
+                    // several callers don't have one in scope. A narrowing
+                    // check (e.g. `self.field isNil ifFalse: [...]`) on a
+                    // cross-file alias-typed field falls back to the
+                    // opaque-name behaviour this fixes elsewhere (BT-2928
+                    // follow-up: thread `alias_registry` through the
+                    // narrowing call chain too).
+                    return Self::resolve_type_name_string(&field_type, None);
                 }
             }
         }
@@ -6087,7 +6144,7 @@ mod tests {
     #[test]
     fn resolve_type_name_string_simple() {
         assert_eq!(
-            TypeChecker::resolve_type_name_string(&"Integer".into()),
+            TypeChecker::resolve_type_name_string(&"Integer".into(), None),
             InferredType::known("Integer")
         );
     }
@@ -6095,14 +6152,14 @@ mod tests {
     #[test]
     fn resolve_type_name_string_nil_keyword() {
         assert_eq!(
-            TypeChecker::resolve_type_name_string(&"nil".into()),
+            TypeChecker::resolve_type_name_string(&"nil".into(), None),
             InferredType::known("UndefinedObject")
         );
     }
 
     #[test]
     fn resolve_type_name_string_union() {
-        let result = TypeChecker::resolve_type_name_string(&"String | nil".into());
+        let result = TypeChecker::resolve_type_name_string(&"String | nil".into(), None);
         match result {
             InferredType::Union { members, .. } => {
                 assert_eq!(members.len(), 2);
@@ -6115,7 +6172,7 @@ mod tests {
 
     #[test]
     fn resolve_type_name_string_three_way_union() {
-        let result = TypeChecker::resolve_type_name_string(&"Integer | String | nil".into());
+        let result = TypeChecker::resolve_type_name_string(&"Integer | String | nil".into(), None);
         match result {
             InferredType::Union { members, .. } => {
                 assert_eq!(members.len(), 3);
@@ -6125,6 +6182,65 @@ mod tests {
             }
             other => panic!("Expected Union, got {other:?}"),
         }
+    }
+
+    /// BT-2928: a cross-file alias name (as stored raw in a `ClassInfo`/
+    /// `MethodInfo` string, e.g. a `MethodInfo::return_type` extracted from
+    /// another file's `-> RestartStrategy` annotation) expands to its
+    /// declared union through the alias registry, instead of staying an
+    /// opaque, unresolved nominal class.
+    #[test]
+    fn resolve_type_name_string_expands_alias_from_registry() {
+        use crate::ast::{Module, TypeAliasDefinition};
+        use crate::semantic_analysis::alias_registry::AliasRegistry;
+        use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
+
+        let ann = TypeAnnotation::Union {
+            types: vec![
+                TypeAnnotation::Singleton {
+                    name: "permanent".into(),
+                    span: span(),
+                },
+                TypeAnnotation::Singleton {
+                    name: "temporary".into(),
+                    span: span(),
+                },
+            ],
+            span: span(),
+        };
+        let module = Module {
+            type_aliases: vec![TypeAliasDefinition {
+                name: ident("RestartStrategy"),
+                annotation: ann,
+                is_internal: false,
+                comments: crate::ast::CommentAttachment::default(),
+                doc_comment: None,
+                span: span(),
+            }],
+            ..Module::new(vec![], span())
+        };
+        let hierarchy = ClassHierarchy::with_builtins();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+        assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+
+        let result =
+            TypeChecker::resolve_type_name_string(&"RestartStrategy".into(), Some(&registry));
+        match result {
+            InferredType::Union { members, .. } => {
+                assert_eq!(members.len(), 2);
+                assert!(members.contains(&InferredType::known("#permanent")));
+                assert!(members.contains(&InferredType::known("#temporary")));
+            }
+            other => panic!("Expected Union (alias expansion), got {other:?}"),
+        }
+
+        // Without the registry, the same raw string stays an opaque nominal
+        // class — the pre-BT-2928 behaviour this test guards against
+        // regressing back to.
+        let unresolved = TypeChecker::resolve_type_name_string(&"RestartStrategy".into(), None);
+        assert_eq!(unresolved, InferredType::known("RestartStrategy"));
     }
 
     // ---- detect_narrowing ----

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
@@ -466,7 +466,26 @@ impl TypeChecker {
             return;
         };
 
-        let declared_type = type_annotation.type_name();
+        // BT-2928: resolve the declared type through the alias table before
+        // comparing against the default value's inferred type — mirroring
+        // `check_state_defaults`'s alias-aware resolution (its same-file
+        // sibling, fixed in BT-2923/ADR 0108). This method is only reached
+        // for `TypeAnnotation::Generic` fields (see
+        // `check_generic_variance_in_module`'s caller-side gate), so the
+        // alias in question is typically a type *argument* — e.g. `field:
+        // items :: Array(RestartStrategy) = Array new` — and
+        // `resolve_type_annotation_with_alias_deps` recurses into `Generic`
+        // parameters, expanding the alias before `is_assignable_to_with_variance`
+        // ever sees it, instead of comparing against its opaque unresolved name.
+        let (resolved_declared, alias_deps) =
+            super::type_resolver::resolve_type_annotation_with_alias_deps(
+                type_annotation,
+                &super::type_resolver::SubstitutionMap::new(),
+                None,
+                self.alias_registry.as_ref(),
+            );
+        self.referenced_aliases.extend(alias_deps);
+        let declared_type = Self::inferred_type_to_string(&resolved_declared);
         let mut env = TypeEnv::new();
         env.set_local("self", InferredType::known(class.name.name.clone()));
         let inferred = self.infer_expr(default_value, hierarchy, &mut env, false);

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/sendability.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/sendability.rs
@@ -300,7 +300,12 @@ fn tier_of_known(
                 // no such class, and a generic field would silently drop to
                 // `Unknown` instead of composing its element tier (BT-2770).
                 Some(field_ty) => {
-                    let field_type = super::TypeChecker::resolve_type_name_string(&field_ty);
+                    // No alias registry threaded here (BT-2928 follow-up) —
+                    // this free function's callers don't have one in scope.
+                    // An alias-typed field's sendability tier falls back to
+                    // treating the alias name as an unresolved nominal class
+                    // (`Tier::Unknown`), same as before this fix.
+                    let field_type = super::TypeChecker::resolve_type_name_string(&field_ty, None);
                     tier_of_depth(&field_type, hierarchy, depth + 1)
                 }
                 // An untyped field carries no static tier — treat as Unknown.

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2865_dynamic_type_arg_iskindof.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2865_dynamic_type_arg_iskindof.rs
@@ -108,7 +108,7 @@ fn resolve_type_annotation_dynamic_nested_in_generic_resolves_to_dynamic_variant
 /// resolve a bare `Dynamic` to the real `InferredType::Dynamic` variant.
 #[test]
 fn resolve_type_name_string_dynamic_keyword_resolves_to_dynamic_variant() {
-    let result = TypeChecker::resolve_type_name_string(&eco_string("Dynamic"));
+    let result = TypeChecker::resolve_type_name_string(&eco_string("Dynamic"), None);
     assert!(
         matches!(result, InferredType::Dynamic(_)),
         "expected the real Dynamic variant, got: {result:?}"
@@ -119,7 +119,8 @@ fn resolve_type_name_string_dynamic_keyword_resolves_to_dynamic_variant() {
 /// a generic's type args too.
 #[test]
 fn resolve_type_name_string_dynamic_nested_in_generic_resolves_to_dynamic_variant() {
-    let result = TypeChecker::resolve_type_name_string(&eco_string("MyResult(Dynamic, Error)"));
+    let result =
+        TypeChecker::resolve_type_name_string(&eco_string("MyResult(Dynamic, Error)"), None);
     let InferredType::Known {
         class_name,
         type_args,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
@@ -282,7 +282,7 @@ fn block_params_remain_dynamic_for_unparameterized_list() {
 #[test]
 fn resolve_type_name_string_parametric() {
     // List(String) should parse to Known("List") with type_args [Known("String")]
-    let result = TypeChecker::resolve_type_name_string(&"List(String)".into());
+    let result = TypeChecker::resolve_type_name_string(&"List(String)".into(), None);
     match &result {
         InferredType::Known {
             class_name,
@@ -300,7 +300,8 @@ fn resolve_type_name_string_parametric() {
 #[test]
 fn resolve_type_name_string_nested_parametric() {
     // Result(List(Integer), String) should parse correctly
-    let result = TypeChecker::resolve_type_name_string(&"Result(List(Integer), String)".into());
+    let result =
+        TypeChecker::resolve_type_name_string(&"Result(List(Integer), String)".into(), None);
     match &result {
         InferredType::Known {
             class_name,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/local_annotations.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/local_annotations.rs
@@ -480,7 +480,7 @@ fn method_call_union_return_no_false_binary_warning() {
 /// "Integer | Nil" into a proper Union type (not Known("Integer | Nil")).
 #[test]
 fn resolve_type_name_string_splits_union() {
-    let ty = TypeChecker::resolve_type_name_string(&"Integer | Nil".into());
+    let ty = TypeChecker::resolve_type_name_string(&"Integer | Nil".into(), None);
     match &ty {
         InferredType::Union { members, .. } => {
             assert_eq!(

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
@@ -162,13 +162,13 @@ fn resolve_type_annotation_false_or() {
 
 #[test]
 fn resolve_type_name_string_simple() {
-    let result = TypeChecker::resolve_type_name_string(&"Integer".into());
+    let result = TypeChecker::resolve_type_name_string(&"Integer".into(), None);
     assert_eq!(result, InferredType::known("Integer"));
 }
 
 #[test]
 fn resolve_type_name_string_union() {
-    let result = TypeChecker::resolve_type_name_string(&"String | nil".into());
+    let result = TypeChecker::resolve_type_name_string(&"String | nil".into(), None);
     assert_eq!(
         result,
         InferredType::simple_union(&["String", "UndefinedObject"])

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -541,8 +541,12 @@ pub(in crate::semantic_analysis) fn super_receiver_type(
             // generics (`List(Integer)`), unions (`Integer | Nil`), and `Nil`
             // keyword aliases canonicalise correctly instead of becoming an
             // opaque `Known("List(Integer)")`.
+            // No alias registry threaded here (BT-2928 follow-up) — this
+            // free function's callers don't have one in scope; an
+            // alias-typed `extends Base(SomeAlias)` type arg falls back to
+            // an opaque nominal class, same as before this fix.
             SuperclassTypeArg::Concrete { type_name } => {
-                super::TypeChecker::resolve_type_name_string(type_name)
+                super::TypeChecker::resolve_type_name_string(type_name, None)
             }
         })
         .collect();


### PR DESCRIPTION
## Summary

Fixes cross-file/package type-alias resolution for `beamtalk build` (manifest-based package builds) and the LSP diagnostic pipeline, per BT-2928. Scoped down from the full issue per its own guidance — see "Scoped out" below, with follow-up issues filed for each deferred piece.

**Root cause found to be two-layered**, both fixed here:

1. **`AliasRegistry` was never seeded project-wide.** `AnalysisContext::pre_loaded_aliases` already existed (wired for REPL cross-turn continuity) but no CLI/LSP caller ever populated it for cross-file use. Added:
   - `ProjectDiagnosticContext::pre_loaded_aliases` (`diagnostic_provider.rs`) — the single shared pipeline both CLI and LSP call now threads aliases through `analyse_with_natives_and_protocols_and_aliases`.
   - `ClassHierarchyContext::pre_loaded_aliases` (`beam_compiler.rs`) — CLI-side plumbing.
   - `build.rs`'s Pass 1: new `collect_project_alias_infos` helper does a lightweight full-project scan (lex+parse only, not the incremental `.beamtalk-pass1-cache.json`) to extract every file's `type Name = ...` declarations, merged into `ClassHierarchyContext::pre_loaded_aliases` for Pass 2. Also wired into `deps/path.rs`'s dependency-package compilation (same-package cross-file resolution within a dependency's own multi-file build).
   - LSP: `ProjectIndex::cross_file_alias_infos_for` (mirrors `cross_file_class_infos_for`) + wired into `language_service/mod.rs`'s `diagnostics()`.

2. **`resolve_type_name_string` (the *other* type-name→`InferredType` resolver) was alias-blind.** This is the function that converts a cross-file `ClassInfo`/`MethodInfo`'s raw `return_type`/`param_types` strings (extracted once at Pass 1, no live `TypeAnnotation` to re-resolve) into an `InferredType` — used for message-send return types and cross-file field-access types. Even with (1)'s registry seeded, this function had no way to consult it, so a cross-file alias name stayed an opaque nominal class. This is the literal `A new heading` repro from the issue, and the actual mechanism behind the real stdlib bug that blocked BT-2923 (`RestartStrategy`/`SupervisionSpec.bt`): the *declared* parameter side resolved fine (same-file `TypeAnnotation`), but the *argument's* inferred type — read back from a cross-file method's raw return-type string — never expanded, so `is_type_compatible` compared an opaque `"RestartStrategy"` against the expanded union and failed.

   Added an `alias_registry: Option<&AliasRegistry>` parameter to `resolve_type_name_string`, threaded through every call site with `self` in scope (message-send return type, field access, union-member return types). A few call sites without ready `self` access (`resolve_narrowing_variable_type`, `sendability.rs`'s `tier_of_depth`, `type_resolver.rs`'s `super_receiver_type`) pass `None`, preserving pre-fix behaviour there — filed as BT-2936.

3. **`check_state_variance` alias-resolution fix** (`protocol.rs`) — the concretely-specified sibling fix from the issue: mirrors `check_state_defaults`'s already-fixed pattern (BT-2923), routing the declared type through `resolve_type_annotation_with_alias_deps` before comparing against the default value's inferred type, instead of using the raw unresolved `type_annotation.type_name()`.

## Regression coverage

- `build.rs`: `test_cross_file_alias_resolution_no_false_type_mismatch` — 2-file fixture (`type Direction = ...` in file A, consumed as a cross-file argument in file B), reproducing the exact stdlib bug shape. Includes a **negative control** (same compile without `pre_loaded_aliases`) proving the test actually exercises the fix, not a scenario that never warned.
- `inference.rs`: `resolve_type_name_string_expands_alias_from_registry` — unit test for the alias-registry-aware resolver, with and without a registry.
- Full existing suite (5182 beamtalk-core lib tests, 849 beamtalk-cli bin tests, 147 language_service tests, 223 stdlib tests) passes with zero regressions; `just build-stdlib` still succeeds unmodified (no behaviour change there — `pre_loaded_aliases` defaults to empty).
- `just ci-changed` (clippy, fmt, Dialyzer spec validation, Rust/stdlib/BUnit/Erlang-runtime tests, corpus + surface-drift checks) passes clean.

## Scoped down / deferred (follow-ups filed, all parented to BT-2893)

Per the task's own guidance, this is a large (L) issue with several root-cause candidates; scoped to the concretely-specified `build.rs` Pass-1 fix + `check_state_variance` fix, landing the central `AliasRegistry`-seeding plumbing both depend on. Deferred:

- **BT-2935** — `build_stdlib.rs`: seed `AliasRegistry` from `generated_builtins.rs` so stdlib's *own* cross-file aliases resolve (blocks re-aliasing `RestartStrategy`/`Timeout`). Needs a design decision on serializing `TypeAnnotation` (no `serde` support today) vs. a stringly-typed alias table.
- **BT-2936** — thread `alias_registry` through `resolve_type_name_string`'s remaining `None`-passing call sites (narrowing, sendability tiers, `super_receiver_type`).
- **BT-2937** — cross-*package* alias export: merge a path/hex dependency's exported aliases into the consuming package's `AliasRegistry` (mirrors `dependency_classes.rs`'s existing class merging). Check for overlap with BT-2898 first.
- **BT-2938** — wire compiled stdlib aliases into the REPL/workspace session's alias table (`:help <StdlibAlias>` in a fresh session). Blocked on BT-2935.
- **BT-2939** — re-alias `RestartStrategy`/`Timeout` in stdlib once BT-2935 lands (the clean revert BT-2923 left behind).

## Review notes

- `dependency_classes.rs` itself (the acceptance criteria's third file) was not modified — the intra-package fix landed in `build.rs`'s Pass 1 and `deps/path.rs`'s `compile_path_dependency` instead (a dependency's *own* multi-file compilation), which turned out to be the more direct locus for "verify empirically" per the issue's own note. Cross-*package* export (the part that actually belongs in `dependency_classes.rs`) is BT-2937.
- `alias_registry.rs` was not modified — no new serialization/merge API was needed; `AliasInfo`/`AliasRegistry::extract_alias_infos`/`add_pre_loaded` already had everything required (their doc comments explicitly anticipated this build-pipeline caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz)_